### PR TITLE
test: add admin, rotation, and application library tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,245 @@
+# dj-site
+
+React frontend for the WXYC DJ flowsheet and card catalog. Provides the DJ interface for logging playlists, searching the music library, managing the mail bin, and station administration.
+
+**Production URL:** https://dj.wxyc.org
+
+## Architecture
+
+### Tech Stack
+
+- **Next.js 16** (App Router) with React 18
+- **Redux Toolkit** + **RTK Query** for state management and API calls
+- **MUI Joy UI** for component library
+- **better-auth** client for authentication
+- **OpenNext** + **Cloudflare Pages** for deployment
+- **Vitest** + React Testing Library + MSW for testing
+
+### Project Structure
+
+```
+app/                              # Next.js App Router
+  dashboard/                      # Main authenticated area
+    @modern/                      # Modern UI (route slot)
+    @classic/                     # Classic UI (route slot)
+    @information/                 # Modal slot (album details, settings)
+  login/                          # Auth pages
+  api/                            # Route handlers
+  auth/                           # better-auth integration
+  layout.tsx                      # Root layout with providers
+
+lib/                              # Core business logic
+  features/                       # Redux slices + RTK Query APIs
+    authentication/               # Auth state, better-auth client
+    flowsheet/                    # Show entries, queue, now playing
+    catalog/                      # Album/artist search
+    bin/                          # DJ mail bin
+    rotation/                     # Rotation bins (heavy/medium/light)
+    admin/                        # Roster management
+    application/                  # App-wide state
+    experiences/                  # Theme switching
+    backend.ts                    # Centralized backendBaseQuery
+    session.ts                    # Server-side session utils
+  test-utils/                     # Testing utilities
+  hooks.ts                        # Typed Redux hooks
+  store.ts                        # Redux store config
+  createAppSlice.ts               # Custom createSlice with asyncThunk
+  __tests__/features/             # Feature tests
+
+src/components/                   # React components
+  experiences/modern/             # New UI components
+  experiences/classic/            # Legacy-look components
+  shared/                         # Shared components (Theme, layouts)
+src/hooks/                        # Feature-specific hooks
+src/styles/                       # Global CSS, fonts
+```
+
+### Feature Module Pattern
+
+Each feature in `lib/features/` follows a consistent structure:
+
+| File | Purpose |
+|------|---------|
+| `api.ts` | RTK Query endpoint definitions (queries and mutations) |
+| `types.ts` | TypeScript interfaces for the feature |
+| `frontend.ts` | Redux slice (state, actions, selectors) |
+| `conversions.ts` | Transform API responses (snake_case) to frontend types (camelCase) |
+
+### State Management
+
+Redux store (`lib/store.ts`) uses `combineSlices` (RTK 2.0). Slices and APIs:
+
+- **Slices**: authentication, application, catalog, flowsheet, bin, rotation, admin
+- **RTK Query APIs**: catalogApi, flowsheetApi, binApi, rotationApi, applicationApi, experienceApi
+
+Custom middleware `rtkQueryErrorLogger` toasts error messages from rejected RTK Query calls.
+
+Typed hooks in `lib/hooks.ts`: `useAppDispatch`, `useAppSelector`, `useAppStore`.
+
+### API Integration
+
+All API calls go through `backendBaseQuery` (`lib/features/backend.ts`), which:
+1. Prepends `NEXT_PUBLIC_BACKEND_URL/{domain}` to all requests
+2. Attaches a Bearer token from `getJWTToken()` (fetched from better-auth's `/token` endpoint)
+
+API domains: `/library/`, `/flowsheet/`, `/rotation/`, `/bin/`, `/admin/`, `/experiences/`
+
+### Authentication
+
+**Client-side** (`lib/features/authentication/client.ts`):
+- `createAuthClient()` with better-auth plugins (admin, username, jwt, organization)
+- `getBaseURL()` detects same-origin proxy for session cookies
+- Falls back to `NEXT_PUBLIC_BETTER_AUTH_URL` or `https://api.wxyc.org/auth`
+
+**Server-side** (`lib/features/authentication/server-utils.ts`):
+- `requireAuth()` validates session via HTTP-only cookies, redirects to login if unauthenticated
+
+**Redux slice** (`lib/features/authentication/frontend.ts`):
+- Stores form validation state only (username, password, djName, etc.)
+- Auth session state is managed by better-auth via cookies + `authClient.useSession()` hook
+
+### Experience System (Theme Switching)
+
+The app supports two UI experiences:
+- **Modern** -- New UI with updated components
+- **Classic** -- Preserves the original WXYC flowsheet look
+
+Switching is handled via Next.js parallel route slots (`@modern`, `@classic`) and a `data-experience` attribute on `<html>`. The CSS class `"ignoreClassic"` excludes elements from classic styling.
+
+### Provider Stack
+
+Root layout (`app/layout.tsx`) wraps the app with:
+1. `<StoreProvider>` -- Redux store (created once via `useRef`)
+2. `<ThemeRegistry>` -- MUI Joy UI theming with CssVarsProvider
+3. `<Toaster>` -- sonner toast notifications
+4. `<PageTitleUpdater>` -- Dynamic page titles
+
+## Development
+
+### Running Locally
+
+```bash
+npm install
+npm run dev              # Next.js dev server (port 3000)
+```
+
+Requires Backend-Service (port 8080) and Auth (port 8082) running. Use `wxyc-shared`'s setup script for the full stack:
+
+```bash
+cd ../wxyc-shared && ./scripts/setup-dev-environment.sh
+```
+
+### Key Dependencies
+
+- `@mui/joy` (5.0.0-beta) -- Component library
+- `@atlaskit/pragmatic-drag-and-drop` -- Flowsheet entry reordering
+- `motion` -- Animations
+- `sonner` -- Toast notifications
+- `jose` -- JWT handling
+- `webcrypt-session` -- Server-side session handling
+
+## Testing
+
+### Running Tests
+
+```bash
+npm test                 # Watch mode
+npm run test:run         # Single run
+npm run test:ui          # Vitest UI
+npm run test:coverage    # With coverage report
+```
+
+### Configuration
+
+- **Framework**: Vitest with jsdom environment
+- **Config**: `vitest.config.mts`
+- **Setup**: `vitest.setup.ts` (MSW server lifecycle, localStorage/matchMedia/ResizeObserver mocks)
+- **Coverage**: v8 provider, includes `lib/**/*` and `src/**/*`
+
+### Test Structure
+
+- `lib/__tests__/features/{feature}/` -- Feature tests (slices, APIs, conversions)
+- `src/components/**/*.test.tsx` -- Component tests (co-located)
+- `lib/test-utils/` -- Shared test utilities
+
+### Test Utilities (`lib/test-utils/`)
+
+| Utility | Purpose |
+|---------|---------|
+| `renderWithProviders(ui, options)` | Render with Redux + MUI providers |
+| `createTestStore()` | Fresh Redux store per test |
+| `describeSlice(slice, defaultState, fn)` | Slice test harness |
+| `createSliceHarness()` | Direct reducer testing, action chaining |
+| Factory functions | `createTestAlbum()`, `createTestFlowsheetEntry()`, `createTestUser()`, etc. |
+| `TEST_BACKEND_URL` | Backend URL constant for MSW handlers |
+| `TEST_ENTITY_IDS` | Stable IDs for test data |
+
+### MSW Setup (`lib/test-utils/msw/`)
+
+- `server.ts` -- MSW server instance
+- `handlers.ts` -- Default mock responses for catalog, flowsheet, rotation, auth APIs
+
+Override handlers per test:
+```typescript
+server.use(
+  http.get(`${TEST_BACKEND_URL}/library/`, () => {
+    return HttpResponse.json([{ id: 1, title: "Test Album" }]);
+  })
+);
+```
+
+### Writing Tests
+
+**Redux slice tests:**
+```typescript
+import { describe, it, expect } from "vitest";
+import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+
+describe("flowsheetSlice", () => {
+  it("should set autoplay", () => {
+    const nextState = flowsheetSlice.reducer(
+      initialState,
+      flowsheetSlice.actions.setAutoplay(true)
+    );
+    expect(nextState.autoplay).toBe(true);
+  });
+});
+```
+
+**Component tests:**
+```typescript
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils";
+
+describe("MyComponent", () => {
+  it("should render", () => {
+    renderWithProviders(<MyComponent />);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+});
+```
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NEXT_PUBLIC_BACKEND_URL` | `http://localhost:3001` | Backend API base URL |
+| `NEXT_PUBLIC_BETTER_AUTH_URL` | same-origin `/auth` or `https://api.wxyc.org/auth` | better-auth endpoint |
+| `NEXT_PUBLIC_VERSION` | -- | App version displayed in UI |
+
+## Deployment
+
+- **Platform**: Cloudflare Pages via OpenNext
+- **Build**: `npm run build:opennext` produces `.open-next/assets`
+- **Deploy**: `npm run deploy` (builds + Wrangler Pages deploy)
+- **Preview**: `npm run preview` (local preview of production build)
+- **Wrangler config**: `wrangler.jsonc` (project: `wxyc-dj-site`, `nodejs_compat_v2` flag)
+
+GitHub Actions auto-deploys after PR merge.
+
+## Relationship to Other Repos
+
+- **[Backend-Service](https://github.com/WXYC/Backend-Service)** -- API provider. All data comes from here.
+- **[@wxyc/shared](https://github.com/WXYC/wxyc-shared)** -- Shared DTOs (used in conversions), auth client, test utilities (factory functions).
+- **[tubafrenzy](https://github.com/WXYC/tubafrenzy)** -- Legacy Java flowsheet this app is replacing. Both UIs operate on the same data.

--- a/lib/__tests__/features/admin/types.test.ts
+++ b/lib/__tests__/features/admin/types.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  Authorization,
+  AdminAuthenticationStatus,
+  AdminProtectedRoutes,
+} from "@/lib/features/admin/types";
+
+describe("admin types", () => {
+  describe("Authorization enum", () => {
+    it("should have NO as value 0", () => {
+      expect(Authorization.NO).toBe(0);
+    });
+
+    it("should have DJ as value 1", () => {
+      expect(Authorization.DJ).toBe(1);
+    });
+
+    it("should have MD as value 2", () => {
+      expect(Authorization.MD).toBe(2);
+    });
+
+    it("should have SM as value 3", () => {
+      expect(Authorization.SM).toBe(3);
+    });
+
+    it("should have correct hierarchy (NO < DJ < MD < SM)", () => {
+      expect(Authorization.NO).toBeLessThan(Authorization.DJ);
+      expect(Authorization.DJ).toBeLessThan(Authorization.MD);
+      expect(Authorization.MD).toBeLessThan(Authorization.SM);
+    });
+  });
+
+  describe("AdminAuthenticationStatus enum", () => {
+    it("should have Confirmed as value 0", () => {
+      expect(AdminAuthenticationStatus.Confirmed).toBe(0);
+    });
+
+    it("should have New as value 1", () => {
+      expect(AdminAuthenticationStatus.New).toBe(1);
+    });
+
+    it("should have Reset as value 2", () => {
+      expect(AdminAuthenticationStatus.Reset).toBe(2);
+    });
+  });
+
+  describe("AdminProtectedRoutes", () => {
+    it("should allow SM access to roster and catalog", () => {
+      expect(AdminProtectedRoutes[Authorization.SM]).toContain("roster");
+      expect(AdminProtectedRoutes[Authorization.SM]).toContain("catalog");
+    });
+
+    it("should allow MD access to catalog only", () => {
+      expect(AdminProtectedRoutes[Authorization.MD]).toContain("catalog");
+      expect(AdminProtectedRoutes[Authorization.MD]).not.toContain("roster");
+    });
+
+    it("should not allow NO access to any routes", () => {
+      expect(AdminProtectedRoutes[Authorization.NO]).toEqual([]);
+    });
+
+    it("should have SM access to more routes than MD", () => {
+      const smRoutes = AdminProtectedRoutes[Authorization.SM];
+      const mdRoutes = AdminProtectedRoutes[Authorization.MD];
+      expect(smRoutes.length).toBeGreaterThan(mdRoutes.length);
+    });
+  });
+});

--- a/lib/__tests__/features/application/application.test.ts
+++ b/lib/__tests__/features/application/application.test.ts
@@ -73,12 +73,27 @@ describeSlice(applicationSlice, defaultApplicationFrontendState, ({ harness, act
     });
   });
 
+  describe("setAuthStage action", () => {
+    it.each(["login", "forgot", "reset"] as const)(
+      "should set authStage to %s",
+      (stage) => {
+        const result = harness().reduce(actions.setAuthStage(stage));
+        expect(result.authFlow.stage).toBe(stage);
+      }
+    );
+
+    it("should default to login stage", () => {
+      expect(harness().initialState.authFlow.stage).toBe("login");
+    });
+  });
+
   describe("reset action", () => {
     it("should reset state to default", () => {
       const result = harness().chain(
         actions.setRightbarMini(true),
         actions.toggleSidebar(),
         actions.setRightbarMenu(RightbarMenu.CATALOG_EDITOR),
+        actions.setAuthStage("forgot"),
         actions.reset()
       );
       expect(result).toEqual(defaultApplicationFrontendState);
@@ -98,6 +113,12 @@ describeSlice(applicationSlice, defaultApplicationFrontendState, ({ harness, act
     describe("getRightbarMenu", () => {
       it("should be defined", () => {
         expect(applicationSlice.selectors.getRightbarMenu).toBeDefined();
+      });
+    });
+
+    describe("getAuthStage", () => {
+      it("should be defined", () => {
+        expect(applicationSlice.selectors.getAuthStage).toBeDefined();
       });
     });
   });

--- a/lib/__tests__/features/application/application.test.ts
+++ b/lib/__tests__/features/application/application.test.ts
@@ -82,8 +82,8 @@ describeSlice(applicationSlice, defaultApplicationFrontendState, ({ harness, act
       }
     );
 
-    it("should default to login stage", () => {
-      expect(harness().initialState.authFlow.stage).toBe("login");
+    it("should default to otp-email stage", () => {
+      expect(harness().initialState.authFlow.stage).toBe("otp-email");
     });
   });
 

--- a/lib/__tests__/features/backend.test.ts
+++ b/lib/__tests__/features/backend.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the authentication client module before importing
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn(),
+}));
+
+// We need to mock fetchBaseQuery from Redux Toolkit
+const mockPrepareHeaders = vi.fn();
+const mockFetchBaseQuery = vi.fn((config) => {
+  // Store the config so we can test it
+  mockFetchBaseQuery.lastConfig = config;
+  // Return a mock base query function
+  return vi.fn(async () => ({ data: {} }));
+});
+mockFetchBaseQuery.lastConfig = null as any;
+
+vi.mock("@reduxjs/toolkit/query", () => ({
+  fetchBaseQuery: (config: any) => mockFetchBaseQuery(config),
+}));
+
+import { getJWTToken } from "@/lib/features/authentication/client";
+import { backendBaseQuery } from "@/lib/features/backend";
+
+const mockedGetJWTToken = vi.mocked(getJWTToken);
+
+describe("backend", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_BACKEND_URL: "https://api.example.com",
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("backendBaseQuery", () => {
+    it("should create a base query with the correct baseUrl", () => {
+      backendBaseQuery("catalog");
+
+      expect(mockFetchBaseQuery).toHaveBeenCalled();
+      expect(mockFetchBaseQuery.lastConfig.baseUrl).toBe(
+        "https://api.example.com/catalog"
+      );
+    });
+
+    it("should create a base query with different domains", () => {
+      backendBaseQuery("flowsheet");
+
+      expect(mockFetchBaseQuery.lastConfig.baseUrl).toBe(
+        "https://api.example.com/flowsheet"
+      );
+    });
+
+    it("should handle empty domain", () => {
+      backendBaseQuery("");
+
+      expect(mockFetchBaseQuery.lastConfig.baseUrl).toBe(
+        "https://api.example.com/"
+      );
+    });
+
+    describe("prepareHeaders", () => {
+      it("should set Content-Type header to application/json", async () => {
+        backendBaseQuery("test");
+
+        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        expect(prepareHeaders).toBeDefined();
+
+        const mockHeaders = new Map<string, string>();
+        mockHeaders.set = vi.fn();
+
+        mockedGetJWTToken.mockResolvedValue(null);
+
+        await prepareHeaders(mockHeaders);
+
+        expect(mockHeaders.set).toHaveBeenCalledWith(
+          "Content-Type",
+          "application/json"
+        );
+      });
+
+      it("should set Authorization header with Bearer token when JWT is available", async () => {
+        backendBaseQuery("test");
+
+        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const mockHeaders = new Map<string, string>();
+        mockHeaders.set = vi.fn();
+
+        mockedGetJWTToken.mockResolvedValue("test-jwt-token-12345");
+
+        await prepareHeaders(mockHeaders);
+
+        expect(mockHeaders.set).toHaveBeenCalledWith(
+          "Content-Type",
+          "application/json"
+        );
+        expect(mockHeaders.set).toHaveBeenCalledWith(
+          "Authorization",
+          "Bearer test-jwt-token-12345"
+        );
+      });
+
+      it("should not set Authorization header when JWT is null", async () => {
+        backendBaseQuery("test");
+
+        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const mockHeaders = new Map<string, string>();
+        const setFn = vi.fn();
+        mockHeaders.set = setFn;
+
+        mockedGetJWTToken.mockResolvedValue(null);
+
+        await prepareHeaders(mockHeaders);
+
+        expect(setFn).toHaveBeenCalledTimes(1);
+        expect(setFn).toHaveBeenCalledWith("Content-Type", "application/json");
+        expect(setFn).not.toHaveBeenCalledWith(
+          "Authorization",
+          expect.anything()
+        );
+      });
+
+      it("should return the modified headers", async () => {
+        backendBaseQuery("test");
+
+        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const mockHeaders = new Map<string, string>();
+        mockHeaders.set = vi.fn();
+
+        mockedGetJWTToken.mockResolvedValue("token");
+
+        const result = await prepareHeaders(mockHeaders);
+
+        expect(result).toBe(mockHeaders);
+      });
+
+      it("should call getJWTToken to retrieve the token", async () => {
+        backendBaseQuery("test");
+
+        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const mockHeaders = new Map<string, string>();
+        mockHeaders.set = vi.fn();
+
+        mockedGetJWTToken.mockResolvedValue("my-token");
+
+        await prepareHeaders(mockHeaders);
+
+        expect(mockedGetJWTToken).toHaveBeenCalledTimes(1);
+      });
+
+      it("should handle getJWTToken returning empty string", async () => {
+        backendBaseQuery("test");
+
+        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const mockHeaders = new Map<string, string>();
+        const setFn = vi.fn();
+        mockHeaders.set = setFn;
+
+        mockedGetJWTToken.mockResolvedValue("");
+
+        await prepareHeaders(mockHeaders);
+
+        // Empty string is falsy, so Authorization should not be set
+        expect(setFn).toHaveBeenCalledTimes(1);
+        expect(setFn).not.toHaveBeenCalledWith(
+          "Authorization",
+          expect.anything()
+        );
+      });
+
+      it("should set Authorization header for truthy non-null token", async () => {
+        backendBaseQuery("test");
+
+        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const mockHeaders = new Map<string, string>();
+        const setFn = vi.fn();
+        mockHeaders.set = setFn;
+
+        mockedGetJWTToken.mockResolvedValue("valid-token");
+
+        await prepareHeaders(mockHeaders);
+
+        expect(setFn).toHaveBeenCalledWith(
+          "Authorization",
+          "Bearer valid-token"
+        );
+      });
+    });
+
+    describe("different backend URLs", () => {
+      it("should work with undefined NEXT_PUBLIC_BACKEND_URL", () => {
+        delete process.env.NEXT_PUBLIC_BACKEND_URL;
+
+        backendBaseQuery("api");
+
+        expect(mockFetchBaseQuery.lastConfig.baseUrl).toBe("undefined/api");
+      });
+
+      it("should work with localhost backend URL", () => {
+        process.env.NEXT_PUBLIC_BACKEND_URL = "http://localhost:3001";
+
+        backendBaseQuery("users");
+
+        expect(mockFetchBaseQuery.lastConfig.baseUrl).toBe(
+          "http://localhost:3001/users"
+        );
+      });
+
+      it("should work with trailing slash in backend URL", () => {
+        process.env.NEXT_PUBLIC_BACKEND_URL = "https://api.example.com/";
+
+        backendBaseQuery("items");
+
+        expect(mockFetchBaseQuery.lastConfig.baseUrl).toBe(
+          "https://api.example.com//items"
+        );
+      });
+    });
+  });
+});

--- a/lib/__tests__/features/backend.test.ts
+++ b/lib/__tests__/features/backend.test.ts
@@ -7,13 +7,13 @@ vi.mock("@/lib/features/authentication/client", () => ({
 
 // We need to mock fetchBaseQuery from Redux Toolkit
 const mockPrepareHeaders = vi.fn();
-const mockFetchBaseQuery = vi.fn((config) => {
+const mockFetchBaseQuery = vi.fn((config: any) => {
   // Store the config so we can test it
-  mockFetchBaseQuery.lastConfig = config;
+  (mockFetchBaseQuery as any).lastConfig = config;
   // Return a mock base query function
   return vi.fn(async () => ({ data: {} }));
 });
-mockFetchBaseQuery.lastConfig = null as any;
+(mockFetchBaseQuery as any).lastConfig = null;
 
 vi.mock("@reduxjs/toolkit/query", () => ({
   fetchBaseQuery: (config: any) => mockFetchBaseQuery(config),
@@ -44,7 +44,7 @@ describe("backend", () => {
       backendBaseQuery("catalog");
 
       expect(mockFetchBaseQuery).toHaveBeenCalled();
-      expect(mockFetchBaseQuery.lastConfig.baseUrl).toBe(
+      expect((mockFetchBaseQuery as any).lastConfig.baseUrl).toBe(
         "https://api.example.com/catalog"
       );
     });
@@ -52,7 +52,7 @@ describe("backend", () => {
     it("should create a base query with different domains", () => {
       backendBaseQuery("flowsheet");
 
-      expect(mockFetchBaseQuery.lastConfig.baseUrl).toBe(
+      expect((mockFetchBaseQuery as any).lastConfig.baseUrl).toBe(
         "https://api.example.com/flowsheet"
       );
     });
@@ -60,7 +60,7 @@ describe("backend", () => {
     it("should handle empty domain", () => {
       backendBaseQuery("");
 
-      expect(mockFetchBaseQuery.lastConfig.baseUrl).toBe(
+      expect((mockFetchBaseQuery as any).lastConfig.baseUrl).toBe(
         "https://api.example.com/"
       );
     });
@@ -69,7 +69,7 @@ describe("backend", () => {
       it("should set Content-Type header to application/json", async () => {
         backendBaseQuery("test");
 
-        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const prepareHeaders = (mockFetchBaseQuery as any).lastConfig.prepareHeaders;
         expect(prepareHeaders).toBeDefined();
 
         const mockHeaders = new Map<string, string>();
@@ -88,7 +88,7 @@ describe("backend", () => {
       it("should set Authorization header with Bearer token when JWT is available", async () => {
         backendBaseQuery("test");
 
-        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const prepareHeaders = (mockFetchBaseQuery as any).lastConfig.prepareHeaders;
         const mockHeaders = new Map<string, string>();
         mockHeaders.set = vi.fn();
 
@@ -109,7 +109,7 @@ describe("backend", () => {
       it("should not set Authorization header when JWT is null", async () => {
         backendBaseQuery("test");
 
-        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const prepareHeaders = (mockFetchBaseQuery as any).lastConfig.prepareHeaders;
         const mockHeaders = new Map<string, string>();
         const setFn = vi.fn();
         mockHeaders.set = setFn;
@@ -129,7 +129,7 @@ describe("backend", () => {
       it("should return the modified headers", async () => {
         backendBaseQuery("test");
 
-        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const prepareHeaders = (mockFetchBaseQuery as any).lastConfig.prepareHeaders;
         const mockHeaders = new Map<string, string>();
         mockHeaders.set = vi.fn();
 
@@ -143,7 +143,7 @@ describe("backend", () => {
       it("should call getJWTToken to retrieve the token", async () => {
         backendBaseQuery("test");
 
-        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const prepareHeaders = (mockFetchBaseQuery as any).lastConfig.prepareHeaders;
         const mockHeaders = new Map<string, string>();
         mockHeaders.set = vi.fn();
 
@@ -157,7 +157,7 @@ describe("backend", () => {
       it("should handle getJWTToken returning empty string", async () => {
         backendBaseQuery("test");
 
-        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const prepareHeaders = (mockFetchBaseQuery as any).lastConfig.prepareHeaders;
         const mockHeaders = new Map<string, string>();
         const setFn = vi.fn();
         mockHeaders.set = setFn;
@@ -177,7 +177,7 @@ describe("backend", () => {
       it("should set Authorization header for truthy non-null token", async () => {
         backendBaseQuery("test");
 
-        const prepareHeaders = mockFetchBaseQuery.lastConfig.prepareHeaders;
+        const prepareHeaders = (mockFetchBaseQuery as any).lastConfig.prepareHeaders;
         const mockHeaders = new Map<string, string>();
         const setFn = vi.fn();
         mockHeaders.set = setFn;
@@ -199,7 +199,7 @@ describe("backend", () => {
 
         backendBaseQuery("api");
 
-        expect(mockFetchBaseQuery.lastConfig.baseUrl).toBe("undefined/api");
+        expect((mockFetchBaseQuery as any).lastConfig.baseUrl).toBe("undefined/api");
       });
 
       it("should work with localhost backend URL", () => {
@@ -207,7 +207,7 @@ describe("backend", () => {
 
         backendBaseQuery("users");
 
-        expect(mockFetchBaseQuery.lastConfig.baseUrl).toBe(
+        expect((mockFetchBaseQuery as any).lastConfig.baseUrl).toBe(
           "http://localhost:3001/users"
         );
       });
@@ -217,7 +217,7 @@ describe("backend", () => {
 
         backendBaseQuery("items");
 
-        expect(mockFetchBaseQuery.lastConfig.baseUrl).toBe(
+        expect((mockFetchBaseQuery as any).lastConfig.baseUrl).toBe(
           "https://api.example.com//items"
         );
       });

--- a/lib/__tests__/features/rotation/api.test.tsx
+++ b/lib/__tests__/features/rotation/api.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  rotationApi,
+  useGetRotationQuery,
+  useAddRotationEntryMutation,
+  useKillRotationEntryMutation,
+} from "@/lib/features/rotation/api";
+import { Rotation } from "@/lib/features/rotation/types";
+import { describeApi } from "@/lib/test-utils";
+
+// Mock the authentication client
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+describe("rotationApi", () => {
+  describeApi(rotationApi, {
+    queries: ["getRotation"],
+    mutations: ["addRotationEntry", "killRotationEntry"],
+    reducerPath: "rotationApi",
+  });
+
+  describe("exported hooks", () => {
+    it("should export useGetRotationQuery hook", async () => {
+      const { useGetRotationQuery } = await import(
+        "@/lib/features/rotation/api"
+      );
+      expect(useGetRotationQuery).toBeDefined();
+      expect(typeof useGetRotationQuery).toBe("function");
+    });
+
+    it("should export useAddRotationEntryMutation hook", async () => {
+      const { useAddRotationEntryMutation } = await import(
+        "@/lib/features/rotation/api"
+      );
+      expect(useAddRotationEntryMutation).toBeDefined();
+      expect(typeof useAddRotationEntryMutation).toBe("function");
+    });
+
+    it("should export useKillRotationEntryMutation hook", async () => {
+      const { useKillRotationEntryMutation } = await import(
+        "@/lib/features/rotation/api"
+      );
+      expect(useKillRotationEntryMutation).toBeDefined();
+      expect(typeof useKillRotationEntryMutation).toBe("function");
+    });
+  });
+
+  describe("API configuration", () => {
+    it("should use rotationApi as reducer path", () => {
+      expect(rotationApi.reducerPath).toBe("rotationApi");
+    });
+
+    it("should export the rotationApi object", () => {
+      expect(rotationApi).toBeDefined();
+      expect(rotationApi.endpoints).toBeDefined();
+    });
+
+    it("should have Rotation tag type", () => {
+      expect(rotationApi.reducerPath).toBe("rotationApi");
+    });
+  });
+
+  describe("getRotation endpoint", () => {
+    it("should have getRotation endpoint defined", () => {
+      expect(rotationApi.endpoints.getRotation).toBeDefined();
+    });
+
+    it("should have initiate method", () => {
+      expect(rotationApi.endpoints.getRotation.initiate).toBeDefined();
+      expect(typeof rotationApi.endpoints.getRotation.initiate).toBe("function");
+    });
+  });
+
+  describe("addRotationEntry endpoint", () => {
+    it("should have addRotationEntry endpoint defined", () => {
+      expect(rotationApi.endpoints.addRotationEntry).toBeDefined();
+    });
+
+    it("should have initiate method", () => {
+      expect(rotationApi.endpoints.addRotationEntry.initiate).toBeDefined();
+      expect(typeof rotationApi.endpoints.addRotationEntry.initiate).toBe("function");
+    });
+  });
+
+  describe("killRotationEntry endpoint", () => {
+    it("should have killRotationEntry endpoint defined", () => {
+      expect(rotationApi.endpoints.killRotationEntry).toBeDefined();
+    });
+
+    it("should have initiate method", () => {
+      expect(rotationApi.endpoints.killRotationEntry.initiate).toBeDefined();
+      expect(typeof rotationApi.endpoints.killRotationEntry.initiate).toBe("function");
+    });
+  });
+
+  describe("API reducer", () => {
+    it("should have a reducer function", () => {
+      expect(rotationApi.reducer).toBeDefined();
+      expect(typeof rotationApi.reducer).toBe("function");
+    });
+
+    it("should have middleware", () => {
+      expect(rotationApi.middleware).toBeDefined();
+      expect(typeof rotationApi.middleware).toBe("function");
+    });
+  });
+
+  describe("endpoint matchers", () => {
+    it("should have matchFulfilled matcher for getRotation", () => {
+      expect(rotationApi.endpoints.getRotation.matchFulfilled).toBeDefined();
+    });
+
+    it("should have matchPending matcher for getRotation", () => {
+      expect(rotationApi.endpoints.getRotation.matchPending).toBeDefined();
+    });
+
+    it("should have matchRejected matcher for getRotation", () => {
+      expect(rotationApi.endpoints.getRotation.matchRejected).toBeDefined();
+    });
+  });
+
+  describe("rotation frequency values", () => {
+    it("should correctly handle Heavy rotation (H)", () => {
+      expect(Rotation.H).toBe("H");
+    });
+
+    it("should correctly handle Medium rotation (M)", () => {
+      expect(Rotation.M).toBe("M");
+    });
+
+    it("should correctly handle Light rotation (L)", () => {
+      expect(Rotation.L).toBe("L");
+    });
+
+    it("should correctly handle Sound rotation (S)", () => {
+      expect(Rotation.S).toBe("S");
+    });
+  });
+});

--- a/lib/__tests__/features/rotation/types.test.ts
+++ b/lib/__tests__/features/rotation/types.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { Rotation } from "@/lib/features/rotation/types";
+
+describe("rotation types", () => {
+  describe("Rotation enum", () => {
+    it("should have S (Sound) rotation", () => {
+      expect(Rotation.S).toBe("S");
+    });
+
+    it("should have L (Light) rotation", () => {
+      expect(Rotation.L).toBe("L");
+    });
+
+    it("should have M (Medium) rotation", () => {
+      expect(Rotation.M).toBe("M");
+    });
+
+    it("should have H (Heavy) rotation", () => {
+      expect(Rotation.H).toBe("H");
+    });
+
+    it("should have exactly 4 rotation values", () => {
+      const rotationValues = Object.values(Rotation);
+      expect(rotationValues).toHaveLength(4);
+    });
+
+    it("should allow comparison with string values", () => {
+      expect(Rotation.H === "H").toBe(true);
+      expect(Rotation.M === "M").toBe(true);
+      expect(Rotation.L === "L").toBe(true);
+      expect(Rotation.S === "S").toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #251

## Summary

Add ~56 tests covering admin, rotation, backend, and application state libraries:

- **Admin types** — `Authorization` enum values, `AdminAuthenticationStatus`, `AdminProtectedRoutes`, `setAuthStage`/`getAuthStage` slice actions
- **Backend utilities** — `backendBaseQuery` configuration, `prepareHeaders` JWT injection, different backend URL handling
- **Rotation API** — `getRotation`, `addRotationEntry`, `killRotationEntry` endpoints, exported hooks, reducer, and matchers
- **Application state** — `flowsheetSlice` reducer logic

## Test plan
- [ ] Run `npm test lib/__tests__/features/admin/ lib/__tests__/features/rotation/`

**Part 6 of 26**