### PR TITLE
test: add NowPlaying widget tests

### DIFF
--- a/src/widgets/NowPlaying/AlbumArtAndIcons.test.tsx
+++ b/src/widgets/NowPlaying/AlbumArtAndIcons.test.tsx
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AlbumArtAndIcons from "./AlbumArtAndIcons";
+import type {
+  FlowsheetSongEntry,
+  FlowsheetBreakpointEntry,
+  FlowsheetShowBlockEntry,
+  FlowsheetMessageEntry,
+} from "@/lib/features/flowsheet/types";
+
+// Mock useAlbumImages hook
+const mockSetAlbum = vi.fn();
+const mockSetArtist = vi.fn();
+const mockUseAlbumImages = vi.fn(() => ({
+  setAlbum: mockSetAlbum,
+  setArtist: mockSetArtist,
+  loading: false,
+  url: "https://example.com/album-art.jpg",
+}));
+
+vi.mock("@/src/hooks/applicationHooks", () => ({
+  useAlbumImages: () => mockUseAlbumImages(),
+}));
+
+// Mock MUI components - render children to allow img testing
+vi.mock("@mui/joy", () => ({
+  AspectRatio: ({ children, ...props }: any) => (
+    <div data-testid="aspect-ratio" {...props}>
+      {children}
+    </div>
+  ),
+  Box: ({ children, ...props }: any) => (
+    <div data-testid="box" {...props}>
+      {children}
+    </div>
+  ),
+}));
+
+// Mock MUI icons
+vi.mock("@mui/icons-material", () => ({
+  Timer: (props: any) => <span data-testid="timer-icon" {...props} />,
+  Headphones: (props: any) => <span data-testid="headphones-icon" {...props} />,
+  Logout: (props: any) => <span data-testid="logout-icon" {...props} />,
+  Mic: (props: any) => <span data-testid="mic-icon" {...props} />,
+}));
+
+describe("AlbumArtAndIcons", () => {
+  const baseEntry = {
+    id: 1,
+    play_order: 1,
+    show_id: 1,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAlbumImages.mockReturnValue({
+      setAlbum: mockSetAlbum,
+      setArtist: mockSetArtist,
+      loading: false,
+      url: "https://example.com/album-art.jpg",
+    });
+  });
+
+  describe("when entry is undefined", () => {
+    it("should render without crashing", () => {
+      expect(() => render(<AlbumArtAndIcons entry={undefined} />)).not.toThrow();
+    });
+
+    it("should display aspect-ratio wrapper", () => {
+      render(<AlbumArtAndIcons entry={undefined} />);
+      expect(screen.getByTestId("aspect-ratio")).toBeInTheDocument();
+    });
+  });
+
+  describe("when loading is true", () => {
+    it("should display aspect-ratio wrapper while loading", () => {
+      mockUseAlbumImages.mockReturnValue({
+        setAlbum: mockSetAlbum,
+        setArtist: mockSetArtist,
+        loading: true,
+        url: "https://example.com/album-art.jpg",
+      });
+
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+      };
+
+      render(<AlbumArtAndIcons entry={songEntry} />);
+
+      expect(screen.getByTestId("aspect-ratio")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry is a song entry", () => {
+    it("should call setAlbum and setArtist with entry data", () => {
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+      };
+
+      render(<AlbumArtAndIcons entry={songEntry} />);
+
+      expect(mockSetAlbum).toHaveBeenCalledWith("Test Album");
+      expect(mockSetArtist).toHaveBeenCalledWith("Test Artist");
+    });
+
+    it("should render aspect-ratio wrapper", () => {
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+      };
+
+      render(<AlbumArtAndIcons entry={songEntry} />);
+
+      expect(screen.getByTestId("aspect-ratio")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry is a breakpoint entry", () => {
+    it("should display Timer icon", () => {
+      mockUseAlbumImages.mockReturnValue({
+        setAlbum: mockSetAlbum,
+        setArtist: mockSetArtist,
+        loading: false,
+        url: "",
+      });
+
+      const breakpointEntry: FlowsheetBreakpointEntry = {
+        ...baseEntry,
+        message: "Breakpoint: Station ID",
+        day: "Monday",
+        time: "10:00",
+      };
+
+      render(<AlbumArtAndIcons entry={breakpointEntry} />);
+
+      expect(screen.getByTestId("timer-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry is a start show entry", () => {
+    it("should display Headphones icon", () => {
+      mockUseAlbumImages.mockReturnValue({
+        setAlbum: mockSetAlbum,
+        setArtist: mockSetArtist,
+        loading: false,
+        url: "",
+      });
+
+      const startShowEntry: FlowsheetShowBlockEntry = {
+        ...baseEntry,
+        dj_name: "DJ Cool",
+        isStart: true,
+        day: "Monday",
+        time: "10:00",
+      };
+
+      render(<AlbumArtAndIcons entry={startShowEntry} />);
+
+      expect(screen.getByTestId("headphones-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry is an end show entry", () => {
+    it("should display Logout icon", () => {
+      mockUseAlbumImages.mockReturnValue({
+        setAlbum: mockSetAlbum,
+        setArtist: mockSetArtist,
+        loading: false,
+        url: "",
+      });
+
+      const endShowEntry: FlowsheetShowBlockEntry = {
+        ...baseEntry,
+        dj_name: "DJ Cool",
+        isStart: false,
+        day: "Monday",
+        time: "22:00",
+      };
+
+      render(<AlbumArtAndIcons entry={endShowEntry} />);
+
+      expect(screen.getByTestId("logout-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry is a talkset entry", () => {
+    it("should display Mic icon", () => {
+      mockUseAlbumImages.mockReturnValue({
+        setAlbum: mockSetAlbum,
+        setArtist: mockSetArtist,
+        loading: false,
+        url: "",
+      });
+
+      const talksetEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        message: "Talkset",
+      };
+
+      render(<AlbumArtAndIcons entry={talksetEntry} />);
+
+      expect(screen.getByTestId("mic-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry is a generic message entry", () => {
+    it("should render aspect ratio wrapper for fallback", () => {
+      mockUseAlbumImages.mockReturnValue({
+        setAlbum: mockSetAlbum,
+        setArtist: mockSetArtist,
+        loading: false,
+        url: "",
+      });
+
+      const messageEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        message: "PSA: Community announcement",
+      };
+
+      render(<AlbumArtAndIcons entry={messageEntry} />);
+
+      expect(screen.getByTestId("aspect-ratio")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry changes from song to non-song", () => {
+    it("should clear album and artist", () => {
+      mockUseAlbumImages.mockReturnValue({
+        setAlbum: mockSetAlbum,
+        setArtist: mockSetArtist,
+        loading: false,
+        url: "",
+      });
+
+      const messageEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        message: "PSA: Community announcement",
+      };
+
+      render(<AlbumArtAndIcons entry={messageEntry} />);
+
+      expect(mockSetAlbum).toHaveBeenCalledWith(undefined);
+      expect(mockSetArtist).toHaveBeenCalledWith(undefined);
+    });
+  });
+});

--- a/src/widgets/NowPlaying/EntryText.test.tsx
+++ b/src/widgets/NowPlaying/EntryText.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import EntryText from "./EntryText";
+import type {
+  FlowsheetSongEntry,
+  FlowsheetBreakpointEntry,
+  FlowsheetShowBlockEntry,
+  FlowsheetMessageEntry,
+} from "@/lib/features/flowsheet/types";
+
+// Mock MUI Joy components
+vi.mock("@mui/joy", () => ({
+  Stack: ({ children, ...props }: any) => (
+    <div data-testid="stack" {...props}>
+      {children}
+    </div>
+  ),
+  Typography: ({ children, level, color, ...props }: any) => (
+    <span data-testid="typography" data-level={level} data-color={color} {...props}>
+      {children}
+    </span>
+  ),
+}));
+
+describe("EntryText", () => {
+  const baseEntry = {
+    id: 1,
+    play_order: 1,
+    show_id: 1,
+  };
+
+  describe("when entry is undefined", () => {
+    it("should display default WXYC message", () => {
+      render(<EntryText entry={undefined} />);
+
+      expect(screen.getByText("You're Listening To")).toBeInTheDocument();
+      expect(screen.getByText("WXYC Chapel Hill")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry is a song entry", () => {
+    it("should display album title and artist name", () => {
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+      };
+
+      render(<EntryText entry={songEntry} />);
+
+      expect(screen.getByText("Test Album")).toBeInTheDocument();
+      expect(screen.getByText("Test Artist")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry is a breakpoint entry", () => {
+    it("should display breakpoint message with warning color", () => {
+      const breakpointEntry: FlowsheetBreakpointEntry = {
+        ...baseEntry,
+        message: "Breakpoint: Station ID",
+        day: "Monday",
+        time: "10:00",
+      };
+
+      render(<EntryText entry={breakpointEntry} />);
+
+      expect(screen.getByText("Breakpoint: Station ID")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry is a start show entry", () => {
+    it("should display DJ name and 'started the set' message", () => {
+      const startShowEntry: FlowsheetShowBlockEntry = {
+        ...baseEntry,
+        dj_name: "DJ Cool",
+        isStart: true,
+        day: "Monday",
+        time: "10:00",
+      };
+
+      render(<EntryText entry={startShowEntry} />);
+
+      expect(screen.getByText("DJ Cool")).toBeInTheDocument();
+      expect(screen.getByText("started the set")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry is an end show entry", () => {
+    it("should display DJ name and 'ended the set' message", () => {
+      const endShowEntry: FlowsheetShowBlockEntry = {
+        ...baseEntry,
+        dj_name: "DJ Cool",
+        isStart: false,
+        day: "Monday",
+        time: "22:00",
+      };
+
+      render(<EntryText entry={endShowEntry} />);
+
+      expect(screen.getByText("DJ Cool")).toBeInTheDocument();
+      expect(screen.getByText("ended the set")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry is a talkset entry", () => {
+    it("should display 'Talkset' with danger color", () => {
+      const talksetEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        message: "Talkset",
+      };
+
+      render(<EntryText entry={talksetEntry} />);
+
+      expect(screen.getByText("Talkset")).toBeInTheDocument();
+    });
+  });
+
+  describe("when entry is a generic message entry", () => {
+    it("should display the message", () => {
+      const messageEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        message: "PSA: Community announcement",
+      };
+
+      render(<EntryText entry={messageEntry} />);
+
+      expect(screen.getByText("PSA: Community announcement")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/widgets/NowPlaying/GradientAudioVisualizer.test.tsx
+++ b/src/widgets/NowPlaying/GradientAudioVisualizer.test.tsx
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { createRef } from "react";
+import { GradientAudioVisualizer } from "./GradientAudioVisualizer";
+
+// Mock MUI Joy components
+vi.mock("@mui/joy", () => ({
+  Box: ({ children, sx, ...props }: any) => (
+    <div
+      data-testid="overlay-box"
+      data-opacity={sx?.opacity}
+      data-background-color={sx?.backgroundColor}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+}));
+
+describe("GradientAudioVisualizer", () => {
+  let mockAudioContext: any;
+  let mockAnalyser: any;
+  let mockSource: any;
+  let mockGradient: any;
+  let mockCanvasContext: any;
+
+  beforeEach(() => {
+    mockGradient = {
+      addColorStop: vi.fn(),
+    };
+
+    mockCanvasContext = {
+      fillStyle: "",
+      fillRect: vi.fn(),
+      createLinearGradient: vi.fn(() => mockGradient),
+    };
+
+    mockAnalyser = {
+      fftSize: 512,
+      frequencyBinCount: 256,
+      connect: vi.fn(),
+      getByteFrequencyData: vi.fn(),
+    };
+
+    mockSource = {
+      connect: vi.fn(),
+    };
+
+    mockAudioContext = {
+      createAnalyser: vi.fn(() => mockAnalyser),
+      createMediaElementSource: vi.fn(() => mockSource),
+      resume: vi.fn(),
+      close: vi.fn(),
+    };
+
+    // Mock AudioContext
+    (window as any).AudioContext = vi.fn(() => mockAudioContext);
+    (window as any).webkitAudioContext = vi.fn(() => mockAudioContext);
+
+    // Mock requestAnimationFrame
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => 1);
+
+    // Mock canvas getContext
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => mockCanvasContext) as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("rendering", () => {
+    it("should render without crashing", () => {
+      expect(() =>
+        render(<GradientAudioVisualizer src="https://example.com/audio.mp3" />)
+      ).not.toThrow();
+    });
+
+    it("should render a canvas element", () => {
+      const { container } = render(
+        <GradientAudioVisualizer src="https://example.com/audio.mp3" />
+      );
+      const canvas = container.querySelector("canvas");
+      expect(canvas).toBeInTheDocument();
+    });
+
+    it("should render an audio element with the provided src", () => {
+      const { container } = render(
+        <GradientAudioVisualizer src="https://example.com/audio.mp3" />
+      );
+      const audio = container.querySelector("audio");
+      expect(audio).toBeInTheDocument();
+      expect(audio).toHaveAttribute("src", "https://example.com/audio.mp3");
+    });
+
+    it("should render overlay Box component", () => {
+      render(<GradientAudioVisualizer src="https://example.com/audio.mp3" />);
+      expect(screen.getByTestId("overlay-box")).toBeInTheDocument();
+    });
+
+    it("should set crossOrigin attribute on audio element", () => {
+      const { container } = render(
+        <GradientAudioVisualizer src="https://example.com/audio.mp3" />
+      );
+      const audio = container.querySelector("audio");
+      expect(audio).toHaveAttribute("crossOrigin", "anonymous");
+    });
+
+    it("should set playsInline attribute on audio element", () => {
+      const { container } = render(
+        <GradientAudioVisualizer src="https://example.com/audio.mp3" />
+      );
+      const audio = container.querySelector("audio");
+      expect(audio).toHaveAttribute("playsinline");
+    });
+
+    it("should hide audio element with display none", () => {
+      const { container } = render(
+        <GradientAudioVisualizer src="https://example.com/audio.mp3" />
+      );
+      const audio = container.querySelector("audio");
+      expect(audio).toHaveStyle({ display: "none" });
+    });
+  });
+
+  describe("canvas styling", () => {
+    it("should apply gradient background to canvas", () => {
+      const { container } = render(
+        <GradientAudioVisualizer src="https://example.com/audio.mp3" />
+      );
+      const canvas = container.querySelector("canvas");
+      expect(canvas).toHaveStyle({
+        background: "linear-gradient(135deg, #ff6ec4, #7873f5, #00f2fe)",
+      });
+    });
+
+    it("should position canvas absolutely", () => {
+      const { container } = render(
+        <GradientAudioVisualizer src="https://example.com/audio.mp3" />
+      );
+      const canvas = container.querySelector("canvas");
+      expect(canvas).toHaveStyle({
+        position: "absolute",
+        inset: "0",
+        width: "100%",
+        height: "100%",
+      });
+    });
+
+    it("should set pointer-events to none on canvas", () => {
+      const { container } = render(
+        <GradientAudioVisualizer src="https://example.com/audio.mp3" />
+      );
+      const canvas = container.querySelector("canvas");
+      expect(canvas).toHaveStyle({ pointerEvents: "none" });
+    });
+  });
+
+  describe("overlay styling", () => {
+    it("should apply overlay color when provided", () => {
+      render(
+        <GradientAudioVisualizer
+          src="https://example.com/audio.mp3"
+          overlayColor="white"
+        />
+      );
+      expect(screen.getByTestId("overlay-box")).toHaveAttribute(
+        "data-background-color",
+        "white"
+      );
+    });
+
+    it("should have opacity 1 when not playing", () => {
+      render(
+        <GradientAudioVisualizer
+          src="https://example.com/audio.mp3"
+          overlayColor="white"
+        />
+      );
+      expect(screen.getByTestId("overlay-box")).toHaveAttribute(
+        "data-opacity",
+        "1"
+      );
+    });
+  });
+
+  describe("imperative handle", () => {
+    it("should expose play method through ref", () => {
+      const ref = createRef<{
+        play: () => void;
+        pause: () => void;
+        readonly isPlaying: boolean;
+      }>();
+
+      render(
+        <GradientAudioVisualizer
+          src="https://example.com/audio.mp3"
+          ref={ref}
+        />
+      );
+
+      expect(ref.current).toBeDefined();
+      expect(typeof ref.current?.play).toBe("function");
+    });
+
+    it("should expose pause method through ref", () => {
+      const ref = createRef<{
+        play: () => void;
+        pause: () => void;
+        readonly isPlaying: boolean;
+      }>();
+
+      render(
+        <GradientAudioVisualizer
+          src="https://example.com/audio.mp3"
+          ref={ref}
+        />
+      );
+
+      expect(ref.current).toBeDefined();
+      expect(typeof ref.current?.pause).toBe("function");
+    });
+
+    it("should expose isPlaying getter through ref", () => {
+      const ref = createRef<{
+        play: () => void;
+        pause: () => void;
+        readonly isPlaying: boolean;
+      }>();
+
+      render(
+        <GradientAudioVisualizer
+          src="https://example.com/audio.mp3"
+          ref={ref}
+        />
+      );
+
+      expect(ref.current).toBeDefined();
+      expect(typeof ref.current?.isPlaying).toBe("boolean");
+    });
+
+    it("should return false for isPlaying when audio is paused", () => {
+      const ref = createRef<{
+        play: () => void;
+        pause: () => void;
+        readonly isPlaying: boolean;
+      }>();
+
+      render(
+        <GradientAudioVisualizer
+          src="https://example.com/audio.mp3"
+          ref={ref}
+        />
+      );
+
+      // Initially paused
+      expect(ref.current?.isPlaying).toBe(false);
+    });
+  });
+
+  describe("without overlayColor prop", () => {
+    it("should render overlay with undefined background color", () => {
+      render(<GradientAudioVisualizer src="https://example.com/audio.mp3" />);
+      // When overlayColor is undefined, data-background-color will be empty or not present
+      const overlayBox = screen.getByTestId("overlay-box");
+      expect(overlayBox).toBeInTheDocument();
+    });
+  });
+
+  describe("component structure", () => {
+    it("should render canvas and audio elements", () => {
+      const { container } = render(
+        <GradientAudioVisualizer src="https://example.com/audio.mp3" />
+      );
+
+      expect(container.querySelector("canvas")).toBeInTheDocument();
+      expect(screen.getByTestId("overlay-box")).toBeInTheDocument();
+      expect(container.querySelector("audio")).toBeInTheDocument();
+    });
+  });
+
+  describe("canvas z-index", () => {
+    it("should have z-index 0 on canvas", () => {
+      const { container } = render(
+        <GradientAudioVisualizer src="https://example.com/audio.mp3" />
+      );
+      const canvas = container.querySelector("canvas");
+      expect(canvas).toHaveStyle({ zIndex: "0" });
+    });
+  });
+
+  describe("audio context setup", () => {
+    it("should create AudioContext on mount", () => {
+      render(<GradientAudioVisualizer src="https://example.com/audio.mp3" />);
+      expect(window.AudioContext).toHaveBeenCalled();
+    });
+
+    it("should create analyser from audio context", () => {
+      render(<GradientAudioVisualizer src="https://example.com/audio.mp3" />);
+      expect(mockAudioContext.createAnalyser).toHaveBeenCalled();
+    });
+
+    it("should create media element source from audio context", () => {
+      render(<GradientAudioVisualizer src="https://example.com/audio.mp3" />);
+      expect(mockAudioContext.createMediaElementSource).toHaveBeenCalled();
+    });
+
+    it("should connect source to analyser", () => {
+      render(<GradientAudioVisualizer src="https://example.com/audio.mp3" />);
+      expect(mockSource.connect).toHaveBeenCalledWith(mockAnalyser);
+    });
+
+    it("should connect analyser to destination", () => {
+      render(<GradientAudioVisualizer src="https://example.com/audio.mp3" />);
+      expect(mockAnalyser.connect).toHaveBeenCalled();
+    });
+
+    it("should set fftSize on analyser", () => {
+      render(<GradientAudioVisualizer src="https://example.com/audio.mp3" />);
+      expect(mockAnalyser.fftSize).toBe(512);
+    });
+  });
+
+  describe("different src props", () => {
+    it("should render with different audio source", () => {
+      const { container } = render(
+        <GradientAudioVisualizer src="https://different.com/stream.mp3" />
+      );
+      const audio = container.querySelector("audio");
+      expect(audio).toHaveAttribute("src", "https://different.com/stream.mp3");
+    });
+  });
+});

--- a/src/widgets/NowPlaying/Main.test.tsx
+++ b/src/widgets/NowPlaying/Main.test.tsx
@@ -1,0 +1,437 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type {
+  FlowsheetSongEntry,
+  FlowsheetBreakpointEntry,
+  FlowsheetShowBlockEntry,
+  FlowsheetMessageEntry,
+} from "@/lib/features/flowsheet/types";
+import React from "react";
+
+// Track the ref's mock methods
+const mockPlay = vi.fn();
+const mockPause = vi.fn();
+let mockIsPlayingState = false;
+
+// Mock child components
+vi.mock("./AlbumArtAndIcons", () => ({
+  default: ({ entry }: any) => (
+    <div data-testid="album-art-icons" data-has-entry={entry !== undefined} data-entry-id={entry?.id} />
+  ),
+}));
+
+vi.mock("./EntryText", () => ({
+  default: ({ entry }: any) => (
+    <div data-testid="entry-text" data-has-entry={entry !== undefined} data-entry-id={entry?.id} />
+  ),
+}));
+
+// Mock GradientAudioVisualizer with ref support using factory function
+vi.mock("./GradientAudioVisualizer", () => ({
+  GradientAudioVisualizer: React.forwardRef(({ src }: { src: string }, ref: any) => {
+    React.useImperativeHandle(ref, () => ({
+      play: () => {
+        mockPlay();
+        mockIsPlayingState = true;
+      },
+      pause: () => {
+        mockPause();
+        mockIsPlayingState = false;
+      },
+      get isPlaying() {
+        return mockIsPlayingState;
+      },
+    }));
+    return <div data-testid="gradient-visualizer" data-src={src} />;
+  }),
+}));
+
+// Mock MUI Joy components
+vi.mock("@mui/joy", () => ({
+  Box: ({ children, ...props }: any) => (
+    <div data-testid="box" {...props}>
+      {children}
+    </div>
+  ),
+  CircularProgress: (props: any) => (
+    <div data-testid="circular-progress" {...props} />
+  ),
+}));
+
+vi.mock("@mui/joy/AspectRatio", () => ({
+  default: ({ children, ratio, ...props }: any) => (
+    <div data-testid="aspect-ratio" data-ratio={ratio} {...props}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@mui/joy/Card", () => ({
+  default: ({ children, sx, ...props }: any) => (
+    <div
+      data-testid="card"
+      data-width={sx?.width}
+      data-height={sx?.height}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@mui/joy/CardContent", () => ({
+  default: ({ children, orientation, ...props }: any) => (
+    <div data-testid="card-content" data-orientation={orientation} {...props}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@mui/joy/CardOverflow", () => ({
+  default: ({ children, variant, color, ...props }: any) => (
+    <div
+      data-testid="card-overflow"
+      data-variant={variant}
+      data-color={color}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@mui/joy/Divider", () => ({
+  default: ({ orientation, ...props }: any) => (
+    <hr data-testid="divider" data-orientation={orientation} {...props} />
+  ),
+}));
+
+vi.mock("@mui/joy/IconButton", () => ({
+  default: ({ children, onClick, "aria-label": ariaLabel, ...props }: any) => (
+    <button
+      data-testid="icon-button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      {...props}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@mui/joy/Typography", () => ({
+  default: ({ children, level, ...props }: any) => (
+    <span data-testid="typography" data-level={level} {...props}>
+      {children}
+    </span>
+  ),
+}));
+
+// Mock MUI icons
+vi.mock("@mui/icons-material", () => ({
+  Pause: () => <span data-testid="pause-icon" />,
+  PlayArrow: () => <span data-testid="play-icon" />,
+}));
+
+// Import after mocks are set up
+import NowPlayingMain from "./Main";
+
+describe("NowPlayingMain", () => {
+  const baseEntry = {
+    id: 1,
+    play_order: 1,
+    show_id: 1,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsPlayingState = false;
+  });
+
+  describe("rendering", () => {
+    it("should render without crashing", () => {
+      expect(() =>
+        render(<NowPlayingMain live={false} />)
+      ).not.toThrow();
+    });
+
+    it("should render Card component", () => {
+      render(<NowPlayingMain live={false} />);
+      expect(screen.getByTestId("card")).toBeInTheDocument();
+    });
+
+    it("should render GradientAudioVisualizer", () => {
+      render(<NowPlayingMain live={false} />);
+      expect(screen.getByTestId("gradient-visualizer")).toBeInTheDocument();
+    });
+
+    it("should render AlbumArtAndIcons component", () => {
+      render(<NowPlayingMain live={false} />);
+      expect(screen.getByTestId("album-art-icons")).toBeInTheDocument();
+    });
+
+    it("should render EntryText component", () => {
+      render(<NowPlayingMain live={false} />);
+      expect(screen.getByTestId("entry-text")).toBeInTheDocument();
+    });
+
+    it("should pass audio source to GradientAudioVisualizer", () => {
+      render(<NowPlayingMain live={false} />);
+      expect(screen.getByTestId("gradient-visualizer")).toHaveAttribute(
+        "data-src",
+        "https://audio-mp3.ibiblio.org/wxyc.mp3"
+      );
+    });
+  });
+
+  describe("dimensions", () => {
+    it("should apply width prop to card", () => {
+      render(<NowPlayingMain live={false} width={400} />);
+      expect(screen.getByTestId("card")).toHaveAttribute("data-width", "400");
+    });
+
+    it("should apply height prop to card", () => {
+      render(<NowPlayingMain live={false} height={300} />);
+      expect(screen.getByTestId("card")).toHaveAttribute("data-height", "300");
+    });
+
+    it("should use 100% width when not specified", () => {
+      render(<NowPlayingMain live={false} />);
+      expect(screen.getByTestId("card")).toHaveAttribute("data-width", "100%");
+    });
+
+    it("should use 100% height when not specified", () => {
+      render(<NowPlayingMain live={false} />);
+      expect(screen.getByTestId("card")).toHaveAttribute("data-height", "100%");
+    });
+  });
+
+  describe("play/pause toggle", () => {
+    it("should show PlayArrow icon initially", () => {
+      render(<NowPlayingMain live={false} />);
+      expect(screen.getByTestId("play-icon")).toBeInTheDocument();
+    });
+
+    it("should call play when clicking play button while paused", () => {
+      render(<NowPlayingMain live={false} />);
+      const button = screen.getByTestId("icon-button");
+      fireEvent.click(button);
+      expect(mockPlay).toHaveBeenCalledTimes(1);
+    });
+
+    it("should show Pause icon after clicking play", () => {
+      render(<NowPlayingMain live={false} />);
+      const button = screen.getByTestId("icon-button");
+      fireEvent.click(button);
+      expect(screen.getByTestId("pause-icon")).toBeInTheDocument();
+    });
+
+    it("should call pause when clicking button while playing", () => {
+      render(<NowPlayingMain live={false} />);
+      const button = screen.getByTestId("icon-button");
+      // First click to play
+      fireEvent.click(button);
+      // Second click to pause
+      fireEvent.click(button);
+      expect(mockPause).toHaveBeenCalledTimes(1);
+    });
+
+    it("should show PlayArrow icon after pausing", () => {
+      render(<NowPlayingMain live={false} />);
+      const button = screen.getByTestId("icon-button");
+      // First click to play
+      fireEvent.click(button);
+      // Second click to pause
+      fireEvent.click(button);
+      expect(screen.getByTestId("play-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("live status", () => {
+    it("should display 'LIVE' when live is true", () => {
+      render(<NowPlayingMain live={true} />);
+      expect(screen.getByText("LIVE")).toBeInTheDocument();
+    });
+
+    it("should display 'OFF AIR' when live is false", () => {
+      render(<NowPlayingMain live={false} />);
+      expect(screen.getByText("OFF AIR")).toBeInTheDocument();
+    });
+
+    it("should apply primary color to card overflow when live", () => {
+      render(<NowPlayingMain live={true} />);
+      const cardOverflows = screen.getAllByTestId("card-overflow");
+      const liveOverflow = cardOverflows.find(
+        (el) => el.getAttribute("data-color") === "primary"
+      );
+      expect(liveOverflow).toBeInTheDocument();
+    });
+
+    it("should apply neutral color to card overflow when not live", () => {
+      render(<NowPlayingMain live={false} />);
+      const cardOverflows = screen.getAllByTestId("card-overflow");
+      const neutralOverflow = cardOverflows.find(
+        (el) => el.getAttribute("data-color") === "neutral"
+      );
+      expect(neutralOverflow).toBeInTheDocument();
+    });
+  });
+
+  describe("DJ name display", () => {
+    it("should display DJ name when live and onAirDJ is provided", () => {
+      render(<NowPlayingMain live={true} onAirDJ="DJ Cool" />);
+      expect(screen.getByText("DJ Cool")).toBeInTheDocument();
+    });
+
+    it("should not display DJ name when not live", () => {
+      render(<NowPlayingMain live={false} onAirDJ="DJ Cool" />);
+      expect(screen.queryByText("DJ Cool")).not.toBeInTheDocument();
+    });
+
+    it("should display vertical divider when live", () => {
+      render(<NowPlayingMain live={true} onAirDJ="DJ Cool" />);
+      const dividers = screen.getAllByTestId("divider");
+      const verticalDivider = dividers.find(
+        (el) => el.getAttribute("data-orientation") === "vertical"
+      );
+      expect(verticalDivider).toBeInTheDocument();
+    });
+  });
+
+  describe("loading state", () => {
+    it("should show CircularProgress when loading is true and live", () => {
+      render(<NowPlayingMain live={true} loading={true} />);
+      expect(screen.getByTestId("circular-progress")).toBeInTheDocument();
+    });
+
+    it("should show CircularProgress when loading is true even if not live", () => {
+      render(<NowPlayingMain live={false} loading={true} />);
+      expect(screen.getByTestId("circular-progress")).toBeInTheDocument();
+    });
+
+    it("should not show DJ name when loading", () => {
+      render(<NowPlayingMain live={true} loading={true} onAirDJ="DJ Cool" />);
+      expect(screen.queryByText("DJ Cool")).not.toBeInTheDocument();
+    });
+
+    it("should not show CircularProgress when not loading and live", () => {
+      render(<NowPlayingMain live={true} loading={false} onAirDJ="DJ Cool" />);
+      expect(screen.queryByTestId("circular-progress")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("entry prop", () => {
+    it("should pass song entry to AlbumArtAndIcons", () => {
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+      };
+
+      render(<NowPlayingMain live={false} entry={songEntry} />);
+      const albumArt = screen.getByTestId("album-art-icons");
+      expect(albumArt).toHaveAttribute("data-has-entry", "true");
+      expect(albumArt).toHaveAttribute("data-entry-id", "1");
+    });
+
+    it("should pass song entry to EntryText", () => {
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+      };
+
+      render(<NowPlayingMain live={false} entry={songEntry} />);
+      const entryText = screen.getByTestId("entry-text");
+      expect(entryText).toHaveAttribute("data-has-entry", "true");
+      expect(entryText).toHaveAttribute("data-entry-id", "1");
+    });
+
+    it("should pass breakpoint entry to child components", () => {
+      const breakpointEntry: FlowsheetBreakpointEntry = {
+        ...baseEntry,
+        id: 2,
+        message: "Breakpoint: Station ID",
+        day: "Monday",
+        time: "10:00",
+      };
+
+      render(<NowPlayingMain live={false} entry={breakpointEntry} />);
+      const albumArt = screen.getByTestId("album-art-icons");
+      expect(albumArt).toHaveAttribute("data-has-entry", "true");
+      expect(albumArt).toHaveAttribute("data-entry-id", "2");
+    });
+
+    it("should pass show block entry to child components", () => {
+      const showBlockEntry: FlowsheetShowBlockEntry = {
+        ...baseEntry,
+        id: 3,
+        dj_name: "DJ Cool",
+        isStart: true,
+        day: "Monday",
+        time: "10:00",
+      };
+
+      render(<NowPlayingMain live={true} entry={showBlockEntry} />);
+      const entryText = screen.getByTestId("entry-text");
+      expect(entryText).toHaveAttribute("data-has-entry", "true");
+      expect(entryText).toHaveAttribute("data-entry-id", "3");
+    });
+
+    it("should pass message entry to child components", () => {
+      const messageEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        id: 4,
+        message: "PSA: Community announcement",
+      };
+
+      render(<NowPlayingMain live={false} entry={messageEntry} />);
+      const albumArt = screen.getByTestId("album-art-icons");
+      expect(albumArt).toHaveAttribute("data-has-entry", "true");
+      expect(albumArt).toHaveAttribute("data-entry-id", "4");
+    });
+
+    it("should handle undefined entry", () => {
+      render(<NowPlayingMain live={false} entry={undefined} />);
+      const albumArt = screen.getByTestId("album-art-icons");
+      expect(albumArt).toHaveAttribute("data-has-entry", "false");
+    });
+  });
+
+  describe("aspect ratio", () => {
+    it("should render AspectRatio component with ratio 2.5", () => {
+      render(<NowPlayingMain live={false} />);
+      expect(screen.getByTestId("aspect-ratio")).toHaveAttribute(
+        "data-ratio",
+        "2.5"
+      );
+    });
+  });
+
+  describe("card content structure", () => {
+    it("should render CardContent component", () => {
+      render(<NowPlayingMain live={false} />);
+      expect(screen.getAllByTestId("card-content").length).toBeGreaterThan(0);
+    });
+
+    it("should render CardOverflow components", () => {
+      render(<NowPlayingMain live={false} />);
+      expect(screen.getAllByTestId("card-overflow").length).toBe(2);
+    });
+
+    it("should render horizontal CardContent for live status", () => {
+      render(<NowPlayingMain live={true} onAirDJ="DJ Cool" />);
+      const cardContents = screen.getAllByTestId("card-content");
+      const horizontalContent = cardContents.find(
+        (el) => el.getAttribute("data-orientation") === "horizontal"
+      );
+      expect(horizontalContent).toBeInTheDocument();
+    });
+  });
+});

--- a/src/widgets/NowPlaying/Mini.test.tsx
+++ b/src/widgets/NowPlaying/Mini.test.tsx
@@ -1,0 +1,444 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type {
+  FlowsheetSongEntry,
+  FlowsheetBreakpointEntry,
+  FlowsheetShowBlockEntry,
+  FlowsheetMessageEntry,
+  OnAirDJResponse,
+} from "@/lib/features/flowsheet/types";
+import React from "react";
+
+// Track the ref's mock methods
+const mockPlay = vi.fn();
+const mockPause = vi.fn();
+let mockIsPlayingState = false;
+
+// Mock child components
+vi.mock("./AlbumArtAndIcons", () => ({
+  default: ({ entry }: any) => (
+    <div data-testid="album-art-icons" data-has-entry={entry !== undefined} data-entry-id={entry?.id} />
+  ),
+}));
+
+vi.mock("./EntryText", () => ({
+  default: ({ entry }: any) => (
+    <div data-testid="entry-text" data-has-entry={entry !== undefined} data-entry-id={entry?.id} />
+  ),
+}));
+
+// Mock GradientAudioVisualizer with ref support using factory function
+vi.mock("./GradientAudioVisualizer", () => ({
+  GradientAudioVisualizer: React.forwardRef(({ src, overlayColor }: { src: string; overlayColor?: string }, ref: any) => {
+    React.useImperativeHandle(ref, () => ({
+      play: () => {
+        mockPlay();
+        mockIsPlayingState = true;
+      },
+      pause: () => {
+        mockPause();
+        mockIsPlayingState = false;
+      },
+      get isPlaying() {
+        return mockIsPlayingState;
+      },
+    }));
+    return (
+      <div
+        data-testid="gradient-visualizer"
+        data-src={src}
+        data-overlay-color={overlayColor}
+      />
+    );
+  }),
+}));
+
+// Mock useColorScheme hook
+const mockMode = vi.fn(() => "light");
+vi.mock("@mui/joy/styles", () => ({
+  useColorScheme: () => ({ mode: mockMode() }),
+}));
+
+// Mock MUI Joy components
+vi.mock("@mui/joy", () => ({
+  Card: ({ children, orientation, ...props }: any) => (
+    <div
+      data-testid="card"
+      data-orientation={orientation}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+  CardContent: ({ children, ...props }: any) => (
+    <div data-testid="card-content" {...props}>
+      {children}
+    </div>
+  ),
+  CardOverflow: ({ children, variant, color, ...props }: any) => (
+    <div
+      data-testid="card-overflow"
+      data-variant={variant}
+      data-color={color}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+  Chip: ({ children, startDecorator, ...props }: any) => (
+    <div data-testid="chip" {...props}>
+      {startDecorator}
+      {children}
+    </div>
+  ),
+  IconButton: ({ children, onClick, "aria-label": ariaLabel, ...props }: any) => (
+    <button
+      data-testid="icon-button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      {...props}
+    >
+      {children}
+    </button>
+  ),
+  Stack: ({ children, direction, ...props }: any) => (
+    <div data-testid="stack" data-direction={direction} {...props}>
+      {children}
+    </div>
+  ),
+}));
+
+// Mock MUI icons
+vi.mock("@mui/icons-material", () => ({
+  Headset: () => <span data-testid="headset-icon" />,
+  Pause: () => <span data-testid="pause-icon" />,
+  PlayArrow: () => <span data-testid="play-icon" />,
+}));
+
+// Import after mocks are set up
+import NowPlayingMini from "./Mini";
+
+describe("NowPlayingMini", () => {
+  const baseEntry = {
+    id: 1,
+    play_order: 1,
+    show_id: 1,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsPlayingState = false;
+    mockMode.mockReturnValue("light");
+  });
+
+  describe("rendering", () => {
+    it("should render without crashing", () => {
+      expect(() => render(<NowPlayingMini live={false} />)).not.toThrow();
+    });
+
+    it("should render Card component with horizontal orientation", () => {
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getByTestId("card")).toHaveAttribute(
+        "data-orientation",
+        "horizontal"
+      );
+    });
+
+    it("should render GradientAudioVisualizer", () => {
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getByTestId("gradient-visualizer")).toBeInTheDocument();
+    });
+
+    it("should render AlbumArtAndIcons component", () => {
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getByTestId("album-art-icons")).toBeInTheDocument();
+    });
+
+    it("should render EntryText component", () => {
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getByTestId("entry-text")).toBeInTheDocument();
+    });
+
+    it("should pass audio source to GradientAudioVisualizer", () => {
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getByTestId("gradient-visualizer")).toHaveAttribute(
+        "data-src",
+        "https://audio-mp3.ibiblio.org/wxyc.mp3"
+      );
+    });
+  });
+
+  describe("color scheme", () => {
+    it("should pass white overlay color in light mode", () => {
+      mockMode.mockReturnValue("light");
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getByTestId("gradient-visualizer")).toHaveAttribute(
+        "data-overlay-color",
+        "white"
+      );
+    });
+
+    it("should pass neutral.800 overlay color in dark mode", () => {
+      mockMode.mockReturnValue("dark");
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getByTestId("gradient-visualizer")).toHaveAttribute(
+        "data-overlay-color",
+        "neutral.800"
+      );
+    });
+
+    it("should pass neutral.800 overlay color when mode is undefined", () => {
+      mockMode.mockReturnValue(undefined);
+      render(<NowPlayingMini live={false} />);
+      // When mode is undefined, it's not "light", so it goes to else branch
+      expect(screen.getByTestId("gradient-visualizer")).toHaveAttribute(
+        "data-overlay-color",
+        "neutral.800"
+      );
+    });
+  });
+
+  describe("play/pause toggle", () => {
+    it("should show PlayArrow icon initially", () => {
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getByTestId("play-icon")).toBeInTheDocument();
+    });
+
+    it("should call play when clicking play button while paused", () => {
+      render(<NowPlayingMini live={false} />);
+      const button = screen.getByTestId("icon-button");
+      fireEvent.click(button);
+      expect(mockPlay).toHaveBeenCalledTimes(1);
+    });
+
+    it("should show Pause icon after clicking play", () => {
+      render(<NowPlayingMini live={false} />);
+      const button = screen.getByTestId("icon-button");
+      fireEvent.click(button);
+      expect(screen.getByTestId("pause-icon")).toBeInTheDocument();
+    });
+
+    it("should call pause when clicking button while playing", () => {
+      render(<NowPlayingMini live={false} />);
+      const button = screen.getByTestId("icon-button");
+      // First click to play
+      fireEvent.click(button);
+      // Second click to pause
+      fireEvent.click(button);
+      expect(mockPause).toHaveBeenCalledTimes(1);
+    });
+
+    it("should show PlayArrow icon after pausing", () => {
+      render(<NowPlayingMini live={false} />);
+      const button = screen.getByTestId("icon-button");
+      // First click to play
+      fireEvent.click(button);
+      // Second click to pause
+      fireEvent.click(button);
+      expect(screen.getByTestId("play-icon")).toBeInTheDocument();
+    });
+
+    it("should have correct aria-label when not playing", () => {
+      render(<NowPlayingMini live={false} />);
+      const button = screen.getByTestId("icon-button");
+      expect(button).toHaveAttribute("aria-label", "Play audio");
+    });
+
+    it("should have correct aria-label when playing", () => {
+      render(<NowPlayingMini live={false} />);
+      const button = screen.getByTestId("icon-button");
+      fireEvent.click(button);
+      expect(button).toHaveAttribute("aria-label", "Pause audio");
+    });
+  });
+
+  describe("live status", () => {
+    it("should display 'LIVE' when live is true", () => {
+      render(<NowPlayingMini live={true} />);
+      expect(screen.getByText("LIVE")).toBeInTheDocument();
+    });
+
+    it("should display 'OFF AIR' when live is false", () => {
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getByText("OFF AIR")).toBeInTheDocument();
+    });
+
+    it("should apply primary color to card overflow when live", () => {
+      render(<NowPlayingMini live={true} />);
+      expect(screen.getByTestId("card-overflow")).toHaveAttribute(
+        "data-color",
+        "primary"
+      );
+    });
+
+    it("should apply neutral color to card overflow when not live", () => {
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getByTestId("card-overflow")).toHaveAttribute(
+        "data-color",
+        "neutral"
+      );
+    });
+  });
+
+  describe("DJs display", () => {
+    it("should display DJ chips when onAirDJs is provided", () => {
+      const djs: OnAirDJResponse[] = [
+        { id: "1", dj_name: "DJ Cool" },
+        { id: "2", dj_name: "DJ Hot" },
+      ];
+      render(<NowPlayingMini live={true} onAirDJs={djs} />);
+      expect(screen.getByText("DJ DJ Cool")).toBeInTheDocument();
+      expect(screen.getByText("DJ DJ Hot")).toBeInTheDocument();
+    });
+
+    it("should render Chip component for each DJ", () => {
+      const djs: OnAirDJResponse[] = [
+        { id: "1", dj_name: "DJ Cool" },
+        { id: "2", dj_name: "DJ Hot" },
+      ];
+      render(<NowPlayingMini live={true} onAirDJs={djs} />);
+      expect(screen.getAllByTestId("chip").length).toBe(2);
+    });
+
+    it("should render Headset icon in each DJ chip", () => {
+      const djs: OnAirDJResponse[] = [{ id: "1", dj_name: "DJ Cool" }];
+      render(<NowPlayingMini live={true} onAirDJs={djs} />);
+      expect(screen.getByTestId("headset-icon")).toBeInTheDocument();
+    });
+
+    it("should render multiple Headset icons for multiple DJs", () => {
+      const djs: OnAirDJResponse[] = [
+        { id: "1", dj_name: "DJ Cool" },
+        { id: "2", dj_name: "DJ Hot" },
+      ];
+      render(<NowPlayingMini live={true} onAirDJs={djs} />);
+      expect(screen.getAllByTestId("headset-icon").length).toBe(2);
+    });
+
+    it("should not render chips when onAirDJs is undefined", () => {
+      render(<NowPlayingMini live={true} />);
+      expect(screen.queryByTestId("chip")).not.toBeInTheDocument();
+    });
+
+    it("should not render chips when onAirDJs is empty", () => {
+      render(<NowPlayingMini live={true} onAirDJs={[]} />);
+      expect(screen.queryByTestId("chip")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("entry prop", () => {
+    it("should pass song entry to AlbumArtAndIcons", () => {
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+      };
+
+      render(<NowPlayingMini live={false} entry={songEntry} />);
+      const albumArt = screen.getByTestId("album-art-icons");
+      expect(albumArt).toHaveAttribute("data-has-entry", "true");
+      expect(albumArt).toHaveAttribute("data-entry-id", "1");
+    });
+
+    it("should pass song entry to EntryText", () => {
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+      };
+
+      render(<NowPlayingMini live={false} entry={songEntry} />);
+      const entryText = screen.getByTestId("entry-text");
+      expect(entryText).toHaveAttribute("data-has-entry", "true");
+      expect(entryText).toHaveAttribute("data-entry-id", "1");
+    });
+
+    it("should pass breakpoint entry to child components", () => {
+      const breakpointEntry: FlowsheetBreakpointEntry = {
+        ...baseEntry,
+        id: 2,
+        message: "Breakpoint: Station ID",
+        day: "Monday",
+        time: "10:00",
+      };
+
+      render(<NowPlayingMini live={false} entry={breakpointEntry} />);
+      const albumArt = screen.getByTestId("album-art-icons");
+      expect(albumArt).toHaveAttribute("data-has-entry", "true");
+      expect(albumArt).toHaveAttribute("data-entry-id", "2");
+    });
+
+    it("should pass show block entry to child components", () => {
+      const showBlockEntry: FlowsheetShowBlockEntry = {
+        ...baseEntry,
+        id: 3,
+        dj_name: "DJ Cool",
+        isStart: true,
+        day: "Monday",
+        time: "10:00",
+      };
+
+      render(<NowPlayingMini live={true} entry={showBlockEntry} />);
+      const entryText = screen.getByTestId("entry-text");
+      expect(entryText).toHaveAttribute("data-has-entry", "true");
+      expect(entryText).toHaveAttribute("data-entry-id", "3");
+    });
+
+    it("should pass message entry to child components", () => {
+      const messageEntry: FlowsheetMessageEntry = {
+        ...baseEntry,
+        id: 4,
+        message: "PSA: Community announcement",
+      };
+
+      render(<NowPlayingMini live={false} entry={messageEntry} />);
+      const albumArt = screen.getByTestId("album-art-icons");
+      expect(albumArt).toHaveAttribute("data-has-entry", "true");
+      expect(albumArt).toHaveAttribute("data-entry-id", "4");
+    });
+
+    it("should handle undefined entry", () => {
+      render(<NowPlayingMini live={false} entry={undefined} />);
+      const albumArt = screen.getByTestId("album-art-icons");
+      expect(albumArt).toHaveAttribute("data-has-entry", "false");
+    });
+  });
+
+  describe("card structure", () => {
+    it("should render CardContent components", () => {
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getAllByTestId("card-content").length).toBe(2);
+    });
+
+    it("should render CardOverflow component", () => {
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getByTestId("card-overflow")).toBeInTheDocument();
+    });
+
+    it("should render Stack for DJ chips with row direction", () => {
+      const djs: OnAirDJResponse[] = [{ id: "1", dj_name: "DJ Cool" }];
+      render(<NowPlayingMini live={true} onAirDJs={djs} />);
+      const stacks = screen.getAllByTestId("stack");
+      const rowStack = stacks.find(
+        (el) => el.getAttribute("data-direction") === "row"
+      );
+      expect(rowStack).toBeInTheDocument();
+    });
+  });
+
+  describe("variant styling", () => {
+    it("should render CardOverflow with soft variant", () => {
+      render(<NowPlayingMini live={false} />);
+      expect(screen.getByTestId("card-overflow")).toHaveAttribute(
+        "data-variant",
+        "soft"
+      );
+    });
+  });
+});

--- a/src/widgets/NowPlaying/index.test.tsx
+++ b/src/widgets/NowPlaying/index.test.tsx
@@ -1,0 +1,495 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import NowPlaying from "./index";
+import type {
+  FlowsheetSongEntry,
+  OnAirDJResponse,
+  OnAirDJData,
+} from "@/lib/features/flowsheet/types";
+
+// Mock the API hooks
+const mockUseWhoIsLiveQuery = vi.fn();
+const mockUseGetNowPlayingQuery = vi.fn();
+
+vi.mock("@/lib/features/flowsheet/api", () => ({
+  useGetNowPlayingQuery: (arg: any, options: any) =>
+    mockUseGetNowPlayingQuery(arg, options),
+  useWhoIsLiveQuery: () => mockUseWhoIsLiveQuery(),
+}));
+
+// Mock the useAlbumImages hook
+vi.mock("@/src/hooks/applicationHooks", () => ({
+  useAlbumImages: () => ({
+    setAlbum: vi.fn(),
+    setArtist: vi.fn(),
+    loading: false,
+    url: "https://example.com/album.jpg",
+  }),
+}));
+
+// Mock NowPlayingMain component
+vi.mock("./Main", () => ({
+  default: ({
+    entry,
+    live,
+    onAirDJ,
+    loading,
+  }: {
+    entry?: any;
+    live: boolean;
+    onAirDJ?: string;
+    loading?: boolean;
+  }) => (
+    <div
+      data-testid="now-playing-main"
+      data-has-entry={entry !== undefined}
+      data-entry-id={entry?.id}
+      data-live={live}
+      data-on-air-dj={onAirDJ || ""}
+      data-loading={loading}
+    />
+  ),
+}));
+
+// Mock NowPlayingMini component
+vi.mock("./Mini", () => ({
+  default: ({
+    entry,
+    live,
+    onAirDJs,
+  }: {
+    entry?: any;
+    live: boolean;
+    onAirDJs?: OnAirDJResponse[];
+  }) => (
+    <div
+      data-testid="now-playing-mini"
+      data-has-entry={entry !== undefined}
+      data-entry-id={entry?.id}
+      data-live={live}
+      data-djs-count={onAirDJs?.length || 0}
+    />
+  ),
+}));
+
+describe("NowPlaying", () => {
+  const mockSongEntry: FlowsheetSongEntry = {
+    id: 1,
+    play_order: 1,
+    show_id: 1,
+    track_title: "Test Track",
+    artist_name: "Test Artist",
+    album_title: "Test Album",
+    record_label: "Test Label",
+    request_flag: false,
+  };
+
+  const mockDJsOnAirData: OnAirDJData = {
+    onAir: "DJ Cool",
+    djs: [{ id: "1", dj_name: "DJ Cool" }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default mock returns
+    mockUseWhoIsLiveQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    });
+
+    mockUseGetNowPlayingQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    });
+  });
+
+  describe("rendering", () => {
+    it("should render without crashing", () => {
+      expect(() => render(<NowPlaying mini={false} />)).not.toThrow();
+    });
+
+    it("should render NowPlayingMain when mini is false", () => {
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toBeInTheDocument();
+      expect(screen.queryByTestId("now-playing-mini")).not.toBeInTheDocument();
+    });
+
+    it("should render NowPlayingMini when mini is true", () => {
+      render(<NowPlaying mini={true} />);
+      expect(screen.getByTestId("now-playing-mini")).toBeInTheDocument();
+      expect(screen.queryByTestId("now-playing-main")).not.toBeInTheDocument();
+    });
+
+    it("should render audio element", () => {
+      const { container } = render(<NowPlaying mini={false} />);
+      const audio = container.querySelector("audio#now-playing-music");
+      expect(audio).toBeInTheDocument();
+    });
+
+    it("should set crossOrigin on audio element", () => {
+      const { container } = render(<NowPlaying mini={false} />);
+      const audio = container.querySelector("audio");
+      expect(audio).toHaveAttribute("crossOrigin", "anonymous");
+    });
+  });
+
+  describe("live status logic", () => {
+    it("should be live when onAir is a DJ name (not Off Air)", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: mockDJsOnAirData,
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-live",
+        "true"
+      );
+    });
+
+    it("should not be live when onAir is Off Air", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: { onAir: "Off Air", djs: [] },
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-live",
+        "false"
+      );
+    });
+
+    it("should not be live when onAir is undefined", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: { onAir: undefined, djs: [] },
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-live",
+        "false"
+      );
+    });
+
+    it("should not be live when djError is true", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: mockDJsOnAirData,
+        isLoading: false,
+        isError: true,
+      });
+
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-live",
+        "false"
+      );
+    });
+
+    it("should not be live when data is undefined", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-live",
+        "false"
+      );
+    });
+  });
+
+  describe("loading state", () => {
+    it("should pass loading to NowPlayingMain when djLoading is true", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-loading",
+        "true"
+      );
+    });
+
+    it("should pass loading=false when not loading", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: mockDJsOnAirData,
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-loading",
+        "false"
+      );
+    });
+  });
+
+  describe("entry data", () => {
+    it("should pass entry to NowPlayingMain", () => {
+      mockUseGetNowPlayingQuery.mockReturnValue({
+        data: mockSongEntry,
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+      const main = screen.getByTestId("now-playing-main");
+      expect(main).toHaveAttribute("data-has-entry", "true");
+      expect(main).toHaveAttribute("data-entry-id", "1");
+    });
+
+    it("should pass entry to NowPlayingMini", () => {
+      mockUseGetNowPlayingQuery.mockReturnValue({
+        data: mockSongEntry,
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={true} />);
+      const mini = screen.getByTestId("now-playing-mini");
+      expect(mini).toHaveAttribute("data-has-entry", "true");
+      expect(mini).toHaveAttribute("data-entry-id", "1");
+    });
+
+    it("should pass undefined entry when no data", () => {
+      mockUseGetNowPlayingQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-has-entry",
+        "false"
+      );
+    });
+  });
+
+  describe("DJ data", () => {
+    it("should pass onAirDJ to NowPlayingMain", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: mockDJsOnAirData,
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-on-air-dj",
+        "DJ Cool"
+      );
+    });
+
+    it("should pass onAirDJs to NowPlayingMini", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: mockDJsOnAirData,
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={true} />);
+      expect(screen.getByTestId("now-playing-mini")).toHaveAttribute(
+        "data-djs-count",
+        "1"
+      );
+    });
+
+    it("should pass empty onAirDJ when data is undefined", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-on-air-dj",
+        ""
+      );
+    });
+
+    it("should pass zero djs when data is undefined", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={true} />);
+      expect(screen.getByTestId("now-playing-mini")).toHaveAttribute(
+        "data-djs-count",
+        "0"
+      );
+    });
+  });
+
+  describe("API polling", () => {
+    it("should call useGetNowPlayingQuery with pollingInterval", () => {
+      render(<NowPlaying mini={false} />);
+      expect(mockUseGetNowPlayingQuery).toHaveBeenCalledWith(undefined, {
+        pollingInterval: 60000,
+      });
+    });
+  });
+
+  describe("multiple DJs", () => {
+    it("should pass multiple DJs to NowPlayingMini", () => {
+      const multipleDJs: OnAirDJData = {
+        onAir: "DJ Cool & DJ Hot",
+        djs: [
+          { id: "1", dj_name: "DJ Cool" },
+          { id: "2", dj_name: "DJ Hot" },
+        ],
+      };
+
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: multipleDJs,
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={true} />);
+      expect(screen.getByTestId("now-playing-mini")).toHaveAttribute(
+        "data-djs-count",
+        "2"
+      );
+    });
+  });
+
+  describe("error states", () => {
+    it("should handle latestEntryError gracefully", () => {
+      mockUseGetNowPlayingQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+      });
+
+      expect(() => render(<NowPlaying mini={false} />)).not.toThrow();
+    });
+
+    it("should handle djError gracefully", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+      });
+
+      expect(() => render(<NowPlaying mini={false} />)).not.toThrow();
+    });
+
+    it("should handle both errors gracefully", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+      });
+
+      mockUseGetNowPlayingQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+      });
+
+      expect(() => render(<NowPlaying mini={false} />)).not.toThrow();
+    });
+  });
+
+  describe("default props", () => {
+    it("should default to mini=false", () => {
+      // TypeScript requires mini prop, but test the behavior with false
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toBeInTheDocument();
+    });
+  });
+
+  describe("combined states", () => {
+    it("should render correctly with all data present", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: mockDJsOnAirData,
+        isLoading: false,
+        isError: false,
+      });
+
+      mockUseGetNowPlayingQuery.mockReturnValue({
+        data: mockSongEntry,
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+
+      const main = screen.getByTestId("now-playing-main");
+      expect(main).toHaveAttribute("data-live", "true");
+      expect(main).toHaveAttribute("data-on-air-dj", "DJ Cool");
+      expect(main).toHaveAttribute("data-has-entry", "true");
+      expect(main).toHaveAttribute("data-entry-id", "1");
+      expect(main).toHaveAttribute("data-loading", "false");
+    });
+
+    it("should render correctly with loading states", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+      });
+
+      mockUseGetNowPlayingQuery.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+
+      const main = screen.getByTestId("now-playing-main");
+      expect(main).toHaveAttribute("data-live", "false");
+      expect(main).toHaveAttribute("data-loading", "true");
+    });
+  });
+
+  describe("mini vs main switching", () => {
+    it("should pass different props to mini vs main", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: mockDJsOnAirData,
+        isLoading: false,
+        isError: false,
+      });
+
+      mockUseGetNowPlayingQuery.mockReturnValue({
+        data: mockSongEntry,
+        isLoading: false,
+        isError: false,
+      });
+
+      // Test main gets onAirDJ (string)
+      const { unmount } = render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-on-air-dj",
+        "DJ Cool"
+      );
+      unmount();
+
+      // Test mini gets onAirDJs (array) - we check count
+      render(<NowPlaying mini={true} />);
+      expect(screen.getByTestId("now-playing-mini")).toHaveAttribute(
+        "data-djs-count",
+        "1"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add tests for Main NowPlaying component
- Add tests for Mini NowPlaying component
- Add tests for NowPlaying index
- Add tests for AlbumArtAndIcons
- Add tests for EntryText
- Add tests for GradientAudioVisualizer

## Test plan
- [ ] Run `npm test src/widgets/NowPlaying/`

**Part 24 of 26**