### PR TITLE
fix: return new state from rightbar toggle route

### DIFF
--- a/app/api/view/__tests__/rightbar.test.ts
+++ b/app/api/view/__tests__/rightbar.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { defaultApplicationState } from "@/lib/features/application/types";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/headers", () => {
+  let cookieStore: Record<string, string> = {};
+  return {
+    cookies: vi.fn(async () => ({
+      get: (name: string) => {
+        const value = cookieStore[name];
+        return value ? { name, value } : undefined;
+      },
+      set: (opts: { name: string; value: string }) => {
+        cookieStore[opts.name] = opts.value;
+      },
+      _reset: () => { cookieStore = {}; },
+    })),
+  };
+});
+
+vi.mock("next/server", () => {
+  return {
+    NextRequest: class {},
+    NextResponse: {
+      json: (body: unknown, init?: ResponseInit) => ({
+        body,
+        status: init?.status ?? 200,
+      }),
+    },
+  };
+});
+
+describe("POST /api/view/rightbar (Bug 5)", () => {
+  beforeEach(async () => {
+    const { cookies } = await import("next/headers");
+    const store = await cookies();
+    (store as any)._reset();
+  });
+
+  it("should return the NEW state after toggling, not the old state", async () => {
+    const { POST } = await import("@/app/api/view/rightbar/route");
+
+    const response = await POST({} as any);
+    const body = (response as any).body;
+
+    expect(body.rightBarMini).toBe(!defaultApplicationState.rightBarMini);
+  });
+
+  it("should toggle rightBarMini from the current cookie state", async () => {
+    const { cookies } = await import("next/headers");
+    const store = await cookies();
+    store.set({
+      name: "app_state",
+      value: JSON.stringify({ ...defaultApplicationState, rightBarMini: false }),
+    });
+
+    const { POST } = await import("@/app/api/view/rightbar/route");
+
+    const response = await POST({} as any);
+    const body = (response as any).body;
+
+    expect(body.rightBarMini).toBe(true);
+  });
+});

--- a/app/api/view/rightbar/route.ts
+++ b/app/api/view/rightbar/route.ts
@@ -20,7 +20,7 @@ export async function POST(request: NextRequest) {
     value: JSON.stringify(newState),
   });
 
-  return NextResponse.json(appState ?? defaultApplicationState, {
+  return NextResponse.json(newState, {
     status: 200,
   });
 }


### PR DESCRIPTION
## Summary

- `POST /api/view/rightbar` wrote `newState` to the cookie but returned `appState` (old state) in the response
- The `toggleRightbar` RTK Query mutation reads `response.rightBarMini` from the response, which was the pre-toggle value
- Tag invalidation eventually corrected the UI, but the intermediate mutation result was wrong

## Verification

**Call stack:** `useToggleRightbarMutation` → POST `/api/view/rightbar` → returns `appState` (old) → `transformResponse` extracts `rightBarMini` → wrong value displayed until `invalidatesTags` refetches.

**One-line diff:** Change `return NextResponse.json(appState ...)` to `return NextResponse.json(newState ...)`.

## Test plan

- [x] 2 tests asserting the response reflects the new toggled state


Made with [Cursor](https://cursor.com)