### PR TITLE
fix: don't destroy existing sessions on login failure

### DIFF
--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -27,8 +27,6 @@ export const useLogin = () => {
     authenticationSlice.selectors.allCredentialsVerified
   );
 
-  const { handleLogout } = useLogout();
-
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
@@ -57,7 +55,6 @@ export const useLogin = () => {
         if (errorMessage.trim().length > 0) {
           toast.error(errorMessage);
         }
-        handleLogout();
       } else {
         // Sign in successful, session cookie is set
         const dashboardHome = String(process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/catalog");
@@ -74,7 +71,6 @@ export const useLogin = () => {
       if (errorMessage.trim().length > 0) {
         toast.error(errorMessage);
       }
-      handleLogout();
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Summary

- When login failed (wrong credentials or network error), \`handleLogout()\` was called
- \`handleLogout\` calls \`authClient.signOut()\`, which destroys any existing session cookies
- If a user was already logged in (e.g., from another tab) and mistyped their password on a login page they navigated to, their valid session was destroyed
- Removed the \`handleLogout()\` calls from the error and catch paths — login failure now only shows the error message

## Verification

**Call stack:** \`useLogin.handleLogin\` → \`authClient.signIn.username\` fails → \`handleLogout()\` → \`authClient.signOut()\` → session cookie deleted.

**Impact:** A DJ who accidentally navigates to /login while logged in, types wrong credentials, and their existing session is invalidated.

## Test plan

- [x] Login failure shows error toast without calling signOut
- [x] Existing sessions survive failed login attempts


Made with [Cursor](https://cursor.com)