### PR TITLE
fix: Flowsheet Entry Caching

### DIFF
--- a/lib/__tests__/features/flowsheet/constants.test.ts
+++ b/lib/__tests__/features/flowsheet/constants.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import {
+  FLOWSHEET_OPTIMISTIC_DJ_PLACEHOLDER,
+  FLOWSHEET_PAGE_SIZE,
+  OFF_AIR_LABEL,
+} from "@/lib/features/flowsheet/constants";
+
+describe("flowsheet constants", () => {
+  it("exports stable pagination and copy constants", () => {
+    expect(FLOWSHEET_PAGE_SIZE).toBe(20);
+    expect(OFF_AIR_LABEL).toBe("Off Air");
+    expect(FLOWSHEET_OPTIMISTIC_DJ_PLACEHOLDER).toBeTruthy();
+  });
+});

--- a/lib/__tests__/features/flowsheet/infinite-cache.test.ts
+++ b/lib/__tests__/features/flowsheet/infinite-cache.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import type { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
+import {
+  buildOptimisticEntry,
+  insertEntrySortedFirstPage,
+  maxPlayOrder,
+  primaryShowId,
+  removeEntryById,
+  replaceEntryIdAllPages,
+  swapPlayOrdersForSwitch,
+} from "@/lib/features/flowsheet/infinite-cache";
+
+function song(
+  id: number,
+  play_order: number,
+  show_id: number
+): FlowsheetSongEntry {
+  return {
+    id,
+    play_order,
+    show_id,
+    track_title: `t${id}`,
+    artist_name: "a",
+    album_title: "al",
+    record_label: "",
+    request_flag: false,
+  };
+}
+
+describe("infinite-cache", () => {
+  it("maxPlayOrder and primaryShowId read pages", () => {
+    const draft = {
+      pages: [
+        [song(1, 10, 5), song(2, 5, 5)],
+        [song(3, 3, 5)],
+      ],
+      pageParams: [0, 1],
+    };
+    expect(maxPlayOrder(draft)).toBe(10);
+    expect(primaryShowId(draft)).toBe(5);
+  });
+
+  it("insertEntrySortedFirstPage keeps descending play_order on page 0", () => {
+    const draft = {
+      pages: [[song(1, 10, 1), song(2, 8, 1)]],
+      pageParams: [0],
+    };
+    insertEntrySortedFirstPage(draft, song(99, 12, 1));
+    expect(draft.pages[0].map((e) => e.id)).toEqual([99, 1, 2]);
+  });
+
+  it("insertEntrySortedFirstPage initializes empty cache", () => {
+    const draft = { pages: [] as FlowsheetSongEntry[][], pageParams: [] as number[] };
+    insertEntrySortedFirstPage(draft, song(1, 1, 2));
+    expect(draft.pages).toEqual([[song(1, 1, 2)]]);
+    expect(draft.pageParams).toEqual([0]);
+  });
+
+  it("removeEntryById removes from nested page", () => {
+    const draft = {
+      pages: [[song(1, 10, 1)], [song(2, 5, 1)]],
+      pageParams: [0, 1],
+    };
+    removeEntryById(draft, 2);
+    expect(draft.pages[1]).toHaveLength(0);
+  });
+
+  it("replaceEntryIdAllPages swaps temp id for server entry", () => {
+    const draft = {
+      pages: [[song(-1, 10, 1)]],
+      pageParams: [0],
+    };
+    const server = song(42, 10, 1);
+    replaceEntryIdAllPages(draft, -1, server);
+    expect(draft.pages[0][0].id).toBe(42);
+  });
+
+  it("swapPlayOrdersForSwitch swaps play_order between two entries", () => {
+    const a = song(1, 100, 1);
+    const b = song(2, 50, 1);
+    const draft = { pages: [[a, b]], pageParams: [0] };
+    swapPlayOrdersForSwitch(draft, 1, 50);
+    expect(draft.pages[0][0].play_order).toBe(50);
+    expect(draft.pages[0][1].play_order).toBe(100);
+  });
+
+  it("buildOptimisticEntry builds a track row from manual submission", () => {
+    const draft = { pages: [[song(1, 10, 7)]], pageParams: [0] };
+    const { entry, tempId } = buildOptimisticEntry(
+      {
+        track_title: "X",
+        artist_name: "Y",
+        album_title: "Z",
+        request_flag: false,
+      },
+      draft
+    );
+    expect(tempId).toBeLessThan(0);
+    expect(entry.play_order).toBe(11);
+    expect("track_title" in entry && entry.track_title).toBe("X");
+  });
+});

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -8,6 +8,14 @@ import {
   extractFlowsheetEntries,
 } from "./conversions";
 import {
+  buildOptimisticEntry,
+  insertEntrySortedFirstPage,
+  patchEntryById,
+  removeEntryById,
+  replaceEntryIdAllPages,
+  swapPlayOrdersForSwitch,
+} from "./infinite-cache";
+import {
   FlowsheetEntry,
   FlowsheetSubmissionParams,
   FlowsheetSwitchParams,
@@ -57,23 +65,95 @@ export const flowsheetApi = createApi({
         method: "PATCH",
         body: params,
       }),
-      invalidatesTags: ["Flowsheet", "NowPlaying"],
+      invalidatesTags: ["NowPlaying"],
+      async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+        const patchResult = dispatch(
+          flowsheetApi.util.updateQueryData(
+            "getInfiniteEntries",
+            undefined,
+            (draft) => {
+              swapPlayOrdersForSwitch(draft, arg.entry_id, arg.new_position);
+            }
+          )
+        );
+        try {
+          await queryFulfilled;
+          dispatch(
+            flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
+              forceRefetch: true,
+            })
+          );
+        } catch {
+          patchResult.undo();
+        }
+      },
     }),
