### PR TITLE
chore: cd into workspace to ensure proper build target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Set up working directory
+      run: cd ${{ github.workspace }}
+
     - name: Build and Deploy React app to GitHub Pages
       uses: omkartapale/react-deployment-gh-pages@v1.0.0
       


### PR DESCRIPTION
Right now, our workflow does not leave the .git directory before it performs the next JS build. This creates an unnecessary build failure.