### PR TITLE
Unified permissions column for roster page

### DIFF
--- a/e2e/pages/roster.page.ts
+++ b/e2e/pages/roster.page.ts
@@ -21,9 +21,8 @@ export class RosterPage {
   readonly emailInput: Locator;
   readonly saveButton: Locator;
 
-  // Role checkboxes in new account form
-  readonly newAccountSmCheckbox: Locator;
-  readonly newAccountMdCheckbox: Locator;
+  // Role select in new account form
+  readonly newAccountRoleSelect: Locator;
 
   // Table elements
   readonly rosterTable: Locator;
@@ -57,9 +56,8 @@ export class RosterPage {
     // Save button is inside the new account row
     this.saveButton = page.locator('tr:has(button:has-text("Save")) button:has-text("Save")');
 
-    // Role checkboxes in new account form - first and second checkbox in the form row
-    this.newAccountSmCheckbox = this.newAccountRow.locator('input[type="checkbox"]').first();
-    this.newAccountMdCheckbox = this.newAccountRow.locator('input[type="checkbox"]').nth(1);
+    // Role select in new account form — MUI Joy Select renders a button[role="combobox"]
+    this.newAccountRoleSelect = this.newAccountRow.locator('[role="combobox"]').first();
 
     // Table — scoped to the roster form to avoid matching tables on other pages
     this.rosterTable = page.locator("form table");
@@ -108,13 +106,16 @@ export class RosterPage {
       await this.djNameInput.fill(data.djName);
     }
 
-    // Set role via checkboxes
-    if (data.role === "stationManager") {
-      await this.newAccountSmCheckbox.check();
-    } else if (data.role === "musicDirector") {
-      await this.newAccountMdCheckbox.check();
+    // Set role via select dropdown
+    if (data.role) {
+      const roleLabel =
+        data.role === "stationManager" ? "Station Manager"
+        : data.role === "musicDirector" ? "Music Director"
+        : "DJ";
+      await this.newAccountRoleSelect.click();
+      await this.page.getByRole("option", { name: roleLabel }).click();
     }
-    // DJ role is default, no checkbox needed
+    // DJ role is default, no selection needed if not specified
   }
 
   async submitNewAccount(): Promise<void> {
@@ -148,14 +149,45 @@ export class RosterPage {
   }
 
   /**
-   * Get role checkboxes for a user row
+   * Get the role select dropdown for a user row.
+   * MUI Joy Select renders a button[role="combobox"].
    */
-  getRoleCheckboxes(username: string): { sm: Locator; md: Locator } {
+  getRoleSelect(username: string): Locator {
     const row = this.getUserRow(username);
-    return {
-      sm: row.locator('input[type="checkbox"]').first(),
-      md: row.locator('input[type="checkbox"]').nth(1),
-    };
+    return row.locator('[role="combobox"]').first();
+  }
+
+  /**
+   * Set a user's role via the select dropdown.
+   * @param username - The username of the user row
+   * @param roleLabel - Display label: "Member", "DJ", "Music Director", or "Station Manager"
+   */
+  async setUserRole(username: string, roleLabel: string): Promise<void> {
+    const select = this.getRoleSelect(username);
+    await select.waitFor({ state: "visible", timeout: 5000 });
+    await select.click();
+    await this.page.getByRole("option", { name: roleLabel }).click();
+    await this.page.waitForTimeout(1000);
+  }
+
+  /** Wrapper for backward compatibility */
+  async promoteToStationManager(username: string): Promise<void> {
+    await this.setUserRole(username, "Station Manager");
+  }
+
+  /** Wrapper for backward compatibility */
+  async promoteToMusicDirector(username: string): Promise<void> {
+    await this.setUserRole(username, "Music Director");
+  }
+
+  /** Wrapper for backward compatibility */
+  async demoteFromStationManager(username: string): Promise<void> {
+    await this.setUserRole(username, "Music Director");
+  }
+
+  /** Wrapper for backward compatibility */
+  async demoteFromMusicDirector(username: string): Promise<void> {
+    await this.setUserRole(username, "DJ");
   }
 
   /**
@@ -171,38 +203,6 @@ export class RosterPage {
       resetPassword: buttons.first(),
       delete: buttons.last(),
     };
-  }
-
-  async promoteToStationManager(username: string): Promise<void> {
-    const { sm } = this.getRoleCheckboxes(username);
-    // Wait for checkbox to be ready
-    await sm.waitFor({ state: "visible", timeout: 5000 });
-    // Use force click to ensure the checkbox is toggled
-    await sm.click({ force: true });
-    await this.page.waitForTimeout(1000);
-  }
-
-  async promoteToMusicDirector(username: string): Promise<void> {
-    const { md } = this.getRoleCheckboxes(username);
-    // Wait for checkbox to be ready
-    await md.waitFor({ state: "visible", timeout: 5000 });
-    // Use force click to ensure the checkbox is toggled
-    await md.click({ force: true });
-    await this.page.waitForTimeout(1000);
-  }
-
-  async demoteFromStationManager(username: string): Promise<void> {
-    const { sm } = this.getRoleCheckboxes(username);
-    await sm.waitFor({ state: "visible", timeout: 5000 });
-    await sm.click({ force: true });
-    await this.page.waitForTimeout(1000);
-  }
-
-  async demoteFromMusicDirector(username: string): Promise<void> {
-    const { md } = this.getRoleCheckboxes(username);
-    await md.waitFor({ state: "visible", timeout: 5000 });
-    await md.click({ force: true });
-    await this.page.waitForTimeout(1000);
   }
 
   async deleteUser(username: string): Promise<void> {
@@ -317,9 +317,20 @@ export class RosterPage {
     }
   }
 
-  async expectRoleCheckboxDisabled(username: string, role: "sm" | "md"): Promise<void> {
-    const checkboxes = this.getRoleCheckboxes(username);
-    await expect(checkboxes[role]).toBeDisabled();
+  /**
+   * Assert the role select dropdown is disabled for a user (e.g., self-modification prevention)
+   */
+  async expectRoleSelectDisabled(username: string): Promise<void> {
+    const select = this.getRoleSelect(username);
+    await expect(select).toBeDisabled();
+  }
+
+  /**
+   * Assert the role select shows a specific role label for a user
+   */
+  async expectUserRole(username: string, roleLabel: string): Promise<void> {
+    const select = this.getRoleSelect(username);
+    await expect(select).toContainText(roleLabel, { timeout: 10000 });
   }
 
   async expectDeleteButtonDisabled(username: string): Promise<void> {

--- a/e2e/tests/admin/role-modification.spec.ts
+++ b/e2e/tests/admin/role-modification.spec.ts
@@ -26,11 +26,8 @@ test.describe("Admin Role Modification", () => {
 
   test.describe("Promotion", () => {
     test("should promote DJ to Music Director", async ({ page }) => {
-      // Use existing seeded user who is already an organization member
-      // test_dj1 is a DJ-level user seeded in the database (test_dj2 might not be visible in roster)
       const username = TEST_USERS.dj1.username;
 
-      // Ensure the user row is visible (in case of scrolling issues)
       const userRow = rosterPage.getUserRow(username);
       await expect(userRow).toBeVisible({ timeout: 5000 });
 
@@ -46,18 +43,17 @@ test.describe("Admin Role Modification", () => {
       // Wait for data refetch
       await page.waitForTimeout(1500);
 
-      // Verify checkbox is now checked
-      const { md } = rosterPage.getRoleCheckboxes(username);
-      await expect(md).toBeChecked({ timeout: 10000 });
+      // Verify role select now shows Music Director
+      await rosterPage.expectUserRole(username, "Music Director");
     });
 
     test.afterEach(async ({ page }) => {
       // Reset test_dj1 back to DJ role if it was promoted
       const username = TEST_USERS.dj1.username;
-      const { md, sm } = rosterPage.getRoleCheckboxes(username);
+      const select = rosterPage.getRoleSelect(username);
+      const currentText = await select.textContent();
 
-      // If MD is checked but SM is not, demote to DJ
-      if (await md.isChecked() && !(await sm.isChecked())) {
+      if (currentText?.includes("Music Director")) {
         rosterPage.acceptConfirmDialog();
         await rosterPage.demoteFromMusicDirector(username);
         await page.waitForTimeout(1000);
@@ -65,10 +61,8 @@ test.describe("Admin Role Modification", () => {
     });
 
     test("should promote Music Director to Station Manager", async ({ page }) => {
-      // Use existing seeded Music Director user
       const username = TEST_USERS.musicDirector.username;
 
-      // Ensure the user row is visible
       const userRow = rosterPage.getUserRow(username);
       await expect(userRow).toBeVisible({ timeout: 5000 });
 
@@ -81,9 +75,8 @@ test.describe("Admin Role Modification", () => {
       // Should show success toast
       await rosterPage.expectSuccessToast("Station Manager");
 
-      // Verify SM checkbox is now checked
-      const { sm } = rosterPage.getRoleCheckboxes(username);
-      await expect(sm).toBeChecked({ timeout: 10000 });
+      // Verify role select now shows Station Manager
+      await rosterPage.expectUserRole(username, "Station Manager");
 
       // Demote back to MD to reset state
       rosterPage.acceptConfirmDialog();
@@ -95,26 +88,22 @@ test.describe("Admin Role Modification", () => {
 
   test.describe("Demotion", () => {
     test("should demote Station Manager to Music Director", async ({ page }) => {
-      // Use existing seeded demotable SM user
       const username = TEST_USERS.demotableSm.username;
 
-      // Ensure the user row is visible
       const userRow = rosterPage.getUserRow(username);
       await expect(userRow).toBeVisible({ timeout: 5000 });
 
       // Accept confirmation dialog
       rosterPage.acceptConfirmDialog();
 
-      // Demote from SM (uncheck SM checkbox)
+      // Demote from SM to MD
       await rosterPage.demoteFromStationManager(username);
 
       // Should show success toast
       await rosterPage.expectSuccessToast("Music Director");
 
-      // Verify SM checkbox is now unchecked
-      const { sm, md } = rosterPage.getRoleCheckboxes(username);
-      await expect(sm).not.toBeChecked({ timeout: 10000 });
-      await expect(md).toBeChecked({ timeout: 10000 });
+      // Verify role select now shows Music Director
+      await rosterPage.expectUserRole(username, "Music Director");
 
       // Promote back to SM to reset state
       rosterPage.acceptConfirmDialog();
@@ -123,17 +112,15 @@ test.describe("Admin Role Modification", () => {
     });
 
     test("should demote Music Director to DJ", async ({ page }) => {
-      // Use test_dj1 user that was promoted to MD in a previous test
-      // First promote test_dj1 to MD, then demote back to DJ
       const username = TEST_USERS.dj1.username;
 
-      // Ensure the user row is visible
       const userRow = rosterPage.getUserRow(username);
       await expect(userRow).toBeVisible({ timeout: 5000 });
 
       // First, ensure the user is MD (promote if needed)
-      const { md } = rosterPage.getRoleCheckboxes(username);
-      if (!(await md.isChecked())) {
+      const select = rosterPage.getRoleSelect(username);
+      const currentText = await select.textContent();
+      if (!currentText?.includes("Music Director")) {
         rosterPage.acceptConfirmDialog();
         await rosterPage.promoteToMusicDirector(username);
         await page.waitForTimeout(1500);
@@ -145,39 +132,36 @@ test.describe("Admin Role Modification", () => {
       // Accept confirmation dialog for demotion
       rosterPage.acceptConfirmDialog();
 
-      // Demote from MD (uncheck MD checkbox)
+      // Demote from MD to DJ
       await rosterPage.demoteFromMusicDirector(username);
 
-      // Should show success toast - use specific text to avoid matching user name
+      // Should show success toast
       await rosterPage.expectSuccessToast("role updated to DJ");
 
-      // Verify MD checkbox is now unchecked
-      const checkboxes = rosterPage.getRoleCheckboxes(username);
-      await expect(checkboxes.md).not.toBeChecked({ timeout: 10000 });
+      // Verify role select now shows DJ
+      await rosterPage.expectUserRole(username, "DJ");
     });
   });
 
   test.describe("Self-Modification Prevention", () => {
-    test("should disable role checkboxes for own account", async ({ page }) => {
+    test("should disable role select for own account", async () => {
       const currentUser = TEST_USERS.stationManager.username;
 
-      // Both checkboxes should be disabled for self
-      await rosterPage.expectRoleCheckboxDisabled(currentUser, "sm");
-      await rosterPage.expectRoleCheckboxDisabled(currentUser, "md");
+      // Role select should be disabled for self
+      await rosterPage.expectRoleSelectDisabled(currentUser);
     });
 
-    test("should not allow admin to demote themselves", async ({ page }) => {
+    test("should show Station Manager as own role", async () => {
       const currentUser = TEST_USERS.stationManager.username;
 
-      // Verify the SM checkbox is checked but disabled
-      const { sm } = rosterPage.getRoleCheckboxes(currentUser);
-      await expect(sm).toBeChecked();
-      await expect(sm).toBeDisabled();
+      // Verify the select shows Station Manager but is disabled
+      await rosterPage.expectUserRole(currentUser, "Station Manager");
+      await rosterPage.expectRoleSelectDisabled(currentUser);
     });
   });
 
   test.describe("Confirmation Dialogs", () => {
-    test("should show confirmation before promoting to Station Manager", async ({ page }) => {
+    test("should show confirmation before changing role to Station Manager", async ({ page }) => {
       const username = generateUsername();
       const email = `${username}@test.wxyc.org`;
 
@@ -197,13 +181,13 @@ test.describe("Admin Role Modification", () => {
         await dialog.dismiss();
       });
 
-      await rosterPage.promoteToStationManager(username);
+      await rosterPage.setUserRole(username, "Station Manager");
 
-      // Verify dialog was shown with promotion message
+      // Verify dialog was shown with role change message
       expect(dialogMessage).toContain("Station Manager");
     });
 
-    test("should show confirmation before demoting from Station Manager", async ({ page }) => {
+    test("should show confirmation before changing role to Music Director", async ({ page }) => {
       const username = generateUsername();
       const email = `${username}@test.wxyc.org`;
 
@@ -223,10 +207,10 @@ test.describe("Admin Role Modification", () => {
         await dialog.dismiss();
       });
 
-      await rosterPage.demoteFromStationManager(username);
+      await rosterPage.setUserRole(username, "Music Director");
 
       // Verify dialog was shown
-      expect(dialogMessage).toContain("Station Manager");
+      expect(dialogMessage).toContain("Music Director");
     });
 
     test("should not change role if confirmation is cancelled", async ({ page }) => {
@@ -246,25 +230,24 @@ test.describe("Admin Role Modification", () => {
       // Dismiss confirmation
       rosterPage.dismissConfirmDialog();
 
-      // Try to promote
-      await rosterPage.promoteToMusicDirector(username);
+      // Try to change role
+      await rosterPage.setUserRole(username, "Music Director");
 
       // Wait a moment
       await page.waitForTimeout(500);
 
-      // MD checkbox should still be unchecked
-      const { md } = rosterPage.getRoleCheckboxes(username);
-      await expect(md).not.toBeChecked();
+      // Role should still show DJ
+      await rosterPage.expectUserRole(username, "DJ");
     });
   });
 
-  test.describe("MD Checkbox Behavior", () => {
-    test("MD checkbox should be disabled when SM is checked", async ({ page }) => {
+  test.describe("Role Select Display", () => {
+    test("should show Station Manager for SM users", async ({ page }) => {
       const username = generateUsername();
       const email = `${username}@test.wxyc.org`;
 
       await rosterPage.createAccount({
-        realName: "MD Disable Test",
+        realName: "SM Display Test",
         username,
         email,
         role: "stationManager",
@@ -273,19 +256,15 @@ test.describe("Admin Role Modification", () => {
       await rosterPage.expectSuccessToast();
       await page.waitForTimeout(1000);
 
-      // For SM users, MD checkbox should be checked but disabled
-      const { md, sm } = rosterPage.getRoleCheckboxes(username);
-      await expect(sm).toBeChecked();
-      await expect(md).toBeChecked(); // MD is implicitly included in SM
-      await expect(md).toBeDisabled(); // Can't uncheck MD while SM is checked
+      await rosterPage.expectUserRole(username, "Station Manager");
     });
 
-    test("MD checkbox should be enabled for non-SM users", async ({ page }) => {
+    test("should show DJ for DJ users", async ({ page }) => {
       const username = generateUsername();
       const email = `${username}@test.wxyc.org`;
 
       await rosterPage.createAccount({
-        realName: "MD Enable Test",
+        realName: "DJ Display Test",
         username,
         email,
         role: "dj",
@@ -294,9 +273,7 @@ test.describe("Admin Role Modification", () => {
       await rosterPage.expectSuccessToast();
       await page.waitForTimeout(1000);
 
-      // For DJ users, MD checkbox should be enabled
-      const { md } = rosterPage.getRoleCheckboxes(username);
-      await expect(md).toBeEnabled();
+      await rosterPage.expectUserRole(username, "DJ");
     });
   });
 });
@@ -323,13 +300,14 @@ test.describe("Role Change Persistence", () => {
     // Use existing seeded user who is already an organization member
     const username = TEST_USERS.dj1.username;
 
-    // Verify user row exists and checkbox is visible
+    // Verify user row exists and role select is visible
     await rosterPage.expectUserInRoster(username);
-    const { md } = rosterPage.getRoleCheckboxes(username);
-    await expect(md).toBeVisible({ timeout: 5000 });
+    const select = rosterPage.getRoleSelect(username);
+    await expect(select).toBeVisible({ timeout: 5000 });
 
     // First ensure the user is a DJ (not MD) - demote if needed
-    if (await md.isChecked()) {
+    const currentText = await select.textContent();
+    if (currentText?.includes("Music Director")) {
       rosterPage.acceptConfirmDialog();
       await rosterPage.demoteFromMusicDirector(username);
       await page.waitForTimeout(1500);
@@ -350,9 +328,8 @@ test.describe("Role Change Persistence", () => {
     await page.reload();
     await rosterPage.waitForTableLoaded();
 
-    // Verify MD checkbox is still checked after refresh
-    const updatedCheckboxes = rosterPage.getRoleCheckboxes(username);
-    await expect(updatedCheckboxes.md).toBeChecked({ timeout: 10000 });
+    // Verify role select still shows Music Director after refresh
+    await rosterPage.expectUserRole(username, "Music Director");
 
     // Clean up: demote back to DJ
     rosterPage.acceptConfirmDialog();
@@ -363,7 +340,7 @@ test.describe("Role Change Persistence", () => {
 });
 
 test.describe("Non-Admin Role Modification Restrictions", () => {
-  test("Music Director cannot see role checkboxes", async ({ page }) => {
+  test("Music Director cannot access roster page", async ({ page }) => {
     const loginPage = new LoginPage(page);
     const dashboardPage = new DashboardPage(page);
 

--- a/lib/__tests__/features/admin/admin.test.ts
+++ b/lib/__tests__/features/admin/admin.test.ts
@@ -4,7 +4,33 @@ import {
   defaultAdminFrontendState,
 } from "@/lib/features/admin/frontend";
 import { Authorization } from "@/lib/features/admin/types";
+import {
+  authorizationToRole,
+  AUTHORIZATION_LABELS,
+} from "@/lib/features/authentication/types";
 import { describeSlice } from "@/lib/test-utils";
+
+describe("authorizationToRole", () => {
+  it.each([
+    [Authorization.SM, "stationManager"],
+    [Authorization.MD, "musicDirector"],
+    [Authorization.DJ, "dj"],
+    [Authorization.NO, "member"],
+  ] as const)("should map Authorization.%s to %s", (auth, role) => {
+    expect(authorizationToRole(auth)).toBe(role);
+  });
+});
+
+describe("AUTHORIZATION_LABELS", () => {
+  it.each([
+    [Authorization.NO, "Member"],
+    [Authorization.DJ, "DJ"],
+    [Authorization.MD, "Music Director"],
+    [Authorization.SM, "Station Manager"],
+  ] as const)("should label Authorization.%s as %s", (auth, label) => {
+    expect(AUTHORIZATION_LABELS[auth]).toBe(label);
+  });
+});
 
 describeSlice(adminSlice, defaultAdminFrontendState, ({ harness, actions }) => {
   describe("default state", () => {

--- a/lib/features/admin/conversions-better-auth.ts
+++ b/lib/features/admin/conversions-better-auth.ts
@@ -15,6 +15,7 @@ export type BetterAuthUser = {
   updatedAt: Date;
   banned?: boolean;
   banReason?: string;
+  capabilities?: string[];
 };
 
 /**
@@ -33,6 +34,7 @@ export function convertBetterAuthToAccountResult(
       ? AdminAuthenticationStatus.Confirmed
       : AdminAuthenticationStatus.New,
     email: user.email,
+    capabilities: user.capabilities ?? [],
   };
 }
 

--- a/lib/features/authentication/types.ts
+++ b/lib/features/authentication/types.ts
@@ -208,3 +208,24 @@ export function mapRoleToAuthorization(role: WXYCRole | string | undefined): Aut
       return Authorization.NO;
   }
 }
+
+/**
+ * Maps an Authorization enum value to its corresponding WXYCRole string.
+ * This is the reverse of mapRoleToAuthorization.
+ */
+export function authorizationToRole(auth: Authorization): "member" | "dj" | "musicDirector" | "stationManager" {
+  switch (auth) {
+    case Authorization.SM: return "stationManager";
+    case Authorization.MD: return "musicDirector";
+    case Authorization.DJ: return "dj";
+    case Authorization.NO: return "member";
+  }
+}
+
+/** Human-readable labels for each Authorization level, used in UI dropdowns. */
+export const AUTHORIZATION_LABELS: Record<Authorization, string> = {
+  [Authorization.NO]: "Member",
+  [Authorization.DJ]: "DJ",
+  [Authorization.MD]: "Music Director",
+  [Authorization.SM]: "Station Manager",
+};

--- a/src/components/experiences/modern/admin/roster/AccountEntry.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEntry.tsx
@@ -6,13 +6,18 @@ import {
   Account,
   Authorization,
 } from "@/lib/features/admin/types";
+import {
+  AUTHORIZATION_LABELS,
+  authorizationToRole,
+} from "@/lib/features/authentication/types";
 import { Check, Close, DeleteForever, Edit, Language, SyncLock } from "@mui/icons-material";
 import {
-  ButtonGroup,
-  Checkbox,
   Chip,
+  FormControl,
   IconButton,
   Input,
+  Option,
+  Select,
   Stack,
   Tooltip,
 } from "@mui/joy";
@@ -139,6 +144,40 @@ export const AccountEntry = ({
       setIsUpdatingCapabilities(false);
     }
   };
+
+  /**
+   * Change the user's role via the organization membership API
+   */
+  const handleRoleChange = async (newAuth: Authorization) => {
+    if (newAuth === account.authorization) return;
+
+    const newRole = authorizationToRole(newAuth);
+    const label = AUTHORIZATION_LABELS[newAuth];
+
+    if (!confirm(`Are you sure you want to change ${account.realName}'s role to ${label}?`)) {
+      return;
+    }
+
+    setIsPromoting(true);
+    setPromoteError(null);
+    try {
+      const targetUserId = await resolveUserId();
+      await updateOrganizationRole(targetUserId, newRole);
+      toast.success(`${account.realName}'s role updated to ${label}`);
+      if (onAccountChange) {
+        await onAccountChange();
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to update role";
+      setPromoteError(err instanceof Error ? err : new Error(errorMessage));
+      if (errorMessage.trim().length > 0) {
+        toast.error(errorMessage);
+      }
+    } finally {
+      setIsPromoting(false);
+    }
+  };
+
   /**
    * Resolve organization slug to organization ID
    */
@@ -240,159 +279,84 @@ export const AccountEntry = ({
 
   return (
     <tr>
-      <td
-        style={{
-          verticalAlign: "middle",
-          textAlign: "center",
-        }}
-      >
-        <ButtonGroup>
-          <Checkbox
-            color={"success"}
-            sx={{ transform: "translateY(3px)" }}
-            checked={account.authorization == Authorization.SM}
-            disabled={isSelf || isPromoting}
-            onChange={async (e) => {
-              if (e.target.checked) {
-                if (
-                  confirm(
-                    `Are you sure you want to promote ${account.realName}${
-                      account.realName.length > 0 ? "'s" : ""
-                    } account to Station Manager?`
-                  )
-                ) {
-                  setIsPromoting(true);
-                  setPromoteError(null);
-                  try {
-                    const targetUserId = await resolveUserId();
-
-                    // Update organization member role
-                    await updateOrganizationRole(targetUserId, "stationManager");
-
-                    toast.success(`${account.realName} promoted to Station Manager`);
-                    if (onAccountChange) {
-                      await onAccountChange();
-                    }
-                  } catch (err) {
-                    const errorMessage = err instanceof Error ? err.message : "Failed to promote user";
-                    setPromoteError(err instanceof Error ? err : new Error(errorMessage));
-                    if (errorMessage.trim().length > 0) {
-                      toast.error(errorMessage);
-                    }
-                  } finally {
-                    setIsPromoting(false);
-                  }
-                }
-              } else {
-                if (
-                  confirm(
-                    `Are you sure you want to remove ${account.realName}${
-                      account.realName.length > 0 ? "'s" : ""
-                    } access to Station Manager privileges?`
-                  )
-                ) {
-                  setIsPromoting(true);
-                  setPromoteError(null);
-                  try {
-                    const targetUserId = await resolveUserId();
-
-                    // Update organization member role - demote to Music Director
-                    await updateOrganizationRole(targetUserId, "musicDirector");
-
-                    toast.success(`${account.realName} role updated to Music Director`);
-                    if (onAccountChange) {
-                      await onAccountChange();
-                    }
-                  } catch (err) {
-                    const errorMessage = err instanceof Error ? err.message : "Failed to update user role";
-                    setPromoteError(err instanceof Error ? err : new Error(errorMessage));
-                    if (errorMessage.trim().length > 0) {
-                      toast.error(errorMessage);
-                    }
-                  } finally {
-                    setIsPromoting(false);
-                  }
-                }
+      <td style={{ verticalAlign: "middle" }}>
+        <Stack spacing={0.5}>
+          <FormControl size="sm">
+            <Select
+              size="sm"
+              color="success"
+              value={account.authorization}
+              disabled={isSelf || isPromoting}
+              onChange={(_, newValue) => {
+                if (newValue !== null) handleRoleChange(newValue as Authorization);
+              }}
+              slotProps={{ button: { sx: { whiteSpace: "nowrap" } } }}
+            >
+              <Option value={Authorization.NO}>Member</Option>
+              <Option value={Authorization.DJ}>DJ</Option>
+              <Option value={Authorization.MD}>Music Director</Option>
+              <Option value={Authorization.SM}>Station Manager</Option>
+            </Select>
+          </FormControl>
+          <Stack direction="row" spacing={0.5}>
+            <Tooltip
+              title={
+                isSelf
+                  ? "You cannot modify your own capabilities"
+                  : userCapabilities.includes("editor")
+                    ? "Remove editor capability"
+                    : "Grant editor capability (allows website editing)"
               }
-            }}
-          />
-          <Checkbox
-            disabled={
-              isSelf ||
-              account.authorization == Authorization.SM ||
-              isPromoting
-            }
-            color={"success"}
-            sx={{ transform: "translateY(3px)" }}
-            checked={
-              account.authorization == Authorization.SM ||
-              account.authorization == Authorization.MD
-            }
-            onChange={async (e) => {
-              if (e.target.checked) {
-                if (
-                  confirm(
-                    `Are you sure you want to promote ${account.realName}${
-                      account.realName.length > 0 ? "'s" : ""
-                    } account to Music Director?`
-                  )
-                ) {
-                  setIsPromoting(true);
-                  setPromoteError(null);
-                  try {
-                    const targetUserId = await resolveUserId();
-
-                    // Update organization member role
-                    await updateOrganizationRole(targetUserId, "musicDirector");
-
-                    toast.success(`${account.realName} promoted to Music Director`);
-                    if (onAccountChange) {
-                      await onAccountChange();
-                    }
-                  } catch (err) {
-                    const errorMessage = err instanceof Error ? err.message : "Failed to promote user";
-                    setPromoteError(err instanceof Error ? err : new Error(errorMessage));
-                    if (errorMessage.trim().length > 0) {
-                      toast.error(errorMessage);
-                    }
-                  } finally {
-                    setIsPromoting(false);
-                  }
-                }
-              } else {
-                if (
-                  confirm(
-                    `Are you sure you want to remove ${account.realName}${
-                      account.realName.length > 0 ? "'s" : ""
-                    } access to Music Director privileges?`
-                  )
-                ) {
-                  setIsPromoting(true);
-                  setPromoteError(null);
-                  try {
-                    const targetUserId = await resolveUserId();
-
-                    // Update organization member role - demote to DJ
-                    await updateOrganizationRole(targetUserId, "dj");
-
-                    toast.success(`${account.realName} role updated to DJ`);
-                    if (onAccountChange) {
-                      await onAccountChange();
-                    }
-                  } catch (err) {
-                    const errorMessage = err instanceof Error ? err.message : "Failed to update user role";
-                    setPromoteError(err instanceof Error ? err : new Error(errorMessage));
-                    if (errorMessage.trim().length > 0) {
-                      toast.error(errorMessage);
-                    }
-                  } finally {
-                    setIsPromoting(false);
-                  }
-                }
+              arrow
+              placement="top"
+              variant="outlined"
+              size="sm"
+            >
+              <Chip
+                variant={userCapabilities.includes("editor") ? "solid" : "outlined"}
+                color={userCapabilities.includes("editor") ? "success" : "neutral"}
+                size="sm"
+                startDecorator={<Edit sx={{ fontSize: 14 }} />}
+                onClick={() => !isSelf && handleCapabilityToggle("editor")}
+                disabled={isSelf || isUpdatingCapabilities}
+                sx={{
+                  cursor: isSelf ? "not-allowed" : "pointer",
+                  opacity: isUpdatingCapabilities ? 0.5 : 1,
+                }}
+              >
+                Editor
+              </Chip>
+            </Tooltip>
+            <Tooltip
+              title={
+                isSelf
+                  ? "You cannot modify your own capabilities"
+                  : userCapabilities.includes("webmaster")
+                    ? "Remove webmaster capability"
+                    : "Grant webmaster capability (can delegate editor)"
               }
-            }}
-          />
-        </ButtonGroup>
+              arrow
+              placement="top"
+              variant="outlined"
+              size="sm"
+            >
+              <Chip
+                variant={userCapabilities.includes("webmaster") ? "solid" : "outlined"}
+                color={userCapabilities.includes("webmaster") ? "primary" : "neutral"}
+                size="sm"
+                startDecorator={<Language sx={{ fontSize: 14 }} />}
+                onClick={() => !isSelf && handleCapabilityToggle("webmaster")}
+                disabled={isSelf || isUpdatingCapabilities}
+                sx={{
+                  cursor: isSelf ? "not-allowed" : "pointer",
+                  opacity: isUpdatingCapabilities ? 0.5 : 1,
+                }}
+              >
+                Webmaster
+              </Chip>
+            </Tooltip>
+          </Stack>
+        </Stack>
       </td>
       <td>{account.realName}</td>
       <td>{account.userName}</td>
@@ -451,66 +415,6 @@ export const AccountEntry = ({
             )}
           </Stack>
         )}
-      </td>
-      <td>
-        <Stack direction="row" spacing={0.5}>
-          <Tooltip
-            title={
-              isSelf
-                ? "You cannot modify your own capabilities"
-                : userCapabilities.includes("editor")
-                  ? "Remove editor capability"
-                  : "Grant editor capability (allows website editing)"
-            }
-            arrow
-            placement="top"
-            variant="outlined"
-            size="sm"
-          >
-            <Chip
-              variant={userCapabilities.includes("editor") ? "solid" : "outlined"}
-              color={userCapabilities.includes("editor") ? "success" : "neutral"}
-              size="sm"
-              startDecorator={<Edit sx={{ fontSize: 14 }} />}
-              onClick={() => !isSelf && handleCapabilityToggle("editor")}
-              disabled={isSelf || isUpdatingCapabilities}
-              sx={{
-                cursor: isSelf ? "not-allowed" : "pointer",
-                opacity: isUpdatingCapabilities ? 0.5 : 1,
-              }}
-            >
-              Editor
-            </Chip>
-          </Tooltip>
-          <Tooltip
-            title={
-              isSelf
-                ? "You cannot modify your own capabilities"
-                : userCapabilities.includes("webmaster")
-                  ? "Remove webmaster capability"
-                  : "Grant webmaster capability (can delegate editor)"
-            }
-            arrow
-            placement="top"
-            variant="outlined"
-            size="sm"
-          >
-            <Chip
-              variant={userCapabilities.includes("webmaster") ? "solid" : "outlined"}
-              color={userCapabilities.includes("webmaster") ? "primary" : "neutral"}
-              size="sm"
-              startDecorator={<Language sx={{ fontSize: 14 }} />}
-              onClick={() => !isSelf && handleCapabilityToggle("webmaster")}
-              disabled={isSelf || isUpdatingCapabilities}
-              sx={{
-                cursor: isSelf ? "not-allowed" : "pointer",
-                opacity: isUpdatingCapabilities ? 0.5 : 1,
-              }}
-            >
-              Webmaster
-            </Chip>
-          </Tooltip>
-        </Stack>
       </td>
       <td>
         <Stack direction="row" spacing={0.5}>

--- a/src/components/experiences/modern/admin/roster/NewAccountForm.test.tsx
+++ b/src/components/experiences/modern/admin/roster/NewAccountForm.test.tsx
@@ -55,35 +55,34 @@ describe("NewAccountForm", () => {
     expect(screen.getByRole("button", { name: /Save/i })).toHaveAttribute("type", "submit");
   });
 
-  it("should render checkboxes for authorization", () => {
+  it("should render role select dropdown", () => {
     renderInTable();
 
-    const checkboxes = screen.getAllByRole("checkbox");
-    expect(checkboxes).toHaveLength(2);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 
-  it("should default to DJ authorization (both unchecked)", () => {
+  it("should default to DJ authorization", () => {
     const { store } = renderInTable();
 
     const formData = adminSlice.selectors.getFormData(store.getState());
     expect(formData.authorization).toBe(Authorization.DJ);
   });
 
-  it("should update authorization to SM when first checkbox is checked", async () => {
+  it("should update authorization to SM when Station Manager is selected", async () => {
     const { user, store } = renderInTable();
 
-    const checkboxes = screen.getAllByRole("checkbox");
-    await user.click(checkboxes[0]);
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: "Station Manager" }));
 
     const formData = adminSlice.selectors.getFormData(store.getState());
     expect(formData.authorization).toBe(Authorization.SM);
   });
 
-  it("should update authorization to MD when second checkbox is checked", async () => {
+  it("should update authorization to MD when Music Director is selected", async () => {
     const { user, store } = renderInTable();
 
-    const checkboxes = screen.getAllByRole("checkbox");
-    await user.click(checkboxes[1]);
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: "Music Director" }));
 
     const formData = adminSlice.selectors.getFormData(store.getState());
     expect(formData.authorization).toBe(Authorization.MD);

--- a/src/components/experiences/modern/admin/roster/NewAccountForm.tsx
+++ b/src/components/experiences/modern/admin/roster/NewAccountForm.tsx
@@ -4,7 +4,7 @@ import { adminSlice } from "@/lib/features/admin/frontend";
 import { Authorization } from "@/lib/features/admin/types";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { PersonAdd } from "@mui/icons-material";
-import { Button, ButtonGroup, Checkbox, Input } from "@mui/joy";
+import { Button, FormControl, Input, Option, Select } from "@mui/joy";
 import { ClickAwayListener } from "@mui/material";
 
 export default function NewAccountForm() {
@@ -22,40 +22,23 @@ export default function NewAccountForm() {
       onClickAway={() => dispatch(adminSlice.actions.setAdding(false))}
     >
       <tr>
-        <td
-          style={{
-            verticalAlign: "middle",
-            textAlign: "center",
-          }}
-        >
-          <ButtonGroup>
-            <Checkbox
+        <td style={{ verticalAlign: "middle" }}>
+          <FormControl size="sm">
+            <Select
+              size="sm"
               color="success"
-              onChange={(e) => {
-                if (e.target.checked) {
-                  setAuthorizationOfNewAccount(Authorization.SM);
-                } else {
-                  setAuthorizationOfNewAccount(Authorization.DJ);
-                }
+              value={authorizationOfNewAccount}
+              onChange={(_, newValue) => {
+                if (newValue !== null) setAuthorizationOfNewAccount(newValue as Authorization);
               }}
-              checked={authorizationOfNewAccount == Authorization.SM}
-            />
-            <Checkbox
-              color="success"
-              checked={
-                authorizationOfNewAccount == Authorization.MD ||
-                authorizationOfNewAccount == Authorization.SM
-              }
-              onChange={(e) => {
-                if (e.target.checked) {
-                  setAuthorizationOfNewAccount(Authorization.MD);
-                } else {
-                  setAuthorizationOfNewAccount(Authorization.DJ);
-                }
-              }}
-              disabled={authorizationOfNewAccount == Authorization.SM}
-            />
-          </ButtonGroup>
+              slotProps={{ button: { sx: { whiteSpace: "nowrap" } } }}
+            >
+              <Option value={Authorization.NO}>Member</Option>
+              <Option value={Authorization.DJ}>DJ</Option>
+              <Option value={Authorization.MD}>Music Director</Option>
+              <Option value={Authorization.SM}>Station Manager</Option>
+            </Select>
+          </FormControl>
         </td>
         <td>
           <Input
@@ -95,7 +78,6 @@ export default function NewAccountForm() {
             type="email"
           />
         </td>
-        <td>{/* Capabilities assigned after creation */}</td>
         <td
           style={{
             display: "flex",

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -7,14 +7,12 @@ import { User, WXYCRole } from "@/lib/features/authentication/types";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useAccountListResults } from "@/src/hooks/adminHooks";
 import { Add, GppBad } from "@mui/icons-material";
-import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
 import {
   Button,
   CircularProgress,
   Sheet,
   Stack,
   Table,
-  Tooltip,
   Typography,
 } from "@mui/joy";
 import { useCallback, useState } from "react";
@@ -230,28 +228,11 @@ export default function RosterTable({ user }: { user: User }) {
         >
           <thead>
             <tr>
-              <th
-                style={{
-                  width: 55,
-                  verticalAlign: "middle",
-                  textAlign: "center",
-                }}
-              >
-                <Tooltip
-                  title="Toggle Admin Status"
-                  arrow={true}
-                  placement="top"
-                  variant="outlined"
-                  size="sm"
-                >
-                  <AdminPanelSettingsIcon />
-                </Tooltip>
-              </th>
+              <th style={{ minWidth: "180px" }}>Permissions</th>
               <th style={{ minWidth: "100px" }}>Name</th>
               <th style={{ minWidth: "100px" }}>Username</th>
               <th style={{ minWidth: "100px" }}>DJ Name</th>
               <th style={{ minWidth: "100px" }}>Email</th>
-              <th style={{ minWidth: "140px" }}>Capabilities</th>
               <th
                 aria-label="last"
                 style={{ width: "var(--Table-lastColumnWidth)" }}
@@ -262,7 +243,7 @@ export default function RosterTable({ user }: { user: User }) {
             {isLoading ? (
               <tr style={{ background: "transparent" }}>
                 <td
-                  colSpan={7}
+                  colSpan={6}
                   style={{ textAlign: "center", paddingTop: "2rem" }}
                 >
                   <CircularProgress color={"success"} />
@@ -271,7 +252,7 @@ export default function RosterTable({ user }: { user: User }) {
             ) : isError ? (
               <tr style={{ background: "transparent" }}>
                 <td
-                  colSpan={7}
+                  colSpan={6}
                   style={{ textAlign: "center", paddingTop: "2rem" }}
                 >
                   <GppBad color="error" sx={{ fontSize: "5rem" }} />
@@ -296,7 +277,7 @@ export default function RosterTable({ user }: { user: User }) {
               <NewAccountForm />
             ) : (
               <tr>
-                <td colSpan={6}></td>
+                <td colSpan={5}></td>
                 <td
                   style={{
                     display: "flex",

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect } from "vitest";
+import {
+  convertBetterAuthToAccountResult,
+  BetterAuthUser,
+} from "@/lib/features/admin/conversions-better-auth";
 
 /**
  * Phase 3 Tests: DJ-Site Capability Management
@@ -43,26 +47,33 @@ describe("Account capabilities", () => {
   });
 
   describe("BetterAuthUser conversion with capabilities", () => {
-    it("should preserve capabilities from better-auth user", () => {
-      const betterAuthUser = {
+    it("should preserve capabilities through conversion", () => {
+      const user: BetterAuthUser = {
         id: "user-123",
         email: "test@wxyc.org",
         name: "testuser",
-        capabilities: ["editor", "webmaster"] as Capability[],
+        emailVerified: true,
+        role: "dj",
+        capabilities: ["editor", "webmaster"],
+        createdAt: new Date(),
+        updatedAt: new Date(),
       };
-
-      expect(betterAuthUser.capabilities).toEqual(["editor", "webmaster"]);
+      const account = convertBetterAuthToAccountResult(user);
+      expect(account.capabilities).toEqual(["editor", "webmaster"]);
     });
 
-    it("should handle undefined capabilities", () => {
-      const betterAuthUser = {
+    it("should default undefined capabilities to empty array", () => {
+      const user: BetterAuthUser = {
         id: "user-123",
         email: "test@wxyc.org",
-        capabilities: undefined as Capability[] | undefined,
+        name: "testuser",
+        emailVerified: true,
+        role: "dj",
+        createdAt: new Date(),
+        updatedAt: new Date(),
       };
-
-      const capabilities = betterAuthUser.capabilities ?? [];
-      expect(capabilities).toEqual([]);
+      const account = convertBetterAuthToAccountResult(user);
+      expect(account.capabilities).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Replace disconnected checkbox column + capabilities column with a single "Permissions" column containing a role Select dropdown and capability toggle chips
- Fix bug where capabilities data was dropped in `convertBetterAuthToAccountResult`, causing chips to always render inactive
- Add `authorizationToRole()` and `AUTHORIZATION_LABELS` utilities to `lib/features/authentication/types.ts`
- Collapse ~150 lines of duplicated checkbox `onChange` handlers into a single `handleRoleChange` function

Closes #350, closes #349

## Test plan

- [x] `npx tsc --noEmit` passes (0 type errors)
- [x] `npm run test:run` passes (150 test files, 1838 tests)
- [ ] Manual: roster page shows unified Permissions column with role Select + capability chips
- [ ] Manual: changing a role via Select triggers confirmation dialog, persists after refresh
- [ ] Manual: capability chips toggle correctly, self-modification is disabled
- [ ] Manual: "Add DJ" form uses role Select dropdown
- [ ] E2E: `npm run test:e2e -- --grep "Role Modification"` passes