### PR TITLE
test: add unit tests for flowsheet pure logic

### DIFF
--- a/lib/__tests__/features/experiences/preferences.test.ts
+++ b/lib/__tests__/features/experiences/preferences.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  isAppSkinPreference,
+  parseAppSkinPreference,
+  toAppSkinPreference,
+  getPreferenceFromAppState,
+  isColorMode,
+} from "@/lib/features/experiences/preferences";
+import type { ApplicationState } from "@/lib/features/application/types";
+
+describe("preferences", () => {
+  describe("isColorMode", () => {
+    it.each(["light", "dark"])('should return true for "%s"', (value) => {
+      expect(isColorMode(value)).toBe(true);
+    });
+
+    it.each([
+      "Light",
+      "DARK",
+      "auto",
+      "",
+      null,
+      undefined,
+      42,
+      true,
+    ])("should return false for %s", (value) => {
+      expect(isColorMode(value)).toBe(false);
+    });
+  });
+
+  describe("isAppSkinPreference", () => {
+    it.each([
+      "classic-light",
+      "classic-dark",
+      "modern-light",
+      "modern-dark",
+    ])('should return true for "%s"', (value) => {
+      expect(isAppSkinPreference(value)).toBe(true);
+    });
+
+    it.each([
+      "classic",
+      "modern",
+      "light",
+      "dark",
+      "classic-auto",
+      "future-light",
+      "",
+      null,
+      undefined,
+      42,
+      true,
+      "classic-light-extra",
+    ])("should return false for %s", (value) => {
+      expect(isAppSkinPreference(value)).toBe(false);
+    });
+  });
+
+  describe("toAppSkinPreference", () => {
+    it.each([
+      { experience: "classic" as const, colorMode: "light" as const, expected: "classic-light" },
+      { experience: "classic" as const, colorMode: "dark" as const, expected: "classic-dark" },
+      { experience: "modern" as const, colorMode: "light" as const, expected: "modern-light" },
+      { experience: "modern" as const, colorMode: "dark" as const, expected: "modern-dark" },
+    ])(
+      "should return $expected for $experience + $colorMode",
+      ({ experience, colorMode, expected }) => {
+        expect(toAppSkinPreference(experience, colorMode)).toBe(expected);
+      }
+    );
+  });
+
+  describe("parseAppSkinPreference", () => {
+    it.each([
+      { input: "classic-light", experience: "classic", colorMode: "light" },
+      { input: "classic-dark", experience: "classic", colorMode: "dark" },
+      { input: "modern-light", experience: "modern", colorMode: "light" },
+      { input: "modern-dark", experience: "modern", colorMode: "dark" },
+    ])(
+      'should parse "$input" into experience=$experience and colorMode=$colorMode',
+      ({ input, experience, colorMode }) => {
+        const result = parseAppSkinPreference(input);
+        expect(result).toEqual({ experience, colorMode });
+      }
+    );
+
+    it.each([
+      "invalid",
+      "classic",
+      "modern-auto",
+      "",
+      null,
+      undefined,
+      42,
+    ])("should return null for invalid input %s", (value) => {
+      expect(parseAppSkinPreference(value)).toBeNull();
+    });
+  });
+
+  describe("getPreferenceFromAppState", () => {
+    it("should return preference from valid app state", () => {
+      const state: ApplicationState = {
+        experience: "modern",
+        colorMode: "dark",
+        rightBarMini: true,
+      };
+      expect(getPreferenceFromAppState(state)).toBe("modern-dark");
+    });
+
+    it("should return preference for classic light state", () => {
+      const state: ApplicationState = {
+        experience: "classic",
+        colorMode: "light",
+        rightBarMini: false,
+      };
+      expect(getPreferenceFromAppState(state)).toBe("classic-light");
+    });
+
+    it("should return null for null state", () => {
+      expect(getPreferenceFromAppState(null)).toBeNull();
+    });
+
+    it("should return null for undefined state", () => {
+      expect(getPreferenceFromAppState(undefined)).toBeNull();
+    });
+  });
+});

