### PR TITLE
Fix Enter key submission on auto-filled flowsheet inputs

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.test.tsx
@@ -169,7 +169,7 @@ describe("FlowsheetSearchInput", () => {
     expect(input).toHaveAttribute("readonly");
   });
 
-  it("should prevent keydown when auto-filled except Tab and Shift", async () => {
+  it("should prevent keydown when auto-filled except Tab, Shift, and Enter", async () => {
     const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
     vi.mocked(useFlowsheetSearch).mockReturnValue({
       getDisplayValue: () => "Auto-filled value",
@@ -186,12 +186,37 @@ describe("FlowsheetSearchInput", () => {
 
     // Regular key should be prevented
     const letterEvent = fireEvent.keyDown(input, { key: 'a' });
+    expect(letterEvent).toBe(false); // preventDefault was called
+
     // Tab should not be prevented
     const tabEvent = fireEvent.keyDown(input, { key: 'Tab' });
+    expect(tabEvent).toBe(true); // default not prevented
+
     // Shift should not be prevented
     const shiftEvent = fireEvent.keyDown(input, { key: 'Shift' });
+    expect(shiftEvent).toBe(true);
 
     expect(input).toHaveAttribute("readonly");
+  });
+
+  it("should not prevent Enter keydown when auto-filled so form submission works", async () => {
+    const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
+    vi.mocked(useFlowsheetSearch).mockReturnValue({
+      getDisplayValue: () => "Auto-filled value",
+      setSearchProperty: mockSetSearchProperty,
+      selectedIndex: 1,
+      selectedEntry: {
+        artist: { name: "Test Artist" },
+      },
+    } as any);
+
+    render(<FlowsheetSearchInput name="artist" />);
+
+    const input = screen.getByRole("textbox");
+
+    // Enter should not be prevented — it must propagate for form submission
+    const enterEvent = fireEvent.keyDown(input, { key: 'Enter' });
+    expect(enterEvent).toBe(true);
   });
 
   it("should not call setSearchProperty when auto-filled", async () => {

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.tsx
@@ -95,7 +95,7 @@ export default function FlowsheetSearchInput({
           }
         }}
         onKeyDown={(e) => {
-          if (isAutoFilled && e.key !== "Tab" && e.key !== "Shift") {
+          if (isAutoFilled && e.key !== "Tab" && e.key !== "Shift" && e.key !== "Enter") {
             e.preventDefault();
             return;
           }


### PR DESCRIPTION
## Summary

- The `onKeyDown` handler in `FlowsheetSearchInput` was blocking Enter on auto-filled fields, preventing form submission when a search result was selected via arrow keys
- Added `'Enter'` to the allow-list alongside Tab and Shift so the browser's default form submission behavior is preserved
- Added test coverage verifying Enter keydown is not prevented on auto-filled inputs

Closes #302

## Test plan

- [ ] Verify `FlowsheetSearchInput` tests pass, including the new Enter key assertion
- [ ] Manually test: use arrow keys to select a search result, then press Enter -- the entry should be submitted to the flowsheet
- [ ] Verify Tab and Shift still work as expected on auto-filled fields
- [ ] Verify typing letter keys into auto-filled fields is still blocked