### PR TITLE
Add WXYC Exclusive badge for non-streaming albums

### DIFF
--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -33,6 +33,7 @@ export function convertToAlbumEntry(
     plays: (isSearchResult(response) ? response.plays : undefined) ?? 0,
     label: response.label ?? "",
     rotation_id: isSearchResult(response) ? response.rotation_id : undefined,
+    on_streaming: isSearchResult(response) ? response.on_streaming : undefined,
   };
 }
 

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -33,7 +33,7 @@ export function convertToAlbumEntry(
     plays: (isSearchResult(response) ? response.plays : undefined) ?? 0,
     label: response.label ?? "",
     rotation_id: isSearchResult(response) ? response.rotation_id : undefined,
-    on_streaming: isSearchResult(response) ? response.on_streaming : undefined,
+    on_streaming: isSearchResult(response) ? (response as Record<string, unknown>).on_streaming as boolean | undefined : undefined,
   };
 }
 

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -50,6 +50,7 @@ export type AlbumEntry = {
   plays: number | undefined;
   add_date: string | undefined;
   label: string;
+  on_streaming: boolean | undefined;
 };
 
 export type ArtistEntry = {

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -50,7 +50,7 @@ export type AlbumEntry = {
   plays: number | undefined;
   add_date: string | undefined;
   label: string;
-  on_streaming: boolean | undefined;
+  on_streaming?: boolean;
 };
 
 export type ArtistEntry = {

--- a/lib/test-utils/fixtures.ts
+++ b/lib/test-utils/fixtures.ts
@@ -184,6 +184,7 @@ export function createTestAlbum(overrides: Partial<AlbumEntry> = {}): AlbumEntry
     plays: 0,
     add_date: toDateString(TEST_TIMESTAMPS.ONE_WEEK_AGO),
     label: TEST_SEARCH_STRINGS.LABEL,
+    on_streaming: undefined,
     ...overrides,
   };
 }

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -88,6 +88,22 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
         >
           {album.format}
         </Chip>
+        {album.on_streaming === false && (
+          <Chip
+            variant="soft"
+            size="sm"
+            sx={{
+              ml: 0.5,
+              backgroundColor: "#7B2D8E",
+              color: "#fff",
+              fontWeight: "bold",
+              fontSize: "0.65rem",
+              letterSpacing: "0.5px",
+            }}
+          >
+            WXYC EXCLUSIVE
+          </Chip>
+        )}
       </td>
       <td>{album.plays ?? 0}</td>
       <td>

--- a/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
@@ -83,3 +83,47 @@ describe("CatalogResult plays column (Bug 12)", () => {
     expect(playsCell).toBeDefined();
   });
 });
+
+describe("CatalogResult WXYC Exclusive badge", () => {
+  it("should display WXYC EXCLUSIVE chip when on_streaming is false", () => {
+    const album = createTestAlbum({ on_streaming: false });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByText("WXYC EXCLUSIVE")).toBeDefined();
+  });
+
+  it("should not display WXYC EXCLUSIVE chip when on_streaming is true", () => {
+    const album = createTestAlbum({ on_streaming: true });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.queryByText("WXYC EXCLUSIVE")).toBeNull();
+  });
+
+  it("should not display WXYC EXCLUSIVE chip when on_streaming is undefined", () => {
+    const album = createTestAlbum({ on_streaming: undefined });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.queryByText("WXYC EXCLUSIVE")).toBeNull();
+  });
+});

--- a/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
@@ -81,6 +81,21 @@ export default function FlowsheetBackendResult({
           >
             {entry.format.includes("vinyl") ? "vinyl" : "cd"}
           </Chip>
+          {entry.on_streaming === false && (
+            <Chip
+              variant="soft"
+              size="sm"
+              sx={{
+                ml: 1,
+                backgroundColor: "#7B2D8E",
+                color: "#fff",
+                fontWeight: "bold",
+                fontSize: "0.6rem",
+              }}
+            >
+              EXCLUSIVE
+            </Chip>
+          )}
         </Typography>
       </Stack>
       <Stack direction="column" sx={{ width: "calc(20%)" }}>


### PR DESCRIPTION
## Summary

- Deep purple "WXYC EXCLUSIVE" chip on catalog search results for `on_streaming === false`
- Compact "EXCLUSIVE" chip on flowsheet search results
- `on_streaming` field added to `AlbumEntry` type and conversion function
- Badge only shown when explicitly false, not when null/undefined

Requires:
- WXYC/wxyc-shared#43 (api.yaml schema)
- Backend-Service ON_STREAMING column in PostgreSQL

## Test plan

- [ ] Badge appears for albums with `on_streaming: false`
- [ ] Badge hidden for albums with `on_streaming: true` or `undefined`
- [ ] Deep purple color (#7B2D8E) is visually distinct from existing badges