### PR TITLE
Extract throwIfBetterAuthError utility

### DIFF
--- a/src/hooks/adminHooks.ts
+++ b/src/hooks/adminHooks.ts
@@ -4,6 +4,7 @@ import { useAppSelector } from "@/lib/hooks";
 import { convertBetterAuthToAccountResult, BetterAuthUser } from "@/lib/features/admin/conversions-better-auth";
 import { Account } from "@/lib/features/admin/types";
 import { useMemo, useEffect, useState, useCallback } from "react";
+import { throwIfBetterAuthError } from "@/src/utilities/throwIfBetterAuthError";
 
 /**
  * Get the organization ID from environment variable
@@ -49,9 +50,7 @@ export const useAccountListResults = () => {
         },
       });
 
-      if (result.error) {
-        throw new Error(result.error.message || "Failed to fetch users");
-      }
+      throwIfBetterAuthError(result, "Failed to fetch users");
 
       const users = result.data?.users || [];
 

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -18,6 +18,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { resetApplication } from "./applicationHooks";
+import { throwIfBetterAuthError } from "@/src/utilities/throwIfBetterAuthError";
 
 export const useLogin = () => {
   const router = useRouter();
@@ -111,10 +112,7 @@ export const useOTPRequest = () => {
         type: "sign-in",
       });
 
-      if ((result as any).error) {
-        const errorMessage = (result as any).error?.message || "Failed to send login code";
-        throw new Error(errorMessage);
-      }
+      throwIfBetterAuthError(result as any, "Failed to send login code");
 
       toast.success("Login code sent! Check your email.");
     } catch (err) {
@@ -356,10 +354,7 @@ export const useNewUser = () => {
       // Update user profile data (non-admin - updates current user)
       const result = await authClient.updateUser(updateRequest);
 
-      if (result.error) {
-        const errorMessage = result.error.message || 'Failed to update user profile';
-        throw new Error(errorMessage);
-      }
+      throwIfBetterAuthError(result, "Failed to update user profile");
 
       if (params.password) {
         const passwordResult = await authClient.changePassword({
@@ -367,11 +362,7 @@ export const useNewUser = () => {
           newPassword: params.password,
         });
 
-        if (passwordResult.error) {
-          const errorMessage =
-            passwordResult.error.message || "Failed to update password";
-          throw new Error(errorMessage);
-        }
+        throwIfBetterAuthError(passwordResult, "Failed to update password");
       }
 
       // User updated successfully, redirect to dashboard
@@ -446,10 +437,7 @@ export const useResetPassword = () => {
         redirectTo,
       });
 
-      if (result.error) {
-        const errorMessage = result.error.message || "Failed to request password reset";
-        throw new Error(errorMessage);
-      }
+      throwIfBetterAuthError(result, "Failed to request password reset");
 
       toast.success(result.data?.message || "If this email exists, check for a reset link.");
       dispatch(applicationSlice.actions.setAuthStage("otp-email"));
@@ -492,10 +480,7 @@ export const useResetPassword = () => {
         token,
       });
 
-      if (result.error) {
-        const errorMessage = result.error.message || "Password reset failed";
-        throw new Error(errorMessage);
-      }
+      throwIfBetterAuthError(result, "Password reset failed");
 
       toast.success("Password reset successfully. Please log in.");
       dispatch(applicationSlice.actions.setAuthStage("otp-email"));

--- a/src/hooks/djHooks.ts
+++ b/src/hooks/djHooks.ts
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useRegistry } from "./authenticationHooks";
+import { throwIfBetterAuthError } from "@/src/utilities/throwIfBetterAuthError";
 
 export function useDJAccount() {
   const router = useRouter();
@@ -69,9 +70,7 @@ export function useDJAccount() {
             // Use non-admin updateUser (same pattern as onboarding fix)
             const result = await authClient.updateUser(updateData);
 
-            if (result.error) {
-              throw new Error(result.error.message || "Failed to update user");
-            }
+            throwIfBetterAuthError(result, "Failed to update user");
 
             // Update successful
             toast.success("User settings saved.");

--- a/src/utilities/throwIfBetterAuthError.ts
+++ b/src/utilities/throwIfBetterAuthError.ts
@@ -1,0 +1,13 @@
+/**
+ * Checks a better-auth client result for an error and throws with the error message.
+ * Handles the common pattern of extracting error messages from better-auth responses.
+ */
+export function throwIfBetterAuthError(
+  result: { error?: any },
+  fallbackMessage: string,
+): void {
+  if (!result.error) return;
+
+  const errorMessage = result.error.message || fallbackMessage;
+  throw new Error(errorMessage);
+}


### PR DESCRIPTION
## Summary

- 7 call sites across auth, DJ, and admin hooks repeated the same pattern: check `result.error`, extract `.message`, throw.
- Extract into a one-liner `throwIfBetterAuthError(result, fallback)` utility.
- Hooks with custom error mapping logic (`useLogin`'s multi-type extraction, `useOTPVerify`'s friendly message map) are left as-is.

## Files changed

| File | Change |
|------|--------|
| `src/utilities/throwIfBetterAuthError.ts` | New: error extraction + throw utility |
| `src/hooks/authenticationHooks.ts` | 5 call sites replaced |
| `src/hooks/djHooks.ts` | 1 call site replaced |
| `src/hooks/adminHooks.ts` | 1 call site replaced |

## Test plan

- [x] Typecheck passes
- [x] No regressions in hook tests

Closes #339