-    joinShow: builder.mutation<any, DJRequestParams>({
+    joinShow: builder.mutation<void, DJRequestParams>({
       query: (params) => ({
         url: "/join",
         method: "POST",
         body: params,
       }),
-      invalidatesTags: ["NowPlaying", "WhoIsLive", "Flowsheet"],
+      invalidatesTags: ["NowPlaying", "WhoIsLive"],
+      async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+        const patchLive = dispatch(
+          flowsheetApi.util.updateQueryData(
+            "whoIsLive",
+            undefined,
+            (draft) => {
+              if (!draft?.djs) return;
+              if (!draft.djs.some((d) => d.id === arg.dj_id)) {
+                draft.djs.push({ id: arg.dj_id, dj_name: "Live" });
+                draft.onAir = draft.djs.map((d) => `DJ ${d.dj_name}`).join(", ");
+              }
+            }
+          )
+        );
+        try {
+          await queryFulfilled;
+          dispatch(
+            flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
+              forceRefetch: true,
+            })
+          );
+        } catch {
+          patchLive.undo();
+        }
+      },
     }),
-    leaveShow: builder.mutation<any, DJRequestParams>({
+    leaveShow: builder.mutation<void, DJRequestParams>({
       query: (params) => ({
         url: "/end",
         method: "POST",
         body: params,
       }),
-      invalidatesTags: ["NowPlaying", "WhoIsLive", "Flowsheet"],
+      invalidatesTags: ["NowPlaying", "WhoIsLive"],
+      async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+        const patchLive = dispatch(
+          flowsheetApi.util.updateQueryData(
+            "whoIsLive",
+            undefined,
+            (draft) => {
+              if (!draft?.djs) return;
+              draft.djs = draft.djs.filter((d) => d.id !== arg.dj_id);
+              draft.onAir =
+                draft.djs.length > 0
+                  ? draft.djs.map((d) => `DJ ${d.dj_name}`).join(", ")
+                  : "Off Air";
+            }
+          )
+        );
+        try {
+          await queryFulfilled;
+          dispatch(
+            flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
+              forceRefetch: true,
+            })
+          );
+        } catch {
+          patchLive.undo();
+        }
+      },
     }),
     whoIsLive: builder.query<OnAirDJData, void>({
       query: () => ({
@@ -83,15 +163,68 @@ export const flowsheetApi = createApi({
         convertDJsOnAir(response),
       providesTags: ["WhoIsLive"],
     }),
-    addToFlowsheet: builder.mutation<any, FlowsheetSubmissionParams>({
-      query: (params) => ({
-        url: "/",
-        method: "POST",
-        body: params,
-      }),
-      invalidatesTags: ["Flowsheet", "NowPlaying"],
-    }),
-    removeFromFlowsheet: builder.mutation<any, number>({
+    addToFlowsheet: builder.mutation<FlowsheetEntry, FlowsheetSubmissionParams>(
+      {
+        query: (params) => ({
+          url: "/",
+          method: "POST",
+          body: params,
+        }),
+        transformResponse: (response: FlowsheetV2EntryJSON) =>
+          convertV2Entry(response),
+        invalidatesTags: ["NowPlaying"],
+        async onQueryStarted(arg, { dispatch, queryFulfilled, getState }) {
+          const selector = flowsheetApi.endpoints.getInfiniteEntries.select(
+            undefined
+          );
+          const cached = selector(getState() as never);
+          let tempId: number | undefined;
+          let patchResult: { undo: () => void } | undefined;
+
+          if (cached?.data?.pages?.length) {
+            const { entry, tempId: tid } = buildOptimisticEntry(
+              arg,
+              cached.data
+            );
+            tempId = tid;
+            patchResult = dispatch(
+              flowsheetApi.util.updateQueryData(
+                "getInfiniteEntries",
+                undefined,
+                (draft) => {
+                  insertEntrySortedFirstPage(draft, entry);
+                }
+              )
+            );
+          }
+
+          try {
+            const { data } = await queryFulfilled;
+            dispatch(
+              flowsheetApi.util.updateQueryData(
+                "getInfiniteEntries",
+                undefined,
+                (draft) => {
+                  if (tempId !== undefined) {
+                    replaceEntryIdAllPages(draft, tempId, data);
+                  } else {
+                    insertEntrySortedFirstPage(draft, data);
+                  }
+                }
+              )
+            );
+            dispatch(
+              flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
+                forceRefetch: true,
+              })
+            );
+          } catch {
+            patchResult?.undo();
+          }
+        },
+      }
+    ),
+    removeFromFlowsheet: builder.mutation<void, number>({
       query: (entry_id) => ({
         url: "/",
         method: "DELETE",
@@ -99,15 +232,57 @@ export const flowsheetApi = createApi({
           entry_id,
         },
       }),
-      invalidatesTags: ["Flowsheet", "NowPlaying"],
+      invalidatesTags: ["NowPlaying"],
+      async onQueryStarted(entry_id, { dispatch, queryFulfilled }) {
+        const patchResult = dispatch(
+          flowsheetApi.util.updateQueryData(
+            "getInfiniteEntries",
+            undefined,
+            (draft) => {
+              removeEntryById(draft, entry_id);
+            }
+          )
+        );
+        try {
+          await queryFulfilled;
+          dispatch(
+            flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
+              forceRefetch: true,
+            })
+          );
+        } catch {
+          patchResult.undo();
+        }
+      },
     }),
-    updateFlowsheet: builder.mutation<any, FlowsheetUpdateParams>({
+    updateFlowsheet: builder.mutation<void, FlowsheetUpdateParams>({
       query: (params) => ({
         url: "/",
         method: "PATCH",
         body: params,
       }),
-      invalidatesTags: ["Flowsheet", "NowPlaying"],
+      invalidatesTags: ["NowPlaying"],
+      async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+        const patchResult = dispatch(
+          flowsheetApi.util.updateQueryData(
+            "getInfiniteEntries",
+            undefined,
+            (draft) => {
+              patchEntryById(draft, arg.entry_id, arg.data as Partial<FlowsheetEntry>);
+            }
+          )
+        );
+        try {
+          await queryFulfilled;
+          dispatch(
+            flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
+              forceRefetch: true,
+            })
+          );
+        } catch {
+          patchResult.undo();
+        }
+      },
     }),
   }),
 });

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -2,10 +2,15 @@ import { createApi } from "@reduxjs/toolkit/query/react";
 import { DJRequestParams } from "../authentication/types";
 import { backendBaseQuery } from "../backend";
 import {
+  FLOWSHEET_OPTIMISTIC_DJ_PLACEHOLDER,
+  FLOWSHEET_PAGE_SIZE,
+} from "./constants";
+import {
   convertDJsOnAir,
   convertV2Entry,
   convertV2FlowsheetResponse,
   extractFlowsheetEntries,
+  formatOnAirSummary,
 } from "./conversions";
 import {
   buildOptimisticEntry,
@@ -25,6 +30,12 @@ import {
   OnAirDJData,
   OnAirDJResponse,
 } from "./types";
+
+function flowsheetMutationCatch(endpoint: string, err: unknown) {
+  if (process.env.NODE_ENV === "development") {
+    console.warn(`[flowsheet] ${endpoint}`, err);
+  }
+}
 
 export const flowsheetApi = createApi({
   reducerPath: "flowsheetApi",
@@ -47,11 +58,13 @@ export const flowsheetApi = createApi({
       infiniteQueryOptions: {
         initialPageParam: 0,
         getNextPageParam: (lastPage, _allPages, lastPageParam) =>
-          lastPage.length < 20 ? undefined : lastPageParam + 1,
+          lastPage.length < FLOWSHEET_PAGE_SIZE
+            ? undefined
+            : lastPageParam + 1,
       },
       query({ pageParam }) {
         return {
-          url: `/?page=${pageParam}&limit=20`,
+          url: `/?page=${pageParam}&limit=${FLOWSHEET_PAGE_SIZE}`,
         };
       },
       transformResponse: (
@@ -78,12 +91,9 @@ export const flowsheetApi = createApi({
         );
         try {
           await queryFulfilled;
-          dispatch(
-            flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
-              forceRefetch: true,
-            })
-          );
-        } catch {
+          dispatch(flowsheetApi.util.invalidateTags(["Flowsheet"]));
+        } catch (err) {
+          flowsheetMutationCatch("switchEntries", err);
           patchResult.undo();
         }
       },
@@ -103,20 +113,20 @@ export const flowsheetApi = createApi({
             (draft) => {
               if (!draft?.djs) return;
               if (!draft.djs.some((d) => d.id === arg.dj_id)) {
-                draft.djs.push({ id: arg.dj_id, dj_name: "Live" });
-                draft.onAir = draft.djs.map((d) => `DJ ${d.dj_name}`).join(", ");
+                draft.djs.push({
+                  id: arg.dj_id,
+                  dj_name: FLOWSHEET_OPTIMISTIC_DJ_PLACEHOLDER,
+                });
+                draft.onAir = formatOnAirSummary(draft.djs);
               }
             }
           )
         );
         try {
           await queryFulfilled;
-          dispatch(
-            flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
-              forceRefetch: true,
-            })
-          );
-        } catch {
+          dispatch(flowsheetApi.util.invalidateTags(["Flowsheet"]));
+        } catch (err) {
+          flowsheetMutationCatch("joinShow", err);
           patchLive.undo();
         }
       },
@@ -136,21 +146,15 @@ export const flowsheetApi = createApi({
             (draft) => {
               if (!draft?.djs) return;
               draft.djs = draft.djs.filter((d) => d.id !== arg.dj_id);
-              draft.onAir =
-                draft.djs.length > 0
-                  ? draft.djs.map((d) => `DJ ${d.dj_name}`).join(", ")
-                  : "Off Air";
+              draft.onAir = formatOnAirSummary(draft.djs);
             }
           )
         );
         try {
           await queryFulfilled;
-          dispatch(
-            flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
-              forceRefetch: true,
-            })
-          );
-        } catch {
+          dispatch(flowsheetApi.util.invalidateTags(["Flowsheet"]));
+        } catch (err) {
+          flowsheetMutationCatch("leaveShow", err);
           patchLive.undo();
         }
       },
