### PR TITLE
Extract shared BinActionMenuItem component

### DIFF
--- a/src/components/experiences/modern/Rightbar/Bin/AddToQueueFromBin.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/AddToQueueFromBin.tsx
@@ -1,49 +1,20 @@
 "use client";
 import { AlbumEntry } from "@/lib/features/catalog/types";
-import { Chip, MenuItem, Typography } from "@mui/joy";
-
 import { convertBinToQueue } from "@/lib/features/bin/conversions";
-import { useShiftKey } from "@/src/hooks/applicationHooks";
-import { useDeleteFromBin } from "@/src/hooks/binHooks";
 import { useQueue } from "@/src/hooks/flowsheetHooks";
 import PlaylistAdd from "@mui/icons-material/PlaylistAdd";
+import BinActionMenuItem from "./BinActionMenuItem";
 
 export default function AddToQueueFromBin({ entry }: { entry: AlbumEntry }) {
-  const shiftKeyPressed = useShiftKey();
-
   const { addToQueue } = useQueue();
-  const { deleteFromBin } = useDeleteFromBin();
 
   return (
-    <MenuItem
+    <BinActionMenuItem
+      entry={entry}
+      icon={<PlaylistAdd />}
+      label="Add to Queue"
       color="success"
-      onClick={() => {
-        if (shiftKeyPressed) {
-          deleteFromBin(entry.id);
-        }
-
-        addToQueue(convertBinToQueue(entry));
-      }}
-    >
-      <PlaylistAdd />
-      Add to Queue
-      <Chip
-        size="sm"
-        variant="outlined"
-        sx={{
-          color: shiftKeyPressed ? "CaptionText" : "neutral.400",
-        }}
-      >
-        + Shift
-      </Chip>{" "}
-      <Typography
-        level="body-xxs"
-        sx={{
-          color: shiftKeyPressed ? "CaptionText" : "neutral.400",
-        }}
-      >
-        to remove from bin
-      </Typography>
-    </MenuItem>
+      onAction={(entry) => addToQueue(convertBinToQueue(entry))}
+    />
   );
 }

--- a/src/components/experiences/modern/Rightbar/Bin/BinActionMenuItem.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/BinActionMenuItem.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { AlbumEntry } from "@/lib/features/catalog/types";
+import { Chip, MenuItem, Typography } from "@mui/joy";
+import { useShiftKey } from "@/src/hooks/applicationHooks";
+import { useDeleteFromBin } from "@/src/hooks/binHooks";
+import { type ColorPaletteProp } from "@mui/joy";
+
+export default function BinActionMenuItem({
+  entry,
+  icon,
+  label,
+  color,
+  onAction,
+}: {
+  entry: AlbumEntry;
+  icon: React.ReactNode;
+  label: string;
+  color: ColorPaletteProp;
+  onAction: (entry: AlbumEntry) => void;
+}) {
+  const shiftKeyPressed = useShiftKey();
+  const { deleteFromBin } = useDeleteFromBin();
+
+  return (
+    <MenuItem
+      color={color}
+      onClick={() => {
+        if (shiftKeyPressed) {
+          deleteFromBin(entry.id);
+        }
+        onAction(entry);
+      }}
+    >
+      {icon}
+      {label}
+      <Chip
+        size="sm"
+        variant="outlined"
+        sx={{
+          color: shiftKeyPressed ? "CaptionText" : "neutral.400",
+        }}
+      >
+        + Shift
+      </Chip>{" "}
+      <Typography
+        level="body-xxs"
+        sx={{
+          color: shiftKeyPressed ? "CaptionText" : "neutral.400",
+        }}
+      >
+        to remove from bin
+      </Typography>
+    </MenuItem>
+  );
+}

--- a/src/components/experiences/modern/Rightbar/Bin/PlayFromBin.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/PlayFromBin.tsx
@@ -1,49 +1,20 @@
 "use client";
 import { AlbumEntry } from "@/lib/features/catalog/types";
-import { Chip, MenuItem, Typography } from "@mui/joy";
-
 import { convertBinToFlowsheet } from "@/lib/features/bin/conversions";
-import { useShiftKey } from "@/src/hooks/applicationHooks";
-import { useDeleteFromBin } from "@/src/hooks/binHooks";
 import { useFlowsheet } from "@/src/hooks/flowsheetHooks";
 import { PlayArrowOutlined } from "@mui/icons-material";
+import BinActionMenuItem from "./BinActionMenuItem";
 
 export default function PlayFromBin({ entry }: { entry: AlbumEntry }) {
-  const shiftKeyPressed = useShiftKey();
-
   const { addToFlowsheet } = useFlowsheet();
-  const { deleteFromBin } = useDeleteFromBin();
 
   return (
-    <MenuItem
+    <BinActionMenuItem
+      entry={entry}
+      icon={<PlayArrowOutlined />}
+      label="Play Now"
       color="primary"
-      onClick={() => {
-        if (shiftKeyPressed) {
-          deleteFromBin(entry.id);
-        }
-
-        addToFlowsheet(convertBinToFlowsheet(entry));
-      }}
-    >
-      <PlayArrowOutlined />
-      Play Now
-      <Chip
-        size="sm"
-        variant="outlined"
-        sx={{
-          color: shiftKeyPressed ? "CaptionText" : "neutral.400",
-        }}
-      >
-        + Shift
-      </Chip>{" "}
-      <Typography
-        level="body-xxs"
-        sx={{
-          color: shiftKeyPressed ? "CaptionText" : "neutral.400",
-        }}
-      >
-        to remove from bin
-      </Typography>
-    </MenuItem>
+      onAction={(entry) => addToFlowsheet(convertBinToFlowsheet(entry))}
+    />
   );
 }


### PR DESCRIPTION
## Summary

- `AddToQueueFromBin` and `PlayFromBin` were 90% identical (49 lines each) — same shift-key logic, same delete-from-bin behavior, same Chip/Typography markup.
- Extract the common structure into a parameterized `BinActionMenuItem` component that accepts icon, label, color, and action props.
- Both original components become thin wrappers (~19 lines each).

## Files changed

| File | Change |
|------|--------|
| `src/components/.../Bin/BinActionMenuItem.tsx` | New: shared component |
| `src/components/.../Bin/AddToQueueFromBin.tsx` | Thin wrapper |
| `src/components/.../Bin/PlayFromBin.tsx` | Thin wrapper |

## Test plan

- [x] Existing Bin tests pass (57 tests across 7 files)

Closes #331