### PR TITLE
test: add modern login component tests

### DIFF
--- a/src/components/experiences/modern/login/Forms/AuthBackButton.test.tsx
+++ b/src/components/experiences/modern/login/Forms/AuthBackButton.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import AuthBackButton from "./AuthBackButton";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { applicationSlice } from "@/lib/features/application/frontend";
+
+// Mock hooks
+const mockHandleLogout = vi.fn(() => Promise.resolve());
+
+vi.mock("@/src/hooks/authenticationHooks", () => ({
+  useLogout: vi.fn(() => ({
+    handleLogout: mockHandleLogout,
+    loggingOut: false,
+  })),
+}));
+
+// Mock MUI icons
+vi.mock("@mui/icons-material", () => ({
+  ArrowBack: () => <span data-testid="arrow-back-icon" />,
+}));
+
+function createTestStore() {
+  return configureStore({
+    reducer: {
+      application: applicationSlice.reducer,
+    },
+  });
+}
+
+describe("AuthBackButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render with default text", () => {
+    const store = createTestStore();
+
+    render(
+      <Provider store={store}>
+        <AuthBackButton />
+      </Provider>
+    );
+
+    expect(screen.getByText("Back to Login")).toBeInTheDocument();
+  });
+
+  it("should render with custom text", () => {
+    const store = createTestStore();
+
+    render(
+      <Provider store={store}>
+        <AuthBackButton text="Go Back" />
+      </Provider>
+    );
+
+    expect(screen.getByText("Go Back")).toBeInTheDocument();
+  });
+
+  it("should render arrow back icon", () => {
+    const store = createTestStore();
+
+    render(
+      <Provider store={store}>
+        <AuthBackButton />
+      </Provider>
+    );
+
+    expect(screen.getByTestId("arrow-back-icon")).toBeInTheDocument();
+  });
+
+  it("should call handleLogout when clicked", async () => {
+    const store = createTestStore();
+
+    render(
+      <Provider store={store}>
+        <AuthBackButton />
+      </Provider>
+    );
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(mockHandleLogout).toHaveBeenCalled();
+  });
+
+  it("should dispatch setAuthStage action when clicked", () => {
+    const store = createTestStore();
+    const dispatchSpy = vi.spyOn(store, "dispatch");
+
+    render(
+      <Provider store={store}>
+        <AuthBackButton />
+      </Provider>
+    );
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(dispatchSpy).toHaveBeenCalled();
+  });
+
+  it("should have disabled class when logging out", async () => {
+    const { useLogout } = await import("@/src/hooks/authenticationHooks");
+    vi.mocked(useLogout).mockReturnValue({
+      handleLogout: mockHandleLogout,
+      loggingOut: true,
+    });
+
+    const store = createTestStore();
+
+    render(
+      <Provider store={store}>
+        <AuthBackButton />
+      </Provider>
+    );
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("Mui-disabled");
+  });
+});

