### PR TITLE
refactor: migrate local auth types to @wxyc/shared

### DIFF
--- a/lib/__tests__/features/authentication/shared-type-compatibility.test.ts
+++ b/lib/__tests__/features/authentication/shared-type-compatibility.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import {
+  Authorization as SharedAuthorization,
+  roleToAuthorization,
+  type WXYCRole as SharedWXYCRole,
+} from "@wxyc/shared/auth-client/auth";
+import { Authorization, AdminProtectedRoutes } from "@/lib/features/admin/types";
+import { mapRoleToAuthorization, type WXYCRole } from "@/lib/features/authentication/types";
+
+describe("shared type compatibility", () => {
+  describe("Authorization enum", () => {
+    it("has identical values for NO, DJ, MD, SM", () => {
+      expect(SharedAuthorization.NO).toBe(0);
+      expect(SharedAuthorization.DJ).toBe(1);
+      expect(SharedAuthorization.MD).toBe(2);
+      expect(SharedAuthorization.SM).toBe(3);
+    });
+
+    it("re-exported Authorization matches shared Authorization", () => {
+      expect(Authorization.NO).toBe(SharedAuthorization.NO);
+      expect(Authorization.DJ).toBe(SharedAuthorization.DJ);
+      expect(Authorization.MD).toBe(SharedAuthorization.MD);
+      expect(Authorization.SM).toBe(SharedAuthorization.SM);
+    });
+  });
+
+  describe("mapRoleToAuthorization aliases roleToAuthorization", () => {
+    it("maps standard WXYC roles identically", () => {
+      const standardRoles: Array<SharedWXYCRole> = [
+        "member",
+        "dj",
+        "musicDirector",
+        "stationManager",
+      ];
+
+      for (const role of standardRoles) {
+        expect(mapRoleToAuthorization(role)).toBe(roleToAuthorization(role));
+      }
+    });
+
+    it("maps edge-case inputs identically", () => {
+      const edgeCases = [
+        "user",
+        "station_manager",
+        "music_director",
+        undefined,
+      ] as const;
+
+      for (const input of edgeCases) {
+        expect(mapRoleToAuthorization(input)).toBe(roleToAuthorization(input));
+      }
+    });
+
+    it("maps null to NO authorization", () => {
+      expect(roleToAuthorization(null)).toBe(SharedAuthorization.NO);
+    });
+  });
+
+  describe("AdminProtectedRoutes compatibility", () => {
+    it("Authorization.SM resolves to correct routes", () => {
+      expect(AdminProtectedRoutes[Authorization.SM]).toEqual([
+        "roster",
+        "catalog",
+      ]);
+      expect(AdminProtectedRoutes[Authorization.MD]).toEqual(["catalog"]);
+      expect(AdminProtectedRoutes[Authorization.NO]).toEqual([]);
+    });
+  });
+
+  describe("type compatibility", () => {
+    it("WXYCRole from shared is assignable to local usage", () => {
+      const sharedRole: SharedWXYCRole = "dj";
+      const localRole: WXYCRole = sharedRole;
+      expect(localRole).toBe("dj");
+    });
+  });
+});

--- a/lib/features/admin/types.ts
+++ b/lib/features/admin/types.ts
@@ -1,3 +1,6 @@
+export { Authorization } from "@wxyc/shared/auth-client/auth";
+import { Authorization } from "@wxyc/shared/auth-client/auth";
+
 export type AdminFrontendState = {
   searchString: string;
   adding: boolean;
@@ -5,13 +8,6 @@ export type AdminFrontendState = {
     authorization: Authorization;
   }
 };
-
-export enum Authorization {
-  NO,
-  DJ,
-  MD,
-  SM,
-}
 
 export type Account = {
   id?: string;


### PR DESCRIPTION
## Summary
- Replace local `Authorization` enum, `WXYCRole` type, and `mapRoleToAuthorization` function with re-exports from `@wxyc/shared/auth-client/auth`
- All ~30 consumer files keep their existing import paths unchanged (zero migration cost)
- Add compatibility test verifying shared types match expected values

Closes #259

## Test plan
- [x] Compatibility test verifies enum values (NO=0, DJ=1, MD=2, SM=3)
- [x] Compatibility test verifies `mapRoleToAuthorization` matches `roleToAuthorization` for all standard roles
- [x] AdminProtectedRoutes lookup still works with shared Authorization values
- [x] `npx tsc --noEmit` passes (no new type errors)
- [x] `npm run build` succeeds
- [x] All auth-related tests pass (pre-existing failure in authentication.test.ts is unrelated)

> **Note:** Depends on #130 (role roundtrip fix) as a logical prerequisite — the type migration should be based on the corrected role model.