### PR TITLE
refactor: collapse three album converters into single convertToAlbumEntry

### DIFF
--- a/lib/__tests__/features/bin/conversions.test.ts
+++ b/lib/__tests__/features/bin/conversions.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
-  convertAlbumFromBin,
   convertBinToFlowsheet,
   convertBinToQueue,
 } from "@/lib/features/bin/conversions";
+import { convertToAlbumEntry } from "@/lib/features/catalog/conversions";
 import {
   createTestBinResponse,
   createTestAlbum,
@@ -25,12 +25,12 @@ type BinFlowsheetSubmission = {
 };
 
 describe("bin conversions", () => {
-  describe("convertAlbumFromBin", () => {
+  describe("convertToAlbumEntry", () => {
     it("should convert album_id to id", () => {
       const response = createTestBinResponse({
         album_id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM,
       });
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.id).toBe(TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM);
     });
 
@@ -38,7 +38,7 @@ describe("bin conversions", () => {
       const response = createTestBinResponse({
         album_title: "Great Album",
       });
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.title).toBe("Great Album");
     });
 
@@ -46,7 +46,7 @@ describe("bin conversions", () => {
       const response = createTestBinResponse({
         artist_name: "Cool Artist",
       });
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.artist.name).toBe("Cool Artist");
     });
 
@@ -54,7 +54,7 @@ describe("bin conversions", () => {
       const response = createTestBinResponse({
         code_letters: "CA",
       });
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.artist.lettercode).toBe("CA");
     });
 
@@ -62,7 +62,7 @@ describe("bin conversions", () => {
       const response = createTestBinResponse({
         code_artist_number: 42,
       });
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.artist.numbercode).toBe(42);
     });
 
@@ -70,7 +70,7 @@ describe("bin conversions", () => {
       const response = createTestBinResponse({
         genre_name: "Jazz",
       });
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.artist.genre).toBe("Jazz");
     });
 
@@ -78,7 +78,7 @@ describe("bin conversions", () => {
       const response = createTestBinResponse({
         genre_name: null as unknown as string,
       });
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.artist.genre).toBe("Unknown");
     });
 
@@ -86,7 +86,7 @@ describe("bin conversions", () => {
       const response = createTestBinResponse({
         code_number: 99,
       });
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.entry).toBe(99);
     });
 
@@ -94,7 +94,7 @@ describe("bin conversions", () => {
       const response = createTestBinResponse({
         format_name: "Vinyl",
       });
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.format).toBe("Vinyl");
     });
 
@@ -102,7 +102,7 @@ describe("bin conversions", () => {
       const response = createTestBinResponse({
         format_name: null as unknown as string,
       });
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.format).toBe("Unknown");
     });
 
@@ -110,7 +110,7 @@ describe("bin conversions", () => {
       const response = createTestBinResponse({
         label: "Indie Records",
       });
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.label).toBe("Indie Records");
     });
 
@@ -118,43 +118,43 @@ describe("bin conversions", () => {
       const response = createTestBinResponse({
         label: undefined,
       });
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.label).toBe("");
     });
 
     it("should set alternate_artist to empty string", () => {
       const response = createTestBinResponse();
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.alternate_artist).toBe("");
     });
 
     it("should set rotation_bin to undefined", () => {
       const response = createTestBinResponse();
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.rotation_bin).toBeUndefined();
     });
 
     it("should set add_date to undefined", () => {
       const response = createTestBinResponse();
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.add_date).toBeUndefined();
     });
 
-    it("should set plays to undefined", () => {
+    it("should default plays to 0", () => {
       const response = createTestBinResponse();
-      const result = convertAlbumFromBin(response);
-      expect(result.plays).toBeUndefined();
+      const result = convertToAlbumEntry(response);
+      expect(result.plays).toBe(0);
     });
 
     it("should set rotation_id to undefined", () => {
       const response = createTestBinResponse();
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.rotation_id).toBeUndefined();
     });
 
     it("should set artist.id to undefined", () => {
       const response = createTestBinResponse();
-      const result = convertAlbumFromBin(response);
+      const result = convertToAlbumEntry(response);
       expect(result.artist.id).toBeUndefined();
     });
   });

--- a/lib/features/bin/api.ts
+++ b/lib/features/bin/api.ts
@@ -2,7 +2,7 @@ import { createApi } from "@reduxjs/toolkit/query/react";
 import { backendBaseQuery } from "../backend";
 import { AlbumEntry } from "../catalog/types";
 import type { BinLibraryDetails } from "@wxyc/shared/dtos";
