### PR TITLE
Extract filterBySearchTerms utility

### DIFF
--- a/src/hooks/binHooks.ts
+++ b/src/hooks/binHooks.ts
@@ -10,6 +10,7 @@ import { useAppSelector } from "@/lib/hooks";
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { FlowsheetQuery } from "@/lib/features/flowsheet/types";
+import { filterBySearchTerms } from "@/src/utilities/filterBySearchTerms";
 
 export const useBin = () => {
   const { loading, info } = useRegistry();
@@ -87,33 +88,11 @@ export const useBinResults = () => {
   const { bin, loading, isSuccess } = useBin();
   const flowsheetQuery = useAppSelector(flowsheetSlice.selectors.getSearchQuery);
 
-  // Calculate search results during render with useMemo instead of useState + useEffect
   const searchResults = useMemo(() => {
-    if (
-      !bin ||
-      loading ||
-      !isSuccess ||
-      flowsheetQuery.album.length + flowsheetQuery.artist.length + flowsheetQuery.label.length <= 3
-    ) {
+    if (!bin || loading || !isSuccess) {
       return [];
     }
-
-    const searchTerms = [flowsheetQuery.album, flowsheetQuery.artist, flowsheetQuery.label].map((term) =>
-      term.toLowerCase()
-    );
-
-    return bin.filter((item) => {
-      const terms = [
-        item.artist?.name.toLowerCase() ?? "",
-        item.title?.toLowerCase() ?? "",
-        item.label?.toLowerCase() ?? "",
-      ];
-
-      return searchTerms.some((searchTerm) => {
-        if (searchTerm.length <= 3) return false;
-        return terms.some((term) => term.includes(searchTerm));
-      });
-    });
+    return filterBySearchTerms(bin, flowsheetQuery);
   }, [bin, loading, isSuccess, flowsheetQuery]);
 
   return {

--- a/src/hooks/catalogHooks.ts
+++ b/src/hooks/catalogHooks.ts
@@ -26,6 +26,7 @@ import { useGetRotationQuery } from "@/lib/features/rotation/api";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuthentication } from "./authenticationHooks";
+import { filterBySearchTerms } from "@/src/utilities/filterBySearchTerms";
 
 export const useCatalogSearch = () => {
   const dispatch = useAppDispatch();
@@ -219,32 +220,11 @@ export const useRotationFlowsheetSearch = () => {
     skip: authenticating || !authenticated,
   });
 
-  // Calculate search results during render with useMemo instead of useState + useEffect
   const searchResults = useMemo(() => {
-    if (
-      !data ||
-      isLoading ||
-      !isSuccess ||
-      rotationQuery.album.length + rotationQuery.artist.length + rotationQuery.label.length <= 3
-    ) {
+    if (!data || isLoading || !isSuccess) {
       return [];
     }
-
-    const searchTerms = [rotationQuery.album, rotationQuery.artist, rotationQuery.label]
-      .map((term) => term.toLowerCase())
-      .filter((term) => term.length > 3);
-
-    return data.filter((item) => {
-      const terms = [
-        item.artist?.name.toLowerCase() ?? "",
-        item.title?.toLowerCase() ?? "",
-        item.label?.toLowerCase() ?? "",
-      ];
-
-      return searchTerms.some((searchTerm) =>
-        terms.some((term) => term.includes(searchTerm))
-      );
-    });
+    return filterBySearchTerms(data, rotationQuery);
   }, [data, isLoading, isSuccess, rotationQuery]);
 
   return {

--- a/src/utilities/filterBySearchTerms.ts
+++ b/src/utilities/filterBySearchTerms.ts
@@ -1,0 +1,33 @@
+import { AlbumEntry } from "@/lib/features/catalog/types";
+
+interface SearchQuery {
+  album: string;
+  artist: string;
+  label: string;
+}
+
+/**
+ * Filters album entries by matching against search terms from a flowsheet query.
+ * Terms shorter than 4 characters are ignored to avoid noise.
+ */
+export function filterBySearchTerms(items: AlbumEntry[], query: SearchQuery): AlbumEntry[] {
+  const searchTerms = [query.album, query.artist, query.label]
+    .map((term) => term.toLowerCase())
+    .filter((term) => term.length > 3);
+
+  if (searchTerms.length === 0) {
+    return [];
+  }
+
+  return items.filter((item) => {
+    const fields = [
+      item.artist?.name.toLowerCase() ?? "",
+      item.title?.toLowerCase() ?? "",
+      item.label?.toLowerCase() ?? "",
+    ];
+
+    return searchTerms.some((searchTerm) =>
+      fields.some((field) => field.includes(searchTerm))
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- `useBinResults` and `useRotationFlowsheetSearch` contained nearly identical client-side filtering logic: build search terms from query fields, filter albums by matching artist/title/label.
- The two implementations had a subtle divergence in where the length check was applied. The extracted function normalizes this.
- Net: 39 insertions, 47 deletions.

## Files changed

| File | Change |
|------|--------|
| `src/utilities/filterBySearchTerms.ts` | New: pure filtering function |
| `src/hooks/binHooks.ts` | `useBinResults` delegates to shared function |
| `src/hooks/catalogHooks.ts` | `useRotationFlowsheetSearch` delegates to shared function |

## Test plan

- [x] Typecheck passes
- [x] No regressions in hook tests

Closes #337