### PR TITLE
Combine CI workflow jobs to reduce pipeline duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,58 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  lint-and-typecheck:
-    name: Lint & Type Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Type check
-        run: npx tsc --noEmit
-
-  unit-tests:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Run unit tests
-        run: npm run test:run
-
-      - name: Upload coverage
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: coverage-report
-          path: coverage/
-          retention-days: 7
-
-  build:
-    name: Build
+  lint-test-build:
+    name: Lint, Test & Build
     runs-on: ubuntu-latest
     env:
       NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
@@ -83,5 +33,21 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Run unit tests
+        run: npm run test:run
+
       - name: Build
         run: npm run build
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 7


### PR DESCRIPTION
## Summary

- Combines the three separate CI jobs (`lint-and-typecheck`, `unit-tests`, `build`) into a single "Lint, Test & Build" job
- Eliminates two redundant checkout + `npm ci` cycles, saving ~2 minutes of setup overhead per CI run
- Preserves all existing checks: TypeScript type checking, unit tests with coverage upload, and production build

Closes #275

## Test plan

- [ ] Verify the CI workflow triggers on this PR and all steps pass (type check, unit tests, build)
- [ ] Confirm the coverage artifact is uploaded successfully
- [ ] Confirm the build step has access to the `NEXT_PUBLIC_*` environment variables