### PR TITLE
fix: display actual play count in catalog results

### DIFF
--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -89,7 +89,7 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
           {album.format}
         </Chip>
       </td>
-      <td>0</td>
+      <td>{album.plays ?? 0}</td>
       <td>
         <Stack direction="row" gap={0.25}>
           <Tooltip variant="outlined" size="sm" title="More information">

--- a/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createTestAlbum } from "@/lib/test-utils";
+import { renderWithProviders } from "@/lib/test-utils/render";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/dashboard/catalog",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useShowControl: () => ({ live: false }),
+  useQueue: () => ({ addToQueue: vi.fn() }),
+}));
+
+vi.mock("@/src/hooks/catalogHooks", () => ({
+  useCatalogSearch: () => ({
+    selected: [],
+    setSelection: vi.fn(),
+    orderBy: "title",
+  }),
+}));
+
+import CatalogResult from "../Result";
+
+describe("CatalogResult plays column (Bug 12)", () => {
+  it("should display the actual play count, not hardcoded 0", () => {
+    const album = createTestAlbum({ plays: 42 });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    const cells = document.querySelectorAll("td");
+    const playsCell = Array.from(cells).find(
+      (cell) => cell.textContent?.trim() === "42"
+    );
+    expect(playsCell).toBeDefined();
+  });
+
+  it("should display 0 when plays is 0", () => {
+    const album = createTestAlbum({ plays: 0 });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    const cells = document.querySelectorAll("td");
+    const playsCell = Array.from(cells).find(
+      (cell) => cell.textContent?.trim() === "0"
+    );
+    expect(playsCell).toBeDefined();
+  });
+
+  it("should display 0 when plays is undefined", () => {
+    const album = createTestAlbum({ plays: undefined });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    const cells = document.querySelectorAll("td");
+    const playsCell = Array.from(cells).find(
+      (cell) => cell.textContent?.trim() === "0"
+    );
+    expect(playsCell).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Catalog search results hardcoded `<td>0</td>` for the Plays column
- Changed to `<td>{album.plays ?? 0}</td>` to show the actual play count from the backend

## Verification

**Call stack:** `CatalogResult` component receives `album: AlbumEntry` which has `plays: number | undefined`. The JSX was `<td>0</td>` with no reference to `album.plays`.

## Test plan

- [x] 3 tests: plays=42 shows "42", plays=0 shows "0", plays=undefined shows "0"


Made with [Cursor](https://cursor.com)