### PR TITLE
fix: handle bare array response from flowsheet getEntries

### DIFF
--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -4,6 +4,7 @@ import {
   convertDJsOnAir,
   convertV2Entry,
   convertV2FlowsheetResponse,
+  extractFlowsheetEntries,
 } from "@/lib/features/flowsheet/conversions";
 import {
   createTestFlowsheetQuery,
@@ -294,6 +295,55 @@ describe("flowsheet conversions", () => {
         expect(result).toHaveLength(5);
         expect(result[0].play_order).toBe(5);
         expect(result[4].play_order).toBe(1);
+      });
+    });
+
+    describe("extractFlowsheetEntries", () => {
+      it("should return entries directly when response is a bare array", () => {
+        const entries = [
+          createTestV2TrackEntry({ id: 1 }),
+          createTestV2TrackEntry({ id: 2 }),
+        ];
+
+        const result = extractFlowsheetEntries(entries);
+
+        expect(result).toBe(entries);
+        expect(result).toHaveLength(2);
+      });
+
+      it("should unwrap entries from paginated response", () => {
+        const entries = [
+          createTestV2TrackEntry({ id: 1 }),
+          createTestV2TrackEntry({ id: 2 }),
+        ];
+        const paginatedResponse = {
+          entries,
+          page: 0,
+          limit: 20,
+          total: 2,
+          total_pages: 1,
+        };
+
+        const result = extractFlowsheetEntries(paginatedResponse);
+
+        expect(result).toBe(entries);
+        expect(result).toHaveLength(2);
+      });
+
+      it("should return empty array for bare empty array", () => {
+        const result = extractFlowsheetEntries([]);
+        expect(result).toEqual([]);
+      });
+
+      it("should return empty array from paginated response with no entries", () => {
+        const result = extractFlowsheetEntries({
+          entries: [],
+          page: 0,
+          limit: 20,
+          total: 0,
+          total_pages: 0,
+        });
+        expect(result).toEqual([]);
       });
     });
   });

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -5,6 +5,7 @@ import {
   convertDJsOnAir,
   convertV2Entry,
   convertV2FlowsheetResponse,
+  extractFlowsheetEntries,
 } from "./conversions";
 import {
   FlowsheetEntry,
@@ -40,10 +41,7 @@ export const flowsheetApi = createApi({
       serializeQueryArgs: ({ endpointName }) => endpointName,
       transformResponse: (
         response: FlowsheetV2PaginatedResponseJSON | FlowsheetV2EntryJSON[]
-      ) =>
-        convertV2FlowsheetResponse(
-          Array.isArray(response) ? response : response.entries
-        ),
+      ) => convertV2FlowsheetResponse(extractFlowsheetEntries(response)),
       providesTags: ["Flowsheet"],
       merge: (currentCache = [], newItems) => {
         const map = new Map(currentCache.map((entry) => [entry.id, entry]));

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -4,6 +4,7 @@ import {
   FlowsheetQuery,
   FlowsheetSubmissionParams,
   FlowsheetV2EntryJSON,
+  FlowsheetV2PaginatedResponseJSON,
   OnAirDJData,
   OnAirDJResponse,
 } from "./types";
@@ -149,6 +150,16 @@ export function convertV2Entry(entry: FlowsheetV2EntryJSON): FlowsheetEntry {
     default:
       throw new Error(`Unknown entry type: ${(entry as any).entry_type}`);
   }
+}
+
+/**
+ * Extracts the entries array from a flowsheet API response,
+ * handling both bare-array (V1) and paginated-wrapper (V2) formats.
+ */
+export function extractFlowsheetEntries(
+  response: FlowsheetV2PaginatedResponseJSON | FlowsheetV2EntryJSON[]
+): FlowsheetV2EntryJSON[] {
+  return Array.isArray(response) ? response : response.entries;
 }
 
 export function convertV2FlowsheetResponse(


### PR DESCRIPTION
## Summary

- Fix `TypeError: e.map is not a function` when tapping "On Air" on `/dashboard/flowsheet`
- The backend `GET /flowsheet/` returns a bare array, but `transformResponse` expected a paginated wrapper (`response.entries`). On a bare array, `.entries` resolves to `Array.prototype.entries` (a function), and calling `.map()` on it crashes.
- Use `Array.isArray()` to handle both the current bare-array backend and a future paginated wrapper.

Closes #263

## Test plan

- [x] All 192 flowsheet tests pass (`lib/__tests__/features/flowsheet/`)
- [ ] Verify on staging: tap "On Air", confirm no console errors and flowsheet entries load
- [ ] Verify "Off Air" also works without errors