@@ -174,10 +178,13 @@ export const flowsheetApi = createApi({
           convertV2Entry(response),
         invalidatesTags: ["NowPlaying"],
         async onQueryStarted(arg, { dispatch, queryFulfilled, getState }) {
-          const selector = flowsheetApi.endpoints.getInfiniteEntries.select(
-            undefined
-          );
-          const cached = selector(getState() as never);
+          const root = getState() as {
+            flowsheetApi: ReturnType<typeof flowsheetApi.reducer>;
+          };
+          const cached =
+            flowsheetApi.endpoints.getInfiniteEntries.select(undefined)(root);
+          const hadCachedList = cached?.data != null;
+
           let tempId: number | undefined;
           let patchResult: { undo: () => void } | undefined;
 
@@ -200,25 +207,25 @@ export const flowsheetApi = createApi({
 
           try {
             const { data } = await queryFulfilled;
-            dispatch(
-              flowsheetApi.util.updateQueryData(
-                "getInfiniteEntries",
-                undefined,
-                (draft) => {
-                  if (tempId !== undefined) {
-                    replaceEntryIdAllPages(draft, tempId, data);
-                  } else {
-                    insertEntrySortedFirstPage(draft, data);
+            if (hadCachedList) {
+              dispatch(
+                flowsheetApi.util.updateQueryData(
+                  "getInfiniteEntries",
+                  undefined,
+                  (draft) => {
+                    if (tempId !== undefined) {
+                      replaceEntryIdAllPages(draft, tempId, data);
+                    } else {
+                      insertEntrySortedFirstPage(draft, data);
+                    }
                   }
-                }
-              )
-            );
-            dispatch(
-              flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
-                forceRefetch: true,
-              })
-            );
-          } catch {
+                )
+              );
+            } else {
+              dispatch(flowsheetApi.util.invalidateTags(["Flowsheet"]));
+            }
+          } catch (err) {
+            flowsheetMutationCatch("addToFlowsheet", err);
             patchResult?.undo();
           }
         },
@@ -245,12 +252,9 @@ export const flowsheetApi = createApi({
         );
         try {
           await queryFulfilled;
-          dispatch(
-            flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
-              forceRefetch: true,
-            })
-          );
-        } catch {
+          dispatch(flowsheetApi.util.invalidateTags(["Flowsheet"]));
+        } catch (err) {
+          flowsheetMutationCatch("removeFromFlowsheet", err);
           patchResult.undo();
         }
       },
@@ -274,12 +278,9 @@ export const flowsheetApi = createApi({
         );
         try {
           await queryFulfilled;
-          dispatch(
-            flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
-              forceRefetch: true,
-            })
-          );
-        } catch {
+          dispatch(flowsheetApi.util.invalidateTags(["Flowsheet"]));
+        } catch (err) {
+          flowsheetMutationCatch("updateFlowsheet", err);
           patchResult.undo();
         }
       },

