### PR TITLE
test: add leftbar component tests

### DIFF
--- a/src/components/experiences/modern/Leftbar/FlowsheetLink.test.tsx
+++ b/src/components/experiences/modern/Leftbar/FlowsheetLink.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import FlowsheetLink from "./FlowsheetLink";
+
+// Mock hooks
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useShowControl: vi.fn(() => ({
+    live: false,
+  })),
+}));
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/dashboard"),
+}));
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock MUI icons
+vi.mock("@mui/icons-material", () => ({
+  Stream: () => <span data-testid="stream-icon" />,
+}));
+
+describe("FlowsheetLink", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render link to flowsheet", () => {
+    render(<FlowsheetLink />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/dashboard/flowsheet");
+  });
+
+  it("should render stream icon", () => {
+    render(<FlowsheetLink />);
+
+    expect(screen.getByTestId("stream-icon")).toBeInTheDocument();
+  });
+
+  it("should show 'Flowsheet' title when not live", () => {
+    render(<FlowsheetLink />);
+
+    // The tooltip should contain just "Flowsheet" when not live
+    const link = screen.getByRole("link");
+    expect(link).toBeInTheDocument();
+  });
+
+  it("should show 'ON AIR' indicator when live", async () => {
+    const { useShowControl } = await import("@/src/hooks/flowsheetHooks");
+    vi.mocked(useShowControl).mockReturnValue({
+      live: true,
+    } as any);
+
+    render(<FlowsheetLink />);
+
+    // The link should be in the document and badge should be visible
+    expect(screen.getByRole("link")).toBeInTheDocument();
+  });
+
+  it("should render badge around link", () => {
+    render(<FlowsheetLink />);
+
+    // Badge wrapper should exist
+    const link = screen.getByRole("link");
+    expect(link.closest(".MuiBadge-root")).toBeInTheDocument();
+  });
+
+  it("should have invisible badge when not live", () => {
+    render(<FlowsheetLink />);
+
+    // Badge should be invisible (no visible badge indicator)
+    const badgeRoot = screen.getByRole("link").closest(".MuiBadge-root");
+    expect(badgeRoot).toBeInTheDocument();
+  });
+
+  it("should have visible badge when live", async () => {
+    const { useShowControl } = await import("@/src/hooks/flowsheetHooks");
+    vi.mocked(useShowControl).mockReturnValue({
+      live: true,
+    } as any);
+
+    render(<FlowsheetLink />);
+
+    // Badge should be visible when live
+    const badgeRoot = screen.getByRole("link").closest(".MuiBadge-root");
+    expect(badgeRoot).toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/Leftbar/Leftbar.test.tsx
+++ b/src/components/experiences/modern/Leftbar/Leftbar.test.tsx
@@ -1,0 +1,335 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Leftbar from "./Leftbar";
+import { Authorization } from "@/lib/features/admin/types";
+import type { User } from "@/lib/features/authentication/types";
+
+// Mock server-side authentication utilities
+const mockUser: User = {
+  username: "testuser",
+  email: "test@example.com",
+  realName: "Test User",
+  djName: "DJ Test",
+  authority: Authorization.DJ,
+};
+
+vi.mock("@/lib/features/authentication/server-utils", () => ({
+  requireAuth: vi.fn(() =>
+    Promise.resolve({
+      user: { id: "123", name: "testuser", email: "test@example.com" },
+      session: { id: "session-123" },
+    })
+  ),
+  getUserFromSession: vi.fn(() => Promise.resolve(mockUser)),
+}));
+
+// Mock child components to simplify testing
+vi.mock("./LeftbarContainer", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="leftbar-container">{children}</div>
+  ),
+}));
+
+vi.mock("./LeftbarLink", () => ({
+  default: ({
+    path,
+    title,
+    disabled,
+    children,
+  }: {
+    path: string;
+    title: string;
+    disabled?: boolean;
+    children: React.ReactNode;
+  }) => (
+    <div
+      data-testid={`leftbar-link-${path.replace(/\//g, "-")}`}
+      data-disabled={disabled}
+    >
+      <span data-testid="link-title">{title}</span>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("./FlowsheetLink", () => ({
+  default: () => <div data-testid="flowsheet-link">Flowsheet</div>,
+}));
+
+vi.mock("./LeftbarLogout", () => ({
+  default: ({ user }: { user: User }) => (
+    <div data-testid="leftbar-logout">{user.username}</div>
+  ),
+}));
+
+// Mock MUI components
+vi.mock("@mui/joy/List", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <ul data-testid="list">{children}</ul>
+  ),
+}));
+
+vi.mock("@mui/joy/Divider", () => ({
+  default: () => <hr data-testid="divider" />,
+}));
+
+// Mock MUI icons
+vi.mock("@mui/icons-material/Album", () => ({
+  default: () => <svg data-testid="album-icon" />,
+}));
+
+vi.mock("@mui/icons-material/Settings", () => ({
+  default: () => <svg data-testid="settings-icon" />,
+}));
+
+vi.mock("@mui/icons-material/Storage", () => ({
+  default: () => <svg data-testid="storage-icon" />,
+}));
+
+vi.mock("@mui/icons-material", () => ({
+  EditCalendar: () => <svg data-testid="edit-calendar-icon" />,
+  ManageAccounts: () => <svg data-testid="manage-accounts-icon" />,
+}));
+
+describe("Leftbar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the leftbar container", async () => {
+    const Component = await Leftbar();
+    render(Component);
+
+    expect(screen.getByTestId("leftbar-container")).toBeInTheDocument();
+  });
+
+  it("should render catalog link", async () => {
+    const Component = await Leftbar();
+    render(Component);
+
+    const catalogLink = screen.getByTestId(
+      "leftbar-link--dashboard-catalog"
+    );
+    expect(catalogLink).toBeInTheDocument();
+    expect(screen.getByText("Card Catalog")).toBeInTheDocument();
+  });
+
+  it("should render flowsheet link", async () => {
+    const Component = await Leftbar();
+    render(Component);
+
+    expect(screen.getByTestId("flowsheet-link")).toBeInTheDocument();
+  });
+
+  it("should render previous sets link as disabled", async () => {
+    const Component = await Leftbar();
+    render(Component);
+
+    const playlistsLink = screen.getByTestId(
+      "leftbar-link--dashboard-playlists"
+    );
+    expect(playlistsLink).toBeInTheDocument();
+    expect(playlistsLink).toHaveAttribute("data-disabled", "true");
+    expect(screen.getByText("Previous Sets")).toBeInTheDocument();
+  });
+
+  it("should render settings link", async () => {
+    const Component = await Leftbar();
+    render(Component);
+
+    const settingsLink = screen.getByTestId(
+      "leftbar-link--dashboard-settings"
+    );
+    expect(settingsLink).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("should render logout component with user", async () => {
+    const Component = await Leftbar();
+    render(Component);
+
+    const logout = screen.getByTestId("leftbar-logout");
+    expect(logout).toBeInTheDocument();
+    expect(logout).toHaveTextContent("testuser");
+  });
+
+  it("should not render admin links for DJ authority", async () => {
+    const Component = await Leftbar();
+    render(Component);
+
+    // DJ users should not see admin links
+    expect(
+      screen.queryByTestId("leftbar-link--dashboard-admin-roster")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("leftbar-link--dashboard-admin-schedule")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render admin links for MD authority", async () => {
+    const { getUserFromSession } = await import(
+      "@/lib/features/authentication/server-utils"
+    );
+    vi.mocked(getUserFromSession).mockResolvedValue({
+      ...mockUser,
+      authority: Authorization.MD,
+    });
+
+    const Component = await Leftbar();
+    render(Component);
+
+    // MD users should see admin links
+    expect(
+      screen.getByTestId("leftbar-link--dashboard-admin-roster")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("leftbar-link--dashboard-admin-schedule")
+    ).toBeInTheDocument();
+  });
+
+  it("should render admin links for SM authority", async () => {
+    const { getUserFromSession } = await import(
+      "@/lib/features/authentication/server-utils"
+    );
+    vi.mocked(getUserFromSession).mockResolvedValue({
+      ...mockUser,
+      authority: Authorization.SM,
+    });
+
+    const Component = await Leftbar();
+    render(Component);
+
+    // SM users should see admin links
+    expect(
+      screen.getByTestId("leftbar-link--dashboard-admin-roster")
+    ).toBeInTheDocument();
+  });
+
+  it("should disable roster link for MD authority (below SM)", async () => {
+    const { getUserFromSession } = await import(
+      "@/lib/features/authentication/server-utils"
+    );
+    vi.mocked(getUserFromSession).mockResolvedValue({
+      ...mockUser,
+      authority: Authorization.MD,
+    });
+
+    const Component = await Leftbar();
+    render(Component);
+
+    const rosterLink = screen.getByTestId(
+      "leftbar-link--dashboard-admin-roster"
+    );
+    expect(rosterLink).toHaveAttribute("data-disabled", "true");
+  });
+
+  it("should enable roster link for SM authority", async () => {
+    const { getUserFromSession } = await import(
+      "@/lib/features/authentication/server-utils"
+    );
+    vi.mocked(getUserFromSession).mockResolvedValue({
+      ...mockUser,
+      authority: Authorization.SM,
+    });
+
+    const Component = await Leftbar();
+    render(Component);
+
+    const rosterLink = screen.getByTestId(
+      "leftbar-link--dashboard-admin-roster"
+    );
+    expect(rosterLink).toHaveAttribute("data-disabled", "false");
+  });
+
+  it("should always disable schedule link", async () => {
+    const { getUserFromSession } = await import(
+      "@/lib/features/authentication/server-utils"
+    );
+    vi.mocked(getUserFromSession).mockResolvedValue({
+      ...mockUser,
+      authority: Authorization.SM,
+    });
+
+    const Component = await Leftbar();
+    render(Component);
+
+    const scheduleLink = screen.getByTestId(
+      "leftbar-link--dashboard-admin-schedule"
+    );
+    expect(scheduleLink).toHaveAttribute("data-disabled", "true");
+  });
+
+  it("should render dividers", async () => {
+    const { getUserFromSession } = await import(
+      "@/lib/features/authentication/server-utils"
+    );
+    vi.mocked(getUserFromSession).mockResolvedValue({
+      ...mockUser,
+      authority: Authorization.SM,
+    });
+
+    const Component = await Leftbar();
+    render(Component);
+
+    // Should have dividers between sections
+    expect(screen.getAllByTestId("divider").length).toBeGreaterThan(0);
+  });
+
+  it("should render list component", async () => {
+    const Component = await Leftbar();
+    render(Component);
+
+    expect(screen.getByTestId("list")).toBeInTheDocument();
+  });
+
+  it("should render album icon for catalog link", async () => {
+    const Component = await Leftbar();
+    render(Component);
+
+    expect(screen.getByTestId("album-icon")).toBeInTheDocument();
+  });
+
+  it("should render settings icon for settings link", async () => {
+    const Component = await Leftbar();
+    render(Component);
+
+    expect(screen.getByTestId("settings-icon")).toBeInTheDocument();
+  });
+
+  it("should render storage icon for playlists link", async () => {
+    const Component = await Leftbar();
+    render(Component);
+
+    expect(screen.getByTestId("storage-icon")).toBeInTheDocument();
+  });
+
+  it("should render manage accounts icon for roster link when visible", async () => {
+    const { getUserFromSession } = await import(
+      "@/lib/features/authentication/server-utils"
+    );
+    vi.mocked(getUserFromSession).mockResolvedValue({
+      ...mockUser,
+      authority: Authorization.SM,
+    });
+
+    const Component = await Leftbar();
+    render(Component);
+
+    expect(screen.getByTestId("manage-accounts-icon")).toBeInTheDocument();
+  });
+
+  it("should render edit calendar icon for schedule link when visible", async () => {
+    const { getUserFromSession } = await import(
+      "@/lib/features/authentication/server-utils"
+    );
+    vi.mocked(getUserFromSession).mockResolvedValue({
+      ...mockUser,
+      authority: Authorization.SM,
+    });
+
+    const Component = await Leftbar();
+    render(Component);
+
+    expect(screen.getByTestId("edit-calendar-icon")).toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/Leftbar/LeftbarContainer.test.tsx
+++ b/src/components/experiences/modern/Leftbar/LeftbarContainer.test.tsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import LeftbarContainer from "./LeftbarContainer";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/dashboard"),
+}));
+
+// Mock Logo component
+vi.mock("@/src/components/shared/Branding/Logo", () => ({
+  default: ({ color }: any) => (
+    <div data-testid="logo" data-color={color}>
+      Logo
+    </div>
+  ),
+}));
+
+describe("LeftbarContainer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render children", () => {
+    render(
+      <LeftbarContainer>
+        <div data-testid="child-content">Child Content</div>
+      </LeftbarContainer>
+    );
+
+    expect(screen.getByTestId("child-content")).toBeInTheDocument();
+  });
+
+  it("should render logo", () => {
+    render(
+      <LeftbarContainer>
+        <div>Content</div>
+      </LeftbarContainer>
+    );
+
+    expect(screen.getByTestId("logo")).toBeInTheDocument();
+  });
+
+  it("should have FirstSidebar class", () => {
+    render(
+      <LeftbarContainer>
+        <div>Content</div>
+      </LeftbarContainer>
+    );
+
+    const container = document.querySelector(".FirstSidebar");
+    expect(container).toBeInTheDocument();
+  });
+
+  it("should use primary color for non-admin paths", () => {
+    render(
+      <LeftbarContainer>
+        <div>Content</div>
+      </LeftbarContainer>
+    );
+
+    expect(screen.getByTestId("logo")).toHaveAttribute("data-color", "primary");
+  });
+
+  it("should use success color for admin paths", async () => {
+    const { usePathname } = await import("next/navigation");
+    vi.mocked(usePathname).mockReturnValue("/dashboard/admin/roster");
+
+    render(
+      <LeftbarContainer>
+        <div>Content</div>
+      </LeftbarContainer>
+    );
+
+    expect(screen.getByTestId("logo")).toHaveAttribute("data-color", "success");
+  });
+
+  it("should render multiple children", () => {
+    render(
+      <LeftbarContainer>
+        <div data-testid="child-1">Child 1</div>
+        <div data-testid="child-2">Child 2</div>
+      </LeftbarContainer>
+    );
+
+    expect(screen.getByTestId("child-1")).toBeInTheDocument();
+    expect(screen.getByTestId("child-2")).toBeInTheDocument();
+  });
+
+  it("should render as Sheet component", () => {
+    render(
+      <LeftbarContainer>
+        <div data-testid="content">Content</div>
+      </LeftbarContainer>
+    );
+
+    const container = document.querySelector(".MuiSheet-root");
+    expect(container).toBeInTheDocument();
+  });
+
+  describe("admin path detection", () => {
+    it("should use success color for admin schedule path", async () => {
+      const { usePathname } = await import("next/navigation");
+      vi.mocked(usePathname).mockReturnValue("/dashboard/admin/schedule");
+
+      render(
+        <LeftbarContainer>
+          <div>Content</div>
+        </LeftbarContainer>
+      );
+
+      expect(screen.getByTestId("logo")).toHaveAttribute(
+        "data-color",
+        "success"
+      );
+    });
+
+    it("should use primary color for catalog path", async () => {
+      const { usePathname } = await import("next/navigation");
+      vi.mocked(usePathname).mockReturnValue("/dashboard/catalog");
+
+      render(
+        <LeftbarContainer>
+          <div>Content</div>
+        </LeftbarContainer>
+      );
+
+      expect(screen.getByTestId("logo")).toHaveAttribute(
+        "data-color",
+        "primary"
+      );
+    });
+
+    it("should use primary color for flowsheet path", async () => {
+      const { usePathname } = await import("next/navigation");
+      vi.mocked(usePathname).mockReturnValue("/dashboard/flowsheet");
+
+      render(
+        <LeftbarContainer>
+          <div>Content</div>
+        </LeftbarContainer>
+      );
+
+      expect(screen.getByTestId("logo")).toHaveAttribute(
+        "data-color",
+        "primary"
+      );
+    });
+
+    it("should use primary color for settings path", async () => {
+      const { usePathname } = await import("next/navigation");
+      vi.mocked(usePathname).mockReturnValue("/dashboard/settings");
+
+      render(
+        <LeftbarContainer>
+          <div>Content</div>
+        </LeftbarContainer>
+      );
+
+      expect(screen.getByTestId("logo")).toHaveAttribute(
+        "data-color",
+        "primary"
+      );
+    });
+
+    it("should use success color when admin appears anywhere in path", async () => {
+      const { usePathname } = await import("next/navigation");
+      vi.mocked(usePathname).mockReturnValue("/some/admin/nested/path");
+
+      render(
+        <LeftbarContainer>
+          <div>Content</div>
+        </LeftbarContainer>
+      );
+
+      expect(screen.getByTestId("logo")).toHaveAttribute(
+        "data-color",
+        "success"
+      );
+    });
+  });
+
+  describe("sheet styling", () => {
+    it("should render Sheet with soft variant", () => {
+      render(
+        <LeftbarContainer>
+          <div>Content</div>
+        </LeftbarContainer>
+      );
+
+      const container = document.querySelector(".MuiSheet-variantSoft");
+      expect(container).toBeInTheDocument();
+    });
+
+    it("should render Sheet component with MuiSheet-root class", () => {
+      render(
+        <LeftbarContainer>
+          <div>Content</div>
+        </LeftbarContainer>
+      );
+
+      const container = document.querySelector(".MuiSheet-root");
+      expect(container).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/experiences/modern/Leftbar/LeftbarLink.test.tsx
+++ b/src/components/experiences/modern/Leftbar/LeftbarLink.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import LeftbarLink from "./LeftbarLink";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/dashboard"),
+}));
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("LeftbarLink", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render link with correct href", () => {
+    render(
+      <LeftbarLink path="/dashboard/catalog" title="Catalog">
+        <span data-testid="icon">Icon</span>
+      </LeftbarLink>
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/dashboard/catalog");
+  });
+
+  it("should render children", () => {
+    render(
+      <LeftbarLink path="/dashboard/catalog" title="Catalog">
+        <span data-testid="icon">Icon</span>
+      </LeftbarLink>
+    );
+
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+
+  it("should be disabled when disabled prop is true", () => {
+    render(
+      <LeftbarLink path="/dashboard/catalog" title="Catalog" disabled={true}>
+        <span>Icon</span>
+      </LeftbarLink>
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("aria-disabled", "true");
+    expect(link).toHaveStyle({ pointerEvents: "none" });
+  });
+
+  it("should be enabled when disabled prop is false", () => {
+    render(
+      <LeftbarLink path="/dashboard/catalog" title="Catalog" disabled={false}>
+        <span>Icon</span>
+      </LeftbarLink>
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("aria-disabled", "false");
+    expect(link).toHaveStyle({ pointerEvents: "auto" });
+  });
+
+  it("should show solid variant when path matches current pathname", async () => {
+    const { usePathname } = await import("next/navigation");
+    vi.mocked(usePathname).mockReturnValue("/dashboard/catalog");
+
+    render(
+      <LeftbarLink path="/dashboard/catalog" title="Catalog">
+        <span>Icon</span>
+      </LeftbarLink>
+    );
+
+    // The ListItemButton should have solid variant when path matches
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("MuiListItemButton-variantSolid");
+  });
+
+  it("should show plain variant when path does not match current pathname", async () => {
+    const { usePathname } = await import("next/navigation");
+    vi.mocked(usePathname).mockReturnValue("/dashboard/other");
+
+    render(
+      <LeftbarLink path="/dashboard/catalog" title="Catalog">
+        <span>Icon</span>
+      </LeftbarLink>
+    );
+
+    // The ListItemButton should have plain variant when path doesn't match
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("MuiListItemButton-variantPlain");
+  });
+
+  it("should render tooltip with title", () => {
+    render(
+      <LeftbarLink path="/dashboard/catalog" title="Card Catalog">
+        <span>Icon</span>
+      </LeftbarLink>
+    );
+
+    // Tooltip title is not directly visible but is in the DOM
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/Leftbar/LeftbarLogout.test.tsx
+++ b/src/components/experiences/modern/Leftbar/LeftbarLogout.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import LeftbarLogout from "./LeftbarLogout";
+import type { User } from "@/lib/features/authentication/types";
+import { Authorization } from "@/lib/features/admin/types";
+
+// Mock the useLogout hook
+const mockHandleLogout = vi.fn((e?: React.FormEvent<HTMLFormElement>) => {
+  e?.preventDefault();
+});
+vi.mock("@/src/hooks/authenticationHooks", () => ({
+  useLogout: vi.fn(() => ({
+    handleLogout: mockHandleLogout,
+    loggingOut: false,
+  })),
+}));
+
+describe("LeftbarLogout", () => {
+  const mockUser: User = {
+    username: "testuser",
+    email: "test@example.com",
+    realName: "Test User",
+    djName: "DJ Test",
+    authority: Authorization.DJ,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the logout button", () => {
+    render(<LeftbarLogout user={mockUser} />);
+
+    const button = screen.getByRole("button");
+    expect(button).toBeInTheDocument();
+  });
+
+  it("should display PersonOutlined icon by default", () => {
+    render(<LeftbarLogout user={mockUser} />);
+
+    const button = screen.getByRole("button");
+    expect(button).toBeInTheDocument();
+    // PersonOutlined icon should be visible by default
+    expect(button.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("should call handleLogout when form is submitted", () => {
+    render(<LeftbarLogout user={mockUser} />);
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(mockHandleLogout).toHaveBeenCalled();
+  });
+
+  it("should show loading state when loggingOut is true", async () => {
+    const { useLogout } = await import("@/src/hooks/authenticationHooks");
+    vi.mocked(useLogout).mockReturnValue({
+      handleLogout: mockHandleLogout,
+      loggingOut: true,
+    });
+
+    render(<LeftbarLogout user={mockUser} />);
+
+    const button = screen.getByRole("button");
+    // MUI Joy uses loading class when loading prop is true
+    expect(button).toHaveClass("MuiIconButton-loading");
+  });
+
+  it("should change icon on hover", () => {
+    render(<LeftbarLogout user={mockUser} />);
+
+    const button = screen.getByRole("button");
+
+    // Before hover - PersonOutlined
+    fireEvent.mouseOver(button);
+    // After hover - LogoutOutlined icon should appear
+
+    fireEvent.mouseOut(button);
+    // After mouse out - PersonOutlined icon should appear again
+    expect(button).toBeInTheDocument();
+  });
+
+  it("should render with username in tooltip content", () => {
+    render(<LeftbarLogout user={mockUser} />);
+
+    // The tooltip content includes the username
+    // Note: Tooltip content is rendered but may not be visible until hover
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("should render with user without realName", () => {
+    const userWithoutRealName: User = {
+      username: "testuser",
+      email: "test@example.com",
+      djName: "DJ Test",
+      authority: Authorization.DJ,
+    };
+
+    render(<LeftbarLogout user={userWithoutRealName} />);
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("should render with user without djName", () => {
+    const userWithoutDjName: User = {
+      username: "testuser",
+      email: "test@example.com",
+      realName: "Test User",
+      authority: Authorization.DJ,
+    };
+
+    render(<LeftbarLogout user={userWithoutDjName} />);
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("should render with user without both realName and djName", () => {
+    const minimalUser: User = {
+      username: "testuser",
+      email: "test@example.com",
+      authority: Authorization.DJ,
+    };
+
+    render(<LeftbarLogout user={minimalUser} />);
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("should have outlined variant on the button", () => {
+    render(<LeftbarLogout user={mockUser} />);
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("MuiIconButton-variantOutlined");
+  });
+
+  it("should render form element", () => {
+    render(<LeftbarLogout user={mockUser} />);
+
+    const form = screen.getByRole("button").closest("form");
+    expect(form).toBeInTheDocument();
+  });
+
+  it("should render with SM authority user", () => {
+    const smUser: User = {
+      username: "admin",
+      email: "admin@example.com",
+      realName: "Admin User",
+      djName: "DJ Admin",
+      authority: Authorization.SM,
+    };
+
+    render(<LeftbarLogout user={smUser} />);
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("should render with MD authority user", () => {
+    const mdUser: User = {
+      username: "md",
+      email: "md@example.com",
+      realName: "Music Director",
+      djName: "DJ MD",
+      authority: Authorization.MD,
+    };
+
+    render(<LeftbarLogout user={mdUser} />);
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add tests for Leftbar main component
- Add tests for LeftbarContainer
- Add tests for LeftbarLink
- Add tests for LeftbarLogout
- Add tests for FlowsheetLink

## Test plan
- [x] Run `npm test src/components/experiences/modern/Leftbar/`

**Part 14 of 26**