### PR TITLE
test: add layout component tests

### DIFF
--- a/src/Layout/Background.test.tsx
+++ b/src/Layout/Background.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BackgroundImage, BackgroundBox } from "./Background";
+
+describe("Background", () => {
+  describe("BackgroundImage", () => {
+    it("should render a Box element", () => {
+      const { container } = render(<BackgroundImage />);
+
+      expect(container.querySelector(".MuiBox-root")).toBeInTheDocument();
+    });
+
+    it("should have fixed positioning style", () => {
+      const { container } = render(<BackgroundImage />);
+
+      const box = container.querySelector(".MuiBox-root");
+      expect(box).toHaveStyle({ position: "fixed" });
+    });
+  });
+
+  describe("BackgroundBox", () => {
+    it("should render children", () => {
+      render(
+        <BackgroundBox>
+          <div data-testid="child-content">Test Content</div>
+        </BackgroundBox>
+      );
+
+      expect(screen.getByTestId("child-content")).toBeInTheDocument();
+    });
+
+    it("should render multiple children", () => {
+      render(
+        <BackgroundBox>
+          <div data-testid="child-1">Child 1</div>
+          <div data-testid="child-2">Child 2</div>
+        </BackgroundBox>
+      );
+
+      expect(screen.getByTestId("child-1")).toBeInTheDocument();
+      expect(screen.getByTestId("child-2")).toBeInTheDocument();
+    });
+
+    it("should have relative positioning", () => {
+      const { container } = render(
+        <BackgroundBox>
+          <span>Content</span>
+        </BackgroundBox>
+      );
+
+      const box = container.querySelector(".MuiBox-root");
+      expect(box).toHaveStyle({ position: "relative" });
+    });
+  });
+});

--- a/src/Layout/Footer.test.tsx
+++ b/src/Layout/Footer.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Footer from "./Footer";
+
+describe("Footer", () => {
+  it("should render a footer element", () => {
+    render(<Footer />);
+    expect(document.querySelector("footer")).toBeInTheDocument();
+  });
+
+  it("should display copyright text", () => {
+    render(<Footer />);
+    expect(screen.getByText(/Copyright/)).toBeInTheDocument();
+  });
+
+  it("should display current year", () => {
+    render(<Footer />);
+    const currentYear = new Date().getFullYear();
+    expect(screen.getByText(new RegExp(String(currentYear)))).toBeInTheDocument();
+  });
+
+  it("should display WXYC Chapel Hill", () => {
+    render(<Footer />);
+    expect(screen.getByText(/WXYC Chapel Hill/)).toBeInTheDocument();
+  });
+});

--- a/src/Layout/Header.test.tsx
+++ b/src/Layout/Header.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Header from "./Header";
+
+// Mock Logo component
+vi.mock("@/src/components/shared/Branding/Logo", () => ({
+  default: () => <div data-testid="logo">Logo</div>,
+}));
+
+// Mock dynamic import of ColorSchemeToggle
+vi.mock("next/dynamic", () => ({
+  default: () => () => <div data-testid="color-scheme-toggle">Toggle</div>,
+}));
+
+describe("Header", () => {
+  it("should render as header element", () => {
+    render(<Header />);
+
+    expect(screen.getByRole("banner")).toBeInTheDocument();
+  });
+
+  it("should render Logo component", () => {
+    render(<Header />);
+
+    expect(screen.getByTestId("logo")).toBeInTheDocument();
+  });
+
+  it("should have MuiBox class", () => {
+    render(<Header />);
+
+    const header = screen.getByRole("banner");
+    expect(header).toHaveClass("MuiBox-root");
+  });
+});

--- a/src/Layout/Main.test.tsx
+++ b/src/Layout/Main.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Main from "./Main";
+
+describe("Main", () => {
+  it("should render children", () => {
+    render(
+      <Main>
+        <div data-testid="child-content">Test Content</div>
+      </Main>
+    );
+
+    expect(screen.getByTestId("child-content")).toBeInTheDocument();
+  });
+
+  it("should render as main element", () => {
+    render(
+      <Main>
+        <span>Content</span>
+      </Main>
+    );
+
+    expect(screen.getByRole("main")).toBeInTheDocument();
+  });
+
+  it("should render multiple children", () => {
+    render(
+      <Main>
+        <div data-testid="child-1">Child 1</div>
+        <div data-testid="child-2">Child 2</div>
+        <div data-testid="child-3">Child 3</div>
+      </Main>
+    );
+
+    expect(screen.getByTestId("child-1")).toBeInTheDocument();
+    expect(screen.getByTestId("child-2")).toBeInTheDocument();
+    expect(screen.getByTestId("child-3")).toBeInTheDocument();
+  });
+
+  it("should render text children", () => {
+    render(<Main>Simple text content</Main>);
+
+    expect(screen.getByText("Simple text content")).toBeInTheDocument();
+  });
+});

