### PR TITLE
fix: guard arrow key handlers behind search open state

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
@@ -53,23 +53,24 @@ export default function FlowsheetSearchbar() {
         if (!live) return;
         searchRef.current?.querySelector("input")?.focus();
       }
-      if (e.key === "ArrowDown") {
+      if (e.key === "ArrowDown" && searchOpen) {
         e.preventDefault();
-        let nextIndex = Math.min(
+        const nextIndex = Math.min(
           selectedResult + 1,
           binResults.length + catalogResults.length + rotationResults.length
         );
         dispatch(flowsheetSlice.actions.setSelectedResult(nextIndex));
       }
-      if (e.key === "ArrowUp") {
+      if (e.key === "ArrowUp" && searchOpen) {
         e.preventDefault();
-        let prevIndex = Math.max(selectedResult - 1, 0);
+        const prevIndex = Math.max(selectedResult - 1, 0);
         dispatch(flowsheetSlice.actions.setSelectedResult(prevIndex));
       }
     },
     [
       live,
       dispatch,
+      searchOpen,
       binResults,
       catalogResults,
       rotationResults,


### PR DESCRIPTION
## Summary

- Arrow key handlers were registered on \`document\` and fired globally regardless of whether the search dropdown was open
- \`e.preventDefault()\` on every ArrowUp/ArrowDown prevented normal page scrolling and text navigation
- Added \`&& searchOpen\` guard so the handlers only fire when the search dropdown is visible
- Added \`searchOpen\` to the \`useCallback\` dependency array

## Test plan

- [x] Arrow keys navigate search results when dropdown is open
- [x] Arrow keys behave normally (scroll, text navigation) when dropdown is closed


Made with [Cursor](https://cursor.com)