### PR TITLE
feat: Save queue to local storage

### DIFF
--- a/app/dashboard/@modern/flowsheet/@queue/page.tsx
+++ b/app/dashboard/@modern/flowsheet/@queue/page.tsx
@@ -5,12 +5,18 @@ import SongEntry from "@/src/components/modern/flowsheet/Entries/SongEntry/SongE
 import { Table, useColorScheme } from "@mui/joy";
 import { Reorder } from "motion/react";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export default function Queue() {
   const { mode } = useColorScheme();
   const queue = useAppSelector((state) => state.flowsheet.queue);
   const dispatch = useAppDispatch();
+  const [isMounted, setIsMounted] = useState(false);
+
+  // Only render queue content after client-side mount to avoid hydration mismatch
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   // Handler for reordering queue items - Disabled for now
   const handleReorder = useCallback((newOrder: typeof queue) => {
@@ -39,12 +45,12 @@ export default function Queue() {
         </tr>
       </thead>
       <Reorder.Group
-        values={queue.toReversed()}
+        values={isMounted ? queue.toReversed() : []}
         axis="y"
         onReorder={handleReorder}
         as="tbody"
       >
-        {queue.toReversed().map((entry) => (
+        {isMounted && queue.toReversed().map((entry) => (
           <SongEntry
             key={`queue-${entry.id}`}
             entry={entry}

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -1,6 +1,7 @@
 import { createAppSlice } from "@/lib/createAppSlice";
 import { PayloadAction } from "@reduxjs/toolkit";
 import { FlowsheetEntry, FlowsheetFrontendState, FlowsheetQuery, FlowsheetRequestParams, FlowsheetSearchProperty, FlowsheetSongEntry, FlowsheetSwitchParams } from "./types";
+import { clearQueueFromStorage, loadQueueFromStorage, saveQueueToStorage } from "./queue-storage";
 
 export const defaultFlowsheetFrontendState: FlowsheetFrontendState = {
   autoplay: false,
@@ -61,19 +62,30 @@ export const flowsheetSlice = createAppSlice({
         rotation: action.payload.play_freq,
         rotation_id: action.payload.rotation_id,
         album_id: action.payload.album_id,
-      })
+      });
+      saveQueueToStorage(state.queue);
     },
     removeFromQueue: (state, action) => {
       state.queue = state.queue.filter((entry) => entry.id !== action.payload);
+      saveQueueToStorage(state.queue);
+    },
+    clearQueue: (state) => {
+      state.queue = [];
+      clearQueueFromStorage();
+    },
+    loadQueue: (state) => {
+      state.queue = loadQueueFromStorage();
     },
     updateQueueEntry: (state, action: PayloadAction<{ entry_id: number; field: keyof FlowsheetSongEntry; value: string | boolean }>) => {
       const entry = state.queue.find((e) => e.id === action.payload.entry_id);
       if (entry) {
         (entry as any)[action.payload.field] = action.payload.value;
       }
+      saveQueueToStorage(state.queue);
     },
     reorderQueue: (state, action: PayloadAction<FlowsheetSongEntry[]>) => {
       state.queue = action.payload;
+      saveQueueToStorage(state.queue);
     },
     setSelectedResult: (state, action) => {
       state.search.selectedResult = action.payload;

--- a/lib/features/flowsheet/queue-storage.ts
+++ b/lib/features/flowsheet/queue-storage.ts
@@ -1,0 +1,37 @@
+import { createAppSlice } from "@/lib/createAppSlice";
+import { PayloadAction } from "@reduxjs/toolkit";
+import { FlowsheetEntry, FlowsheetFrontendState, FlowsheetQuery, FlowsheetRequestParams, FlowsheetSearchProperty, FlowsheetSongEntry, FlowsheetSwitchParams } from "./types";
+
+const QUEUE_STORAGE_KEY = "wxyc_flowsheet_queue";
+
+// Load queue from localStorage
+export const loadQueueFromStorage = (): FlowsheetSongEntry[] => {
+  if (typeof window === "undefined") return [];
+  try {
+    const stored = localStorage.getItem(QUEUE_STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch (error) {
+    console.error("Failed to load queue from localStorage:", error);
+    return [];
+  }
+};
+
+// Save queue to localStorage
+export const saveQueueToStorage = (queue: FlowsheetSongEntry[]) => {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(QUEUE_STORAGE_KEY, JSON.stringify(queue));
+  } catch (error) {
+    console.error("Failed to save queue to localStorage:", error);
+  }
+};
+
+// Clear queue from localStorage
+export const clearQueueFromStorage = () => {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(QUEUE_STORAGE_KEY);
+  } catch (error) {
+    console.error("Failed to clear queue from localStorage:", error);
+  }
+};

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -96,6 +96,9 @@ export const useShowControl = () => {
       return;
     }
 
+    // Clear the queue when ending the show
+    dispatch(flowsheetSlice.actions.clearQueue());
+    
     dispatch(
       flowsheetSlice.actions.setPagination({
         page: 0,
@@ -309,6 +312,18 @@ export const useQueue = () => {
   const dispatch = useAppDispatch();
 
   const queue = useAppSelector((state) => state.flowsheet.queue);
+
+  // Load queue from localStorage on mount
+  useEffect(() => {
+    dispatch(flowsheetSlice.actions.loadQueue());
+  }, [dispatch]); // Only run on mount
+
+  // Clear queue when user goes offline or is not live after loading completes
+  useEffect(() => {
+    if (!loading && !live && queue.length > 0) {
+      dispatch(flowsheetSlice.actions.clearQueue());
+    }
+  }, [live, loading, queue.length, dispatch]);
 
   const addToQueue = useCallback(
     (entry: FlowsheetQuery) => {


### PR DESCRIPTION
## Fixes #100

### Changes Made

#### 1. localStorage Persistence Layer

**File: `lib/features/flowsheet/frontend.ts`**
- Added three localStorage utility functions:
  - `loadQueueFromStorage()`: Loads queue with SSR-safe checks and error handling
  - `saveQueueToStorage()`: Saves queue state to localStorage
  - `clearQueueFromStorage()`: Removes queue from localStorage
- Storage key: `"wxyc_flowsheet_queue"`

#### 2. Redux State Management

**File: `lib/features/flowsheet/frontend.ts`**
- Added new actions:
  - `loadQueue`: Loads queue from localStorage into Redux state
  - `clearQueue`: Clears queue from both state and localStorage
- Modified existing actions to auto-persist:
  - `addToQueue`: Now saves to localStorage after adding
  - `removeFromQueue`: Now saves to localStorage after removing
  - `updateQueueEntry`: Now saves to localStorage after updating
  - `reorderQueue`: Now saves to localStorage after reordering

#### 3. Queue Lifecycle Management

**File: `src/hooks/flowsheetHooks.ts`**

**`useQueue` hook:**
- Loads queue from localStorage on component mount
- Automatically clears queue if user is not live (prevents stale queue items)

**`useShowControl` hook:**
- Modified `leave()` function to clear queue when DJ ends their show

### Behavior

**Queue Persistence:**
- Queue survives page refreshes during a DJ's show
- Queue persists across browser tabs for the same machine

**Queue Clearing:**
- Automatically clears when DJ ends their show (clicks "Leave")
- Automatically clears if page loads and user is not live
- Automatically clears when DJ goes offline
