### PR TITLE
Extract shared password validation utility

### DIFF
--- a/src/components/experiences/modern/login/Forms/NewUserForm.tsx
+++ b/src/components/experiences/modern/login/Forms/NewUserForm.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/features/authentication/types";
 import { useAppDispatch } from "@/lib/hooks";
 import { useNewUser } from "@/src/hooks/authenticationHooks";
+import { isStrongPassword } from "@/src/utilities/passwordValidation";
 import { Typography } from "@mui/joy";
 import { useEffect, useState } from "react";
 import RequiredBox from "./Fields/RequiredBox";
@@ -62,11 +63,7 @@ export default function NewUserForm({
         }
         validationFunction={(value: string) => {
           setNewPassword(value);
-          return (
-            value.length >= 8 &&
-            !!value.match(/[A-Z]/) &&
-            !!value.match(/[0-9]/)
-          );
+          return isStrongPassword(value);
         }}
       />
       <RequiredBox

--- a/src/components/experiences/modern/login/Forms/OnboardingForm.tsx
+++ b/src/components/experiences/modern/login/Forms/OnboardingForm.tsx
@@ -4,6 +4,7 @@ import { authenticationSlice } from "@/lib/features/authentication/frontend";
 import { VerifiedData } from "@/lib/features/authentication/types";
 import { useAppDispatch } from "@/lib/hooks";
 import { useNewUser } from "@/src/hooks/authenticationHooks";
+import { isStrongPassword } from "@/src/utilities/passwordValidation";
 import { FormControl, FormLabel, Input, Typography } from "@mui/joy";
 import { useEffect, useState } from "react";
 import RequiredBox from "./Fields/RequiredBox";
@@ -76,11 +77,7 @@ export default function OnboardingForm({
         }
         validationFunction={(value: string) => {
           setNewPassword(value);
-          return (
-            value.length >= 8 &&
-            !!value.match(/[A-Z]/) &&
-            !!value.match(/[0-9]/)
-          );
+          return isStrongPassword(value);
         }}
       />
       <RequiredBox

--- a/src/components/experiences/modern/login/Forms/ResetPasswordForm.tsx
+++ b/src/components/experiences/modern/login/Forms/ResetPasswordForm.tsx
@@ -3,6 +3,7 @@
 import { authenticationSlice } from "@/lib/features/authentication/frontend";
 import { useAppDispatch } from "@/lib/hooks";
 import { useResetPassword } from "@/src/hooks/authenticationHooks";
+import { isStrongPassword } from "@/src/utilities/passwordValidation";
 import { Typography } from "@mui/joy";
 import { useEffect, useState } from "react";
 import RequiredBox from "./Fields/RequiredBox";
@@ -41,11 +42,7 @@ export default function ResetPasswordForm({
         }
         validationFunction={(value: string) => {
           setNewPassword(value);
-          return (
-            value.length >= 8 &&
-            !!value.match(/[A-Z]/) &&
-            !!value.match(/[0-9]/)
-          );
+          return isStrongPassword(value);
         }}
         disabled={requestingReset}
       />

--- a/src/utilities/passwordValidation.ts
+++ b/src/utilities/passwordValidation.ts
@@ -1,0 +1,7 @@
+/**
+ * Validates that a password meets the minimum strength requirements:
+ * at least 8 characters, one uppercase letter, and one digit.
+ */
+export function isStrongPassword(value: string): boolean {
+  return value.length >= 8 && /[A-Z]/.test(value) && /[0-9]/.test(value);
+}


### PR DESCRIPTION
## Summary

- The same password strength check (`value.length >= 8 && /[A-Z]/ && /[0-9]/`) was duplicated inline across NewUserForm, OnboardingForm, and ResetPasswordForm.
- Extract it into a reusable `isStrongPassword` function in `src/utilities/passwordValidation.ts`.
- All three forms now import and call the shared validator.

## Files changed

| File | Change |
|------|--------|
| `src/utilities/passwordValidation.ts` | New: `isStrongPassword` function |
| `src/components/.../NewUserForm.tsx` | Use shared validator |
| `src/components/.../OnboardingForm.tsx` | Use shared validator |
| `src/components/.../ResetPasswordForm.tsx` | Use shared validator |

## Test plan

- [x] Existing form tests pass (90 tests across 11 files)

Closes #329