### PR TITLE
fix: add COOKIE_SAME_SITE and NODE_ENV to E2E backend .env

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -96,6 +96,8 @@ jobs:
           E2E_DB_PORT=5434
           E2E_AUTH_PORT=8084
           E2E_BACKEND_PORT=8085
+          COOKIE_SAME_SITE=none
+          NODE_ENV=test
           EOF
 
       - name: Cache Playwright browsers


### PR DESCRIPTION
## Summary

Backend-Service recently added two features that break the E2E test suite:
- **Cookie sameSite default changed to 'lax'** (8e2fc5f) — with `sameSite: 'lax'` + `secure: true`, session cookies aren't set on localhost (not HTTPS), so login appears to succeed but the session is immediately lost
- **Rate limiting on auth endpoints** (2598653) — 10 requests per 15 minutes throttles the E2E auth setup which authenticates 5 users sequentially

This adds two env vars to the E2E workflow's Backend .env:
- `COOKIE_SAME_SITE=none` — allows cookies on localhost
- `NODE_ENV=test` — disables rate limiting (matching the pattern from e9be9e0)

## Test plan

- [ ] E2E workflow passes on this branch
- [ ] Verify auth setup authenticates all 5 users without timeout or throttling