### PR TITLE
Fix flowsheet entry ordering across show boundaries

### DIFF
--- a/lib/__tests__/features/flowsheet/partition.test.ts
+++ b/lib/__tests__/features/flowsheet/partition.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { partitionFlowsheetEntries } from "@/lib/features/flowsheet/partition";
+import type {
+  FlowsheetEntry,
+  FlowsheetSongEntry,
+  FlowsheetShowBlockEntry,
+} from "@/lib/features/flowsheet/types";
+import { TEST_ENTITY_IDS } from "@/lib/test-utils";
+
+const CURRENT_SHOW = TEST_ENTITY_IDS.SHOW.CURRENT_SHOW;
+const PAST_SHOW = TEST_ENTITY_IDS.SHOW.PAST_SHOW;
+
+function song(id: number, show_id: number): FlowsheetSongEntry {
+  return {
+    id,
+    play_order: id,
+    show_id,
+    track_title: `Track ${id}`,
+    artist_name: "Autechre",
+    album_title: "Confield",
+    record_label: "Warp",
+    request_flag: false,
+  };
+}
+
+function showMarker(
+  id: number,
+  show_id: number,
+  isStart: boolean
+): FlowsheetShowBlockEntry {
+  return {
+    id,
+    play_order: id,
+    show_id,
+    dj_name: "Test DJ",
+    isStart,
+    day: "4/20/2026",
+    time: "2:00:00 PM",
+  };
+}
+
+describe("partitionFlowsheetEntries", () => {
+  it("returns everything in previous when not live", () => {
+    const entries: FlowsheetEntry[] = [
+      song(103, CURRENT_SHOW),
+      song(102, CURRENT_SHOW),
+      showMarker(101, CURRENT_SHOW, true),
+    ];
+
+    const result = partitionFlowsheetEntries(entries, CURRENT_SHOW, false);
+
+    expect(result.current).toEqual([]);
+    expect(result.previous).toEqual(entries);
+  });
+
+  it("returns everything in previous when currentShow is -1", () => {
+    const entries: FlowsheetEntry[] = [song(100, CURRENT_SHOW)];
+
+    const result = partitionFlowsheetEntries(entries, -1, true);
+
+    expect(result.current).toEqual([]);
+    expect(result.previous).toEqual(entries);
+  });
+
+  it("partitions entries by show_id when live", () => {
+    const entries: FlowsheetEntry[] = [
+      song(105, CURRENT_SHOW),
+      song(104, CURRENT_SHOW),
+      showMarker(103, CURRENT_SHOW, true),
+      song(102, PAST_SHOW),
+      showMarker(101, PAST_SHOW, true),
+    ];
+
+    const result = partitionFlowsheetEntries(entries, CURRENT_SHOW, true);
+
+    expect(result.current.map((e) => e.id)).toEqual([105, 104, 103]);
+    expect(result.previous.map((e) => e.id)).toEqual([102, 101]);
+  });
+
+  it("includes start and end markers in current show entries", () => {
+    const entries: FlowsheetEntry[] = [
+      showMarker(107, CURRENT_SHOW, false), // end marker
+      song(106, CURRENT_SHOW),
+      song(105, CURRENT_SHOW),
+      showMarker(104, CURRENT_SHOW, true), // start marker
+    ];
+
+    const result = partitionFlowsheetEntries(entries, CURRENT_SHOW, true);
+
+    expect(result.current).toHaveLength(4);
+    expect(result.current.map((e) => e.id)).toEqual([107, 106, 105, 104]);
+    expect(result.previous).toEqual([]);
+  });
+
+  it("preserves chronological order across show boundaries", () => {
+    // Simulates: DJ A plays show, ends, DJ B starts new show, ends.
+    // IDs are strictly increasing over time. Entries sorted id DESC.
+    const entries: FlowsheetEntry[] = [
+      showMarker(110, CURRENT_SHOW, false), // B ended the set
+      song(109, CURRENT_SHOW),              // B played a track
+      song(108, CURRENT_SHOW),              // B played a track
+      showMarker(107, CURRENT_SHOW, true),  // B started the set
+      showMarker(106, PAST_SHOW, false),    // A ended the set
+      song(105, PAST_SHOW),                 // A played a track
+      song(104, PAST_SHOW),                 // A played a track
+      showMarker(103, PAST_SHOW, true),     // A started the set
+    ];
+
+    const result = partitionFlowsheetEntries(entries, CURRENT_SHOW, true);
+
+    // Current show has all B entries (including markers)
+    expect(result.current.map((e) => e.id)).toEqual([110, 109, 108, 107]);
+    // Previous show has all A entries
+    expect(result.previous.map((e) => e.id)).toEqual([106, 105, 104, 103]);
+
+    // Concatenation preserves strict id DESC order
+    const concatenated = [...result.current, ...result.previous];
+    for (let i = 0; i < concatenated.length - 1; i++) {
+      expect(concatenated[i].id).toBeGreaterThan(concatenated[i + 1].id);
+    }
+  });
+
+  it("returns empty partitions for empty input", () => {
+    const result = partitionFlowsheetEntries([], CURRENT_SHOW, true);
+
+    expect(result.current).toEqual([]);
+    expect(result.previous).toEqual([]);
+  });
+
+  it("puts all entries in current when only one show exists", () => {
+    const entries: FlowsheetEntry[] = [
+      song(103, CURRENT_SHOW),
+      song(102, CURRENT_SHOW),
+      showMarker(101, CURRENT_SHOW, true),
+    ];
+
+    const result = partitionFlowsheetEntries(entries, CURRENT_SHOW, true);
+
+    expect(result.current).toEqual(entries);
+    expect(result.previous).toEqual([]);
+  });
+});

