### PR TITLE
fix: remove dead runtime='edge' export from session.ts

### DIFF
--- a/lib/features/session.ts
+++ b/lib/features/session.ts
@@ -8,8 +8,6 @@ import { SiteProps } from "./types";
 import { serverAuthClient } from "./authentication/server-client";
 import { parseAppSkinPreference } from "./experiences/preferences";
 
-export const runtime = "edge";
-
 export const sessionOptions = {
   cookieOptions: {
     path: "/",


### PR DESCRIPTION
## Summary

- `export const runtime = "edge"` in `lib/features/session.ts` has no effect — it's only meaningful in route segment config files (`page.ts`, `layout.ts`, `route.ts`)
- Verified no route file re-exports this value
- Removing misleading dead code

## Verification

`grep -r 'export.*runtime\|from.*session.*runtime' app/` returns no results.

## Test plan

- [x] Verified no route segment re-exports this value
- [x] Build unaffected (this was dead code)


Made with [Cursor](https://cursor.com)