### PR TITLE
fix: guard flowsheet merge crash and suppress disabled link prefetch

### DIFF
--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -41,7 +41,7 @@ export const flowsheetApi = createApi({
       transformResponse: (response: FlowsheetV2PaginatedResponseJSON) =>
         convertV2FlowsheetResponse(response.entries),
       providesTags: ["Flowsheet"],
-      merge: (currentCache, newItems) => {
+      merge: (currentCache = [], newItems) => {
         const map = new Map(currentCache.map((entry) => [entry.id, entry]));
         newItems.forEach((entry) => {
           map.set(entry.id, entry);

--- a/src/components/experiences/modern/Leftbar/LeftbarLink.test.tsx
+++ b/src/components/experiences/modern/Leftbar/LeftbarLink.test.tsx
@@ -9,7 +9,7 @@ vi.mock("next/navigation", () => ({
 
 // Mock next/link
 vi.mock("next/link", () => ({
-  default: ({ children, href, ...props }: any) => (
+  default: ({ children, href, prefetch, ...props }: any) => (
     <a href={href} {...props}>
       {children}
     </a>

--- a/src/components/experiences/modern/Leftbar/LeftbarLink.tsx
+++ b/src/components/experiences/modern/Leftbar/LeftbarLink.tsx
@@ -17,6 +17,7 @@ export default function LeftbarLink(props: LeftbarLinkProps): JSX.Element {
     <Link
       aria-disabled={props.disabled}
       href={props.path}
+      prefetch={props.disabled ? false : undefined}
       style={{
         pointerEvents: props.disabled ? "none" : "auto",
       }}


### PR DESCRIPTION
Closes #261

## Summary
- Default `currentCache` to `[]` in the flowsheet API `merge` callback to prevent `TypeError: e.map is not a function` when the cache is undefined after a failed initial fetch
- Add `prefetch={false}` to disabled `LeftbarLink` components to suppress 404 prefetch requests for unimplemented routes (`/dashboard/playlists`, `/dashboard/admin/schedule`)
- Update `LeftbarLink` test mock to destructure `prefetch` prop

## Test plan
- [x] Flowsheet API tests pass (12 tests)
- [x] LeftbarLink tests pass (7 tests)
- [ ] Verify on https://dj.wxyc.org/dashboard/flowsheet that the `TypeError` and 404 console errors are gone

## Related
- Backend-Service PR #184 fixes the underlying 500 errors (5s server timeout -> 30s)