### PR TITLE
test: add catalog, bin, admin, and DJ hooks tests

### DIFF
--- a/src/hooks/adminHooks.test.tsx
+++ b/src/hooks/adminHooks.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useAccountListResults } from "./adminHooks";
+import { adminSlice } from "@/lib/features/admin/frontend";
+import { createHookWrapperFactory } from "@/lib/test-utils";
+
+// Mock authClient
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: {
+    admin: {
+      listUsers: vi.fn(() =>
+        Promise.resolve({
+          data: {
+            users: [
+              { id: "user-1", name: "Test User", email: "test@example.com", realName: "Real Name", djName: "DJ Test", role: "member" },
+              { id: "user-2", name: "Admin User", email: "admin@example.com", realName: "Admin Real", djName: "DJ Admin", role: "admin" },
+            ],
+          },
+          error: null,
+        })
+      ),
+    },
+    organization: {
+      getFullOrganization: vi.fn(() => Promise.resolve({ data: { id: "org-1" } })),
+      listMembers: vi.fn(() =>
+        Promise.resolve({
+          data: { members: [{ userId: "user-1", role: "member" }, { userId: "user-2", role: "admin" }] },
+          error: null,
+        })
+      ),
+    },
+  },
+}));
+
+// Mock conversions
+vi.mock("@/lib/features/admin/conversions-better-auth", () => ({
+  convertBetterAuthToAccountResult: vi.fn((user) => ({
+    id: user.id,
+    userName: user.email || user.name,
+    realName: user.realName || "",
+    djName: user.djName || "",
+    role: user.role,
+  })),
+}));
+
+const createWrapper = createHookWrapperFactory({ admin: adminSlice });
+
+describe("adminHooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useAccountListResults", () => {
+    it("should initially be loading", () => {
+      const { result } = renderHook(() => useAccountListResults(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it("should return accounts after loading", async () => {
+      const { result } = renderHook(() => useAccountListResults(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.data).toHaveLength(2);
+    });
+
+    it("should provide refetch function", async () => {
+      const { result } = renderHook(() => useAccountListResults(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(typeof result.current.refetch).toBe("function");
+    });
+
+    it("should return isError status", async () => {
+      const { result } = renderHook(() => useAccountListResults(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.isError).toBe(false);
+    });
+
+    it("should filter accounts by search string", async () => {
+      const { result } = renderHook(() => useAccountListResults(), {
+        wrapper: createWrapper({ admin: { searchString: "admin" } }),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Should filter to only admin user
+      expect(result.current.data.some((a) => a.userName.includes("admin"))).toBe(
+        true
+      );
+    });
+
+    it("should return error state on fetch failure", async () => {
+      // Override mock to return error
+      const { authClient } = await import("@/lib/features/authentication/client");
+      vi.mocked(authClient.admin.listUsers).mockResolvedValueOnce({
+        data: null,
+        error: { message: "Failed to fetch" },
+      } as any);
+
+      const { result } = renderHook(() => useAccountListResults(), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/src/hooks/artwork/artwork.test.ts
+++ b/src/hooks/artwork/artwork.test.ts
@@ -1,0 +1,469 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import getArtworkFromDiscogs from "./discogs-image";
+import getArtworkFromItunes from "./itunes-image";
+import getArtworkFromLastFM, { getSongInfoFromLastFM } from "./last-fm-image";
+
+// Mock sonner
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+describe("artwork hooks", () => {
+  const originalFetch = global.fetch;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.DISCOGS_CONSUMER_KEY = "test-discogs-key";
+    process.env.DISCOGS_CONSUMER_SECRET = "test-discogs-secret";
+    process.env.LAST_FM_KEY = "test-lastfm-key";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env = { ...originalEnv };
+  });
+
+  describe("getArtworkFromDiscogs", () => {
+    it("should return cover image when found", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [{ cover_image: "https://discogs.com/artwork.jpg" }],
+          }),
+      });
+
+      const result = await getArtworkFromDiscogs({
+        title: "Test Album",
+        artist: "Test Artist",
+      });
+
+      expect(result).toBe("https://discogs.com/artwork.jpg");
+    });
+
+    it("should return null when no results", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      });
+
+      const result = await getArtworkFromDiscogs({
+        title: "Unknown Album",
+        artist: "Unknown Artist",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when response is not ok", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+
+      const result = await getArtworkFromDiscogs({
+        title: "Test Album",
+        artist: "Test Artist",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null on network error", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+      const result = await getArtworkFromDiscogs({
+        title: "Test Album",
+        artist: "Test Artist",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should encode artist and title in URL", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      });
+
+      await getArtworkFromDiscogs({
+        title: "Album With Spaces",
+        artist: "Artist & Special",
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("artist=Artist%20%26%20Special")
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("title=Album%20With%20Spaces")
+      );
+    });
+
+    it("should include API credentials in URL", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      });
+
+      await getArtworkFromDiscogs({
+        title: "Test",
+        artist: "Test",
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("key=test-discogs-key")
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("secret=test-discogs-secret")
+      );
+    });
+  });
+
+  describe("getArtworkFromItunes", () => {
+    it("should return high-res artwork URL when found", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [{ artworkUrl100: "https://itunes.com/100x100bb.jpg" }],
+          }),
+      });
+
+      const result = await getArtworkFromItunes({
+        title: "Test Album",
+        artist: "Test Artist",
+      });
+
+      expect(result).toBe("https://itunes.com/600x600bb.jpg");
+    });
+
+    it("should replace 100x100 with 600x600 in artwork URL", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              {
+                artworkUrl100:
+                  "https://is1-ssl.mzstatic.com/image/100x100bb.jpg",
+              },
+            ],
+          }),
+      });
+
+      const result = await getArtworkFromItunes({
+        title: "Test",
+        artist: "Test",
+      });
+
+      expect(result).toBe("https://is1-ssl.mzstatic.com/image/600x600bb.jpg");
+    });
+
+    it("should return null when no results", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      });
+
+      const result = await getArtworkFromItunes({
+        title: "Unknown Album",
+        artist: "Unknown Artist",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when artworkUrl100 is missing", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [{ someOtherField: "value" }] }),
+      });
+
+      const result = await getArtworkFromItunes({
+        title: "Test",
+        artist: "Test",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when response is not ok", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      const result = await getArtworkFromItunes({
+        title: "Test Album",
+        artist: "Test Artist",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null on network error", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+      const result = await getArtworkFromItunes({
+        title: "Test Album",
+        artist: "Test Artist",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should combine title and artist in search term", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ results: [] }),
+      });
+
+      await getArtworkFromItunes({
+        title: "My Album",
+        artist: "My Artist",
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("term=My%20Album%20My%20Artist")
+      );
+    });
+  });
+
+  describe("getArtworkFromLastFM", () => {
+    it("should return largest image when found", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            album: {
+              image: [
+                { size: "small", "#text": "https://lastfm.com/small.jpg" },
+                { size: "medium", "#text": "https://lastfm.com/medium.jpg" },
+                { size: "large", "#text": "https://lastfm.com/large.jpg" },
+              ],
+            },
+          }),
+      });
+
+      const result = await getArtworkFromLastFM({
+        title: "Test Album",
+        artist: "Test Artist",
+      });
+
+      expect(result).toBe("https://lastfm.com/large.jpg");
+    });
+
+    it("should return null when no album data", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      const result = await getArtworkFromLastFM({
+        title: "Unknown Album",
+        artist: "Unknown Artist",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when images array is empty", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            album: { image: [] },
+          }),
+      });
+
+      const result = await getArtworkFromLastFM({
+        title: "Test",
+        artist: "Test",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when images is not an array", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            album: { image: "not an array" },
+          }),
+      });
+
+      const result = await getArtworkFromLastFM({
+        title: "Test",
+        artist: "Test",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when response is not ok", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+      });
+
+      const result = await getArtworkFromLastFM({
+        title: "Test Album",
+        artist: "Test Artist",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null on network error", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+      const result = await getArtworkFromLastFM({
+        title: "Test Album",
+        artist: "Test Artist",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should include API key in URL", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await getArtworkFromLastFM({
+        title: "Test",
+        artist: "Test",
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("api_key=test-lastfm-key")
+      );
+    });
+
+    it("should encode album and artist in URL", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await getArtworkFromLastFM({
+        title: "Album With Spaces",
+        artist: "Artist & Special",
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("album=Album%20With%20Spaces")
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("artist=Artist%20%26%20Special")
+      );
+    });
+  });
+
+  describe("getSongInfoFromLastFM", () => {
+    it("should return song info when found", async () => {
+      const mockTrackInfo = {
+        track: {
+          name: "Test Track",
+          artist: { name: "Test Artist" },
+          duration: "180000",
+        },
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockTrackInfo),
+      });
+
+      const result = await getSongInfoFromLastFM({
+        title: "Test Track",
+        artist: "Test Artist",
+      });
+
+      expect(result).toEqual(mockTrackInfo);
+    });
+
+    it("should return null when response is not ok", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+
+      const result = await getSongInfoFromLastFM({
+        title: "Unknown Track",
+        artist: "Unknown Artist",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null on network error", async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+      const result = await getSongInfoFromLastFM({
+        title: "Test Track",
+        artist: "Test Artist",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should call toast.error when response is not ok", async () => {
+      const { toast } = await import("sonner");
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      await getSongInfoFromLastFM({
+        title: "Test Track",
+        artist: "Test Artist",
+      });
+
+      expect(toast.error).toHaveBeenCalledWith(
+        "Failed to fetch song info from Last.fm (500)"
+      );
+    });
+
+    it("should call toast.error on network error", async () => {
+      const { toast } = await import("sonner");
+
+      global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+      await getSongInfoFromLastFM({
+        title: "Test Track",
+        artist: "Test Artist",
+      });
+
+      expect(toast.error).toHaveBeenCalledWith(
+        "Error fetching song info from Last.fm"
+      );
+    });
+
+    it("should use track.getInfo method in URL", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await getSongInfoFromLastFM({
+        title: "My Track",
+        artist: "My Artist",
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("method=track.getInfo")
+      );
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("track=My%20Track")
+      );
+    });
+  });
+});

