### PR TITLE
Add segue toggle to DJ flowsheet UI

### DIFF
--- a/src/components/experiences/modern/flowsheet/Entries/Components/RemoveButton.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/Components/RemoveButton.test.tsx
@@ -21,6 +21,7 @@ const mockSongEntry = {
   album_title: "Test Album",
   record_label: "Test Label",
   request_flag: false,
+  segue: false,
 };
 
 const mockBreakpointEntry = {

--- a/src/components/experiences/modern/flowsheet/Entries/DraggableEntryWrapper.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/DraggableEntryWrapper.test.tsx
@@ -85,6 +85,7 @@ describe("DraggableEntryWrapper", () => {
     album_title: "Test Album",
     record_label: "Test Label",
     request_flag: false,
+    segue: false,
   };
 
   const mockMessageEntry: FlowsheetMessageEntry = {
@@ -422,6 +423,7 @@ describe("DraggableEntryWrapper", () => {
         album_title: "Album Title",
         record_label: "Label",
         request_flag: true,
+        segue: false,
         album_id: 123,
         rotation_id: 456,
         rotation: "H",

--- a/src/components/experiences/modern/flowsheet/Entries/Entry.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/Entry.test.tsx
@@ -63,6 +63,7 @@ describe("Entry", () => {
       album_title: "Test Album",
       record_label: "Test Label",
       request_flag: false,
+      segue: false,
     };
 
     it("should render SongEntry for song entries", () => {
@@ -354,6 +355,7 @@ describe("Entry", () => {
       album_title: "Test Album",
       record_label: "Test Label",
       request_flag: false,
+      segue: false,
     };
 
     it("should pass playing=true to SongEntry when playing", () => {

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.test.tsx
@@ -43,6 +43,7 @@ describe("FlowsheetEntryField", () => {
     album_title: "Test Album",
     record_label: "Test Label",
     request_flag: false,
+    segue: false,
     album_id: 42,
   };
 

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
@@ -123,6 +123,7 @@ describe("SongEntry", () => {
     album_title: "Test Album",
     record_label: "Test Label",
     request_flag: false,
+    segue: false,
     album_id: 42,
     rotation: "H",
     rotation_id: 10,
@@ -372,11 +373,66 @@ describe("SongEntry", () => {
     });
   });
 
+  describe("Segue checkbox", () => {
+    it("should render segue checkbox", () => {
+      render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
+
+      const checkboxes = screen.getAllByRole("checkbox");
+      expect(checkboxes.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should reflect segue state", () => {
+      const entryWithSegue = { ...mockEntry, segue: true };
+
+      render(
+        <SongEntry entry={entryWithSegue} playing={false} queue={false} />
+      );
+
+      const checkboxes = screen.getAllByRole("checkbox");
+      // Segue checkbox is the first one
+      expect(checkboxes[0]).toBeChecked();
+    });
+
+    it("should call updateFlowsheet when segue checkbox changes (not in queue)", () => {
+      mockUseShowControl.mockReturnValue({
+        live: true,
+        autoplay: false,
+        currentShow: 100,
+      });
+
+      render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
+
+      const checkboxes = screen.getAllByRole("checkbox");
+      fireEvent.click(checkboxes[0]);
+
+      expect(mockUpdateFlowsheet).toHaveBeenCalledWith({
+        entry_id: 1,
+        data: { segue: true },
+      });
+    });
+
+    it("should dispatch updateQueueEntry when segue checkbox changes (in queue)", () => {
+      mockUseShowControl.mockReturnValue({
+        live: true,
+        autoplay: false,
+        currentShow: 100,
+      });
+
+      render(<SongEntry entry={mockEntry} playing={false} queue={true} />);
+
+      const checkboxes = screen.getAllByRole("checkbox");
+      fireEvent.click(checkboxes[0]);
+
+      expect(mockDispatch).toHaveBeenCalled();
+    });
+  });
+
   describe("Request flag checkbox", () => {
     it("should render request flag checkbox", () => {
       render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
 
-      expect(screen.getByRole("checkbox")).toBeInTheDocument();
+      const checkboxes = screen.getAllByRole("checkbox");
+      expect(checkboxes.length).toBeGreaterThanOrEqual(2);
     });
 
     it("should reflect request_flag state", () => {
@@ -386,7 +442,9 @@ describe("SongEntry", () => {
         <SongEntry entry={entryWithRequest} playing={false} queue={false} />
       );
 
-      expect(screen.getByRole("checkbox")).toBeChecked();
+      const checkboxes = screen.getAllByRole("checkbox");
+      // Request checkbox is the second one
+      expect(checkboxes[1]).toBeChecked();
     });
 
     it("should be disabled when not editable", () => {
@@ -398,7 +456,8 @@ describe("SongEntry", () => {
 
       render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
 
-      expect(screen.getByRole("checkbox")).toBeDisabled();
+      const checkboxes = screen.getAllByRole("checkbox");
+      checkboxes.forEach((cb) => expect(cb).toBeDisabled());
     });
 
     it("should be enabled when editable", () => {
@@ -410,7 +469,8 @@ describe("SongEntry", () => {
 
       render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
 
-      expect(screen.getByRole("checkbox")).not.toBeDisabled();
+      const checkboxes = screen.getAllByRole("checkbox");
+      checkboxes.forEach((cb) => expect(cb).not.toBeDisabled());
     });
 
     it("should call updateFlowsheet when checkbox changes (not in queue)", () => {
@@ -422,8 +482,8 @@ describe("SongEntry", () => {
 
       render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
 
-      const checkbox = screen.getByRole("checkbox");
-      fireEvent.click(checkbox);
+      const checkboxes = screen.getAllByRole("checkbox");
+      fireEvent.click(checkboxes[1]);
 
       expect(mockUpdateFlowsheet).toHaveBeenCalledWith({
         entry_id: 1,
@@ -440,8 +500,8 @@ describe("SongEntry", () => {
 
       render(<SongEntry entry={mockEntry} playing={false} queue={true} />);
 
-      const checkbox = screen.getByRole("checkbox");
-      fireEvent.click(checkbox);
+      const checkboxes = screen.getAllByRole("checkbox");
+      fireEvent.click(checkboxes[1]);
 
       expect(mockDispatch).toHaveBeenCalled();
     });

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
@@ -15,6 +15,8 @@ import {
   Album,
   InfoOutlined,
   KeyboardArrowDown,
+  LinkRounded,
+  LinkOff,
   MusicNote,
   PhoneDisabled,
   PhoneEnabled,
@@ -160,6 +162,7 @@ export default function SongEntry({
                     album_title: entry.album_title,
                     record_label: entry.record_label,
                     request_flag: entry.request_flag,
+                    segue: entry.segue,
                     rotation_id: entry.rotation_id,
                     album_id: entry.album_id,
                     rotation_bin: entry.rotation,
@@ -226,6 +229,55 @@ export default function SongEntry({
           alignItems={"center"}
           spacing={0.5}
         >
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: "40px",
+              height: "40px",
+            }}
+          >
+            <Tooltip
+              variant="outlined"
+              size="sm"
+              title="Does this track segue from the previous?"
+            >
+              <Checkbox
+                size="sm"
+                variant="soft"
+                color={entry.segue ? "primary" : "neutral"}
+                uncheckedIcon={<LinkOff />}
+                checkedIcon={<LinkRounded />}
+                disabled={!editable}
+                sx={{
+                  opacity: entry.segue ? 1 : 0.3,
+                  "& .MuiCheckbox-checkbox": {
+                    background: "transparent",
+                  },
+                }}
+                checked={entry.segue}
+                onChange={(e) => {
+                  if (queue) {
+                    // Update queue entry in Redux state
+                    dispatch(flowsheetSlice.actions.updateQueueEntry({
+                      entry_id: entry.id,
+                      field: 'segue',
+                      value: e.target.checked,
+                    }));
+                  } else {
+                    // Update flowsheet entry via API
+                    updateFlowsheet({
+                      entry_id: entry.id,
+                      data: {
+                        segue: e.target.checked,
+                      },
+                    });
+                  }
+                }}
+              />
+            </Tooltip>
+          </Box>
           <Box
             sx={{
               display: "flex",

--- a/src/components/experiences/modern/flowsheet/RemoveFromQueueButton.test.tsx
+++ b/src/components/experiences/modern/flowsheet/RemoveFromQueueButton.test.tsx
@@ -21,6 +21,7 @@ describe("RemoveFromQueueButton", () => {
     album_title: "Test Album",
     record_label: "Test Label",
     request_flag: false,
+    segue: false,
   };
 
   beforeEach(() => {
@@ -258,6 +259,7 @@ describe("RemoveFromQueueButton", () => {
         album_title: "Full Album",
         record_label: "Full Label",
         request_flag: true,
+        segue: false,
         album_id: 123,
         rotation_id: 456,
         rotation: "H",

--- a/src/widgets/NowPlaying/AlbumArtAndIcons.test.tsx
+++ b/src/widgets/NowPlaying/AlbumArtAndIcons.test.tsx
@@ -88,6 +88,7 @@ describe("AlbumArtAndIcons", () => {
         album_title: "Test Album",
         record_label: "Test Label",
         request_flag: false,
+        segue: false,
       };
 
       render(<AlbumArtAndIcons entry={songEntry} />);
@@ -105,6 +106,7 @@ describe("AlbumArtAndIcons", () => {
         album_title: "Test Album",
         record_label: "Test Label",
         request_flag: false,
+        segue: false,
       };
 
       render(<AlbumArtAndIcons entry={songEntry} />);
@@ -121,6 +123,7 @@ describe("AlbumArtAndIcons", () => {
         album_title: "Test Album",
         record_label: "Test Label",
         request_flag: false,
+        segue: false,
       };
 
       render(<AlbumArtAndIcons entry={songEntry} />);

--- a/src/widgets/NowPlaying/EntryText.test.tsx
+++ b/src/widgets/NowPlaying/EntryText.test.tsx
@@ -47,6 +47,7 @@ describe("EntryText", () => {
         album_title: "Test Album",
         record_label: "Test Label",
         request_flag: false,
+        segue: false,
       };
 
       render(<EntryText entry={songEntry} />);

--- a/src/widgets/NowPlaying/Main.test.tsx
+++ b/src/widgets/NowPlaying/Main.test.tsx
@@ -310,6 +310,7 @@ describe("NowPlayingMain", () => {
         album_title: "Test Album",
         record_label: "Test Label",
         request_flag: false,
+        segue: false,
       };
 
       render(<NowPlayingMain {...createDefaultProps({ entry: songEntry })} />);
@@ -326,6 +327,7 @@ describe("NowPlayingMain", () => {
         album_title: "Test Album",
         record_label: "Test Label",
         request_flag: false,
+        segue: false,
       };
 
       render(<NowPlayingMain {...createDefaultProps({ entry: songEntry })} />);

--- a/src/widgets/NowPlaying/Mini.test.tsx
+++ b/src/widgets/NowPlaying/Mini.test.tsx
@@ -306,6 +306,7 @@ describe("NowPlayingMini", () => {
         album_title: "Test Album",
         record_label: "Test Label",
         request_flag: false,
+        segue: false,
       };
 
       render(<NowPlayingMini {...createDefaultProps({ entry: songEntry })} />);
@@ -322,6 +323,7 @@ describe("NowPlayingMini", () => {
         album_title: "Test Album",
         record_label: "Test Label",
         request_flag: false,
+        segue: false,
       };
 
       render(<NowPlayingMini {...createDefaultProps({ entry: songEntry })} />);

--- a/src/widgets/NowPlaying/index.test.tsx
+++ b/src/widgets/NowPlaying/index.test.tsx
@@ -82,6 +82,7 @@ describe("NowPlaying", () => {
     album_title: "Test Album",
     record_label: "Test Label",
     request_flag: false,
+    segue: false,
   };
 
   const mockDJsOnAirData: OnAirDJData = {


### PR DESCRIPTION
## Summary

- Add `segue: boolean` to `FlowsheetSongBase` and submission params
- Add segue to V2 track conversion and `addToQueue` reducer
- Add `LinkRounded`/`LinkOff` segue checkbox in modern `SongEntry.tsx`
- Add segue radio buttons in classic `EntryForm.tsx` and indicator in `EntryRow.tsx`
- Add localStorage migration for old queue entries
- Update factories, slice tests, conversion tests, and component tests (22 files)

Closes #296

## Test plan

- [x] `npm run test:run` passes (1780 tests across 142 files)
- [ ] Log in as test DJ, start a show, add tracks, toggle segue on/off
- [ ] Verify segue persists after page reload
- [ ] Test both modern and classic experiences