### PR TITLE
Add WXYC-representative lyrics to login greeting

### DIFF
--- a/src/components/experiences/modern/login/Quotes/Welcome.test.tsx
+++ b/src/components/experiences/modern/login/Quotes/Welcome.test.tsx
@@ -12,20 +12,11 @@ describe("WelcomeQuotes", () => {
     vi.restoreAllMocks();
   });
 
-  it("should render 'Welcome...' heading", () => {
+  it("should render greeting, fragment, and artist", () => {
+    // With Math.random() returning 0, first entry should be selected
     render(<WelcomeQuotes />);
     expect(screen.getByText("Welcome...")).toBeInTheDocument();
-  });
-
-  it("should render a quote from the list", () => {
-    // With Math.random() returning 0, first quote "to the Jungle" should be selected
-    render(<WelcomeQuotes />);
     expect(screen.getByText("to the Jungle")).toBeInTheDocument();
-  });
-
-  it("should render the artist name", () => {
-    // With Math.random() returning 0, first artist "Guns N' Roses" should be selected
-    render(<WelcomeQuotes />);
     expect(screen.getByText("- Guns N' Roses")).toBeInTheDocument();
   });
 
@@ -33,16 +24,26 @@ describe("WelcomeQuotes", () => {
     // Return 0.5 to select middle of array
     vi.spyOn(Math, "random").mockReturnValue(0.5);
     render(<WelcomeQuotes />);
-    // Index 4 (Math.floor(0.5 * 9)) should be "Home" by Coheed and Cambria
-    expect(screen.getByText("Home")).toBeInTheDocument();
-    expect(screen.getByText("- Coheed and Cambria")).toBeInTheDocument();
+    // Index 10 (Math.floor(0.5 * 20)) should be "to Love" by Pharoah Sanders
+    expect(screen.getByText("Welcome...")).toBeInTheDocument();
+    expect(screen.getByText("to Love")).toBeInTheDocument();
+    expect(screen.getByText("- Pharoah Sanders")).toBeInTheDocument();
+  });
+
+  it("should render non-Welcome greeting", () => {
+    // Index 18 (Math.floor(0.9 * 20)) is "Hello..." by Erykah Badu
+    vi.spyOn(Math, "random").mockReturnValue(0.9);
+    render(<WelcomeQuotes />);
+    expect(screen.getByText("Hello...")).toBeInTheDocument();
+    expect(screen.getByText("- Erykah Badu ft. André 3000")).toBeInTheDocument();
   });
 
   it("should render last quote when random approaches 1", () => {
     vi.spyOn(Math, "random").mockReturnValue(0.99);
     render(<WelcomeQuotes />);
-    // Index 8 (last item) should be "to the Club"
-    expect(screen.getByText("to the Club")).toBeInTheDocument();
-    expect(screen.getByText("- Manian ft. Aila")).toBeInTheDocument();
+    // Index 19 (last item) should be "Come On..." / "Let's Go" by Broadcast
+    expect(screen.getByText("Come On...")).toBeInTheDocument();
+    expect(screen.getByText("Let's Go")).toBeInTheDocument();
+    expect(screen.getByText("- Broadcast")).toBeInTheDocument();
   });
 });

--- a/src/components/experiences/modern/login/Quotes/Welcome.tsx
+++ b/src/components/experiences/modern/login/Quotes/Welcome.tsx
@@ -3,36 +3,49 @@ import React from "react";
 import { Box, Typography } from "@mui/joy";
 
 export default function WelcomeQuotes() {
-  const welcomeQuotesAndArtists = [
-    ["to the Jungle", "Guns N' Roses"],
-    ["to the Hotel California", "Eagles"],
-    ["to the Black Parade", "My Chemical Romance"],
-    ["to the Pleasuredome", "Frankie Goes to Hollywood"],
-    ["Home", "Coheed and Cambria"],
-    ["to My Life", "Simple Plan"],
-    ["to the Family", "Avenged Sevenfold"],
-    ["to the Machine", "Pink Floyd"],
-    ["to the Club", "Manian ft. Aila"],
+  const greetingsAndArtists: [string, string, string][] = [
+    ["Welcome...", "to the Jungle", "Guns N' Roses"],
+    ["Welcome...", "to the Hotel California", "Eagles"],
+    ["Welcome...", "to the Black Parade", "My Chemical Romance"],
+    ["Welcome...", "to the Pleasuredome", "Frankie Goes to Hollywood"],
+    ["Welcome...", "Home", "Coheed and Cambria"],
+    ["Welcome...", "to My Life", "Simple Plan"],
+    ["Welcome...", "to the Family", "Avenged Sevenfold"],
+    ["Welcome...", "to the Machine", "Pink Floyd"],
+    ["Welcome...", "to the Club", "Manian ft. Aila"],
+    ["Welcome...", "to Wonderland", "Little Simz"],
+    ["Welcome...", "to Love", "Pharoah Sanders"],
+    ["Welcome...", "to the Magnetic Fields", "The Magnetic Fields"],
+    ["Welcome...", "Home", "Dolly Parton"],
+    ["Welcome...", "to the Monkey House", "The Dandy Warhols"],
+    ["Welcome...", "", "Harmonia & Brian Eno"],
+    ["Welcome...", "to the Terrordome", "Public Enemy"],
+    ["Welcome...", "to Four Tet", "Four Tet"],
+    ["Welcome...", "Back", "Theo Parrish"],
+    ["Hello...", "", "Erykah Badu ft. André 3000"],
+    ["Come On...", "Let's Go", "Broadcast"],
   ];
 
-  const randomIndexForWelcomeQuote = Math.floor(
-    Math.random() * welcomeQuotesAndArtists.length
+  const randomIndex = Math.floor(
+    Math.random() * greetingsAndArtists.length
   );
+
+  const [greeting, fragment, artist] = greetingsAndArtists[randomIndex];
 
   return (
     <div>
-      <Typography level="h1">
-        Welcome...
+      <Typography level="h1" suppressHydrationWarning>
+        {greeting}
       </Typography>
       <Typography level="h1" suppressHydrationWarning>
-        {welcomeQuotesAndArtists[randomIndexForWelcomeQuote][0]}
+        {fragment}
       </Typography>
       <Typography
         level="body-md"
         sx={{ my: 1, mb: 3, textAlign: "right" }}
         suppressHydrationWarning
       >
-        - {welcomeQuotesAndArtists[randomIndexForWelcomeQuote][1]}
+        - {artist}
       </Typography>
     </div>
   );


### PR DESCRIPTION
## Summary

- Expand login greeting rotation from 9 mainstream entries to 20, adding artists representative of WXYC's freeform programming (Pharoah Sanders, The Magnetic Fields, Broadcast, Public Enemy, etc.)
- Refactor from hardcoded "Welcome..." prefix to per-entry `[greeting, fragment, artist]` triples, enabling non-Welcome greetings like "Hello..." (Erykah Badu ft. Andre 3000) and "Come On... Let's Go" (Broadcast)
- Update tests for new data structure and entry list

Closes #360

## Test plan

- [x] All 4 Welcome component tests pass
- [x] TypeScript compiles cleanly
- [ ] Verify login screen displays greeting correctly in browser
- [ ] Confirm non-Welcome entries ("Hello...", "Come On...") render properly