### PR TITLE
fix: show toast for network and timeout errors

### DIFF
--- a/lib/__tests__/store.test.ts
+++ b/lib/__tests__/store.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import { rtkQueryErrorLogger } from "@/lib/store";
+import { toast } from "sonner";
+
+function createRejectedAction(payload: unknown) {
+  return {
+    type: "api/executeQuery/rejected",
+    payload,
+    meta: {
+      rejectedWithValue: true,
+      requestId: "test-req",
+      requestStatus: "rejected" as const,
+      aborted: false,
+      condition: false,
+    },
+  };
+}
+
+describe("rtkQueryErrorLogger (Bug 29)", () => {
+  const next = vi.fn((action: unknown) => action);
+  const api = { dispatch: vi.fn(), getState: vi.fn() };
+  const middleware = rtkQueryErrorLogger(api)(next);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should show toast for server errors with data.message", () => {
+    const action = createRejectedAction({ data: { message: "Session expired" } });
+    middleware(action);
+    expect(toast.error).toHaveBeenCalledWith("Session expired");
+  });
+
+  it("should show toast for network errors (FETCH_ERROR)", () => {
+    const action = createRejectedAction({
+      status: "FETCH_ERROR",
+      error: "TypeError: Failed to fetch",
+    });
+    middleware(action);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("should show toast for timeout errors", () => {
+    const action = createRejectedAction({
+      status: "TIMEOUT_ERROR",
+      error: "Request timed out",
+    });
+    middleware(action);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("should not show toast for non-rejected actions", () => {
+    const action = { type: "some/action" };
+    middleware(action);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("should pass all actions through to next middleware", () => {
+    const action = { type: "some/action" };
+    middleware(action);
+    expect(next).toHaveBeenCalledWith(action);
+  });
+});

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -69,11 +69,22 @@ export type AppThunk<ThunkReturnType = void> = ThunkAction<
 
 export const rtkQueryErrorLogger: Middleware =
   (api: MiddlewareAPI) => (next) => (action) => {
-    // RTK Query uses `createAsyncThunk` from redux-toolkit under the hood, so we're able to utilize these matchers!
     if (isRejectedWithValue(action)) {
-      const message = (action.payload as { data?: { message?: string } })?.data?.message;
-      if (message && message.trim().length > 0) {
-        toast.error(message);
+      const payload = action.payload as {
+        data?: { message?: string };
+        status?: string;
+        error?: string;
+      };
+
+      const serverMessage = payload?.data?.message;
+      if (serverMessage && serverMessage.trim().length > 0) {
+        toast.error(serverMessage);
+      } else if (payload?.status === "FETCH_ERROR") {
+        toast.error("Network error — please check your connection.");
+      } else if (payload?.status === "TIMEOUT_ERROR") {
+        toast.error("Request timed out — please try again.");
+      } else if (payload?.error && typeof payload.error === "string") {
+        toast.error(payload.error);
       }
     }
 


### PR DESCRIPTION
## Summary

- `rtkQueryErrorLogger` only showed toasts for backend errors with `payload.data.message`
- Network errors (`FETCH_ERROR`) and timeouts (`TIMEOUT_ERROR`) have `payload.status` + `payload.error` instead — these were silently swallowed
- Users saw no feedback when the backend was unreachable or requests timed out
- Add fallback checks for `FETCH_ERROR`, `TIMEOUT_ERROR`, and generic `payload.error`

## Test plan

- [x] 5 unit tests: server error, network error, timeout error, non-rejected passthrough, next middleware chain


Made with [Cursor](https://cursor.com)