### PR TITLE
test: add header component tests

### DIFF
--- a/src/components/experiences/modern/Header/DesktopHeader.test.tsx
+++ b/src/components/experiences/modern/Header/DesktopHeader.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import DesktopHeader from "./DesktopHeader";
+
+describe("DesktopHeader", () => {
+  describe("Rendering", () => {
+    it("should render without crashing", () => {
+      render(<DesktopHeader />);
+
+      // Component renders MUI Box elements
+      const boxes = document.querySelectorAll(".MuiBox-root");
+      expect(boxes.length).toBeGreaterThan(0);
+    });
+
+    it("should render as a flex container", () => {
+      render(<DesktopHeader />);
+
+      const container = document.querySelector(".MuiBox-root");
+      expect(container).toHaveStyle({ display: "flex" });
+    });
+
+    it("should have align-items center", () => {
+      render(<DesktopHeader />);
+
+      const container = document.querySelector(".MuiBox-root");
+      expect(container).toHaveStyle({ alignItems: "center" });
+    });
+  });
+
+  describe("Component Structure", () => {
+    it("should have nested Box element", () => {
+      render(<DesktopHeader />);
+
+      const boxes = document.querySelectorAll(".MuiBox-root");
+      expect(boxes.length).toBe(2);
+    });
+
+    it("should render container with inner box", () => {
+      render(<DesktopHeader />);
+
+      const outerBox = document.querySelector(".MuiBox-root");
+      expect(outerBox).toBeInTheDocument();
+      expect(outerBox?.querySelector(".MuiBox-root")).toBeInTheDocument();
+    });
+  });
+
+  describe("Layout", () => {
+    it("should have inner box with ml auto for right alignment", () => {
+      render(<DesktopHeader />);
+
+      // The inner box has ml: "auto" to push content to the right
+      const boxes = document.querySelectorAll(".MuiBox-root");
+      expect(boxes.length).toBe(2);
+    });
+
+    it("should contain empty inner box for future content", () => {
+      render(<DesktopHeader />);
+
+      const innerBox = document.querySelectorAll(".MuiBox-root")[1];
+      expect(innerBox?.children.length).toBe(0);
+    });
+  });
+
+  describe("Responsive Design", () => {
+    it("should render with display styles for responsive behavior", () => {
+      render(<DesktopHeader />);
+
+      // Inner box has display: { xs: "none", md: "inline-flex" }
+      // This is applied via MUI sx prop - testing that component renders
+      const innerBox = document.querySelectorAll(".MuiBox-root")[1];
+      expect(innerBox).toBeInTheDocument();
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("should be semantically valid", () => {
+      const { container } = render(<DesktopHeader />);
+
+      // Should not have any accessibility violations for empty header
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+
+  describe("Empty State", () => {
+    it("should render with no visible content", () => {
+      render(<DesktopHeader />);
+
+      // The component renders empty boxes as a placeholder
+      const boxes = document.querySelectorAll(".MuiBox-root");
+      expect(boxes[0]?.textContent).toBe("");
+    });
+  });
+});

--- a/src/components/experiences/modern/Header/MobileHeader.test.tsx
+++ b/src/components/experiences/modern/Header/MobileHeader.test.tsx
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import MobileHeader from "./MobileHeader";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { applicationSlice } from "@/lib/features/application/frontend";
+import { render } from "@testing-library/react";
+
+// Mock Logo component
+vi.mock("@/src/components/shared/Branding/Logo", () => ({
+  default: () => <div data-testid="logo">Logo</div>,
+}));
+
+// Mock toggleSidebarCSS utility
+const mockToggleSidebarCSS = vi.fn();
+vi.mock("@/src/utilities/modern/catalog/utilities", () => ({
+  toggleSidebarCSS: () => mockToggleSidebarCSS(),
+}));
+
+// Mock MUI icons
+vi.mock("@mui/icons-material/DragHandle", () => ({
+  default: () => <span data-testid="drag-handle-icon" />,
+}));
+
+function createTestStore(initialState?: { rightbar?: { sidebarOpen?: boolean } }) {
+  return configureStore({
+    reducer: {
+      application: applicationSlice.reducer,
+    },
+    preloadedState: initialState
+      ? { application: { ...applicationSlice.getInitialState(), ...initialState } }
+      : undefined,
+  });
+}
+
+describe("MobileHeader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Rendering", () => {
+    it("should render as a Sheet component", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const sheet = document.querySelector(".MuiSheet-root");
+      expect(sheet).toBeInTheDocument();
+    });
+
+    it("should render Logo component", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      expect(screen.getByTestId("logo")).toBeInTheDocument();
+    });
+
+    it("should render menu toggle button", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("should render DragHandle icon in menu button", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      expect(screen.getByTestId("drag-handle-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("Sidebar Toggle", () => {
+    it("should dispatch toggleSidebar action when button is clicked", () => {
+      const store = createTestStore();
+      const dispatchSpy = vi.spyOn(store, "dispatch");
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        applicationSlice.actions.toggleSidebar()
+      );
+    });
+
+    it("should call toggleSidebarCSS when button is clicked", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      expect(mockToggleSidebarCSS).toHaveBeenCalled();
+    });
+
+    it("should toggle sidebar state in store when clicked", () => {
+      const store = createTestStore({
+        rightbar: { sidebarOpen: false },
+      });
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      // Initial state
+      expect(store.getState().application.rightbar.sidebarOpen).toBe(false);
+
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      // After click
+      expect(store.getState().application.rightbar.sidebarOpen).toBe(true);
+    });
+
+    it("should toggle sidebar from open to closed", () => {
+      const store = createTestStore({
+        rightbar: { sidebarOpen: true },
+      });
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      // Initial state
+      expect(store.getState().application.rightbar.sidebarOpen).toBe(true);
+
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      // After click
+      expect(store.getState().application.rightbar.sidebarOpen).toBe(false);
+    });
+  });
+
+  describe("Button Styling", () => {
+    it("should have outlined variant on button", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("MuiIconButton-variantOutlined");
+    });
+
+    it("should have neutral color on button", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("MuiIconButton-colorNeutral");
+    });
+
+    it("should have small size on button", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("MuiIconButton-sizeSm");
+    });
+  });
+
+  describe("Layout", () => {
+    it("should position header at top of viewport", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const sheet = document.querySelector(".MuiSheet-root");
+      expect(sheet).toHaveStyle({ position: "fixed", top: "0px" });
+    });
+
+    it("should have full viewport width", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const sheet = document.querySelector(".MuiSheet-root");
+      expect(sheet).toHaveStyle({ width: "100vw" });
+    });
+  });
+
+  describe("Multiple Interactions", () => {
+    it("should handle multiple toggle clicks", () => {
+      const store = createTestStore({
+        rightbar: { sidebarOpen: false },
+      });
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const button = screen.getByRole("button");
+
+      // Click 1: false -> true
+      fireEvent.click(button);
+      expect(store.getState().application.rightbar.sidebarOpen).toBe(true);
+
+      // Click 2: true -> false
+      fireEvent.click(button);
+      expect(store.getState().application.rightbar.sidebarOpen).toBe(false);
+
+      // Click 3: false -> true
+      fireEvent.click(button);
+      expect(store.getState().application.rightbar.sidebarOpen).toBe(true);
+    });
+
+    it("should call toggleSidebarCSS on each click", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const button = screen.getByRole("button");
+
+      fireEvent.click(button);
+      fireEvent.click(button);
+      fireEvent.click(button);
+
+      expect(mockToggleSidebarCSS).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("should have accessible button element", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const button = screen.getByRole("button");
+      expect(button).toBeInTheDocument();
+      expect(button.tagName.toLowerCase()).toBe("button");
+    });
+
+    it("should be keyboard accessible", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const button = screen.getByRole("button");
+      button.focus();
+      expect(document.activeElement).toBe(button);
+    });
+  });
+
+  describe("Component Structure", () => {
+    it("should have three child elements in header (button, logo container, empty box)", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const sheet = document.querySelector(".MuiSheet-root");
+      // Button, Logo Box, Empty Box
+      expect(sheet?.children.length).toBe(3);
+    });
+
+    it("should render logo inside a container box", () => {
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <MobileHeader />
+        </Provider>
+      );
+
+      const logo = screen.getByTestId("logo");
+      expect(logo.parentElement).toHaveClass("MuiBox-root");
+    });
+  });
+});