--- a/src/hooks/binHooks.test.tsx
+++ b/src/hooks/binHooks.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useBin, useDeleteFromBin, useAddToBin, useBinResults } from "./binHooks";
+import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { createHookWrapper, createTestAlbum, createTestArtist } from "@/lib/test-utils";
+
+// Mock authentication hooks
+vi.mock("./authenticationHooks", () => ({
+  useRegistry: vi.fn(() => ({
+    loading: false,
+    info: { id: 1, djName: "Test DJ" },
+  })),
+}));
+
+// Mock sonner toast
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+// Mock bin API hooks
+const mockDeleteFromBin = vi.fn();
+const mockAddToBin = vi.fn();
+
+const mockBinData = [
+  createTestAlbum({ id: 1, title: "Test Album", artist: createTestArtist({ name: "Test Artist" }) }),
+  createTestAlbum({ id: 2, title: "Another Album", artist: createTestArtist({ name: "Another Artist" }) }),
+];
+
+vi.mock("@/lib/features/bin/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/bin/api")>();
+  return {
+    ...actual,
+    useGetBinQuery: vi.fn(() => ({
+      data: mockBinData,
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+    })),
+    useDeleteFromBinMutation: vi.fn(() => [
+      mockDeleteFromBin,
+      { isLoading: false, isError: false },
+    ]),
+    useAddToBinMutation: vi.fn(() => [
+      mockAddToBin,
+      { isLoading: false, isError: false },
+    ]),
+  };
+});
+
+const createWrapper = () => createHookWrapper({ flowsheet: flowsheetSlice });
+
+describe("binHooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("useBin", () => {
+    it("should return bin data when loaded", () => {
+      const { result } = renderHook(() => useBin(), { wrapper: createWrapper() });
+
+      expect(result.current.bin).toHaveLength(2);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    it("should return isError status", () => {
+      const { result } = renderHook(() => useBin(), { wrapper: createWrapper() });
+
+      expect(result.current.isError).toBe(false);
+    });
+  });
+
+  describe("useDeleteFromBin", () => {
+    it("should return deleteFromBin function", () => {
+      const { result } = renderHook(() => useDeleteFromBin(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.deleteFromBin).toBe("function");
+    });
+
+    it("should call mutation when deleteFromBin is called", () => {
+      const { result } = renderHook(() => useDeleteFromBin(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.deleteFromBin(1);
+      });
+
+      expect(mockDeleteFromBin).toHaveBeenCalledWith({ dj_id: 1, album_id: 1 });
+    });
+
+    it("should return loading state", () => {
+      const { result } = renderHook(() => useDeleteFromBin(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  describe("useAddToBin", () => {
+    it("should return addToBin function", () => {
+      const { result } = renderHook(() => useAddToBin(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.addToBin).toBe("function");
+    });
+
+    it("should call mutation when addToBin is called", () => {
+      const { result } = renderHook(() => useAddToBin(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.addToBin(2);
+      });
+
+      expect(mockAddToBin).toHaveBeenCalledWith({ dj_id: 1, album_id: 2 });
+    });
+
+    it("should return loading state", () => {
+      const { result } = renderHook(() => useAddToBin(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  describe("useBinResults", () => {
+    it("should return empty results when search query is too short", () => {
+      const { result } = renderHook(() => useBinResults(), {
+        wrapper: createWrapper(),
+      });
+
+      // Default search query is empty, so should return empty results
+      expect(result.current.searchResults).toEqual([]);
+    });
+
+    it("should filter bin by search terms", () => {
+      const initialState = flowsheetSlice.getInitialState();
+      const wrapper = createHookWrapper(
+        { flowsheet: flowsheetSlice },
+        {
+          flowsheet: {
+            ...initialState,
+            search: {
+              ...initialState.search,
+              query: { ...initialState.search.query, album: "Test Album", artist: "", label: "" },
+            },
+          },
+        }
+      );
+
+      const { result } = renderHook(() => useBinResults(), { wrapper });
+
+      expect(result.current.searchResults).toHaveLength(1);
+      expect(result.current.searchResults[0].title).toBe("Test Album");
+    });
+
+    it("should search by artist name", () => {
+      const initialState = flowsheetSlice.getInitialState();
+      const wrapper = createHookWrapper(
+        { flowsheet: flowsheetSlice },
+        {
+          flowsheet: {
+            ...initialState,
+            search: {
+              ...initialState.search,
+              query: { ...initialState.search.query, album: "", artist: "Another Artist", label: "" },
+            },
+          },
+        }
+      );
+
+      const { result } = renderHook(() => useBinResults(), { wrapper });
+
+      expect(result.current.searchResults).toHaveLength(1);
+      expect(result.current.searchResults[0].artist?.name).toBe("Another Artist");
+    });
+  });
+});

--- a/src/hooks/catalogHooks.test.tsx
+++ b/src/hooks/catalogHooks.test.tsx
@@ -1,0 +1,578 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  useCatalogSearch,
+  useCatalogResults,
+  useCatalogFlowsheetSearch,
+  useRotationFlowsheetSearch,
+} from "./catalogHooks";
+import { catalogSlice } from "@/lib/features/catalog/frontend";
+import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import {
+  createHookWrapper,
+  createTestAlbum,
+  createTestArtist,
+} from "@/lib/test-utils";
+
+// Mock authentication hooks
+vi.mock("./authenticationHooks", () => ({
+  useAuthentication: vi.fn(() => ({
+    authenticating: false,
+    authenticated: true,
+  })),
+  useRegistry: vi.fn(() => ({
+    loading: false,
+    info: { id: "test-user-1", djName: "Test DJ" },
+  })),
+}));
+
+// Mock catalog API hooks
+const mockCatalogData = [
+  createTestAlbum({
+    id: 1,
+    title: "Test Album",
+    artist: createTestArtist({ name: "Test Artist" }),
+    label: "Test Label",
+  }),
+  createTestAlbum({
+    id: 2,
+    title: "Another Album",
+    artist: createTestArtist({ name: "Another Artist" }),
+    label: "Another Label",
+  }),
+];
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return {
+    ...actual,
+    useSearchCatalogQuery: vi.fn(() => ({
+      data: mockCatalogData,
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+    })),
+  };
+});
+
+// Mock rotation API hooks
+const mockRotationData = [
+  createTestAlbum({
+    id: 3,
+    title: "Rotation Album",
+    artist: createTestArtist({ name: "Rotation Artist" }),
+    label: "Rotation Label",
+    play_freq: "H",
+    rotation_id: 1,
+  }),
+];
+
+vi.mock("@/lib/features/rotation/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/rotation/api")>();
+  return {
+    ...actual,
+    useGetRotationQuery: vi.fn(() => ({
+      data: mockRotationData,
+      isLoading: false,
+      isSuccess: true,
+    })),
+  };
+});
+
+const createWrapper = () =>
+  createHookWrapper({ catalog: catalogSlice, flowsheet: flowsheetSlice });
+
+describe("catalogHooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("useCatalogSearch", () => {
+    it("should return initial search state", () => {
+      const { result } = renderHook(() => useCatalogSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.searchString).toBe("");
+      expect(result.current.orderBy).toBe("title");
+      expect(result.current.orderDirection).toBe("asc");
+      expect(result.current.selected).toEqual([]);
+      expect(result.current.n).toBe(10);
+    });
+
+    it("should update search string when setSearchString is called", () => {
+      const { result } = renderHook(() => useCatalogSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSearchString("test query");
+      });
+
+      expect(result.current.searchString).toBe("test query");
+    });
+
+    it("should update search in when setSearchIn is called", () => {
+      const { result } = renderHook(() => useCatalogSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSearchIn("Artists");
+      });
+
+      // The state update happens via dispatch, check the action was called
+      expect(typeof result.current.setSearchIn).toBe("function");
+    });
+
+    it("should update search genre when setSearchGenre is called", () => {
+      const { result } = renderHook(() => useCatalogSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSearchGenre("Rock");
+      });
+
+      expect(typeof result.current.setSearchGenre).toBe("function");
+    });
+
+    it("should add selection when addSelection is called", () => {
+      const { result } = renderHook(() => useCatalogSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.addSelection(1);
+      });
+
+      expect(result.current.selected).toContain(1);
+    });
+
+    it("should remove selection when removeSelection is called", () => {
+      const { result } = renderHook(() => useCatalogSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.addSelection(1);
+        result.current.addSelection(2);
+      });
+
+      expect(result.current.selected).toContain(1);
+      expect(result.current.selected).toContain(2);
+
+      act(() => {
+        result.current.removeSelection(1);
+      });
+
+      expect(result.current.selected).not.toContain(1);
+      expect(result.current.selected).toContain(2);
+    });
+
+    it("should set selection when setSelection is called", () => {
+      const { result } = renderHook(() => useCatalogSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSelection([1, 2, 3]);
+      });
+
+      expect(result.current.selected).toEqual([1, 2, 3]);
+    });
+
+    it("should clear selection when clearSelection is called", () => {
+      const { result } = renderHook(() => useCatalogSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.addSelection(1);
+        result.current.addSelection(2);
+      });
+
+      expect(result.current.selected.length).toBe(2);
+
+      act(() => {
+        result.current.clearSelection();
+      });
+
+      expect(result.current.selected).toEqual([]);
+    });
+
+    it("should toggle sort direction when handleRequestSort is called with same column", () => {
+      const { result } = renderHook(() => useCatalogSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.orderDirection).toBe("asc");
+
+      act(() => {
+        result.current.handleRequestSort("title");
+      });
+
+      expect(result.current.orderDirection).toBe("desc");
+
+      act(() => {
+        result.current.handleRequestSort("title");
+      });
+
+      expect(result.current.orderDirection).toBe("asc");
+    });
+
+    it("should update orderBy when handleRequestSort is called with different column", () => {
+      const { result } = renderHook(() => useCatalogSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.orderBy).toBe("title");
+
+      act(() => {
+        result.current.handleRequestSort("artist");
+      });
+
+      expect(result.current.orderBy).toBe("artist");
+    });
+
+    it("should expose dispatch and catalogSlice", () => {
+      const { result } = renderHook(() => useCatalogSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.dispatch).toBe("function");
+      expect(result.current.catalogSlice).toBeDefined();
+    });
+  });
+
+  describe("useCatalogResults", () => {
+    it("should return data from the catalog API", () => {
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.data).toBeDefined();
+    });
+
+    it("should return loading state", () => {
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.loading).toBe("boolean");
+    });
+
+    it("should return setSearchString function", () => {
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.setSearchString).toBe("function");
+    });
+
+    it("should return setSearchIn function", () => {
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.setSearchIn).toBe("function");
+    });
+
+    it("should return setSearchGenre function", () => {
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.setSearchGenre).toBe("function");
+    });
+
+    it("should return addSelection function", () => {
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.addSelection).toBe("function");
+    });
+
+    it("should return removeSelection function", () => {
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.removeSelection).toBe("function");
+    });
+
+    it("should return loadMore function", () => {
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.loadMore).toBe("function");
+    });
+
+    it("should return reachedEndForQuery state", () => {
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.reachedEndForQuery).toBe("boolean");
+    });
+
+    it("should clear selection when search changes", async () => {
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setSearchString("test");
+      });
+
+      // Fast-forward timers to trigger the debounced effect
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+
+      // The clearSelection should have been called as part of the search update effect
+      expect(typeof result.current.setSearchString).toBe("function");
+    });
+
+    it("should skip query when not authenticated", async () => {
+      const { useAuthentication } = await import("./authenticationHooks");
+      vi.mocked(useAuthentication).mockReturnValue({
+        authenticating: false,
+        authenticated: false,
+        data: { message: "Not Authenticated" },
+        error: null,
+      });
+
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.data).toBeDefined();
+    });
+
+    it("should skip query when search string is too short", async () => {
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: createWrapper(),
+      });
+
+      // Initial search string is empty
+      expect(result.current.searchString).toBe("");
+    });
+  });
+
+  describe("useCatalogFlowsheetSearch", () => {
+    it("should return empty results when query is too short", () => {
+      const { result } = renderHook(() => useCatalogFlowsheetSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      // Default flowsheet query is empty, so should return empty results
+      expect(result.current.searchResults).toEqual([]);
+    });
+
+    it("should return search results when query is long enough", () => {
+      const initialState = flowsheetSlice.getInitialState();
+      const wrapper = createHookWrapper(
+        { flowsheet: flowsheetSlice, catalog: catalogSlice },
+        {
+          flowsheet: {
+            ...initialState,
+            search: {
+              ...initialState.search,
+              query: {
+                ...initialState.search.query,
+                artist: "Test Artist",
+                album: "",
+                label: "",
+                song: "",
+                request: false,
+              },
+            },
+          },
+        }
+      );
+
+      const { result } = renderHook(() => useCatalogFlowsheetSearch(), {
+        wrapper,
+      });
+
+      // Should have results because query is long enough
+      expect(result.current.searchResults).toBeDefined();
+    });
+
+    it("should skip query when authenticating", async () => {
+      const { useAuthentication } = await import("./authenticationHooks");
+      vi.mocked(useAuthentication).mockReturnValue({
+        authenticating: true,
+        authenticated: false,
+        data: { message: "Not Authenticated" },
+        error: null,
+      });
+
+      const { result } = renderHook(() => useCatalogFlowsheetSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.searchResults).toEqual([]);
+    });
+  });
+
+  describe("useRotationFlowsheetSearch", () => {
+    it("should return empty results when query is too short", () => {
+      const { result } = renderHook(() => useRotationFlowsheetSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.searchResults).toEqual([]);
+      expect(typeof result.current.loading).toBe("boolean");
+    });
+
+    it("should filter rotation data when query is long enough", () => {
+      const initialState = flowsheetSlice.getInitialState();
+      const wrapper = createHookWrapper(
+        { flowsheet: flowsheetSlice, catalog: catalogSlice },
+        {
+          flowsheet: {
+            ...initialState,
+            search: {
+              ...initialState.search,
+              query: {
+                ...initialState.search.query,
+                artist: "Rotation Artist",
+                album: "",
+                label: "",
+                song: "",
+                request: false,
+              },
+            },
+          },
+        }
+      );
+
+      const { result } = renderHook(() => useRotationFlowsheetSearch(), {
+        wrapper,
+      });
+
+      // Results should be filtered based on the rotation data
+      expect(Array.isArray(result.current.searchResults)).toBe(true);
+    });
+
+    it("should return loading state", () => {
+      const { result } = renderHook(() => useRotationFlowsheetSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.loading).toBe("boolean");
+    });
+
+    it("should skip query when not authenticated", async () => {
+      const { useAuthentication } = await import("./authenticationHooks");
+      vi.mocked(useAuthentication).mockReturnValue({
+        authenticating: false,
+        authenticated: false,
+        data: { message: "Not Authenticated" },
+        error: null,
+      });
+
+      const { result } = renderHook(() => useRotationFlowsheetSearch(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.searchResults).toEqual([]);
+    });
+
+    it("should filter by artist name", () => {
+      const initialState = flowsheetSlice.getInitialState();
+      const wrapper = createHookWrapper(
+        { flowsheet: flowsheetSlice, catalog: catalogSlice },
+        {
+          flowsheet: {
+            ...initialState,
+            search: {
+              ...initialState.search,
+              query: {
+                ...initialState.search.query,
+                artist: "Rotation",
+                album: "",
+                label: "",
+                song: "",
+                request: false,
+              },
+            },
+          },
+        }
+      );
+
+      const { result } = renderHook(() => useRotationFlowsheetSearch(), {
+        wrapper,
+      });
+
+      expect(Array.isArray(result.current.searchResults)).toBe(true);
+    });
+
+    it("should filter by album title", () => {
+      const initialState = flowsheetSlice.getInitialState();
+      const wrapper = createHookWrapper(
+        { flowsheet: flowsheetSlice, catalog: catalogSlice },
+        {
+          flowsheet: {
+            ...initialState,
+            search: {
+              ...initialState.search,
+              query: {
+                ...initialState.search.query,
+                artist: "",
+                album: "Rotation Album",
+                label: "",
+                song: "",
+                request: false,
+              },
+            },
+          },
+        }
+      );
+
+      const { result } = renderHook(() => useRotationFlowsheetSearch(), {
+        wrapper,
+      });
+
+      expect(Array.isArray(result.current.searchResults)).toBe(true);
+    });
+
+    it("should filter by label", () => {
+      const initialState = flowsheetSlice.getInitialState();
+      const wrapper = createHookWrapper(
+        { flowsheet: flowsheetSlice, catalog: catalogSlice },
+        {
+          flowsheet: {
+            ...initialState,
+            search: {
+              ...initialState.search,
+              query: {
+                ...initialState.search.query,
+                artist: "",
+                album: "",
+                label: "Rotation Label",
+                song: "",
+                request: false,
+              },
+            },
+          },
+        }
+      );
+
+      const { result } = renderHook(() => useRotationFlowsheetSearch(), {
+        wrapper,
+      });
+
+      expect(Array.isArray(result.current.searchResults)).toBe(true);
+    });
+  });
+});

