### PR TITLE
Fix flowsheet sort to use id instead of play_order

### DIFF
--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -264,17 +264,17 @@ describe("flowsheet conversions", () => {
     });
 
     describe("convertV2FlowsheetResponse", () => {
-      it("should convert and sort entries by play_order descending", () => {
+      it("should convert and sort entries by id descending", () => {
         const entries = [
-          createTestV2TrackEntry({ id: 1, play_order: 1 }),
-          createTestV2TrackEntry({ id: 3, play_order: 3 }),
-          createTestV2TrackEntry({ id: 2, play_order: 2 }),
+          createTestV2TrackEntry({ id: 1, play_order: 99 }),
+          createTestV2TrackEntry({ id: 3, play_order: 1 }),
+          createTestV2TrackEntry({ id: 2, play_order: 50 }),
         ];
         const result = convertV2FlowsheetResponse(entries);
 
-        expect(result[0].play_order).toBe(3);
-        expect(result[1].play_order).toBe(2);
-        expect(result[2].play_order).toBe(1);
+        expect(result[0].id).toBe(3);
+        expect(result[1].id).toBe(2);
+        expect(result[2].id).toBe(1);
       });
 
       it("should handle empty array", () => {
@@ -293,8 +293,8 @@ describe("flowsheet conversions", () => {
         const result = convertV2FlowsheetResponse(entries);
 
         expect(result).toHaveLength(5);
-        expect(result[0].play_order).toBe(5);
-        expect(result[4].play_order).toBe(1);
+        expect(result[0].id).toBe(5);
+        expect(result[4].id).toBe(1);
       });
     });
 

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -174,5 +174,5 @@ export function convertV2FlowsheetResponse(
 ): FlowsheetEntry[] {
   return entries
     .map(convertV2Entry)
-    .sort((a, b) => b.play_order - a.play_order);
+    .sort((a, b) => b.id - a.id);
 }


### PR DESCRIPTION
## Summary

- Changes `convertV2FlowsheetResponse` sort from `play_order DESC` to `id DESC`
- Updates tests to verify id-based ordering with divergent play_order values

Closes #325

## Context

After the tubafrenzy ETL bulk load synced 2.6M entries to Backend-Service, entries from old shows with high per-show `play_order` values sorted above current show entries. The backend was fixed in WXYC/Backend-Service#330, but the frontend re-sorted the response by `play_order` in `convertV2FlowsheetResponse`, reintroducing the same bug client-side.

## Test plan

- [ ] 1818 tests pass (148 test files)
- [ ] Conversion test verifies entries with high play_order but low id sort after entries with high id
- [ ] dj.wxyc.org displays the current show's entries after deploy