--- a/src/components/experiences/modern/Header/PageHeader.test.tsx
+++ b/src/components/experiences/modern/Header/PageHeader.test.tsx
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PageHeader from "./PageHeader";
+
+// Mock PageData component
+vi.mock("@/src/Layout/PageData", () => ({
+  default: ({ title }: { title: string }) => (
+    <div data-testid="page-data" data-title={title}>
+      PageData
+    </div>
+  ),
+}));
+
+describe("PageHeader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Title Rendering", () => {
+    it("should render title as h2 heading", () => {
+      render(<PageHeader title="Dashboard" />);
+
+      const heading = screen.getByRole("heading", { level: 2 });
+      expect(heading).toBeInTheDocument();
+      expect(heading).toHaveTextContent("Dashboard");
+    });
+
+    it("should render different titles correctly", () => {
+      const { rerender } = render(<PageHeader title="Catalog" />);
+      expect(screen.getByRole("heading")).toHaveTextContent("Catalog");
+
+      rerender(<PageHeader title="Flowsheet" />);
+      expect(screen.getByRole("heading")).toHaveTextContent("Flowsheet");
+
+      rerender(<PageHeader title="Admin" />);
+      expect(screen.getByRole("heading")).toHaveTextContent("Admin");
+    });
+
+    it("should handle long titles", () => {
+      render(<PageHeader title="This Is A Very Long Title For Testing" />);
+
+      expect(screen.getByRole("heading")).toHaveTextContent(
+        "This Is A Very Long Title For Testing"
+      );
+    });
+
+    it("should handle empty title", () => {
+      render(<PageHeader title="" />);
+
+      const heading = screen.getByRole("heading");
+      expect(heading).toBeInTheDocument();
+      expect(heading).toHaveTextContent("");
+    });
+
+    it("should handle title with special characters", () => {
+      render(<PageHeader title="Music & Artists - 2024" />);
+
+      expect(screen.getByRole("heading")).toHaveTextContent(
+        "Music & Artists - 2024"
+      );
+    });
+  });
+
+  describe("PageData Integration", () => {
+    it("should render PageData component with title", () => {
+      render(<PageHeader title="Dashboard" />);
+
+      const pageData = screen.getByTestId("page-data");
+      expect(pageData).toBeInTheDocument();
+      expect(pageData).toHaveAttribute("data-title", "Dashboard");
+    });
+
+    it("should pass title prop to PageData", () => {
+      render(<PageHeader title="My Custom Page" />);
+
+      expect(screen.getByTestId("page-data")).toHaveAttribute(
+        "data-title",
+        "My Custom Page"
+      );
+    });
+  });
+
+  describe("Children Rendering", () => {
+    it("should render children when provided", () => {
+      render(
+        <PageHeader title="Dashboard">
+          <button data-testid="action-button">Action</button>
+        </PageHeader>
+      );
+
+      expect(screen.getByTestId("action-button")).toBeInTheDocument();
+    });
+
+    it("should render multiple children", () => {
+      render(
+        <PageHeader title="Dashboard">
+          <button data-testid="button-1">Button 1</button>
+          <button data-testid="button-2">Button 2</button>
+          <button data-testid="button-3">Button 3</button>
+        </PageHeader>
+      );
+
+      expect(screen.getByTestId("button-1")).toBeInTheDocument();
+      expect(screen.getByTestId("button-2")).toBeInTheDocument();
+      expect(screen.getByTestId("button-3")).toBeInTheDocument();
+    });
+
+    it("should render without children", () => {
+      render(<PageHeader title="Dashboard" />);
+
+      expect(screen.getByRole("heading")).toBeInTheDocument();
+    });
+
+    it("should render text children", () => {
+      render(<PageHeader title="Dashboard">Some text content</PageHeader>);
+
+      expect(screen.getByText("Some text content")).toBeInTheDocument();
+    });
+
+    it("should render complex children", () => {
+      render(
+        <PageHeader title="Dashboard">
+          <div data-testid="complex-child">
+            <span>Nested content</span>
+            <button>Click me</button>
+          </div>
+        </PageHeader>
+      );
+
+      expect(screen.getByTestId("complex-child")).toBeInTheDocument();
+      expect(screen.getByText("Nested content")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Click me" })).toBeInTheDocument();
+    });
+  });
+
+  describe("Layout Structure", () => {
+    it("should render container Box", () => {
+      render(<PageHeader title="Dashboard" />);
+
+      const box = document.querySelector(".MuiBox-root");
+      expect(box).toBeInTheDocument();
+    });
+
+    it("should render with flex display", () => {
+      render(<PageHeader title="Dashboard" />);
+
+      const box = document.querySelector(".MuiBox-root");
+      expect(box).toHaveStyle({ display: "flex" });
+    });
+
+    it("should align items to center", () => {
+      render(<PageHeader title="Dashboard" />);
+
+      const box = document.querySelector(".MuiBox-root");
+      expect(box).toHaveStyle({ alignItems: "center" });
+    });
+
+    it("should allow flex wrapping", () => {
+      render(<PageHeader title="Dashboard" />);
+
+      const box = document.querySelector(".MuiBox-root");
+      expect(box).toHaveStyle({ flexWrap: "wrap" });
+    });
+
+    it("should have spacer box between title and children", () => {
+      render(
+        <PageHeader title="Dashboard">
+          <button>Action</button>
+        </PageHeader>
+      );
+
+      // There should be multiple Box elements including the spacer
+      const boxes = document.querySelectorAll(".MuiBox-root");
+      expect(boxes.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("Typography", () => {
+    it("should render title with h2 level", () => {
+      render(<PageHeader title="Dashboard" />);
+
+      const typography = document.querySelector(".MuiTypography-root");
+      expect(typography).toBeInTheDocument();
+      expect(typography?.tagName.toLowerCase()).toBe("h2");
+    });
+
+    it("should have Typography component with proper MUI class", () => {
+      render(<PageHeader title="Dashboard" />);
+
+      const typography = document.querySelector(".MuiTypography-root");
+      expect(typography).toBeInTheDocument();
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle null children", () => {
+      render(<PageHeader title="Dashboard">{null}</PageHeader>);
+
+      expect(screen.getByRole("heading")).toBeInTheDocument();
+    });
+
+    it("should handle undefined children", () => {
+      render(<PageHeader title="Dashboard">{undefined}</PageHeader>);
+
+      expect(screen.getByRole("heading")).toBeInTheDocument();
+    });
+
+    it("should handle boolean children", () => {
+      render(
+        <PageHeader title="Dashboard">
+          {true}
+          {false}
+        </PageHeader>
+      );
+
+      expect(screen.getByRole("heading")).toBeInTheDocument();
+    });
+
+    it("should handle conditional children", () => {
+      const showButton = true;
+      render(
+        <PageHeader title="Dashboard">
+          {showButton && <button data-testid="conditional">Conditional</button>}
+        </PageHeader>
+      );
+
+      expect(screen.getByTestId("conditional")).toBeInTheDocument();
+    });
+
+    it("should not render conditional children when false", () => {
+      const showButton = false;
+      render(
+        <PageHeader title="Dashboard">
+          {showButton && <button data-testid="conditional">Conditional</button>}
+        </PageHeader>
+      );
+
+      expect(screen.queryByTestId("conditional")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("should have accessible heading structure", () => {
+      render(<PageHeader title="Dashboard" />);
+
+      const heading = screen.getByRole("heading", { level: 2 });
+      expect(heading).toBeInTheDocument();
+    });
+
+    it("should maintain accessible structure with children", () => {
+      render(
+        <PageHeader title="Dashboard">
+          <button>Action</button>
+        </PageHeader>
+      );
+
+      expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+  });
+
+  describe("Fragment Wrapper", () => {
+    it("should render PageData and Box inside a fragment", () => {
+      const { container } = render(<PageHeader title="Dashboard" />);
+
+      // Should have both PageData and Box as children
+      expect(screen.getByTestId("page-data")).toBeInTheDocument();
+      expect(document.querySelector(".MuiBox-root")).toBeInTheDocument();
+    });
+  });
+
+  describe("Common Page Titles", () => {
+    const commonTitles = [
+      "Catalog",
+      "Flowsheet",
+      "Dashboard",
+      "Admin",
+      "Roster",
+      "Settings",
+      "Profile",
+    ];
+
+    commonTitles.forEach((title) => {
+      it(`should render correctly with title: ${title}`, () => {
+        render(<PageHeader title={title} />);
+
+        expect(screen.getByRole("heading")).toHaveTextContent(title);
+        expect(screen.getByTestId("page-data")).toHaveAttribute(
+          "data-title",
+          title
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add tests for DesktopHeader
- Add tests for MobileHeader
- Add tests for PageHeader

## Test plan
- [x] Run `npm test src/components/experiences/modern/Header/`

**Part 13 of 26**