### PR TITLE
feat: add historical playlist search feature

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,6 +36,11 @@ export default async function HomePage() {
             Listen
           </Button>
         </Link>
+        <Link href="/playlists" style={{ width: "100%" }}>
+          <Button variant="outlined" color="neutral" fullWidth>
+            Playlist Archive
+          </Button>
+        </Link>
       </Stack>
     </WXYCPage>
   );

--- a/app/playlists/page.tsx
+++ b/app/playlists/page.tsx
@@ -1,10 +1,16 @@
 import WXYCPage from "@/src/Layout/WXYCPage";
 import { PlaylistSearchContainer } from "@/src/components/experiences/modern/playlist-search";
 import { Box } from "@mui/joy";
+import { Metadata } from "next";
+import { getPageTitle } from "@/lib/utils/page-title";
+
+export const metadata: Metadata = {
+  title: getPageTitle("Playlist Archive"),
+};
 
 export default function PlaylistsPage() {
   return (
-    <WXYCPage title="Playlist Archive">
+    <WXYCPage>
       <Box
         sx={{
           width: "100%",

--- a/app/playlists/page.tsx
+++ b/app/playlists/page.tsx
@@ -1,0 +1,20 @@
+import WXYCPage from "@/src/Layout/WXYCPage";
+import { PlaylistSearchContainer } from "@/src/components/experiences/modern/playlist-search";
+import { Box } from "@mui/joy";
+
+export default function PlaylistsPage() {
+  return (
+    <WXYCPage title="Playlist Archive">
+      <Box
+        sx={{
+          width: "100%",
+          maxWidth: 1200,
+          mx: "auto",
+          py: 2,
+        }}
+      >
+        <PlaylistSearchContainer />
+      </Box>
+    </WXYCPage>
+  );
+}

--- a/lib/features/playlist-search/api.ts
+++ b/lib/features/playlist-search/api.ts
@@ -1,0 +1,21 @@
+import { createApi } from "@reduxjs/toolkit/query/react";
+import { backendBaseQuery } from "../backend";
+import type {
+  PlaylistSearchParams,
+  PlaylistSearchResponse,
+} from "@wxyc/shared";
+
+export const playlistSearchApi = createApi({
+  reducerPath: "playlistSearchApi",
+  baseQuery: backendBaseQuery("flowsheet"),
+  endpoints: (builder) => ({
+    searchPlaylists: builder.query<PlaylistSearchResponse, PlaylistSearchParams>({
+      query: ({ q, page = 0, limit = 50, sort = "date", order = "desc" }) => ({
+        url: "/search",
+        params: { q, page, limit, sort, order },
+      }),
+    }),
+  }),
+});
+
+export const { useSearchPlaylistsQuery, useLazySearchPlaylistsQuery } = playlistSearchApi;

--- a/lib/features/playlist-search/frontend.ts
+++ b/lib/features/playlist-search/frontend.ts
@@ -1,0 +1,103 @@
+import { createAppSlice } from "@/lib/createAppSlice";
+import type { PayloadAction } from "@reduxjs/toolkit";
+import type {
+  PlaylistSearchParamsSortEnum,
+  PlaylistSearchParamsOrderEnum,
+} from "@wxyc/shared";
+
+type SortField = PlaylistSearchParamsSortEnum;
+type SortOrder = PlaylistSearchParamsOrderEnum;
+type Operator = "AND" | "OR" | "NOT";
+type SearchField = "artist" | "song" | "album" | "label" | "dj" | "date" | "dateRange";
+
+export type SearchRow = {
+  id: string;
+  operator: Operator;
+  field: SearchField;
+  value: string;
+  valueTo?: string; // For date range "to" value
+  exact: boolean;   // Exact phrase match
+};
+
+export type SearchMode = "simple" | "advanced";
+
+export type PlaylistSearchState = {
+  mode: SearchMode;
+  simpleQuery: string;
+  advancedRows: SearchRow[];
+  sortBy: SortField;
+  sortOrder: SortOrder;
+  page: number;
+};
+
+const createInitialRow = (): SearchRow => ({
+  id: crypto.randomUUID(),
+  operator: "AND",
+  field: "artist",
+  value: "",
+  exact: false,
+});
+
+const initialState: PlaylistSearchState = {
+  mode: "simple",
+  simpleQuery: "",
+  advancedRows: [createInitialRow()],
+  sortBy: "date",
+  sortOrder: "desc",
+  page: 0,
+};
+
+export const playlistSearchSlice = createAppSlice({
+  name: "playlistSearch",
+  initialState,
+  reducers: {
+    setMode: (state, action: PayloadAction<SearchMode>) => {
+      state.mode = action.payload;
+      state.page = 0;
+    },
+    setSimpleQuery: (state, action: PayloadAction<string>) => {
+      state.simpleQuery = action.payload;
+      state.page = 0;
+    },
+    addRow: (state) => {
+      state.advancedRows.push(createInitialRow());
+    },
+    removeRow: (state, action: PayloadAction<string>) => {
+      if (state.advancedRows.length > 1) {
+        state.advancedRows = state.advancedRows.filter(r => r.id !== action.payload);
+        state.page = 0;
+      }
+    },
+    updateRow: (state, action: PayloadAction<{ id: string; updates: Partial<SearchRow> }>) => {
+      const row = state.advancedRows.find(r => r.id === action.payload.id);
+      if (row) {
+        Object.assign(row, action.payload.updates);
+        state.page = 0;
+      }
+    },
+    setSort: (state, action: PayloadAction<SortField>) => {
+      if (state.sortBy === action.payload) {
+        state.sortOrder = state.sortOrder === "asc" ? "desc" : "asc";
+      } else {
+        state.sortBy = action.payload;
+        state.sortOrder = "desc";
+      }
+      state.page = 0;
+    },
+    nextPage: (state) => {
+      state.page += 1;
+    },
+    resetPage: (state) => {
+      state.page = 0;
+    },
+    reset: () => initialState,
+  },
+  selectors: {
+    getMode: (state) => state.mode,
+    getSimpleQuery: (state) => state.simpleQuery,
+    getAdvancedRows: (state) => state.advancedRows,
+    getSortBy: (state) => state.sortBy,
+    getSortOrder: (state) => state.sortOrder,
+    getPage: (state) => state.page,
+  },
+});

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -20,6 +20,8 @@ import { catalogSlice } from "./features/catalog/frontend";
 import { experienceApi } from "./features/experiences/api";
 import { flowsheetApi } from "./features/flowsheet/api";
 import { flowsheetSlice } from "./features/flowsheet/frontend";
+import { playlistSearchApi } from "./features/playlist-search/api";
+import { playlistSearchSlice } from "./features/playlist-search/frontend";
 import { rotationApi } from "./features/rotation/api";
 import { rotationSlice } from "./features/rotation/frontend";
 
@@ -33,6 +35,8 @@ const rootReducer = combineSlices(
   binApi,
   flowsheetSlice,
   flowsheetApi,
+  playlistSearchSlice,
+  playlistSearchApi,
   rotationSlice,
   rotationApi,
   adminSlice
@@ -51,6 +55,7 @@ export const makeStore = () => {
         .concat(catalogApi.middleware)
         .concat(binApi.middleware)
         .concat(flowsheetApi.middleware)
+        .concat(playlistSearchApi.middleware)
         .concat(rotationApi.middleware);
     },
   });

--- a/src/components/experiences/modern/playlist-search/PlaylistAdvancedSearch.tsx
+++ b/src/components/experiences/modern/playlist-search/PlaylistAdvancedSearch.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { SearchRow } from "@/lib/features/playlist-search/frontend";
+import { Box, Button, CircularProgress, Stack, Typography } from "@mui/joy";
+import PlaylistSearchRow from "./PlaylistSearchRow";
+
+interface PlaylistAdvancedSearchProps {
+  rows: SearchRow[];
+  onAddRow: () => void;
+  onRemoveRow: (id: string) => void;
+  onUpdateRow: (id: string, updates: Partial<SearchRow>) => void;
+  isLoading: boolean;
+}
+
+export default function PlaylistAdvancedSearch({
+  rows,
+  onAddRow,
+  onRemoveRow,
+  onUpdateRow,
+  isLoading,
+}: PlaylistAdvancedSearchProps) {
+  return (
+    <Box
+      sx={{
+        p: 2,
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: "sm",
+        bgcolor: "background.surface",
+      }}
+    >
+      <Typography level="body-sm" sx={{ mb: 2, color: "text.secondary" }}>
+        Build your search query by adding conditions. Combine with AND, OR, NOT operators.
+      </Typography>
+
+      <Stack spacing={2}>
+        {rows.map((row, index) => (
+          <PlaylistSearchRow
+            key={row.id}
+            row={row}
+            isFirst={index === 0}
+            canRemove={rows.length > 1}
+            onUpdate={(updates) => onUpdateRow(row.id, updates)}
+            onAdd={onAddRow}
+            onRemove={() => onRemoveRow(row.id)}
+          />
+        ))}
+      </Stack>
+
+      <Box sx={{ mt: 2, display: "flex", alignItems: "center", gap: 2 }}>
+        <Button
+          variant="solid"
+          color="primary"
+          disabled={isLoading || rows.every((r) => !r.value.trim())}
+          startDecorator={isLoading ? <CircularProgress size="sm" /> : null}
+        >
+          {isLoading ? "Searching..." : "Search"}
+        </Button>
+        <Typography level="body-xs" sx={{ color: "text.tertiary" }}>
+          Results update automatically as you type
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/experiences/modern/playlist-search/PlaylistInfiniteScroll.tsx
+++ b/src/components/experiences/modern/playlist-search/PlaylistInfiniteScroll.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Box, CircularProgress, Sheet, Typography } from "@mui/joy";
+import { useEffect, useRef } from "react";
+
+interface PlaylistInfiniteScrollProps {
+  children: React.ReactNode;
+  hasMore: boolean;
+  isLoading: boolean;
+  onLoadMore: () => void;
+}
+
+export default function PlaylistInfiniteScroll({
+  children,
+  hasMore,
+  isLoading,
+  onLoadMore,
+}: PlaylistInfiniteScrollProps) {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+        if (entry.isIntersecting && hasMore && !isLoading) {
+          onLoadMore();
+        }
+      },
+      {
+        root: null,
+        rootMargin: "100px",
+        threshold: 0,
+      }
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasMore, isLoading, onLoadMore]);
+
+  return (
+    <Sheet
+      sx={{
+        maxHeight: "calc(100vh - 350px)",
+        minHeight: 400,
+        overflowY: "auto",
+        background: "transparent",
+        borderRadius: "sm",
+      }}
+    >
+      {children}
+
+      {/* Sentinel element for intersection observer */}
+      <Box
+        ref={sentinelRef}
+        sx={{
+          height: 1,
+          width: "100%",
+        }}
+      />
+
+      {/* Loading indicator at bottom */}
+      {isLoading && (
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            py: 3,
+          }}
+        >
+          <CircularProgress size="sm" />
+          <Typography level="body-sm" sx={{ ml: 1, color: "text.secondary" }}>
+            Loading more results...
+          </Typography>
+        </Box>
+      )}
+
+      {/* End of results indicator */}
+      {!hasMore && !isLoading && (
+        <Box sx={{ textAlign: "center", py: 2 }}>
+          <Typography level="body-sm" sx={{ color: "text.tertiary" }}>
+            End of results
+          </Typography>
+        </Box>
+      )}
+    </Sheet>
+  );
+}

