### PR TITLE
Redirect authenticated users from / to dashboard

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Mock server-only (required for server component imports)
+vi.mock("server-only", () => ({}));
+
+// Mock next/navigation
+const mockRedirect = vi.fn();
+vi.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => {
+    mockRedirect(...args);
+    // redirect() throws in Next.js to halt rendering
+    throw new Error("NEXT_REDIRECT");
+  },
+  usePathname: () => "/",
+}));
+
+// Mock getServerSession
+vi.mock("@/lib/features/authentication/server-utils", () => ({
+  getServerSession: vi.fn(),
+}));
+
+// Mock child components to keep tests focused
+vi.mock("@/src/components/experiences/modern/login/Quotes/Welcome", () => ({
+  default: () => <div data-testid="welcome-quotes">Welcome</div>,
+}));
+
+vi.mock("@/src/Layout/WXYCPage", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="wxyc-page">{children}</div>
+  ),
+}));
+
+import HomePage from "./page";
+import { getServerSession } from "@/lib/features/authentication/server-utils";
+
+const mockGetServerSession = getServerSession as ReturnType<typeof vi.fn>;
+
+describe("HomePage (/)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the landing page when not logged in", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const Component = await HomePage();
+    render(Component);
+
+    expect(screen.getByText("Log In")).toBeInTheDocument();
+    expect(screen.getByText("Listen")).toBeInTheDocument();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /dashboard/catalog when logged in and verified", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: {
+        id: "user-1",
+        email: "dj@wxyc.org",
+        name: "Test DJ",
+        emailVerified: true,
+      },
+      session: { token: "test-token" },
+    });
+
+    await expect(HomePage()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mockRedirect).toHaveBeenCalledWith("/dashboard/catalog");
+  });
+
+  it("renders the landing page when logged in but email not verified", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: {
+        id: "user-1",
+        email: "dj@wxyc.org",
+        name: "Test DJ",
+        emailVerified: false,
+      },
+      session: { token: "test-token" },
+    });
+
+    const Component = await HomePage();
+    render(Component);
+
+    expect(screen.getByText("Log In")).toBeInTheDocument();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("uses NEXT_PUBLIC_DASHBOARD_HOME_PAGE env var for redirect target", async () => {
+    process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE = "/dashboard/flowsheet";
+
+    mockGetServerSession.mockResolvedValue({
+      user: {
+        id: "user-1",
+        email: "dj@wxyc.org",
+        name: "Test DJ",
+        emailVerified: true,
+      },
+      session: { token: "test-token" },
+    });
+
+    await expect(HomePage()).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(mockRedirect).toHaveBeenCalledWith("/dashboard/flowsheet");
+
+    delete process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE;
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,13 +3,24 @@ import WXYCPage from "@/src/Layout/WXYCPage";
 import { Button, Divider, Stack } from "@mui/joy";
 import Link from "next/link";
 import { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { getPageTitle } from "@/lib/utils/page-title";
+import { getServerSession } from "@/lib/features/authentication/server-utils";
 
 export const metadata: Metadata = {
   title: getPageTitle("DJ Site"),
 };
 
-export default function HomePage() {
+export default async function HomePage() {
+  const session = await getServerSession();
+
+  if (session?.user?.emailVerified) {
+    redirect(
+      String(
+        process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/catalog"
+      )
+    );
+  }
   return (
     <WXYCPage>
       <Stack


### PR DESCRIPTION
## Summary

- Authenticated + email-verified users visiting `/` are now redirected to `/dashboard/catalog` (or `NEXT_PUBLIC_DASHBOARD_HOME_PAGE`)
- Unauthenticated or unverified users still see the landing page
- Uses the same `getServerSession` + `redirect` pattern as `app/login/@modern/layout.tsx`

Closes #226

## Test plan

- [x] Not logged in: renders landing page with Log In and Listen buttons
- [x] Logged in + verified: redirects to `/dashboard/catalog`
- [x] Logged in + unverified: renders landing page (no redirect)
- [x] Respects `NEXT_PUBLIC_DASHBOARD_HOME_PAGE` env var for redirect target