### PR TITLE
fix: include error details in flowsheet toast message

### DIFF
--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
@@ -166,7 +166,7 @@ export default function SongEntry({
                       dispatch(flowsheetSlice.actions.removeFromQueue(entry.id));
                     })
                     .catch((error) => {
-                      toast.error("Failed to add to flowsheet:", error);
+                      toast.error(`Failed to add to flowsheet: ${error}`);
                     });
                 }}
               >


### PR DESCRIPTION
## Summary

- `toast.error("Failed to add to flowsheet:", error)` passes `error` as the second argument (options), not as part of the message string
- Users saw "Failed to add to flowsheet:" with no actual error information
- Fixed to use template literal: `` toast.error(\`Failed to add to flowsheet: \${error}\`) ``

## Verification

**sonner API:** `toast.error(message: string, options?: ExternalToast)` — the second argument is options, not a message continuation.

## Test plan

- [x] One-line fix, verified by sonner API contract


Made with [Cursor](https://cursor.com)