### PR TITLE
Extract fetchJsonOrNull utility for artwork fetchers

### DIFF
--- a/src/hooks/artwork/fetchJsonOrNull.ts
+++ b/src/hooks/artwork/fetchJsonOrNull.ts
@@ -1,0 +1,21 @@
+/**
+ * Fetches a URL and parses the JSON response, returning null on any failure.
+ * Used by artwork fetchers that gracefully degrade when external APIs are unavailable.
+ */
+export async function fetchJsonOrNull(
+  url: string,
+  source: string,
+  onError: (message: string) => void = console.log,
+): Promise<any | null> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      onError(`Failed to fetch from ${source} (${response.status})`);
+      return null;
+    }
+    return await response.json();
+  } catch {
+    onError(`Error fetching from ${source}`);
+    return null;
+  }
+}

--- a/src/hooks/artwork/itunes-image.ts
+++ b/src/hooks/artwork/itunes-image.ts
@@ -1,4 +1,4 @@
-import { toast } from "sonner";
+import { fetchJsonOrNull } from "./fetchJsonOrNull";
 
 export default async function getArtworkFromItunes({
   title,
@@ -7,27 +7,10 @@ export default async function getArtworkFromItunes({
   title: string;
   artist: string;
 }) {
-  try {
-    const searchTerm = encodeURIComponent(`${title} ${artist}`);
-    const url = `https://itunes.apple.com/search?term=${searchTerm}&entity=album`;
-    
-    const response = await fetch(url);
-    
-    if (!response.ok) {
-      console.log(`Failed to fetch album art from iTunes (${response.status})`);
-      return null;
-    }
-    
-    const jsonResponse = await response.json();
-    
-    const lowResDefault = jsonResponse?.results?.[0]?.artworkUrl100;
-    if (!lowResDefault) {
-      return null;
-    }
-    
-    return lowResDefault.replace("100x100", "600x600");
-  } catch (e) {
-    console.log("Error fetching album art from iTunes");
-    return null;
-  }
+  const searchTerm = encodeURIComponent(`${title} ${artist}`);
+  const url = `https://itunes.apple.com/search?term=${searchTerm}&entity=album`;
+
+  const json = await fetchJsonOrNull(url, "iTunes");
+  const lowResDefault = json?.results?.[0]?.artworkUrl100;
+  return lowResDefault ? lowResDefault.replace("100x100", "600x600") : null;
 }

--- a/src/hooks/artwork/last-fm-image.ts
+++ b/src/hooks/artwork/last-fm-image.ts
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import { fetchJsonOrNull } from "./fetchJsonOrNull";
 
 export default async function getArtworkFromLastFM({
   title,
@@ -7,38 +8,23 @@ export default async function getArtworkFromLastFM({
   title: string;
   artist: string;
 }) {
-  try {
-    const url =
-      "https://ws.audioscrobbler.com/2.0/?" +
-      "api_key=" +
-      process.env.LAST_FM_KEY +
-      "&method=album.getInfo" +
-      "&album=" +
-      encodeURIComponent(title) +
-      "&artist=" +
-      encodeURIComponent(artist) +
-      "&format=json";
-    
-    const response = await fetch(url);
-    
-    if (!response.ok) {
-      console.log(`Failed to fetch album art from Last.fm (${response.status})`);
-      return null;
-    }
-    
-    const jsonResponse = await response.json();
-    
-    const images = jsonResponse?.album?.image;
-    if (!images || !Array.isArray(images) || images.length === 0) {
-      return null;
-    }
-    
-    // Return the largest image (last in array)
-    return images[images.length - 1]?.["#text"] || null;
-  } catch (e) {
-    console.log("Error fetching album art from Last.fm");
+  const url =
+    "https://ws.audioscrobbler.com/2.0/?" +
+    "api_key=" +
+    process.env.LAST_FM_KEY +
+    "&method=album.getInfo" +
+    "&album=" +
+    encodeURIComponent(title) +
+    "&artist=" +
+    encodeURIComponent(artist) +
+    "&format=json";
+
+  const json = await fetchJsonOrNull(url, "Last.fm");
+  const images = json?.album?.image;
+  if (!images || !Array.isArray(images) || images.length === 0) {
     return null;
   }
+  return images[images.length - 1]?.["#text"] || null;
 }
 
 export async function getSongInfoFromLastFM({
@@ -48,29 +34,16 @@ export async function getSongInfoFromLastFM({
   title: string;
   artist: string;
 }) {
-  try {
-    const url =
-      "https://ws.audioscrobbler.com/2.0/?" +
-      "api_key=" +
-      process.env.LAST_FM_KEY +
-      "&method=track.getInfo" +
-      "&track=" +
-      encodeURIComponent(title) +
-      "&artist=" +
-      encodeURIComponent(artist) +
-      "&format=json";
-    
-    const response = await fetch(url);
-    
-    if (!response.ok) {
-      toast.error(`Failed to fetch song info from Last.fm (${response.status})`);
-      return null;
-    }
-    
-    const jsonResponse = await response.json();
-    return jsonResponse;
-  } catch (e) {
-    toast.error("Error fetching song info from Last.fm");
-    return null;
-  }
+  const url =
+    "https://ws.audioscrobbler.com/2.0/?" +
+    "api_key=" +
+    process.env.LAST_FM_KEY +
+    "&method=track.getInfo" +
+    "&track=" +
+    encodeURIComponent(title) +
+    "&artist=" +
+    encodeURIComponent(artist) +
+    "&format=json";
+
+  return await fetchJsonOrNull(url, "Last.fm", (msg) => toast.error(msg));
 }


### PR DESCRIPTION
## Summary

- Three artwork fetch functions (iTunes, Last.fm album art, Last.fm song info) all followed the same fetch-parse-or-null pattern with identical try/catch/response.ok handling.
- Extract shared logic into `fetchJsonOrNull` with a configurable error callback (`console.log` by default, `toast.error` for `getSongInfoFromLastFM`).
- Net: 56 insertions, 79 deletions.

## Files changed

| File | Change |
|------|--------|
| `src/hooks/artwork/fetchJsonOrNull.ts` | New: shared fetch utility |
| `src/hooks/artwork/itunes-image.ts` | Simplified, removed unused toast import |
| `src/hooks/artwork/last-fm-image.ts` | Both functions simplified |

## Test plan

- [x] No regressions in artwork hook tests

Closes #335