--- a/src/Layout/PageData.test.tsx
+++ b/src/Layout/PageData.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import PageData from "./PageData";
+
+// Mock next/head
+vi.mock("next/head", () => ({
+  default: ({ children }: any) => <>{children}</>,
+}));
+
+describe("PageData", () => {
+  it("should render title with site prefix", () => {
+    const { container } = render(<PageData title="Test Page" />);
+
+    const title = container.querySelector("title");
+    expect(title?.textContent).toBe("WXYC | Test Page");
+  });
+
+  it("should render different titles", () => {
+    const { container } = render(<PageData title="Dashboard" />);
+
+    const title = container.querySelector("title");
+    expect(title?.textContent).toBe("WXYC | Dashboard");
+  });
+
+  it("should include WXYC prefix", () => {
+    const { container } = render(<PageData title="Login" />);
+
+    const title = container.querySelector("title");
+    expect(title?.textContent).toContain("WXYC");
+  });
+});

--- a/src/Layout/WXYCPage.test.tsx
+++ b/src/Layout/WXYCPage.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import WXYCPage from "./WXYCPage";
+
+// Mock child components
+vi.mock("./Background", () => ({
+  BackgroundBox: ({ children }: any) => (
+    <div data-testid="background-box">{children}</div>
+  ),
+  BackgroundImage: () => <div data-testid="background-image" />,
+}));
+
+vi.mock("./Header", () => ({
+  default: () => <header data-testid="header">Header</header>,
+}));
+
+vi.mock("./Main", () => ({
+  default: ({ children }: any) => (
+    <main data-testid="main">{children}</main>
+  ),
+}));
+
+vi.mock("./Footer", () => ({
+  default: () => <footer data-testid="footer">Footer</footer>,
+}));
+
+vi.mock("./PageData", () => ({
+  default: ({ title }: any) => (
+    <div data-testid="page-data" data-title={title}>
+      Page Data
+    </div>
+  ),
+}));
+
+describe("WXYCPage", () => {
+  it("should render children in Main component", () => {
+    render(
+      <WXYCPage title="Test Page">
+        <div data-testid="page-content">Page Content</div>
+      </WXYCPage>
+    );
+
+    expect(screen.getByTestId("page-content")).toBeInTheDocument();
+  });
+
+  it("should render Header component", () => {
+    render(
+      <WXYCPage title="Test Page">
+        <span>Content</span>
+      </WXYCPage>
+    );
+
+    expect(screen.getByTestId("header")).toBeInTheDocument();
+  });
+
+  it("should render Footer component", () => {
+    render(
+      <WXYCPage title="Test Page">
+        <span>Content</span>
+      </WXYCPage>
+    );
+
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+  });
+
+  it("should render BackgroundBox component", () => {
+    render(
+      <WXYCPage title="Test Page">
+        <span>Content</span>
+      </WXYCPage>
+    );
+
+    expect(screen.getByTestId("background-box")).toBeInTheDocument();
+  });
+
+  it("should render BackgroundImage component", () => {
+    render(
+      <WXYCPage title="Test Page">
+        <span>Content</span>
+      </WXYCPage>
+    );
+
+    expect(screen.getByTestId("background-image")).toBeInTheDocument();
+  });
+
+  it("should pass title to PageData", () => {
+    render(
+      <WXYCPage title="Custom Title">
+        <span>Content</span>
+      </WXYCPage>
+    );
+
+    expect(screen.getByTestId("page-data")).toHaveAttribute(
+      "data-title",
+      "Custom Title"
+    );
+  });
+
+  it("should have ignoreClassic class", () => {
+    const { container } = render(
+      <WXYCPage title="Test Page">
+        <span>Content</span>
+      </WXYCPage>
+    );
+
+    expect(container.querySelector(".ignoreClassic")).toBeInTheDocument();
+  });
+});

