### PR TITLE
fix: operator precedence bug in DraggableEntryWrapper background

### DIFF
--- a/src/components/experiences/modern/flowsheet/Entries/DraggableEntryWrapper.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/DraggableEntryWrapper.tsx
@@ -36,7 +36,7 @@ export default function DraggableEntryWrapper({
       style={{
         ...style,
         background:
-          variant ?? "plain" == "plain"
+          (variant ?? "plain") == "plain"
             ? theme.palette?.[color ?? "neutral"]?.[
                 `${variant ?? "plain"}Bg` as keyof typeof theme.palette.primary
               ]

--- a/src/components/experiences/modern/flowsheet/Entries/__tests__/DraggableEntryWrapper.test.ts
+++ b/src/components/experiences/modern/flowsheet/Entries/__tests__/DraggableEntryWrapper.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+
+/**
+ * Bug 1: Operator precedence in DraggableEntryWrapper background color.
+ *
+ * The expression `variant ?? "plain" == "plain"` evaluates as
+ * `variant ?? ("plain" == "plain")` = `variant ?? true`, which is
+ * always truthy. The backdrop branch is dead code.
+ *
+ * The correct expression is `(variant ?? "plain") == "plain"`.
+ */
+
+function resolveBackground(variant: string | undefined): "palette" | "backdrop" {
+  // Current (buggy) logic, extracted from DraggableEntryWrapper.tsx L39
+  const usePalette = variant ?? "plain" == "plain";
+  return usePalette ? "palette" : "backdrop";
+}
+
+function resolveBackgroundFixed(variant: string | undefined): "palette" | "backdrop" {
+  const usePalette = (variant ?? "plain") == "plain";
+  return usePalette ? "palette" : "backdrop";
+}
+
+describe("DraggableEntryWrapper background (Bug 1)", () => {
+  describe("buggy behavior (without parentheses)", () => {
+    it("uses palette for variant=undefined (correct by accident)", () => {
+      expect(resolveBackground(undefined)).toBe("palette");
+    });
+
+    it("uses palette for variant='plain' (correct by accident)", () => {
+      expect(resolveBackground("plain")).toBe("palette");
+    });
+
+    it("INCORRECTLY uses palette for variant='solid' (should be backdrop)", () => {
+      // This demonstrates the bug: "solid" is truthy, so `"solid" ?? true` = "solid"
+      // which is truthy, so palette is always chosen
+      expect(resolveBackground("solid")).toBe("palette");
+    });
+  });
+
+  describe("fixed behavior (with parentheses)", () => {
+    it("uses palette for variant=undefined", () => {
+      expect(resolveBackgroundFixed(undefined)).toBe("palette");
+    });
+
+    it("uses palette for variant='plain'", () => {
+      expect(resolveBackgroundFixed("plain")).toBe("palette");
+    });
+
+    it("uses backdrop for variant='solid'", () => {
+      expect(resolveBackgroundFixed("solid")).toBe("backdrop");
+    });
+
+    it("uses backdrop for variant='soft'", () => {
+      expect(resolveBackgroundFixed("soft")).toBe("backdrop");
+    });
+
+    it("uses backdrop for variant='outlined'", () => {
+      expect(resolveBackgroundFixed("outlined")).toBe("backdrop");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `variant ?? "plain" == "plain"` evaluates as `variant ?? ("plain" == "plain")` = `variant ?? true`
- Since `variant` is always a truthy string when provided, the ternary always took the first branch
- The `theme.palette.background.backdrop` branch was dead code
- Non-plain variants (solid, soft, outlined) incorrectly got palette backgrounds instead of backdrop

## Verification

**JS semantics:** `==` (precedence 10) binds tighter than `??` (precedence 5). So `variant ?? "plain" == "plain"` parses as `variant ?? ("plain" == "plain")` which is `variant ?? true`.

- `variant = "solid"` → `"solid" ?? true` = `"solid"` (truthy) → palette (WRONG, should be backdrop)
- `variant = undefined` → `undefined ?? true` = `true` (truthy) → palette (correct by accident)

## Test plan

- [x] 8 unit tests documenting both buggy and fixed behavior across all variant values


Made with [Cursor](https://cursor.com)