### PR TITLE
Fix album_name to album_title in catalog search params

### DIFF
--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -16,9 +16,9 @@ export const catalogApi = createApi({
   tagTypes: ["Rotation"],
   endpoints: (builder) => ({
     searchCatalog: builder.query<AlbumEntry[], SearchCatalogQueryParams>({
-      query: ({ artist_name, album_name, n }) => ({
+      query: ({ artist_name, album_title, n }) => ({
         url: "/",
-        params: { artist_name, album_name, n },
+        params: { artist_name, album_title, n },
       }),
       transformResponse: (response: AlbumSearchResultJSON[]) =>
         response.map(convertToAlbumEntry),

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -13,7 +13,7 @@ export type AlbumSearchResultJSON = Omit<AlbumSearchResult, "add_date"> & {
 
 export type SearchCatalogQueryParams = {
   artist_name: string | undefined;
-  album_name: string | undefined;
+  album_title: string | undefined;
   n: number | undefined;
 };
 

--- a/lib/test-utils/msw/handlers.ts
+++ b/lib/test-utils/msw/handlers.ts
@@ -8,7 +8,7 @@ export const handlers = [
   http.get(`${BACKEND_URL}/library/`, ({ request }) => {
     const url = new URL(request.url);
     const artistName = url.searchParams.get("artist_name");
-    const albumName = url.searchParams.get("album_name");
+    const albumName = url.searchParams.get("album_title");
 
     // Return empty array by default - tests can override with specific handlers
     return HttpResponse.json([]);

--- a/src/components/experiences/classic/catalog/SearchResults.tsx
+++ b/src/components/experiences/classic/catalog/SearchResults.tsx
@@ -13,7 +13,7 @@ export default function SearchResults() {
   const { data: results, isLoading, error } = useSearchCatalogQuery(
     {
       artist_name: searchString || undefined,
-      album_name: searchString || undefined,
+      album_title: searchString || undefined,
       n: 50,
     },
     {

--- a/src/hooks/__tests__/catalogSearchQuery.test.ts
+++ b/src/hooks/__tests__/catalogSearchQuery.test.ts
@@ -8,21 +8,21 @@ describe("catalog search query formatting (Bug 11)", () => {
     const query = formatCatalogSearchQuery("Albums", "test album", 10);
 
     expect(query.artist_name).toBeUndefined();
-    expect(query.album_name).toBe("test album");
+    expect(query.album_title).toBe("test album");
   });
 
-  it("should set album_name to undefined when searching Artists only", () => {
+  it("should set album_title to undefined when searching Artists only", () => {
     const query = formatCatalogSearchQuery("Artists", "test artist", 10);
 
     expect(query.artist_name).toBe("test artist");
-    expect(query.album_name).toBeUndefined();
+    expect(query.album_title).toBeUndefined();
   });
 
   it("should set both fields to the search string when searching Both", () => {
     const query = formatCatalogSearchQuery("All", "search term", 10);
 
     expect(query.artist_name).toBe("search term");
-    expect(query.album_name).toBe("search term");
+    expect(query.album_title).toBe("search term");
   });
 
   it("should never produce the literal string 'undefined'", () => {
@@ -34,7 +34,7 @@ describe("catalog search query formatting (Bug 11)", () => {
 
     for (const query of queries) {
       expect(query.artist_name).not.toBe("undefined");
-      expect(query.album_name).not.toBe("undefined");
+      expect(query.album_title).not.toBe("undefined");
     }
   });
 });

--- a/src/hooks/catalogHooks.ts
+++ b/src/hooks/catalogHooks.ts
@@ -13,11 +13,11 @@ export function formatCatalogSearchQuery(
 ): SearchCatalogQueryParams {
   switch (searchIn) {
     case "Albums":
-      return { artist_name: undefined, album_name: searchString, n };
+      return { artist_name: undefined, album_title: searchString, n };
     case "Artists":
-      return { artist_name: searchString, album_name: undefined, n };
+      return { artist_name: searchString, album_title: undefined, n };
     default:
-      return { artist_name: searchString, album_name: searchString, n };
+      return { artist_name: searchString, album_title: searchString, n };
   }
 }
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
@@ -107,7 +107,7 @@ export const useCatalogResults = () => {
   const [formattedQuery, setFormattedQuery] =
     useState<SearchCatalogQueryParams>({
       artist_name: undefined,
-      album_name: undefined,
+      album_title: undefined,
       n: 10,
     });
   const loadMore = () => dispatch(catalogSlice.actions.loadMore());
@@ -188,7 +188,7 @@ export const useCatalogFlowsheetSearch = () => {
   const { data } = useSearchCatalogQuery(
     {
       artist_name: flowsheetQuery.artist,
-      album_name: flowsheetQuery.album,
+      album_title: flowsheetQuery.album,
       n: 10,
     },
     {


### PR DESCRIPTION
## Summary

- Renames `album_name` to `album_title` in catalog search query params, API calls, hooks, components, MSW handlers, and tests
- Fixes a bug where album-only catalog searches silently failed because the frontend sent `album_name` but the backend expected `album_title`

Closes #289

## Context

The `CatalogSearchParams` schema in wxyc-shared was the sole source of `album_name` — every other schema, endpoint, and the backend controller use `album_title`. The generated types propagated this typo into the frontend.

Companion PR: WXYC/wxyc-shared#26

## Test plan

- [ ] `catalogSearchQuery.test.ts` passes (verified locally)
- [ ] Album-only catalog search returns results after both PRs merge
- [ ] Combined artist+album search still works