### PR TITLE
Fix 50 failing tests across 10 test files

### DIFF
--- a/app/api/view/__tests__/rightbar.test.ts
+++ b/app/api/view/__tests__/rightbar.test.ts
@@ -3,6 +3,14 @@ import { defaultApplicationState } from "@/lib/features/application/types";
 
 vi.mock("server-only", () => ({}));
 
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    cache: (fn: Function) => fn,
+  };
+});
+
 vi.mock("next/headers", () => {
   let cookieStore: Record<string, string> = {};
   return {

--- a/lib/__tests__/features/authentication/authentication.test.ts
+++ b/lib/__tests__/features/authentication/authentication.test.ts
@@ -232,6 +232,7 @@ describeSlice(authenticationSlice, defaultAuthenticationState, ({ harness, actio
         realName: false,
         djName: false,
         password: false,
+        currentPassword: false,
         confirmPassword: false,
         code: false,
       });

--- a/src/Layout/WXYCPage.test.tsx
+++ b/src/Layout/WXYCPage.test.tsx
@@ -24,18 +24,10 @@ vi.mock("./Footer", () => ({
   default: () => <footer data-testid="footer">Footer</footer>,
 }));
 
-vi.mock("./PageData", () => ({
-  default: ({ title }: any) => (
-    <div data-testid="page-data" data-title={title}>
-      Page Data
-    </div>
-  ),
-}));
-
 describe("WXYCPage", () => {
   it("should render children in Main component", () => {
     render(
-      <WXYCPage title="Test Page">
+      <WXYCPage>
         <div data-testid="page-content">Page Content</div>
       </WXYCPage>
     );
@@ -45,7 +37,7 @@ describe("WXYCPage", () => {
 
   it("should render Header component", () => {
     render(
-      <WXYCPage title="Test Page">
+      <WXYCPage>
         <span>Content</span>
       </WXYCPage>
     );
@@ -55,7 +47,7 @@ describe("WXYCPage", () => {
 
   it("should render Footer component", () => {
     render(
-      <WXYCPage title="Test Page">
+      <WXYCPage>
         <span>Content</span>
       </WXYCPage>
     );
@@ -65,7 +57,7 @@ describe("WXYCPage", () => {
 
   it("should render BackgroundBox component", () => {
     render(
-      <WXYCPage title="Test Page">
+      <WXYCPage>
         <span>Content</span>
       </WXYCPage>
     );
@@ -75,7 +67,7 @@ describe("WXYCPage", () => {
 
   it("should render BackgroundImage component", () => {
     render(
-      <WXYCPage title="Test Page">
+      <WXYCPage>
         <span>Content</span>
       </WXYCPage>
     );
@@ -83,22 +75,9 @@ describe("WXYCPage", () => {
     expect(screen.getByTestId("background-image")).toBeInTheDocument();
   });
 
-  it("should pass title to PageData", () => {
-    render(
-      <WXYCPage title="Custom Title">
-        <span>Content</span>
-      </WXYCPage>
-    );
-
-    expect(screen.getByTestId("page-data")).toHaveAttribute(
-      "data-title",
-      "Custom Title"
-    );
-  });
-
   it("should have ignoreClassic class", () => {
     const { container } = render(
-      <WXYCPage title="Test Page">
+      <WXYCPage>
         <span>Content</span>
       </WXYCPage>
     );

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
@@ -215,6 +215,7 @@ describe("FlowsheetSearchbar", () => {
     it("should handle ArrowDown key to increment selected result", () => {
       // Provide mock results so the max index is > 0
       mockCatalogResults = [{ id: "1" }, { id: "2" }];
+      mockSearchOpen = true;
 
       const store = createTestStore();
 
@@ -234,6 +235,7 @@ describe("FlowsheetSearchbar", () => {
     it("should handle ArrowUp key to decrement selected result", () => {
       // Provide mock results so there are valid indices
       mockCatalogResults = [{ id: "1" }, { id: "2" }, { id: "3" }];
+      mockSearchOpen = true;
 
       const store = createTestStore({
         flowsheet: {

--- a/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
@@ -50,7 +50,7 @@ describe("FlowsheetBackendResult", () => {
     entry: 5,
     format: "CD",
     label: "Test Label",
-    play_freq: "H",
+    rotation_bin: "H",
     rotation_id: 10,
     artist: {
       id: 1,
@@ -290,7 +290,7 @@ describe("FlowsheetBackendResult", () => {
         entry: 10,
         format: "vinyl" as any,
         label: "Complete Label",
-        play_freq: "M",
+        rotation_bin: "M",
         rotation_id: 20,
         artist: {
           id: 50,
@@ -375,7 +375,7 @@ describe("FlowsheetBackendResult", () => {
     it("should handle missing rotation", () => {
       const entryWithoutRotation: AlbumEntry = {
         ...mockEntry,
-        play_freq: undefined,
+        rotation_bin: undefined,
       };
 
       render(<FlowsheetBackendResult entry={entryWithoutRotation} index={1} />);

--- a/src/components/experiences/modern/login/Forms/AuthBackButton.test.tsx
+++ b/src/components/experiences/modern/login/Forms/AuthBackButton.test.tsx
@@ -7,11 +7,23 @@ import { applicationSlice } from "@/lib/features/application/frontend";
 
 // Mock hooks
 const mockHandleLogout = vi.fn(() => Promise.resolve());
+const mockReplace = vi.fn();
 
 vi.mock("@/src/hooks/authenticationHooks", () => ({
   useLogout: vi.fn(() => ({
     handleLogout: mockHandleLogout,
     loggingOut: false,
+  })),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({
+    replace: mockReplace,
+    push: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
   })),
 }));
 

--- a/src/components/experiences/modern/login/Forms/OnboardingForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/OnboardingForm.test.tsx
@@ -131,7 +131,6 @@ describe("OnboardingForm", () => {
     expect(mockAddRequiredCredentials).toHaveBeenCalledWith([
       "username",
       "realName",
-      "djName",
       "password",
       "confirmPassword",
     ]);


### PR DESCRIPTION
## Summary
- Fix 50 test failures across 10 test files caused by source code changes that were not accompanied by test updates
- No source code changes -- only test files are modified
- All 119 test files (1382 tests) pass after this fix

Closes #228

## Changes by file

| File | Failures | Root cause | Fix |
|------|----------|------------|-----|
| `rightbar.test.ts` | 2 | `React.cache` not available in test env | Mock `react` module with `cache: (fn) => fn` |
| `authentication.test.ts` | 1 | `currentPassword` added to verifications | Add to expected default state |
| `FlowsheetSearchbar.test.tsx` | 2 | ArrowDown/ArrowUp gated on `searchOpen` | Set `mockSearchOpen = true` |
| `FlowsheetBackendResult.test.tsx` | 2 | `play_freq` renamed to `rotation_bin` | Update mock data field name |
| `AuthBackButton.test.tsx` | 6 | `useRouter()` added to component | Mock `next/navigation` |
| `OnboardingForm.test.tsx` | 1 | `djName` no longer a required credential | Remove from expected array |
| `WXYCPage.test.tsx` | 1 | `title` prop and `PageData` removed | Remove that test, update renders |
| `GradientAudioVisualizer.test.tsx` | 26 | Refactored from forwardRef/src to prop-based API | Rewrite tests for new API |
| `Main.test.tsx` | 5 | Audio state lifted to parent (new required props) | Pass required props via helper |
| `Mini.test.tsx` | 4 | Same audio state lift as Main | Pass required props via helper |

## Test plan
- [x] All 10 previously failing test files now pass
- [x] Full test suite passes (119 files, 1382 tests, 0 failures)
- [x] No source code changes -- only test files modified