### PR TITLE
Add optional user profile fields

### DIFF
--- a/lib/__tests__/features/authentication/authentication.test.ts
+++ b/lib/__tests__/features/authentication/authentication.test.ts
@@ -243,6 +243,13 @@ describeSlice(authenticationSlice, defaultAuthenticationState, ({ harness, actio
         realName: false,
         djName: false,
         email: false,
+        pronouns: false,
+        namePronunciation: false,
+        showTimes: false,
+        title: false,
+        semesterHired: false,
+        bio: false,
+        location: false,
       });
     });
 

--- a/lib/features/authentication/frontend.ts
+++ b/lib/features/authentication/frontend.ts
@@ -25,6 +25,13 @@ export const defaultAuthenticationState: AuthenticationState = {
     realName: false,
     djName: false,
     email: false,
+    pronouns: false,
+    namePronunciation: false,
+    showTimes: false,
+    title: false,
+    semesterHired: false,
+    bio: false,
+    location: false,
   },
   required: ["username", "password", "confirmPassword"],
 };

--- a/lib/features/authentication/types.ts
+++ b/lib/features/authentication/types.ts
@@ -65,14 +65,21 @@ export type NewUserCredentials = Credentials & Record<string, string>;
 export type User = {
   username: string;
   email: string;
-  realName?: string;     // Optional: User's real name
-  djName?: string;        // Optional: DJ name/on-air name
+  realName?: string;          // Optional: User's real name
+  djName?: string;            // Optional: DJ name/on-air name
+  pronouns?: string;          // Optional: User's pronouns (e.g., "they/them")
+  namePronunciation?: string; // Optional: Phonetic pronunciation guide
+  showTimes?: string;         // Optional: When the DJ has their show
+  title?: string;             // Optional: Role/title at the station
+  semesterHired?: string;     // Optional: When they joined (e.g., "Fall 2024")
+  bio?: string;               // Optional: Short biography
+  location?: string;          // Optional: Where they're based
   authority: Authorization;
   // Better-auth fields (optional for compatibility)
   id?: string;
-  name?: string;          // Username (duplicate of username)
+  name?: string;              // Username (duplicate of username)
   emailVerified?: boolean;
-  appSkin?: string;       // UI theme
+  appSkin?: string;           // UI theme
   createdAt?: Date;
   updatedAt?: Date;
 };
