### PR TITLE
fix: remove build-specific MUI class hash from FlowsheetSearchbar

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
@@ -197,7 +197,7 @@ export default function FlowsheetSearchbar() {
             <input type="submit" hidden />
             <Box
               component="div"
-              className="MuiInput-endDecorator css-x3cgwv-JoyInput-endDecorator"
+              className="MuiInput-endDecorator"
               sx={{
                 display: "flex",
                 alignItems: "center",


### PR DESCRIPTION
## Summary

- The className included a build-specific Emotion hash: \`css-x3cgwv-JoyInput-endDecorator\`
- This hash changes across builds, environments, and MUI versions
- In any non-matching build, the class would silently not apply, breaking styling
- The stable \`MuiInput-endDecorator\` class and the \`sx\` prop already handle the layout

## Test plan

- [x] Visual verification: search bar end decorator renders correctly without the hash


Made with [Cursor](https://cursor.com)