### PR TITLE
fix: restore E2E validation tests with timeout fix

### DIFF
--- a/e2e/pages/roster.page.ts
+++ b/e2e/pages/roster.page.ts
@@ -122,9 +122,9 @@ export class RosterPage {
     await expect(this.saveButton).toBeEnabled({ timeout: 5000 });
     await this.saveButton.click();
     await Promise.race([
-      this.saveButton.waitFor({ state: "hidden", timeout: 15000 }),
-      this.errorToast.waitFor({ state: "visible", timeout: 15000 }),
-      this.successToast.waitFor({ state: "visible", timeout: 15000 }),
+      this.saveButton.waitFor({ state: "hidden", timeout: 10000 }),
+      this.errorToast.waitFor({ state: "visible", timeout: 10000 }),
+      this.successToast.waitFor({ state: "visible", timeout: 10000 }),
     ]).catch(() => {});
   }
 

--- a/e2e/tests/admin/user-creation.spec.ts
+++ b/e2e/tests/admin/user-creation.spec.ts
@@ -94,6 +94,54 @@ test.describe("Admin User Creation", () => {
     await rosterPage.expectUserInRoster(username);
   });
 
+  test("should require real name field", async ({ page }) => {
+    await rosterPage.clickAddDj();
+
+    // Fill all fields except realName
+    await rosterPage.usernameInput.fill(generateUsername());
+    await rosterPage.emailInput.fill("test@test.wxyc.org");
+
+    // Try to submit
+    await rosterPage.submitNewAccount();
+
+    // HTML5 validation should prevent submission — form stays open
+    const formStillVisible = await rosterPage.realNameInput.isVisible().catch(() => false);
+    const errorShown = await rosterPage.errorToast.isVisible().catch(() => false);
+    expect(formStillVisible || errorShown).toBe(true);
+  });
+
+  test("should require username field", async ({ page }) => {
+    await rosterPage.clickAddDj();
+
+    // Fill all fields except username
+    await rosterPage.realNameInput.fill("Test User");
+    await rosterPage.emailInput.fill("test@test.wxyc.org");
+
+    // Try to submit
+    await rosterPage.submitNewAccount();
+
+    // HTML5 validation should prevent submission — form stays open
+    const formStillVisible = await rosterPage.usernameInput.isVisible().catch(() => false);
+    const errorShown = await rosterPage.errorToast.isVisible().catch(() => false);
+    expect(formStillVisible || errorShown).toBe(true);
+  });
+
+  test("should require email field", async ({ page }) => {
+    await rosterPage.clickAddDj();
+
+    // Fill all fields except email
+    await rosterPage.realNameInput.fill("Test User");
+    await rosterPage.usernameInput.fill(generateUsername());
+
+    // Try to submit
+    await rosterPage.submitNewAccount();
+
+    // HTML5 validation should prevent submission — form stays open
+    const formStillVisible = await rosterPage.emailInput.isVisible().catch(() => false);
+    const errorShown = await rosterPage.errorToast.isVisible().catch(() => false);
+    expect(formStillVisible || errorShown).toBe(true);
+  });
+
   test("should allow DJ name to be optional", async ({ page }) => {
     const username = generateUsername();
     const email = `${username}@test.wxyc.org`;
@@ -142,6 +190,23 @@ test.describe("Admin User Creation", () => {
 
     // Should show error toast
     await rosterPage.expectErrorToast();
+  });
+
+  test("should validate email format", async ({ page }) => {
+    await rosterPage.clickAddDj();
+
+    await rosterPage.fillNewAccountForm({
+      realName: "Invalid Email User",
+      username: generateUsername(),
+      email: "invalid-email", // Invalid email format
+    });
+
+    await rosterPage.submitNewAccount();
+
+    // HTML5 type="email" validation should prevent submission — form stays open
+    const formStillVisible = await rosterPage.emailInput.isVisible().catch(() => false);
+    const errorShown = await rosterPage.errorToast.isVisible().catch(() => false);
+    expect(formStillVisible || errorShown).toBe(true);
   });
 
   test("should close form when clicking away", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Restore the 4 user-creation validation tests that were incorrectly removed in the E2E workflow performance PR
- Reduce `submitNewAccount()` internal `Promise.race` timeout from 15s to 10s

## Root cause

The validation tests (require real name, require username, require email, validate email format) test HTML5 form validation — MUI Joy's `Input` components pass `required` to native `<input>` elements, which prevents form submission when fields are empty.

The tests were timing out because `submitNewAccount()` had a 15s internal `Promise.race` waiting for one of: save button hidden, success toast, or error toast. When HTML5 validation prevents submission, none of these conditions resolve, so the race sits for the full 15s. With a 20s test timeout, there wasn't enough headroom for form setup (~5s) + race (15s) + assertion.

Reducing the race to 10s leaves ~10s for setup and assertions within the 20s budget.

## Test plan
- [x] Verified HTML5 validation works via Playwright DOM inspection: `form.checkValidity()` returns `false`, `invalid` event fires, `submit` event does not fire, form stays visible
- [x] All 147 non-skipped tests pass locally (including the 4 restored tests)
- [x] Validation tests complete in ~15s each (10s race timeout + 5s setup)