### PR TITLE
fix: correct invalid CSS verticalAlign value

### DIFF
--- a/src/components/experiences/modern/admin/roster/AccountEntry.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEntry.tsx
@@ -61,7 +61,7 @@ export const AccountEntry = ({
     <tr>
       <td
         style={{
-          verticalAlign: "center",
+          verticalAlign: "middle",
           textAlign: "center",
         }}
       >

--- a/src/components/experiences/modern/admin/roster/NewAccountForm.tsx
+++ b/src/components/experiences/modern/admin/roster/NewAccountForm.tsx
@@ -24,7 +24,7 @@ export default function NewAccountForm() {
       <tr>
         <td
           style={{
-            verticalAlign: "center",
+            verticalAlign: "middle",
             textAlign: "center",
           }}
         >

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -173,7 +173,7 @@ export default function RosterTable({ user }: { user: User }) {
               <th
                 style={{
                   width: 55,
-                  verticalAlign: "center",
+                  verticalAlign: "middle",
                   textAlign: "center",
                 }}
               >


### PR DESCRIPTION
## Summary

- `verticalAlign: "center"` is not a valid CSS value — the correct value is `"middle"`
- Browsers silently ignore invalid values, so the alignment rule had no effect
- Fixed in `AccountEntry.tsx`, `NewAccountForm.tsx`, and `RosterTable.tsx`

## Verification

[MDN: vertical-align](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) — valid values include `middle`, `top`, `bottom`, etc. `center` is not among them.

## Test plan

- [x] Visual verification: admin roster table cells now properly center-align
- [x] No other occurrences of `verticalAlign: "center"` in the codebase


Made with [Cursor](https://cursor.com)