### PR TITLE
fix: prevent props spread from overriding auto-fill styles

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.tsx
@@ -7,6 +7,7 @@ import { InputHTMLAttributes } from "react";
 
 export default function FlowsheetSearchInput({
   name,
+  style: externalStyle,
   ...props
 }: Omit<
   InputHTMLAttributes<HTMLInputElement>,
@@ -59,13 +60,13 @@ export default function FlowsheetSearchInput({
       onClick={(e) => e.stopPropagation()}
       readOnly={isAutoFilled}
       disabled={Boolean(props.disabled)}
-      style={{
-        cursor: isAutoFilled ? "not-allowed" : undefined,
-        opacity: isAutoFilled ? 0.6 : undefined,
-        backgroundColor: isAutoFilled ? "rgba(0, 0, 0, 0.05)" : undefined,
-        ...props.style,
-      }}
       {...props}
+      style={{
+        ...externalStyle,
+        cursor: isAutoFilled ? "not-allowed" : externalStyle?.cursor,
+        opacity: isAutoFilled ? 0.6 : externalStyle?.opacity,
+        backgroundColor: isAutoFilled ? "rgba(0, 0, 0, 0.05)" : externalStyle?.backgroundColor,
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary

- \`{...props}\` was spread after the \`style\` attribute, completely replacing the computed auto-fill styles
- When \`isAutoFilled\` was true, the \`cursor: not-allowed\`, \`opacity: 0.6\`, and \`backgroundColor\` were lost
- Destructure \`style\` from props separately and merge it properly with auto-fill styles
- Move \`{...props}\` before \`style\` so computed styles take precedence

## Test plan

- [x] Auto-filled fields show correct visual indicators (cursor, opacity, background)
- [x] External style props are preserved and merged


Made with [Cursor](https://cursor.com)