### PR TITLE
Fix remaining play_order sorts in hooks and infinite cache

### DIFF
--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -264,17 +264,17 @@ describe("flowsheet conversions", () => {
     });
 
     describe("convertV2FlowsheetResponse", () => {
-      it("should convert and sort entries by play_order descending", () => {
+      it("should convert and sort entries by id descending", () => {
         const entries = [
-          createTestV2TrackEntry({ id: 1, play_order: 1 }),
-          createTestV2TrackEntry({ id: 3, play_order: 3 }),
-          createTestV2TrackEntry({ id: 2, play_order: 2 }),
+          createTestV2TrackEntry({ id: 1, play_order: 99 }),
+          createTestV2TrackEntry({ id: 3, play_order: 1 }),
+          createTestV2TrackEntry({ id: 2, play_order: 50 }),
         ];
         const result = convertV2FlowsheetResponse(entries);
 
-        expect(result[0].play_order).toBe(3);
-        expect(result[1].play_order).toBe(2);
-        expect(result[2].play_order).toBe(1);
+        expect(result[0].id).toBe(3);
+        expect(result[1].id).toBe(2);
+        expect(result[2].id).toBe(1);
       });
 
       it("should handle empty array", () => {
@@ -293,8 +293,8 @@ describe("flowsheet conversions", () => {
         const result = convertV2FlowsheetResponse(entries);
 
         expect(result).toHaveLength(5);
-        expect(result[0].play_order).toBe(5);
-        expect(result[4].play_order).toBe(1);
+        expect(result[0].id).toBe(5);
+        expect(result[4].id).toBe(1);
       });
     });
 

--- a/lib/__tests__/features/flowsheet/infinite-cache.test.ts
+++ b/lib/__tests__/features/flowsheet/infinite-cache.test.ts
@@ -40,13 +40,13 @@ describe("infinite-cache", () => {
     expect(primaryShowId(draft)).toBe(5);
   });
 
-  it("insertEntrySortedFirstPage keeps descending play_order on page 0", () => {
+  it("insertEntrySortedFirstPage keeps descending id on page 0", () => {
     const draft = {
-      pages: [[song(1, 10, 1), song(2, 8, 1)]],
+      pages: [[song(10, 5, 1), song(8, 10, 1)]],
       pageParams: [0],
     };
-    insertEntrySortedFirstPage(draft, song(99, 12, 1));
-    expect(draft.pages[0].map((e) => e.id)).toEqual([99, 1, 2]);
+    insertEntrySortedFirstPage(draft, song(99, 1, 1));
+    expect(draft.pages[0].map((e) => e.id)).toEqual([99, 10, 8]);
   });
 
   it("insertEntrySortedFirstPage initializes empty cache", () => {

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -174,5 +174,5 @@ export function convertV2FlowsheetResponse(
 ): FlowsheetEntry[] {
   return entries
     .map(convertV2Entry)
-    .sort((a, b) => b.play_order - a.play_order);
+    .sort((a, b) => b.id - a.id);
 }

--- a/lib/features/flowsheet/infinite-cache.ts
+++ b/lib/features/flowsheet/infinite-cache.ts
@@ -83,7 +83,7 @@ export function buildOptimisticEntry(
   return { entry, tempId };
 }
 
-/** Insert so `pages[0]` stays sorted by `play_order` descending (highest first). */
+/** Insert so `pages[0]` stays sorted by `id` descending (newest first). */
 export function insertEntrySortedFirstPage(
   draft: InfiniteEntriesDraft,
   entry: FlowsheetEntry
@@ -94,7 +94,7 @@ export function insertEntrySortedFirstPage(
     return;
   }
   const page0 = draft.pages[0];
-  const idx = page0.findIndex((e) => e.play_order < entry.play_order);
+  const idx = page0.findIndex((e) => e.id < entry.id);
   if (idx === -1) {
     page0.push(entry);
   } else {

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -80,7 +80,7 @@ export const useShowControl = () => {
     const map = new Map<number, FlowsheetEntry>();
     infiniteData.pages.flat().forEach((entry) => map.set(entry.id, entry));
     return Array.from(map.values()).sort(
-      (a, b) => b.play_order - a.play_order
+      (a, b) => b.id - a.id
     );
   }, [infiniteData?.pages]);
 
@@ -236,7 +236,7 @@ export const useFlowsheet = () => {
     const map = new Map<number, FlowsheetEntry>();
     infiniteData.pages.flat().forEach((entry) => map.set(entry.id, entry));
     return Array.from(map.values()).sort(
-      (a, b) => b.play_order - a.play_order
+      (a, b) => b.id - a.id
     );
   }, [infiniteData?.pages]);
 


### PR DESCRIPTION
## Summary

- Fixes `play_order` sort in `flowsheetHooks.ts` (2 occurrences) and `infinite-cache.ts` insertion logic
- Updates infinite-cache test to verify id-based ordering

## Context

Follow-up to #326 which only fixed `conversions.ts`. The deployed bundles still contained `play_order` sorts from two other locations, keeping the stale-show-first bug active.

## Test plan

- [ ] 1818 tests pass
- [ ] No remaining `play_order` sort in source (only in `swapPlayOrdersForSwitch` which is for drag reorder within a show)