### PR TITLE
fix: replace mobile search stub with clear button

### DIFF
--- a/src/components/experiences/modern/catalog/Search/MobileSearchBar.tsx
+++ b/src/components/experiences/modern/catalog/Search/MobileSearchBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAppSelector } from "@/lib/hooks";
-import { FilterAlt, SendOutlined, Troubleshoot } from "@mui/icons-material";
+import { Cancel, FilterAlt, Troubleshoot } from "@mui/icons-material";
 import {
   Button,
   ColorPaletteProp,
@@ -51,16 +51,16 @@ export default function MobileSearchBar({
       <IconButton size="sm" variant="outlined" color="neutral" onClick={open}>
         <FilterAlt />
       </IconButton>
-      <IconButton
-        size="sm"
-        variant="solid"
-        color={color ?? "primary"}
-        onClick={() => {
-          console.log("Search!");
-        }}
-      >
-        <SendOutlined />
-      </IconButton>
+      {searchString.length > 0 && (
+        <IconButton
+          size="sm"
+          variant="plain"
+          color={color ?? "primary"}
+          onClick={() => setSearchString("")}
+        >
+          <Cancel />
+        </IconButton>
+      )}
       <Modal open={isOpen} onClose={close}>
         <ModalDialog
           aria-labelledby="filter-modal"


### PR DESCRIPTION
## Summary

- The mobile catalog search \`SendOutlined\` button only called \`console.log("Search!")\` -- a production-facing stub
- Catalog search is live (debounced via \`useCatalogResults\`), so a submit button is unnecessary
- Replaced with a \`Cancel\` clear button that appears when there's a search string, matching the desktop \`SearchBar\` pattern

## Verification

**Sibling comparison:** Desktop \`SearchBar.tsx\` has a clear button (\`Cancel\` icon) that appears when \`searchString != ""\`. Mobile version now matches.

## Test plan

- [x] Mobile search input clears when Cancel button is tapped
- [x] Clear button only appears when search string is non-empty


Made with [Cursor](https://cursor.com)