### PR TITLE
fix: validate localStorage queue data shape before returning

### DIFF
--- a/lib/__tests__/features/flowsheet/queue-storage.test.ts
+++ b/lib/__tests__/features/flowsheet/queue-storage.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  loadQueueFromStorage,
+  saveQueueToStorage,
+  clearQueueFromStorage,
+} from "@/lib/features/flowsheet/queue-storage";
+import { createTestFlowsheetEntry } from "@/lib/test-utils";
+
+const QUEUE_STORAGE_KEY = "wxyc_flowsheet_queue";
+
+describe("queue-storage (Bug 33)", () => {
+  let store: Record<string, string> = {};
+  const realLocalStorage = {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+    get length() { return Object.keys(store).length; },
+    key: vi.fn((i: number) => Object.keys(store)[i] ?? null),
+  };
+
+  beforeEach(() => {
+    store = {};
+    Object.defineProperty(window, "localStorage", { value: realLocalStorage, writable: true });
+  });
+
+  afterEach(() => {
+    store = {};
+  });
+
+  describe("loadQueueFromStorage", () => {
+    it("should return an empty array when nothing is stored", () => {
+      expect(loadQueueFromStorage()).toEqual([]);
+    });
+
+    it("should return valid queue entries from localStorage", () => {
+      const entries = [createTestFlowsheetEntry({ id: 1 }), createTestFlowsheetEntry({ id: 2 })];
+      localStorage.setItem(QUEUE_STORAGE_KEY, JSON.stringify(entries));
+
+      const result = loadQueueFromStorage();
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe(1);
+      expect(result[1].id).toBe(2);
+    });
+
+    it("should return an empty array for invalid JSON", () => {
+      localStorage.setItem(QUEUE_STORAGE_KEY, "not valid json{{{");
+      expect(loadQueueFromStorage()).toEqual([]);
+    });
+
+    it("should filter out entries missing required fields", () => {
+      const data = [
+        { bad: "data", missing: "required fields" },
+        createTestFlowsheetEntry({ id: 10 }),
+        { id: 5 },
+        null,
+        "not an object",
+      ];
+      localStorage.setItem(QUEUE_STORAGE_KEY, JSON.stringify(data));
+
+      const result = loadQueueFromStorage();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(10);
+    });
+
+    it("should filter out non-array stored values", () => {
+      localStorage.setItem(QUEUE_STORAGE_KEY, JSON.stringify({ id: 1 }));
+      expect(loadQueueFromStorage()).toEqual([]);
+    });
+
+    it("should filter out entries where id is not a number", () => {
+      const data = [
+        { ...createTestFlowsheetEntry(), id: "not-a-number" },
+      ];
+      localStorage.setItem(QUEUE_STORAGE_KEY, JSON.stringify(data));
+      expect(loadQueueFromStorage()).toEqual([]);
+    });
+  });
+
+  describe("saveQueueToStorage", () => {
+    it("should save queue entries to localStorage", () => {
+      const entries = [createTestFlowsheetEntry({ id: 42 })];
+      saveQueueToStorage(entries);
+
+      const stored = JSON.parse(localStorage.getItem(QUEUE_STORAGE_KEY) ?? "[]");
+      expect(stored).toHaveLength(1);
+      expect(stored[0].id).toBe(42);
+    });
+  });
+
+  describe("clearQueueFromStorage", () => {
+    it("should remove the queue from localStorage", () => {
+      localStorage.setItem(QUEUE_STORAGE_KEY, "some data");
+      clearQueueFromStorage();
+      expect(localStorage.getItem(QUEUE_STORAGE_KEY)).toBeNull();
+    });
+  });
+});

--- a/lib/features/flowsheet/queue-storage.ts
+++ b/lib/features/flowsheet/queue-storage.ts
@@ -1,15 +1,28 @@
-import { createAppSlice } from "@/lib/createAppSlice";
-import { PayloadAction } from "@reduxjs/toolkit";
-import { FlowsheetEntry, FlowsheetFrontendState, FlowsheetQuery, FlowsheetRequestParams, FlowsheetSearchProperty, FlowsheetSongEntry, FlowsheetSwitchParams } from "./types";
+import { FlowsheetSongEntry } from "./types";
 
 const QUEUE_STORAGE_KEY = "wxyc_flowsheet_queue";
 
-// Load queue from localStorage
+function isValidQueueEntry(entry: unknown): entry is FlowsheetSongEntry {
+  if (typeof entry !== "object" || entry === null) return false;
+  const e = entry as Record<string, unknown>;
+  return (
+    typeof e.id === "number" &&
+    typeof e.track_title === "string" &&
+    typeof e.artist_name === "string" &&
+    typeof e.album_title === "string" &&
+    typeof e.record_label === "string" &&
+    typeof e.request_flag === "boolean"
+  );
+}
+
 export const loadQueueFromStorage = (): FlowsheetSongEntry[] => {
   if (typeof window === "undefined") return [];
   try {
     const stored = localStorage.getItem(QUEUE_STORAGE_KEY);
-    return stored ? JSON.parse(stored) : [];
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isValidQueueEntry);
   } catch (error) {
     console.error("Failed to load queue from localStorage:", error);
     return [];


### PR DESCRIPTION
## Summary

- `loadQueueFromStorage` returned `JSON.parse` output with no runtime validation
- Stale or corrupted localStorage data (e.g., from a schema change between deploys) with missing fields would cause runtime errors in consumers expecting `FlowsheetSongEntry` properties
- Add `isValidQueueEntry` type guard that checks required fields (`id`, `track_title`, `artist_name`, `album_title`, `record_label`, `request_flag`) and their types
- Also clean up unused imports (`createAppSlice`, `PayloadAction`, 6 unused type imports)

## Verification

**Call stack:** `flowsheetSlice.reducers.loadQueue` → `loadQueueFromStorage()` → `JSON.parse(stored)` → returned directly to Redux state. Any component reading `state.flowsheet.queue` would access objects without guaranteed shape.

**Reproduction:** Set `localStorage.setItem("wxyc_flowsheet_queue", '[{"bad":"data"}]')` before the app loads. Without validation, the queue contains `{bad: "data"}` and any access to `.track_title` would be `undefined`.

## Test plan

- [x] 8 unit tests covering load, save, clear, and validation
- [x] Tests for valid entries, missing required fields, non-array data, invalid JSON, wrong types


Made with [Cursor](https://cursor.com)