### PR TITLE
feat: add admin Better Auth integration

### DIFF
--- a/app/api/admin/organization/add-member/route.ts
+++ b/app/api/admin/organization/add-member/route.ts
@@ -1,0 +1,187 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { serverAuthClient } from "@/lib/features/authentication/server-client";
+import { betterAuthSessionToAuthenticationData } from "@/lib/features/authentication/utilities";
+import { isAuthenticated } from "@/lib/features/authentication/types";
+import { Authorization } from "@/lib/features/admin/types";
+import type { BetterAuthSessionResponse } from "@/lib/features/authentication/utilities";
+
+/**
+ * POST /api/admin/organization/add-member
+ *
+ * Server-side endpoint to add a user directly to an organization.
+ * This bypasses the invitation flow and immediately adds the user as a member.
+ *
+ * Required: Station Manager (SM) authorization
+ *
+ * Body:
+ * - userId: string - The user ID to add
+ * - organizationId: string - The organization ID
+ * - role: string - The role to assign (e.g., "member", "dj", "musicDirector", "stationManager")
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // Verify admin authentication
+    const cookieStore = await cookies();
+    const cookieHeader = cookieStore.toString();
+
+    const session = await serverAuthClient.getSession({
+      fetchOptions: {
+        headers: {
+          cookie: cookieHeader,
+        },
+      },
+    }) as BetterAuthSessionResponse;
+
+    if (!session.data) {
+      return NextResponse.json(
+        { error: "Unauthorized: Not authenticated" },
+        { status: 401 }
+      );
+    }
+
+    const authData = betterAuthSessionToAuthenticationData(session.data);
+
+    if (!isAuthenticated(authData)) {
+      return NextResponse.json(
+        { error: "Unauthorized: Not authenticated" },
+        { status: 401 }
+      );
+    }
+
+    // Only Station Managers can add members
+    if (authData.user?.authority !== Authorization.SM) {
+      return NextResponse.json(
+        { error: "Forbidden: Requires Station Manager privileges" },
+        { status: 403 }
+      );
+    }
+
+    // Parse request body
+    const body = await request.json();
+    const { userId, organizationId, role } = body;
+
+    if (!userId || !organizationId || !role) {
+      return NextResponse.json(
+        { error: "Bad Request: userId, organizationId, and role are required" },
+        { status: 400 }
+      );
+    }
+
+    // Try to use the SDK's addMember method if available
+    // This is a server-side only function that bypasses the invitation flow
+    // If not available, fall back to inviting the member (which requires acceptance)
+    let result: any;
+    let usedInvitation = false;
+
+    // Check if organization SDK has addMember method
+    const orgClient = serverAuthClient.organization as any;
+    if (typeof orgClient?.addMember === "function") {
+      // Use SDK method directly
+      const addResult = await orgClient.addMember({
+        userId,
+        organizationId,
+        role,
+      }, {
+        fetchOptions: {
+          headers: {
+            cookie: cookieHeader,
+          },
+        },
+      });
+
+      if (addResult.error) {
+        console.error("SDK addMember failed:", addResult.error);
+        return NextResponse.json(
+          { error: addResult.error.message || "Failed to add member to organization" },
+          { status: 400 }
+        );
+      }
+      result = addResult.data;
+    } else {
+      // Fallback: Try HTTP endpoint (may not exist on all Better Auth servers)
+      const baseURL = process.env.NEXT_PUBLIC_BETTER_AUTH_URL || "https://api.wxyc.org/auth";
+      const response = await fetch(`${baseURL}/organization/add-member`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          cookie: cookieHeader,
+        },
+        body: JSON.stringify({
+          userId,
+          organizationId,
+          role,
+        }),
+      });
+
+      if (!response.ok) {
+        // If add-member endpoint doesn't exist (404), try inviteMember as fallback
+        // Note: This requires the user to accept the invitation
+        if (response.status === 404) {
+          console.warn("add-member endpoint not available, falling back to invitation");
+
+          // Get user email for invitation
+          const userResult = await serverAuthClient.admin.listUsers({
+            query: {
+              filterField: "id",
+              filterValue: userId,
+              limit: 1,
+            },
+            fetchOptions: {
+              headers: {
+                cookie: cookieHeader,
+              },
+            },
+          });
+
+          const userEmail = userResult.data?.users?.[0]?.email;
+          if (!userEmail) {
+            return NextResponse.json(
+              { error: "Could not find user email for invitation" },
+              { status: 400 }
+            );
+          }
+
+          // Send invitation (user will need to accept)
+          const inviteResult = await serverAuthClient.organization.inviteMember({
+            email: userEmail,
+            organizationId,
+            role: role as "admin" | "member" | "owner",
+          });
+
+          if (inviteResult.error) {
+            return NextResponse.json(
+              { error: inviteResult.error.message || "Failed to invite member" },
+              { status: 400 }
+            );
+          }
+
+          result = inviteResult.data;
+          usedInvitation = true;
+        } else {
+          const errorData = await response.json().catch(() => ({ message: response.statusText }));
+          console.error("Failed to add member to organization:", errorData);
+          return NextResponse.json(
+            { error: errorData.message || "Failed to add member to organization" },
+            { status: response.status }
+          );
+        }
+      } else {
+        result = await response.json();
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: result,
+      // Indicate if invitation was used (requires user acceptance) vs direct add
+      usedInvitation,
+    });
+  } catch (error) {
+    console.error("Error in add-member endpoint:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/dashboard/@modern/admin/roster/page.tsx
+++ b/app/dashboard/@modern/admin/roster/page.tsx
@@ -1,12 +1,14 @@
-import { AuthenticatedUser } from "@/lib/features/authentication/types";
-import { createServerSideProps } from "@/lib/features/session";
+import { requireAuth, requireRole, getUserFromSession } from "@/lib/features/authentication/server-utils";
+import { Authorization } from "@/lib/features/admin/types";
 import PageHeader from "@/src/components/experiences/modern/Header/PageHeader";
 import RosterTable from "@/src/components/experiences/modern/admin/roster/RosterTable";
 
 export default async function AdminPage() {
-  const user = (
-    (await createServerSideProps()).authentication as AuthenticatedUser
-  ).user!;
+  const session = await requireAuth();
+  await requireRole(session, Authorization.SM);
+  
+  const user = await getUserFromSession(session);
+  
   return (
     <>
       <PageHeader title="DJ Roster" />

--- a/lib/features/admin/better-auth-client.ts
+++ b/lib/features/admin/better-auth-client.ts
@@ -1,0 +1,46 @@
+import { cookies } from "next/headers";
+import { serverAuthClient } from "../authentication/server-client";
+import { Authorization } from "./types";
+import { isAuthenticated } from "../authentication/types";
+import { betterAuthSessionToAuthenticationData as convertSession, BetterAuthSessionResponse } from "../authentication/utilities";
+
+/**
+ * Verifies that the current user is authenticated and has admin (stationManager) privileges
+ * @throws Error if user is not authenticated or not an admin
+ */
+export async function verifyAdminAccess(): Promise<void> {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.toString();
+
+  const session = await serverAuthClient.getSession({
+    fetchOptions: {
+      headers: {
+        cookie: cookieHeader,
+      },
+    },
+  }) as BetterAuthSessionResponse;
+
+  if (!session.data) {
+    throw new Error("User is not authenticated");
+  }
+
+  const authData = convertSession(session.data);
+  
+  if (!isAuthenticated(authData)) {
+    throw new Error("User is not authenticated");
+  }
+
+  if (authData.user?.authority !== Authorization.SM) {
+    throw new Error("User does not have admin privileges");
+  }
+}
+
+/**
+ * Gets the better-auth admin client for making admin API calls
+ * Verifies admin access before returning
+ */
+export async function getBetterAuthAdminClient() {
+  await verifyAdminAccess();
+  return serverAuthClient;
+}
+