--- a/lib/features/flowsheet/partition.ts
+++ b/lib/features/flowsheet/partition.ts
@@ -1,0 +1,43 @@
+import type { FlowsheetEntry } from "./types";
+
+export interface PartitionedEntries {
+  current: FlowsheetEntry[];
+  previous: FlowsheetEntry[];
+}
+
+/**
+ * Partitions a sorted (id DESC) list of flowsheet entries into
+ * "current show" and "previous shows" buckets.
+ *
+ * When live: current = ALL entries with show_id === currentShow
+ * (including start/end markers); previous = everything else.
+ *
+ * When not live (or no current show): current is empty,
+ * previous is the full list.
+ *
+ * Invariant: [...current, ...previous] preserves the original
+ * id-DESC ordering because all current-show entries have higher
+ * IDs than any previous-show entries.
+ */
+export function partitionFlowsheetEntries(
+  allEntries: FlowsheetEntry[],
+  currentShow: number,
+  live: boolean
+): PartitionedEntries {
+  if (currentShow === -1 || !live) {
+    return { current: [], previous: allEntries };
+  }
+
+  const current: FlowsheetEntry[] = [];
+  const previous: FlowsheetEntry[] = [];
+
+  for (const entry of allEntries) {
+    if (entry.show_id === currentShow) {
+      current.push(entry);
+    } else {
+      previous.push(entry);
+    }
+  }
+
+  return { current, previous };
+}

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -13,14 +13,13 @@ import {
 } from "@/lib/features/flowsheet/api";
 import { convertQueryToSubmission } from "@/lib/features/flowsheet/conversions";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { partitionFlowsheetEntries } from "@/lib/features/flowsheet/partition";
 import {
   FlowsheetEntry,
   FlowsheetQuery,
   FlowsheetSearchProperty,
   FlowsheetSubmissionParams,
   FlowsheetUpdateParams,
-  isFlowsheetEndShowEntry,
-  isFlowsheetStartShowEntry,
 } from "@/lib/features/flowsheet/types";
 import type { RootState } from "@/lib/store";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
@@ -271,36 +270,25 @@ export const useFlowsheet = () => {
 
   const { currentShow, live } = useShowControl();
 
-  // Calculate derived state during render instead of useEffect + Redux
-  const currentShowEntries = useMemo(() => {
-    if (currentShow === -1 || !live) return [];
-    return allEntries.filter(
-      (entry) =>
-        entry.show_id === currentShow &&
-        !isFlowsheetStartShowEntry(entry) &&
-        !isFlowsheetEndShowEntry(entry)
-    );
-  }, [allEntries, currentShow, live]);
+  // Partition entries into current show vs previous shows.
+  // All entries from the current show (including start/end markers) go into
+  // currentShowEntries so that concatenation with lastShowsEntries preserves
+  // strict id-DESC chronological order.
+  const { current: currentShowEntries, previous: lastShowsEntries } = useMemo(
+    () => partitionFlowsheetEntries(allEntries, currentShow, live),
+    [allEntries, currentShow, live]
+  );
 
   const setCurrentShowEntries = (entries: FlowsheetEntry[]) => {
     dispatch(flowsheetSlice.actions.setCurrentShowEntries(entries));
   };
 
-  const lastShowsEntries = useMemo(() => {
-    if (allEntries.length === 0) return [];
-    return live
-      ? allEntries.filter(
-          (entry) =>
-            entry.show_id !== currentShow ||
-            isFlowsheetStartShowEntry(entry) ||
-            isFlowsheetEndShowEntry(entry)
-        )
-      : allEntries;
-  }, [allEntries, live, currentShow]);
-
   const [switchBackendEntries, switchBackendResult] =
     useSwitchEntriesMutation();
 
+  // TODO: newLocation is an index into currentShowEntries but used as an index
+  // into allEntries — these arrays have different lengths and contents. This is
+  // safe only because drag-and-drop is currently disabled in the UI.
   const switchEntries = useCallback(
     async (entry: FlowsheetEntry) => {
       if (!userData?.id || userloading) return;


### PR DESCRIPTION
## Summary

- Extracts `partitionFlowsheetEntries()` into a pure utility (`lib/features/flowsheet/partition.ts`) that partitions entries strictly by `show_id` — all entries from the current show (including start/end markers) go to `current`, everything else to `previous`
- Fixes the ordering bug where show start/end markers were excluded from `currentShowEntries` and placed in `lastShowsEntries`, causing the page to render a show's end marker after its song entries when concatenating the two arrays
- Also fixes a secondary bug where the classic layout's `currentShowEntries.find(isFlowsheetStartShowEntry)` always returned `undefined` because markers were excluded from `current`

Closes #345

## Test plan

- [x] New unit tests for `partitionFlowsheetEntries()` cover: not-live, no current show, basic partitioning, markers in current, multi-show chronological order, empty input, single show
- [x] Full test suite passes (1810 tests, 148 files)
- [x] TypeScript type check passes
- [ ] Manual: go live, add entries, end set, start new set, end new set — verify entries display in correct chronological order