### PR TITLE
fix: bump @wxyc/shared to ^0.3.0 for V2 flowsheet types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@opennextjs/cloudflare": "^1.10.1",
         "@reduxjs/toolkit": "^2.2.0",
         "@uidotdev/usehooks": "^2.4.1",
-        "@wxyc/shared": "^0.2.0",
+        "@wxyc/shared": "^0.3.0",
         "better-auth": "^1.4.9",
         "cookie": "^1.0.2",
         "jose": "^5.9.6",
@@ -13668,9 +13668,9 @@
       }
     },
     "node_modules/@wxyc/shared": {
-      "version": "0.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.2.0/ce6b71bf6b1b2cec5f559eeee8f917de3130cbcc",
-      "integrity": "sha512-vsST4GiDUBllhmonaExQf9bPjGGIXpkcPElc4EMOklRaqMhqevXKf0migb7ADb9iKtMDYfn4DcG9llwrDAAaAA==",
+      "version": "0.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.3.0/860f0669f9bf2a86889d6a88c39fc8e2637d215d",
+      "integrity": "sha512-CwrneM/No/jjo8Q2vK6zi9FQlOoxoh/RIJAXSpIZxCnNJEqjJXoMWIKu9X26HxB4re4EbAbvuKNZ3qH4QyZAPw==",
       "license": "MIT",
       "dependencies": {
         "better-auth": "^1.4.9",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@opennextjs/cloudflare": "^1.10.1",
     "@reduxjs/toolkit": "^2.2.0",
     "@uidotdev/usehooks": "^2.4.1",
-    "@wxyc/shared": "^0.2.0",
+    "@wxyc/shared": "^0.3.0",
     "better-auth": "^1.4.9",
     "cookie": "^1.0.2",
     "jose": "^5.9.6",


### PR DESCRIPTION
## Summary

- Bump `@wxyc/shared` from `^0.2.0` to `^0.3.0` so V2 flowsheet types resolve correctly

The V2 flowsheet types (`FlowsheetV2TrackEntry`, etc.) imported in `lib/features/flowsheet/types.ts` were published in `@wxyc/shared` v0.3.0 (WXYC/wxyc-shared#17). The previous `^0.2.0` range cannot resolve to 0.3.0 under semver, causing import failures on fresh installs.

Closes #272

## Test plan

- [x] All 1459 tests pass across 123 test files
- [x] `npm install` resolves `@wxyc/shared@0.3.0` from GitHub Packages
- [ ] Verify flowsheet entries load correctly in the UI after deploy