### PR TITLE
Replace direct Discogs artwork call with backend proxy

### DIFF
--- a/src/hooks/applicationHooks.ts
+++ b/src/hooks/applicationHooks.ts
@@ -7,6 +7,7 @@ import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { useAppDispatch } from "@/lib/hooks";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
+import getArtworkFromProxy from "./artwork/proxy-image";
 import getArtworkFromItunes from "./artwork/itunes-image";
 import getArtworkFromLastFM from "./artwork/last-fm-image";
 
@@ -66,6 +67,7 @@ export const useAlbumImages = () => {
   const [url, setUrl] = useState<string>(DEFAULT_URL);
 
   let functions = [
+    getArtworkFromProxy,
     getArtworkFromItunes,
     getArtworkFromLastFM,
   ];

--- a/src/hooks/artwork/__tests__/proxy-image.test.ts
+++ b/src/hooks/artwork/__tests__/proxy-image.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/lib/test-utils/msw/server";
+
+const BACKEND_URL = "http://localhost:3001";
+
+// Mock the auth client module to avoid pulling in better-auth React internals
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn(),
+}));
+
+import { getJWTToken } from "@/lib/features/authentication/client";
+import getArtworkFromProxy from "../proxy-image";
+
+const mockedGetJWTToken = vi.mocked(getJWTToken);
+
+describe("getArtworkFromProxy", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_BACKEND_URL", BACKEND_URL);
+    mockedGetJWTToken.mockResolvedValue("test-jwt-token");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns a blob URL when the proxy returns image bytes", async () => {
+    const fakeImageBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]); // PNG magic bytes
+
+    server.use(
+      http.get(`${BACKEND_URL}/proxy/artwork/search`, () => {
+        return new HttpResponse(fakeImageBytes, {
+          headers: { "Content-Type": "image/png" },
+        });
+      }),
+    );
+
+    const result = await getArtworkFromProxy({
+      title: "Confield",
+      artist: "Autechre",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).toMatch(/^blob:/);
+  });
+
+  it("passes artistName and releaseTitle as query parameters", async () => {
+    let capturedUrl: URL | null = null;
+
+    server.use(
+      http.get(`${BACKEND_URL}/proxy/artwork/search`, ({ request }) => {
+        capturedUrl = new URL(request.url);
+        return new HttpResponse(new Uint8Array([1, 2, 3]), {
+          headers: { "Content-Type": "image/jpeg" },
+        });
+      }),
+    );
+
+    await getArtworkFromProxy({
+      title: "Moon Pix",
+      artist: "Cat Power",
+    });
+
+    expect(capturedUrl).not.toBeNull();
+    expect(capturedUrl!.searchParams.get("artistName")).toBe("Cat Power");
+    expect(capturedUrl!.searchParams.get("releaseTitle")).toBe("Moon Pix");
+  });
+
+  it("includes JWT Bearer token in the request", async () => {
+    let capturedAuthHeader: string | null = null;
+
+    server.use(
+      http.get(`${BACKEND_URL}/proxy/artwork/search`, ({ request }) => {
+        capturedAuthHeader = request.headers.get("Authorization");
+        return new HttpResponse(new Uint8Array([1, 2, 3]), {
+          headers: { "Content-Type": "image/jpeg" },
+        });
+      }),
+    );
+
+    await getArtworkFromProxy({ title: "Confield", artist: "Autechre" });
+
+    expect(capturedAuthHeader).toBe("Bearer test-jwt-token");
+  });
+
+  it("works without a JWT token (unauthenticated)", async () => {
+    mockedGetJWTToken.mockResolvedValue(null);
+
+    let capturedAuthHeader: string | null = null;
+
+    server.use(
+      http.get(`${BACKEND_URL}/proxy/artwork/search`, ({ request }) => {
+        capturedAuthHeader = request.headers.get("Authorization");
+        return new HttpResponse(new Uint8Array([1, 2, 3]), {
+          headers: { "Content-Type": "image/jpeg" },
+        });
+      }),
+    );
+
+    const result = await getArtworkFromProxy({
+      title: "Confield",
+      artist: "Autechre",
+    });
+
+    expect(capturedAuthHeader).toBeNull();
+    expect(result).toMatch(/^blob:/);
+  });
+
+  it("returns null when the proxy returns a non-OK response", async () => {
+    server.use(
+      http.get(`${BACKEND_URL}/proxy/artwork/search`, () => {
+        return HttpResponse.json(
+          { message: "No artwork found" },
+          { status: 404 },
+        );
+      }),
+    );
+
+    const result = await getArtworkFromProxy({
+      title: "Nonexistent Album",
+      artist: "Unknown Artist",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fetch throws a network error", async () => {
+    server.use(
+      http.get(`${BACKEND_URL}/proxy/artwork/search`, () => {
+        return HttpResponse.error();
+      }),
+    );
+
+    const result = await getArtworkFromProxy({
+      title: "Confield",
+      artist: "Autechre",
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/hooks/artwork/proxy-image.ts
+++ b/src/hooks/artwork/proxy-image.ts
@@ -1,0 +1,43 @@
+import { getJWTToken } from "@/lib/features/authentication/client";
+
+/**
+ * Fetches album artwork from the Backend-Service artwork proxy.
+ *
+ * The proxy searches Discogs, Last.fm, and iTunes server-side, downloads the
+ * image, runs NSFW classification, and returns raw image bytes. This avoids
+ * exposing any API credentials to the client.
+ *
+ * @returns A blob URL pointing to the image data, or null if no artwork was found.
+ */
+export default async function getArtworkFromProxy({
+  title,
+  artist,
+}: {
+  title: string;
+  artist: string;
+}): Promise<string | null> {
+  try {
+    const params = new URLSearchParams({
+      artistName: artist,
+      releaseTitle: title,
+    });
+    const url = `${process.env.NEXT_PUBLIC_BACKEND_URL}/proxy/artwork/search?${params}`;
+
+    const headers: HeadersInit = {};
+    const token = await getJWTToken();
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
+    }
+
+    const response = await fetch(url, { headers });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const blob = await response.blob();
+    return URL.createObjectURL(blob);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Replace the direct Discogs API call in `discogs-image.ts` with a call to `GET /proxy/artwork/search` on the Backend-Service, eliminating client-side Discogs credential exposure
- The proxy returns image bytes directly; the hook creates a blob URL for use as an img src
- Remove `DISCOGS_CONSUMER_KEY` and `DISCOGS_CONSUMER_SECRET` from the client-side environment (no other code references them)

Closes #304

## Dependencies

- Depends on WXYC/Backend-Service#266 (proxy endpoint must be deployed)

## Test plan

- [x] `npm run test` passes (143 files, 1778 tests)
- [x] 6 new tests for `getArtworkFromProxy` covering: successful blob URL creation, query parameter passing, JWT auth header inclusion, unauthenticated fallback, 404 handling, network error handling
- [x] Verified no other code in dj-site references `DISCOGS_CONSUMER_KEY` or `DISCOGS_CONSUMER_SECRET`
- [ ] Artwork loads in playlist view without Discogs credentials in client config (manual verification after Backend-Service#266 deploys)