### PR TITLE
Redirect incomplete users to onboarding

### DIFF
--- a/app/login/@modern/layout.tsx
+++ b/app/login/@modern/layout.tsx
@@ -1,4 +1,4 @@
-import { getServerSession } from "@/lib/features/authentication/server-utils";
+import { getServerSession, isUserIncomplete } from "@/lib/features/authentication/server-utils";
 import { redirect } from "next/navigation";
 import WXYCPage from "@/src/Layout/WXYCPage";
 import LoginSlotSwitcher from "./LoginSlotSwitcher";
@@ -22,7 +22,20 @@ export default async function ModernLoginLayout({
   const session = await getServerSession();
 
   if (session?.user?.emailVerified) {
-    // User is authenticated and verified — redirect to dashboard
+    // If user is incomplete (missing realName), show onboarding form
+    if (isUserIncomplete(session)) {
+      return (
+        <WXYCPage>
+          <LoginSlotSwitcher
+            normal={normal}
+            newuser={newuser}
+            reset={reset}
+            isIncomplete={true}
+          />
+        </WXYCPage>
+      );
+    }
+    // User is authenticated, verified, and complete — redirect to dashboard
     redirect(String(process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/catalog"));
   }
   // If authenticated but NOT verified, stay on login to show verification message

--- a/e2e/pages/onboarding.page.ts
+++ b/e2e/pages/onboarding.page.ts
@@ -118,7 +118,8 @@ export class OnboardingPage {
 
   async isOnOnboardingPage(): Promise<boolean> {
     const url = this.page.url();
-    return url.includes("/newuser") || url.includes("/onboarding");
+    return url.includes("/newuser") || url.includes("/onboarding") ||
+      (url.includes("/login") && url.includes("incomplete=true"));
   }
 
   /**

--- a/lib/__tests__/features/authentication/server-utils.test.ts
+++ b/lib/__tests__/features/authentication/server-utils.test.ts
@@ -145,6 +145,26 @@ describe("server-utils", () => {
       await expect(requireAuth()).rejects.toThrow("REDIRECT:/login?error=email-not-verified");
       expect(mockRedirect).toHaveBeenCalledWith("/login?error=email-not-verified");
     });
+
+    it("should redirect to /login?incomplete=true when user is incomplete", async () => {
+      const session = createTestIncompleteSession(["realName"]);
+      mockGetSession.mockResolvedValue({ data: session, error: null });
+
+      await expect(requireAuth()).rejects.toThrow("REDIRECT:/login?incomplete=true");
+      expect(mockRedirect).toHaveBeenCalledWith("/login?incomplete=true");
+    });
+
+    it("should not redirect incomplete users when realName is not in session", async () => {
+      // Simulate a session where better-auth didn't include realName at all
+      const session = createTestBetterAuthSession();
+      delete (session.user as any).realName;
+      mockGetSession.mockResolvedValue({ data: session, error: null });
+
+      const result = await requireAuth();
+
+      expect(result.user.id).toBe(session.user.id);
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
   });
 
   describe("checkRole", () => {

--- a/lib/features/authentication/server-utils.ts
+++ b/lib/features/authentication/server-utils.ts
@@ -56,6 +56,13 @@ export async function requireAuth(): Promise<BetterAuthSession> {
     redirect("/login?error=email-not-verified");
   }
 
+  // Redirect incomplete users (missing realName) back to login for onboarding.
+  // Only check if realName is explicitly present as a key in the user object
+  // (better-auth includes additional fields when configured).
+  if ("realName" in session.user && isUserIncomplete(session)) {
+    redirect("/login?incomplete=true");
+  }
+
   return session;
 }
 


### PR DESCRIPTION
## Summary

Extracted from #271 (fix/e2e-test-infrastructure). Adds redirect logic so that users with incomplete profiles (missing `realName`) are sent to the onboarding form instead of the dashboard.

- **Login layout** (`app/login/@modern/layout.tsx`): Verified but incomplete users now see the onboarding form (`isIncomplete={true}`) instead of being redirected to the dashboard.
- **`requireAuth()`** (`lib/features/authentication/server-utils.ts`): Dashboard pages redirect incomplete users back to `/login?incomplete=true`. Uses an `"in"` check so the redirect only fires when better-auth actually includes `realName` in the session object.
- **E2E page object** (`e2e/pages/onboarding.page.ts`): `isOnOnboardingPage()` now recognizes `/login?incomplete=true` as an onboarding page.

## Test plan

- [x] Unit tests added for `requireAuth()` incomplete user redirect and the `realName`-not-in-session bypass
- [ ] Verify existing `server-utils.test.ts` tests pass (`npm run test:run`)
- [ ] Verify CI passes (lint, typecheck, unit tests, build)