--- a/lib/features/admin/conversions-better-auth.ts
+++ b/lib/features/admin/conversions-better-auth.ts
@@ -1,0 +1,47 @@
+import { Account, AdminAuthenticationStatus, Authorization } from "./types";
+import { mapRoleToAuthorization } from "../authentication/types";
+
+// Better-auth user type (from admin API)
+export type BetterAuthUser = {
+  id: string;
+  email: string;
+  name: string;
+  username?: string;
+  emailVerified: boolean;
+  realName?: string;
+  djName?: string;
+  role: "member" | "dj" | "musicDirector" | "stationManager";
+  createdAt: Date;
+  updatedAt: Date;
+  banned?: boolean;
+  banReason?: string;
+};
+
+/**
+ * Converts better-auth user to Account format
+ */
+export function convertBetterAuthToAccountResult(
+  user: BetterAuthUser
+): Account {
+  return {
+    id: user.id,
+    userName: user.username || user.name,
+    realName: user.realName || user.name || "No Real Name",
+    djName: user.djName || "No DJ Name",
+    authorization: mapRoleToAuthorization(user.role),
+    authType: user.emailVerified 
+      ? AdminAuthenticationStatus.Confirmed 
+      : AdminAuthenticationStatus.New,
+    email: user.email,
+  };
+}
+
+/**
+ * Maps better-auth role to Authorization enum
+ */
+export function mapBetterAuthRoleToAuthorization(
+  role: "member" | "dj" | "musicDirector" | "stationManager"
+): Authorization {
+  return mapRoleToAuthorization(role);
+}
+

