### PR TITLE
fix: use onMouseEnter/Leave for logout button hover state

### DIFF
--- a/src/components/experiences/modern/Leftbar/LeftbarLogout.tsx
+++ b/src/components/experiences/modern/Leftbar/LeftbarLogout.tsx
@@ -63,8 +63,8 @@ export default function LeftbarLogout({ user }: { user: User }): JSX.Element {
         <IconButton
           type="submit"
           variant="outlined"
-          onMouseOver={() => setLogoutHovered(true)}
-          onMouseOut={() => setLogoutHovered(false)}
+          onMouseEnter={() => setLogoutHovered(true)}
+          onMouseLeave={() => setLogoutHovered(false)}
           loading={loggingOut}
         >
           {logoutHovered ? <LogoutOutlined /> : <PersonOutlined />}


### PR DESCRIPTION
## Summary

- \`onMouseOver\`/\`onMouseOut\` bubble from child elements (e.g., the icon SVG inside the button)
- Moving the cursor within the button triggered state toggles as events bubbled from children
- This caused the icon to flicker between \`LogoutOutlined\` and \`PersonOutlined\`
- \`onMouseEnter\`/\`onMouseLeave\` don't bubble and correctly track the pointer on the button element itself

## Test plan

- [x] Visual verification: hovering over the logout button smoothly transitions the icon without flickering


Made with [Cursor](https://cursor.com)