### PR TITLE
fix: sync FlowsheetEntryField with server-side entry updates

### DIFF
--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.tsx
@@ -5,7 +5,7 @@ import { useFlowsheet, useShowControl } from "@/src/hooks/flowsheetHooks";
 import { toTitleCase } from "@/src/utilities/stringutilities";
 import { Typography, TypographyProps } from "@mui/joy";
 import { ClickAwayListener } from "@mui/material";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useAppDispatch } from "@/lib/hooks";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 
@@ -30,6 +30,12 @@ export default function FlowsheetEntryField({
 
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(String(entry[name]));
+
+  useEffect(() => {
+    if (!editing) {
+      setValue(String(entry[name]));
+    }
+  }, [entry[name], editing]);
 
   const { updateFlowsheet } = useFlowsheet();
 


### PR DESCRIPTION
## Summary

- \`useState(String(entry[name]))\` only captures the initial value
- When \`entry[name]\` changes from server updates (RTK Query cache invalidation, 60s polling), the displayed value remained stale
- Added \`useEffect\` that resyncs the local \`value\` state with \`entry[name]\` whenever the entry prop changes, unless the user is actively editing

## Verification

**Reproduction:** Two DJs on the same show. DJ A edits a track title. DJ B's flowsheet polls and receives the updated entry, but the \`FlowsheetEntryField\` continues showing the old title because local state wasn't resynced.

## Test plan

- [x] Entry field updates when entry prop changes from server
- [x] Active editing is not interrupted by incoming prop changes


Made with [Cursor](https://cursor.com)