### PR TITLE
fix: select-all checkbox incorrectly checked on empty results

### DIFF
--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -52,7 +52,11 @@ export default function Results({
                 indeterminate={
                   selected.length > 0 && selected.length !== releaseList?.length
                 }
-                checked={selected.length === releaseList?.length}
+                checked={
+                  releaseList != null &&
+                  releaseList.length > 0 &&
+                  selected.length === releaseList.length
+                }
                 onChange={(event: ChangeEvent<HTMLInputElement>) => {
                   setSelection(
                     event.target.checked


### PR DESCRIPTION
## Summary

- When \`selected.length === 0\` and \`releaseList?.length === 0\`, the expression \`0 === 0\` is \`true\`
- The select-all checkbox appeared checked even though there were no results to select
- Add \`releaseList != null && releaseList.length > 0\` guard before the equality check

## Test plan

- [x] Checkbox unchecked when no results are loaded
- [x] Checkbox checked only when all results are selected


Made with [Cursor](https://cursor.com)