--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -261,6 +261,19 @@ describe("flowsheet conversions", () => {
 
         expect(result.show_id).toBe(0);
       });
+
+      it("should throw for unknown entry type", () => {
+        const entry = { ...createTestV2TrackEntry(), entry_type: "unknown_type" } as any;
+        expect(() => convertV2Entry(entry)).toThrow("Unknown entry type: unknown_type");
+      });
+
+      it("should handle timestamp without comma in show entries", () => {
+        const entry = createTestV2ShowStartEntry({ timestamp: "no comma here" });
+        const result = convertV2Entry(entry) as FlowsheetShowBlockEntry;
+
+        expect(result.day).toBe("Unknown");
+        expect(result.time).toBe("Unknown");
+      });
     });
 
     describe("convertV2FlowsheetResponse", () => {

--- a/lib/__tests__/features/flowsheet/flowsheet.test.ts
+++ b/lib/__tests__/features/flowsheet/flowsheet.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   flowsheetSlice,
   defaultFlowsheetFrontendState,
@@ -9,7 +9,23 @@ import {
   createTestFlowsheetEntry,
   TEST_SEARCH_STRINGS,
 } from "@/lib/test-utils";
-import type { FlowsheetFrontendState } from "@/lib/features/flowsheet/types";
+import type { FlowsheetFrontendState, FlowsheetEntry } from "@/lib/features/flowsheet/types";
+
+vi.mock("@/lib/features/flowsheet/queue-storage", () => ({
+  saveQueueToStorage: vi.fn(),
+  loadQueueFromStorage: vi.fn(() => []),
+  clearQueueFromStorage: vi.fn(),
+}));
+
+import {
+  saveQueueToStorage,
+  loadQueueFromStorage,
+  clearQueueFromStorage,
+} from "@/lib/features/flowsheet/queue-storage";
+
+const mockedSaveQueue = vi.mocked(saveQueueToStorage);
+const mockedLoadQueue = vi.mocked(loadQueueFromStorage);
+const mockedClearQueue = vi.mocked(clearQueueFromStorage);
 
 describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions }) => {
   describe("setAutoplay", () => {
@@ -25,12 +41,21 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.search.open).toBe(true);
     });
 