--- a/src/hooks/djHooks.test.tsx
+++ b/src/hooks/djHooks.test.tsx
@@ -1,0 +1,698 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useDJAccount } from "./djHooks";
+import { authenticationSlice } from "@/lib/features/authentication/frontend";
+import { createHookWrapper } from "@/lib/test-utils";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+import React from "react";
+
+// Use vi.hoisted for variables used in vi.mock
+const {
+  mockRefresh,
+  mockToastError,
+  mockToastSuccess,
+  mockUpdateUser,
+  mockGetSession,
+} = vi.hoisted(() => ({
+  mockRefresh: vi.fn(),
+  mockToastError: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockUpdateUser: vi.fn(),
+  mockGetSession: vi.fn(),
+}));
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: mockRefresh,
+    push: vi.fn(),
+  }),
+}));
+
+// Mock sonner toast
+vi.mock("sonner", () => ({
+  toast: {
+    error: mockToastError,
+    success: mockToastSuccess,
+  },
+}));
+
+// Mock authentication hooks - create a variable that can be changed per test
+let mockRegistryInfo: { id: string; real_name: string; dj_name: string } | null = {
+  id: "test-user-1",
+  real_name: "Test User",
+  dj_name: "Test DJ",
+};
+let mockRegistryLoading = false;
+
+vi.mock("./authenticationHooks", () => ({
+  useRegistry: () => ({
+    loading: mockRegistryLoading,
+    info: mockRegistryInfo,
+  }),
+}));
+
+// Mock auth client
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: {
+    updateUser: (...args: any[]) => mockUpdateUser(...args),
+    getSession: () => mockGetSession(),
+  },
+}));
+
+const createWrapper = () =>
+  createHookWrapper({ authentication: authenticationSlice });
+
+// Helper to create a wrapper that also returns the store for dispatching actions
+function createWrapperWithStore() {
+  const store = configureStore({
+    reducer: {
+      authentication: authenticationSlice.reducer,
+    },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  return { Wrapper, store };
+}
+
+// Helper to create mock form with actual inputs that FormData can read
+function createMockForm(fields: Record<string, string>): HTMLFormElement {
+  const form = document.createElement("form");
+  document.body.appendChild(form);
+
+  for (const [name, value] of Object.entries(fields)) {
+    const input = document.createElement("input");
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  }
+
+  return form;
+}
+
+function cleanupForm(form: HTMLFormElement): void {
+  if (form.parentNode) {
+    form.parentNode.removeChild(form);
+  }
+}
+
+describe("djHooks", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Reset mock values
+    mockRegistryInfo = {
+      id: "test-user-1",
+      real_name: "Test User",
+      dj_name: "Test DJ",
+    };
+    mockRegistryLoading = false;
+    mockUpdateUser.mockResolvedValue({});
+    mockGetSession.mockResolvedValue({
+      data: { user: { id: "test-user-1" } },
+    });
+  });
+
+  describe("useDJAccount", () => {
+    it("should return user info", () => {
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.info).toEqual(mockRegistryInfo);
+    });
+
+    it("should return loading state", () => {
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.loading).toBe("boolean");
+    });
+
+    it("should return handleSaveData function", () => {
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.handleSaveData).toBe("function");
+    });
+
+    it("should call preventDefault when handleSaveData is called", async () => {
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(),
+      });
+
+      const mockForm = createMockForm({});
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      cleanupForm(mockForm);
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+    });
+
+    it("should handle form submission without errors", async () => {
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify action after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "realName", value: true }));
+      });
+
+      const mockForm = createMockForm({ realName: "New Name" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      cleanupForm(mockForm);
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+    });
+
+    it("should not call updateUser when no modifications exist", async () => {
+      // Use the default wrapper - no modifications are set after reset
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(),
+      });
+
+      const mockForm = createMockForm({});
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      cleanupForm(mockForm);
+      expect(mockUpdateUser).not.toHaveBeenCalled();
+    });
+
+    it("should return early when info is null", async () => {
+      mockRegistryInfo = null;
+
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(),
+      });
+
+      const mockForm = createMockForm({ realName: "New Name" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      cleanupForm(mockForm);
+      // Should return early and not call updateUser
+      expect(mockUpdateUser).not.toHaveBeenCalled();
+    });
+
+    it("should return early when info is undefined", async () => {
+      mockRegistryInfo = undefined as any;
+
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(),
+      });
+
+      const mockForm = createMockForm({ realName: "New Name" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      cleanupForm(mockForm);
+      // Should return early and not call updateUser
+      expect(mockUpdateUser).not.toHaveBeenCalled();
+    });
+
+    it("should call updateUser with realName when modified", async () => {
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify action after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "realName", value: true }));
+      });
+
+      const mockForm = createMockForm({ realName: "New Name" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      cleanupForm(mockForm);
+      expect(mockUpdateUser).toHaveBeenCalledWith({ realName: "New Name" });
+      expect(mockToastSuccess).toHaveBeenCalledWith("User settings saved.");
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+
+    it("should call updateUser with djName when modified", async () => {
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify action after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "djName", value: true }));
+      });
+
+      const mockForm = createMockForm({ djName: "DJ New" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      cleanupForm(mockForm);
+      expect(mockUpdateUser).toHaveBeenCalledWith({ djName: "DJ New" });
+    });
+
+    it("should call updateUser with email when modified", async () => {
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify action after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "email", value: true }));
+      });
+
+      const mockForm = createMockForm({ email: "new@email.com" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      cleanupForm(mockForm);
+      expect(mockUpdateUser).toHaveBeenCalledWith({ email: "new@email.com" });
+    });
+
+    it("should call updateUser with all fields when all modified", async () => {
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify actions after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "realName", value: true }));
+        store.dispatch(authenticationSlice.actions.modify({ key: "djName", value: true }));
+        store.dispatch(authenticationSlice.actions.modify({ key: "email", value: true }));
+      });
+
+      const mockForm = createMockForm({
+        realName: "New Name",
+        djName: "DJ New",
+        email: "new@email.com",
+      });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      cleanupForm(mockForm);
+
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        realName: "New Name",
+        djName: "DJ New",
+        email: "new@email.com",
+      });
+    });
+
+    it("should skip empty values even if modification flag is set", async () => {
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify actions after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "realName", value: true }));
+        store.dispatch(authenticationSlice.actions.modify({ key: "djName", value: true }));
+      });
+
+      // Only realName has a value, djName is empty string
+      const mockForm = createMockForm({
+        realName: "New Name",
+        djName: "",
+      });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      expect(mockUpdateUser).toHaveBeenCalledWith({ realName: "New Name" });
+    });
+
+    it("should not call updateUser if updateData is empty after filtering", async () => {
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify action after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "realName", value: true }));
+      });
+
+      // realName is modified flag is set, but value is empty
+      const mockForm = createMockForm({ realName: "" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      expect(mockUpdateUser).not.toHaveBeenCalled();
+    });
+
+    it("should handle updateUser returning error without message", async () => {
+      mockUpdateUser.mockResolvedValue({
+        error: {},
+      });
+
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify action after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "realName", value: true }));
+      });
+
+      const mockForm = createMockForm({ realName: "New Name" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      expect(mockToastError).toHaveBeenCalledWith("Failed to update user");
+    });
+
+    it("should support djName modification", async () => {
+      // This test verifies that the djName modification path exists
+      // The actual authClient.updateUser call depends on the modifications selector
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(),
+      });
+
+      const mockForm = createMockForm({ djName: "New DJ Name" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      // Should finish without errors
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+    });
+
+    it("should support email modification", async () => {
+      // This test verifies that the email modification path exists
+      // The actual authClient.updateUser call depends on the modifications selector
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(),
+      });
+
+      const mockForm = createMockForm({ email: "new@email.com" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      // Should finish without errors
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+    });
+
+    it("should handle updateUser error and finish loading", async () => {
+      mockUpdateUser.mockResolvedValue({
+        error: { message: "Update failed" },
+      });
+
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify action after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "realName", value: true }));
+      });
+
+      const mockForm = createMockForm({ realName: "New Name" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      // Should finish loading after error
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+      expect(mockToastError).toHaveBeenCalledWith("Update failed");
+    });
+
+    it("should handle session error and finish loading", async () => {
+      mockGetSession.mockResolvedValue({
+        data: { user: null },
+      });
+
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify action after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "realName", value: true }));
+      });
+
+      const mockForm = createMockForm({ realName: "New Name" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      // Should finish loading after session error
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+      expect(mockToastError).toHaveBeenCalledWith("User not authenticated");
+    });
+
+    it("should handle thrown exceptions and finish loading", async () => {
+      mockGetSession.mockRejectedValue(new Error("Network error"));
+
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify action after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "realName", value: true }));
+      });
+
+      const mockForm = createMockForm({ realName: "New Name" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      // Should finish loading after thrown exception
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+      expect(mockToastError).toHaveBeenCalledWith("Network error");
+    });
+
+    it("should handle non-Error exceptions and finish loading", async () => {
+      mockGetSession.mockRejectedValue("String error");
+
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify action after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "realName", value: true }));
+      });
+
+      const mockForm = createMockForm({ realName: "New Name" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      // Should finish loading after non-Error exception
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+      // Non-Error exceptions use the fallback message
+      expect(mockToastError).toHaveBeenCalledWith("Failed to update user settings");
+    });
+
+    it("should show loading true when isUpdating is true", async () => {
+      let resolveGetSession: () => void;
+      mockGetSession.mockReturnValue(
+        new Promise((resolve) => {
+          resolveGetSession = () => resolve({ data: { user: { id: "test-user-1" } } });
+        })
+      );
+
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify action after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "realName", value: true }));
+      });
+
+      const mockForm = createMockForm({ realName: "New Name" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      act(() => {
+        result.current.handleSaveData(mockEvent);
+      });
+
+      // Loading should be true while updating
+      expect(result.current.loading).toBe(true);
+
+      await act(async () => {
+        resolveGetSession!();
+      });
+    });
+
+    it("should show loading true when registry is loading", async () => {
+      mockRegistryLoading = true;
+
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.loading).toBe(true);
+    });
+
+    it("should not show toast for empty error message", async () => {
+      mockGetSession.mockRejectedValue(new Error("   "));
+
+      const { Wrapper, store } = createWrapperWithStore();
+
+      const { result } = renderHook(() => useDJAccount(), { wrapper: Wrapper });
+
+      // Dispatch modify action after initial mount (which resets modifications)
+      act(() => {
+        store.dispatch(authenticationSlice.actions.modify({ key: "realName", value: true }));
+      });
+
+      const mockForm = createMockForm({ realName: "New Name" });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        currentTarget: mockForm,
+      } as unknown as React.FormEvent<HTMLFormElement>;
+
+      await act(async () => {
+        await result.current.handleSaveData(mockEvent);
+      });
+
+      // Toast should not be called for whitespace-only error messages
+      expect(mockToastError).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Closes #255

## Summary

Add ~101 tests covering catalog, bin, admin, DJ, and artwork hooks:

- **Admin hooks** — `useAccountListResults` for roster management
- **Artwork hooks** — `getArtworkFromDiscogs`, `getArtworkFromItunes`, `getArtworkFromLastFM`, `getSongInfoFromLastFM` — external API integration for album art fetching
- **Bin hooks** — `useBin`, `useDeleteFromBin`, `useAddToBin`, `useBinResults`
- **Catalog hooks** — `useCatalogSearch`, `useCatalogResults`, `useCatalogFlowsheetSearch`, `useRotationFlowsheetSearch`
- **DJ hooks** — `useDJAccount` for profile data access

## Test plan
- [ ] Run `npm test src/hooks/adminHooks.test.tsx src/hooks/artwork/ src/hooks/binHooks.test.tsx src/hooks/catalogHooks.test.tsx src/hooks/djHooks.test.tsx`

**Part 10 of 26**