--- a/lib/features/flowsheet/constants.ts
+++ b/lib/features/flowsheet/constants.ts
@@ -1,0 +1,8 @@
+/** Page size for flowsheet list / infinite query (must match backend pagination). */
+export const FLOWSHEET_PAGE_SIZE = 20;
+
+/** Shown as `dj_name` until WhoIsLive refetches after join. */
+export const FLOWSHEET_OPTIMISTIC_DJ_PLACEHOLDER = "Live";
+
+/** Empty / off-air summary label (keep in sync with API copy). */
+export const OFF_AIR_LABEL = "Off Air";

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -1,4 +1,5 @@
 import { Rotation } from "../rotation/types";
+import { OFF_AIR_LABEL } from "./constants";
 import {
   FlowsheetEntry,
   FlowsheetQuery,
@@ -8,6 +9,12 @@ import {
   OnAirDJData,
   OnAirDJResponse,
 } from "./types";
+
+/** Single place for "DJ A, DJ B" on-air string (WhoIsLive + optimistic patches). */
+export function formatOnAirSummary(djs: OnAirDJResponse[]): string {
+  if (!djs.length) return OFF_AIR_LABEL;
+  return djs.map((dj) => `DJ ${dj.dj_name}`).join(", ");
+}
 
 export function convertQueryToSubmission(
   query: FlowsheetQuery
@@ -29,13 +36,13 @@ export function convertDJsOnAir(
   if (!response || response.length === 0) {
     return {
       djs: [],
-      onAir: "Off Air",
+      onAir: OFF_AIR_LABEL,
     };
   }
 
   return {
     djs: response,
-    onAir: response.map((dj) => `DJ ${dj.dj_name}`).join(", "),
+    onAir: formatOnAirSummary(response),
   };
 }
 

--- a/lib/features/flowsheet/infinite-cache.ts
+++ b/lib/features/flowsheet/infinite-cache.ts
@@ -1,0 +1,161 @@
+import type {
+  FlowsheetEntry,
+  FlowsheetMessageEntry,
+  FlowsheetSongEntry,
+  FlowsheetSubmissionParams,
+} from "./types";
+
+/** Draft shape for RTK `getInfiniteEntries` cache (Immer draft). */
+export type InfiniteEntriesDraft = {
+  pages: FlowsheetEntry[][];
+  pageParams: number[];
+};
+
+export function maxPlayOrder(draft: Pick<InfiniteEntriesDraft, "pages">): number {
+  let m = 0;
+  for (const page of draft.pages) {
+    for (const e of page) {
+      if (e.play_order > m) m = e.play_order;
+    }
+  }
+  return m;
+}
+
+/** First non-empty `show_id` in page order, or `-1` if none. */
+export function primaryShowId(draft: Pick<InfiniteEntriesDraft, "pages">): number {
+  for (const page of draft.pages) {
+    if (page.length > 0) return page[0].show_id;
+  }
+  return -1;
+}
+
+export function nextOptimisticTempId(): number {
+  return -(Date.now() * 1000 + Math.floor(Math.random() * 1000));
+}
+
+export function buildOptimisticEntry(
+  arg: FlowsheetSubmissionParams,
+  draft: Pick<InfiniteEntriesDraft, "pages">
+): { entry: FlowsheetEntry; tempId: number } {
+  const tempId = nextOptimisticTempId();
+  const play_order = maxPlayOrder(draft) + 1;
+  const sid = primaryShowId(draft);
+  const show_id = sid >= 0 ? sid : 0;
+
+  if ("message" in arg) {
+    const entry: FlowsheetMessageEntry = {
+      id: tempId,
+      play_order,
+      show_id,
+      message: arg.message,
+    };
+    return { entry, tempId };
+  }
+
+  if ("album_id" in arg) {
+    const entry: FlowsheetSongEntry = {
+      id: tempId,
+      play_order,
+      show_id,
+      track_title: arg.track_title,
+      artist_name: "",
+      album_title: "",
+      record_label: arg.record_label ?? "",
+      request_flag: arg.request_flag,
+      album_id: arg.album_id,
+      rotation_id: arg.rotation_id,
+      rotation: arg.rotation_bin,
+    };
+    return { entry, tempId };
+  }
+
+  const entry: FlowsheetSongEntry = {
+    id: tempId,
+    play_order,
+    show_id,
+    track_title: arg.track_title,
+    artist_name: arg.artist_name,
+    album_title: arg.album_title,
+    record_label: arg.record_label ?? "",
+    request_flag: arg.request_flag,
+  };
+  return { entry, tempId };
+}
+
+/** Insert so `pages[0]` stays sorted by `play_order` descending (highest first). */
+export function insertEntrySortedFirstPage(
+  draft: InfiniteEntriesDraft,
+  entry: FlowsheetEntry
+): void {
+  if (!draft.pages.length) {
+    draft.pages.push([entry]);
+    draft.pageParams.push(0);
+    return;
+  }
+  const page0 = draft.pages[0];
+  const idx = page0.findIndex((e) => e.play_order < entry.play_order);
+  if (idx === -1) {
+    page0.push(entry);
+  } else {
+    page0.splice(idx, 0, entry);
+  }
+}
+
+export function removeEntryById(draft: InfiniteEntriesDraft, id: number): void {
+  for (const page of draft.pages) {
+    const index = page.findIndex((item) => item.id === id);
+    if (index !== -1) {
+      page.splice(index, 1);
+      return;
+    }
+  }
+}
+
+export function patchEntryById(
+  draft: InfiniteEntriesDraft,
+  id: number,
+  data: Partial<FlowsheetEntry>
+): void {
+  for (const page of draft.pages) {
+    const index = page.findIndex((item) => item.id === id);
+    if (index !== -1) {
+      Object.assign(page[index], data);
+      return;
+    }
+  }
+}
+
+/** Replace the entry with `tempId` everywhere it appears with `serverEntry`. */
+export function replaceEntryIdAllPages(
+  draft: InfiniteEntriesDraft,
+  tempId: number,
+  serverEntry: FlowsheetEntry
+): void {
+  for (const page of draft.pages) {
+    const index = page.findIndex((item) => item.id === tempId);
+    if (index !== -1) {
+      page[index] = serverEntry;
+      return;
+    }
+  }
+  insertEntrySortedFirstPage(draft, serverEntry);
+}
+
+export function swapPlayOrdersForSwitch(
+  draft: InfiniteEntriesDraft,
+  entryId: number,
+  newPosition: number
+): void {
+  let a: FlowsheetEntry | undefined;
+  let b: FlowsheetEntry | undefined;
+  for (const page of draft.pages) {
+    for (const e of page) {
+      if (e.id === entryId) a = e;
+      if (e.play_order === newPosition) b = e;
+    }
+  }
+  if (!a || !b || a.id === b.id) return;
+  const poA = a.play_order;
+  a.play_order = b.play_order;
+  b.play_order = poA;
+}

--- a/lib/features/flowsheet/infinite-cache.ts
+++ b/lib/features/flowsheet/infinite-cache.ts
@@ -40,6 +40,7 @@ export function buildOptimisticEntry(
   const tempId = nextOptimisticTempId();
   const play_order = maxPlayOrder(draft) + 1;
   const sid = primaryShowId(draft);
+  // Fallback until POST response replaces row (empty cache / unknown show).
   const show_id = sid >= 0 ? sid : 0;
 
   if ("message" in arg) {

--- a/src/components/experiences/modern/flowsheet/GoLive.test.tsx
+++ b/src/components/experiences/modern/flowsheet/GoLive.test.tsx
@@ -13,6 +13,8 @@ vi.mock("@/src/hooks/flowsheetHooks", () => ({
     autoplay: false,
     setAutoPlay: mockSetAutoPlay,
     loading: false,
+    isSaving: false,
+    currentShow: -1,
     goLive: mockGoLive,
     leave: mockLeave,
   })),
@@ -35,6 +37,7 @@ describe("GoLive", () => {
       autoplay: false,
       setAutoPlay: mockSetAutoPlay,
       loading: false,
+      isSaving: false,
       goLive: mockGoLive,
       leave: mockLeave,
       currentShow: 1,
@@ -51,6 +54,7 @@ describe("GoLive", () => {
       autoplay: false,
       setAutoPlay: mockSetAutoPlay,
       loading: false,
+      isSaving: false,
       goLive: mockGoLive,
       leave: mockLeave,
       currentShow: -1,
@@ -72,6 +76,7 @@ describe("GoLive", () => {
       autoplay: false,
       setAutoPlay: mockSetAutoPlay,
       loading: false,
+      isSaving: false,
       goLive: mockGoLive,
       leave: mockLeave,
       currentShow: 1,
@@ -92,6 +97,7 @@ describe("GoLive", () => {
       autoplay: false,
       setAutoPlay: mockSetAutoPlay,
       loading: false,
+      isSaving: false,
       goLive: mockGoLive,
       leave: mockLeave,
       currentShow: 1,
@@ -112,6 +118,7 @@ describe("GoLive", () => {
       autoplay: false,
       setAutoPlay: mockSetAutoPlay,
       loading: false,
+      isSaving: false,
       goLive: mockGoLive,
       leave: mockLeave,
       currentShow: -1,
@@ -130,6 +137,7 @@ describe("GoLive", () => {
       autoplay: false,
       setAutoPlay: mockSetAutoPlay,
       loading: true,
+      isSaving: false,
       goLive: mockGoLive,
       leave: mockLeave,
       currentShow: -1,
@@ -139,5 +147,22 @@ describe("GoLive", () => {
     const buttons = screen.getAllByRole("button");
     // Go live button should be disabled when loading
     expect(buttons[1]).toBeDisabled();
+  });
+
+  it("should show saving indicator when isSaving", async () => {
+    const { useShowControl } = await import("@/src/hooks/flowsheetHooks");
+    vi.mocked(useShowControl).mockReturnValue({
+      live: true,
+      autoplay: false,
+      setAutoPlay: mockSetAutoPlay,
+      loading: false,
+      isSaving: true,
+      goLive: mockGoLive,
+      leave: mockLeave,
+      currentShow: 1,
+    });
+
+    render(<GoLive />);
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 });

--- a/src/components/experiences/modern/flowsheet/GoLive.tsx
+++ b/src/components/experiences/modern/flowsheet/GoLive.tsx
@@ -7,14 +7,21 @@ import {
   PortableWifiOff,
   WifiTethering,
 } from "@mui/icons-material";
-import { Button, ButtonGroup, IconButton, Tooltip } from "@mui/joy";
+import {
+  Button,
+  ButtonGroup,
+  CircularProgress,
+  IconButton,
+  Stack,
+  Tooltip,
+} from "@mui/joy";
 
 export default function GoLive() {
-  const { live, autoplay, setAutoPlay, loading, goLive, leave } =
+  const { live, autoplay, setAutoPlay, loading, isSaving, goLive, leave } =
     useShowControl();
 
   return (
-    <>
+    <Stack direction="row" spacing={1} alignItems="center">
       <Tooltip
         title={`Autoplay is ${autoplay ? "On" : "Off"}`}
         placement="top"
@@ -30,6 +37,16 @@ export default function GoLive() {
           {autoplay ? <PlayArrow /> : <PlayDisabled />}
         </IconButton>
       </Tooltip>
+      {isSaving ? (
+        <Tooltip title="Saving changes…" placement="top" variant="outlined">
+          <CircularProgress
+            size="sm"
+            color="neutral"
+            variant="soft"
+            sx={{ "--CircularProgress-size": "22px" }}
+          />
+        </Tooltip>
+      ) : null}
       <ButtonGroup>
         <Tooltip
           title={loading ? "Loading..." : live ? "Leave" : "Go Live"}
@@ -64,6 +81,6 @@ export default function GoLive() {
           </Button>
         </Tooltip>
       </ButtonGroup>
-    </>
+    </Stack>
   );
 }

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
@@ -83,7 +83,7 @@ export default function FlowsheetSearchbar() {
   const handleFormSubmit = useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-      handleSubmit(e);
+      void handleSubmit(e);
     },
     [handleSubmit]
   );

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -22,14 +22,38 @@ import {
   isFlowsheetEndShowEntry,
   isFlowsheetStartShowEntry,
 } from "@/lib/features/flowsheet/types";
+import type { RootState } from "@/lib/store";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import type { FormEvent } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import { useRegistry } from "./authenticationHooks";
 import { useBinResults } from "./binHooks";
 import {
   useCatalogFlowsheetSearch,
   useRotationFlowsheetSearch,
 } from "./catalogHooks";
+
+const FLOWSHEET_MUTATION_ENDPOINTS = new Set([
+  "addToFlowsheet",
+  "removeFromFlowsheet",
+  "updateFlowsheet",
+  "switchEntries",
+  "joinShow",
+  "leaveShow",
+]);
+
+export function selectFlowsheetMutationPending(state: RootState): boolean {
+  const mutations = state.flowsheetApi?.mutations;
+  if (!mutations) return false;
+  return Object.values(mutations).some(
+    (m) =>
+      m &&
+      m.status === "pending" &&
+      typeof m.endpointName === "string" &&
+      FLOWSHEET_MUTATION_ENDPOINTS.has(m.endpointName)
+  );
+}
 
 export const useShowControl = () => {
   const { loading: userloading, info: userData } = useRegistry();
@@ -44,8 +68,7 @@ export const useShowControl = () => {
 
   const {
     data: infiniteData,
-    isLoading: entriesLoading,
-    isSuccess,
+    isSuccess: entriesQuerySuccess,
   } = useGetInfiniteEntriesInfiniteQuery(undefined, {
     skip: !userData || userloading,
     pollingInterval: 60000, // Poll every 60 seconds to keep flowsheet updated
@@ -63,17 +86,20 @@ export const useShowControl = () => {
 
   // Calculate derived state during render - no useState/useEffect needed
   const currentShow = useMemo(() => {
-    return isSuccess && allEntries.length > 0 ? allEntries[0].show_id : -1;
-  }, [allEntries, isSuccess]);
+    return entriesQuerySuccess && allEntries.length > 0
+      ? allEntries[0].show_id
+      : -1;
+  }, [allEntries, entriesQuerySuccess]);
 
   const live = useMemo(() => {
-    if (!isSuccess) return false;
     return (
       liveList?.djs !== undefined &&
       liveList?.djs.length !== 0 &&
       liveList.djs.some((dj) => dj.id === userData?.id)
     );
-  }, [liveList, isSuccess, userData?.id]);
+  }, [liveList, userData?.id]);
+
+  const isSaving = useAppSelector(selectFlowsheetMutationPending);
 
   const [goLiveFunction, goingLiveResult] = useJoinShowMutation();
   const [leaveFunction, leavingResult] = useLeaveShowMutation();
@@ -111,8 +137,8 @@ export const useShowControl = () => {
       loadingLiveList ||
       userloading ||
       goingLiveResult.isLoading ||
-      leavingResult.isLoading ||
-      entriesLoading,
+      leavingResult.isLoading,
+    isSaving,
     currentShow,
     goLive,
     leave,
@@ -120,7 +146,7 @@ export const useShowControl = () => {
 };
 
 export const useFlowsheetSearch = () => {
-  const { live, loading } = useShowControl();
+  const { live, loading, isSaving } = useShowControl();
 
   const dispatch = useAppDispatch();
   const searchOpen = useAppSelector((state) => state.flowsheet.search.open);
@@ -175,6 +201,7 @@ export const useFlowsheetSearch = () => {
   return {
     live,
     loading,
+    isSaving,
     searchOpen,
     setSearchOpen,
     resetSearch,
@@ -213,7 +240,7 @@ export const useFlowsheet = () => {
     );
   }, [infiniteData?.pages]);
 
-  const [addToFlowsheet, addToFlowsheetResult] = useAddToFlowsheetMutation();
+  const [addToFlowsheet] = useAddToFlowsheetMutation();
   const addToFlowsheetCallback = (arg: FlowsheetSubmissionParams) => {
     if (!userData || userData.id === undefined || userloading) {
       return Promise.reject('User not logged in');
@@ -228,49 +255,14 @@ export const useFlowsheet = () => {
     if (!userData || userData.id === undefined || userloading) {
       return;
     }
-    // Optimistic update: remove entry from all pages in the infinite query cache
-    dispatch(
-      flowsheetApi.util.updateQueryData(
-        "getInfiniteEntries",
-        undefined,
-        (draft) => {
-          for (const page of draft.pages) {
-            const index = page.findIndex((item) => item.id === entry);
-            if (index !== -1) {
-              page.splice(index, 1);
-              return;
-            }
-          }
-        }
-      )
-    );
     removeFromFlowsheet(entry);
   };
 
-  const [updateFlowsheetEntry, updateFlowsheetResult] =
-    useUpdateFlowsheetMutation();
+  const [updateFlowsheetEntry] = useUpdateFlowsheetMutation();
   const updateFlowsheet = (updateData: FlowsheetUpdateParams) => {
     if (!userData || userData.id === undefined || userloading) {
       return;
     }
-    // Optimistic update: apply field changes across all pages
-    dispatch(
-      flowsheetApi.util.updateQueryData(
-        "getInfiniteEntries",
-        undefined,
-        (draft) => {
-          for (const page of draft.pages) {
-            const index = page.findIndex(
-              (item) => item.id === updateData.entry_id
-            );
-            if (index !== -1) {
-              Object.assign(page[index], updateData.data);
-              return;
-            }
-          }
-        }
-      )
-    );
     updateFlowsheetEntry(updateData);
   };
 
@@ -281,7 +273,7 @@ export const useFlowsheet = () => {
 
   // Calculate derived state during render instead of useEffect + Redux
   const currentShowEntries = useMemo(() => {
-    if (currentShow === -1 || !live || allEntries.length === 0) return [];
+    if (currentShow === -1 || !live) return [];
     return allEntries.filter(
       (entry) =>
         entry.show_id === currentShow &&
@@ -352,7 +344,7 @@ export const useFlowsheet = () => {
     removeFromFlowsheet: removeFromFlowsheetCallback,
     updateFlowsheet,
     removeFromQueue,
-    loading: isLoading || userloading || !infiniteData,
+    loading: isLoading || userloading,
     isFetching,
     hasNextPage,
     fetchNextPage,
@@ -482,15 +474,31 @@ export const useFlowsheetSubmit = () => {
   }, [selectedResult, selectedEntry, flowSheetRawQuery]);
 
   const handleSubmit = useCallback(
-    (e: any) => {
+    async (e: FormEvent) => {
+      e.preventDefault();
       if (ctrlKeyPressed) {
         addToQueue(selectedResultData);
-      } else {
-        addToFlowsheet(convertQueryToSubmission(selectedResultData));
+        dispatch(flowsheetSlice.actions.resetSearch());
+        return;
       }
-
-      // Close the search bar after submission
-      dispatch(flowsheetSlice.actions.resetSearch());
+      try {
+        await addToFlowsheet(convertQueryToSubmission(selectedResultData));
+        dispatch(flowsheetSlice.actions.resetSearch());
+      } catch (err) {
+        const message =
+          err &&
+          typeof err === "object" &&
+          "data" in err &&
+          err.data &&
+          typeof err.data === "object" &&
+          "message" in err.data &&
+          typeof (err.data as { message: unknown }).message === "string"
+            ? (err.data as { message: string }).message
+            : err instanceof Error
+              ? err.message
+              : "Could not add to flowsheet";
+        toast.error(message);
+      }
     },
     [
       ctrlKeyPressed,


### PR DESCRIPTION
### Summary

This PR replaces the old means of adding to, loading, and editing the flowsheet with a central, optimistic cache - preventing issues with stale state.

**Flowsheet: RTK Query cache, live UX, and canonical refetch behavior**

- Centralized flowsheet list updates in **`flowsheetApi`** with **`onQueryStarted`**: optimistic add/remove/update/reorder, **`transformResponse`** on create (201 body → `FlowsheetEntry`), rollback on failure, and **`invalidateTags(['Flowsheet'])`** after successful mutations that need a full list sync (instead of ad-hoc `forceRefetch`). Cold adds with no list cache **`invalidateTags(['Flowsheet'])`** so data still loads.
- **Hooks/UI**: `live` no longer depends on entries query success; **`currentShowEntries`** and entries **loading** avoid over-empty / full-skeleton edge cases; search submit **`await`s** add, **`toast`** on error, **`resetSearch`** only on success; **`isSaving`** + small spinner by **Go Live**.
- **Shared helpers**: [`infinite-cache.ts`](lib/features/flowsheet/infinite-cache.ts) for insert/replace/swap; [`constants.ts`](lib/features/flowsheet/constants.ts) for page size and copy; **`formatOnAirSummary`** / **`OFF_AIR_LABEL`** for WhoIsLive + optimistic join/leave; dev-only **`console.warn`** on mutation failures in **`onQueryStarted`**.
- **Tests**: infinite-cache + constants + GoLive saving; existing flowsheet Vitest suites updated as needed.