### PR TITLE
test: add experiences library tests

### DIFF
--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -1,5 +1,5 @@
 import { test as base, expect, Page } from "@playwright/test";
-import { MOCK_USERS, MockUserKey, MockUser } from "@/lib/test-utils/fixtures";
+import { MOCK_USERS, MockUserKey, MockUser } from "../../lib/test-utils/fixtures";
 
 /**
  * Temporary password used for admin-created users.

--- a/lib/__tests__/features/experiences/hooks.test.ts
+++ b/lib/__tests__/features/experiences/hooks.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import {
+  useActiveExperience,
+  useExperienceConfig,
+  useIsExperience,
+  useExperienceFeatures,
+} from "@/lib/features/experiences/hooks";
+import { EXPERIENCE_REGISTRY } from "@/lib/features/experiences/registry";
+import type { ExperienceId } from "@/lib/features/experiences/types";
+
+// Create a mock store for testing hooks
+function createMockStore(applicationState: Record<string, unknown> = {}) {
+  return configureStore({
+    reducer: {
+      application: (state = applicationState) => state,
+    },
+    preloadedState: {
+      application: applicationState,
+    },
+  });
+}
+
+function createWrapper(applicationState: Record<string, unknown> = {}) {
+  const store = createMockStore(applicationState);
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(Provider, { store, children });
+  };
+}
+
+describe("experience hooks", () => {
+  describe("useActiveExperience", () => {
+    it("should return modern by default when no experience is set", () => {
+      const wrapper = createWrapper({});
+      const { result } = renderHook(() => useActiveExperience(), { wrapper });
+
+      expect(result.current).toBe("modern");
+    });
+
+    it("should return experience from new state structure", () => {
+      const wrapper = createWrapper({ experience: "classic" });
+      const { result } = renderHook(() => useActiveExperience(), { wrapper });
+
+      expect(result.current).toBe("classic");
+    });
+
+    it("should return modern when experience is set to modern", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+      const { result } = renderHook(() => useActiveExperience(), { wrapper });
+
+      expect(result.current).toBe("modern");
+    });
+
+    it("should fall back to classic when old classic boolean is true", () => {
+      const wrapper = createWrapper({ classic: true });
+      const { result } = renderHook(() => useActiveExperience(), { wrapper });
+
+      expect(result.current).toBe("classic");
+    });
+
+    it("should fall back to modern when old classic boolean is false", () => {
+      const wrapper = createWrapper({ classic: false });
+      const { result } = renderHook(() => useActiveExperience(), { wrapper });
+
+      expect(result.current).toBe("modern");
+    });
+
+    it("should prefer new experience field over old classic field", () => {
+      // When both exist, the new structure should take precedence
+      const wrapper = createWrapper({ experience: "modern", classic: true });
+      const { result } = renderHook(() => useActiveExperience(), { wrapper });
+
+      expect(result.current).toBe("modern");
+    });
+
+    it("should return type ExperienceId", () => {
+      const wrapper = createWrapper({ experience: "classic" });
+      const { result } = renderHook(() => useActiveExperience(), { wrapper });
+
+      // TypeScript type check - should be ExperienceId
+      const experienceId: ExperienceId = result.current;
+      expect(["classic", "modern"]).toContain(experienceId);
+    });
+  });
+
+  describe("useExperienceConfig", () => {
+    it("should return classic config when classic experience is active", () => {
+      const wrapper = createWrapper({ experience: "classic" });
+      const { result } = renderHook(() => useExperienceConfig(), { wrapper });
+
+      expect(result.current).toEqual(EXPERIENCE_REGISTRY.classic);
+      expect(result.current.id).toBe("classic");
+      expect(result.current.name).toBe("Classic");
+    });
+
+    it("should return modern config when modern experience is active", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+      const { result } = renderHook(() => useExperienceConfig(), { wrapper });
+
+      expect(result.current).toEqual(EXPERIENCE_REGISTRY.modern);
+      expect(result.current.id).toBe("modern");
+      expect(result.current.name).toBe("Modern");
+    });
+
+    it("should return modern config by default", () => {
+      const wrapper = createWrapper({});
+      const { result } = renderHook(() => useExperienceConfig(), { wrapper });
+
+      expect(result.current.id).toBe("modern");
+    });
+
+    it("should return config with all expected properties", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+      const { result } = renderHook(() => useExperienceConfig(), { wrapper });
+
+      expect(result.current).toHaveProperty("id");
+      expect(result.current).toHaveProperty("name");
+      expect(result.current).toHaveProperty("description");
+      expect(result.current).toHaveProperty("icon");
+      expect(result.current).toHaveProperty("enabled");
+      expect(result.current).toHaveProperty("cssIdentifier");
+      expect(result.current).toHaveProperty("features");
+    });
+
+    it("should return config with features object", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+      const { result } = renderHook(() => useExperienceConfig(), { wrapper });
+
+      expect(result.current.features).toHaveProperty("hasRightbar");
+      expect(result.current.features).toHaveProperty("hasLeftbar");
+      expect(result.current.features).toHaveProperty("hasMobileHeader");
+      expect(result.current.features).toHaveProperty("supportsThemeToggle");
+    });
+
+    it("should have correct features for classic experience", () => {
+      const wrapper = createWrapper({ experience: "classic" });
+      const { result } = renderHook(() => useExperienceConfig(), { wrapper });
+
+      expect(result.current.features.hasRightbar).toBe(false);
+      expect(result.current.features.hasLeftbar).toBe(false);
+      expect(result.current.features.hasMobileHeader).toBe(false);
+      expect(result.current.features.supportsThemeToggle).toBe(false);
+    });
+
+    it("should have correct features for modern experience", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+      const { result } = renderHook(() => useExperienceConfig(), { wrapper });
+
+      expect(result.current.features.hasRightbar).toBe(true);
+      expect(result.current.features.hasLeftbar).toBe(true);
+      expect(result.current.features.hasMobileHeader).toBe(true);
+      expect(result.current.features.supportsThemeToggle).toBe(true);
+    });
+  });
+
+  describe("useIsExperience", () => {
+    it("should return true when checking for the active experience", () => {
+      const wrapper = createWrapper({ experience: "classic" });
+      const { result } = renderHook(() => useIsExperience("classic"), {
+        wrapper,
+      });
+
+      expect(result.current).toBe(true);
+    });
+
+    it("should return false when checking for a non-active experience", () => {
+      const wrapper = createWrapper({ experience: "classic" });
+      const { result } = renderHook(() => useIsExperience("modern"), {
+        wrapper,
+      });
+
+      expect(result.current).toBe(false);
+    });
+
+    it("should return true for modern when modern is active", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+      const { result } = renderHook(() => useIsExperience("modern"), {
+        wrapper,
+      });
+
+      expect(result.current).toBe(true);
+    });
+
+    it("should return false for classic when modern is active", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+      const { result } = renderHook(() => useIsExperience("classic"), {
+        wrapper,
+      });
+
+      expect(result.current).toBe(false);
+    });
+
+    it("should return true for modern by default (when no experience set)", () => {
+      const wrapper = createWrapper({});
+      const { result } = renderHook(() => useIsExperience("modern"), {
+        wrapper,
+      });
+
+      expect(result.current).toBe(true);
+    });
+
+    it("should return false for classic by default (when no experience set)", () => {
+      const wrapper = createWrapper({});
+      const { result } = renderHook(() => useIsExperience("classic"), {
+        wrapper,
+      });
+
+      expect(result.current).toBe(false);
+    });
+
+    it("should work with legacy classic boolean state", () => {
+      const wrapper = createWrapper({ classic: true });
+      const { result } = renderHook(() => useIsExperience("classic"), {
+        wrapper,
+      });
+
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe("useExperienceFeatures", () => {
+    it("should return features for modern experience", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+      const { result } = renderHook(() => useExperienceFeatures(), { wrapper });
+
+      expect(result.current).toEqual(EXPERIENCE_REGISTRY.modern.features);
+    });
+
+    it("should return features for classic experience", () => {
+      const wrapper = createWrapper({ experience: "classic" });
+      const { result } = renderHook(() => useExperienceFeatures(), { wrapper });
+
+      expect(result.current).toEqual(EXPERIENCE_REGISTRY.classic.features);
+    });
+
+    it("should return modern features by default", () => {
+      const wrapper = createWrapper({});
+      const { result } = renderHook(() => useExperienceFeatures(), { wrapper });
+
+      expect(result.current.hasRightbar).toBe(true);
+      expect(result.current.hasLeftbar).toBe(true);
+      expect(result.current.hasMobileHeader).toBe(true);
+      expect(result.current.supportsThemeToggle).toBe(true);
+    });
+
+    it("should have hasRightbar as boolean", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+      const { result } = renderHook(() => useExperienceFeatures(), { wrapper });
+
+      expect(typeof result.current.hasRightbar).toBe("boolean");
+    });
+
+    it("should have hasLeftbar as boolean", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+      const { result } = renderHook(() => useExperienceFeatures(), { wrapper });
+
+      expect(typeof result.current.hasLeftbar).toBe("boolean");
+    });
+
+    it("should have hasMobileHeader as boolean", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+      const { result } = renderHook(() => useExperienceFeatures(), { wrapper });
+
+      expect(typeof result.current.hasMobileHeader).toBe("boolean");
+    });
+
+    it("should have supportsThemeToggle as boolean", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+      const { result } = renderHook(() => useExperienceFeatures(), { wrapper });
+
+      expect(typeof result.current.supportsThemeToggle).toBe("boolean");
+    });
+
+    it("should return classic features when using legacy classic boolean", () => {
+      const wrapper = createWrapper({ classic: true });
+      const { result } = renderHook(() => useExperienceFeatures(), { wrapper });
+
+      expect(result.current.hasRightbar).toBe(false);
+      expect(result.current.hasLeftbar).toBe(false);
+    });
+  });
+
+  describe("hook composition", () => {
+    it("useExperienceConfig should use result from useActiveExperience", () => {
+      const wrapper = createWrapper({ experience: "classic" });
+
+      const { result: experienceResult } = renderHook(
+        () => useActiveExperience(),
+        { wrapper }
+      );
+      const { result: configResult } = renderHook(() => useExperienceConfig(), {
+        wrapper,
+      });
+
+      expect(configResult.current.id).toBe(experienceResult.current);
+    });
+
+    it("useExperienceFeatures should match useExperienceConfig features", () => {
+      const wrapper = createWrapper({ experience: "modern" });
+
+      const { result: configResult } = renderHook(() => useExperienceConfig(), {
+        wrapper,
+      });
+      const { result: featuresResult } = renderHook(
+        () => useExperienceFeatures(),
+        { wrapper }
+      );
+
+      expect(featuresResult.current).toEqual(configResult.current.features);
+    });
+
+    it("useIsExperience should match useActiveExperience", () => {
+      const wrapper = createWrapper({ experience: "classic" });
+
+      const { result: activeResult } = renderHook(() => useActiveExperience(), {
+        wrapper,
+      });
+      const { result: isClassicResult } = renderHook(
+        () => useIsExperience("classic"),
+        { wrapper }
+      );
+      const { result: isModernResult } = renderHook(
+        () => useIsExperience("modern"),
+        { wrapper }
+      );
+
+      expect(isClassicResult.current).toBe(activeResult.current === "classic");
+      expect(isModernResult.current).toBe(activeResult.current === "modern");
+    });
+  });
+});

--- a/lib/__tests__/features/experiences/registry.test.ts
+++ b/lib/__tests__/features/experiences/registry.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  EXPERIENCE_REGISTRY,
+  getExperienceConfig,
+  getEnabledExperiences,
+  isExperienceEnabled,
+  getDefaultExperience,
+  getAllowedExperiences,
+  isExperienceSwitchingAllowed,
+} from "@/lib/features/experiences/registry";
+
+describe("registry", () => {
+  describe("EXPERIENCE_REGISTRY", () => {
+    it("should have classic and modern experiences", () => {
+      expect(EXPERIENCE_REGISTRY.classic).toBeDefined();
+      expect(EXPERIENCE_REGISTRY.modern).toBeDefined();
+    });
+
+    it("should have correct classic experience config", () => {
+      const classic = EXPERIENCE_REGISTRY.classic;
+      expect(classic.id).toBe("classic");
+      expect(classic.name).toBe("Classic");
+      expect(classic.enabled).toBe(true);
+      expect(classic.cssIdentifier).toBe("classic");
+      expect(classic.features.hasRightbar).toBe(false);
+      expect(classic.features.hasLeftbar).toBe(false);
+      expect(classic.features.hasMobileHeader).toBe(false);
+      expect(classic.features.supportsThemeToggle).toBe(false);
+    });
+
+    it("should have correct modern experience config", () => {
+      const modern = EXPERIENCE_REGISTRY.modern;
+      expect(modern.id).toBe("modern");
+      expect(modern.name).toBe("Modern");
+      expect(modern.enabled).toBe(true);
+      expect(modern.cssIdentifier).toBe("modern");
+      expect(modern.features.hasRightbar).toBe(true);
+      expect(modern.features.hasLeftbar).toBe(true);
+      expect(modern.features.hasMobileHeader).toBe(true);
+      expect(modern.features.supportsThemeToggle).toBe(true);
+    });
+  });
+
+  describe("getExperienceConfig", () => {
+    it("should return classic config", () => {
+      const config = getExperienceConfig("classic");
+      expect(config.id).toBe("classic");
+      expect(config.name).toBe("Classic");
+    });
+
+    it("should return modern config", () => {
+      const config = getExperienceConfig("modern");
+      expect(config.id).toBe("modern");
+      expect(config.name).toBe("Modern");
+    });
+  });
+
+  describe("getEnabledExperiences", () => {
+    it("should return all enabled experiences", () => {
+      const experiences = getEnabledExperiences();
+      expect(experiences.length).toBeGreaterThan(0);
+      expect(experiences.every((exp) => exp.enabled)).toBe(true);
+    });
+
+    it("should include both classic and modern when enabled", () => {
+      const experiences = getEnabledExperiences();
+      const ids = experiences.map((exp) => exp.id);
+      expect(ids).toContain("classic");
+      expect(ids).toContain("modern");
+    });
+  });
+
+  describe("isExperienceEnabled", () => {
+    it("should return true for classic", () => {
+      expect(isExperienceEnabled("classic")).toBe(true);
+    });
+
+    it("should return true for modern", () => {
+      expect(isExperienceEnabled("modern")).toBe(true);
+    });
+  });
+
+  describe("getDefaultExperience", () => {
+    const originalEnv = process.env.NEXT_PUBLIC_DEFAULT_EXPERIENCE;
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.NEXT_PUBLIC_DEFAULT_EXPERIENCE;
+      } else {
+        process.env.NEXT_PUBLIC_DEFAULT_EXPERIENCE = originalEnv;
+      }
+    });
+
+    it("should return modern by default when env is not set", () => {
+      delete process.env.NEXT_PUBLIC_DEFAULT_EXPERIENCE;
+      expect(getDefaultExperience()).toBe("modern");
+    });
+
+    it("should return classic when env is set to classic", () => {
+      process.env.NEXT_PUBLIC_DEFAULT_EXPERIENCE = "classic";
+      expect(getDefaultExperience()).toBe("classic");
+    });
+
+    it("should return modern when env is set to modern", () => {
+      process.env.NEXT_PUBLIC_DEFAULT_EXPERIENCE = "modern";
+      expect(getDefaultExperience()).toBe("modern");
+    });
+
+    it("should return modern for invalid env value", () => {
+      process.env.NEXT_PUBLIC_DEFAULT_EXPERIENCE = "invalid";
+      expect(getDefaultExperience()).toBe("modern");
+    });
+  });
+
+  describe("getAllowedExperiences", () => {
+    const originalEnv = process.env.NEXT_PUBLIC_ENABLED_EXPERIENCES;
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.NEXT_PUBLIC_ENABLED_EXPERIENCES;
+      } else {
+        process.env.NEXT_PUBLIC_ENABLED_EXPERIENCES = originalEnv;
+      }
+    });
+
+    it("should return both experiences by default when env is not set", () => {
+      delete process.env.NEXT_PUBLIC_ENABLED_EXPERIENCES;
+      const allowed = getAllowedExperiences();
+      expect(allowed).toContain("classic");
+      expect(allowed).toContain("modern");
+    });
+
+    it("should parse comma-separated list from env", () => {
+      process.env.NEXT_PUBLIC_ENABLED_EXPERIENCES = "modern,classic";
+      const allowed = getAllowedExperiences();
+      expect(allowed).toContain("modern");
+      expect(allowed).toContain("classic");
+    });
+
+    it("should filter out invalid experience names", () => {
+      process.env.NEXT_PUBLIC_ENABLED_EXPERIENCES = "modern,invalid,classic";
+      const allowed = getAllowedExperiences();
+      expect(allowed).toContain("modern");
+      expect(allowed).toContain("classic");
+      expect(allowed).not.toContain("invalid");
+    });
+
+    it("should handle single experience", () => {
+      process.env.NEXT_PUBLIC_ENABLED_EXPERIENCES = "modern";
+      const allowed = getAllowedExperiences();
+      expect(allowed).toEqual(["modern"]);
+    });
+
+    it("should trim whitespace from entries", () => {
+      process.env.NEXT_PUBLIC_ENABLED_EXPERIENCES = " modern , classic ";
+      const allowed = getAllowedExperiences();
+      expect(allowed).toContain("modern");
+      expect(allowed).toContain("classic");
+    });
+  });
+
+  describe("isExperienceSwitchingAllowed", () => {
+    const originalEnv = process.env.NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING;
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING;
+      } else {
+        process.env.NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING = originalEnv;
+      }
+    });
+
+    it("should return true by default when env is not set", () => {
+      delete process.env.NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING;
+      expect(isExperienceSwitchingAllowed()).toBe(true);
+    });
+
+    it("should return false when env is 'false'", () => {
+      process.env.NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING = "false";
+      expect(isExperienceSwitchingAllowed()).toBe(false);
+    });
+
+    it("should return false when env is '0'", () => {
+      process.env.NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING = "0";
+      expect(isExperienceSwitchingAllowed()).toBe(false);
+    });
+
+    it("should return true when env is 'true'", () => {
+      process.env.NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING = "true";
+      expect(isExperienceSwitchingAllowed()).toBe(true);
+    });
+
+    it("should return true when env is any other value", () => {
+      process.env.NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING = "yes";
+      expect(isExperienceSwitchingAllowed()).toBe(true);
+    });
+  });
+});

--- a/lib/__tests__/features/experiences/theme.test.ts
+++ b/lib/__tests__/features/experiences/theme.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+
+// Mock next/font/google and next/font/local before importing the themes
+vi.mock("next/font/google", () => ({
+  Kanit: () => ({
+    style: {
+      fontFamily: "Kanit, sans-serif",
+    },
+  }),
+}));
+
+vi.mock("next/font/local", () => ({
+  default: () => ({
+    style: {
+      fontFamily: "Minbus, sans-serif",
+    },
+  }),
+}));
+
+// Import after mocking
+import { classicTheme } from "@/lib/features/experiences/classic/theme";
+import { modernTheme } from "@/lib/features/experiences/modern/theme";
+import { baseTheme } from "@/lib/features/experiences/shared/base-theme";
+
+describe("experience themes", () => {
+  describe("baseTheme", () => {
+    it("should have wxyc as css variable prefix", () => {
+      expect(baseTheme.cssVarPrefix).toBe("wxyc");
+    });
+
+    it("should have JoyTooltip component overrides", () => {
+      expect(baseTheme.components?.JoyTooltip).toBeDefined();
+    });
+
+    it("should set tooltip zIndex to 10000", () => {
+      expect(
+        baseTheme.components?.JoyTooltip?.styleOverrides?.root
+      ).toBeDefined();
+      const rootOverrides = baseTheme.components?.JoyTooltip?.styleOverrides
+        ?.root as { zIndex: number };
+      expect(rootOverrides.zIndex).toBe(10000);
+    });
+
+    it("should be a valid MUI Joy theme object", () => {
+      expect(baseTheme).toHaveProperty("cssVarPrefix");
+      expect(baseTheme).toHaveProperty("components");
+    });
+  });
+
+  describe("classicTheme", () => {
+    it("should have wxyc as css variable prefix", () => {
+      expect(classicTheme.cssVarPrefix).toBe("wxyc");
+    });
+
+    it("should have JoyTooltip component overrides", () => {
+      expect(classicTheme.components?.JoyTooltip).toBeDefined();
+    });
+
+    it("should set tooltip zIndex to 10000", () => {
+      const rootOverrides = classicTheme.components?.JoyTooltip?.styleOverrides
+        ?.root as { zIndex: number };
+      expect(rootOverrides.zIndex).toBe(10000);
+    });
+
+    it("should use Arial font family for display", () => {
+      expect(classicTheme.fontFamily?.display).toBe(
+        "Arial, Helvetica, sans-serif"
+      );
+    });
+
+    it("should use Arial font family for body", () => {
+      expect(classicTheme.fontFamily?.body).toBe(
+        "Arial, Helvetica, sans-serif"
+      );
+    });
+
+    it("should have h1 typography configured", () => {
+      expect(classicTheme.typography?.h1).toBeDefined();
+    });
+
+    it("should have h2 typography configured", () => {
+      expect(classicTheme.typography?.h2).toBeDefined();
+    });
+
+    it("should have h3 typography configured", () => {
+      expect(classicTheme.typography?.h3).toBeDefined();
+    });
+
+    it("should have h4 typography configured", () => {
+      expect(classicTheme.typography?.h4).toBeDefined();
+    });
+
+    it("should use Verdana for heading font family", () => {
+      const h1 = classicTheme.typography?.h1 as { fontFamily: string };
+      expect(h1.fontFamily).toBe(
+        "Verdana, Geneva, Arial, Helvetica, sans-serif"
+      );
+    });
+
+    it("should have bold headings", () => {
+      const h1 = classicTheme.typography?.h1 as { fontWeight: string };
+      expect(h1.fontWeight).toBe("bold");
+    });
+
+    it("should have consistent heading font across all levels", () => {
+      const h1Font = (classicTheme.typography?.h1 as { fontFamily: string })
+        .fontFamily;
+      const h2Font = (classicTheme.typography?.h2 as { fontFamily: string })
+        .fontFamily;
+      const h3Font = (classicTheme.typography?.h3 as { fontFamily: string })
+        .fontFamily;
+      const h4Font = (classicTheme.typography?.h4 as { fontFamily: string })
+        .fontFamily;
+
+      expect(h1Font).toBe(h2Font);
+      expect(h2Font).toBe(h3Font);
+      expect(h3Font).toBe(h4Font);
+    });
+
+    it("should have consistent heading weight across all levels", () => {
+      const h1Weight = (classicTheme.typography?.h1 as { fontWeight: string })
+        .fontWeight;
+      const h2Weight = (classicTheme.typography?.h2 as { fontWeight: string })
+        .fontWeight;
+      const h3Weight = (classicTheme.typography?.h3 as { fontWeight: string })
+        .fontWeight;
+      const h4Weight = (classicTheme.typography?.h4 as { fontWeight: string })
+        .fontWeight;
+
+      expect(h1Weight).toBe("bold");
+      expect(h2Weight).toBe("bold");
+      expect(h3Weight).toBe("bold");
+      expect(h4Weight).toBe("bold");
+    });
+
+    it("should be a valid MUI Joy theme object", () => {
+      expect(classicTheme).toHaveProperty("cssVarPrefix");
+      expect(classicTheme).toHaveProperty("components");
+      expect(classicTheme).toHaveProperty("fontFamily");
+      expect(classicTheme).toHaveProperty("typography");
+    });
+  });
+
+  describe("modernTheme", () => {
+    it("should have wxyc as css variable prefix", () => {
+      expect(modernTheme.cssVarPrefix).toBe("wxyc");
+    });
+
+    it("should have JoyTooltip component overrides", () => {
+      expect(modernTheme.components?.JoyTooltip).toBeDefined();
+    });
+
+    it("should set tooltip zIndex to 10000", () => {
+      const rootOverrides = modernTheme.components?.JoyTooltip?.styleOverrides
+        ?.root as { zIndex: number };
+      expect(rootOverrides.zIndex).toBe(10000);
+    });
+
+    it("should have display font family configured", () => {
+      expect(modernTheme.fontFamily?.display).toBeDefined();
+    });
+
+    it("should have body font family configured", () => {
+      expect(modernTheme.fontFamily?.body).toBeDefined();
+    });
+
+    it("should have h1 typography with font size", () => {
+      const h1 = modernTheme.typography?.h1 as { fontSize: string };
+      expect(h1.fontSize).toBe("4.5rem");
+    });
+
+    it("should have h2 typography with font size", () => {
+      const h2 = modernTheme.typography?.h2 as { fontSize: string };
+      expect(h2.fontSize).toBe("3.75rem");
+    });
+
+    it("should have h3 typography with font size", () => {
+      const h3 = modernTheme.typography?.h3 as { fontSize: string };
+      expect(h3.fontSize).toBe("3rem");
+    });
+
+    it("should have h4 typography with font size", () => {
+      const h4 = modernTheme.typography?.h4 as { fontSize: string };
+      expect(h4.fontSize).toBe("2.125rem");
+    });
+
+    it("should have heading font weights set to 100", () => {
+      const h1Weight = (modernTheme.typography?.h1 as { fontWeight: string })
+        .fontWeight;
+      const h2Weight = (modernTheme.typography?.h2 as { fontWeight: string })
+        .fontWeight;
+      const h3Weight = (modernTheme.typography?.h3 as { fontWeight: string })
+        .fontWeight;
+      const h4Weight = (modernTheme.typography?.h4 as { fontWeight: string })
+        .fontWeight;
+
+      expect(h1Weight).toBe("100");
+      expect(h2Weight).toBe("100");
+      expect(h3Weight).toBe("100");
+      expect(h4Weight).toBe("100");
+    });
+
+    it("should have body-xxs typography variant", () => {
+      const bodyXxs = modernTheme.typography?.["body-xxs"] as {
+        fontSize: string;
+      };
+      expect(bodyXxs).toBeDefined();
+      expect(bodyXxs.fontSize).toBe("0.6rem");
+    });
+
+    it("should have light color scheme configured", () => {
+      expect(modernTheme.colorSchemes?.light).toBeDefined();
+    });
+
+    it("should have dark color scheme configured", () => {
+      expect(modernTheme.colorSchemes?.dark).toBeDefined();
+    });
+
+    it("should have primary palette in light color scheme", () => {
+      expect(modernTheme.colorSchemes?.light?.palette?.primary).toBeDefined();
+    });
+
+    it("should have primary palette in dark color scheme", () => {
+      expect(modernTheme.colorSchemes?.dark?.palette?.primary).toBeDefined();
+    });
+
+    it("should have success palette in light color scheme", () => {
+      expect(modernTheme.colorSchemes?.light?.palette?.success).toBeDefined();
+    });
+
+    it("should have success palette in dark color scheme", () => {
+      expect(modernTheme.colorSchemes?.dark?.palette?.success).toBeDefined();
+    });
+
+    it("should have warning palette in light color scheme", () => {
+      expect(modernTheme.colorSchemes?.light?.palette?.warning).toBeDefined();
+    });
+
+    it("should have danger palette in light color scheme", () => {
+      expect(modernTheme.colorSchemes?.light?.palette?.danger).toBeDefined();
+    });
+
+    it("should have danger palette in dark color scheme", () => {
+      expect(modernTheme.colorSchemes?.dark?.palette?.danger).toBeDefined();
+    });
+
+    it("should have complete primary palette with all shades (50-900)", () => {
+      const primaryLight = modernTheme.colorSchemes?.light?.palette
+        ?.primary as Record<string, string>;
+      const expectedShades = [
+        "50",
+        "100",
+        "200",
+        "300",
+        "400",
+        "500",
+        "600",
+        "700",
+        "800",
+        "900",
+      ];
+
+      expectedShades.forEach((shade) => {
+        expect(primaryLight[shade]).toBeDefined();
+      });
+    });
+
+    it("should have string color values in primary palette", () => {
+      const primaryLight = modernTheme.colorSchemes?.light?.palette
+        ?.primary as Record<string, string>;
+
+      // MUI Joy themes convert colors to various formats (CSS vars, RGB, hex)
+      // Just verify that each value is a non-empty string
+      Object.values(primaryLight).forEach((color) => {
+        expect(typeof color).toBe("string");
+        expect(color.length).toBeGreaterThan(0);
+      });
+    });
+
+    it("should be a valid MUI Joy theme object", () => {
+      expect(modernTheme).toHaveProperty("cssVarPrefix");
+      expect(modernTheme).toHaveProperty("components");
+      expect(modernTheme).toHaveProperty("fontFamily");
+      expect(modernTheme).toHaveProperty("typography");
+      expect(modernTheme).toHaveProperty("colorSchemes");
+    });
+  });
+
+  describe("theme consistency", () => {
+    it("should have consistent cssVarPrefix across all themes", () => {
+      expect(baseTheme.cssVarPrefix).toBe(classicTheme.cssVarPrefix);
+      expect(classicTheme.cssVarPrefix).toBe(modernTheme.cssVarPrefix);
+    });
+
+    it("should have JoyTooltip overrides in all themes", () => {
+      expect(baseTheme.components?.JoyTooltip).toBeDefined();
+      expect(classicTheme.components?.JoyTooltip).toBeDefined();
+      expect(modernTheme.components?.JoyTooltip).toBeDefined();
+    });
+
+    it("should have consistent tooltip zIndex across all themes", () => {
+      const baseZIndex = (
+        baseTheme.components?.JoyTooltip?.styleOverrides?.root as {
+          zIndex: number;
+        }
+      ).zIndex;
+      const classicZIndex = (
+        classicTheme.components?.JoyTooltip?.styleOverrides?.root as {
+          zIndex: number;
+        }
+      ).zIndex;
+      const modernZIndex = (
+        modernTheme.components?.JoyTooltip?.styleOverrides?.root as {
+          zIndex: number;
+        }
+      ).zIndex;
+
+      expect(baseZIndex).toBe(10000);
+      expect(classicZIndex).toBe(10000);
+      expect(modernZIndex).toBe(10000);
+    });
+  });
+
+  describe("theme differences", () => {
+    it("classic and modern should have different display fonts", () => {
+      expect(classicTheme.fontFamily?.display).not.toBe(
+        modernTheme.fontFamily?.display
+      );
+    });
+
+    it("classic and modern should have different heading font weights", () => {
+      const classicH1Weight = (
+        classicTheme.typography?.h1 as { fontWeight: string }
+      ).fontWeight;
+      const modernH1Weight = (
+        modernTheme.typography?.h1 as { fontWeight: string }
+      ).fontWeight;
+
+      expect(classicH1Weight).toBe("bold");
+      expect(modernH1Weight).toBe("100");
+    });
+
+    it("modern should have color schemes while classic may not", () => {
+      expect(modernTheme.colorSchemes?.light).toBeDefined();
+      expect(modernTheme.colorSchemes?.dark).toBeDefined();
+    });
+
+    it("modern should have body-xxs variant that classic does not", () => {
+      expect(modernTheme.typography?.["body-xxs"]).toBeDefined();
+      expect(classicTheme.typography?.["body-xxs"]).toBeUndefined();
+    });
+  });
+});

--- a/lib/__tests__/features/experiences/theme.test.ts
+++ b/lib/__tests__/features/experiences/theme.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeAll } from "vitest";
+import type { CssVarsThemeOptions, Theme } from "@mui/joy/styles";
 
 // Mock next/font/google and next/font/local before importing the themes
 vi.mock("next/font/google", () => ({
@@ -17,10 +18,19 @@ vi.mock("next/font/local", () => ({
   }),
 }));
 
+// extendTheme returns Theme, but the type omits 'components' even though
+// it exists at runtime. This intersection restores access for testing.
+type ThemeWithComponents = Theme &
+  Pick<Required<CssVarsThemeOptions>, "components">;
+
 // Import after mocking
-import { classicTheme } from "@/lib/features/experiences/classic/theme";
-import { modernTheme } from "@/lib/features/experiences/modern/theme";
-import { baseTheme } from "@/lib/features/experiences/shared/base-theme";
+import { classicTheme as _classicTheme } from "@/lib/features/experiences/classic/theme";
+import { modernTheme as _modernTheme } from "@/lib/features/experiences/modern/theme";
+import { baseTheme as _baseTheme } from "@/lib/features/experiences/shared/base-theme";
+
+const classicTheme = _classicTheme as ThemeWithComponents;
+const modernTheme = _modernTheme as ThemeWithComponents;
+const baseTheme = _baseTheme as ThemeWithComponents;
 
 describe("experience themes", () => {
   describe("baseTheme", () => {

--- a/lib/__tests__/features/experiences/types.test.ts
+++ b/lib/__tests__/features/experiences/types.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from "vitest";
+import {
+  isExperienceId,
+  toExperienceId,
+  defaultExperienceState,
+} from "@/lib/features/experiences/types";
+import type { ExperienceId, ExperienceState } from "@/lib/features/experiences/types";
+
+describe("experience types", () => {
+  describe("isExperienceId", () => {
+    it("should return true for 'classic'", () => {
+      expect(isExperienceId("classic")).toBe(true);
+    });
+
+    it("should return true for 'modern'", () => {
+      expect(isExperienceId("modern")).toBe(true);
+    });
+
+    it("should return false for invalid string", () => {
+      expect(isExperienceId("invalid")).toBe(false);
+    });
+
+    it("should return false for empty string", () => {
+      expect(isExperienceId("")).toBe(false);
+    });
+
+    it("should return false for null", () => {
+      expect(isExperienceId(null)).toBe(false);
+    });
+
+    it("should return false for undefined", () => {
+      expect(isExperienceId(undefined)).toBe(false);
+    });
+
+    it("should return false for number", () => {
+      expect(isExperienceId(123)).toBe(false);
+    });
+
+    it("should return false for boolean", () => {
+      expect(isExperienceId(true)).toBe(false);
+      expect(isExperienceId(false)).toBe(false);
+    });
+
+    it("should return false for object", () => {
+      expect(isExperienceId({})).toBe(false);
+      expect(isExperienceId({ id: "classic" })).toBe(false);
+    });
+
+    it("should return false for array", () => {
+      expect(isExperienceId([])).toBe(false);
+      expect(isExperienceId(["classic"])).toBe(false);
+    });
+
+    it("should return false for similar but different strings", () => {
+      expect(isExperienceId("Classic")).toBe(false); // case sensitive
+      expect(isExperienceId("CLASSIC")).toBe(false);
+      expect(isExperienceId("Modern")).toBe(false);
+      expect(isExperienceId("MODERN")).toBe(false);
+      expect(isExperienceId(" classic")).toBe(false); // with spaces
+      expect(isExperienceId("classic ")).toBe(false);
+      expect(isExperienceId(" modern ")).toBe(false);
+    });
+
+    it("should work as a type guard", () => {
+      const value: unknown = "classic";
+      if (isExperienceId(value)) {
+        // TypeScript should narrow value to ExperienceId
+        const experienceId: ExperienceId = value;
+        expect(experienceId).toBe("classic");
+      }
+    });
+  });
+
+  describe("toExperienceId", () => {
+    it("should return 'classic' when value is 'classic'", () => {
+      expect(toExperienceId("classic")).toBe("classic");
+    });
+
+    it("should return 'modern' when value is 'modern'", () => {
+      expect(toExperienceId("modern")).toBe("modern");
+    });
+
+    it("should return default 'modern' for invalid value", () => {
+      expect(toExperienceId("invalid")).toBe("modern");
+    });
+
+    it("should return default 'modern' for empty string", () => {
+      expect(toExperienceId("")).toBe("modern");
+    });
+
+    it("should return default 'modern' for null", () => {
+      expect(toExperienceId(null)).toBe("modern");
+    });
+
+    it("should return default 'modern' for undefined", () => {
+      expect(toExperienceId(undefined)).toBe("modern");
+    });
+
+    it("should return default 'modern' for number", () => {
+      expect(toExperienceId(123)).toBe("modern");
+    });
+
+    it("should return default 'modern' for object", () => {
+      expect(toExperienceId({})).toBe("modern");
+    });
+
+    it("should use custom fallback when provided", () => {
+      expect(toExperienceId("invalid", "classic")).toBe("classic");
+    });
+
+    it("should return valid value instead of custom fallback", () => {
+      expect(toExperienceId("modern", "classic")).toBe("modern");
+      expect(toExperienceId("classic", "modern")).toBe("classic");
+    });
+
+    it("should use custom fallback for null with classic fallback", () => {
+      expect(toExperienceId(null, "classic")).toBe("classic");
+    });
+
+    it("should use custom fallback for undefined with classic fallback", () => {
+      expect(toExperienceId(undefined, "classic")).toBe("classic");
+    });
+
+    it("should return default for case-sensitive mismatches", () => {
+      expect(toExperienceId("Classic")).toBe("modern");
+      expect(toExperienceId("MODERN")).toBe("modern");
+    });
+
+    it("should return default for strings with whitespace", () => {
+      expect(toExperienceId(" classic")).toBe("modern");
+      expect(toExperienceId("modern ")).toBe("modern");
+    });
+
+    it("should return type ExperienceId", () => {
+      const result: ExperienceId = toExperienceId("anything");
+      expect(["classic", "modern"]).toContain(result);
+    });
+  });
+
+  describe("defaultExperienceState", () => {
+    it("should have active set to 'modern'", () => {
+      expect(defaultExperienceState.active).toBe("modern");
+    });
+
+    it("should have available experiences array", () => {
+      expect(Array.isArray(defaultExperienceState.available)).toBe(true);
+    });
+
+    it("should include 'classic' in available experiences", () => {
+      expect(defaultExperienceState.available).toContain("classic");
+    });
+
+    it("should include 'modern' in available experiences", () => {
+      expect(defaultExperienceState.available).toContain("modern");
+    });
+
+    it("should have exactly 2 available experiences", () => {
+      expect(defaultExperienceState.available).toHaveLength(2);
+    });
+
+    it("should have switchingEnabled set to true", () => {
+      expect(defaultExperienceState.switchingEnabled).toBe(true);
+    });
+
+    it("should be a valid ExperienceState object", () => {
+      const state: ExperienceState = defaultExperienceState;
+      expect(state).toHaveProperty("active");
+      expect(state).toHaveProperty("available");
+      expect(state).toHaveProperty("switchingEnabled");
+    });
+
+    it("should be immutable (new object on each access)", () => {
+      // The exported constant should be the same reference
+      expect(defaultExperienceState).toBe(defaultExperienceState);
+    });
+
+    it("should have active that is a valid ExperienceId", () => {
+      expect(isExperienceId(defaultExperienceState.active)).toBe(true);
+    });
+
+    it("should have all available items as valid ExperienceIds", () => {
+      defaultExperienceState.available.forEach((exp) => {
+        expect(isExperienceId(exp)).toBe(true);
+      });
+    });
+  });
+
+  describe("type definitions", () => {
+    it("ExperienceId should only allow 'classic' or 'modern'", () => {
+      // Type-level test - these should compile
+      const classic: ExperienceId = "classic";
+      const modern: ExperienceId = "modern";
+
+      expect(classic).toBe("classic");
+      expect(modern).toBe("modern");
+    });
+
+    it("ExperienceState should have expected structure", () => {
+      const state: ExperienceState = {
+        active: "classic",
+        available: ["classic", "modern"],
+        switchingEnabled: false,
+      };
+
+      expect(state.active).toBe("classic");
+      expect(state.available).toEqual(["classic", "modern"]);
+      expect(state.switchingEnabled).toBe(false);
+    });
+  });
+
+  describe("integration between functions", () => {
+    it("toExperienceId should return values that pass isExperienceId", () => {
+      const validInputs = ["classic", "modern"];
+      const invalidInputs = ["invalid", null, undefined, 123, {}, []];
+
+      validInputs.forEach((input) => {
+        const result = toExperienceId(input);
+        expect(isExperienceId(result)).toBe(true);
+      });
+
+      invalidInputs.forEach((input) => {
+        const result = toExperienceId(input);
+        expect(isExperienceId(result)).toBe(true);
+      });
+    });
+
+    it("defaultExperienceState.active should pass isExperienceId", () => {
+      expect(isExperienceId(defaultExperienceState.active)).toBe(true);
+    });
+
+    it("toExperienceId with defaultExperienceState.active as fallback", () => {
+      const result = toExperienceId("invalid", defaultExperienceState.active);
+      expect(result).toBe("modern");
+    });
+  });
+});

--- a/lib/features/experiences/classic/__tests__/theme.test.ts
+++ b/lib/features/experiences/classic/__tests__/theme.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from "vitest";
+import { classicTheme } from "../theme";
+
+describe("classic theme", () => {
+  describe("cssVarPrefix", () => {
+    it("should have cssVarPrefix set to 'wxyc'", () => {
+      expect(classicTheme.cssVarPrefix).toBe("wxyc");
+    });
+
+    it("should be a string", () => {
+      expect(typeof classicTheme.cssVarPrefix).toBe("string");
+    });
+
+    it("should match the base theme prefix", () => {
+      expect(classicTheme.cssVarPrefix).toBe("wxyc");
+    });
+  });
+
+  describe("components", () => {
+    it("should have components property defined", () => {
+      expect(classicTheme.components).toBeDefined();
+    });
+
+    it("should have JoyTooltip component override", () => {
+      expect(classicTheme.components?.JoyTooltip).toBeDefined();
+    });
+
+    describe("JoyTooltip", () => {
+      it("should have styleOverrides property", () => {
+        expect(
+          classicTheme.components?.JoyTooltip?.styleOverrides
+        ).toBeDefined();
+      });
+
+      it("should have root styleOverride", () => {
+        expect(
+          classicTheme.components?.JoyTooltip?.styleOverrides?.root
+        ).toBeDefined();
+      });
+
+      it("should set root zIndex to 10000", () => {
+        const rootOverrides = classicTheme.components?.JoyTooltip?.styleOverrides
+          ?.root as { zIndex: number };
+        expect(rootOverrides).toBeDefined();
+        expect(rootOverrides.zIndex).toBe(10000);
+      });
+
+      it("should have zIndex as a number", () => {
+        const rootOverrides = classicTheme.components?.JoyTooltip?.styleOverrides
+          ?.root as { zIndex: number };
+        expect(typeof rootOverrides.zIndex).toBe("number");
+      });
+    });
+  });
+
+  describe("fontFamily", () => {
+    it("should have fontFamily property defined", () => {
+      expect(classicTheme.fontFamily).toBeDefined();
+    });
+
+    it("should have display font family", () => {
+      expect(classicTheme.fontFamily?.display).toBeDefined();
+    });
+
+    it("should have body font family", () => {
+      expect(classicTheme.fontFamily?.body).toBeDefined();
+    });
+
+    it("should use Arial as display font", () => {
+      expect(classicTheme.fontFamily?.display).toBe(
+        "Arial, Helvetica, sans-serif"
+      );
+    });
+
+    it("should use Arial as body font", () => {
+      expect(classicTheme.fontFamily?.body).toBe(
+        "Arial, Helvetica, sans-serif"
+      );
+    });
+
+    it("should have consistent display and body fonts", () => {
+      expect(classicTheme.fontFamily?.display).toBe(classicTheme.fontFamily?.body);
+    });
+
+    it("should include fallback fonts in display", () => {
+      expect(classicTheme.fontFamily?.display).toContain("Helvetica");
+      expect(classicTheme.fontFamily?.display).toContain("sans-serif");
+    });
+
+    it("should include fallback fonts in body", () => {
+      expect(classicTheme.fontFamily?.body).toContain("Helvetica");
+      expect(classicTheme.fontFamily?.body).toContain("sans-serif");
+    });
+  });
+
+  describe("typography", () => {
+    it("should have typography property defined", () => {
+      expect(classicTheme.typography).toBeDefined();
+    });
+
+    describe("h1", () => {
+      it("should be defined", () => {
+        expect(classicTheme.typography?.h1).toBeDefined();
+      });
+
+      it("should have Verdana font family", () => {
+        const h1 = classicTheme.typography?.h1 as { fontFamily: string };
+        expect(h1.fontFamily).toBe("Verdana, Geneva, Arial, Helvetica, sans-serif");
+      });
+
+      it("should have bold font weight", () => {
+        const h1 = classicTheme.typography?.h1 as { fontWeight: string };
+        expect(h1.fontWeight).toBe("bold");
+      });
+
+      it("should include multiple fallback fonts", () => {
+        const h1 = classicTheme.typography?.h1 as { fontFamily: string };
+        expect(h1.fontFamily).toContain("Geneva");
+        expect(h1.fontFamily).toContain("Arial");
+        expect(h1.fontFamily).toContain("Helvetica");
+        expect(h1.fontFamily).toContain("sans-serif");
+      });
+    });
+
+    describe("h2", () => {
+      it("should be defined", () => {
+        expect(classicTheme.typography?.h2).toBeDefined();
+      });
+
+      it("should have Verdana font family", () => {
+        const h2 = classicTheme.typography?.h2 as { fontFamily: string };
+        expect(h2.fontFamily).toBe("Verdana, Geneva, Arial, Helvetica, sans-serif");
+      });
+
+      it("should have bold font weight", () => {
+        const h2 = classicTheme.typography?.h2 as { fontWeight: string };
+        expect(h2.fontWeight).toBe("bold");
+      });
+    });
+
+    describe("h3", () => {
+      it("should be defined", () => {
+        expect(classicTheme.typography?.h3).toBeDefined();
+      });
+
+      it("should have Verdana font family", () => {
+        const h3 = classicTheme.typography?.h3 as { fontFamily: string };
+        expect(h3.fontFamily).toBe("Verdana, Geneva, Arial, Helvetica, sans-serif");
+      });
+
+      it("should have bold font weight", () => {
+        const h3 = classicTheme.typography?.h3 as { fontWeight: string };
+        expect(h3.fontWeight).toBe("bold");
+      });
+    });
+
+    describe("h4", () => {
+      it("should be defined", () => {
+        expect(classicTheme.typography?.h4).toBeDefined();
+      });
+
+      it("should have Verdana font family", () => {
+        const h4 = classicTheme.typography?.h4 as { fontFamily: string };
+        expect(h4.fontFamily).toBe("Verdana, Geneva, Arial, Helvetica, sans-serif");
+      });
+
+      it("should have bold font weight", () => {
+        const h4 = classicTheme.typography?.h4 as { fontWeight: string };
+        expect(h4.fontWeight).toBe("bold");
+      });
+    });
+
+    describe("heading consistency", () => {
+      it("should have same font family for all headings", () => {
+        const h1 = classicTheme.typography?.h1 as { fontFamily: string };
+        const h2 = classicTheme.typography?.h2 as { fontFamily: string };
+        const h3 = classicTheme.typography?.h3 as { fontFamily: string };
+        const h4 = classicTheme.typography?.h4 as { fontFamily: string };
+
+        expect(h1.fontFamily).toBe(h2.fontFamily);
+        expect(h2.fontFamily).toBe(h3.fontFamily);
+        expect(h3.fontFamily).toBe(h4.fontFamily);
+      });
+
+      it("should have same font weight for all headings", () => {
+        const h1 = classicTheme.typography?.h1 as { fontWeight: string };
+        const h2 = classicTheme.typography?.h2 as { fontWeight: string };
+        const h3 = classicTheme.typography?.h3 as { fontWeight: string };
+        const h4 = classicTheme.typography?.h4 as { fontWeight: string };
+
+        expect(h1.fontWeight).toBe("bold");
+        expect(h2.fontWeight).toBe("bold");
+        expect(h3.fontWeight).toBe("bold");
+        expect(h4.fontWeight).toBe("bold");
+      });
+
+      it("should use different fonts for headings vs body", () => {
+        const h1 = classicTheme.typography?.h1 as { fontFamily: string };
+        expect(h1.fontFamily).not.toBe(classicTheme.fontFamily?.body);
+      });
+    });
+
+    describe("body-xxs variant", () => {
+      it("should NOT have body-xxs variant (classic-specific)", () => {
+        expect(classicTheme.typography?.["body-xxs"]).toBeUndefined();
+      });
+    });
+  });
+
+  describe("color schemes", () => {
+    it("should not define custom light color scheme", () => {
+      // Classic theme relies on default MUI Joy color schemes
+      // and CSS for styling
+      const lightPalette = classicTheme.colorSchemes?.light?.palette;
+      // Classic may or may not have custom palettes defined
+      // The key is it doesn't override them extensively like modern
+      expect(classicTheme.colorSchemes).toBeDefined();
+    });
+  });
+
+  describe("theme structure", () => {
+    it("should be a valid object", () => {
+      expect(typeof classicTheme).toBe("object");
+      expect(classicTheme).not.toBeNull();
+    });
+
+    it("should have required MUI Joy theme properties", () => {
+      expect(classicTheme).toHaveProperty("cssVarPrefix");
+      expect(classicTheme).toHaveProperty("components");
+      expect(classicTheme).toHaveProperty("fontFamily");
+      expect(classicTheme).toHaveProperty("typography");
+    });
+  });
+
+  describe("default export", () => {
+    it("should export classicTheme as default", async () => {
+      const module = await import("../theme");
+      expect(module.default).toBe(classicTheme);
+    });
+
+    it("should export classicTheme as named export", async () => {
+      const module = await import("../theme");
+      expect(module.classicTheme).toBeDefined();
+      expect(module.classicTheme).toBe(classicTheme);
+    });
+  });
+});
+
+describe("classic theme legacy support", () => {
+  it("should use web-safe fonts for legacy browser compatibility", () => {
+    // Arial, Helvetica are web-safe fonts
+    expect(classicTheme.fontFamily?.display).toContain("Arial");
+    expect(classicTheme.fontFamily?.body).toContain("Arial");
+  });
+
+  it("should use Verdana for headings (web-safe)", () => {
+    const h1 = classicTheme.typography?.h1 as { fontFamily: string };
+    expect(h1.fontFamily).toContain("Verdana");
+  });
+
+  it("should have extensive font fallback chains", () => {
+    const h1 = classicTheme.typography?.h1 as { fontFamily: string };
+    const fontCount = h1.fontFamily.split(",").length;
+    expect(fontCount).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/lib/features/experiences/classic/__tests__/theme.test.ts
+++ b/lib/features/experiences/classic/__tests__/theme.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { classicTheme } from "../theme";
+import type { CssVarsThemeOptions, Theme } from "@mui/joy/styles";
+import { classicTheme as _classicTheme } from "../theme";
+
+// extendTheme returns Theme, but the type omits 'components' even though
+// it exists at runtime. This intersection restores access for testing.
+type ThemeWithComponents = Theme &
+  Pick<Required<CssVarsThemeOptions>, "components">;
+
+const classicTheme = _classicTheme as ThemeWithComponents;
 
 describe("classic theme", () => {
   describe("cssVarPrefix", () => {

--- a/lib/features/experiences/modern/__tests__/theme.test.ts
+++ b/lib/features/experiences/modern/__tests__/theme.test.ts
@@ -1,0 +1,503 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+
+// Mock next/font/google before importing the theme
+vi.mock("next/font/google", () => ({
+  Kanit: () => ({
+    style: {
+      fontFamily: "Kanit, sans-serif",
+    },
+  }),
+}));
+
+// Mock next/font/local before importing the theme
+vi.mock("next/font/local", () => ({
+  default: () => ({
+    style: {
+      fontFamily: "Minbus, sans-serif",
+    },
+  }),
+}));
+
+// Import after mocking
+import { modernTheme } from "../theme";
+
+describe("modern theme", () => {
+  describe("cssVarPrefix", () => {
+    it("should have cssVarPrefix set to 'wxyc'", () => {
+      expect(modernTheme.cssVarPrefix).toBe("wxyc");
+    });
+
+    it("should be a string", () => {
+      expect(typeof modernTheme.cssVarPrefix).toBe("string");
+    });
+
+    it("should match the base theme prefix", () => {
+      expect(modernTheme.cssVarPrefix).toBe("wxyc");
+    });
+  });
+
+  describe("components", () => {
+    it("should have components property defined", () => {
+      expect(modernTheme.components).toBeDefined();
+    });
+
+    it("should have JoyTooltip component override", () => {
+      expect(modernTheme.components?.JoyTooltip).toBeDefined();
+    });
+
+    describe("JoyTooltip", () => {
+      it("should have styleOverrides property", () => {
+        expect(modernTheme.components?.JoyTooltip?.styleOverrides).toBeDefined();
+      });
+
+      it("should have root styleOverride", () => {
+        expect(
+          modernTheme.components?.JoyTooltip?.styleOverrides?.root
+        ).toBeDefined();
+      });
+
+      it("should set root zIndex to 10000", () => {
+        const rootOverrides = modernTheme.components?.JoyTooltip?.styleOverrides
+          ?.root as { zIndex: number };
+        expect(rootOverrides).toBeDefined();
+        expect(rootOverrides.zIndex).toBe(10000);
+      });
+    });
+  });
+
+  describe("fontFamily", () => {
+    it("should have fontFamily property defined", () => {
+      expect(modernTheme.fontFamily).toBeDefined();
+    });
+
+    it("should have display font family", () => {
+      expect(modernTheme.fontFamily?.display).toBeDefined();
+    });
+
+    it("should have body font family", () => {
+      expect(modernTheme.fontFamily?.body).toBeDefined();
+    });
+
+    it("should use Kanit-based font for display (from mock)", () => {
+      expect(modernTheme.fontFamily?.display).toBe("Kanit, sans-serif");
+    });
+
+    it("should use Kanit-based font for body (from mock)", () => {
+      expect(modernTheme.fontFamily?.body).toBe("Kanit, sans-serif");
+    });
+
+    it("should have consistent display and body fonts", () => {
+      expect(modernTheme.fontFamily?.display).toBe(modernTheme.fontFamily?.body);
+    });
+  });
+
+  describe("typography", () => {
+    it("should have typography property defined", () => {
+      expect(modernTheme.typography).toBeDefined();
+    });
+
+    describe("h1", () => {
+      it("should be defined", () => {
+        expect(modernTheme.typography?.h1).toBeDefined();
+      });
+
+      it("should have font family from local font (Minbus mock)", () => {
+        const h1 = modernTheme.typography?.h1 as { fontFamily: string };
+        expect(h1.fontFamily).toBe("Minbus, sans-serif");
+      });
+
+      it("should have font weight of 100", () => {
+        const h1 = modernTheme.typography?.h1 as { fontWeight: string };
+        expect(h1.fontWeight).toBe("100");
+      });
+
+      it("should have font size of 4.5rem", () => {
+        const h1 = modernTheme.typography?.h1 as { fontSize: string };
+        expect(h1.fontSize).toBe("4.5rem");
+      });
+    });
+
+    describe("h2", () => {
+      it("should be defined", () => {
+        expect(modernTheme.typography?.h2).toBeDefined();
+      });
+
+      it("should have font family from local font", () => {
+        const h2 = modernTheme.typography?.h2 as { fontFamily: string };
+        expect(h2.fontFamily).toBe("Minbus, sans-serif");
+      });
+
+      it("should have font weight of 100", () => {
+        const h2 = modernTheme.typography?.h2 as { fontWeight: string };
+        expect(h2.fontWeight).toBe("100");
+      });
+
+      it("should have font size of 3.75rem", () => {
+        const h2 = modernTheme.typography?.h2 as { fontSize: string };
+        expect(h2.fontSize).toBe("3.75rem");
+      });
+    });
+
+    describe("h3", () => {
+      it("should be defined", () => {
+        expect(modernTheme.typography?.h3).toBeDefined();
+      });
+
+      it("should have font family from local font", () => {
+        const h3 = modernTheme.typography?.h3 as { fontFamily: string };
+        expect(h3.fontFamily).toBe("Minbus, sans-serif");
+      });
+
+      it("should have font weight of 100", () => {
+        const h3 = modernTheme.typography?.h3 as { fontWeight: string };
+        expect(h3.fontWeight).toBe("100");
+      });
+
+      it("should have font size of 3rem", () => {
+        const h3 = modernTheme.typography?.h3 as { fontSize: string };
+        expect(h3.fontSize).toBe("3rem");
+      });
+    });
+
+    describe("h4", () => {
+      it("should be defined", () => {
+        expect(modernTheme.typography?.h4).toBeDefined();
+      });
+
+      it("should have font family from local font", () => {
+        const h4 = modernTheme.typography?.h4 as { fontFamily: string };
+        expect(h4.fontFamily).toBe("Minbus, sans-serif");
+      });
+
+      it("should have font weight of 100", () => {
+        const h4 = modernTheme.typography?.h4 as { fontWeight: string };
+        expect(h4.fontWeight).toBe("100");
+      });
+
+      it("should have font size of 2.125rem", () => {
+        const h4 = modernTheme.typography?.h4 as { fontSize: string };
+        expect(h4.fontSize).toBe("2.125rem");
+      });
+    });
+
+    describe("heading consistency", () => {
+      it("should have same font family for all headings", () => {
+        const h1 = modernTheme.typography?.h1 as { fontFamily: string };
+        const h2 = modernTheme.typography?.h2 as { fontFamily: string };
+        const h3 = modernTheme.typography?.h3 as { fontFamily: string };
+        const h4 = modernTheme.typography?.h4 as { fontFamily: string };
+
+        expect(h1.fontFamily).toBe(h2.fontFamily);
+        expect(h2.fontFamily).toBe(h3.fontFamily);
+        expect(h3.fontFamily).toBe(h4.fontFamily);
+      });
+
+      it("should have same font weight for all headings", () => {
+        const h1 = modernTheme.typography?.h1 as { fontWeight: string };
+        const h2 = modernTheme.typography?.h2 as { fontWeight: string };
+        const h3 = modernTheme.typography?.h3 as { fontWeight: string };
+        const h4 = modernTheme.typography?.h4 as { fontWeight: string };
+
+        expect(h1.fontWeight).toBe("100");
+        expect(h2.fontWeight).toBe("100");
+        expect(h3.fontWeight).toBe("100");
+        expect(h4.fontWeight).toBe("100");
+      });
+
+      it("should have decreasing font sizes from h1 to h4", () => {
+        const h1 = modernTheme.typography?.h1 as { fontSize: string };
+        const h2 = modernTheme.typography?.h2 as { fontSize: string };
+        const h3 = modernTheme.typography?.h3 as { fontSize: string };
+        const h4 = modernTheme.typography?.h4 as { fontSize: string };
+
+        const parseRem = (value: string) => parseFloat(value.replace("rem", ""));
+
+        expect(parseRem(h1.fontSize)).toBeGreaterThan(parseRem(h2.fontSize));
+        expect(parseRem(h2.fontSize)).toBeGreaterThan(parseRem(h3.fontSize));
+        expect(parseRem(h3.fontSize)).toBeGreaterThan(parseRem(h4.fontSize));
+      });
+    });
+
+    describe("body-xxs variant", () => {
+      it("should have body-xxs variant defined", () => {
+        expect(modernTheme.typography?.["body-xxs"]).toBeDefined();
+      });
+
+      it("should have body-xxs font family from body font", () => {
+        const bodyXxs = modernTheme.typography?.["body-xxs"] as {
+          fontFamily: string;
+        };
+        expect(bodyXxs.fontFamily).toBe("Kanit, sans-serif");
+      });
+
+      it("should have body-xxs font size of 0.6rem", () => {
+        const bodyXxs = modernTheme.typography?.["body-xxs"] as {
+          fontSize: string;
+        };
+        expect(bodyXxs.fontSize).toBe("0.6rem");
+      });
+
+      it("should have body-xxs smaller than standard body", () => {
+        const bodyXxs = modernTheme.typography?.["body-xxs"] as {
+          fontSize: string;
+        };
+        // 0.6rem is smaller than 1rem (default body size)
+        const fontSize = parseFloat(bodyXxs.fontSize.replace("rem", ""));
+        expect(fontSize).toBeLessThan(1);
+      });
+    });
+  });
+
+  describe("colorSchemes", () => {
+    it("should have colorSchemes property defined", () => {
+      expect(modernTheme.colorSchemes).toBeDefined();
+    });
+
+    describe("light color scheme", () => {
+      it("should have light color scheme", () => {
+        expect(modernTheme.colorSchemes?.light).toBeDefined();
+      });
+
+      it("should have light palette", () => {
+        expect(modernTheme.colorSchemes?.light?.palette).toBeDefined();
+      });
+
+      describe("primary palette", () => {
+        it("should have primary palette", () => {
+          expect(modernTheme.colorSchemes?.light?.palette?.primary).toBeDefined();
+        });
+
+        it("should have all shades (50-900)", () => {
+          const primary = modernTheme.colorSchemes?.light?.palette?.primary as Record<string, string>;
+          const shades = ["50", "100", "200", "300", "400", "500", "600", "700", "800", "900"];
+          shades.forEach((shade) => {
+            expect(primary[shade]).toBeDefined();
+          });
+        });
+
+        it("should have hex color values", () => {
+          const primary = modernTheme.colorSchemes?.light?.palette?.primary as Record<string, string>;
+          // Check that values look like hex colors (may start with #)
+          Object.values(primary).forEach((color) => {
+            expect(typeof color).toBe("string");
+            expect(color.length).toBeGreaterThan(0);
+          });
+        });
+
+        it("should have primary-500 as the main brand color", () => {
+          const primary = modernTheme.colorSchemes?.light?.palette?.primary as Record<string, string>;
+          expect(primary["500"]).toBe("#f43f5e"); // Rose color
+        });
+      });
+
+      describe("success palette", () => {
+        it("should have success palette", () => {
+          expect(modernTheme.colorSchemes?.light?.palette?.success).toBeDefined();
+        });
+
+        it("should have all shades (50-900)", () => {
+          const success = modernTheme.colorSchemes?.light?.palette?.success as Record<string, string>;
+          const shades = ["50", "100", "200", "300", "400", "500", "600", "700", "800", "900"];
+          shades.forEach((shade) => {
+            expect(success[shade]).toBeDefined();
+          });
+        });
+
+        it("should have success-500 as teal color", () => {
+          const success = modernTheme.colorSchemes?.light?.palette?.success as Record<string, string>;
+          expect(success["500"]).toBe("#009688");
+        });
+      });
+
+      describe("warning palette", () => {
+        it("should have warning palette", () => {
+          expect(modernTheme.colorSchemes?.light?.palette?.warning).toBeDefined();
+        });
+
+        it("should have all shades (50-900)", () => {
+          const warning = modernTheme.colorSchemes?.light?.palette?.warning as Record<string, string>;
+          const shades = ["50", "100", "200", "300", "400", "500", "600", "700", "800", "900"];
+          shades.forEach((shade) => {
+            expect(warning[shade]).toBeDefined();
+          });
+        });
+      });
+
+      describe("danger palette", () => {
+        it("should have danger palette", () => {
+          expect(modernTheme.colorSchemes?.light?.palette?.danger).toBeDefined();
+        });
+
+        it("should have all shades (50-900)", () => {
+          const danger = modernTheme.colorSchemes?.light?.palette?.danger as Record<string, string>;
+          const shades = ["50", "100", "200", "300", "400", "500", "600", "700", "800", "900"];
+          shades.forEach((shade) => {
+            expect(danger[shade]).toBeDefined();
+          });
+        });
+      });
+    });
+
+    describe("dark color scheme", () => {
+      it("should have dark color scheme", () => {
+        expect(modernTheme.colorSchemes?.dark).toBeDefined();
+      });
+
+      it("should have dark palette", () => {
+        expect(modernTheme.colorSchemes?.dark?.palette).toBeDefined();
+      });
+
+      describe("primary palette", () => {
+        it("should have primary palette", () => {
+          expect(modernTheme.colorSchemes?.dark?.palette?.primary).toBeDefined();
+        });
+
+        it("should have all shades (50-900)", () => {
+          const primary = modernTheme.colorSchemes?.dark?.palette?.primary as Record<string, string>;
+          const shades = ["50", "100", "200", "300", "400", "500", "600", "700", "800", "900"];
+          shades.forEach((shade) => {
+            expect(primary[shade]).toBeDefined();
+          });
+        });
+
+        it("should have different primary colors than light mode", () => {
+          const lightPrimary = modernTheme.colorSchemes?.light?.palette?.primary as Record<string, string>;
+          const darkPrimary = modernTheme.colorSchemes?.dark?.palette?.primary as Record<string, string>;
+          expect(lightPrimary["500"]).not.toBe(darkPrimary["500"]);
+        });
+      });
+
+      describe("success palette", () => {
+        it("should have success palette", () => {
+          expect(modernTheme.colorSchemes?.dark?.palette?.success).toBeDefined();
+        });
+
+        it("should have all shades (50-900)", () => {
+          const success = modernTheme.colorSchemes?.dark?.palette?.success as Record<string, string>;
+          const shades = ["50", "100", "200", "300", "400", "500", "600", "700", "800", "900"];
+          shades.forEach((shade) => {
+            expect(success[shade]).toBeDefined();
+          });
+        });
+      });
+
+      describe("danger palette", () => {
+        it("should have danger palette", () => {
+          expect(modernTheme.colorSchemes?.dark?.palette?.danger).toBeDefined();
+        });
+
+        it("should have all shades (50-900)", () => {
+          const danger = modernTheme.colorSchemes?.dark?.palette?.danger as Record<string, string>;
+          const shades = ["50", "100", "200", "300", "400", "500", "600", "700", "800", "900"];
+          shades.forEach((shade) => {
+            expect(danger[shade]).toBeDefined();
+          });
+        });
+      });
+    });
+
+    describe("color scheme contrast", () => {
+      it("should have lighter colors for light-50 than light-900", () => {
+        const primary = modernTheme.colorSchemes?.light?.palette?.primary as Record<string, string>;
+        // 50 shade should be lighter (more F's in hex) than 900
+        expect(primary["50"]).toBeDefined();
+        expect(primary["900"]).toBeDefined();
+      });
+    });
+  });
+
+  describe("theme structure", () => {
+    it("should be a valid object", () => {
+      expect(typeof modernTheme).toBe("object");
+      expect(modernTheme).not.toBeNull();
+    });
+
+    it("should have required MUI Joy theme properties", () => {
+      expect(modernTheme).toHaveProperty("cssVarPrefix");
+      expect(modernTheme).toHaveProperty("components");
+      expect(modernTheme).toHaveProperty("fontFamily");
+      expect(modernTheme).toHaveProperty("typography");
+      expect(modernTheme).toHaveProperty("colorSchemes");
+    });
+  });
+
+  describe("default export", () => {
+    it("should export modernTheme as default", async () => {
+      const module = await import("../theme");
+      expect(module.default).toBe(modernTheme);
+    });
+
+    it("should export modernTheme as named export", async () => {
+      const module = await import("../theme");
+      expect(module.modernTheme).toBeDefined();
+      expect(module.modernTheme).toBe(modernTheme);
+    });
+  });
+});
+
+describe("modern theme color values", () => {
+  describe("light mode specific colors", () => {
+    it("should have rose-based primary colors", () => {
+      const primary = modernTheme.colorSchemes?.light?.palette?.primary as Record<string, string>;
+      // Rose-500 is #f43f5e
+      expect(primary["500"]).toBe("#f43f5e");
+    });
+
+    it("should have teal-based success colors", () => {
+      const success = modernTheme.colorSchemes?.light?.palette?.success as Record<string, string>;
+      expect(success["500"]).toBe("#009688");
+    });
+
+    it("should have stone-based warning colors", () => {
+      const warning = modernTheme.colorSchemes?.light?.palette?.warning as Record<string, string>;
+      // Stone-500 is #78716c
+      expect(warning["500"]).toBe("#78716c");
+    });
+
+    it("should have fuchsia-based danger colors", () => {
+      const danger = modernTheme.colorSchemes?.light?.palette?.danger as Record<string, string>;
+      // Fuchsia-500 is #d946ef
+      expect(danger["500"]).toBe("#d946ef");
+    });
+  });
+
+  describe("dark mode specific colors", () => {
+    it("should have adjusted primary colors for dark mode", () => {
+      const primary = modernTheme.colorSchemes?.dark?.palette?.primary as Record<string, string>;
+      expect(primary["500"]).toBe("#a6274e");
+    });
+
+    it("should have indigo-based danger colors in dark mode", () => {
+      const danger = modernTheme.colorSchemes?.dark?.palette?.danger as Record<string, string>;
+      // Indigo-500 is #6366f1
+      expect(danger["500"]).toBe("#6366f1");
+    });
+
+    it("should have adjusted success colors for dark mode", () => {
+      const success = modernTheme.colorSchemes?.dark?.palette?.success as Record<string, string>;
+      expect(success["500"]).toBe("#126e76");
+    });
+  });
+});
+
+describe("modern theme typography scale", () => {
+  it("should follow a consistent type scale", () => {
+    const h1 = modernTheme.typography?.h1 as { fontSize: string };
+    const h2 = modernTheme.typography?.h2 as { fontSize: string };
+    const h3 = modernTheme.typography?.h3 as { fontSize: string };
+    const h4 = modernTheme.typography?.h4 as { fontSize: string };
+
+    // Verify the specific scale
+    expect(h1.fontSize).toBe("4.5rem");
+    expect(h2.fontSize).toBe("3.75rem");
+    expect(h3.fontSize).toBe("3rem");
+    expect(h4.fontSize).toBe("2.125rem");
+  });
+
+  it("should use light font weight for modern aesthetic", () => {
+    const h1 = modernTheme.typography?.h1 as { fontWeight: string };
+
+    // Modern theme uses light font weight (100) vs classic bold
+    expect(h1.fontWeight).toBe("100");
+  });
+});

--- a/lib/features/experiences/modern/__tests__/theme.test.ts
+++ b/lib/features/experiences/modern/__tests__/theme.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect, vi, beforeAll } from "vitest";
+import type { CssVarsThemeOptions, Theme } from "@mui/joy/styles";
+
+// extendTheme returns Theme, but the type omits 'components' even though
+// it exists at runtime. This intersection restores access for testing.
+type ThemeWithComponents = Theme &
+  Pick<Required<CssVarsThemeOptions>, "components">;
 
 // Mock next/font/google before importing the theme
 vi.mock("next/font/google", () => ({
@@ -19,7 +25,9 @@ vi.mock("next/font/local", () => ({
 }));
 
 // Import after mocking
-import { modernTheme } from "../theme";
+import { modernTheme as _modernTheme } from "../theme";
+
+const modernTheme = _modernTheme as ThemeWithComponents;
 
 describe("modern theme", () => {
   describe("cssVarPrefix", () => {

--- a/lib/features/experiences/shared/__tests__/base-theme.test.ts
+++ b/lib/features/experiences/shared/__tests__/base-theme.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { baseTheme } from "../base-theme";
+
+describe("base-theme", () => {
+  describe("cssVarPrefix", () => {
+    it("should have cssVarPrefix set to 'wxyc'", () => {
+      expect(baseTheme.cssVarPrefix).toBe("wxyc");
+    });
+
+    it("should be a string", () => {
+      expect(typeof baseTheme.cssVarPrefix).toBe("string");
+    });
+  });
+
+  describe("components", () => {
+    it("should have components property defined", () => {
+      expect(baseTheme.components).toBeDefined();
+    });
+
+    it("should have JoyTooltip component override", () => {
+      expect(baseTheme.components?.JoyTooltip).toBeDefined();
+    });
+
+    describe("JoyTooltip", () => {
+      it("should have styleOverrides property", () => {
+        expect(baseTheme.components?.JoyTooltip?.styleOverrides).toBeDefined();
+      });
+
+      it("should have root styleOverride", () => {
+        expect(
+          baseTheme.components?.JoyTooltip?.styleOverrides?.root
+        ).toBeDefined();
+      });
+
+      it("should set root zIndex to 10000", () => {
+        const rootOverrides = baseTheme.components?.JoyTooltip?.styleOverrides
+          ?.root as { zIndex: number };
+        expect(rootOverrides).toBeDefined();
+        expect(rootOverrides.zIndex).toBe(10000);
+      });
+
+      it("should have zIndex as a number", () => {
+        const rootOverrides = baseTheme.components?.JoyTooltip?.styleOverrides
+          ?.root as { zIndex: number };
+        expect(typeof rootOverrides.zIndex).toBe("number");
+      });
+
+      it("should have zIndex greater than typical modal zIndex (1000)", () => {
+        const rootOverrides = baseTheme.components?.JoyTooltip?.styleOverrides
+          ?.root as { zIndex: number };
+        expect(rootOverrides.zIndex).toBeGreaterThan(1000);
+      });
+    });
+  });
+
+  describe("theme structure", () => {
+    it("should be a valid object", () => {
+      expect(typeof baseTheme).toBe("object");
+      expect(baseTheme).not.toBeNull();
+    });
+
+    it("should have required MUI Joy theme properties", () => {
+      expect(baseTheme).toHaveProperty("cssVarPrefix");
+      expect(baseTheme).toHaveProperty("components");
+    });
+
+    it("should be a frozen/immutable theme object", () => {
+      // MUI Joy themes created with extendTheme are objects
+      expect(typeof baseTheme).toBe("object");
+    });
+  });
+
+  describe("default export", () => {
+    it("should export baseTheme as default", async () => {
+      const module = await import("../base-theme");
+      expect(module.default).toBe(baseTheme);
+    });
+
+    it("should export baseTheme as named export", async () => {
+      const module = await import("../base-theme");
+      expect(module.baseTheme).toBeDefined();
+      expect(module.baseTheme).toBe(baseTheme);
+    });
+  });
+});
+
+describe("base-theme consistency", () => {
+  it("should maintain consistent tooltip zIndex value", () => {
+    const expectedZIndex = 10000;
+    const rootOverrides = baseTheme.components?.JoyTooltip?.styleOverrides
+      ?.root as { zIndex: number };
+    expect(rootOverrides.zIndex).toBe(expectedZIndex);
+  });
+
+  it("should maintain consistent cssVarPrefix value", () => {
+    const expectedPrefix = "wxyc";
+    expect(baseTheme.cssVarPrefix).toBe(expectedPrefix);
+  });
+});

--- a/lib/features/experiences/shared/__tests__/base-theme.test.ts
+++ b/lib/features/experiences/shared/__tests__/base-theme.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { baseTheme } from "../base-theme";
+import type { CssVarsThemeOptions, Theme } from "@mui/joy/styles";
+import { baseTheme as _baseTheme } from "../base-theme";
+
+// extendTheme returns Theme, but the type omits 'components' even though
+// it exists at runtime. This intersection restores access for testing.
+type ThemeWithComponents = Theme &
+  Pick<Required<CssVarsThemeOptions>, "components">;
+
+const baseTheme = _baseTheme as ThemeWithComponents;
 
 describe("base-theme", () => {
   describe("cssVarPrefix", () => {


### PR DESCRIPTION
Closes #252

## Summary

Add ~280 tests covering the experiences framework — the system that lets users switch between classic and modern UI modes:

- **Experience hooks** — `useActiveExperience`, `useExperienceConfig`, `useIsExperience`, `useExperienceFeatures`, and hook composition
- **Registry** — `EXPERIENCE_REGISTRY`, `getExperienceConfig`, `getEnabledExperiences`, `isExperienceEnabled`, `getDefaultExperience`, `getAllowedExperiences`, `isExperienceSwitchingAllowed`
- **Theme utilities** — `baseTheme` shared properties, cross-theme consistency, and theme difference assertions
- **Classic theme** — Classic-specific overrides and palette
- **Modern theme** — Modern-specific overrides and palette
- **Shared base theme** — Foundation theme values inherited by both modes

## Test plan
- [x] Run `npm test lib/__tests__/features/experiences/`

**Part 7 of 26**