### PR TITLE
fix: Bin to Queue to Flowsheet bugs

### DIFF
--- a/src/components/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
+++ b/src/components/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
@@ -36,6 +36,7 @@ import DragButton from "../Components/DragButton";
 import RemoveButton from "../Components/RemoveButton";
 import DraggableEntryWrapper from "../DraggableEntryWrapper";
 import FlowsheetEntryField from "./FlowsheetEntryField";
+import { toast } from "sonner";
 
 export default function SongEntry({
   playing,
@@ -160,9 +161,13 @@ export default function SongEntry({
                     rotation_id: entry.rotation_id,
                     album_id: entry.album_id,
                     play_freq: entry.rotation,
-                  } as FlowsheetSubmissionParams).then(() => {
-                    dispatch(flowsheetSlice.actions.removeFromQueue(entry.id));
-                  });
+                  } as FlowsheetSubmissionParams)
+                    .then(() => {
+                      dispatch(flowsheetSlice.actions.removeFromQueue(entry.id));
+                    })
+                    .catch((error) => {
+                      toast.error("Failed to add to flowsheet:", error);
+                    });
                 }}
               >
                 <PlayArrow />


### PR DESCRIPTION
### Fixes #98 

**Root Cause**: The queue to flowsheet callback wasn't returning a promise, causing the queue entry to be removed immediately before the backend confirmed the flowsheet addition. This created a race condition where the UI state became out of sync with the backend.

### Changes Made

#### 1. Fixed Queue-to-Flowsheet State Synchronization

**File: `src/hooks/flowsheetHooks.ts`**
- Modified `addToFlowsheetCallback` to return a promise from the mutation
- Changed from fire-and-forget to properly awaiting the backend response using `.unwrap()`
- Moved pagination update to occur only after successful mutation completion
- Added proper error handling with `Promise.reject()` when user is not logged in

**File: `src/components/modern/flowsheet/Entries/SongEntry/SongEntry.tsx`**
- Updated the play button click handler to wait for the promise resolution
- Queue entry is now only removed after backend confirms successful addition to flowsheet
- Added `.catch()` block to log errors if the backend operation fails

#### 2. Added Polling for Real-Time Updates

**File: `src/hooks/flowsheetHooks.ts`**
- Added 60-second polling interval to `useWhoIsLiveQuery` (line 43)
- Added 60-second polling interval to both `useGetEntriesQuery` calls (lines 53 and 157)
- Polling interval matches the existing `useGetNowPlayingQuery` behavior
