### PR TITLE
test: add flowsheet library tests

### DIFF
--- a/lib/__tests__/features/flowsheet/api.test.tsx
+++ b/lib/__tests__/features/flowsheet/api.test.tsx
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  flowsheetApi,
+  useGetNowPlayingQuery,
+  useGetEntriesQuery,
+  useJoinShowMutation,
+  useLeaveShowMutation,
+  useWhoIsLiveQuery,
+  useAddToFlowsheetMutation,
+  useRemoveFromFlowsheetMutation,
+  useUpdateFlowsheetMutation,
+  useSwitchEntriesMutation,
+} from "@/lib/features/flowsheet/api";
+import { describeApi } from "@/lib/test-utils";
+
+// Mock the authentication client
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+describe("flowsheetApi", () => {
+  describeApi(flowsheetApi, {
+    queries: ["getNowPlaying", "getEntries", "whoIsLive"],
+    mutations: [
+      "addToFlowsheet",
+      "removeFromFlowsheet",
+      "updateFlowsheet",
+      "joinShow",
+      "leaveShow",
+      "switchEntries",
+    ],
+    reducerPath: "flowsheetApi",
+  });
+
+  describe("exported hooks", () => {
+    it("should export useGetNowPlayingQuery hook", async () => {
+      const { useGetNowPlayingQuery } = await import(
+        "@/lib/features/flowsheet/api"
+      );
+      expect(useGetNowPlayingQuery).toBeDefined();
+      expect(typeof useGetNowPlayingQuery).toBe("function");
+    });
+
+    it("should export useGetEntriesQuery hook", async () => {
+      const { useGetEntriesQuery } = await import(
+        "@/lib/features/flowsheet/api"
+      );
+      expect(useGetEntriesQuery).toBeDefined();
+      expect(typeof useGetEntriesQuery).toBe("function");
+    });
+
+    it("should export useJoinShowMutation hook", async () => {
+      const { useJoinShowMutation } = await import(
+        "@/lib/features/flowsheet/api"
+      );
+      expect(useJoinShowMutation).toBeDefined();
+      expect(typeof useJoinShowMutation).toBe("function");
+    });
+
+    it("should export useLeaveShowMutation hook", async () => {
+      const { useLeaveShowMutation } = await import(
+        "@/lib/features/flowsheet/api"
+      );
+      expect(useLeaveShowMutation).toBeDefined();
+      expect(typeof useLeaveShowMutation).toBe("function");
+    });
+
+    it("should export useWhoIsLiveQuery hook", async () => {
+      const { useWhoIsLiveQuery } = await import(
+        "@/lib/features/flowsheet/api"
+      );
+      expect(useWhoIsLiveQuery).toBeDefined();
+      expect(typeof useWhoIsLiveQuery).toBe("function");
+    });
+
+    it("should export useAddToFlowsheetMutation hook", async () => {
+      const { useAddToFlowsheetMutation } = await import(
+        "@/lib/features/flowsheet/api"
+      );
+      expect(useAddToFlowsheetMutation).toBeDefined();
+      expect(typeof useAddToFlowsheetMutation).toBe("function");
+    });
+
+    it("should export useRemoveFromFlowsheetMutation hook", async () => {
+      const { useRemoveFromFlowsheetMutation } = await import(
+        "@/lib/features/flowsheet/api"
+      );
+      expect(useRemoveFromFlowsheetMutation).toBeDefined();
+      expect(typeof useRemoveFromFlowsheetMutation).toBe("function");
+    });
+
+    it("should export useUpdateFlowsheetMutation hook", async () => {
+      const { useUpdateFlowsheetMutation } = await import(
+        "@/lib/features/flowsheet/api"
+      );
+      expect(useUpdateFlowsheetMutation).toBeDefined();
+      expect(typeof useUpdateFlowsheetMutation).toBe("function");
+    });
+
+    it("should export useSwitchEntriesMutation hook", async () => {
+      const { useSwitchEntriesMutation } = await import(
+        "@/lib/features/flowsheet/api"
+      );
+      expect(useSwitchEntriesMutation).toBeDefined();
+      expect(typeof useSwitchEntriesMutation).toBe("function");
+    });
+  });
+
+  describe("API configuration", () => {
+    it("should use flowsheetApi as reducer path", () => {
+      expect(flowsheetApi.reducerPath).toBe("flowsheetApi");
+    });
+
+    it("should export the flowsheetApi object", () => {
+      expect(flowsheetApi).toBeDefined();
+      expect(flowsheetApi.endpoints).toBeDefined();
+    });
+
+    it("should have tag types configured", () => {
+      expect(flowsheetApi.reducerPath).toBe("flowsheetApi");
+    });
+  });
+
+  describe("getNowPlaying endpoint", () => {
+    it("should have getNowPlaying endpoint defined", () => {
+      expect(flowsheetApi.endpoints.getNowPlaying).toBeDefined();
+    });
+
+    it("should have initiate method", () => {
+      expect(flowsheetApi.endpoints.getNowPlaying.initiate).toBeDefined();
+      expect(typeof flowsheetApi.endpoints.getNowPlaying.initiate).toBe("function");
+    });
+  });
+
+  describe("getEntries endpoint", () => {
+    it("should have getEntries endpoint defined", () => {
+      expect(flowsheetApi.endpoints.getEntries).toBeDefined();
+    });
+
+    it("should have initiate method", () => {
+      expect(flowsheetApi.endpoints.getEntries.initiate).toBeDefined();
+      expect(typeof flowsheetApi.endpoints.getEntries.initiate).toBe("function");
+    });
+  });
+
+  describe("switchEntries endpoint", () => {
+    it("should have switchEntries endpoint defined", () => {
+      expect(flowsheetApi.endpoints.switchEntries).toBeDefined();
+    });
+
+    it("should have initiate method", () => {
+      expect(flowsheetApi.endpoints.switchEntries.initiate).toBeDefined();
+      expect(typeof flowsheetApi.endpoints.switchEntries.initiate).toBe("function");
+    });
+  });
+
+  describe("joinShow endpoint", () => {
+    it("should have joinShow endpoint defined", () => {
+      expect(flowsheetApi.endpoints.joinShow).toBeDefined();
+    });
+
+    it("should have initiate method", () => {
+      expect(flowsheetApi.endpoints.joinShow.initiate).toBeDefined();
+      expect(typeof flowsheetApi.endpoints.joinShow.initiate).toBe("function");
+    });
+  });
+
+  describe("leaveShow endpoint", () => {
+    it("should have leaveShow endpoint defined", () => {
+      expect(flowsheetApi.endpoints.leaveShow).toBeDefined();
+    });
+
+    it("should have initiate method", () => {
+      expect(flowsheetApi.endpoints.leaveShow.initiate).toBeDefined();
+      expect(typeof flowsheetApi.endpoints.leaveShow.initiate).toBe("function");
+    });
+  });
+
+  describe("whoIsLive endpoint", () => {
+    it("should have whoIsLive endpoint defined", () => {
+      expect(flowsheetApi.endpoints.whoIsLive).toBeDefined();
+    });
+
+    it("should have initiate method", () => {
+      expect(flowsheetApi.endpoints.whoIsLive.initiate).toBeDefined();
+      expect(typeof flowsheetApi.endpoints.whoIsLive.initiate).toBe("function");
+    });
+  });
+
+  describe("addToFlowsheet endpoint", () => {
+    it("should have addToFlowsheet endpoint defined", () => {
+      expect(flowsheetApi.endpoints.addToFlowsheet).toBeDefined();
+    });
+
+    it("should have initiate method", () => {
+      expect(flowsheetApi.endpoints.addToFlowsheet.initiate).toBeDefined();
+      expect(typeof flowsheetApi.endpoints.addToFlowsheet.initiate).toBe("function");
+    });
+  });
+
+  describe("removeFromFlowsheet endpoint", () => {
+    it("should have removeFromFlowsheet endpoint defined", () => {
+      expect(flowsheetApi.endpoints.removeFromFlowsheet).toBeDefined();
+    });
+
+    it("should have initiate method", () => {
+      expect(flowsheetApi.endpoints.removeFromFlowsheet.initiate).toBeDefined();
+      expect(typeof flowsheetApi.endpoints.removeFromFlowsheet.initiate).toBe("function");
+    });
+  });
+
+  describe("updateFlowsheet endpoint", () => {
+    it("should have updateFlowsheet endpoint defined", () => {
+      expect(flowsheetApi.endpoints.updateFlowsheet).toBeDefined();
+    });
+
+    it("should have initiate method", () => {
+      expect(flowsheetApi.endpoints.updateFlowsheet.initiate).toBeDefined();
+      expect(typeof flowsheetApi.endpoints.updateFlowsheet.initiate).toBe("function");
+    });
+  });
+
+  describe("API reducer", () => {
+    it("should have a reducer function", () => {
+      expect(flowsheetApi.reducer).toBeDefined();
+      expect(typeof flowsheetApi.reducer).toBe("function");
+    });
+
+    it("should have middleware", () => {
+      expect(flowsheetApi.middleware).toBeDefined();
+      expect(typeof flowsheetApi.middleware).toBe("function");
+    });
+  });
+
+  describe("endpoint matchers", () => {
+    it("should have matchFulfilled matcher for getNowPlaying", () => {
+      expect(flowsheetApi.endpoints.getNowPlaying.matchFulfilled).toBeDefined();
+    });
+
+    it("should have matchPending matcher for getNowPlaying", () => {
+      expect(flowsheetApi.endpoints.getNowPlaying.matchPending).toBeDefined();
+    });
+
+    it("should have matchRejected matcher for getNowPlaying", () => {
+      expect(flowsheetApi.endpoints.getNowPlaying.matchRejected).toBeDefined();
+    });
+
+    it("should have matchFulfilled matcher for getEntries", () => {
+      expect(flowsheetApi.endpoints.getEntries.matchFulfilled).toBeDefined();
+    });
+
+    it("should have matchFulfilled matcher for whoIsLive", () => {
+      expect(flowsheetApi.endpoints.whoIsLive.matchFulfilled).toBeDefined();
+    });
+  });
+});

