### PR TITLE
fix: handle errors in batch add-to-bin operations

### DIFF
--- a/src/components/experiences/modern/catalog/Results/ResultsContainer.tsx
+++ b/src/components/experiences/modern/catalog/Results/ResultsContainer.tsx
@@ -17,15 +17,23 @@ export default function ResultsContainer({
   const { addToBin, loading } = useAddToBin();
   const tableRef = useRef<HTMLTableElement>(null);
 
-  const handleAddSelectedToBin = () => {
+  const handleAddSelectedToBin = async () => {
     if (selected.length === 0) return;
-    
-    // Add each selected album to bin
-    selected.forEach((albumId) => {
-      addToBin(albumId);
-    });
-    
-    toast.success(`Added ${selected.length} album${selected.length > 1 ? 's' : ''} to bin`);
+
+    const results = await Promise.allSettled(
+      selected.map((albumId) => addToBin(albumId))
+    );
+
+    const failures = results.filter((r) => r.status === "rejected");
+    if (failures.length > 0) {
+      toast.error(`Failed to add ${failures.length} album${failures.length > 1 ? "s" : ""} to bin`);
+    }
+
+    const successes = results.length - failures.length;
+    if (successes > 0) {
+      toast.success(`Added ${successes} album${successes > 1 ? "s" : ""} to bin`);
+    }
+
     clearSelection();
   };
 


### PR DESCRIPTION
## Summary

- Multiple \`addToBin\` mutations fired in parallel with no \`await\` and no error handling
- Success toast always showed regardless of whether any mutations failed
- Use \`Promise.allSettled\` to await all mutations and report successes/failures separately
- Show error toast with count of failures, success toast with count of successes

## Test plan

- [x] All selected albums added to bin with success toast
- [x] Failed additions show error toast with failure count
- [x] Mixed success/failure shows both toasts


Made with [Cursor](https://cursor.com)