### PR TITLE
fix: show fallback icon when no album art available

### DIFF
--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
@@ -122,14 +122,16 @@ export default function SongEntry({
                 minHeight: "48px",
               }}
             >
-              {image && !imageLoading ? (
+              {imageLoading ? (
+                <CircularProgress />
+              ) : image ? (
                 <img
                   src={image}
                   alt="album art"
                   style={{ minWidth: "48px", minHeight: "48px" }}
                 />
               ) : (
-                <CircularProgress />
+                <Album sx={{ fontSize: 28, opacity: 0.4 }} />
               )}
             </AspectRatio>
           </Badge>


### PR DESCRIPTION
## Summary

- When album art lookup completed with no result (\`image=null, imageLoading=false\`), the spinner ran forever
- Restructured the conditional: loading → spinner, image → \`<img>\`, neither → \`<Album>\` icon fallback
- The \`Album\` icon was already imported in the component

## Test plan

- [x] Entries with album art show the image
- [x] Entries without album art show the Album icon placeholder (not a spinner)
- [x] Loading state shows spinner correctly


Made with [Cursor](https://cursor.com)