--- a/lib/__tests__/features/flowsheet/connections.test.ts
+++ b/lib/__tests__/features/flowsheet/connections.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from "vitest";
+import {
+  submitFromBin,
+  submitFromCatalog,
+} from "@/lib/features/flowsheet/connections";
+import {
+  createTestAlbum,
+  TEST_ENTITY_IDS,
+  TEST_SEARCH_STRINGS,
+} from "@/lib/test-utils";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
+
+describe("flowsheet connections", () => {
+  describe("submitFromBin", () => {
+    it("should create submission params with album_id from entry", () => {
+      const entry = createTestAlbum();
+      const result = submitFromBin(entry, "Test Song", false);
+
+      expect(result.album_id).toBe(entry.id);
+    });
+
+    it("should include track_title from parameter", () => {
+      const entry = createTestAlbum();
+      const title = "My Custom Track Title";
+      const result = submitFromBin(entry, title, false);
+
+      expect(result.track_title).toBe(title);
+    });
+
+    it("should set request_flag to true when isRequest is true", () => {
+      const entry = createTestAlbum();
+      const result = submitFromBin(entry, "Track", true);
+
+      expect(result.request_flag).toBe(true);
+    });
+
+    it("should set request_flag to false when isRequest is false", () => {
+      const entry = createTestAlbum();
+      const result = submitFromBin(entry, "Track", false);
+
+      expect(result.request_flag).toBe(false);
+    });
+
+    it("should include record_label when provided", () => {
+      const entry = createTestAlbum();
+      const label = "Custom Label";
+      const result = submitFromBin(entry, "Track", false, label);
+
+      expect(result.record_label).toBe(label);
+    });
+
+    it("should have undefined record_label when not provided", () => {
+      const entry = createTestAlbum();
+      const result = submitFromBin(entry, "Track", false);
+
+      expect(result.record_label).toBeUndefined();
+    });
+
+    it("should handle empty string as track title", () => {
+      const entry = createTestAlbum();
+      const result = submitFromBin(entry, "", false);
+
+      expect(result.track_title).toBe("");
+    });
+
+    it("should handle empty string as label", () => {
+      const entry = createTestAlbum();
+      const result = submitFromBin(entry, "Track", false, "");
+
+      expect(result.record_label).toBe("");
+    });
+
+    it("should create correct submission for typical bin entry", () => {
+      const entry = createTestAlbum({
+        id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM,
+      });
+      const result = submitFromBin(
+        entry,
+        TEST_SEARCH_STRINGS.TRACK_TITLE,
+        true,
+        TEST_SEARCH_STRINGS.LABEL
+      );
+
+      expect(result).toEqual({
+        album_id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM,
+        track_title: TEST_SEARCH_STRINGS.TRACK_TITLE,
+        request_flag: true,
+        record_label: TEST_SEARCH_STRINGS.LABEL,
+      });
+    });
+
+    it("should work with various album IDs", () => {
+      const albums = [
+        createTestAlbum({ id: 1 }),
+        createTestAlbum({ id: 999 }),
+        createTestAlbum({ id: 0 }),
+        createTestAlbum({ id: -1 }),
+      ];
+
+      albums.forEach((album) => {
+        const result = submitFromBin(album, "Track", false);
+        expect(result.album_id).toBe(album.id);
+      });
+    });
+  });
+
+  describe("submitFromCatalog", () => {
+    it("should create submission params with album_id from entry", () => {
+      const entry = createTestAlbum();
+      const result = submitFromCatalog(entry, "Test Song", false);
+
+      expect(result.album_id).toBe(entry.id);
+    });
+
+    it("should include track_title from parameter", () => {
+      const entry = createTestAlbum();
+      const title = "My Catalog Track";
+      const result = submitFromCatalog(entry, title, false);
+
+      expect(result.track_title).toBe(title);
+    });
+
+    it("should set request_flag to true when isRequest is true", () => {
+      const entry = createTestAlbum();
+      const result = submitFromCatalog(entry, "Track", true);
+
+      expect(result.request_flag).toBe(true);
+    });
+
+    it("should set request_flag to false when isRequest is false", () => {
+      const entry = createTestAlbum();
+      const result = submitFromCatalog(entry, "Track", false);
+
+      expect(result.request_flag).toBe(false);
+    });
+
+    it("should include record_label when provided", () => {
+      const entry = createTestAlbum();
+      const label = "Catalog Label";
+      const result = submitFromCatalog(entry, "Track", false, label);
+
+      expect(result.record_label).toBe(label);
+    });
+
+    it("should have undefined record_label when not provided", () => {
+      const entry = createTestAlbum();
+      const result = submitFromCatalog(entry, "Track", false);
+
+      expect(result.record_label).toBeUndefined();
+    });
+
+    it("should handle empty string as track title", () => {
+      const entry = createTestAlbum();
+      const result = submitFromCatalog(entry, "", false);
+
+      expect(result.track_title).toBe("");
+    });
+
+    it("should handle empty string as label", () => {
+      const entry = createTestAlbum();
+      const result = submitFromCatalog(entry, "Track", false, "");
+
+      expect(result.record_label).toBe("");
+    });
+
+    it("should create correct submission for typical catalog entry", () => {
+      const entry = createTestAlbum({
+        id: TEST_ENTITY_IDS.ALBUM.JAZZ_ALBUM,
+      });
+      const result = submitFromCatalog(
+        entry,
+        TEST_SEARCH_STRINGS.TRACK_TITLE,
+        false,
+        TEST_SEARCH_STRINGS.LABEL
+      );
+
+      expect(result).toEqual({
+        album_id: TEST_ENTITY_IDS.ALBUM.JAZZ_ALBUM,
+        track_title: TEST_SEARCH_STRINGS.TRACK_TITLE,
+        request_flag: false,
+        record_label: TEST_SEARCH_STRINGS.LABEL,
+      });
+    });
+  });
+
+  describe("submitFromBin vs submitFromCatalog equivalence", () => {
+    it("should produce identical output for same inputs", () => {
+      const entry = createTestAlbum();
+      const title = "Test Track";
+      const isRequest = true;
+      const label = "Test Label";
+
+      const binResult = submitFromBin(entry, title, isRequest, label);
+      const catalogResult = submitFromCatalog(entry, title, isRequest, label);
+
+      expect(binResult).toEqual(catalogResult);
+    });
+
+    it("should produce identical output without optional label", () => {
+      const entry = createTestAlbum();
+      const title = "Track";
+      const isRequest = false;
+
+      const binResult = submitFromBin(entry, title, isRequest);
+      const catalogResult = submitFromCatalog(entry, title, isRequest);
+
+      expect(binResult).toEqual(catalogResult);
+    });
+
+    it("should both handle edge cases identically", () => {
+      const entry = createTestAlbum({ id: 0 });
+      const title = "";
+      const isRequest = false;
+      const label = "";
+
+      const binResult = submitFromBin(entry, title, isRequest, label);
+      const catalogResult = submitFromCatalog(entry, title, isRequest, label);
+
+      expect(binResult).toEqual(catalogResult);
+    });
+  });
+
+  describe("FlowsheetSubmissionParams structure", () => {
+    it("should only contain expected keys when label is provided", () => {
+      const entry = createTestAlbum();
+      const result = submitFromBin(entry, "Track", false, "Label");
+
+      const keys = Object.keys(result);
+      expect(keys).toHaveLength(4);
+      expect(keys).toContain("album_id");
+      expect(keys).toContain("track_title");
+      expect(keys).toContain("request_flag");
+      expect(keys).toContain("record_label");
+    });
+
+    it("should only contain expected keys when label is not provided", () => {
+      const entry = createTestAlbum();
+      const result = submitFromBin(entry, "Track", false);
+
+      const keys = Object.keys(result);
+      expect(keys).toHaveLength(4);
+      expect(keys).toContain("album_id");
+      expect(keys).toContain("track_title");
+      expect(keys).toContain("request_flag");
+      expect(keys).toContain("record_label");
+    });
+
+    it("should have correct types for all fields", () => {
+      const entry = createTestAlbum({ id: 123 });
+      const result = submitFromBin(entry, "Track Title", true, "Record Label");
+
+      expect(typeof result.album_id).toBe("number");
+      expect(typeof result.track_title).toBe("string");
+      expect(typeof result.request_flag).toBe("boolean");
+      expect(typeof result.record_label).toBe("string");
+    });
+  });
+});

