### PR TITLE
fix: deduplicate server-side session fetch with React cache()

### DIFF
--- a/lib/features/session.ts
+++ b/lib/features/session.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { cookies } from "next/headers";
 import "server-only";
 import { defaultApplicationState } from "./application/types";
@@ -8,8 +9,6 @@ import { SiteProps } from "./types";
 import { serverAuthClient } from "./authentication/server-client";
 import { parseAppSkinPreference } from "./experiences/preferences";
 
-export const runtime = "edge";
-
 export const sessionOptions = {
   cookieOptions: {
     path: "/",
@@ -18,7 +17,7 @@ export const sessionOptions = {
   },
 };
 
-export const createServerSideProps = async (): Promise<SiteProps> => {
+export const createServerSideProps = cache(async (): Promise<SiteProps> => {
   const cookieStore = await cookies();
 
   const appStateValue = cookieStore.get("app_state")?.value;
@@ -128,4 +127,4 @@ export const createServerSideProps = async (): Promise<SiteProps> => {
     application: appState,
     authentication,
   };
-};
+});


### PR DESCRIPTION
## Summary

- \`createServerSideProps()\` was called twice per page load:
  1. In \`app/layout.tsx\` (RootLayout) for the \`data-experience\` HTML attribute
  2. In \`src/ThemedLayout.tsx\` for authentication and application state
- Each call made a network request to better-auth \`getSession\` + potentially \`getUserRoleInOrganization\`
- Wrap with React\`s \`cache()\` function, which deduplicates calls within a single server-rendering request
- Also removes the dead \`export const runtime = "edge"\` (subsumes PR #197)

## Verification

**Call stack:** \`RootLayout\` → \`createServerSideProps()\` → auth fetch. Then \`ThemedLayout\` (called from login/dashboard/onboarding layout) → \`createServerSideProps()\` → same auth fetch again. With \`cache()\`, the second call returns the memoized result.

## Test plan

- [x] Single session fetch per page load (verified via server logs)
- [x] Both RootLayout and ThemedLayout receive the same props


Made with [Cursor](https://cursor.com)