--- a/src/ThemedLayout.test.tsx
+++ b/src/ThemedLayout.test.tsx
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+// Mock the session module
+vi.mock("@/lib/features/session", () => ({
+  createServerSideProps: vi.fn(),
+}));
+
+// Mock the LoadingPage component
+vi.mock("./components/LoadingPage", () => ({
+  LoadingPage: () => <div data-testid="loading-page">Loading...</div>,
+}));
+
+import ThemedLayout, {
+  DashboardLayoutProps,
+  LoginLayoutProps,
+  ThemedLayoutProps,
+} from "./ThemedLayout";
+import { createServerSideProps } from "@/lib/features/session";
+
+const mockCreateServerSideProps = createServerSideProps as ReturnType<typeof vi.fn>;
+
+describe("ThemedLayout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("type exports", () => {
+    it("should export DashboardLayoutProps type", () => {
+      // Type checking at compile time - this test verifies the type is exported
+      const props: DashboardLayoutProps = {
+        classic: <div>Classic</div>,
+        modern: <div>Modern</div>,
+        information: <div>Information</div>,
+      };
+      expect(props).toBeDefined();
+    });
+
+    it("should export LoginLayoutProps type", () => {
+      // Type checking at compile time
+      const props: LoginLayoutProps = {
+        classic: <div>Classic</div>,
+        modern: <div>Modern</div>,
+      };
+      expect(props).toBeDefined();
+    });
+
+    it("should export ThemedLayoutProps type", () => {
+      // Type checking at compile time - union type
+      const dashboardProps: ThemedLayoutProps = {
+        classic: <div>Classic</div>,
+        modern: <div>Modern</div>,
+        information: <div>Information</div>,
+      };
+      const loginProps: ThemedLayoutProps = {
+        classic: <div>Classic</div>,
+        modern: <div>Modern</div>,
+      };
+      expect(dashboardProps).toBeDefined();
+      expect(loginProps).toBeDefined();
+    });
+  });
+
+  describe("classic experience", () => {
+    beforeEach(() => {
+      mockCreateServerSideProps.mockResolvedValue({
+        application: {
+          experience: "classic",
+          colorMode: "system",
+        },
+        authentication: {
+          isAuthenticated: false,
+          user: undefined,
+        },
+      });
+    });
+
+    it("should render the classic container when experience is classic", async () => {
+      const Component = await ThemedLayout({
+        classic: <div data-testid="classic-content">Classic Content</div>,
+        modern: <div data-testid="modern-content">Modern Content</div>,
+      });
+
+      render(Component);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("classic-content")).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId("modern-content")).not.toBeInTheDocument();
+    });
+
+    it("should render classic container with id", async () => {
+      const Component = await ThemedLayout({
+        classic: <div data-testid="classic-content">Classic</div>,
+        modern: <div data-testid="modern-content">Modern</div>,
+      });
+
+      const { container } = render(Component);
+
+      await waitFor(() => {
+        const classicContainer = container.querySelector("#classic-container");
+        expect(classicContainer).toBeInTheDocument();
+      });
+    });
+
+    it("should render information slot when provided with dashboard props", async () => {
+      const dashboardProps: DashboardLayoutProps = {
+        classic: <div data-testid="classic-content">Classic</div>,
+        modern: <div data-testid="modern-content">Modern</div>,
+        information: <div data-testid="information-slot">Information</div>,
+      };
+
+      const Component = await ThemedLayout(dashboardProps);
+
+      render(Component);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("information-slot")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("modern experience", () => {
+    beforeEach(() => {
+      mockCreateServerSideProps.mockResolvedValue({
+        application: {
+          experience: "modern",
+          colorMode: "system",
+        },
+        authentication: {
+          isAuthenticated: false,
+          user: undefined,
+        },
+      });
+    });
+
+    it("should render the modern container when experience is modern", async () => {
+      const Component = await ThemedLayout({
+        classic: <div data-testid="classic-content">Classic Content</div>,
+        modern: <div data-testid="modern-content">Modern Content</div>,
+      });
+
+      render(Component);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("modern-content")).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId("classic-content")).not.toBeInTheDocument();
+    });
+
+    it("should render modern container with id", async () => {
+      const Component = await ThemedLayout({
+        classic: <div data-testid="classic-content">Classic</div>,
+        modern: <div data-testid="modern-content">Modern</div>,
+      });
+
+      const { container } = render(Component);
+
+      await waitFor(() => {
+        const modernContainer = container.querySelector("#modern-container");
+        expect(modernContainer).toBeInTheDocument();
+      });
+    });
+
+    it("should render information slot when provided with dashboard props", async () => {
+      const dashboardProps: DashboardLayoutProps = {
+        classic: <div data-testid="classic-content">Classic</div>,
+        modern: <div data-testid="modern-content">Modern</div>,
+        information: <div data-testid="information-slot">Information</div>,
+      };
+
+      const Component = await ThemedLayout(dashboardProps);
+
+      render(Component);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("information-slot")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("login layout (no information slot)", () => {
+    beforeEach(() => {
+      mockCreateServerSideProps.mockResolvedValue({
+        application: {
+          experience: "modern",
+          colorMode: "system",
+        },
+        authentication: {
+          isAuthenticated: false,
+          user: undefined,
+        },
+      });
+    });
+
+    it("should handle login props without information slot", async () => {
+      const loginProps: LoginLayoutProps = {
+        classic: <div data-testid="classic-login">Classic Login</div>,
+        modern: <div data-testid="modern-login">Modern Login</div>,
+      };
+
+      const Component = await ThemedLayout(loginProps);
+
+      render(Component);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("modern-login")).toBeInTheDocument();
+      });
+    });
+
+    it("should not render information when using login props", async () => {
+      const loginProps: LoginLayoutProps = {
+        classic: <div data-testid="classic-login">Classic Login</div>,
+        modern: <div data-testid="modern-login">Modern Login</div>,
+      };
+
+      const Component = await ThemedLayout(loginProps);
+
+      render(Component);
+
+      // Information slot should not exist (null in the output)
+      await waitFor(() => {
+        expect(screen.getByTestId("modern-login")).toBeInTheDocument();
+      });
+      // No crash means information was handled correctly as null
+    });
+  });
+
+  describe("fallback behavior", () => {
+    it("should render modern when only modern is provided and experience is classic", async () => {
+      mockCreateServerSideProps.mockResolvedValue({
+        application: {
+          experience: "classic",
+          colorMode: "system",
+        },
+        authentication: {
+          isAuthenticated: false,
+          user: undefined,
+        },
+      });
+
+      // When both classic and modern are provided but the condition checks for both
+      const Component = await ThemedLayout({
+        classic: null as unknown as React.ReactNode, // Simulating missing classic
+        modern: <div data-testid="modern-fallback">Modern Fallback</div>,
+      });
+
+      render(Component);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("modern-fallback")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Suspense boundary", () => {
+    it("should wrap content in Suspense with LoadingPage fallback", async () => {
+      mockCreateServerSideProps.mockResolvedValue({
+        application: {
+          experience: "modern",
+          colorMode: "system",
+        },
+        authentication: {
+          isAuthenticated: false,
+          user: undefined,
+        },
+      });
+
+      const Component = await ThemedLayout({
+        classic: <div>Classic</div>,
+        modern: <div data-testid="modern-content">Modern</div>,
+      });
+
+      render(Component);
+
+      // The Suspense boundary exists (content renders after suspense resolves)
+      await waitFor(() => {
+        expect(screen.getByTestId("modern-content")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("server side props integration", () => {
+    it("should call createServerSideProps", async () => {
+      mockCreateServerSideProps.mockResolvedValue({
+        application: {
+          experience: "modern",
+          colorMode: "system",
+        },
+        authentication: {
+          isAuthenticated: false,
+          user: undefined,
+        },
+      });
+
+      await ThemedLayout({
+        classic: <div>Classic</div>,
+        modern: <div>Modern</div>,
+      });
+
+      expect(mockCreateServerSideProps).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add tests for Background component
- Add tests for Footer component
- Add tests for Header component
- Add tests for Main component
- Add tests for PageData component
- Add tests for WXYCPage component
- Add tests for ThemedLayout component

## Test plan
- [ ] Run `npm test src/Layout/`

**Part 12 of 26**