### PR TITLE
fix: /dashboard 404 for authenticated users

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function DashboardPage() {
+  redirect("/dashboard/flowsheet");
+}


### PR DESCRIPTION
## Summary

- Add `app/dashboard/page.tsx` that redirects to `/dashboard/flowsheet`
- Fixes 404 when authenticated users are redirected from the landing page to `/dashboard`

The root cause: parallel route `default.tsx` files don't make a route directly navigable in Next.js App Router — a `page.tsx` is required.

Closes #343