### PR TITLE
fix: use threshold for infinite scroll bottom detection

### DIFF
--- a/src/components/experiences/modern/flowsheet/InfiniteScroller.tsx
+++ b/src/components/experiences/modern/flowsheet/InfiniteScroller.tsx
@@ -27,8 +27,7 @@ export default function InfiniteScroller({
       }
 
       const scrolledToBottom =
-        scroller.scrollHeight ===
-        scroller.scrollTop + scroller.clientHeight;
+        scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight < 1;
       if (scrolledToBottom && !loading && entries) {
         console.log(pagination.max + 1);
         dispatch(


### PR DESCRIPTION
## Summary

- \`scrollHeight === scrollTop + clientHeight\` uses strict equality for scroll position comparison
- Sub-pixel rounding across browsers can cause these values to never be exactly equal
- \`maxHeight: calc(100vh - 200px)\` guarantees fractional pixel values in most viewports
- Changed to threshold comparison: \`scrollHeight - scrollTop - clientHeight < 1\`

**Note:** PR #174 rewrites this component for RTK Query \`infiniteQuery\` but retains the same strict \`===\`. This fix should be applied there as well.

## Test plan

- [x] Infinite scroll triggers reliably at page bottom across browsers


Made with [Cursor](https://cursor.com)