### PR TITLE
fix: align SearchIn type with UI select options

### DIFF
--- a/lib/__tests__/features/catalog/search-filter.test.ts
+++ b/lib/__tests__/features/catalog/search-filter.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { SearchIn } from "@/lib/features/catalog/types";
+import { defaultCatalogFrontendState } from "@/lib/features/catalog/frontend";
+
+describe("catalog search filter type alignment (Bug 42)", () => {
+  const VALID_SELECT_OPTIONS: SearchIn[] = ["All", "Albums", "Artists"];
+
+  it("should have a default searchIn value that matches a valid Select option", () => {
+    const defaultSearchIn = defaultCatalogFrontendState.search.in;
+    expect(VALID_SELECT_OPTIONS).toContain(defaultSearchIn);
+  });
+
+  it("should use 'All' as the default searchIn, not 'Both'", () => {
+    expect(defaultCatalogFrontendState.search.in).toBe("All");
+  });
+
+  it("SearchIn type should include 'All' as a valid value", () => {
+    const allValue: SearchIn = "All";
+    expect(allValue).toBe("All");
+  });
+});

--- a/lib/features/catalog/frontend.ts
+++ b/lib/features/catalog/frontend.ts
@@ -3,7 +3,7 @@ import { CatalogFrontendState } from "./types";
 
 export const defaultCatalogFrontendState: CatalogFrontendState = {
   search: {
-    in: "Both",
+    in: "All",
     query: "",
     genre: "All",
     mobileOpen: false,

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -89,7 +89,7 @@ export type CatalogResultsState = {
   selected: number[];
 };
 
-export type SearchIn = "Artists" | "Albums" | "Both";
+export type SearchIn = "Artists" | "Albums" | "All";
 
 export type Format = "Vinyl" | "CD" | "Unknown";
 

--- a/src/components/experiences/modern/catalog/Search/Filters.tsx
+++ b/src/components/experiences/modern/catalog/Search/Filters.tsx
@@ -23,7 +23,7 @@ export const Filters = ({ color }: { color: ColorPaletteProp | undefined }) => {
           placeholder="All"
           slotProps={{ button: { sx: { whiteSpace: "nowrap" } } }}
           onChange={(e, newValue) =>
-            setSearchIn((newValue as SearchIn) || "Both")
+            setSearchIn((newValue as SearchIn) || "All")
           }
         >
           <Option value="All">All</Option>


### PR DESCRIPTION
## Summary

- `SearchIn` type was `"Artists" | "Albums" | "Both"` but the Select UI offered `"All"`, `"Albums"`, `"Artists"`
- Default state was `in: "Both"` which is never produced by the UI
- Fallback in `Filters.tsx` used `|| "Both"` which doesn't match any Select option
- Renamed `"Both"` to `"All"` in the type, default state, and fallback

## Verification

**Call stack:** `Filters.onChange` → `setSearchIn(newValue || "Both")` → dispatches to `catalogSlice.setSearchIn` → stored as `state.search.in` → read by `useCatalogResults` switch statement. The switch handles `"Albums"`, `"Artists"`, and `default`. Both `"All"` and `"Both"` hit `default`, so this was not a runtime crash — but the type system was misaligned with the UI, and any code doing `if (searchIn === "All")` would never match.

## Test plan

- [x] 3 unit tests verifying default value matches `"All"` and type alignment


Made with [Cursor](https://cursor.com)