### PR TITLE
Fix flowsheet entries not appearing after submission

### DIFF
--- a/lib/__tests__/features/flowsheet/api.test.ts
+++ b/lib/__tests__/features/flowsheet/api.test.ts
@@ -1,6 +1,8 @@
-import { describe } from "vitest";
+import { describe, it, expect } from "vitest";
 import { flowsheetApi } from "@/lib/features/flowsheet/api";
 import { describeApi } from "@/lib/test-utils";
+import { makeStore } from "@/lib/store";
+import type { RootState } from "@/lib/store";
 
 describe("flowsheetApi", () => {
   describeApi(flowsheetApi, {
@@ -14,5 +16,15 @@ describe("flowsheetApi", () => {
       "switchEntries",
     ],
     reducerPath: "flowsheetApi",
+  });
+
+  it("should use immediate invalidation behavior", () => {
+    const store = makeStore();
+    const state = store.getState() as RootState & Record<string, unknown>;
+    const apiState = state[flowsheetApi.reducerPath] as {
+      config: { invalidationBehavior: string };
+    };
+
+    expect(apiState.config.invalidationBehavior).toBe("immediately");
   });
 });

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -22,6 +22,7 @@ export const flowsheetApi = createApi({
   reducerPath: "flowsheetApi",
   baseQuery: backendBaseQuery("flowsheet"),
   tagTypes: ["NowPlaying", "WhoIsLive", "Flowsheet"],
+  invalidationBehavior: "immediately",
   endpoints: (builder) => ({
     getNowPlaying: builder.query<FlowsheetEntry, void>({
       query: () => ({


### PR DESCRIPTION
## Summary

- Set `invalidationBehavior: 'immediately'` on the flowsheet API slice to fix entries not appearing after submission until hard refresh
- RTK Query's default `'delayed'` invalidation interacts badly with polling infinite queries, causing tag invalidations to be indefinitely deferred ([reduxjs/toolkit#4347](https://github.com/reduxjs/toolkit/issues/4347))
- Added test verifying the invalidation behavior is configured correctly

Closes #298

## Test plan

- [ ] Verify `npm run test:run` passes with the new test for `invalidationBehavior`
- [ ] Verify `npx tsc --noEmit` passes with no new type errors
- [ ] Manually test on local dev: add a flowsheet entry and confirm it appears without refreshing