### PR TITLE
fix: remove obsolete tests and fix type errors

### DIFF
--- a/src/components/experiences/modern/login/Forms/ResetPasswordForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/ResetPasswordForm.test.tsx
@@ -14,8 +14,8 @@ vi.mock("next/navigation", () => ({
 
 describe("ResetPasswordForm", () => {
   const defaultProps: PasswordResetUser = {
-    confirmationMessage: "Password reset requested",
-    token: "test-token",
+    confirmationMessage: "Reset your password",
+    token: "test-token-123",
   };
 
   it("should render new password field", () => {
@@ -49,7 +49,7 @@ describe("ResetPasswordForm", () => {
 
     const hiddenInput = container.querySelector('input[name="token"]');
     expect(hiddenInput).toHaveAttribute("type", "hidden");
-    expect(hiddenInput).toHaveValue("test-token");
+    expect(hiddenInput).toHaveValue("test-token-123");
   });
 
   it("should have submit button disabled initially", () => {
@@ -58,7 +58,7 @@ describe("ResetPasswordForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("should enable submit when password fields are valid", async () => {
+  it("should enable submit when all fields are valid", async () => {
     const { user } = renderWithProviders(<ResetPasswordForm {...defaultProps} />);
 
     const passwordInput = screen.getByPlaceholderText("Enter your new password");
@@ -79,7 +79,6 @@ describe("ResetPasswordForm", () => {
     await user.type(passwordInput, "weak");
     await user.type(confirmInput, "weak");
 
-
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
@@ -95,14 +94,18 @@ describe("ResetPasswordForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("should keep submit disabled without token", () => {
+  it("should keep submit disabled when token is missing", async () => {
     const propsWithoutToken: PasswordResetUser = {
-      token: undefined,
-      confirmationMessage: "Password reset requested",
+      confirmationMessage: "Reset your password",
     };
-    renderWithProviders(<ResetPasswordForm {...propsWithoutToken} />);
+    const { user } = renderWithProviders(<ResetPasswordForm {...propsWithoutToken} />);
 
-    // Even with valid fields, submit should be disabled without token
+    const passwordInput = screen.getByPlaceholderText("Enter your new password");
+    const confirmInput = screen.getByPlaceholderText("Confirm New Password");
+
+    await user.type(passwordInput, "Password1");
+    await user.type(confirmInput, "Password1");
+
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 


### PR DESCRIPTION
Closes #245

## Summary
This PR fixes the TypeScript type check failures that were blocking multiple PRs.

### Changes
- Delete obsolete tests for non-existent modules:
  - `lib/__tests__/features/admin/api.test.ts`
  - `lib/__tests__/features/admin/conversions.test.ts`
  - `lib/__tests__/features/authentication/api.test.ts`
  - `lib/__tests__/features/authentication/utilities.test.ts`

- Fix type errors in remaining tests:
  - `bin/conversions.test.ts`: Add type assertions for union types, fix artist.id
  - `flowsheet/conversions.test.ts`: Add type assertions, fix OnAirDJResponse id type
  - `SearchBar.test.tsx`: Use ColorPaletteProp type for color prop
  - `NewUserForm.test.tsx`: Use IncompleteUser type for props
  - `ResetPasswordForm.test.tsx`: Update to token-based flow (PasswordResetUser type)
  - `fixtures.ts`: Fix OnAirDJResponse id to be string type

## Supersedes
This PR supersedes #142 and #143 which had the same goal but contained extraneous files.

## Test plan
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Unit tests pass (340/342 - 2 pre-existing failures unrelated to this PR)