--- a/src/components/experiences/modern/login/Forms/NewUserForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/NewUserForm.test.tsx
@@ -45,9 +45,11 @@ describe("NewUserForm", () => {
   });
 
   it("should render required attributes as fields", () => {
-    renderWithProviders(
-      <NewUserForm username="testuser" requiredAttributes={["realName", "djName"]} />
-    );
+    const props: IncompleteUser = {
+      username: "testuser",
+      requiredAttributes: ["realName", "djName"],
+    };
+    renderWithProviders(<NewUserForm {...props} />);
 
     expect(screen.getByText("Real Name")).toBeInTheDocument();
     expect(screen.getByText("DJ Name")).toBeInTheDocument();

--- a/src/components/experiences/modern/login/Forms/OnboardingForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/OnboardingForm.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import OnboardingForm from "./OnboardingForm";
+import { authenticationSlice } from "@/lib/features/authentication/frontend";
+import React from "react";
+
+// Mock authentication hooks
+const mockHandleNewUser = vi.fn((e) => e.preventDefault());
+const mockAddRequiredCredentials = vi.fn();
+
+vi.mock("@/src/hooks/authenticationHooks", () => ({
+  useNewUser: vi.fn(() => ({
+    handleNewUser: mockHandleNewUser,
+    verified: false,
+    authenticating: false,
+    addRequiredCredentials: mockAddRequiredCredentials,
+  })),
+}));
+
+function createTestStore() {
+  return configureStore({
+    reducer: {
+      authentication: authenticationSlice.reducer,
+    },
+  });
+}
+
+function createWrapper() {
+  const store = createTestStore();
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <Provider store={store}>{children}</Provider>;
+  };
+}
+
+describe("OnboardingForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the form", () => {
+    const Wrapper = createWrapper();
+    const { container } = render(
+      <Wrapper>
+        <OnboardingForm username="testuser" />
+      </Wrapper>
+    );
+
+    expect(container.querySelector("form")).toBeInTheDocument();
+  });
+
+  it("should render hidden username input with provided value", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <OnboardingForm username="testuser" />
+      </Wrapper>
+    );
+
+    const hiddenInput = document.querySelector('input[name="username"]');
+    expect(hiddenInput).toHaveValue("testuser");
+  });
+
+  it("should render real name input", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <OnboardingForm username="testuser" />
+      </Wrapper>
+    );
+
+    expect(screen.getByText("Real Name")).toBeInTheDocument();
+  });
+
+  it("should render DJ name input", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <OnboardingForm username="testuser" />
+      </Wrapper>
+    );
+
+    expect(screen.getByText("DJ Name")).toBeInTheDocument();
+  });
+
+  it("should render password input with requirements", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <OnboardingForm username="testuser" />
+      </Wrapper>
+    );
+
+    expect(screen.getByText("New Password")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Must be at least 8 characters/)
+    ).toBeInTheDocument();
+  });
+
+  it("should render confirm password input", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <OnboardingForm username="testuser" />
+      </Wrapper>
+    );
+
+    expect(screen.getByText("Confirm New Password")).toBeInTheDocument();
+  });
+
+  it("should render submit button", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <OnboardingForm username="testuser" />
+      </Wrapper>
+    );
+
+    expect(screen.getByRole("button", { name: /submit|sign up/i })).toBeInTheDocument();
+  });
+
+  it("should call addRequiredCredentials on mount", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <OnboardingForm username="testuser" />
+      </Wrapper>
+    );
+
+    expect(mockAddRequiredCredentials).toHaveBeenCalledWith([
+      "username",
+      "realName",
+      "djName",
+      "password",
+      "confirmPassword",
+    ]);
+  });
+
+  it("should render with initial realName and djName values", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <OnboardingForm
+          username="testuser"
+          realName="John Doe"
+          djName="DJ John"
+        />
+      </Wrapper>
+    );
+
+    // Form should render with provided values
+    expect(screen.getByText("Real Name")).toBeInTheDocument();
+    expect(screen.getByText("DJ Name")).toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/login/Forms/RequestPasswordResetForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/RequestPasswordResetForm.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import RequestPasswordResetForm from "./RequestPasswordResetForm";
+
+const mockHandleRequestReset = vi.fn();
+
+vi.mock("@/src/hooks/authenticationHooks", () => ({
+  useResetPassword: () => ({
+    handleRequestReset: mockHandleRequestReset,
+    requestingReset: false,
+  }),
+}));
+
+describe("RequestPasswordResetForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render form element", () => {
+    render(<RequestPasswordResetForm />);
+    expect(document.querySelector("form")).toBeInTheDocument();
+  });
+
+  it("should render email input", () => {
+    render(<RequestPasswordResetForm />);
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+  });
+
+  it("should render email placeholder", () => {
+    render(<RequestPasswordResetForm />);
+    expect(screen.getByPlaceholderText("you@example.com")).toBeInTheDocument();
+  });
+
+  it("should render submit button", () => {
+    render(<RequestPasswordResetForm />);
+    expect(screen.getByRole("button", { name: /send reset link/i })).toBeInTheDocument();
+  });
+
+  it("should render helper text", () => {
+    render(<RequestPasswordResetForm />);
+    expect(
+      screen.getByText(/send a reset link if the email exists/i)
+    ).toBeInTheDocument();
+  });
+
+  it("should have disabled submit button when email is empty", () => {
+    render(<RequestPasswordResetForm />);
+    const button = screen.getByRole("button", { name: /send reset link/i });
+    expect(button).toBeDisabled();
+  });
+
+  it("should enable submit button when email is entered", () => {
+    render(<RequestPasswordResetForm />);
+    const input = screen.getByLabelText(/email/i);
+    fireEvent.change(input, { target: { value: "test@example.com" } });
+
+    const button = screen.getByRole("button", { name: /send reset link/i });
+    expect(button).not.toBeDisabled();
+  });
+
+  it("should call handleRequestReset on form submit", () => {
+    render(<RequestPasswordResetForm />);
+    const input = screen.getByLabelText(/email/i);
+    fireEvent.change(input, { target: { value: "test@example.com" } });
+
+    const form = document.querySelector("form")!;
+    fireEvent.submit(form);
+
+    expect(mockHandleRequestReset).toHaveBeenCalledWith("test@example.com");
+  });
+
+  it("should trim email before submitting", () => {
+    render(<RequestPasswordResetForm />);
+    const input = screen.getByLabelText(/email/i);
+    fireEvent.change(input, { target: { value: "  test@example.com  " } });
+
+    const form = document.querySelector("form")!;
+    fireEvent.submit(form);
+
+    expect(mockHandleRequestReset).toHaveBeenCalledWith("test@example.com");
+  });
+});