-    it("should set search property", () => {
-      const result = harness().reduce(
-        actions.setSearchProperty({ name: "artist", value: TEST_SEARCH_STRINGS.ARTIST_NAME })
-      );
-      expect(result.search.query.artist).toBe(TEST_SEARCH_STRINGS.ARTIST_NAME);
+    it("should close search panel", () => {
+      const opened = harness().reduce(actions.setSearchOpen(true));
+      const result = harness().reduce(actions.setSearchOpen(false), opened);
+      expect(result.search.open).toBe(false);
     });
+
+    it.each(["song", "artist", "album", "label"] as const)(
+      "should set search property %s",
+      (property) => {
+        const result = harness().reduce(
+          actions.setSearchProperty({ name: property, value: "test value" })
+        );
+        expect(result.search.query[property]).toBe("test value");
+      }
+    );
 
     it("should toggle request flag", () => {
       expect(harness().initialState.search.query.request).toBe(false);
@@ -51,6 +76,11 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.search.query).toEqual(defaultFlowsheetFrontendState.search.query);
       expect(result.search.selectedResult).toBe(0);
     });
+
+    it("should set selected result", () => {
+      const result = harness().reduce(actions.setSelectedResult(3));
+      expect(result.search.selectedResult).toBe(3);
+    });
   });
 
   describe("queue actions", () => {
@@ -61,7 +91,26 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.queue[0].track_title).toBe(query.song);
       expect(result.queue[0].artist_name).toBe(query.artist);
       expect(result.queue[0].album_title).toBe(query.album);
+      expect(result.queue[0].record_label).toBe(query.label);
+      expect(result.queue[0].request_flag).toBe(query.request);
+      expect(result.queue[0].show_id).toBe(-1);
       expect(result.queueIdCounter).toBe(1);
+    });
+
+    it("should assign incrementing IDs to queue items", () => {
+      const result = harness().chain(
+        actions.addToQueue(createTestFlowsheetQuery({ song: "Track 1" })),
+        actions.addToQueue(createTestFlowsheetQuery({ song: "Track 2" }))
+      );
+      expect(result.queue[0].id).toBe(0);
+      expect(result.queue[1].id).toBe(1);
+      expect(result.queueIdCounter).toBe(2);
+    });
+
+    it("should call saveQueueToStorage when adding to queue", () => {
+      mockedSaveQueue.mockClear();
+      harness().reduce(actions.addToQueue(createTestFlowsheetQuery()));
+      expect(mockedSaveQueue).toHaveBeenCalled();
     });
 
     it("should remove item from queue", () => {
@@ -70,6 +119,20 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       const entryId = withItem.queue[0].id;
       const result = harness().reduce(actions.removeFromQueue(entryId), withItem);
       expect(result.queue).toHaveLength(0);
+    });
+
+    it("should not remove items with non-matching ID", () => {
+      const withItem = harness().reduce(actions.addToQueue(createTestFlowsheetQuery()));
+      const result = harness().reduce(actions.removeFromQueue(999), withItem);
+      expect(result.queue).toHaveLength(1);
+    });
+
+    it("should call saveQueueToStorage when removing from queue", () => {
+      mockedSaveQueue.mockClear();
+      const withItem = harness().reduce(actions.addToQueue(createTestFlowsheetQuery()));
+      mockedSaveQueue.mockClear();
+      harness().reduce(actions.removeFromQueue(withItem.queue[0].id), withItem);
+      expect(mockedSaveQueue).toHaveBeenCalled();
     });
 
     it("should clear the queue", () => {
@@ -82,6 +145,31 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.queueIdCounter).toBe(0);
     });
 
+    it("should call clearQueueFromStorage when clearing queue", () => {
+      mockedClearQueue.mockClear();
+      harness().reduce(actions.clearQueue());
+      expect(mockedClearQueue).toHaveBeenCalled();
+    });
+
+    it("should load queue from storage", () => {
+      const storedEntries = [
+        createTestFlowsheetEntry({ id: 5, track_title: "Stored Track 1" }),
+        createTestFlowsheetEntry({ id: 10, track_title: "Stored Track 2" }),
+      ];
+      mockedLoadQueue.mockReturnValueOnce(storedEntries);
+
+      const result = harness().reduce(actions.loadQueue());
+      expect(result.queue).toEqual(storedEntries);
+      expect(result.queueIdCounter).toBe(11);
+    });
+
+    it("should set queueIdCounter to 0 when loading empty queue", () => {
+      mockedLoadQueue.mockReturnValueOnce([]);
+      const result = harness().reduce(actions.loadQueue());
+      expect(result.queue).toEqual([]);
+      expect(result.queueIdCounter).toBe(0);
+    });
+
     it("should update queue entry field", () => {
       const withItem = harness().reduce(actions.addToQueue(createTestFlowsheetQuery()));
       const entryId = withItem.queue[0].id;
@@ -90,6 +178,25 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         withItem
       );
       expect(result.queue[0].track_title).toBe("Updated Track Title");
+    });
+
+    it("should not modify state when updating non-existent queue entry", () => {
+      const withItem = harness().reduce(actions.addToQueue(createTestFlowsheetQuery()));
+      const result = harness().reduce(
+        actions.updateQueueEntry({ entry_id: 999, field: "track_title", value: "Should Not Appear" }),
+        withItem
+      );
+      expect(result.queue[0].track_title).toBe(withItem.queue[0].track_title);
+    });
+
+    it("should call saveQueueToStorage when updating queue entry", () => {
+      const withItem = harness().reduce(actions.addToQueue(createTestFlowsheetQuery()));
+      mockedSaveQueue.mockClear();
+      harness().reduce(
+        actions.updateQueueEntry({ entry_id: withItem.queue[0].id, field: "track_title", value: "New" }),
+        withItem
+      );
+      expect(mockedSaveQueue).toHaveBeenCalled();
     });
 
     it("should reorder queue", () => {
@@ -112,6 +219,33 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.queue[1].track_title).toBe("Track 1");
       expect(result.queue[2].track_title).toBe("Track 2");
     });
