### PR TITLE
test: update utilities.test.ts for Better Auth

### DIFF
--- a/lib/__tests__/features/authentication/utilities.test.ts
+++ b/lib/__tests__/features/authentication/utilities.test.ts
@@ -23,7 +23,10 @@ describe("authentication utilities", () => {
 
   describe("defaultAuthenticationData", () => {
     it("should have 'Not Authenticated' message", () => {
-      expect(defaultAuthenticationData.message).toBe("Not Authenticated");
+      expect("message" in defaultAuthenticationData).toBe(true);
+      expect(
+        (defaultAuthenticationData as { message: string }).message
+      ).toBe("Not Authenticated");
     });
   });
 


### PR DESCRIPTION
Closes #239

## Summary
Replace obsolete Cognito-specific tests with Better Auth tests:
- Remove `toUser` and `toClient` tests (Cognito functions no longer exist)
- Add `toUserFromBetterAuthJWT` tests
- Add `betterAuthSessionToAuthenticationData` tests
- Test `IncompleteUser` detection for missing `realName`/`djName`

## Test plan
- [x] All 22 tests pass

> **Note:** E2E tests depend on #271 and WXYC/Backend-Service#223. E2E will pass once those merge.