--- a/src/components/experiences/modern/login/Forms/ResetPasswordForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/ResetPasswordForm.test.tsx
@@ -79,6 +79,30 @@ describe("ResetPasswordForm", () => {
     await user.type(passwordInput, "weak");
     await user.type(confirmInput, "weak");
 
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+
+  it("should keep submit disabled when passwords do not match", async () => {
+    const { user } = renderWithProviders(<ResetPasswordForm {...defaultProps} />);
+
+    const passwordInput = screen.getByPlaceholderText("Enter your new password");
+    const confirmInput = screen.getByPlaceholderText("Confirm New Password");
+
+    await user.type(passwordInput, "Password1");
+    await user.type(confirmInput, "Password2");
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+
+  it("should keep submit disabled without token", () => {
+    const propsWithoutToken: PasswordResetUser = {
+      token: undefined,
+      confirmationMessage: "Password reset requested",
+    };
+    renderWithProviders(<ResetPasswordForm {...propsWithoutToken} />);
+
+    // Even with valid fields, submit should be disabled without token
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 

--- a/src/components/experiences/modern/login/Forms/UserPasswordForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/UserPasswordForm.test.tsx
@@ -58,19 +58,10 @@ describe("UserPasswordForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("should have forgot link disabled without username", () => {
+  it("should have forgot link enabled by default", () => {
     renderWithProviders(<UserPasswordForm />);
 
-    // MUI Joy Link uses Mui-disabled class rather than disabled attribute
-    expect(screen.getByRole("button", { name: "Forgot?" })).toHaveClass("Mui-disabled");
-  });
-
-  it("should enable forgot link when username has value", async () => {
-    const { user } = renderWithProviders(<UserPasswordForm />);
-
-    const usernameInput = screen.getByPlaceholderText("Username");
-    await user.type(usernameInput, "testuser");
-
+    // Forgot link is always enabled except during authentication
     expect(screen.getByRole("button", { name: "Forgot?" })).not.toHaveClass("Mui-disabled");
   });
 

--- a/src/components/experiences/modern/login/Layout/Background.test.tsx
+++ b/src/components/experiences/modern/login/Layout/Background.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BackgroundImage, BackgroundBox } from "./Background";
+
+describe("Background", () => {
+  describe("BackgroundImage", () => {
+    it("should render a Box element", () => {
+      const { container } = render(<BackgroundImage />);
+
+      // Should render a Box (div)
+      expect(container.querySelector(".MuiBox-root")).toBeInTheDocument();
+    });
+
+    it("should have fixed positioning", () => {
+      const { container } = render(<BackgroundImage />);
+
+      const box = container.querySelector(".MuiBox-root");
+      expect(box).toHaveStyle({ position: "fixed" });
+    });
+  });
+
+  describe("BackgroundBox", () => {
+    it("should render children", () => {
+      render(
+        <BackgroundBox>
+          <div data-testid="child-content">Test Content</div>
+        </BackgroundBox>
+      );
+
+      expect(screen.getByTestId("child-content")).toBeInTheDocument();
+    });
+
+    it("should render multiple children", () => {
+      render(
+        <BackgroundBox>
+          <div data-testid="child-1">Child 1</div>
+          <div data-testid="child-2">Child 2</div>
+        </BackgroundBox>
+      );
+
+      expect(screen.getByTestId("child-1")).toBeInTheDocument();
+      expect(screen.getByTestId("child-2")).toBeInTheDocument();
+    });
+
+    it("should render nested Box elements", () => {
+      const { container } = render(
+        <BackgroundBox>
+          <span>Content</span>
+        </BackgroundBox>
+      );
+
+      const boxes = container.querySelectorAll(".MuiBox-root");
+      expect(boxes.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/src/components/experiences/modern/login/Layout/Footer.test.tsx
+++ b/src/components/experiences/modern/login/Layout/Footer.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Footer from "./Footer";
+
+describe("Footer", () => {
+  it("should render footer element", () => {
+    render(<Footer />);
+    expect(document.querySelector("footer")).toBeInTheDocument();
+  });
+
+  it("should display copyright text with current year", () => {
+    render(<Footer />);
+    const currentYear = new Date().getFullYear();
+    expect(
+      screen.getByText(`Copyright © ${currentYear} WXYC Chapel Hill`)
+    ).toBeInTheDocument();
+  });
+
+  it("should include WXYC Chapel Hill in copyright", () => {
+    render(<Footer />);
+    expect(screen.getByText(/WXYC Chapel Hill/)).toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/login/Layout/Header.test.tsx
+++ b/src/components/experiences/modern/login/Layout/Header.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Header from "./Header";
+
+// Mock the Logo component
+vi.mock("@/src/components/shared/Branding/Logo", () => ({
+  default: () => <div data-testid="logo">Logo</div>,
+}));
+
+// Mock the dynamic import for ColorSchemeToggle
+vi.mock("next/dynamic", () => ({
+  default: () => () => null,
+}));
+
+describe("Header", () => {
+  it("should render header element", () => {
+    render(<Header />);
+    expect(document.querySelector("header")).toBeInTheDocument();
+  });
+
+  it("should render Logo component", () => {
+    render(<Header />);
+    expect(screen.getByTestId("logo")).toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/login/Layout/Main.test.tsx
+++ b/src/components/experiences/modern/login/Layout/Main.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Main from "./Main";
+
+describe("Main", () => {
+  it("should render main element", () => {
+    render(<Main>Test Content</Main>);
+    expect(document.querySelector("main")).toBeInTheDocument();
+  });
+
+  it("should render children", () => {
+    render(<Main><span data-testid="child">Child Content</span></Main>);
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+    expect(screen.getByText("Child Content")).toBeInTheDocument();
+  });
+
+  it("should render multiple children", () => {
+    render(
+      <Main>
+        <div data-testid="first">First</div>
+        <div data-testid="second">Second</div>
+      </Main>
+    );
+    expect(screen.getByTestId("first")).toBeInTheDocument();
+    expect(screen.getByTestId("second")).toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/login/Quotes/Forgot.test.tsx
+++ b/src/components/experiences/modern/login/Quotes/Forgot.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ForgotQuotes from "./Forgot";
+
+describe("ForgotQuotes", () => {
+  beforeEach(() => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should render the song title", () => {
+    render(<ForgotQuotes />);
+    expect(screen.getByText("Forgotten")).toBeInTheDocument();
+  });
+
+  it("should render the password-related message", () => {
+    render(<ForgotQuotes />);
+    expect(screen.getByText("...your password?")).toBeInTheDocument();
+  });
+
+  it("should render the artist name", () => {
+    render(<ForgotQuotes />);
+    expect(screen.getByText("- Linkin Park")).toBeInTheDocument();
+  });
+
+  it("should render different quote when random value changes", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.25);
+    render(<ForgotQuotes />);
+    // Index 2 (Math.floor(0.25 * 8)) should be "Forgot About Dre"
+    expect(screen.getByText("Forgot About Dre")).toBeInTheDocument();
+    expect(screen.getByText("- Dr. Dre ft. Eminem")).toBeInTheDocument();
+    expect(screen.getByText("...and your password!")).toBeInTheDocument();
+  });
+
+  it("should render last quote when random approaches 1", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.99);
+    render(<ForgotQuotes />);
+    // Index 7 (last item) should be "Forget About It"
+    expect(screen.getByText("Forget About It")).toBeInTheDocument();
+    expect(screen.getByText("- Alison Krauss")).toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/login/Quotes/HoldOn.test.tsx
+++ b/src/components/experiences/modern/login/Quotes/HoldOn.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import HoldOnQuotes from "./HoldOn";
+
+describe("HoldOnQuotes", () => {
+  beforeEach(() => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should render 'Hold On...' heading", () => {
+    render(<HoldOnQuotes />);
+    expect(screen.getByText("Hold On...")).toBeInTheDocument();
+  });
+
+  it("should render the quote continuation", () => {
+    render(<HoldOnQuotes />);
+    expect(screen.getByText("for one more day.")).toBeInTheDocument();
+  });
+
+  it("should render the artist name", () => {
+    render(<HoldOnQuotes />);
+    expect(screen.getByText("- Wilson Phillips")).toBeInTheDocument();
+  });
+
+  it("should render the information message", () => {
+    render(<HoldOnQuotes />);
+    expect(
+      screen.getByText(
+        "Actually, we just need some more information from you."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("should render different quote when random value changes", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.35);
+    render(<HoldOnQuotes />);
+    // Index 3 (Math.floor(0.35 * 10)) should be 2Pac quote
+    expect(
+      screen.getByText("be strong, and stay true to yourself.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("- 2Pac")).toBeInTheDocument();
+  });
+
+  it("should render Pearl Jam quote for middle value", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.75);
+    render(<HoldOnQuotes />);
+    // Index 7 should be Pearl Jam
+    expect(screen.getByText("I'm still alive.")).toBeInTheDocument();
+    expect(screen.getByText("- Pearl Jam")).toBeInTheDocument();
+  });
+
+  it("should render last quote when random approaches 1", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.99);
+    render(<HoldOnQuotes />);
+    // Index 9 (last item) should be Florence + The Machine
+    expect(
+      screen.getByText("to hope if you got it.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("- Florence + The Machine")).toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/login/Quotes/Welcome.test.tsx
+++ b/src/components/experiences/modern/login/Quotes/Welcome.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import WelcomeQuotes from "./Welcome";
+
+describe("WelcomeQuotes", () => {
+  beforeEach(() => {
+    // Mock Math.random to return predictable values
+    vi.spyOn(Math, "random").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should render 'Welcome...' heading", () => {
+    render(<WelcomeQuotes />);
+    expect(screen.getByText("Welcome...")).toBeInTheDocument();
+  });
+
+  it("should render a quote from the list", () => {
+    // With Math.random() returning 0, first quote "to the Jungle" should be selected
+    render(<WelcomeQuotes />);
+    expect(screen.getByText("to the Jungle")).toBeInTheDocument();
+  });
+
+  it("should render the artist name", () => {
+    // With Math.random() returning 0, first artist "Guns N' Roses" should be selected
+    render(<WelcomeQuotes />);
+    expect(screen.getByText("- Guns N' Roses")).toBeInTheDocument();
+  });
+
+  it("should render different quote when random value changes", () => {
+    // Return 0.5 to select middle of array
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    render(<WelcomeQuotes />);
+    // Index 4 (Math.floor(0.5 * 9)) should be "Home" by Coheed and Cambria
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    expect(screen.getByText("- Coheed and Cambria")).toBeInTheDocument();
+  });
+
+  it("should render last quote when random approaches 1", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.99);
+    render(<WelcomeQuotes />);
+    // Index 8 (last item) should be "to the Club"
+    expect(screen.getByText("to the Club")).toBeInTheDocument();
+    expect(screen.getByText("- Manian ft. Aila")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add tests for AuthBackButton
- Add tests for NewUserForm
- Add tests for OnboardingForm
- Add tests for RequestPasswordResetForm and ResetPasswordForm
- Add tests for UserPasswordForm
- Add tests for Background, Footer, Header, Main layout
- Add tests for Forgot, HoldOn, Welcome quotes

## Test plan
- [ ] Run `npm test src/components/experiences/modern/login/`

**Part 23 of 26**