--- a/src/components/experiences/modern/playlist-search/PlaylistResultsTable.tsx
+++ b/src/components/experiences/modern/playlist-search/PlaylistResultsTable.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import type { PlaylistSearchResult, PlaylistSearchParamsSortEnum } from "@wxyc/shared";
+import { ArrowDownward, ArrowUpward } from "@mui/icons-material";
+import { Box, Link, Table, Typography } from "@mui/joy";
+
+interface PlaylistResultsTableProps {
+  results: PlaylistSearchResult[];
+  sortBy: PlaylistSearchParamsSortEnum;
+  sortOrder: "asc" | "desc";
+  onSort: (field: "date" | "artist" | "song" | "dj") => void;
+}
+
+function SortableHeader({
+  field,
+  label,
+  currentSort,
+  currentOrder,
+  onSort,
+}: {
+  field: "date" | "artist" | "song" | "dj";
+  label: string;
+  currentSort: string;
+  currentOrder: "asc" | "desc";
+  onSort: (field: "date" | "artist" | "song" | "dj") => void;
+}) {
+  const isActive = currentSort === field;
+
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        cursor: "pointer",
+        userSelect: "none",
+        "&:hover": { color: "primary.main" },
+      }}
+      onClick={() => onSort(field)}
+    >
+      {label}
+      {isActive && (
+        <Box component="span" sx={{ ml: 0.5, display: "flex" }}>
+          {currentOrder === "asc" ? (
+            <ArrowUpward sx={{ fontSize: 16 }} />
+          ) : (
+            <ArrowDownward sx={{ fontSize: 16 }} />
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function PlaylistResultsTable({
+  results,
+  sortBy,
+  sortOrder,
+  onSort,
+}: PlaylistResultsTableProps) {
+  return (
+    <Table
+      aria-label="playlist search results"
+      stickyHeader
+      hoverRow
+      sx={{
+        "--TableCell-headBackground": (theme) =>
+          theme.vars.palette.background.level1,
+        "--Table-headerUnderlineThickness": "1px",
+        "--TableRow-hoverBackground": (theme) =>
+          theme.vars.palette.background.level1,
+      }}
+    >
+      <thead>
+        <tr>
+          <th style={{ width: 160, padding: 12 }}>
+            <SortableHeader
+              field="date"
+              label="Date"
+              currentSort={sortBy}
+              currentOrder={sortOrder}
+              onSort={onSort}
+            />
+          </th>
+          <th style={{ width: 180, padding: 12 }}>
+            <SortableHeader
+              field="artist"
+              label="Artist"
+              currentSort={sortBy}
+              currentOrder={sortOrder}
+              onSort={onSort}
+            />
+          </th>
+          <th style={{ width: 200, padding: 12 }}>
+            <SortableHeader
+              field="song"
+              label="Song"
+              currentSort={sortBy}
+              currentOrder={sortOrder}
+              onSort={onSort}
+            />
+          </th>
+          <th style={{ width: 180, padding: 12 }}>Release</th>
+          <th style={{ width: 140, padding: 12 }}>Label</th>
+          <th style={{ width: 120, padding: 12 }}>
+            <SortableHeader
+              field="dj"
+              label="DJ"
+              currentSort={sortBy}
+              currentOrder={sortOrder}
+              onSort={onSort}
+            />
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {results.map((result) => (
+          <tr key={result.id}>
+            <td>
+              <Typography level="body-sm" sx={{ color: "text.secondary" }}>
+                {formatDate(result.play_date)}
+              </Typography>
+            </td>
+            <td>
+              <Typography level="body-sm" fontWeight="md">
+                {result.artist_name}
+              </Typography>
+            </td>
+            <td>
+              <Typography level="body-sm">{result.track_title}</Typography>
+            </td>
+            <td>
+              <Typography level="body-sm" sx={{ color: "text.secondary" }}>
+                {result.album_title}
+              </Typography>
+            </td>
+            <td>
+              <Typography level="body-sm" sx={{ color: "text.tertiary" }}>
+                {result.record_label}
+              </Typography>
+            </td>
+            <td>
+              <Link
+                level="body-sm"
+                href={`/playlists?dj=${encodeURIComponent(result.dj_name)}`}
+                sx={{ textDecoration: "none" }}
+              >
+                {result.dj_name}
+              </Link>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+}

--- a/src/components/experiences/modern/playlist-search/PlaylistSearchBar.tsx
+++ b/src/components/experiences/modern/playlist-search/PlaylistSearchBar.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Cancel, Search } from "@mui/icons-material";
+import {
+  Box,
+  CircularProgress,
+  FormControl,
+  FormHelperText,
+  IconButton,
+  Input,
+} from "@mui/joy";
+
+interface PlaylistSearchBarProps {
+  query: string;
+  onQueryChange: (query: string) => void;
+  isLoading: boolean;
+}
+
+export default function PlaylistSearchBar({
+  query,
+  onQueryChange,
+  isLoading,
+}: PlaylistSearchBarProps) {
+  return (
+    <Box>
+      <FormControl sx={{ width: "100%", maxWidth: 600 }}>
+        <Input
+          placeholder="Search playlists..."
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          startDecorator={<Search />}
+          endDecorator={
+            isLoading ? (
+              <CircularProgress size="sm" />
+            ) : query ? (
+              <IconButton
+                variant="plain"
+                color="neutral"
+                onClick={() => onQueryChange("")}
+              >
+                <Cancel />
+              </IconButton>
+            ) : null
+          }
+          sx={{ fontSize: "md" }}
+        />
+        <FormHelperText>
+          Search by artist, song, album, label, or DJ name. Use AND, OR, NOT for Boolean searches.
+          Wrap phrases in quotes for exact matches.
+        </FormHelperText>
+      </FormControl>
+    </Box>
+  );
+}

--- a/src/components/experiences/modern/playlist-search/PlaylistSearchContainer.tsx
+++ b/src/components/experiences/modern/playlist-search/PlaylistSearchContainer.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { usePlaylistSearch } from "@/src/hooks/playlistSearchHooks";
+import { Box, Tab, TabList, TabPanel, Tabs, Typography } from "@mui/joy";
+import PlaylistAdvancedSearch from "./PlaylistAdvancedSearch";
+import PlaylistResultsTable from "./PlaylistResultsTable";
+import PlaylistSearchBar from "./PlaylistSearchBar";
+import PlaylistInfiniteScroll from "./PlaylistInfiniteScroll";
+
+export default function PlaylistSearchContainer() {
+  const {
+    mode,
+    setMode,
+    simpleQuery,
+    setSimpleQuery,
+    advancedRows,
+    addRow,
+    removeRow,
+    updateRow,
+    sortBy,
+    sortOrder,
+    handleSort,
+    results,
+    total,
+    hasMore,
+    isLoading,
+    isError,
+    loadNextPage,
+    effectiveQuery,
+  } = usePlaylistSearch();
+
+  return (
+    <Box sx={{ width: "100%", px: 2 }}>
+      <Typography level="h2" sx={{ mb: 2 }}>
+        Playlist Archive
+      </Typography>
+      <Typography level="body-sm" sx={{ mb: 3, color: "text.secondary" }}>
+        Search through WXYC playlists from November 2004 to present. Use AND, OR, NOT operators
+        and quotes for exact phrases.
+      </Typography>
+
+      <Tabs
+        value={mode === "simple" ? 0 : 1}
+        onChange={(_, value) => setMode(value === 0 ? "simple" : "advanced")}
+        sx={{ mb: 2 }}
+      >
+        <TabList>
+          <Tab>Simple Search</Tab>
+          <Tab>Advanced Search</Tab>
+        </TabList>
+        <TabPanel value={0} sx={{ p: 0, pt: 2 }}>
+          <PlaylistSearchBar
+            query={simpleQuery}
+            onQueryChange={setSimpleQuery}
+            isLoading={isLoading}
+          />
+        </TabPanel>
+        <TabPanel value={1} sx={{ p: 0, pt: 2 }}>
+          <PlaylistAdvancedSearch
+            rows={advancedRows}
+            onAddRow={addRow}
+            onRemoveRow={removeRow}
+            onUpdateRow={updateRow}
+            isLoading={isLoading}
+          />
+        </TabPanel>
+      </Tabs>
+
+      {effectiveQuery.length >= 2 && (
+        <Box sx={{ mt: 2 }}>
+          <Typography level="body-sm" sx={{ mb: 1, color: "text.secondary" }}>
+            {isLoading
+              ? "Searching..."
+              : total > 0
+              ? `Found ${total.toLocaleString()} results`
+              : "No results found"}
+          </Typography>
+
+          {isError && (
+            <Typography level="body-sm" color="danger" sx={{ mb: 2 }}>
+              An error occurred while searching. Please try again.
+            </Typography>
+          )}
+
+          {results.length > 0 && (
+            <PlaylistInfiniteScroll
+              hasMore={hasMore}
+              isLoading={isLoading}
+              onLoadMore={loadNextPage}
+            >
+              <PlaylistResultsTable
+                results={results}
+                sortBy={sortBy}
+                sortOrder={sortOrder}
+                onSort={handleSort}
+              />
+            </PlaylistInfiniteScroll>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/components/experiences/modern/playlist-search/PlaylistSearchRow.tsx
+++ b/src/components/experiences/modern/playlist-search/PlaylistSearchRow.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import type { SearchRow } from "@/lib/features/playlist-search/frontend";
+import { Add, Remove } from "@mui/icons-material";
+import {
+  Box,
+  Checkbox,
+  IconButton,
+  Input,
+  Option,
+  Select,
+  Stack,
+} from "@mui/joy";
+
+interface PlaylistSearchRowProps {
+  row: SearchRow;
+  isFirst: boolean;
+  canRemove: boolean;
+  onUpdate: (updates: Partial<SearchRow>) => void;
+  onAdd: () => void;
+  onRemove: () => void;
+}
+
+const FIELD_OPTIONS = [
+  { value: "artist", label: "Artist" },
+  { value: "song", label: "Song Title" },
+  { value: "album", label: "Album Name" },
+  { value: "label", label: "Label" },
+  { value: "dj", label: "DJ Name" },
+  { value: "date", label: "Date" },
+  { value: "dateRange", label: "Date Range" },
+] as const;
+
+const OPERATOR_OPTIONS = [
+  { value: "AND", label: "AND" },
+  { value: "OR", label: "OR" },
+  { value: "NOT", label: "NOT" },
+] as const;
+
+export default function PlaylistSearchRow({
+  row,
+  isFirst,
+  canRemove,
+  onUpdate,
+  onAdd,
+  onRemove,
+}: PlaylistSearchRowProps) {
+  const isDateField = row.field === "date";
+  const isDateRangeField = row.field === "dateRange";
+
+  return (
+    <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap", gap: 1 }}>
+      {/* Operator dropdown - hidden on first row */}
+      <Box sx={{ minWidth: 80, visibility: isFirst ? "hidden" : "visible" }}>
+        <Select
+          value={row.operator}
+          onChange={(_, value) => value && onUpdate({ operator: value })}
+          size="sm"
+        >
+          {OPERATOR_OPTIONS.map((opt) => (
+            <Option key={opt.value} value={opt.value}>
+              {opt.label}
+            </Option>
+          ))}
+        </Select>
+      </Box>
+
+      {/* Field dropdown */}
+      <Box sx={{ minWidth: 130 }}>
+        <Select
+          value={row.field}
+          onChange={(_, value) =>
+            value && onUpdate({ field: value, value: "", valueTo: undefined })
+          }
+          size="sm"
+        >
+          {FIELD_OPTIONS.map((opt) => (
+            <Option key={opt.value} value={opt.value}>
+              {opt.label}
+            </Option>
+          ))}
+        </Select>
+      </Box>
+
+      {/* Input field(s) - changes based on field type */}
+      {isDateField ? (
+        <Input
+          type="date"
+          value={row.value}
+          onChange={(e) => onUpdate({ value: e.target.value })}
+          size="sm"
+          sx={{ minWidth: 150 }}
+        />
+      ) : isDateRangeField ? (
+        <>
+          <Input
+            type="date"
+            value={row.value}
+            onChange={(e) => onUpdate({ value: e.target.value })}
+            size="sm"
+            sx={{ minWidth: 140 }}
+            placeholder="From"
+          />
+          <Input
+            type="date"
+            value={row.valueTo || ""}
+            onChange={(e) => onUpdate({ valueTo: e.target.value })}
+            size="sm"
+            sx={{ minWidth: 140 }}
+            placeholder="To"
+          />
+        </>
+      ) : (
+        <Input
+          value={row.value}
+          onChange={(e) => onUpdate({ value: e.target.value })}
+          size="sm"
+          sx={{ flex: 1, minWidth: 200 }}
+          placeholder={`Enter ${FIELD_OPTIONS.find((f) => f.value === row.field)?.label.toLowerCase()}...`}
+        />
+      )}
+
+      {/* Exact match checkbox - only for text fields */}
+      {!isDateField && !isDateRangeField && (
+        <Checkbox
+          label="Exact"
+          checked={row.exact}
+          onChange={(e) => onUpdate({ exact: e.target.checked })}
+          size="sm"
+          sx={{ alignSelf: "center" }}
+        />
+      )}
+
+      {/* Row controls */}
+      <Stack direction="row" spacing={0.5}>
+        <IconButton size="sm" variant="outlined" onClick={onAdd}>
+          <Add />
+        </IconButton>
+        {canRemove && (
+          <IconButton size="sm" variant="outlined" color="danger" onClick={onRemove}>
+            <Remove />
+          </IconButton>
+        )}
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/components/experiences/modern/playlist-search/index.ts
+++ b/src/components/experiences/modern/playlist-search/index.ts
@@ -1,0 +1,6 @@
+export { default as PlaylistSearchContainer } from "./PlaylistSearchContainer";
+export { default as PlaylistSearchBar } from "./PlaylistSearchBar";
+export { default as PlaylistAdvancedSearch } from "./PlaylistAdvancedSearch";
+export { default as PlaylistSearchRow } from "./PlaylistSearchRow";
+export { default as PlaylistResultsTable } from "./PlaylistResultsTable";
+export { default as PlaylistInfiniteScroll } from "./PlaylistInfiniteScroll";

--- a/src/hooks/playlistSearchHooks.ts
+++ b/src/hooks/playlistSearchHooks.ts
@@ -1,0 +1,230 @@
+"use client";
+
+import { useLazySearchPlaylistsQuery } from "@/lib/features/playlist-search/api";
+import { playlistSearchSlice, SearchRow } from "@/lib/features/playlist-search/frontend";
+import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import { useCallback, useEffect, useRef, useMemo } from "react";
+import type { PlaylistSearchResult } from "@wxyc/shared";
+
+const MIN_QUERY_LENGTH = 2;
+const LIMIT = 50;
+
+/**
+ * Build a query string from advanced search rows.
+ * Supports AND, OR, NOT operators and exact phrase matching.
+ */
+function buildAdvancedQuery(rows: SearchRow[]): string {
+  const parts: string[] = [];
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row.value.trim()) continue;
+
+    let term = row.value.trim();
+
+    // Handle field-specific prefixes for backend parsing
+    const fieldPrefixes: Record<string, string> = {
+      artist: "artist:",
+      song: "song:",
+      album: "album:",
+      label: "label:",
+      dj: "dj:",
+      date: "date:",
+      dateRange: "dateRange:",
+    };
+
+    // Format the value based on field type
+    if (row.field === "dateRange" && row.valueTo) {
+      term = `${row.value}..${row.valueTo}`;
+    }
+
+    // Wrap in quotes if exact match is requested
+    if (row.exact) {
+      term = `"${term}"`;
+    }
+
+    const fieldPrefix = fieldPrefixes[row.field] || "";
+    const fullTerm = `${fieldPrefix}${term}`;
+
+    // First row doesn't have an operator prefix
+    if (i === 0) {
+      parts.push(fullTerm);
+    } else {
+      parts.push(`${row.operator} ${fullTerm}`);
+    }
+  }
+
+  return parts.join(" ");
+}
+
+export function usePlaylistSearch() {
+  const dispatch = useAppDispatch();
+
+  const mode = useAppSelector(playlistSearchSlice.selectors.getMode);
+  const simpleQuery = useAppSelector(playlistSearchSlice.selectors.getSimpleQuery);
+  const advancedRows = useAppSelector(playlistSearchSlice.selectors.getAdvancedRows);
+  const sortBy = useAppSelector(playlistSearchSlice.selectors.getSortBy);
+  const sortOrder = useAppSelector(playlistSearchSlice.selectors.getSortOrder);
+  const page = useAppSelector(playlistSearchSlice.selectors.getPage);
+
+  // Build the effective query based on mode
+  const effectiveQuery = useMemo(() => {
+    if (mode === "simple") {
+      return simpleQuery;
+    }
+    return buildAdvancedQuery(advancedRows);
+  }, [mode, simpleQuery, advancedRows]);
+
+  // Track pending query to fire after current request completes
+  const pendingQueryRef = useRef<string | null>(null);
+  const lastFiredQueryRef = useRef<string>("");
+  const lastFiredParamsRef = useRef<{ page: number; sortBy: string; sortOrder: string }>({
+    page: 0,
+    sortBy: "date",
+    sortOrder: "desc",
+  });
+
+  // Accumulated results for infinite scroll
+  const accumulatedResultsRef = useRef<PlaylistSearchResult[]>([]);
+  const lastQueryForAccumulationRef = useRef<string>("");
+
+  const [trigger, { data, isLoading, isFetching, isError }] = useLazySearchPlaylistsQuery();
+
+  // Reset accumulated results when query or sort changes
+  useEffect(() => {
+    const currentParams = `${effectiveQuery}-${sortBy}-${sortOrder}`;
+    if (currentParams !== lastQueryForAccumulationRef.current) {
+      accumulatedResultsRef.current = [];
+      lastQueryForAccumulationRef.current = currentParams;
+    }
+  }, [effectiveQuery, sortBy, sortOrder]);
+
+  // Accumulate results when new data arrives
+  useEffect(() => {
+    if (data?.results) {
+      if (page === 0) {
+        accumulatedResultsRef.current = data.results;
+      } else {
+        // Append new results, avoiding duplicates by ID
+        const existingIds = new Set(accumulatedResultsRef.current.map(r => r.id));
+        const newResults = data.results.filter(r => !existingIds.has(r.id));
+        accumulatedResultsRef.current = [...accumulatedResultsRef.current, ...newResults];
+      }
+    }
+  }, [data, page]);
+
+  // Fire search when query changes (response-based throttling)
+  useEffect(() => {
+    if (effectiveQuery.length < MIN_QUERY_LENGTH) {
+      pendingQueryRef.current = null;
+      return;
+    }
+
+    const paramsChanged =
+      page !== lastFiredParamsRef.current.page ||
+      sortBy !== lastFiredParamsRef.current.sortBy ||
+      sortOrder !== lastFiredParamsRef.current.sortOrder;
+
+    if (isFetching) {
+      // Request in flight - queue this query for later
+      pendingQueryRef.current = effectiveQuery;
+    } else if (effectiveQuery !== lastFiredQueryRef.current || paramsChanged) {
+      // No request in flight and query/params changed - fire immediately
+      lastFiredQueryRef.current = effectiveQuery;
+      lastFiredParamsRef.current = { page, sortBy, sortOrder };
+      pendingQueryRef.current = null;
+      trigger({ q: effectiveQuery, page, limit: LIMIT, sort: sortBy, order: sortOrder });
+    }
+  }, [effectiveQuery, page, sortBy, sortOrder, isFetching, trigger]);
+
+  // When request completes, check if there's a pending query
+  useEffect(() => {
+    if (!isFetching && pendingQueryRef.current && pendingQueryRef.current !== lastFiredQueryRef.current) {
+      const pending = pendingQueryRef.current;
+      lastFiredQueryRef.current = pending;
+      lastFiredParamsRef.current = { page, sortBy, sortOrder };
+      pendingQueryRef.current = null;
+      trigger({ q: pending, page, limit: LIMIT, sort: sortBy, order: sortOrder });
+    }
+  }, [isFetching, page, sortBy, sortOrder, trigger]);
+
+  // Actions
+  const setMode = useCallback(
+    (newMode: "simple" | "advanced") => dispatch(playlistSearchSlice.actions.setMode(newMode)),
+    [dispatch]
+  );
+
+  const setSimpleQuery = useCallback(
+    (q: string) => dispatch(playlistSearchSlice.actions.setSimpleQuery(q)),
+    [dispatch]
+  );
+
+  const addRow = useCallback(
+    () => dispatch(playlistSearchSlice.actions.addRow()),
+    [dispatch]
+  );
+
+  const removeRow = useCallback(
+    (id: string) => dispatch(playlistSearchSlice.actions.removeRow(id)),
+    [dispatch]
+  );
+
+  const updateRow = useCallback(
+    (id: string, updates: Partial<SearchRow>) =>
+      dispatch(playlistSearchSlice.actions.updateRow({ id, updates })),
+    [dispatch]
+  );
+
+  const handleSort = useCallback(
+    (field: "date" | "artist" | "song" | "dj") => dispatch(playlistSearchSlice.actions.setSort(field)),
+    [dispatch]
+  );
+
+  const loadNextPage = useCallback(
+    () => dispatch(playlistSearchSlice.actions.nextPage()),
+    [dispatch]
+  );
+
+  const reset = useCallback(
+    () => {
+      accumulatedResultsRef.current = [];
+      lastQueryForAccumulationRef.current = "";
+      dispatch(playlistSearchSlice.actions.reset());
+    },
+    [dispatch]
+  );
+
+  const hasMore = data ? page < data.totalPages - 1 : false;
+
+  return {
+    // State
+    mode,
+    simpleQuery,
+    advancedRows,
+    sortBy,
+    sortOrder,
+    page,
+    effectiveQuery,
+
+    // Results
+    results: accumulatedResultsRef.current,
+    total: data?.total ?? 0,
+    totalPages: data?.totalPages ?? 0,
+    hasMore,
+
+    // Loading states
+    isLoading: isFetching,
+    hasPendingQuery: pendingQueryRef.current !== null,
+    isError,
+
+    // Actions
+    setMode,
+    setSimpleQuery,
+    addRow,
+    removeRow,
+    updateRow,
+    handleSort,
+    loadNextPage,
+    reset,
+  };
+}


### PR DESCRIPTION
Closes #234

## Summary

- Add public `/playlists` page for searching historical flowsheet entries from November 2004 to present
- Implement simple search (single text field) and advanced search builder (multi-row query builder)
- Support Boolean operators (AND, OR, NOT) and exact phrase matching with quotes
- Add sortable columns (date, artist, song, DJ) with infinite scroll pagination (50 results/batch)
- Use response-based throttling (no new request until previous completes)

## New Files

- `lib/features/playlist-search/api.ts` - RTK Query API for `/flowsheet/search`
- `lib/features/playlist-search/frontend.ts` - Redux slice for search state
- `src/hooks/playlistSearchHooks.ts` - Main search hook with throttling and pagination
- `src/components/experiences/modern/playlist-search/*` - UI components
- `app/playlists/page.tsx` - Public search page

## Test plan

- [ ] Backend: Implement `GET /flowsheet/search` endpoint
- [ ] Search for "Fats Waller" on `/playlists` and verify results
- [ ] Search for a DJ name and verify their plays appear  
- [ ] Click column headers to test sorting
- [ ] Scroll to load more results (infinite scroll)
- [ ] Test Boolean operators: "Elliot Smith AND XO"
- [ ] Use Advanced Search to combine field-specific searches

> **Note:** E2E tests depend on #271 and WXYC/Backend-Service#223. E2E will pass once those merge.