@@ -148,6 +155,13 @@ export type DJInfoResponse = {
 export const djAttributeTitles: Partial<Record<keyof VerifiedData, string>> = {
   realName: "Real Name",
   djName: "DJ Name",
+  pronouns: "Pronouns",
+  namePronunciation: "Name Pronunciation",
+  showTimes: "Show Times",
+  title: "Title",
+  semesterHired: "Semester Hired",
+  bio: "Bio",
+  location: "Location",
   username: "Username",
   password: "Password",
   code: "Code",

--- a/lib/features/authentication/utilities.ts
+++ b/lib/features/authentication/utilities.ts
@@ -21,6 +21,13 @@ export type BetterAuthSession = {
     emailVerified: boolean;
     realName?: string;
     djName?: string;
+    pronouns?: string;
+    namePronunciation?: string;
+    showTimes?: string;
+    title?: string;
+    semesterHired?: string;
+    bio?: string;
+    location?: string;
     appSkin?: string;
     createdAt?: Date;
     updatedAt?: Date;
@@ -120,6 +127,13 @@ export function betterAuthSessionToAuthenticationData(
     email: session.user.email,
     realName: session.user.realName,
     djName: session.user.djName,
+    pronouns: session.user.pronouns,
+    namePronunciation: session.user.namePronunciation,
+    showTimes: session.user.showTimes,
+    title: session.user.title,
+    semesterHired: session.user.semesterHired,
+    bio: session.user.bio,
+    location: session.user.location,
     authority: authority,
     name: session.user.name,
     emailVerified: session.user.emailVerified,
@@ -210,6 +224,13 @@ export async function betterAuthSessionToAuthenticationDataAsync(
     email: session.user.email,
     realName: session.user.realName,
     djName: session.user.djName,
+    pronouns: session.user.pronouns,
+    namePronunciation: session.user.namePronunciation,
+    showTimes: session.user.showTimes,
+    title: session.user.title,
+    semesterHired: session.user.semesterHired,
+    bio: session.user.bio,
+    location: session.user.location,
     authority: authority,
     name: session.user.name,
     emailVerified: session.user.emailVerified,

--- a/src/components/experiences/modern/settings/SettingsPopup.test.tsx
+++ b/src/components/experiences/modern/settings/SettingsPopup.test.tsx
@@ -61,6 +61,13 @@ vi.mock("@mui/icons-material", () => ({
   Edit: () => <span data-testid="edit-icon" />,
   Email: () => <span data-testid="email-icon" />,
   TheaterComedy: () => <span data-testid="theater-comedy-icon" />,
+  RecordVoiceOver: () => <span data-testid="record-voice-over-icon" />,
+  VolumeUp: () => <span data-testid="volume-up-icon" />,
+  Schedule: () => <span data-testid="schedule-icon" />,
+  Work: () => <span data-testid="work-icon" />,
+  School: () => <span data-testid="school-icon" />,
+  Notes: () => <span data-testid="notes-icon" />,
+  LocationOn: () => <span data-testid="location-on-icon" />,
 }));
 
 vi.mock("@mui/icons-material/Badge", () => ({

--- a/src/components/experiences/modern/settings/SettingsPopup.tsx
+++ b/src/components/experiences/modern/settings/SettingsPopup.tsx
@@ -4,6 +4,7 @@ import { User } from "@/lib/features/authentication/types";
 import { useAppSelector } from "@/lib/hooks";
 import EmailChangeModal from "@/src/components/experiences/modern/settings/EmailChangeModal";
 import SettingsInput from "@/src/components/experiences/modern/settings/SettingsInput";
+import SettingsTextarea from "@/src/components/experiences/modern/settings/SettingsTextarea";
 import { useDJAccount } from "@/src/hooks/djHooks";
 import {
   AccountCircle,
@@ -11,6 +12,13 @@ import {
   Edit,
   Email,
   TheaterComedy,
+  RecordVoiceOver,
+  VolumeUp,
+  Schedule,
+  Work,
+  School,
+  Notes,
+  LocationOn,
 } from "@mui/icons-material";
 import BadgeIcon from "@mui/icons-material/Badge";
 import { IconButton, Modal, Stack, Tooltip } from "@mui/joy";
@@ -48,12 +56,11 @@ export default function SettingsPopup({ user }: { user: User }) {
       <Card
         variant="outlined"
         sx={{
-          maxHeight: "max-content",
-          maxWidth: "100%",
+          maxHeight: "90vh",
+          maxWidth: "600px",
+          width: "100%",
           mx: "auto",
-          // to make the demo resizable
           overflow: "auto",
-          resize: "horizontal",
         }}
       >
         <Typography level="title-lg" startDecorator={<AccountCircle />}>
@@ -65,10 +72,14 @@ export default function SettingsPopup({ user }: { user: User }) {
           onSubmit={handleSaveData}
           sx={{
             display: "grid",
-            gridTemplateColumns: "repeat(1, minmax(80px, 1fr))",
+            gridTemplateColumns: "repeat(2, minmax(80px, 1fr))",
             gap: 1.5,
           }}
         >
+          {/* Identity Section */}
+          <Typography level="title-sm" sx={{ gridColumn: "1/-1" }}>
+            Identity
+          </Typography>
           <FormControl sx={{ gridColumn: "1/-1" }}>
             <FormLabel>Username</FormLabel>
             <Input
@@ -77,7 +88,7 @@ export default function SettingsPopup({ user }: { user: User }) {
               value={user.username}
             />
           </FormControl>
-          <FormControl sx={{ gridColumn: "1/-1" }}>
+          <FormControl>
             <FormLabel>Personal Name</FormLabel>
             <SettingsInput
               name="realName"
@@ -85,7 +96,7 @@ export default function SettingsPopup({ user }: { user: User }) {
               endDecorator={<BadgeIcon />}
             />
           </FormControl>
-          <FormControl sx={{ gridColumn: "1/-1" }}>
+          <FormControl>
             <FormLabel>DJ Name</FormLabel>
             <SettingsInput
               name="djName"
@@ -93,7 +104,83 @@ export default function SettingsPopup({ user }: { user: User }) {
               endDecorator={<TheaterComedy />}
             />
           </FormControl>
+          <FormControl>
+            <FormLabel>Pronouns</FormLabel>
+            <SettingsInput
+              name="pronouns"
+              backendValue={user.pronouns}
+              endDecorator={<RecordVoiceOver />}
+              placeholder="e.g., they/them"
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Name Pronunciation</FormLabel>
+            <SettingsInput
+              name="namePronunciation"
+              backendValue={user.namePronunciation}
+              endDecorator={<VolumeUp />}
+              placeholder="e.g., JAY-kub"
+            />
+          </FormControl>
+
+          <Divider sx={{ gridColumn: "1/-1", my: 1 }} />
+
+          {/* Station Info Section */}
+          <Typography level="title-sm" sx={{ gridColumn: "1/-1" }}>
+            Station Info
+          </Typography>
+          <FormControl>
+            <FormLabel>Title</FormLabel>
+            <SettingsInput
+              name="title"
+              backendValue={user.title}
+              endDecorator={<Work />}
+              placeholder="e.g., Music Director"
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Show Times</FormLabel>
+            <SettingsInput
+              name="showTimes"
+              backendValue={user.showTimes}
+              endDecorator={<Schedule />}
+              placeholder="e.g., Fridays 2-4pm"
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Semester Hired</FormLabel>
+            <SettingsInput
+              name="semesterHired"
+              backendValue={user.semesterHired}
+              endDecorator={<School />}
+              placeholder="e.g., Fall 2024"
+            />
+          </FormControl>
+
+          <Divider sx={{ gridColumn: "1/-1", my: 1 }} />
+
+          {/* About Section */}
+          <Typography level="title-sm" sx={{ gridColumn: "1/-1" }}>
+            About
+          </Typography>
           <FormControl sx={{ gridColumn: "1/-1" }}>
+            <FormLabel>Bio</FormLabel>
+            <SettingsTextarea
+              name="bio"
+              backendValue={user.bio}
+              placeholder="Tell us about yourself..."
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Location</FormLabel>
+            <SettingsInput
+              name="location"
+              backendValue={user.location}
+              endDecorator={<LocationOn />}
+              placeholder="e.g., Chapel Hill, NC"
+            />
+          </FormControl>
+          <FormControl>
             <FormLabel>Email</FormLabel>
             <Stack direction="row" spacing={1} alignItems="center">
               <Input

--- a/src/components/experiences/modern/settings/SettingsTextarea.tsx
+++ b/src/components/experiences/modern/settings/SettingsTextarea.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { authenticationSlice } from "@/lib/features/authentication/frontend";
+import { ModifiableData } from "@/lib/features/authentication/types";
+import { useAppDispatch } from "@/lib/hooks";
+import { Textarea, TextareaProps } from "@mui/joy";
+import { useState } from "react";
+
+export default function SettingsTextarea({
+  name,
+  backendValue,
+  ...props
+}: {
+  name: keyof ModifiableData;
+  backendValue?: string;
+} & TextareaProps) {
+  const dispatch = useAppDispatch();
+
+  const [value, setValue] = useState<string>(
+    backendValue !== undefined ? backendValue : ""
+  );
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    e.preventDefault();
+    const newValue = e.target.value;
+    setValue(newValue);
+    dispatch(
+      authenticationSlice.actions.modify({
+        key: name,
+        value: backendValue !== newValue && newValue !== "" ? true : false,
+      })
+    );
+  };
+
+  return (
+    <Textarea
+      name={name}
+      onChange={handleChange}
+      value={value}
+      minRows={2}
+      maxRows={4}
+      {...props}
+    />
+  );
+}

--- a/src/hooks/djHooks.ts
+++ b/src/hooks/djHooks.ts
@@ -56,7 +56,7 @@ export function useDJAccount() {
           }
 
           // Update user via better-auth non-admin updateUser (updates current user)
-          // Custom metadata fields (realName, djName) go at the top level
+          // Custom metadata fields go at the top level
           // Email updates may require special handling in better-auth
           const updateData: Record<string, any> = {};
           if (data.realName) updateData.realName = data.realName;
@@ -64,6 +64,14 @@ export function useDJAccount() {
           // Note: Email updates via non-admin updateUser may have restrictions
           // If email update fails, user may need admin assistance
           if (data.email) updateData.email = data.email;
+          // Optional profile fields - use !== undefined to allow clearing
+          if (data.pronouns !== undefined) updateData.pronouns = data.pronouns;
+          if (data.namePronunciation !== undefined) updateData.namePronunciation = data.namePronunciation;
+          if (data.showTimes !== undefined) updateData.showTimes = data.showTimes;
+          if (data.title !== undefined) updateData.title = data.title;
+          if (data.semesterHired !== undefined) updateData.semesterHired = data.semesterHired;
+          if (data.bio !== undefined) updateData.bio = data.bio;
+          if (data.location !== undefined) updateData.location = data.location;
 
           if (Object.keys(updateData).length > 0) {
             // Use non-admin updateUser (same pattern as onboarding fix)


### PR DESCRIPTION
Closes #235

## Summary

Adds 7 new optional profile fields for DJ accounts:
- **pronouns** - User's pronouns (e.g., "they/them")
- **namePronunciation** - Phonetic pronunciation guide
- **showTimes** - When the DJ has their show
- **title** - Role/title at the station
- **semesterHired** - When they joined (e.g., "Fall 2024")
- **bio** - Short biography (multi-line)
- **location** - Where they're based

### UI Changes
- Redesigned SettingsPopup with 2-column grid layout
- Organized fields into sections: Identity, Station Info, About
- Created new `SettingsTextarea` component for bio field

### Files Changed
- `lib/features/authentication/types.ts` - Added fields to User type
- `lib/features/authentication/utilities.ts` - Added fields to BetterAuthSession, updated conversion functions
- `lib/features/authentication/frontend.ts` - Added modification tracking
- `src/hooks/djHooks.ts` - Updated save handler
- `src/components/experiences/modern/settings/SettingsPopup.tsx` - Redesigned UI
- `src/components/experiences/modern/settings/SettingsTextarea.tsx` - New component

## Prerequisites

The Better Auth server at `api.wxyc.org` needs matching `additionalFields` configuration:

```ts
user: {
  additionalFields: {
    pronouns: { type: "string", required: false },
    namePronunciation: { type: "string", required: false },
    showTimes: { type: "string", required: false },
    title: { type: "string", required: false },
    semesterHired: { type: "string", required: false },
    bio: { type: "string", required: false },
    location: { type: "string", required: false },
  }
}
```

## Test plan

- [ ] Verify TypeScript compilation passes
- [ ] Test settings popup opens and displays all fields
- [ ] Test editing fields enables Save button
- [ ] Test saving changes (requires server configuration)
- [ ] Verify saved data persists after page refresh

> **Note:** E2E tests depend on #271 and WXYC/Backend-Service#223. E2E will pass once those merge.