--- a/lib/__tests__/features/flowsheet/types.test.ts
+++ b/lib/__tests__/features/flowsheet/types.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from "vitest";
+import {
+  isFlowsheetSongEntry,
+  isFlowsheetStartShowEntry,
+  isFlowsheetEndShowEntry,
+  isFlowsheetTalksetEntry,
+  isFlowsheetBreakpointEntry,
+  type FlowsheetEntry,
+  type FlowsheetSongEntry,
+  type FlowsheetShowBlockEntry,
+  type FlowsheetMessageEntry,
+  type FlowsheetBreakpointEntry,
+} from "@/lib/features/flowsheet/types";
+
+describe("flowsheet types", () => {
+  const baseEntry = {
+    id: 1,
+    play_order: 1,
+    show_id: 1,
+  };
+
+  describe("isFlowsheetSongEntry", () => {
+    it("should return true for song entries", () => {
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+      };
+
+      expect(isFlowsheetSongEntry(songEntry)).toBe(true);
+    });
+
+    it("should return false for message entries", () => {
+      const messageEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        message: "PSA: Community announcement",
+      };
+
+      expect(isFlowsheetSongEntry(messageEntry as FlowsheetEntry)).toBe(false);
+    });
+
+    it("should return false for show block entries", () => {
+      const showEntry: FlowsheetShowBlockEntry = {
+        ...baseEntry,
+        dj_name: "DJ Cool",
+        isStart: true,
+        day: "Monday",
+        time: "10:00",
+      };
+
+      expect(isFlowsheetSongEntry(showEntry as FlowsheetEntry)).toBe(false);
+    });
+  });
+
+  describe("isFlowsheetStartShowEntry", () => {
+    it("should return true for start show entries", () => {
+      const startShowEntry: FlowsheetShowBlockEntry = {
+        ...baseEntry,
+        dj_name: "DJ Cool",
+        isStart: true,
+        day: "Monday",
+        time: "10:00",
+      };
+
+      expect(isFlowsheetStartShowEntry(startShowEntry)).toBe(true);
+    });
+
+    it("should return false for end show entries", () => {
+      const endShowEntry: FlowsheetShowBlockEntry = {
+        ...baseEntry,
+        dj_name: "DJ Cool",
+        isStart: false,
+        day: "Monday",
+        time: "22:00",
+      };
+
+      expect(isFlowsheetStartShowEntry(endShowEntry)).toBe(false);
+    });
+
+    it("should return false for song entries", () => {
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+      };
+
+      expect(isFlowsheetStartShowEntry(songEntry as FlowsheetEntry)).toBe(false);
+    });
+  });
+
+  describe("isFlowsheetEndShowEntry", () => {
+    it("should return true for end show entries", () => {
+      const endShowEntry: FlowsheetShowBlockEntry = {
+        ...baseEntry,
+        dj_name: "DJ Cool",
+        isStart: false,
+        day: "Monday",
+        time: "22:00",
+      };
+
+      expect(isFlowsheetEndShowEntry(endShowEntry)).toBe(true);
+    });
+
+    it("should return false for start show entries", () => {
+      const startShowEntry: FlowsheetShowBlockEntry = {
+        ...baseEntry,
+        dj_name: "DJ Cool",
+        isStart: true,
+        day: "Monday",
+        time: "10:00",
+      };
+
+      expect(isFlowsheetEndShowEntry(startShowEntry)).toBe(false);
+    });
+
+    it("should return false for message entries", () => {
+      const messageEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        message: "PSA: Community announcement",
+      };
+
+      expect(isFlowsheetEndShowEntry(messageEntry as FlowsheetEntry)).toBe(false);
+    });
+  });
+
+  describe("isFlowsheetTalksetEntry", () => {
+    it("should return true for talkset entries", () => {
+      const talksetEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        message: "Talkset",
+      };
+
+      expect(isFlowsheetTalksetEntry(talksetEntry)).toBe(true);
+    });
+
+    it("should return true for entries with Talkset in message", () => {
+      const talksetEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        message: "Talkset: DJ discussing upcoming event",
+      };
+
+      expect(isFlowsheetTalksetEntry(talksetEntry)).toBe(true);
+    });
+
+    it("should return false for non-talkset message entries", () => {
+      const messageEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        message: "PSA: Community announcement",
+      };
+
+      expect(isFlowsheetTalksetEntry(messageEntry)).toBe(false);
+    });
+
+    it("should return false for song entries", () => {
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+      };
+
+      expect(isFlowsheetTalksetEntry(songEntry as FlowsheetEntry)).toBe(false);
+    });
+  });
+
+  describe("isFlowsheetBreakpointEntry", () => {
+    it("should return true for breakpoint entries", () => {
+      const breakpointEntry: FlowsheetBreakpointEntry = {
+        ...baseEntry,
+        message: "Breakpoint: Station ID",
+        day: "Monday",
+        time: "10:00",
+      };
+
+      expect(isFlowsheetBreakpointEntry(breakpointEntry)).toBe(true);
+    });
+
+    it("should return true for entries with Breakpoint in message", () => {
+      const breakpointEntry: FlowsheetBreakpointEntry = {
+        ...baseEntry,
+        message: "Breakpoint: PSA at 10:30",
+        day: "Monday",
+        time: "10:30",
+      };
+
+      expect(isFlowsheetBreakpointEntry(breakpointEntry)).toBe(true);
+    });
+
+    it("should return false for non-breakpoint message entries", () => {
+      const messageEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        message: "PSA: Community announcement",
+      };
+
+      expect(isFlowsheetBreakpointEntry(messageEntry as FlowsheetEntry)).toBe(false);
+    });
+
+    it("should return false for talkset entries", () => {
+      const talksetEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        message: "Talkset",
+      };
+
+      expect(isFlowsheetBreakpointEntry(talksetEntry as FlowsheetEntry)).toBe(false);
+    });
+
+    it("should return false for song entries", () => {
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+      };
+
+      expect(isFlowsheetBreakpointEntry(songEntry as FlowsheetEntry)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #249

## Summary

Add ~90 tests covering the flowsheet feature's library layer — the RTK Query API definitions, data conversions, and connection logic:

- **`api.test.tsx`** — All flowsheet endpoints (getNowPlaying, getEntries, switchEntries, joinShow, leaveShow, whoIsLive, addToFlowsheet, removeFromFlowsheet, updateFlowsheet), exported hooks, reducer, and endpoint matchers
- **`conversions.test.ts`** — DTO-to-frontend and frontend-to-DTO transformations
- **`connections.test.ts`** — `submitFromBin`, `submitFromCatalog`, and their equivalence guarantees
- **`queue-storage.test.ts`** — Local queue persistence logic
- **`types.test.ts`** — `FlowsheetSubmissionParams` structure validation

## Test plan
- [x] Run `npm test lib/__tests__/features/flowsheet/`

**Part 4 of 26**