### PR TITLE
Fix E2E login form transition timeouts

### DIFF
--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -25,8 +25,9 @@ export async function login(
   await passwordLink.waitFor({ state: "visible", timeout: 15000 });
   await passwordLink.click();
 
-  // Wait for the password login form to be ready
-  await page.waitForSelector('input[name="username"]');
+  // Wait for the OTP form to unmount before checking for the password form
+  await page.waitForSelector('input[name="email"]', { state: "hidden", timeout: 10000 });
+  await page.waitForSelector('input[name="username"]', { timeout: 10000 });
   await page.fill('input[name="username"]', user.username);
   await page.fill('input[name="password"]', user.password);
   await page.click('button[type="submit"]');

--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -71,7 +71,9 @@ export class LoginPage {
   async switchToPasswordLogin(): Promise<void> {
     await this.switchToPasswordLink.waitFor({ state: "visible", timeout: 15000 });
     await this.switchToPasswordLink.click();
-    await this.usernameInput.waitFor({ state: "visible", timeout: 5000 });
+    // Wait for the OTP form to unmount before checking for the password form
+    await this.otpEmailInput.waitFor({ state: "hidden", timeout: 10000 });
+    await this.usernameInput.waitFor({ state: "visible", timeout: 10000 });
   }
 
   async gotoWithToken(token: string): Promise<void> {

--- a/e2e/tests/auth/session.spec.ts
+++ b/e2e/tests/auth/session.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, TEST_USERS, getSessionCookies, expireUserSession } from "../../fixtures/auth.fixture";
+import { test, expect, TEST_USERS, getSessionCookies } from "../../fixtures/auth.fixture";
 import { LoginPage } from "../../pages/login.page";
 import { DashboardPage } from "../../pages/dashboard.page";
 


### PR DESCRIPTION
## Summary

- Wait for OTP email form to unmount before asserting the password form is visible, ensuring the React state transition completes before proceeding
- Increase `switchToPasswordLogin()` timeout from 5000ms to 10000ms to match CI runner timing
- Remove stale `expireUserSession` import in `session.spec.ts` (renamed to `revokeUserSessions`, unused)

## Test plan

- [ ] E2E `auth/session.spec.ts` passes in CI
- [ ] E2E `settings/email-change.spec.ts` passes in CI