### PR TITLE
Update GitHub Actions to v5 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
       NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -55,12 +55,12 @@ jobs:
 
     steps:
       - name: Checkout dj-site
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: dj-site
 
       - name: Checkout Backend-Service
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ github.repository_owner }}/Backend-Service
           ref: ${{ github.event.inputs.backend_ref || 'main' }}
@@ -68,7 +68,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4 to v5 in `ci.yml` and `e2e-tests.yml`
- Bump `actions/setup-node` from v4 to v5 in `ci.yml` and `e2e-tests.yml`
- v5 runs on Node.js 24, resolving the deprecation warning ahead of the June 2, 2026 force-migration deadline

Closes #281

## Test plan
- [ ] CI workflow passes without Node.js 20 deprecation warnings
- [ ] E2E workflow passes without Node.js 20 deprecation warnings