--- a/lib/features/admin/frontend.ts
+++ b/lib/features/admin/frontend.ts
@@ -10,7 +10,7 @@ export const defaultAdminFrontendState: AdminFrontendState = {
 };
 
 export const adminSlice = createAppSlice({
-  name: "application",
+  name: "admin",
   initialState: defaultAdminFrontendState,
   reducers: {
     setSearchString: (state, action) => {

--- a/lib/features/admin/types.ts
+++ b/lib/features/admin/types.ts
@@ -14,6 +14,7 @@ export enum Authorization {
 }
 
 export type Account = {
+  id?: string;
   userName: string;
   realName: string;
   djName: string;

--- a/src/components/experiences/modern/admin/roster/AccountEntry.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEntry.tsx
@@ -1,30 +1,132 @@
 "use client";
 
+import { authClient } from "@/lib/features/authentication/client";
 import {
-  useDeleteAccountMutation,
-  usePromoteAccountMutation,
-  useResetPasswordMutation,
-} from "@/lib/features/admin/api";
+  getAppOrganizationIdClient,
+} from "@/lib/features/authentication/organization-utils";
 import {
   Account,
   AdminAuthenticationStatus,
   Authorization,
 } from "@/lib/features/admin/types";
-import { useDeleteDJInfoMutation } from "@/lib/features/authentication/api";
 import { DeleteForever, SyncLock } from "@mui/icons-material";
 import { ButtonGroup, Checkbox, IconButton, Stack, Tooltip } from "@mui/joy";
+import { useState } from "react";
+import { toast } from "sonner";
 
 export const AccountEntry = ({
   account,
   isSelf,
+  onAccountChange,
 }: {
   account: Account;
   isSelf: boolean;
+  onAccountChange?: () => Promise<void>;
 }) => {
-  const [promoteAccount, promoteResult] = usePromoteAccountMutation();
-  const [resetPassword, resetResult] = useResetPasswordMutation();
-  const [deleteAccount, deleteResult] = useDeleteAccountMutation();
-  const [clearInfo, clearResult] = useDeleteDJInfoMutation();
+  const [isPromoting, setIsPromoting] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [promoteError, setPromoteError] = useState<Error | null>(null);
+  const [resetError, setResetError] = useState<Error | null>(null);
+  const [deleteError, setDeleteError] = useState<Error | null>(null);
+  /**
+   * Resolve organization slug to organization ID
+   */
+  const resolveOrganizationId = async (): Promise<string> => {
+    // Use NEXT_PUBLIC_APP_ORGANIZATION directly - inlined at build time by Next.js
+    const orgSlugOrId = process.env.NEXT_PUBLIC_APP_ORGANIZATION || getAppOrganizationIdClient();
+
+    if (!orgSlugOrId) {
+      throw new Error("Organization not configured (NEXT_PUBLIC_APP_ORGANIZATION not set)");
+    }
+
+    // Try to resolve slug to ID
+    const orgResult = await authClient.organization.getFullOrganization({
+      query: {
+        organizationSlug: orgSlugOrId,
+      },
+    });
+
+    if (orgResult.data?.id) {
+      return orgResult.data.id;
+    }
+
+    // If slug lookup fails, assume it's already an ID
+    return orgSlugOrId;
+  };
+
+  /**
+   * Get the member ID for a user in the organization
+   */
+  const resolveMemberId = async (userId: string, organizationId: string): Promise<string> => {
+    const result = await authClient.organization.listMembers({
+      query: {
+        organizationId,
+        filterField: "userId",
+        filterOperator: "eq",
+        filterValue: userId,
+        limit: 1,
+      },
+    });
+
+    if (result.error) {
+      throw new Error(result.error.message || "Failed to fetch member");
+    }
+
+    const member = result.data?.members?.find((m: { userId: string }) => m.userId === userId);
+    if (!member) {
+      throw new Error("User is not a member of the organization");
+    }
+
+    return member.id;
+  };
+
+  /**
+   * Update user's role in the organization
+   */
+  const updateOrganizationRole = async (
+    userId: string,
+    newRole: "member" | "dj" | "musicDirector" | "stationManager"
+  ) => {
+    const organizationId = await resolveOrganizationId();
+    const memberId = await resolveMemberId(userId, organizationId);
+
+    const result = await authClient.organization.updateMemberRole({
+      memberId,
+      organizationId,
+      role: newRole,
+    });
+
+    if (result.error) {
+      throw new Error(result.error.message || "Failed to update role");
+    }
+
+    return result;
+  };
+
+  const resolveUserId = async () => {
+    if (account.id) {
+      return account.id;
+    }
+
+    const listResult = await authClient.admin.listUsers({
+      query: {
+        searchValue: account.email || account.userName,
+        searchField: account.email ? "email" : "name",
+        limit: 1,
+      },
+    });
+
+    if (
+      listResult.error ||
+      !listResult.data?.users ||
+      listResult.data.users.length === 0
+    ) {
+      throw new Error(`User with username ${account.userName} not found`);
+    }
+
+    return listResult.data.users[0].id;
+  };
 
   return (
     <tr>
@@ -36,11 +138,11 @@ export const AccountEntry = ({
       >
         <ButtonGroup>
           <Checkbox
-            disabled={isSelf || promoteResult.isLoading}
             color={"success"}
             sx={{ transform: "translateY(3px)" }}
             checked={account.authorization == Authorization.SM}
-            onChange={(e) => {
+            disabled={isSelf || isPromoting}
+            onChange={async (e) => {
               if (e.target.checked) {
                 if (
                   confirm(
@@ -49,11 +151,26 @@ export const AccountEntry = ({
                     } account to Station Manager?`
                   )
                 ) {
-                  promoteAccount({
-                    username: account.userName,
-                    currentAuthorization: account.authorization,
-                    nextAuthorization: Authorization.SM,
-                  });
+                  setIsPromoting(true);
+                  setPromoteError(null);
+                  try {
+                    const targetUserId = await resolveUserId();
+
+                    // Update organization member role
+                    await updateOrganizationRole(targetUserId, "stationManager");
+
+                    toast.success(`${account.realName} promoted to Station Manager`);
+                    if (onAccountChange) {
+                      await onAccountChange();
+                    }
+                  } catch (err) {
+                    const errorMessage = err instanceof Error ? err.message : "Failed to promote user";
+                    setPromoteError(err instanceof Error ? err : new Error(errorMessage));
+                    if (errorMessage.trim().length > 0) {
+                      toast.error(errorMessage);
+                    }
+                  }
+                  setIsPromoting(false);
                 }
               } else {
                 if (
@@ -63,11 +180,26 @@ export const AccountEntry = ({
                     } access to Station Manager privileges?`
                   )
                 ) {
-                  promoteAccount({
-                    username: account.userName,
-                    currentAuthorization: account.authorization,
-                    nextAuthorization: Authorization.MD,
-                  });
+                  setIsPromoting(true);
+                  setPromoteError(null);
+                  try {
+                    const targetUserId = await resolveUserId();
+
+                    // Update organization member role - demote to Music Director
+                    await updateOrganizationRole(targetUserId, "musicDirector");
+
+                    toast.success(`${account.realName} role updated to Music Director`);
+                    if (onAccountChange) {
+                      await onAccountChange();
+                    }
+                  } catch (err) {
+                    const errorMessage = err instanceof Error ? err.message : "Failed to update user role";
+                    setPromoteError(err instanceof Error ? err : new Error(errorMessage));
+                    if (errorMessage.trim().length > 0) {
+                      toast.error(errorMessage);
+                    }
+                  }
+                  setIsPromoting(false);
                 }
               }
             }}
@@ -76,7 +208,7 @@ export const AccountEntry = ({
             disabled={
               isSelf ||
               account.authorization == Authorization.SM ||
-              promoteResult.isLoading
+              isPromoting
             }
             color={"success"}
             sx={{ transform: "translateY(3px)" }}
@@ -84,7 +216,7 @@ export const AccountEntry = ({
               account.authorization == Authorization.SM ||
               account.authorization == Authorization.MD
             }
-            onChange={(e) => {
+            onChange={async (e) => {
               if (e.target.checked) {
                 if (
                   confirm(
@@ -93,11 +225,26 @@ export const AccountEntry = ({
                     } account to Music Director?`
                   )
                 ) {
-                  promoteAccount({
-                    username: account.userName,
-                    currentAuthorization: account.authorization,
-                    nextAuthorization: Authorization.MD,
-                  });
+                  setIsPromoting(true);
+                  setPromoteError(null);
+                  try {
+                    const targetUserId = await resolveUserId();
+
+                    // Update organization member role
+                    await updateOrganizationRole(targetUserId, "musicDirector");
+
+                    toast.success(`${account.realName} promoted to Music Director`);
+                    if (onAccountChange) {
+                      await onAccountChange();
+                    }
+                  } catch (err) {
+                    const errorMessage = err instanceof Error ? err.message : "Failed to promote user";
+                    setPromoteError(err instanceof Error ? err : new Error(errorMessage));
+                    if (errorMessage.trim().length > 0) {
+                      toast.error(errorMessage);
+                    }
+                  }
+                  setIsPromoting(false);
                 }
               } else {
                 if (
@@ -107,11 +254,26 @@ export const AccountEntry = ({
                     } access to Music Director privileges?`
                   )
                 ) {
-                  promoteAccount({
-                    username: account.userName,
-                    currentAuthorization: account.authorization,
-                    nextAuthorization: Authorization.DJ,
-                  });
+                  setIsPromoting(true);
+                  setPromoteError(null);
+                  try {
+                    const targetUserId = await resolveUserId();
+
+                    // Update organization member role - demote to DJ
+                    await updateOrganizationRole(targetUserId, "dj");
+
+                    toast.success(`${account.realName} role updated to DJ`);
+                    if (onAccountChange) {
+                      await onAccountChange();
+                    }
+                  } catch (err) {
+                    const errorMessage = err instanceof Error ? err.message : "Failed to update user role";
+                    setPromoteError(err instanceof Error ? err : new Error(errorMessage));
+                    if (errorMessage.trim().length > 0) {
+                      toast.error(errorMessage);
+                    }
+                  }
+                  setIsPromoting(false);
                 }
               }
             }}
@@ -142,15 +304,45 @@ export const AccountEntry = ({
               disabled={
                 account.authType != AdminAuthenticationStatus.Confirmed ||
                 isSelf ||
-                resetResult.isSuccess
+                isResetting
               }
-              onClick={() => {
+              loading={isResetting}
+              onClick={async () => {
                 if (
                   confirm(
                     "Are you sure you want to reset this user's password?"
                   )
                 ) {
-                  resetPassword(account.userName);
+                  setIsResetting(true);
+                  setResetError(null);
+                  try {
+                    const targetUserId = await resolveUserId();
+
+                    // Use the configured temporary password for consistency with user creation
+                    const tempPassword = String(process.env.NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD || "temppass123");
+
+                    // Reset password via better-auth admin API (setUserPassword properly hashes the password)
+                    const result = await authClient.admin.setUserPassword({
+                      userId: targetUserId,
+                      newPassword: tempPassword,
+                    });
+
+                    if (result.error) {
+                      throw new Error(result.error.message || "Failed to reset password");
+                    }
+
+                    toast.success(`Password reset successfully. Temporary password: ${tempPassword}`, {
+                      duration: 10000, // Show longer so admin can copy password
+                    });
+                  } catch (err) {
+                    const errorMessage = err instanceof Error ? err.message : "Failed to reset password";
+                    setResetError(err instanceof Error ? err : new Error(errorMessage));
+                    if (errorMessage.trim().length > 0) {
+                      toast.error(errorMessage);
+                    }
+                  } finally {
+                    setIsResetting(false);
+                  }
                 }
               }}
             >
@@ -174,17 +366,41 @@ export const AccountEntry = ({
               color="warning"
               variant="outlined"
               size="sm"
-              disabled={isSelf || deleteResult.isSuccess}
-              loading={deleteResult.isLoading}
-              onClick={() => {
+              disabled={isSelf || isDeleting}
+              loading={isDeleting}
+              onClick={async () => {
                 if (
                   confirm(
                     `Are you sure you want to delete ${account.realName}'s account?`
                   )
                 ) {
-                  deleteAccount(account.userName).then(async () => {
-                    return await clearInfo(account.userName);
-                  });
+                  setIsDeleting(true);
+                  setDeleteError(null);
+                  try {
+                    const targetUserId = await resolveUserId();
+
+                    // Delete user via better-auth admin API
+                    const result = await authClient.admin.removeUser({
+                      userId: targetUserId,
+                    });
+
+                    if (result.error) {
+                      throw new Error(result.error.message || "Failed to delete user");
+                    }
+
+                    toast.success(`${account.realName}'s account deleted successfully`);
+                    if (onAccountChange) {
+                      await onAccountChange();
+                    }
+                  } catch (err) {
+                    const errorMessage = err instanceof Error ? err.message : "Failed to delete account";
+                    setDeleteError(err instanceof Error ? err : new Error(errorMessage));
+                    if (errorMessage.trim().length > 0) {
+                      toast.error(errorMessage);
+                    }
+                  } finally {
+                    setIsDeleting(false);
+                  }
                 }
               }}
             >

--- a/src/hooks/adminHooks.ts
+++ b/src/hooks/adminHooks.ts
@@ -1,17 +1,106 @@
-import { useListAccountsQuery } from "@/lib/features/admin/api";
+import { authClient } from "@/lib/features/authentication/client";
 import { adminSlice } from "@/lib/features/admin/frontend";
 import { useAppSelector } from "@/lib/hooks";
-import { useMemo } from "react";
+import { convertBetterAuthToAccountResult, BetterAuthUser } from "@/lib/features/admin/conversions-better-auth";
+import { Account } from "@/lib/features/admin/types";
+import { useMemo, useEffect, useState, useCallback } from "react";
+
+/**
+ * Get the organization ID from environment variable
+ */
+async function getOrganizationId(): Promise<string | null> {
+  const orgSlugOrId = process.env.NEXT_PUBLIC_APP_ORGANIZATION;
+  if (!orgSlugOrId) {
+    return null;
+  }
+
+  const orgResult = await authClient.organization.getFullOrganization({
+    query: {
+      organizationSlug: orgSlugOrId,
+    },
+  });
+
+  if (orgResult.data?.id) {
+    return orgResult.data.id;
+  }
+
+  return orgSlugOrId;
+}
 
 export const useAccountListResults = () => {
-  const { data, isError, isLoading, error } = useListAccountsQuery(undefined);
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
 
   const searchString = useAppSelector(adminSlice.selectors.getSearchString);
+
+  const fetchAccounts = useCallback(async () => {
+    setIsLoading(true);
+    setIsError(false);
+    setError(null);
+
+    try {
+      // Fetch all users
+      const result = await authClient.admin.listUsers({
+        query: {
+          limit: 1000,
+          offset: 0,
+        },
+      });
+
+      if (result.error) {
+        throw new Error(result.error.message || "Failed to fetch users");
+      }
+
+      const users = result.data?.users || [];
+
+      // Fetch organization members to get accurate roles
+      let memberRoleMap = new Map<string, string>();
+      const organizationId = await getOrganizationId();
+
+      if (organizationId) {
+        const membersResult = await authClient.organization.listMembers({
+          query: {
+            organizationId,
+            limit: 1000,
+          },
+        });
+
+        if (!membersResult.error && membersResult.data?.members) {
+          for (const member of membersResult.data.members) {
+            memberRoleMap.set(member.userId, member.role);
+          }
+        }
+      }
+
+      // Convert users and merge with member roles
+      const convertedAccounts = users.map((user) => {
+        const betterAuthUser = user as BetterAuthUser;
+        // Use organization member role if available, otherwise fall back to user role
+        const memberRole = memberRoleMap.get(betterAuthUser.id);
+        if (memberRole) {
+          betterAuthUser.role = memberRole as typeof betterAuthUser.role;
+        }
+        return convertBetterAuthToAccountResult(betterAuthUser);
+      });
+      setAccounts(convertedAccounts);
+    } catch (err) {
+      setIsError(true);
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAccounts();
+  }, [fetchAccounts]);
 
   const filteredData = useMemo(() => {
     if (searchString.length > 0) {
       return (
-        data?.filter(
+        accounts.filter(
           (account) =>
             account.userName
               .toLowerCase()
@@ -23,13 +112,14 @@ export const useAccountListResults = () => {
         ) ?? []
       );
     }
-    return data ?? [];
-  }, [data, searchString]);
+    return accounts ?? [];
+  }, [accounts, searchString]);
 
   return {
     data: filteredData,
     isLoading,
     isError,
     error,
+    refetch: fetchAccounts,
   };
 };


### PR DESCRIPTION
## Summary
Adds admin-specific Better Auth functionality for managing organization members and roles.

### Changes
- Add admin Better Auth client (`lib/features/admin/better-auth-client.ts`)
- Add admin-specific type conversions (`conversions-better-auth.ts`)
- Add API endpoint for adding organization members (`/api/admin/organization/add-member`)
- Update roster table with role management UI
- Update account entry component with Better Auth user details
- Extend admin hooks for Better Auth operations

## PR Stack
This is **PR 3 of 5** in the Better Auth migration:
1. Core infrastructure (#124)
2. Auth migration (#125)
3. **→ This PR:** Admin features ← depends on #125
4. User auth features (login UI, onboarding, theme preferences)
5. Tests & polish

## Test Plan
- [ ] Build passes
- [ ] Admin roster page loads correctly
- [ ] Can view and manage organization members
- [ ] Role changes persist correctly