-import { convertAlbumFromBin } from "./conversions";
+import { convertToAlbumEntry } from "../catalog/conversions";
 import { BinMutationQuery, DJBinQuery } from "./types";
 
 export const binApi = createApi({
@@ -15,7 +15,7 @@ export const binApi = createApi({
         url: `/?dj_id=${dj_id}`,
       }),
       transformResponse: (response: BinLibraryDetails[]) =>
-        response.map(convertAlbumFromBin),
+        response.map(convertToAlbumEntry),
       providesTags: ["Bin"],
     }),
     deleteFromBin: builder.mutation<void, BinMutationQuery>({

--- a/lib/features/bin/conversions.ts
+++ b/lib/features/bin/conversions.ts
@@ -1,28 +1,5 @@
-import type { BinLibraryDetails } from "@wxyc/shared/dtos";
-import { AlbumEntry, Format, Genre } from "../catalog/types";
+import { AlbumEntry } from "../catalog/types";
 import { FlowsheetQuery, FlowsheetSubmissionParams } from "../flowsheet/types";
-
-export function convertAlbumFromBin(response: BinLibraryDetails): AlbumEntry {
-  return {
-    id: response.album_id ?? 0,
-    title: response.album_title ?? "",
-    artist: {
-      name: response.artist_name ?? "",
-      lettercode: response.code_letters ?? "",
-      numbercode: response.code_artist_number ?? 0,
-      genre: (response.genre_name as Genre) ?? "Unknown",
-      id: undefined,
-    },
-    entry: response.code_number ?? 0,
-    format: (response.format_name as Format) ?? "Unknown",
-    alternate_artist: "",
-    rotation_bin: undefined,
-    add_date: undefined,
-    plays: undefined,
-    rotation_id: undefined,
-    label: response.label ?? "",
-  };
-}
 
 export function convertBinToFlowsheet(
   binEntry: AlbumEntry

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -1,6 +1,6 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import { backendBaseQuery } from "../backend";
-import { convertAlbumFromSearch } from "./conversions";
+import { convertToAlbumEntry } from "./conversions";
 import {
   AlbumEntry,
   AlbumParams,
@@ -21,7 +21,7 @@ export const catalogApi = createApi({
         params: { artist_name, album_name, n },
       }),
       transformResponse: (response: AlbumSearchResultJSON[]) =>
-        response.map(convertAlbumFromSearch),
+        response.map(convertToAlbumEntry),
     }),
     addAlbum: builder.mutation<any, AlbumParams>({
       query: (album) => ({
@@ -43,7 +43,7 @@ export const catalogApi = createApi({
         params: { album_id },
       }),
       transformResponse: (response: AlbumSearchResultJSON) =>
-        convertAlbumFromSearch(response),
+        convertToAlbumEntry(response),
     }),
     getFormats: builder.query<any, void>({
       query: () => ({

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -1,50 +1,38 @@
+import type { BinLibraryDetails } from "@wxyc/shared/dtos";
 import { Rotation } from "../rotation/types";
 import { AlbumEntry, AlbumSearchResultJSON, Format, Genre } from "./types";
 
-export function convertAlbumFromSearch(
-  response: AlbumSearchResultJSON
+function isSearchResult(
+  response: AlbumSearchResultJSON | BinLibraryDetails
+): response is AlbumSearchResultJSON {
+  return "id" in response && response.id !== undefined;
+}
+
+export function convertToAlbumEntry(
+  response: AlbumSearchResultJSON | BinLibraryDetails
 ): AlbumEntry {
+  const id = isSearchResult(response) ? response.id : (response.album_id ?? 0);
+
   return {
-    id: response.id,
-    title: response.album_title,
+    id,
+    title: response.album_title ?? "",
     artist: {
-      name: response.artist_name,
-      lettercode: response.code_letters,
-      numbercode: response.code_artist_number,
+      name: response.artist_name ?? "",
+      lettercode: response.code_letters ?? "",
+      numbercode: response.code_artist_number ?? 0,
       genre: (response.genre_name as Genre) ?? "Unknown",
-      id: response.id,
+      id: undefined,
     },
-    entry: response.code_number,
+    entry: response.code_number ?? 0,
     format: (response.format_name as Format) ?? "Unknown",
     alternate_artist: "",
-    rotation_bin: undefined,
-    add_date: response.add_date,
-    plays: response.plays ?? 0,
-    label: response.label,
-    rotation_id: undefined,
+    rotation_bin: isSearchResult(response)
+      ? (response.rotation_bin as Rotation)
+      : undefined,
+    add_date: isSearchResult(response) ? response.add_date : undefined,
+    plays: (isSearchResult(response) ? response.plays : undefined) ?? 0,
+    label: response.label ?? "",
+    rotation_id: isSearchResult(response) ? response.rotation_id : undefined,
   };
 }
 
-export function convertAlbumFromRotation(
-  response: AlbumSearchResultJSON
-): AlbumEntry {
-  return {
-    id: response.id,
-    title: response.album_title,
-    artist: {
-      name: response.artist_name,
-      lettercode: response.code_letters,
-      numbercode: response.code_artist_number,
-      genre: (response.genre_name as Genre) ?? "Unknown",
-      id: response.id,
-    },
-    entry: response.code_number,
-    format: (response.format_name as Format) ?? "Unknown",
-    alternate_artist: "",
-    rotation_bin: response.rotation_bin as Rotation,
-    add_date: response.add_date,
-    plays: response.plays ?? 0,
-    label: response.label,
-    rotation_id: response.rotation_id,
-  };
-}

--- a/lib/features/rotation/api.ts
+++ b/lib/features/rotation/api.ts
@@ -1,6 +1,6 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import { backendBaseQuery } from "../backend";
-import { convertAlbumFromRotation } from "../catalog/conversions";
+import { convertToAlbumEntry } from "../catalog/conversions";
 import { AlbumEntry, AlbumSearchResultJSON } from "../catalog/types";
 import { KillRotationParams, RotationParams } from "./types";
 
@@ -14,7 +14,7 @@ export const rotationApi = createApi({
         url: "",
       }),
       transformResponse: (response: AlbumSearchResultJSON[]) =>
-        response.map(convertAlbumFromRotation),
+        response.map(convertToAlbumEntry),
       providesTags: ["Rotation"],
     }),
     addRotationEntry: builder.mutation<any, RotationParams>({


### PR DESCRIPTION
## Summary
- Unify three separate album conversion functions into a single `convertToAlbumEntry`
- Reduces code duplication across catalog, bin, and flowsheet conversion logic

Replaces #184 (auto-closed when base branch was deleted).