### PR TITLE
test: add bin component tests

### DIFF
--- a/src/components/experiences/modern/Rightbar/Bin/AddToQueueFromBin.test.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/AddToQueueFromBin.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import AddToQueueFromBin from "./AddToQueueFromBin";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
+import { Menu } from "@mui/joy";
+
+// Mock hooks
+const mockAddToQueue = vi.fn();
+const mockDeleteFromBin = vi.fn();
+
+vi.mock("@/src/hooks/applicationHooks", () => ({
+  useShiftKey: vi.fn(() => false),
+}));
+
+vi.mock("@/src/hooks/binHooks", () => ({
+  useDeleteFromBin: vi.fn(() => ({
+    deleteFromBin: mockDeleteFromBin,
+  })),
+}));
+
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useQueue: vi.fn(() => ({
+    addToQueue: mockAddToQueue,
+  })),
+}));
+
+vi.mock("@/lib/features/bin/conversions", () => ({
+  convertBinToQueue: vi.fn((entry) => ({ converted: entry })),
+}));
+
+// Mock MUI icons
+vi.mock("@mui/icons-material/PlaylistAdd", () => ({
+  default: () => <span data-testid="playlist-add-icon" />,
+}));
+
+// Wrapper component to provide Menu context
+function MenuWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <Menu open={true} anchorEl={null}>
+      {children}
+    </Menu>
+  );
+}
+
+describe("AddToQueueFromBin", () => {
+  const mockEntry: AlbumEntry = {
+    id: 1,
+    title: "Test Album",
+    entry: 5,
+    format: "CD",
+    artist: {
+      id: 1,
+      name: "Test Artist",
+      lettercode: "TA",
+      numbercode: 100,
+      genre: "Rock",
+    },
+  } as AlbumEntry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render menu item with text", () => {
+    render(
+      <MenuWrapper>
+        <AddToQueueFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    expect(screen.getByText("Add to Queue")).toBeInTheDocument();
+  });
+
+  it("should render playlist add icon", () => {
+    render(
+      <MenuWrapper>
+        <AddToQueueFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    expect(screen.getByTestId("playlist-add-icon")).toBeInTheDocument();
+  });
+
+  it("should render shift hint", () => {
+    render(
+      <MenuWrapper>
+        <AddToQueueFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    expect(screen.getByText("+ Shift")).toBeInTheDocument();
+    expect(screen.getByText("to remove from bin")).toBeInTheDocument();
+  });
+
+  it("should call addToQueue when clicked", () => {
+    render(
+      <MenuWrapper>
+        <AddToQueueFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    const menuItem = screen.getByRole("menuitem");
+    fireEvent.click(menuItem);
+
+    expect(mockAddToQueue).toHaveBeenCalled();
+  });
+
+  it("should not call deleteFromBin when shift is not pressed", () => {
+    render(
+      <MenuWrapper>
+        <AddToQueueFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    const menuItem = screen.getByRole("menuitem");
+    fireEvent.click(menuItem);
+
+    expect(mockDeleteFromBin).not.toHaveBeenCalled();
+  });
+
+  it("should call deleteFromBin when shift is pressed", async () => {
+    const { useShiftKey } = await import("@/src/hooks/applicationHooks");
+    vi.mocked(useShiftKey).mockReturnValue(true);
+
+    render(
+      <MenuWrapper>
+        <AddToQueueFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    const menuItem = screen.getByRole("menuitem");
+    fireEvent.click(menuItem);
+
+    expect(mockDeleteFromBin).toHaveBeenCalledWith(1);
+    expect(mockAddToQueue).toHaveBeenCalled();
+  });
+
+  it("should render as menuitem role", () => {
+    render(
+      <MenuWrapper>
+        <AddToQueueFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    expect(screen.getByRole("menuitem")).toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/Rightbar/Bin/BinContent.test.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/BinContent.test.tsx
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import BinContent from "./BinContent";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
+
+// Mock the hooks
+const mockUseBin = vi.fn();
+const mockUseGetRightbarQuery = vi.fn();
+
+vi.mock("@/src/hooks/binHooks", () => ({
+  useBin: () => mockUseBin(),
+}));
+
+vi.mock("@/lib/features/application/api", () => ({
+  useGetRightbarQuery: () => mockUseGetRightbarQuery(),
+}));
+
+// Mock child components
+vi.mock("../RightBarContentContainer", () => ({
+  default: ({
+    label,
+    startDecorator,
+    children,
+  }: {
+    label: string;
+    startDecorator: React.ReactNode;
+    children: React.ReactNode;
+  }) => (
+    <div data-testid="content-container">
+      <span data-testid="container-label">{label}</span>
+      <span data-testid="start-decorator">{startDecorator}</span>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("./BinEntry", () => ({
+  default: ({ entry }: { entry: AlbumEntry }) => (
+    <div data-testid={`bin-entry-${entry.id}`}>{entry.title}</div>
+  ),
+}));
+
+// Mock MUI components
+vi.mock("@mui/icons-material", () => ({
+  Inbox: () => <svg data-testid="inbox-icon" />,
+}));
+
+vi.mock("@mui/joy", () => ({
+  Card: ({
+    children,
+    variant,
+    sx,
+  }: {
+    children: React.ReactNode;
+    variant?: string;
+    sx?: any;
+  }) => (
+    <div data-testid="card" data-variant={variant} style={{ height: sx?.height }}>
+      {children}
+    </div>
+  ),
+  Divider: () => <hr data-testid="bin-divider" />,
+  Skeleton: ({ variant, sx }: { variant?: string; sx?: any }) => (
+    <div
+      data-testid="skeleton"
+      data-variant={variant}
+      style={{ height: sx?.height }}
+    />
+  ),
+  Typography: ({
+    children,
+    level,
+  }: {
+    children: React.ReactNode;
+    level?: string;
+  }) => (
+    <span data-testid="typography" data-level={level}>
+      {children}
+    </span>
+  ),
+}));
+
+describe("BinContent", () => {
+  const mockBinEntries: AlbumEntry[] = [
+    {
+      id: 1,
+      title: "Album One",
+      entry: 1,
+      format: "CD",
+      artist: {
+        name: "Artist One",
+        lettercode: "AO",
+        numbercode: 1,
+        genre: "Rock",
+        id: 1,
+      },
+      label: "Label One",
+      add_date: "2024-01-01",
+      alternate_artist: undefined,
+      play_freq: undefined,
+      rotation_id: undefined,
+      plays: undefined,
+    },
+    {
+      id: 2,
+      title: "Album Two",
+      entry: 2,
+      format: "Vinyl",
+      artist: {
+        name: "Artist Two",
+        lettercode: "AT",
+        numbercode: 2,
+        genre: "Jazz",
+        id: 2,
+      },
+      label: "Label Two",
+      add_date: "2024-01-02",
+      alternate_artist: undefined,
+      play_freq: undefined,
+      rotation_id: undefined,
+      plays: undefined,
+    },
+    {
+      id: 3,
+      title: "Album Three",
+      entry: 3,
+      format: "CD",
+      artist: {
+        name: "Artist Three",
+        lettercode: "ATH",
+        numbercode: 3,
+        genre: "Electronic",
+        id: 3,
+      },
+      label: "Label Three",
+      add_date: "2024-01-03",
+      alternate_artist: undefined,
+      play_freq: undefined,
+      rotation_id: undefined,
+      plays: undefined,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseBin.mockReturnValue({
+      bin: mockBinEntries,
+      loading: false,
+      isSuccess: true,
+      isError: false,
+    });
+    mockUseGetRightbarQuery.mockReturnValue({
+      data: false,
+    });
+  });
+
+  it("should render the content container with Mail Bin label", () => {
+    render(<BinContent />);
+
+    expect(screen.getByTestId("content-container")).toBeInTheDocument();
+    expect(screen.getByTestId("container-label")).toHaveTextContent("Mail Bin");
+  });
+
+  it("should render inbox icon in start decorator", () => {
+    render(<BinContent />);
+
+    expect(screen.getByTestId("inbox-icon")).toBeInTheDocument();
+  });
+
+  it("should render skeleton when loading", () => {
+    mockUseBin.mockReturnValue({
+      bin: undefined,
+      loading: true,
+      isSuccess: false,
+      isError: false,
+    });
+
+    render(<BinContent />);
+
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("skeleton")).toHaveAttribute(
+      "data-variant",
+      "rectangular"
+    );
+  });
+
+  it("should render card when not loading", () => {
+    render(<BinContent />);
+
+    expect(screen.getByTestId("card")).toBeInTheDocument();
+    expect(screen.getByTestId("card")).toHaveAttribute(
+      "data-variant",
+      "outlined"
+    );
+  });
+
+  it("should render empty message when bin is empty", () => {
+    mockUseBin.mockReturnValue({
+      bin: [],
+      loading: false,
+      isSuccess: true,
+      isError: false,
+    });
+
+    render(<BinContent />);
+
+    expect(screen.getByText("An empty record...")).toBeInTheDocument();
+  });
+
+  it("should render empty message when bin is null", () => {
+    mockUseBin.mockReturnValue({
+      bin: null,
+      loading: false,
+      isSuccess: true,
+      isError: false,
+    });
+
+    render(<BinContent />);
+
+    expect(screen.getByText("An empty record...")).toBeInTheDocument();
+  });
+
+  it("should render empty message when isError is true", () => {
+    mockUseBin.mockReturnValue({
+      bin: mockBinEntries,
+      loading: false,
+      isSuccess: true,
+      isError: true,
+    });
+
+    render(<BinContent />);
+
+    expect(screen.getByText("An empty record...")).toBeInTheDocument();
+  });
+
+  it("should render bin entries when bin has items", () => {
+    render(<BinContent />);
+
+    expect(screen.getByTestId("bin-entry-1")).toBeInTheDocument();
+    expect(screen.getByTestId("bin-entry-2")).toBeInTheDocument();
+    expect(screen.getByTestId("bin-entry-3")).toBeInTheDocument();
+  });
+
+  it("should render entry titles", () => {
+    render(<BinContent />);
+
+    expect(screen.getByText("Album One")).toBeInTheDocument();
+    expect(screen.getByText("Album Two")).toBeInTheDocument();
+    expect(screen.getByText("Album Three")).toBeInTheDocument();
+  });
+
+  it("should render dividers between entries", () => {
+    render(<BinContent />);
+
+    // Should have dividers between entries (n-1 dividers for n entries)
+    const dividers = screen.getAllByTestId("bin-divider");
+    expect(dividers.length).toBe(mockBinEntries.length - 1);
+  });
+
+  it("should not render divider after last entry", () => {
+    render(<BinContent />);
+
+    const dividers = screen.getAllByTestId("bin-divider");
+    // Should be 2 dividers for 3 entries (no divider after last)
+    expect(dividers.length).toBe(2);
+  });
+
+  it("should use default height when max is false", () => {
+    mockUseGetRightbarQuery.mockReturnValue({
+      data: false,
+    });
+
+    render(<BinContent />);
+
+    const card = screen.getByTestId("card");
+    expect(card).toHaveStyle({ height: "335px" });
+  });
+
+  it("should use taller height when max is true", () => {
+    mockUseGetRightbarQuery.mockReturnValue({
+      data: true,
+    });
+
+    render(<BinContent />);
+
+    const card = screen.getByTestId("card");
+    expect(card).toHaveStyle({ height: "500px" });
+  });
+
+  it("should use default height when max is undefined", () => {
+    mockUseGetRightbarQuery.mockReturnValue({
+      data: undefined,
+    });
+
+    render(<BinContent />);
+
+    const card = screen.getByTestId("card");
+    expect(card).toHaveStyle({ height: "335px" });
+  });
+
+  it("should render skeleton with correct height when loading and max is false", () => {
+    mockUseBin.mockReturnValue({
+      bin: undefined,
+      loading: true,
+      isSuccess: false,
+      isError: false,
+    });
+    mockUseGetRightbarQuery.mockReturnValue({
+      data: false,
+    });
+
+    render(<BinContent />);
+
+    const skeleton = screen.getByTestId("skeleton");
+    expect(skeleton).toHaveStyle({ height: "335px" });
+  });
+
+  it("should render skeleton with taller height when loading and max is true", () => {
+    mockUseBin.mockReturnValue({
+      bin: undefined,
+      loading: true,
+      isSuccess: false,
+      isError: false,
+    });
+    mockUseGetRightbarQuery.mockReturnValue({
+      data: true,
+    });
+
+    render(<BinContent />);
+
+    const skeleton = screen.getByTestId("skeleton");
+    expect(skeleton).toHaveStyle({ height: "500px" });
+  });
+
+  it("should render single entry without divider", () => {
+    mockUseBin.mockReturnValue({
+      bin: [mockBinEntries[0]],
+      loading: false,
+      isSuccess: true,
+      isError: false,
+    });
+
+    render(<BinContent />);
+
+    expect(screen.getByTestId("bin-entry-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("bin-divider")).not.toBeInTheDocument();
+  });
+
+  it("should render two entries with one divider", () => {
+    mockUseBin.mockReturnValue({
+      bin: [mockBinEntries[0], mockBinEntries[1]],
+      loading: false,
+      isSuccess: true,
+      isError: false,
+    });
+
+    render(<BinContent />);
+
+    expect(screen.getByTestId("bin-entry-1")).toBeInTheDocument();
+    expect(screen.getByTestId("bin-entry-2")).toBeInTheDocument();
+    expect(screen.getAllByTestId("bin-divider")).toHaveLength(1);
+  });
+
+  it("should handle entries with same ids correctly using index in key", () => {
+    const duplicateIdEntries = [
+      { ...mockBinEntries[0], id: 1 },
+      { ...mockBinEntries[1], id: 1 }, // Same id but different entry
+    ];
+
+    mockUseBin.mockReturnValue({
+      bin: duplicateIdEntries,
+      loading: false,
+      isSuccess: true,
+      isError: false,
+    });
+
+    render(<BinContent />);
+
+    // Should render both entries even with same id (index is used in key)
+    expect(screen.getAllByTestId("bin-entry-1")).toHaveLength(2);
+  });
+
+  it("should show empty message with typography body-md level", () => {
+    mockUseBin.mockReturnValue({
+      bin: [],
+      loading: false,
+      isSuccess: true,
+      isError: false,
+    });
+
+    render(<BinContent />);
+
+    const typography = screen.getByTestId("typography");
+    expect(typography).toHaveAttribute("data-level", "body-md");
+  });
+});

--- a/src/components/experiences/modern/Rightbar/Bin/BinEntry.test.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/BinEntry.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import BinEntry from "./BinEntry";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
+
+// Mock child components
+vi.mock("../../catalog/ArtistAvatar", () => ({
+  ArtistAvatar: ({ artist, entry, format }: any) => (
+    <div data-testid="artist-avatar">
+      {artist?.name} - {entry}
+    </div>
+  ),
+}));
+
+vi.mock("./BinMenu", () => ({
+  default: ({ entry }: any) => (
+    <div data-testid="bin-menu">{entry.title}</div>
+  ),
+}));
+
+vi.mock("./ScrollOnHoverText", () => ({
+  default: ({ children }: any) => (
+    <span data-testid="scroll-text">{children}</span>
+  ),
+}));
+
+describe("BinEntry", () => {
+  const mockEntry: AlbumEntry = {
+    id: 1,
+    title: "Test Album",
+    entry: 5,
+    format: "CD",
+    artist: {
+      id: 1,
+      name: "Test Artist",
+      lettercode: "AB",
+      numbercode: 123,
+      genre: "Rock",
+    },
+  } as AlbumEntry;
+
+  it("should render ArtistAvatar", () => {
+    render(<BinEntry entry={mockEntry} />);
+
+    expect(screen.getByTestId("artist-avatar")).toBeInTheDocument();
+  });
+
+  it("should render artist name", () => {
+    render(<BinEntry entry={mockEntry} />);
+
+    expect(screen.getByText("Test Artist")).toBeInTheDocument();
+  });
+
+  it("should render album title", () => {
+    render(<BinEntry entry={mockEntry} />);
+
+    // May appear in multiple places (scroll text and bin menu mock)
+    expect(screen.getAllByText("Test Album").length).toBeGreaterThan(0);
+  });
+
+  it("should render BinMenu", () => {
+    render(<BinEntry entry={mockEntry} />);
+
+    expect(screen.getByTestId("bin-menu")).toBeInTheDocument();
+  });
+
+  it("should pass entry to ArtistAvatar", () => {
+    render(<BinEntry entry={mockEntry} />);
+
+    expect(screen.getByTestId("artist-avatar")).toHaveTextContent("Test Artist - 5");
+  });
+
+  it("should render ScrollOnHoverText components", () => {
+    render(<BinEntry entry={mockEntry} />);
+
+    expect(screen.getAllByTestId("scroll-text").length).toBe(2);
+  });
+});

--- a/src/components/experiences/modern/Rightbar/Bin/BinMenu.test.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/BinMenu.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import BinMenu from "./BinMenu";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
+
+// Mock hooks
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useShowControl: vi.fn(() => ({
+    live: false,
+  })),
+}));
+
+vi.mock("@/src/hooks/applicationHooks", () => ({
+  useShiftKey: vi.fn(() => false),
+}));
+
+// Mock child components
+vi.mock("@/src/components/shared/General/LinkButton", () => ({
+  MenuLinkItem: ({ children, href }: any) => (
+    <div data-testid="menu-link" data-href={href}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("./AddToQueueFromBin", () => ({
+  default: ({ entry }: any) => <div data-testid="add-to-queue">{entry.title}</div>,
+}));
+
+vi.mock("./PlayFromBin", () => ({
+  default: ({ entry }: any) => <div data-testid="play-from-bin">{entry.title}</div>,
+}));
+
+vi.mock("./DeleteFromBin", () => ({
+  default: ({ album }: any) => <div data-testid="delete-from-bin">{album.title}</div>,
+}));
+
+// Mock MUI icons
+vi.mock("@mui/icons-material", () => ({
+  MoreVert: () => <span data-testid="more-vert-icon" />,
+}));
+
+vi.mock("@mui/icons-material/InfoOutlined", () => ({
+  default: () => <span data-testid="info-icon" />,
+}));
+
+describe("BinMenu", () => {
+  const mockEntry: AlbumEntry = {
+    id: 1,
+    title: "Test Album",
+    entry: 5,
+    format: "CD",
+    artist: {
+      id: 1,
+      name: "Test Artist",
+      lettercode: "AB",
+      numbercode: 123,
+      genre: "Rock",
+    },
+  } as AlbumEntry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render menu button with more icon", () => {
+    render(<BinMenu entry={mockEntry} />);
+
+    expect(screen.getByTestId("more-vert-icon")).toBeInTheDocument();
+  });
+
+  it("should render dropdown menu button", () => {
+    render(<BinMenu entry={mockEntry} />);
+
+    // The menu button should be in the document
+    const button = screen.getByRole("button");
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-haspopup", "menu");
+  });
+
+  it("should toggle menu expanded state when clicked", () => {
+    render(<BinMenu entry={mockEntry} />);
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/src/components/experiences/modern/Rightbar/Bin/DeleteFromBin.test.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/DeleteFromBin.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import DeleteFromBin from "./DeleteFromBin";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
+import { Menu } from "@mui/joy";
+
+// Mock hooks
+const mockDeleteFromBin = vi.fn();
+
+vi.mock("@/src/hooks/binHooks", () => ({
+  useDeleteFromBin: vi.fn(() => ({
+    deleteFromBin: mockDeleteFromBin,
+  })),
+}));
+
+// Mock MUI icons
+vi.mock("@mui/icons-material", () => ({
+  DeleteOutline: () => <span data-testid="delete-icon" />,
+}));
+
+// Wrapper component to provide Menu context
+function MenuWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <Menu open={true} anchorEl={null}>
+      {children}
+    </Menu>
+  );
+}
+
+describe("DeleteFromBin", () => {
+  const mockAlbum: AlbumEntry = {
+    id: 42,
+    title: "Test Album Title",
+    entry: 5,
+    format: "CD",
+    artist: {
+      id: 1,
+      name: "Test Artist",
+      lettercode: "TA",
+      numbercode: 100,
+      genre: "Rock",
+    },
+  } as AlbumEntry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render menu item with album title", () => {
+    render(
+      <MenuWrapper>
+        <DeleteFromBin album={mockAlbum} />
+      </MenuWrapper>
+    );
+
+    expect(screen.getByText("Remove Test Album Title from Bin")).toBeInTheDocument();
+  });
+
+  it("should render delete icon", () => {
+    render(
+      <MenuWrapper>
+        <DeleteFromBin album={mockAlbum} />
+      </MenuWrapper>
+    );
+
+    expect(screen.getByTestId("delete-icon")).toBeInTheDocument();
+  });
+
+  it("should call deleteFromBin when clicked", () => {
+    render(
+      <MenuWrapper>
+        <DeleteFromBin album={mockAlbum} />
+      </MenuWrapper>
+    );
+
+    const menuItem = screen.getByRole("menuitem");
+    fireEvent.click(menuItem);
+
+    expect(mockDeleteFromBin).toHaveBeenCalledWith(42);
+  });
+
+  it("should render as menuitem role", () => {
+    render(
+      <MenuWrapper>
+        <DeleteFromBin album={mockAlbum} />
+      </MenuWrapper>
+    );
+
+    expect(screen.getByRole("menuitem")).toBeInTheDocument();
+  });
+
+  it("should call deleteFromBin with correct album id", () => {
+    const anotherAlbum: AlbumEntry = {
+      ...mockAlbum,
+      id: 99,
+      title: "Another Album",
+    };
+
+    render(
+      <MenuWrapper>
+        <DeleteFromBin album={anotherAlbum} />
+      </MenuWrapper>
+    );
+
+    const menuItem = screen.getByRole("menuitem");
+    fireEvent.click(menuItem);
+
+    expect(mockDeleteFromBin).toHaveBeenCalledWith(99);
+  });
+});

--- a/src/components/experiences/modern/Rightbar/Bin/PlayFromBin.test.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/PlayFromBin.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import PlayFromBin from "./PlayFromBin";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
+import { Menu } from "@mui/joy";
+
+// Mock hooks
+const mockAddToFlowsheet = vi.fn();
+const mockDeleteFromBin = vi.fn();
+
+vi.mock("@/src/hooks/applicationHooks", () => ({
+  useShiftKey: vi.fn(() => false),
+}));
+
+vi.mock("@/src/hooks/binHooks", () => ({
+  useDeleteFromBin: vi.fn(() => ({
+    deleteFromBin: mockDeleteFromBin,
+  })),
+}));
+
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useFlowsheet: vi.fn(() => ({
+    addToFlowsheet: mockAddToFlowsheet,
+  })),
+}));
+
+vi.mock("@/lib/features/bin/conversions", () => ({
+  convertBinToFlowsheet: vi.fn((entry) => ({ converted: entry })),
+}));
+
+// Mock MUI icons
+vi.mock("@mui/icons-material", () => ({
+  PlayArrowOutlined: () => <span data-testid="play-icon" />,
+}));
+
+// Wrapper component to provide Menu context
+function MenuWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <Menu open={true} anchorEl={null}>
+      {children}
+    </Menu>
+  );
+}
+
+describe("PlayFromBin", () => {
+  const mockEntry: AlbumEntry = {
+    id: 1,
+    title: "Test Album",
+    entry: 5,
+    format: "CD",
+    artist: {
+      id: 1,
+      name: "Test Artist",
+      lettercode: "TA",
+      numbercode: 100,
+      genre: "Rock",
+    },
+  } as AlbumEntry;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render menu item with text", () => {
+    render(
+      <MenuWrapper>
+        <PlayFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    expect(screen.getByText("Play Now")).toBeInTheDocument();
+  });
+
+  it("should render play icon", () => {
+    render(
+      <MenuWrapper>
+        <PlayFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    expect(screen.getByTestId("play-icon")).toBeInTheDocument();
+  });
+
+  it("should render shift hint", () => {
+    render(
+      <MenuWrapper>
+        <PlayFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    expect(screen.getByText("+ Shift")).toBeInTheDocument();
+    expect(screen.getByText("to remove from bin")).toBeInTheDocument();
+  });
+
+  it("should call addToFlowsheet when clicked", () => {
+    render(
+      <MenuWrapper>
+        <PlayFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    const menuItem = screen.getByRole("menuitem");
+    fireEvent.click(menuItem);
+
+    expect(mockAddToFlowsheet).toHaveBeenCalled();
+  });
+
+  it("should not call deleteFromBin when shift is not pressed", () => {
+    render(
+      <MenuWrapper>
+        <PlayFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    const menuItem = screen.getByRole("menuitem");
+    fireEvent.click(menuItem);
+
+    expect(mockDeleteFromBin).not.toHaveBeenCalled();
+  });
+
+  it("should call deleteFromBin when shift is pressed", async () => {
+    const { useShiftKey } = await import("@/src/hooks/applicationHooks");
+    vi.mocked(useShiftKey).mockReturnValue(true);
+
+    render(
+      <MenuWrapper>
+        <PlayFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    const menuItem = screen.getByRole("menuitem");
+    fireEvent.click(menuItem);
+
+    expect(mockDeleteFromBin).toHaveBeenCalledWith(1);
+    expect(mockAddToFlowsheet).toHaveBeenCalled();
+  });
+
+  it("should render as menuitem role", () => {
+    render(
+      <MenuWrapper>
+        <PlayFromBin entry={mockEntry} />
+      </MenuWrapper>
+    );
+
+    expect(screen.getByRole("menuitem")).toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/Rightbar/Bin/ScrollOnHoverText.test.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/ScrollOnHoverText.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ScrollOnHoverText from "./ScrollOnHoverText";
+
+// Mock react-fast-marquee
+vi.mock("react-fast-marquee", () => ({
+  default: ({ children, play }: any) => (
+    <div data-testid="marquee" data-playing={play}>
+      {children}
+    </div>
+  ),
+}));
+
+describe("ScrollOnHoverText", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render children text", () => {
+    render(<ScrollOnHoverText>Test Text</ScrollOnHoverText>);
+
+    expect(screen.getByText("Test Text")).toBeInTheDocument();
+  });
+
+  it("should render marquee component", () => {
+    render(<ScrollOnHoverText>Test Text</ScrollOnHoverText>);
+
+    expect(screen.getByTestId("marquee")).toBeInTheDocument();
+  });
+
+  it("should not play marquee by default", () => {
+    render(<ScrollOnHoverText>Test Text</ScrollOnHoverText>);
+
+    const marquee = screen.getByTestId("marquee");
+    expect(marquee).toHaveAttribute("data-playing", "false");
+  });
+
+  it("should apply custom width", () => {
+    render(<ScrollOnHoverText width={200}>Test Text</ScrollOnHoverText>);
+
+    // Component should render with custom width
+    expect(screen.getByText("Test Text")).toBeInTheDocument();
+  });
+
+  it("should use default width of 100 when not specified", () => {
+    render(<ScrollOnHoverText>Test Text</ScrollOnHoverText>);
+
+    // Component should render with default width
+    expect(screen.getByText("Test Text")).toBeInTheDocument();
+  });
+
+  it("should pass typography props", () => {
+    render(
+      <ScrollOnHoverText level="body-sm" color="primary">
+        Test Text
+      </ScrollOnHoverText>
+    );
+
+    const text = screen.getByText("Test Text");
+    expect(text).toBeInTheDocument();
+  });
+
+  it("should apply custom sx styles", () => {
+    render(
+      <ScrollOnHoverText sx={{ fontWeight: "bold" }}>
+        Test Text
+      </ScrollOnHoverText>
+    );
+
+    const text = screen.getByText("Test Text");
+    expect(text).toBeInTheDocument();
+  });
+
+  it("should handle mouse enter event", () => {
+    render(<ScrollOnHoverText>Test Text</ScrollOnHoverText>);
+
+    const container = screen.getByTestId("marquee").parentElement;
+    if (container) {
+      fireEvent.mouseEnter(container);
+    }
+
+    // After mouseenter, component should be hovering (but may not scroll if text fits)
+    expect(screen.getByText("Test Text")).toBeInTheDocument();
+  });
+
+  it("should handle mouse leave event", () => {
+    render(<ScrollOnHoverText>Test Text</ScrollOnHoverText>);
+
+    const container = screen.getByTestId("marquee").parentElement;
+    if (container) {
+      fireEvent.mouseEnter(container);
+      fireEvent.mouseLeave(container);
+    }
+
+    // After mouseleave, marquee should not be playing
+    expect(screen.getByTestId("marquee")).toHaveAttribute("data-playing", "false");
+  });
+});


### PR DESCRIPTION
## Summary
- Add tests for BinContent
- Add tests for BinEntry
- Add tests for BinMenu
- Add tests for AddToQueueFromBin
- Add tests for DeleteFromBin
- Add tests for PlayFromBin
- Add tests for ScrollOnHoverText

## Test plan
- [x] Run `npm test src/components/experiences/modern/Rightbar/Bin/`

**Part 16 of 26**