### PR TITLE
fix: wait for React hydration in password reset E2E page object

### DIFF
--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -62,7 +62,7 @@ export class LoginPage {
 
   async goto(): Promise<void> {
     await this.page.goto("/login");
-    await this.page.waitForLoadState("domcontentloaded");
+    await this.page.waitForLoadState("load");
   }
 
   /**
@@ -104,12 +104,17 @@ export class LoginPage {
       await this.switchToPasswordLogin();
     }
     await this.forgotPasswordLink.click();
-    // Wait for the password reset form to appear (state change)
+    // Wait for the password reset form to appear and be interactive.
+    // The email input and send button must both be enabled, confirming
+    // React hydration is complete and no stale requestingReset state.
     await this.emailInput.waitFor({ state: "visible", timeout: 5000 });
+    await expect(this.emailInput).toBeEnabled({ timeout: 5000 });
+    await expect(this.sendResetLinkButton).toBeVisible({ timeout: 5000 });
   }
 
   async requestPasswordReset(email: string): Promise<void> {
     await this.emailInput.fill(email);
+    await expect(this.sendResetLinkButton).toBeEnabled({ timeout: 10000 });
     await this.sendResetLinkButton.click();
   }
 
@@ -161,9 +166,9 @@ export class LoginPage {
   async expectSuccessToast(message?: string): Promise<void> {
     if (message) {
       const specificToast = this.page.locator(`[data-sonner-toast][data-type="success"]:has-text("${message}")`);
-      await expect(specificToast).toBeVisible({ timeout: 5000 });
+      await expect(specificToast).toBeVisible({ timeout: 10000 });
     } else {
-      await expect(this.successToast).toBeVisible({ timeout: 5000 });
+      await expect(this.successToast).toBeVisible({ timeout: 10000 });
     }
   }
 


### PR DESCRIPTION
## Summary
- Wait for email input and send button to be enabled in `clickForgotPassword` before returning, confirming React hydration is complete
- Wait for send button to be enabled in `requestPasswordReset` before clicking, handling stale `requestingReset` hook state

Closes #323

## Test plan
- [x] Full E2E suite passes locally (141 passed, 0 failed) — run twice to confirm non-flaky
- [ ] CI E2E passes