+
+    it("should call saveQueueToStorage when reordering queue", () => {
+      mockedSaveQueue.mockClear();
+      harness().reduce(actions.reorderQueue([]));
+      expect(mockedSaveQueue).toHaveBeenCalled();
+    });
+  });
+
+  describe("setCurrentShowEntries", () => {
+    it("should set current show entries", () => {
+      const entries: FlowsheetEntry[] = [
+        createTestFlowsheetEntry({ id: 1 }),
+        createTestFlowsheetEntry({ id: 2 }),
+      ];
+      const result = harness().reduce(actions.setCurrentShowEntries(entries));
+      expect(result.currentShowEntries).toEqual(entries);
+    });
+
+    it("should replace existing show entries", () => {
+      const first = [createTestFlowsheetEntry({ id: 1 })];
+      const second = [createTestFlowsheetEntry({ id: 2 }), createTestFlowsheetEntry({ id: 3 })];
+      const result = harness().chain(
+        actions.setCurrentShowEntries(first),
+        actions.setCurrentShowEntries(second)
+      );
+      expect(result.currentShowEntries).toEqual(second);
+    });
   });
 
   describe("selectors", () => {
@@ -119,6 +253,13 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       const { dispatch, select } = harness().withStore();
       dispatch(actions.setAutoplay(true));
       expect(select(flowsheetSlice.selectors.getAutoplay)).toBe(true);
+    });
+
+    it("should select search open state", () => {
+      const { dispatch, select } = harness().withStore();
+      expect(select(flowsheetSlice.selectors.getSearchOpen)).toBe(false);
+      dispatch(actions.setSearchOpen(true));
+      expect(select(flowsheetSlice.selectors.getSearchOpen)).toBe(true);
     });
 
     it("should select search query", () => {
@@ -147,6 +288,21 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(queue).toHaveLength(2);
       expect(queue[0].track_title).toBe("Track 1");
       expect(queue[1].track_title).toBe("Track 2");
+    });
+
+    it("should select selected result", () => {
+      const { dispatch, select } = harness().withStore();
+      expect(select(flowsheetSlice.selectors.getSelectedResult)).toBe(0);
+      dispatch(actions.setSelectedResult(5));
+      expect(select(flowsheetSlice.selectors.getSelectedResult)).toBe(5);
+    });
+
+    it("should select current show entries", () => {
+      const { dispatch, select } = harness().withStore();
+      expect(select(flowsheetSlice.selectors.getCurrentShowEntries)).toEqual([]);
+      const entries: FlowsheetEntry[] = [createTestFlowsheetEntry({ id: 1 })];
+      dispatch(actions.setCurrentShowEntries(entries));
+      expect(select(flowsheetSlice.selectors.getCurrentShowEntries)).toEqual(entries);
     });
   });
 


### PR DESCRIPTION
## Summary

- Add 45 parameterized tests for experience preferences pure functions
- Extend flowsheet slice tests with queue-storage verification, selector coverage, and edge cases
- Extend flowsheet conversions tests with unknown-type and timestamp edge cases

Closes #307

## Test plan

- [ ] `npm run test:run` passes all tests
- [ ] `npm run test:coverage` shows 100% coverage on `lib/features/experiences/preferences.ts`
- [ ] No changes to production code