### PR TITLE
fix: replace String(undefined) with undefined in catalog search params

### DIFF
--- a/src/hooks/__tests__/catalogSearchQuery.test.ts
+++ b/src/hooks/__tests__/catalogSearchQuery.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { SearchCatalogQueryParams, SearchIn } from "@/lib/features/catalog/types";
+
+import { formatCatalogSearchQuery } from "../catalogHooks";
+
+describe("catalog search query formatting (Bug 11)", () => {
+  it("should set artist_name to undefined when searching Albums only", () => {
+    const query = formatCatalogSearchQuery("Albums", "test album", 10);
+
+    expect(query.artist_name).toBeUndefined();
+    expect(query.album_name).toBe("test album");
+  });
+
+  it("should set album_name to undefined when searching Artists only", () => {
+    const query = formatCatalogSearchQuery("Artists", "test artist", 10);
+
+    expect(query.artist_name).toBe("test artist");
+    expect(query.album_name).toBeUndefined();
+  });
+
+  it("should set both fields to the search string when searching Both", () => {
+    const query = formatCatalogSearchQuery("Both", "search term", 10);
+
+    expect(query.artist_name).toBe("search term");
+    expect(query.album_name).toBe("search term");
+  });
+
+  it("should never produce the literal string 'undefined'", () => {
+    const queries = [
+      formatCatalogSearchQuery("Albums", "test", 10),
+      formatCatalogSearchQuery("Artists", "test", 10),
+      formatCatalogSearchQuery("Both", "test", 10),
+    ];
+
+    for (const query of queries) {
+      expect(query.artist_name).not.toBe("undefined");
+      expect(query.album_name).not.toBe("undefined");
+    }
+  });
+});

--- a/src/hooks/catalogHooks.ts
+++ b/src/hooks/catalogHooks.ts
@@ -1,11 +1,25 @@
 import { useSearchCatalogQuery } from "@/lib/features/catalog/api";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 import {
-  AlbumEntry,
   Genre,
   SearchCatalogQueryParams,
   SearchIn,
 } from "@/lib/features/catalog/types";
+
+export function formatCatalogSearchQuery(
+  searchIn: SearchIn,
+  searchString: string,
+  n: number
+): SearchCatalogQueryParams {
+  switch (searchIn) {
+    case "Albums":
+      return { artist_name: undefined, album_name: searchString, n };
+    case "Artists":
+      return { artist_name: searchString, album_name: undefined, n };
+    default:
+      return { artist_name: searchString, album_name: searchString, n };
+  }
+}
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { FlowsheetQuery } from "@/lib/features/flowsheet/types";
 import { useGetRotationQuery } from "@/lib/features/rotation/api";
@@ -92,8 +106,8 @@ export const useCatalogResults = () => {
   const searchIn = useAppSelector(catalogSlice.selectors.getSearchIn);
   const [formattedQuery, setFormattedQuery] =
     useState<SearchCatalogQueryParams>({
-      artist_name: String(undefined),
-      album_name: String(undefined),
+      artist_name: undefined,
+      album_name: undefined,
       n: 10,
     });
   const loadMore = () => dispatch(catalogSlice.actions.loadMore());
@@ -110,29 +124,7 @@ export const useCatalogResults = () => {
       setTimeout(() => {
         setLoading(true);
         clearSelection();
-        switch (searchIn) {
-          case "Albums":
-            setFormattedQuery({
-              artist_name: String(undefined),
-              album_name: searchString,
-              n: n,
-            });
-            break;
-          case "Artists":
-            setFormattedQuery({
-              artist_name: searchString,
-              album_name: String(undefined),
-              n: n,
-            });
-            break;
-          default:
-            setFormattedQuery({
-              artist_name: searchString,
-              album_name: searchString,
-              n: n,
-            });
-            break;
-        }
+        setFormattedQuery(formatCatalogSearchQuery(searchIn, searchString, n));
       }, 500)
     );
   }, [searchIn, searchString, n]);


### PR DESCRIPTION
## Summary

- `String(undefined)` produces the literal string `"undefined"`, which gets sent to the backend as `?artist_name=undefined` when searching by album only (or `?album_name=undefined` when searching by artist only)
- Extract query formatting into a tested pure function `formatCatalogSearchQuery()` that returns actual `undefined` for unused search fields
- RTK Query's `fetchBaseQuery` correctly omits `undefined` params from the URL

## Verification

**Call stack:** `useCatalogResults` → `useState` initial value / `useEffect` switch → `setFormattedQuery` → `useSearchCatalogQuery` → `catalogApi.searchCatalog.query` → `fetchBaseQuery` with `params: { artist_name, album_name, n }`. When `artist_name` is the string `"undefined"`, it appears in the URL as `?artist_name=undefined`.

**Sibling comparison:** The `useCatalogFlowsheetSearch` hook (same file, L196-209) correctly passes raw string values without `String()` wrapping.

## Test plan

- [x] 4 unit tests in `src/hooks/__tests__/catalogSearchQuery.test.ts` — all pass
- [x] Tests assert `undefined` (not `"undefined"`) for unused search fields across all three `SearchIn` variants


Made with [Cursor](https://cursor.com)