### PR TITLE
feat: implement email-based account setup flow for new users

### DIFF
--- a/app/api/admin/send-password-setup/route.ts
+++ b/app/api/admin/send-password-setup/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { serverAuthClient } from "@/lib/features/authentication/server-client";
+import { betterAuthSessionToAuthenticationData } from "@/lib/features/authentication/utilities";
+import { isAuthenticated } from "@/lib/features/authentication/types";
+import { Authorization } from "@/lib/features/admin/types";
+import type { BetterAuthSessionResponse } from "@/lib/features/authentication/utilities";
+
+/**
+ * POST /api/admin/send-password-setup
+ *
+ * Server-side endpoint to trigger a password setup email for a new user.
+ * Uses Better Auth's forget-password endpoint, which will detect that the
+ * user is new (no realName) and send an "account setup" email instead of
+ * a "password reset" email.
+ *
+ * Required: Station Manager (SM) or Admin authorization
+ *
+ * Body:
+ * - email: string - The email address of the user to send the setup email to
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // Verify admin authentication
+    const cookieStore = await cookies();
+    const cookieHeader = cookieStore.toString();
+
+    const session = (await serverAuthClient.getSession({
+      fetchOptions: {
+        headers: {
+          cookie: cookieHeader,
+        },
+      },
+    })) as BetterAuthSessionResponse;
+
+    if (!session.data) {
+      return NextResponse.json(
+        { error: "Unauthorized: Not authenticated" },
+        { status: 401 }
+      );
+    }
+
+    const authData = betterAuthSessionToAuthenticationData(session.data);
+
+    if (!isAuthenticated(authData)) {
+      return NextResponse.json(
+        { error: "Unauthorized: Not authenticated" },
+        { status: 401 }
+      );
+    }
+
+    // Only Station Managers or Admins can send password setup emails
+    const authority = authData.user?.authority;
+    if (authority !== Authorization.SM && authority !== Authorization.ADMIN) {
+      return NextResponse.json(
+        { error: "Forbidden: Requires Station Manager or Admin privileges" },
+        { status: 403 }
+      );
+    }
+
+    // Parse request body
+    const body = await request.json();
+    const { email } = body;
+
+    if (!email || typeof email !== "string") {
+      return NextResponse.json(
+        { error: "Bad Request: email is required" },
+        { status: 400 }
+      );
+    }
+
+    // Trigger password reset via Better Auth
+    // The backend detects new users (no realName) and sends accountSetup email
+    const authBaseUrl =
+      process.env.NEXT_PUBLIC_BETTER_AUTH_URL || "https://api.wxyc.org/auth";
+
+    // Determine the redirect URL for the password reset link
+    const redirectTo =
+      process.env.PASSWORD_RESET_REDIRECT_URL ||
+      `${process.env.NEXT_PUBLIC_APP_URL || "https://wxyc.org"}/login`;
+
+    const response = await fetch(`${authBaseUrl}/forget-password`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email,
+        redirectTo,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "Unknown error");
+      console.error("Failed to send password setup email:", errorText);
+      return NextResponse.json(
+        { error: "Failed to send password setup email" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error in send-password-setup endpoint:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Internal server error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -76,13 +76,9 @@ export default function RosterTable({ user }: { user: User }) {
 
         const formData = new FormData(e.currentTarget);
 
-        const tempPassword = String(
-          process.env.NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD || ""
-        );
-
-        if (!tempPassword) {
-          throw new Error("Missing onboarding temp password configuration.");
-        }
+        // Generate a random password that will never be shared with the user
+        // The user will set their own password via the setup email link
+        const randomPassword = crypto.randomUUID();
 
         const newAccount: NewAccountParams = {
           realName: (formData.get("realName") as string)?.trim() || "",
@@ -91,7 +87,7 @@ export default function RosterTable({ user }: { user: User }) {
             ? (formData.get("djName") as string).trim()
             : "Anonymous",
           email: (formData.get("email") as string)?.trim() || "",
-          temporaryPassword: tempPassword,
+          temporaryPassword: randomPassword,
           authorization: authorizationOfNewAccount,
         };
 
@@ -122,6 +118,9 @@ export default function RosterTable({ user }: { user: User }) {
 
         // Create user via better-auth admin API
         // Email will be auto-verified by the backend since admin is a trusted source
+        // Note: We intentionally do NOT pass realName/djName here - the user will fill
+        // these in during onboarding. This allows the backend to detect this as a "new user"
+        // and send a welcome/setup email instead of a password reset email.
         const result = await authClient.admin.createUser({
           name: newAccount.realName || newAccount.username,
           email: newAccount.email,
@@ -129,8 +128,7 @@ export default function RosterTable({ user }: { user: User }) {
           role: adminRole,
           data: {
             username: newAccount.username,
-            realName: newAccount.realName || undefined,
-            djName: newAccount.djName || undefined,
+            // realName and djName intentionally omitted - user fills in during onboarding
           },
         });
 
@@ -160,7 +158,23 @@ export default function RosterTable({ user }: { user: User }) {
           console.warn("Organization ID not configured, user created without organization membership");
         }
 
-        toast.success(`Account created successfully for ${newAccount.username}`);
+        // Trigger password setup email for the new user
+        // The backend will detect this is a new user (no realName filled in yet)
+        // and send a "Welcome! Set up your password" email instead of a password reset email
+        const setupEmailResult = await fetch("/api/admin/send-password-setup", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: newAccount.email }),
+        });
+
+        if (!setupEmailResult.ok) {
+          console.warn("Could not send password setup email:", await setupEmailResult.text().catch(() => ""));
+          toast.warning(
+            `Account created for ${newAccount.username}. Could not send setup email - ask them to use "Forgot Password" to set up their account.`
+          );
+        } else {
+          toast.success(`Account created for ${newAccount.username}. Setup email sent.`);
+        }
         
         dispatch(adminSlice.actions.setAdding(false));
         dispatch(adminSlice.actions.reset());


### PR DESCRIPTION
## Summary
Replace temp password flow with email-based password setup:
- Admin creates user with random UUID password (never shared)
- System sends "Welcome! Set up your password" email via new API
- User clicks link to set their own password
- Onboarding now only collects profile info (realName, djName)

## Changes
- Add `/api/admin/send-password-setup` endpoint for triggering setup emails
- Update RosterTable to use `crypto.randomUUID()` and call setup API
- Remove realName/djName from initial user creation (filled in onboarding)
- Simplify useNewUser hook to only update profile fields

## Dependencies
- This PR depends on PR #120 (feat/admin-role-dropdown)
- **IMPORTANT**: Requires Backend-Service PR #143 to be merged first (provides email sending capability)

## Test plan
- [ ] Verify build passes after PR 120 is merged
- [ ] Test user creation triggers setup email
- [ ] Verify new users receive email with password setup link
- [ ] Test onboarding flow collects profile info after password setup