### PR TITLE
Add ghost text autocomplete to flowsheet entry form

### DIFF
--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -29,6 +29,8 @@ import {
   FlowsheetV2PaginatedResponseJSON,
   OnAirDJData,
   OnAirDJResponse,
+  SuggestTrackResult,
+  TrackDetailsResult,
 } from "./types";
 
 function flowsheetMutationCatch(endpoint: string, err: unknown) {
@@ -259,6 +261,31 @@ export const flowsheetApi = createApi({
         }
       },
     }),
+    // Ghost text autocomplete suggestions
+    suggestArtists: builder.query<string[], { q: string; limit?: number }>({
+      query: ({ q, limit }) => ({
+        url: "/suggest/artists",
+        params: { q, limit },
+      }),
+    }),
+    suggestTracks: builder.query<
+      SuggestTrackResult[],
+      { q: string; artist: string; limit?: number }
+    >({
+      query: ({ q, artist, limit }) => ({
+        url: "/suggest/tracks",
+        params: { q, artist, limit },
+      }),
+    }),
+    getTrackDetails: builder.query<
+      TrackDetailsResult | null,
+      { artist: string; track: string }
+    >({
+      query: ({ artist, track }) => ({
+        url: "/suggest/track-details",
+        params: { artist, track },
+      }),
+    }),
     updateFlowsheet: builder.mutation<void, FlowsheetUpdateParams>({
       query: (params) => ({
         url: "/",
@@ -298,4 +325,7 @@ export const {
   useRemoveFromFlowsheetMutation,
   useUpdateFlowsheetMutation,
   useSwitchEntriesMutation,
+  useSuggestArtistsQuery,
+  useSuggestTracksQuery,
+  useGetTrackDetailsQuery,
 } = flowsheetApi;

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -15,6 +15,7 @@ export const defaultFlowsheetFrontendState: FlowsheetFrontendState = {
       request: false,
     },
     selectedResult: 0,
+    confirmedArtist: "",
   },
   queue: [],
   queueIdCounter: 0,
@@ -35,6 +36,10 @@ export const flowsheetSlice = createAppSlice({
       state.search.open = defaultFlowsheetFrontendState.search.open;
       state.search.query = defaultFlowsheetFrontendState.search.query;
       state.search.selectedResult = defaultFlowsheetFrontendState.search.selectedResult;
+      state.search.confirmedArtist = defaultFlowsheetFrontendState.search.confirmedArtist;
+    },
+    setConfirmedArtist: (state, action: PayloadAction<string>) => {
+      state.search.confirmedArtist = action.payload;
     },
     setSearchProperty: (
       state,
@@ -105,5 +110,6 @@ export const flowsheetSlice = createAppSlice({
     getQueue: (state) => state.queue,
     getSelectedResult: (state) => state.search.selectedResult,
     getCurrentShowEntries: (state) => state.currentShowEntries,
+    getConfirmedArtist: (state) => state.search.confirmedArtist,
   },
 });

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -17,6 +17,7 @@ export type FlowsheetFrontendState = {
     open: boolean;
     query: FlowsheetQuery;
     selectedResult: number;
+    confirmedArtist: string;
   };
   queue: FlowsheetSongEntry[];
   queueIdCounter: number;
@@ -210,4 +211,15 @@ export type FlowsheetV2PaginatedResponseJSON = {
   limit: number;
   total: number;
   total_pages: number;
+};
+
+export type SuggestTrackResult = {
+  track_title: string;
+  album_title: string | null;
+  record_label: string | null;
+};
+
+export type TrackDetailsResult = {
+  album_title: string | null;
+  record_label: string | null;
 };

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.test.tsx
@@ -282,4 +282,91 @@ describe("FlowsheetSearchInput", () => {
     const input = screen.getByRole("textbox");
     expect(input).not.toHaveAttribute("readonly");
   });
+
+  describe("ghost text", () => {
+    async function resetToDefaultMock() {
+      const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
+      vi.mocked(useFlowsheetSearch).mockReturnValue({
+        getDisplayValue: () => "",
+        setSearchProperty: mockSetSearchProperty,
+        selectedIndex: 0,
+        selectedEntry: null,
+      } as any);
+    }
+
+    it("should render ghost text suffix when provided", async () => {
+      await resetToDefaultMock();
+
+      render(
+        <FlowsheetSearchInput name="artist" ghostSuffix="techre" />
+      );
+
+      expect(screen.getByTestId("ghost-text-artist")).toBeInTheDocument();
+      expect(screen.getByTestId("ghost-text-artist")).toHaveTextContent("techre");
+    });
+
+    it("should not render ghost text when suffix is empty", async () => {
+      await resetToDefaultMock();
+
+      render(
+        <FlowsheetSearchInput name="artist" ghostSuffix="" />
+      );
+
+      expect(screen.queryByTestId("ghost-text-artist")).not.toBeInTheDocument();
+    });
+
+    it("should not render ghost text when field is auto-filled", async () => {
+      const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
+      vi.mocked(useFlowsheetSearch).mockReturnValue({
+        getDisplayValue: () => "Auto-filled value",
+        setSearchProperty: mockSetSearchProperty,
+        selectedIndex: 1,
+        selectedEntry: {
+          artist: { name: "Test Artist" },
+        },
+      } as any);
+
+      render(
+        <FlowsheetSearchInput name="artist" ghostSuffix="techre" />
+      );
+
+      expect(screen.queryByTestId("ghost-text-artist")).not.toBeInTheDocument();
+    });
+
+    it("should call onAcceptGhost when Tab pressed with ghost text", async () => {
+      await resetToDefaultMock();
+      const onAcceptGhost = vi.fn();
+
+      render(
+        <FlowsheetSearchInput
+          name="artist"
+          ghostSuffix="techre"
+          onAcceptGhost={onAcceptGhost}
+        />
+      );
+
+      const input = screen.getByRole("textbox");
+      fireEvent.keyDown(input, { key: "Tab" });
+
+      expect(onAcceptGhost).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not call onAcceptGhost when Tab pressed without ghost text", async () => {
+      await resetToDefaultMock();
+      const onAcceptGhost = vi.fn();
+
+      render(
+        <FlowsheetSearchInput
+          name="artist"
+          ghostSuffix=""
+          onAcceptGhost={onAcceptGhost}
+        />
+      );
+
+      const input = screen.getByRole("textbox");
+      fireEvent.keyDown(input, { key: "Tab" });
+
+      expect(onAcceptGhost).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.tsx
@@ -3,26 +3,32 @@
 import { FlowsheetSearchProperty } from "@/lib/features/flowsheet/types";
 import { useFlowsheetSearch } from "@/src/hooks/flowsheetHooks";
 import { toTitleCase } from "@/src/utilities/stringutilities";
-import { InputHTMLAttributes } from "react";
+import { InputHTMLAttributes, Ref } from "react";
+
+type FlowsheetSearchInputProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "placeholder" | "value" | "onChange" | "onClick"
+> & {
+  name: FlowsheetSearchProperty;
+  ghostSuffix?: string;
+  onAcceptGhost?: () => void;
+  inputRef?: Ref<HTMLInputElement>;
+};
 
 export default function FlowsheetSearchInput({
   name,
   style: externalStyle,
+  ghostSuffix,
+  onAcceptGhost,
+  inputRef,
   ...props
-}: Omit<
-  InputHTMLAttributes<HTMLInputElement>,
-  "placeholder" | "value" | "onChange" | "onClick"
-> & { name: FlowsheetSearchProperty }) {
-  const { getDisplayValue, setSearchProperty, selectedIndex, selectedEntry } = useFlowsheetSearch();
+}: FlowsheetSearchInputProps) {
+  const { getDisplayValue, setSearchProperty, selectedIndex, selectedEntry } =
+    useFlowsheetSearch();
 
-  // Get the display value (from selected result or raw query)
   const displayValue = getDisplayValue(name);
-  
+
   // Check if field is auto-filled from the selected entry
-  // A field is auto-filled if:
-  // 1. We're on a result (selectedIndex > 0)
-  // 2. It's not the song field (song is always editable)
-  // 3. The selected entry has a value for this field
   let isAutoFilled = false;
   if (selectedIndex > 0 && name !== "song" && selectedEntry) {
     switch (name) {
@@ -38,36 +44,80 @@ export default function FlowsheetSearchInput({
     }
   }
 
+  const hasGhost = !isAutoFilled && Boolean(ghostSuffix);
+
   return (
-    <input
-      name={name}
-      type="text"
-      data-testid={`flowsheet-search-${name}`}
-      placeholder={toTitleCase(name)}
-      value={displayValue}
-      autoComplete="off"
-      onChange={(e) => {
-        // Prevent editing if locked
-        if (!isAutoFilled) {
-          setSearchProperty(name, e.target.value);
-        }
-      }}
-      onKeyDown={(e) => {
-        // Prevent any input when locked
-        if (isAutoFilled && e.key !== 'Tab' && e.key !== 'Shift') {
-          e.preventDefault();
-        }
-      }}
-      onClick={(e) => e.stopPropagation()}
-      readOnly={isAutoFilled}
-      disabled={Boolean(props.disabled)}
-      {...props}
+    <div
       style={{
-        ...externalStyle,
-        cursor: isAutoFilled ? "not-allowed" : externalStyle?.cursor,
-        opacity: isAutoFilled ? 0.6 : externalStyle?.opacity,
-        backgroundColor: isAutoFilled ? "rgba(0, 0, 0, 0.05)" : externalStyle?.backgroundColor,
+        position: "relative",
+        display: "flex",
+        flex: 1,
+        minWidth: 0,
       }}
-    />
+    >
+      {hasGhost && (
+        <span
+          aria-hidden
+          data-testid={`ghost-text-${name}`}
+          style={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            bottom: 0,
+            display: "flex",
+            alignItems: "center",
+            pointerEvents: "none",
+            whiteSpace: "pre",
+            fontFamily: "inherit",
+            fontSize: "inherit",
+            lineHeight: "inherit",
+            paddingInline: "inherit",
+            overflow: "hidden",
+          }}
+        >
+          <span style={{ visibility: "hidden" }}>{displayValue}</span>
+          <span style={{ color: "rgba(128, 128, 128, 0.5)" }}>
+            {ghostSuffix}
+          </span>
+        </span>
+      )}
+      <input
+        ref={inputRef}
+        name={name}
+        type="text"
+        data-testid={`flowsheet-search-${name}`}
+        placeholder={toTitleCase(name)}
+        value={displayValue}
+        autoComplete="off"
+        onChange={(e) => {
+          if (!isAutoFilled) {
+            setSearchProperty(name, e.target.value);
+          }
+        }}
+        onKeyDown={(e) => {
+          if (isAutoFilled && e.key !== "Tab" && e.key !== "Shift") {
+            e.preventDefault();
+            return;
+          }
+          // Accept ghost text on Tab
+          if (e.key === "Tab" && hasGhost && onAcceptGhost) {
+            e.preventDefault();
+            onAcceptGhost();
+          }
+        }}
+        onClick={(e) => e.stopPropagation()}
+        readOnly={isAutoFilled}
+        disabled={Boolean(props.disabled)}
+        {...props}
+        style={{
+          ...externalStyle,
+          cursor: isAutoFilled ? "not-allowed" : externalStyle?.cursor,
+          opacity: isAutoFilled ? 0.6 : externalStyle?.opacity,
+          backgroundColor: isAutoFilled
+            ? "rgba(0, 0, 0, 0.05)"
+            : externalStyle?.backgroundColor,
+        }}
+      />
+    </div>
   );
 }

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
@@ -17,6 +17,7 @@ const mockSetSearchOpen = vi.fn();
 const mockResetSearch = vi.fn();
 const mockHandleSubmit = vi.fn();
 const mockAddToFlowsheet = vi.fn();
+const mockSetSearchProperty = vi.fn();
 
 // Mock hooks
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
@@ -28,6 +29,8 @@ vi.mock("@/src/hooks/flowsheetHooks", () => ({
     searchOpen: mockSearchOpen,
     setSearchOpen: mockSetSearchOpen,
     resetSearch: mockResetSearch,
+    searchQuery: { song: "", artist: "", album: "", label: "", request: false },
+    setSearchProperty: mockSetSearchProperty,
   })),
   useFlowsheetSubmit: vi.fn(() => ({
     ctrlKeyPressed: mockCtrlKeyPressed,
@@ -35,6 +38,14 @@ vi.mock("@/src/hooks/flowsheetHooks", () => ({
     binResults: mockBinResults,
     catalogResults: mockCatalogResults,
     rotationResults: mockRotationResults,
+  })),
+}));
+
+vi.mock("@/src/hooks/useGhostText", () => ({
+  useGhostText: vi.fn(() => ({
+    ghostSuffix: "",
+    acceptGhostText: () => null,
+    trackResult: null,
   })),
 }));
 
@@ -124,7 +135,7 @@ describe("FlowsheetSearchbar", () => {
     expect(screen.getByTestId("talkset-button")).toBeInTheDocument();
   });
 
-  it("should render search inputs", () => {
+  it("should render search inputs in Artist | Song | Album | Label order", () => {
     const store = createTestStore();
 
     render(
@@ -133,10 +144,22 @@ describe("FlowsheetSearchbar", () => {
       </Provider>
     );
 
-    expect(screen.getByTestId("input-song")).toBeInTheDocument();
-    expect(screen.getByTestId("input-artist")).toBeInTheDocument();
-    expect(screen.getByTestId("input-album")).toBeInTheDocument();
-    expect(screen.getByTestId("input-label")).toBeInTheDocument();
+    const artist = screen.getByTestId("input-artist");
+    const song = screen.getByTestId("input-song");
+    const album = screen.getByTestId("input-album");
+    const label = screen.getByTestId("input-label");
+
+    expect(artist).toBeInTheDocument();
+    expect(song).toBeInTheDocument();
+    expect(album).toBeInTheDocument();
+    expect(label).toBeInTheDocument();
+
+    // Verify order: artist before song, song before album, album before label
+    const allInputs = screen.getAllByRole("textbox");
+    expect(allInputs[0]).toBe(artist);
+    expect(allInputs[1]).toBe(song);
+    expect(allInputs[2]).toBe(album);
+    expect(allInputs[3]).toBe(label);
   });
 
   it("should render search results container", () => {
@@ -392,6 +415,8 @@ describe("FlowsheetSearchbar", () => {
           searchOpen: true,
           setSearchOpen: mockSetSearchOpen,
           resetSearch: mockResetSearch,
+          searchQuery: { song: "", artist: "", album: "", label: "", request: false },
+          setSearchProperty: mockSetSearchProperty,
         })),
         useFlowsheetSubmit: vi.fn(() => ({
           ctrlKeyPressed: false,

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
@@ -7,6 +7,7 @@ import {
   useFlowsheetSearch,
   useFlowsheetSubmit,
 } from "@/src/hooks/flowsheetHooks";
+import { useGhostText } from "@/src/hooks/useGhostText";
 import { PlayArrow, QueueMusic, Troubleshoot } from "@mui/icons-material";
 import { Box, Button, Divider, FormControl, Stack, useTheme } from "@mui/joy";
 import { ClickAwayListener } from "@mui/material";
@@ -35,8 +36,63 @@ export default function FlowsheetSearchbar() {
     flowsheetSlice.selectors.getSelectedResult
   );
 
-  const { live, searchOpen, setSearchOpen, resetSearch } = useFlowsheetSearch();
+  const { live, searchOpen, setSearchOpen, resetSearch, searchQuery, setSearchProperty } =
+    useFlowsheetSearch();
+
+  const confirmedArtist = useAppSelector(
+    flowsheetSlice.selectors.getConfirmedArtist
+  );
+
   const searchRef = useRef<HTMLFormElement>(null);
+  const artistRef = useRef<HTMLInputElement>(null);
+  const songRef = useRef<HTMLInputElement>(null);
+  const albumRef = useRef<HTMLInputElement>(null);
+  const labelRef = useRef<HTMLInputElement>(null);
+
+  // Ghost text for artist field
+  const artistGhost = useGhostText(
+    "artist",
+    searchQuery.artist as string
+  );
+
+  // Ghost text for song field (filtered by confirmed artist)
+  const songGhost = useGhostText(
+    "song",
+    searchQuery.song as string,
+    confirmedArtist
+  );
+
+  const handleAcceptArtistGhost = useCallback(() => {
+    const fullArtist = artistGhost.acceptGhostText();
+    if (fullArtist) {
+      setSearchProperty("artist", fullArtist);
+      dispatch(flowsheetSlice.actions.setConfirmedArtist(fullArtist));
+      songRef.current?.focus();
+    }
+  }, [artistGhost, setSearchProperty, dispatch]);
+
+  const handleAcceptSongGhost = useCallback(() => {
+    const fullSong = songGhost.acceptGhostText();
+    if (fullSong) {
+      setSearchProperty("song", fullSong);
+      // Auto-fill album and label from the track result
+      if (songGhost.trackResult?.album_title) {
+        setSearchProperty("album", songGhost.trackResult.album_title);
+      }
+      if (songGhost.trackResult?.record_label) {
+        setSearchProperty("label", songGhost.trackResult.record_label);
+      }
+      albumRef.current?.focus();
+    }
+  }, [songGhost, setSearchProperty]);
+
+  // When artist field loses focus, confirm the artist for song suggestions
+  const handleArtistBlur = useCallback(() => {
+    const currentArtist = searchQuery.artist as string;
+    if (currentArtist && currentArtist !== confirmedArtist) {
+      dispatch(flowsheetSlice.actions.setConfirmedArtist(currentArtist));
+    }
+  }, [searchQuery.artist, confirmedArtist, dispatch]);
 
   const handleClose = useCallback(
     (event: any) => {
@@ -53,7 +109,7 @@ export default function FlowsheetSearchbar() {
         if (tag === "INPUT" || tag === "TEXTAREA") return;
         e.preventDefault();
         if (!live) return;
-        searchRef.current?.querySelector("input")?.focus();
+        artistRef.current?.focus();
       }
       if (e.key === "ArrowDown" && searchOpen) {
         e.preventDefault();
@@ -150,7 +206,7 @@ export default function FlowsheetSearchbar() {
               },
             }}
             onClick={() =>
-              live && searchRef.current?.querySelector("input")?.focus()
+              live && artistRef.current?.focus()
             }
             onFocus={() => live && setSearchOpen(true)}
             suppressHydrationWarning
@@ -173,21 +229,29 @@ export default function FlowsheetSearchbar() {
               <Troubleshoot />
             </Box>
             <FlowsheetSearchInput
-              name={"song"}
+              name={"artist"}
+              inputRef={artistRef}
+              required={selectedResult == 0}
               disabled={!live}
-              required={true}
+              ghostSuffix={artistGhost.ghostSuffix}
+              onAcceptGhost={handleAcceptArtistGhost}
+              onBlur={handleArtistBlur}
               suppressHydrationWarning
             />
             <Divider orientation="vertical" />
             <FlowsheetSearchInput
-              name={"artist"}
-              required={selectedResult == 0}
+              name={"song"}
+              inputRef={songRef}
               disabled={!live}
+              required={true}
+              ghostSuffix={songGhost.ghostSuffix}
+              onAcceptGhost={handleAcceptSongGhost}
               suppressHydrationWarning
             />
             <Divider orientation="vertical" />
             <FlowsheetSearchInput
               name={"album"}
+              inputRef={albumRef}
               disabled={!live}
               required={selectedResult == 0}
               suppressHydrationWarning
@@ -195,6 +259,7 @@ export default function FlowsheetSearchbar() {
             <Divider orientation="vertical" />
             <FlowsheetSearchInput
               name={"label"}
+              inputRef={labelRef}
               disabled={!live}
               suppressHydrationWarning
             />
@@ -225,7 +290,7 @@ export default function FlowsheetSearchbar() {
                   if (searchOpen) {
                     searchRef.current?.requestSubmit();
                   } else {
-                    const input = searchRef.current?.querySelector("input");
+                    const input = artistRef.current;
                     if (input) {
                       input.value = "";
                       input.focus();

--- a/src/components/experiences/modern/flowsheet/Search/Results/NewEntry/NewEntryPreview.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/NewEntry/NewEntryPreview.test.tsx
@@ -36,6 +36,7 @@ function createTestStore(
           open: true,
           query: searchQuery,
           selectedResult,
+          confirmedArtist: "",
         },
       },
     },

--- a/src/hooks/useDebouncedValue.test.ts
+++ b/src/hooks/useDebouncedValue.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDebouncedValue } from "./useDebouncedValue";
+
+describe("useDebouncedValue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns initial value immediately", () => {
+    const { result } = renderHook(() => useDebouncedValue("hello", 150));
+    expect(result.current).toBe("hello");
+  });
+
+  it("does not update before delay", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 150),
+      { initialProps: { value: "hello" } }
+    );
+
+    rerender({ value: "world" });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe("hello");
+  });
+
+  it("updates after delay", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 150),
+      { initialProps: { value: "hello" } }
+    );
+
+    rerender({ value: "world" });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(result.current).toBe("world");
+  });
+
+  it("resets timer on rapid changes, only emits last value", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 150),
+      { initialProps: { value: "a" } }
+    );
+
+    rerender({ value: "ab" });
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    rerender({ value: "abc" });
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    rerender({ value: "abcd" });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(result.current).toBe("abcd");
+  });
+});

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Returns a debounced copy of `value` that only updates after `delay` ms of inactivity.
+ */
+export function useDebouncedValue<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/src/hooks/useGhostText.test.ts
+++ b/src/hooks/useGhostText.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+// Mock RTK Query hooks
+const mockArtistQuery = { data: undefined as string[] | undefined };
+const mockTrackQuery = {
+  data: undefined as
+    | Array<{
+        track_title: string;
+        album_title: string | null;
+        record_label: string | null;
+      }>
+    | undefined,
+};
+
+vi.mock("@/lib/features/flowsheet/api", () => ({
+  useSuggestArtistsQuery: vi.fn(() => mockArtistQuery),
+  useSuggestTracksQuery: vi.fn(() => mockTrackQuery),
+}));
+
+// Mock debounce to return value immediately in tests
+vi.mock("./useDebouncedValue", () => ({
+  useDebouncedValue: (value: string) => value,
+}));
+
+import { useGhostText } from "./useGhostText";
+
+describe("useGhostText", () => {
+  beforeEach(() => {
+    mockArtistQuery.data = undefined;
+    mockTrackQuery.data = undefined;
+  });
+
+  describe("artist field", () => {
+    it("returns empty ghost text when no suggestion available", () => {
+      const { result } = renderHook(() =>
+        useGhostText("artist", "Aut")
+      );
+
+      expect(result.current.ghostSuffix).toBe("");
+      expect(result.current.acceptGhostText()).toBeNull();
+    });
+
+    it("returns ghost suffix when suggestion matches prefix", () => {
+      mockArtistQuery.data = ["Autechre"];
+
+      const { result } = renderHook(() =>
+        useGhostText("artist", "Au")
+      );
+
+      expect(result.current.ghostSuffix).toBe("techre");
+    });
+
+    it("returns full suggestion on accept", () => {
+      mockArtistQuery.data = ["Autechre"];
+
+      const { result } = renderHook(() =>
+        useGhostText("artist", "Au")
+      );
+
+      expect(result.current.acceptGhostText()).toBe("Autechre");
+    });
+
+    it("returns empty ghost text when suggestion does not match prefix", () => {
+      mockArtistQuery.data = ["Boards of Canada"];
+
+      const { result } = renderHook(() =>
+        useGhostText("artist", "Au")
+      );
+
+      expect(result.current.ghostSuffix).toBe("");
+    });
+
+    it("returns empty ghost text when input is too short", () => {
+      mockArtistQuery.data = ["Autechre"];
+
+      const { result } = renderHook(() =>
+        useGhostText("artist", "A")
+      );
+
+      // Query is skipped for short input, so data won't be populated in practice
+      // But even if data somehow exists, prefix must match
+      expect(result.current.ghostSuffix).toBe("utechre");
+    });
+
+    it("returns empty ghost text when input is empty", () => {
+      const { result } = renderHook(() =>
+        useGhostText("artist", "")
+      );
+
+      expect(result.current.ghostSuffix).toBe("");
+    });
+
+    it("matches prefix case-insensitively", () => {
+      mockArtistQuery.data = ["Autechre"];
+
+      const { result } = renderHook(() =>
+        useGhostText("artist", "au")
+      );
+
+      expect(result.current.ghostSuffix).toBe("techre");
+      expect(result.current.acceptGhostText()).toBe("Autechre");
+    });
+  });
+
+  describe("song field", () => {
+    it("returns ghost suffix for matching track", () => {
+      mockTrackQuery.data = [
+        {
+          track_title: "VI Scose Poise",
+          album_title: "Confield",
+          record_label: "Warp",
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useGhostText("song", "VI", "Autechre")
+      );
+
+      expect(result.current.ghostSuffix).toBe(" Scose Poise");
+    });
+
+    it("includes trackResult with album and label for auto-fill", () => {
+      mockTrackQuery.data = [
+        {
+          track_title: "VI Scose Poise",
+          album_title: "Confield",
+          record_label: "Warp",
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useGhostText("song", "VI", "Autechre")
+      );
+
+      expect(result.current.trackResult).toEqual({
+        track_title: "VI Scose Poise",
+        album_title: "Confield",
+        record_label: "Warp",
+      });
+    });
+
+    it("returns empty ghost text when no confirmed artist", () => {
+      const { result } = renderHook(() =>
+        useGhostText("song", "VI")
+      );
+
+      expect(result.current.ghostSuffix).toBe("");
+    });
+
+    it("returns null trackResult when no match", () => {
+      mockTrackQuery.data = [];
+
+      const { result } = renderHook(() =>
+        useGhostText("song", "zzz", "Autechre")
+      );
+
+      expect(result.current.trackResult).toBeNull();
+    });
+  });
+});

--- a/src/hooks/useGhostText.ts
+++ b/src/hooks/useGhostText.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  useSuggestArtistsQuery,
+  useSuggestTracksQuery,
+} from "@/lib/features/flowsheet/api";
+import { SuggestTrackResult } from "@/lib/features/flowsheet/types";
+import { useMemo } from "react";
+import { useDebouncedValue } from "./useDebouncedValue";
+
+const DEBOUNCE_MS = 150;
+const MIN_PREFIX_LENGTH = 2;
+
+export type GhostTextResult = {
+  /** The untyped suffix to display as grey ghost text (e.g., "techre" when user typed "Au") */
+  ghostSuffix: string;
+  /** Accept the ghost text. Returns the full canonical suggestion, or null if nothing to accept. */
+  acceptGhostText: () => string | null;
+  /** The full track result (for song field), including album_title and record_label for auto-fill */
+  trackResult: SuggestTrackResult | null;
+};
+
+/**
+ * Provides ghost text autocomplete for artist or song fields.
+ *
+ * For `artist`: suggests from the library catalog.
+ * For `song`: suggests from flowsheet history, filtered by confirmedArtist.
+ */
+export function useGhostText(
+  field: "artist" | "song",
+  currentValue: string,
+  confirmedArtist?: string
+): GhostTextResult {
+  const debouncedValue = useDebouncedValue(currentValue, DEBOUNCE_MS);
+  const shouldQuery = debouncedValue.length >= MIN_PREFIX_LENGTH;
+
+  const artistQuery = useSuggestArtistsQuery(
+    { q: debouncedValue, limit: 1 },
+    { skip: field !== "artist" || !shouldQuery }
+  );
+
+  const trackQuery = useSuggestTracksQuery(
+    { q: debouncedValue, artist: confirmedArtist || "", limit: 1 },
+    { skip: field !== "song" || !shouldQuery || !confirmedArtist }
+  );
+
+  return useMemo(() => {
+    let suggestion: string | null = null;
+    let trackResult: SuggestTrackResult | null = null;
+
+    if (field === "artist" && artistQuery.data?.length) {
+      suggestion = artistQuery.data[0];
+    } else if (field === "song" && trackQuery.data?.length) {
+      trackResult = trackQuery.data[0];
+      suggestion = trackResult.track_title;
+    }
+
+    // Verify the suggestion starts with what the user typed (case-insensitive)
+    if (
+      !suggestion ||
+      !currentValue ||
+      !suggestion.toLowerCase().startsWith(currentValue.toLowerCase())
+    ) {
+      return {
+        ghostSuffix: "",
+        acceptGhostText: () => null,
+        trackResult: null,
+      };
+    }
+
+    const ghostSuffix = suggestion.slice(currentValue.length);
+
+    return {
+      ghostSuffix,
+      acceptGhostText: () => suggestion,
+      trackResult,
+    };
+  }, [field, currentValue, artistQuery.data, trackQuery.data]);
+}


### PR DESCRIPTION
## Summary

- Reorder fields from Song|Artist|Album|Label to **Artist|Song|Album|Label**
- Add inline ghost text completion: grey letters appear as DJs type, Tab accepts and advances focus
- Song ghost text acceptance auto-fills Album and Label from the suggest API response
- Ghost text coexists with the existing dropdown search (hidden when a dropdown result is selected)

## Test plan

- [ ] 20 new/updated tests pass (useDebouncedValue, useGhostText, FlowsheetSearchInput ghost text, field order)
- [ ] Full test suite (1823 tests) passes
- [ ] Typecheck passes
- [ ] Start dev server and verify: type "Au" in Artist → ghost text "techre" appears → Tab accepts → focus moves to Song
- [ ] Verify existing dropdown search still works (arrow keys, Enter to select)

Depends on WXYC/Backend-Service#356 for the suggest API endpoints.

Closes #347