### PR TITLE
refactor: replace local types with @wxyc/shared/dtos imports

### DIFF
--- a/app/dashboard/@information/(.)album/components/AlbumCard.tsx
+++ b/app/dashboard/@information/(.)album/components/AlbumCard.tsx
@@ -80,7 +80,7 @@ export default function AlbumCard({ album }: { album: AlbumEntry }) {
               artist={album.artist}
               format={album.format}
               entry={album.entry}
-              rotation={album.play_freq}
+              rotation={album.rotation_bin}
             />
           </Box>
           <Typography

--- a/lib/__tests__/features/bin/conversions.test.ts
+++ b/lib/__tests__/features/bin/conversions.test.ts
@@ -5,13 +5,14 @@ import {
   convertBinToQueue,
 } from "@/lib/features/bin/conversions";
 import {
-  createTestBinQueryResponse,
+  createTestBinResponse,
   createTestAlbum,
   TEST_ENTITY_IDS,
   TEST_SEARCH_STRINGS,
 } from "@/lib/test-utils";
 import type { AlbumEntry } from "@/lib/features/catalog/types";
 import { Rotation } from "@/lib/features/rotation/types";
+
 
 /** The shape `convertBinToFlowsheet` actually returns (the album_id variant). */
 type BinFlowsheetSubmission = {
@@ -26,7 +27,7 @@ type BinFlowsheetSubmission = {
 describe("bin conversions", () => {
   describe("convertAlbumFromBin", () => {
     it("should convert album_id to id", () => {
-      const response = createTestBinQueryResponse({
+      const response = createTestBinResponse({
         album_id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM,
       });
       const result = convertAlbumFromBin(response);
@@ -34,7 +35,7 @@ describe("bin conversions", () => {
     });
 
     it("should convert album_title to title", () => {
-      const response = createTestBinQueryResponse({
+      const response = createTestBinResponse({
         album_title: "Great Album",
       });
       const result = convertAlbumFromBin(response);
@@ -42,7 +43,7 @@ describe("bin conversions", () => {
     });
 
     it("should extract artist name", () => {
-      const response = createTestBinQueryResponse({
+      const response = createTestBinResponse({
         artist_name: "Cool Artist",
       });
       const result = convertAlbumFromBin(response);
@@ -50,7 +51,7 @@ describe("bin conversions", () => {
     });
 
     it("should extract artist lettercode", () => {
-      const response = createTestBinQueryResponse({
+      const response = createTestBinResponse({
         code_letters: "CA",
       });
       const result = convertAlbumFromBin(response);
@@ -58,7 +59,7 @@ describe("bin conversions", () => {
     });
 
     it("should extract artist numbercode", () => {
-      const response = createTestBinQueryResponse({
+      const response = createTestBinResponse({
         code_artist_number: 42,
       });
       const result = convertAlbumFromBin(response);
@@ -66,7 +67,7 @@ describe("bin conversions", () => {
     });
 
     it("should extract artist genre", () => {
-      const response = createTestBinQueryResponse({
+      const response = createTestBinResponse({
         genre_name: "Jazz",
       });
       const result = convertAlbumFromBin(response);
@@ -74,7 +75,7 @@ describe("bin conversions", () => {
     });
 
     it("should use Unknown for null genre", () => {
-      const response = createTestBinQueryResponse({
+      const response = createTestBinResponse({
         genre_name: null as unknown as string,
       });
       const result = convertAlbumFromBin(response);
@@ -82,7 +83,7 @@ describe("bin conversions", () => {
     });
 
     it("should extract entry from code_number", () => {
-      const response = createTestBinQueryResponse({
+      const response = createTestBinResponse({
         code_number: 99,
       });
       const result = convertAlbumFromBin(response);
@@ -90,7 +91,7 @@ describe("bin conversions", () => {
     });
 
     it("should extract format", () => {
-      const response = createTestBinQueryResponse({
+      const response = createTestBinResponse({
         format_name: "Vinyl",
       });
       const result = convertAlbumFromBin(response);
@@ -98,7 +99,7 @@ describe("bin conversions", () => {
     });
 
     it("should use Unknown for null format", () => {
-      const response = createTestBinQueryResponse({
+      const response = createTestBinResponse({
         format_name: null as unknown as string,
       });
       const result = convertAlbumFromBin(response);
@@ -106,7 +107,7 @@ describe("bin conversions", () => {
     });
 
     it("should extract label", () => {
-      const response = createTestBinQueryResponse({
+      const response = createTestBinResponse({
         label: "Indie Records",
       });
       const result = convertAlbumFromBin(response);
@@ -114,7 +115,7 @@ describe("bin conversions", () => {
     });
 
     it("should handle undefined label as empty string", () => {
-      const response = createTestBinQueryResponse({
+      const response = createTestBinResponse({
         label: undefined,
       });
       const result = convertAlbumFromBin(response);
@@ -122,37 +123,37 @@ describe("bin conversions", () => {
     });
 
     it("should set alternate_artist to empty string", () => {
-      const response = createTestBinQueryResponse();
+      const response = createTestBinResponse();
       const result = convertAlbumFromBin(response);
       expect(result.alternate_artist).toBe("");
     });
 
-    it("should set play_freq to undefined", () => {
-      const response = createTestBinQueryResponse();
+    it("should set rotation_bin to undefined", () => {
+      const response = createTestBinResponse();
       const result = convertAlbumFromBin(response);
-      expect(result.play_freq).toBeUndefined();
+      expect(result.rotation_bin).toBeUndefined();
     });
 
     it("should set add_date to undefined", () => {
-      const response = createTestBinQueryResponse();
+      const response = createTestBinResponse();
       const result = convertAlbumFromBin(response);
       expect(result.add_date).toBeUndefined();
     });
 
     it("should set plays to undefined", () => {
-      const response = createTestBinQueryResponse();
+      const response = createTestBinResponse();
       const result = convertAlbumFromBin(response);
       expect(result.plays).toBeUndefined();
     });
 
     it("should set rotation_id to undefined", () => {
-      const response = createTestBinQueryResponse();
+      const response = createTestBinResponse();
       const result = convertAlbumFromBin(response);
       expect(result.rotation_id).toBeUndefined();
     });
 
     it("should set artist.id to undefined", () => {
-      const response = createTestBinQueryResponse();
+      const response = createTestBinResponse();
       const result = convertAlbumFromBin(response);
       expect(result.artist.id).toBeUndefined();
     });
@@ -247,10 +248,10 @@ describe("bin conversions", () => {
       expect(result.rotation_id).toBe(TEST_ENTITY_IDS.ROTATION.MEDIUM);
     });
 
-    it("should include play_freq", () => {
-      const binEntry = createBinEntry({ play_freq: Rotation.H });
+    it("should include rotation_bin", () => {
+      const binEntry = createBinEntry({ rotation_bin: Rotation.H });
       const result = convertBinToQueue(binEntry);
-      expect(result.play_freq).toBe("H");
+      expect(result.rotation_bin).toBe(Rotation.H);
     });
 
     it("should set request to false", () => {

--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -5,11 +5,11 @@ import { convertAlbumFromSearch } from "@/lib/features/catalog/conversions";
 import {
   describeApi,
   describeSlice,
-  createTestAlbumQueryResponse,
+  createTestAlbumSearchResult,
   TEST_ENTITY_IDS,
   TEST_SEARCH_STRINGS,
 } from "@/lib/test-utils";
-import type { AlbumQueryResponse } from "@/lib/features/catalog/types";
+import type { AlbumSearchResultJSON } from "@/lib/features/catalog/types";
 
 describe("catalogApi", () => {
   describeApi(catalogApi, {
@@ -21,7 +21,7 @@ describe("catalogApi", () => {
 
 describe("convertAlbumFromSearch", () => {
   it("should convert API response to AlbumEntry format", () => {
-    const apiResponse: AlbumQueryResponse = createTestAlbumQueryResponse({
+    const apiResponse: AlbumSearchResultJSON = createTestAlbumSearchResult({
       id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM,
       album_title: TEST_SEARCH_STRINGS.ALBUM_NAME,
       artist_name: TEST_SEARCH_STRINGS.ARTIST_NAME,
@@ -47,21 +47,21 @@ describe("convertAlbumFromSearch", () => {
   });
 
   it("should not include rotation data (convertAlbumFromSearch ignores rotation)", () => {
-    const apiResponse: AlbumQueryResponse = createTestAlbumQueryResponse({
-      play_freq: "H" as any,
+    const apiResponse: AlbumSearchResultJSON = createTestAlbumSearchResult({
+      rotation_bin: "H" as any,
       rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
       plays: 25,
     });
 
     const result = convertAlbumFromSearch(apiResponse);
 
-    expect(result.play_freq).toBeUndefined();
+    expect(result.rotation_bin).toBeUndefined();
     expect(result.rotation_id).toBeUndefined();
     expect(result.plays).toBe(25);
   });
 
   it("should default plays to 0 when undefined", () => {
-    const apiResponse: AlbumQueryResponse = createTestAlbumQueryResponse({
+    const apiResponse: AlbumSearchResultJSON = createTestAlbumSearchResult({
       plays: undefined,
     });
 
@@ -73,12 +73,12 @@ describe("convertAlbumFromSearch", () => {
     ["Vinyl", "Vinyl"],
     ["CD", "CD"],
   ])("should convert format %s correctly", (input, expected) => {
-    const response = createTestAlbumQueryResponse({ format_name: input });
+    const response = createTestAlbumSearchResult({ format_name: input });
     expect(convertAlbumFromSearch(response).format).toBe(expected);
   });
 
   it("should preserve the add_date", () => {
-    const apiResponse = createTestAlbumQueryResponse({
+    const apiResponse = createTestAlbumSearchResult({
       add_date: "2024-06-08",
     });
 
@@ -87,7 +87,7 @@ describe("convertAlbumFromSearch", () => {
   });
 
   it("should handle distance values when present", () => {
-    const apiResponse = createTestAlbumQueryResponse({
+    const apiResponse = createTestAlbumSearchResult({
       album_dist: 0.5,
       artist_dist: 0.3,
     });

--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -19,7 +19,7 @@ import {
   TEST_ENTITY_IDS,
   TEST_SEARCH_STRINGS,
 } from "@/lib/test-utils";
-import type { FlowsheetEntryResponse } from "@/lib/features/flowsheet/types";
+import type { FlowsheetEntryResponse } from "@wxyc/shared/dtos";
 
 /** The shape `convertQueryToSubmission` actually returns (the artist_name variant, plus album_id/rotation_id). */
 type QuerySubmission = {
@@ -76,7 +76,7 @@ describe("flowsheet conversions", () => {
     it("should preserve rotation data when present", () => {
       const response = createTestFlowsheetEntryResponse({
         rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
-        rotation_play_freq: "H",
+        rotation_bin: "H",
       });
       const result = convertToSong(response);
       expect(result.rotation_id).toBe(TEST_ENTITY_IDS.ROTATION.HEAVY);

--- a/lib/features/bin/api.ts
+++ b/lib/features/bin/api.ts
@@ -1,8 +1,9 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import { backendBaseQuery } from "../backend";
 import { AlbumEntry } from "../catalog/types";
+import type { BinLibraryDetails } from "@wxyc/shared/dtos";
 import { convertAlbumFromBin } from "./conversions";
-import { BinMutationQuery, BinQueryResponse, DJBinQuery } from "./types";
+import { BinMutationQuery, DJBinQuery } from "./types";
 
 export const binApi = createApi({
   reducerPath: "binApi",
@@ -13,7 +14,7 @@ export const binApi = createApi({
       query: ({ dj_id }) => ({
         url: `/?dj_id=${dj_id}`,
       }),
-      transformResponse: (response: BinQueryResponse[]) =>
+      transformResponse: (response: BinLibraryDetails[]) =>
         response.map(convertAlbumFromBin),
       providesTags: ["Bin"],
     }),

--- a/lib/features/bin/conversions.ts
+++ b/lib/features/bin/conversions.ts
@@ -1,22 +1,22 @@
+import type { BinLibraryDetails } from "@wxyc/shared/dtos";
 import { AlbumEntry, Format, Genre } from "../catalog/types";
 import { FlowsheetQuery, FlowsheetSubmissionParams } from "../flowsheet/types";
-import { BinQueryResponse } from "./types";
 
-export function convertAlbumFromBin(response: BinQueryResponse): AlbumEntry {
+export function convertAlbumFromBin(response: BinLibraryDetails): AlbumEntry {
   return {
-    id: response.album_id,
-    title: response.album_title,
+    id: response.album_id ?? 0,
+    title: response.album_title ?? "",
     artist: {
-      name: response.artist_name,
-      lettercode: response.code_letters,
-      numbercode: response.code_artist_number,
+      name: response.artist_name ?? "",
+      lettercode: response.code_letters ?? "",
+      numbercode: response.code_artist_number ?? 0,
       genre: (response.genre_name as Genre) ?? "Unknown",
       id: undefined,
     },
-    entry: response.code_number,
+    entry: response.code_number ?? 0,
     format: (response.format_name as Format) ?? "Unknown",
     alternate_artist: "",
-    play_freq: undefined,
+    rotation_bin: undefined,
     add_date: undefined,
     plays: undefined,
     rotation_id: undefined,
@@ -45,7 +45,7 @@ export function convertBinToQueue(binEntry: AlbumEntry): FlowsheetQuery {
     artist: binEntry.artist.name,
     label: binEntry.label,
     rotation_id: binEntry.rotation_id,
-    play_freq: binEntry.play_freq,
+    rotation_bin: binEntry.rotation_bin,
     request: false,
   };
 }

--- a/lib/features/bin/types.ts
+++ b/lib/features/bin/types.ts
@@ -1,3 +1,7 @@
+import type { BinLibraryDetails } from "@wxyc/shared/dtos";
+
+export type { BinLibraryDetails };
+
 export type BinFrontendState = {
   searchQuery: string;
 };
@@ -8,16 +12,4 @@ export type DJBinQuery = {
 
 export type BinMutationQuery = DJBinQuery & {
   album_id: number;
-};
-
-export type BinQueryResponse = {
-  album_id: number;
-  album_title: string;
-  artist_name: string;
-  code_artist_number: number;
-  code_letters: string;
-  code_number: number;
-  format_name: string;
-  genre_name: string;
-  label: string | undefined;
 };

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -4,7 +4,7 @@ import { convertAlbumFromSearch } from "./conversions";
 import {
   AlbumEntry,
   AlbumParams,
-  AlbumQueryResponse,
+  AlbumSearchResultJSON,
   AlbumRequestParams,
   ArtistParams,
   SearchCatalogQueryParams,
@@ -20,7 +20,7 @@ export const catalogApi = createApi({
         url: "/",
         params: { artist_name, album_name, n },
       }),
-      transformResponse: (response: AlbumQueryResponse[]) =>
+      transformResponse: (response: AlbumSearchResultJSON[]) =>
         response.map(convertAlbumFromSearch),
     }),
     addAlbum: builder.mutation<any, AlbumParams>({
@@ -42,7 +42,7 @@ export const catalogApi = createApi({
         url: "/info",
         params: { album_id },
       }),
-      transformResponse: (response: AlbumQueryResponse) =>
+      transformResponse: (response: AlbumSearchResultJSON) =>
         convertAlbumFromSearch(response),
     }),
     getFormats: builder.query<any, void>({

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -1,8 +1,8 @@
 import { Rotation } from "../rotation/types";
-import { AlbumEntry, AlbumQueryResponse, Format, Genre } from "./types";
+import { AlbumEntry, AlbumSearchResultJSON, Format, Genre } from "./types";
 
 export function convertAlbumFromSearch(
-  response: AlbumQueryResponse
+  response: AlbumSearchResultJSON
 ): AlbumEntry {
   return {
     id: response.id,
@@ -17,7 +17,7 @@ export function convertAlbumFromSearch(
     entry: response.code_number,
     format: (response.format_name as Format) ?? "Unknown",
     alternate_artist: "",
-    play_freq: undefined,
+    rotation_bin: undefined,
     add_date: response.add_date,
     plays: response.plays ?? 0,
     label: response.label,
@@ -26,7 +26,7 @@ export function convertAlbumFromSearch(
 }
 
 export function convertAlbumFromRotation(
-  response: AlbumQueryResponse
+  response: AlbumSearchResultJSON
 ): AlbumEntry {
   return {
     id: response.id,
@@ -41,7 +41,7 @@ export function convertAlbumFromRotation(
     entry: response.code_number,
     format: (response.format_name as Format) ?? "Unknown",
     alternate_artist: "",
-    play_freq: response.play_freq as Rotation,
+    rotation_bin: response.rotation_bin as Rotation,
     add_date: response.add_date,
     plays: response.plays ?? 0,
     label: response.label,

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -1,4 +1,15 @@
+import type { AlbumSearchResult } from "@wxyc/shared/dtos";
 import { Rotation } from "../rotation/types";
+
+export type { AlbumSearchResult };
+
+/**
+ * JSON boundary adapter for AlbumSearchResult.
+ * RTK Query delivers raw JSON where add_date is a string, not a Date.
+ */
+export type AlbumSearchResultJSON = Omit<AlbumSearchResult, "add_date"> & {
+  add_date: string;
+};
 
 export type SearchCatalogQueryParams = {
   artist_name: string | undefined;
@@ -27,25 +38,6 @@ export type ArtistParams = {
   genre_id: string;
 };
 
-
-export type AlbumQueryResponse = {
-  id: number;
-  add_date: string;
-  album_dist: number | undefined;
-  album_title: string;
-  artist_dist: number | undefined;
-  artist_name: string;
-  code_artist_number: number;
-  code_letters: string;
-  code_number: number;
-  format_name: string;
-  genre_name: string;
-  label: string;
-  play_freq: Rotation | undefined;
-  plays: number | undefined;
-  rotation_id: number | undefined;
-};
-
 export type AlbumEntry = {
   id: number;
   title: string;
@@ -53,7 +45,7 @@ export type AlbumEntry = {
   entry: number;
   format: Format;
   alternate_artist: string | undefined;
-  play_freq: Rotation | undefined;
+  rotation_bin: Rotation | undefined;
   rotation_id: number | undefined;
   plays: number | undefined;
   add_date: string | undefined;

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -1,7 +1,7 @@
+import type { FlowsheetEntryResponse } from "@wxyc/shared/dtos";
 import { Rotation } from "../rotation/types";
 import {
   FlowsheetBreakpointEntry,
-  FlowsheetEntryResponse,
   FlowsheetMessageEntry,
   FlowsheetQuery,
   FlowsheetShowBlockEntry,
@@ -45,7 +45,7 @@ export function convertToSong(
     request_flag: response.request_flag,
     album_id: response.album_id,
     rotation_id: response.rotation_id,
-    rotation: response.rotation_play_freq as Rotation,
+    rotation: response.rotation_bin as Rotation,
   };
 }
 

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -61,7 +61,7 @@ export const flowsheetSlice = createAppSlice({
         album_title: action.payload.album,
         record_label: action.payload.label,
         request_flag: action.payload.request,
-        rotation: action.payload.play_freq,
+        rotation: action.payload.rotation_bin,
         rotation_id: action.payload.rotation_id,
         album_id: action.payload.album_id,
       });

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -1,4 +1,7 @@
+import type { FlowsheetEntryResponse } from "@wxyc/shared/dtos";
 import { Rotation } from "../rotation/types";
+
+export type { FlowsheetEntryResponse };
 
 export type FlowsheetFrontendState = {
   autoplay: boolean;
@@ -20,31 +23,19 @@ export type FlowsheetQuery = {
   label: string;
   request: boolean;
   album_id?: number;
-  play_freq?: Rotation;
+  rotation_bin?: Rotation;
   rotation_id?: number;
 };
 
 export type FlowsheetSearchProperty = keyof Omit<
   FlowsheetQuery,
-  "request" | "album_id" | "play_freq" | "rotation_id"
+  "request" | "album_id" | "rotation_bin" | "rotation_id"
 >;
 
 export type FlowsheetEntryBase = {
   id: number;
   play_order: number;
   show_id: number;
-};
-
-export type FlowsheetEntryResponse = FlowsheetEntryBase & {
-  album_id?: number;
-  track_title?: string;
-  album_title?: string;
-  artist_name?: string;
-  record_label?: string;
-  rotation_id?: number;
-  rotation_play_freq?: string;
-  message?: string;
-  request_flag: boolean;
 };
 
 export type FlowsheetSongBase = {
@@ -84,7 +75,7 @@ export type FlowsheetSubmissionParams =
       rotation_id?: number;
       request_flag: boolean;
       record_label?: string;
-      play_freq?: Rotation;
+      rotation_bin?: Rotation;
     }
   | {
       artist_name: string;

--- a/lib/features/rotation/api.ts
+++ b/lib/features/rotation/api.ts
@@ -1,7 +1,7 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import { backendBaseQuery } from "../backend";
 import { convertAlbumFromRotation } from "../catalog/conversions";
-import { AlbumEntry, AlbumQueryResponse } from "../catalog/types";
+import { AlbumEntry, AlbumSearchResultJSON } from "../catalog/types";
 import { KillRotationParams, RotationParams } from "./types";
 
 export const rotationApi = createApi({
@@ -13,7 +13,7 @@ export const rotationApi = createApi({
       query: () => ({
         url: "",
       }),
-      transformResponse: (response: AlbumQueryResponse[]) =>
+      transformResponse: (response: AlbumSearchResultJSON[]) =>
         response.map(convertAlbumFromRotation),
       providesTags: ["Rotation"],
     }),

--- a/lib/features/rotation/types.ts
+++ b/lib/features/rotation/types.ts
@@ -1,23 +1,23 @@
+import { RotationBin } from "@wxyc/shared/dtos";
+
+export { RotationBin };
+
+// Backward-compatible alias for consumers that import { Rotation }
+export const Rotation = RotationBin;
+export type Rotation = RotationBin;
+
 export type RotationFrontendState = {
   orderBy: "title" | "artist" | "album";
   orderDirection: "asc" | "desc";
 };
 
-
 export type RotationParams = {
   album_id: string;
-  play_freq: Rotation;
+  rotation_bin: Rotation;
 };
 
 export type KillRotationParams = {
   rotation_id: number;
   kill_date: Date | undefined;
 };
-
-export enum Rotation {
-  S = "S",
-  L = "L",
-  M = "M",
-  H = "H",
-}
 

--- a/lib/test-utils/fixtures.ts
+++ b/lib/test-utils/fixtures.ts
@@ -12,18 +12,17 @@ import {
   VerifiedData,
   Verification,
 } from "@/lib/features/authentication/types";
+import type { FlowsheetEntryResponse, BinLibraryDetails } from "@wxyc/shared/dtos";
 import {
   AlbumEntry,
-  AlbumQueryResponse,
+  AlbumSearchResultJSON,
   ArtistEntry,
   Genre,
 } from "@/lib/features/catalog/types";
 import {
-  FlowsheetEntryResponse,
   FlowsheetQuery,
   FlowsheetSongEntry,
 } from "@/lib/features/flowsheet/types";
-import { BinQueryResponse } from "@/lib/features/bin/types";
 import { Rotation } from "@/lib/features/rotation/types";
 import { TEST_ENTITY_IDS, TEST_SEARCH_STRINGS } from "./constants";
 import { TEST_TIMESTAMPS, toDateString } from "./time";
@@ -49,7 +48,7 @@ export function createTestAlbum(overrides: Partial<AlbumEntry> = {}): AlbumEntry
     entry: 1,
     format: "CD",
     alternate_artist: undefined,
-    play_freq: undefined,
+    rotation_bin: undefined,
     rotation_id: undefined,
     plays: 0,
     add_date: toDateString(TEST_TIMESTAMPS.ONE_WEEK_AGO),
@@ -58,16 +57,14 @@ export function createTestAlbum(overrides: Partial<AlbumEntry> = {}): AlbumEntry
   };
 }
 
-// Album query response (raw API response format)
-export function createTestAlbumQueryResponse(
-  overrides: Partial<AlbumQueryResponse> = {}
-): AlbumQueryResponse {
+// Album search result (raw API response format)
+export function createTestAlbumSearchResult(
+  overrides: Partial<AlbumSearchResultJSON> = {}
+): AlbumSearchResultJSON {
   return {
     id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM,
     add_date: toDateString(TEST_TIMESTAMPS.ONE_WEEK_AGO),
-    album_dist: undefined,
     album_title: TEST_SEARCH_STRINGS.ALBUM_NAME,
-    artist_dist: undefined,
     artist_name: TEST_SEARCH_STRINGS.ARTIST_NAME,
     code_artist_number: 1,
     code_letters: "TA",
@@ -75,9 +72,7 @@ export function createTestAlbumQueryResponse(
     format_name: "CD",
     genre_name: "Rock",
     label: TEST_SEARCH_STRINGS.LABEL,
-    play_freq: undefined,
     plays: 0,
-    rotation_id: undefined,
     ...overrides,
   };
 }
@@ -113,7 +108,7 @@ export function createTestFlowsheetQuery(
     label: TEST_SEARCH_STRINGS.LABEL,
     request: false,
     album_id: undefined,
-    play_freq: undefined,
+    rotation_bin: undefined,
     rotation_id: undefined,
     ...overrides,
   };
@@ -174,7 +169,7 @@ export function createTestRotationAlbum(
 ): AlbumEntry {
   return createTestAlbum({
     id: TEST_ENTITY_IDS.ALBUM.ROTATION_ALBUM,
-    play_freq: rotation,
+    rotation_bin: rotation,
     rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
     ...overrides,
   });
@@ -195,7 +190,7 @@ export function createTestFlowsheetEntryResponse(
     request_flag: false,
     album_id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM,
     rotation_id: undefined,
-    rotation_play_freq: undefined,
+    rotation_bin: undefined,
     message: undefined,
     ...overrides,
   };
@@ -281,9 +276,9 @@ export function createTestAccountFormData(
 }
 
 // Bin fixtures
-export function createTestBinQueryResponse(
-  overrides: Partial<BinQueryResponse> = {}
-): BinQueryResponse {
+export function createTestBinResponse(
+  overrides: Partial<BinLibraryDetails> = {}
+): BinLibraryDetails {
   return {
     album_id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM,
     album_title: TEST_SEARCH_STRINGS.ALBUM_NAME,

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -48,7 +48,7 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
           entry={album.entry}
           artist={album.artist}
           format={album.format}
-          rotation={album.play_freq}
+          rotation={album.rotation_bin}
         />
       </td>
       <td>

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
@@ -162,7 +162,7 @@ export default function SongEntry({
                     request_flag: entry.request_flag,
                     rotation_id: entry.rotation_id,
                     album_id: entry.album_id,
-                    play_freq: entry.rotation,
+                    rotation_bin: entry.rotation,
                   } as FlowsheetSubmissionParams)
                     .then(() => {
                       dispatch(flowsheetSlice.actions.removeFromQueue(entry.id));

--- a/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
@@ -43,7 +43,7 @@ export default function FlowsheetBackendResult({
         artist={entry.artist}
         format={entry.format}
         entry={entry.entry}
-        rotation={entry.play_freq}
+        rotation={entry.rotation_bin}
       />
       <Stack direction="column" sx={{ width: "calc(20%)" }}>
         <Typography

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -462,7 +462,7 @@ export const useFlowsheetSubmit = () => {
         album: selectedEntry.title || flowSheetRawQuery.album as string,
         label: selectedEntry.label || flowSheetRawQuery.label as string,
         album_id: selectedEntry.id ?? undefined,
-        play_freq: selectedEntry.play_freq ?? undefined,
+        rotation_bin: selectedEntry.rotation_bin ?? undefined,
         rotation_id: selectedEntry.rotation_id ?? undefined,
         request: false,
       };


### PR DESCRIPTION
## Summary
- Replace local DTO type definitions with imports from `@wxyc/shared/dtos`
- Reduces code duplication and ensures type consistency across the stack

Replaces #183 (auto-closed when base branch was deleted).