### PR TITLE
feat: server-side filtering, search, and pagination for admin roster

### DIFF
--- a/lib/__tests__/features/admin/admin.test.ts
+++ b/lib/__tests__/features/admin/admin.test.ts
@@ -3,7 +3,7 @@ import {
   adminSlice,
   defaultAdminFrontendState,
 } from "@/lib/features/admin/frontend";
-import { Authorization } from "@/lib/features/admin/types";
+import { Authorization, ROSTER_PAGE_SIZE } from "@/lib/features/admin/types";
 import {
   authorizationToRole,
   AUTHORIZATION_LABELS,
@@ -45,6 +45,14 @@ describeSlice(adminSlice, defaultAdminFrontendState, ({ harness, actions }) => {
     it("should have formData with DJ authorization", () => {
       expect(harness().initialState.formData.authorization).toBe(Authorization.DJ);
     });
+
+    it("should have page set to 0", () => {
+      expect(harness().initialState.page).toBe(0);
+    });
+
+    it("should have totalAccounts set to 0", () => {
+      expect(harness().initialState.totalAccounts).toBe(0);
+    });
   });
 
   describe("setSearchString action", () => {
@@ -59,6 +67,36 @@ describeSlice(adminSlice, defaultAdminFrontendState, ({ harness, actions }) => {
         actions.setSearchString("")
       );
       expect(result.searchString).toBe("");
+    });
+
+    it("should reset page to 0 when search changes", () => {
+      const result = harness().chain(
+        actions.setPage(3),
+        actions.setSearchString("test")
+      );
+      expect(result.page).toBe(0);
+    });
+  });
+
+  describe("setPage action", () => {
+    it("should set page", () => {
+      const result = harness().reduce(actions.setPage(2));
+      expect(result.page).toBe(2);
+    });
+
+    it("should allow setting page back to 0", () => {
+      const result = harness().chain(
+        actions.setPage(5),
+        actions.setPage(0)
+      );
+      expect(result.page).toBe(0);
+    });
+  });
+
+  describe("setTotalAccounts action", () => {
+    it("should set totalAccounts", () => {
+      const result = harness().reduce(actions.setTotalAccounts(147));
+      expect(result.totalAccounts).toBe(147);
     });
   });
 
@@ -125,6 +163,12 @@ describeSlice(adminSlice, defaultAdminFrontendState, ({ harness, actions }) => {
     });
   });
 
+  describe("ROSTER_PAGE_SIZE constant", () => {
+    it("should be 50", () => {
+      expect(ROSTER_PAGE_SIZE).toBe(50);
+    });
+  });
+
   // Note: Selector tests are skipped because adminSlice and applicationSlice
   // both use name: "application" which causes a conflict in combineSlices.
   describe("selectors", () => {
@@ -143,6 +187,18 @@ describeSlice(adminSlice, defaultAdminFrontendState, ({ harness, actions }) => {
     describe("getFormData", () => {
       it("should be defined", () => {
         expect(adminSlice.selectors.getFormData).toBeDefined();
+      });
+    });
+
+    describe("getPage", () => {
+      it("should be defined", () => {
+        expect(adminSlice.selectors.getPage).toBeDefined();
+      });
+    });
+
+    describe("getTotalAccounts", () => {
+      it("should be defined", () => {
+        expect(adminSlice.selectors.getTotalAccounts).toBeDefined();
       });
     });
   });

--- a/lib/features/admin/frontend.ts
+++ b/lib/features/admin/frontend.ts
@@ -3,6 +3,8 @@ import { AdminFrontendState, Authorization } from "./types";
 
 export const defaultAdminFrontendState: AdminFrontendState = {
   searchString: "",
+  page: 0,
+  totalAccounts: 0,
   adding: false,
   formData: {
     authorization: Authorization.DJ,
@@ -15,6 +17,13 @@ export const adminSlice = createAppSlice({
   reducers: {
     setSearchString: (state, action) => {
       state.searchString = action.payload;
+      state.page = 0;
+    },
+    setPage: (state, action) => {
+      state.page = action.payload;
+    },
+    setTotalAccounts: (state, action) => {
+      state.totalAccounts = action.payload;
     },
     setAdding: (state, action) => {
       state.adding = action.payload;
@@ -34,6 +43,8 @@ export const adminSlice = createAppSlice({
   },
   selectors: {
     getSearchString: (state) => state.searchString,
+    getPage: (state) => state.page,
+    getTotalAccounts: (state) => state.totalAccounts,
     getAdding: (state) => state.adding,
     getFormData: (state) => state.formData,
   },

--- a/lib/features/admin/types.ts
+++ b/lib/features/admin/types.ts
@@ -1,8 +1,12 @@
 export { Authorization } from "@wxyc/shared/auth-client/auth";
 import { Authorization } from "@wxyc/shared/auth-client/auth";
 
+export const ROSTER_PAGE_SIZE = 50;
+
 export type AdminFrontendState = {
   searchString: string;
+  page: number;
+  totalAccounts: number;
   adding: boolean;
   formData: {
     authorization: Authorization;

--- a/src/components/experiences/modern/admin/roster/AccountSearchForm.test.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountSearchForm.test.tsx
@@ -8,7 +8,7 @@ describe("AccountSearchForm", () => {
   it("should render search input", () => {
     renderWithProviders(<AccountSearchForm />);
 
-    expect(screen.getByPlaceholderText("Search Roster")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Search by Name")).toBeInTheDocument();
   });
 
   it("should not show clear button when search is empty", () => {
@@ -20,7 +20,7 @@ describe("AccountSearchForm", () => {
   it("should update Redux state when typing", async () => {
     const { user, store } = renderWithProviders(<AccountSearchForm />);
 
-    const input = screen.getByPlaceholderText("Search Roster");
+    const input = screen.getByPlaceholderText("Search by Name");
     await user.type(input, "test search");
 
     expect(adminSlice.selectors.getSearchString(store.getState())).toBe("test search");
@@ -29,7 +29,7 @@ describe("AccountSearchForm", () => {
   it("should show clear button when search has value", async () => {
     const { user } = renderWithProviders(<AccountSearchForm />);
 
-    const input = screen.getByPlaceholderText("Search Roster");
+    const input = screen.getByPlaceholderText("Search by Name");
     await user.type(input, "test");
 
     expect(screen.getByRole("button")).toBeInTheDocument();
@@ -38,7 +38,7 @@ describe("AccountSearchForm", () => {
   it("should clear search when clear button is clicked", async () => {
     const { user, store } = renderWithProviders(<AccountSearchForm />);
 
-    const input = screen.getByPlaceholderText("Search Roster");
+    const input = screen.getByPlaceholderText("Search by Name");
     await user.type(input, "test search");
     expect(adminSlice.selectors.getSearchString(store.getState())).toBe("test search");
 
@@ -51,7 +51,7 @@ describe("AccountSearchForm", () => {
   it("should have success color styling", () => {
     renderWithProviders(<AccountSearchForm />);
 
-    const input = screen.getByPlaceholderText("Search Roster");
+    const input = screen.getByPlaceholderText("Search by Name");
     expect(input.closest(".MuiInput-root")).toHaveClass("MuiInput-colorSuccess");
   });
 });

--- a/src/components/experiences/modern/admin/roster/AccountSearchForm.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountSearchForm.tsx
@@ -23,7 +23,7 @@ export default function AccountSearchForm() {
           color={"success"}
           size="sm"
           sx={{ minWidth: "400px" }}
-          placeholder="Search Roster"
+          placeholder="Search by Name"
           startDecorator={<Troubleshoot />}
           endDecorator={
             searchString.length > 0 && (

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -2,14 +2,15 @@
 
 import { authClient } from "@/lib/features/authentication/client";
 import { adminSlice } from "@/lib/features/admin/frontend";
-import { NewAccountParams, Authorization } from "@/lib/features/admin/types";
+import { NewAccountParams, Authorization, ROSTER_PAGE_SIZE } from "@/lib/features/admin/types";
 import { User, WXYCRole } from "@/lib/features/authentication/types";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useAccountListResults } from "@/src/hooks/adminHooks";
-import { Add, GppBad } from "@mui/icons-material";
+import { Add, GppBad, KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
 import {
   Button,
   CircularProgress,
+  IconButton,
   Sheet,
   Stack,
   Table,
@@ -55,6 +56,9 @@ export default function RosterTable({ user }: { user: User }) {
 
   const dispatch = useAppDispatch();
   const isAdding = useAppSelector(adminSlice.selectors.getAdding);
+  const page = useAppSelector(adminSlice.selectors.getPage);
+  const totalAccounts = useAppSelector(adminSlice.selectors.getTotalAccounts);
+  const totalPages = Math.max(1, Math.ceil(totalAccounts / ROSTER_PAGE_SIZE));
   const canCreateUser = user.authority >= Authorization.SM;
 
   const authorizationOfNewAccount = useAppSelector(
@@ -298,6 +302,37 @@ export default function RosterTable({ user }: { user: User }) {
             )}
           </tbody>
         </Table>
+        {!isLoading && totalPages > 1 && (
+          <Stack
+            direction="row"
+            spacing={1}
+            sx={{ py: 2, justifyContent: "center", alignItems: "center" }}
+          >
+            <IconButton
+              size="sm"
+              color="success"
+              variant="outlined"
+              disabled={page === 0}
+              onClick={() => dispatch(adminSlice.actions.setPage(page - 1))}
+              aria-label="Previous page"
+            >
+              <KeyboardArrowLeft />
+            </IconButton>
+            <Typography level="body-sm">
+              Page {page + 1} of {totalPages}
+            </Typography>
+            <IconButton
+              size="sm"
+              color="success"
+              variant="outlined"
+              disabled={page >= totalPages - 1}
+              onClick={() => dispatch(adminSlice.actions.setPage(page + 1))}
+              aria-label="Next page"
+            >
+              <KeyboardArrowRight />
+            </IconButton>
+          </Stack>
+        )}
       </form>
     </Sheet>
   );

--- a/src/hooks/adminHooks.test.ts
+++ b/src/hooks/adminHooks.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
 import React from "react";
 import { Provider } from "react-redux";
-import { makeStore } from "@/lib/store";
+import { makeStore, AppStore } from "@/lib/store";
 import { MOCK_USERS } from "@/lib/test-utils/fixtures";
+import { adminSlice } from "@/lib/features/admin/frontend";
+import { ROSTER_PAGE_SIZE } from "@/lib/features/admin/types";
 
 // Mock the auth client before importing the hook
 vi.mock("@/lib/features/authentication/client", () => ({
@@ -68,10 +70,13 @@ const ANONYMOUS_USER = {
   capabilities: [],
 };
 
-function createWrapper() {
-  const store = makeStore();
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(Provider, { store, children });
+function createWrapper(store?: AppStore) {
+  const s = store ?? makeStore();
+  return {
+    store: s,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Provider, { store: s, children }),
+  };
 }
 
 function mockListUsersResponse(users: unknown[]) {
@@ -83,15 +88,21 @@ function mockListUsersResponse(users: unknown[]) {
 
 describe("useAccountListResults", () => {
   beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.clearAllMocks();
     delete process.env.NEXT_PUBLIC_APP_ORGANIZATION;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("extracts users from a parsed SDK response", async () => {
     const users = [betterAuthUser(MOCK_USERS.dj1), betterAuthUser(MOCK_USERS.stationManager)];
     vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
 
-    const { result } = renderHook(() => useAccountListResults(), { wrapper: createWrapper() });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountListResults(), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.isError).toBe(false);
@@ -103,14 +114,13 @@ describe("useAccountListResults", () => {
 
   it("parses a stringified SDK response (better-auth parser fallback)", async () => {
     const users = [betterAuthUser(MOCK_USERS.dj1)];
-    // Simulate the bug: SDK's betterJSONParse with strict:false returns the raw JSON
-    // string when JSON.parse fails internally, instead of throwing.
     vi.mocked(authClient.admin.listUsers).mockResolvedValue({
       data: JSON.stringify({ users, total: 1 }),
       error: null,
     });
 
-    const { result } = renderHook(() => useAccountListResults(), { wrapper: createWrapper() });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountListResults(), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.isError).toBe(false);
@@ -118,34 +128,66 @@ describe("useAccountListResults", () => {
     expect(result.current.data[0].email).toBe(MOCK_USERS.dj1.email);
   });
 
-  it("filters out anonymous users", async () => {
-    const users = [
-      betterAuthUser(MOCK_USERS.dj1),
-      ANONYMOUS_USER,
-      betterAuthUser(MOCK_USERS.dj2),
-      { ...ANONYMOUS_USER, id: "anon-2", email: "temp-xyz789@anonymous.wxyc.org" },
-    ];
-    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
+  it("passes server-side filter and pagination params to listUsers", async () => {
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse([]));
 
-    const { result } = renderHook(() => useAccountListResults(), { wrapper: createWrapper() });
+    const { wrapper } = createWrapper();
+    renderHook(() => useAccountListResults(), { wrapper });
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.data).toHaveLength(2);
-    expect(result.current.data.every((a) => !a.email?.includes("@anonymous.wxyc.org"))).toBe(true);
+    await waitFor(() => expect(authClient.admin.listUsers).toHaveBeenCalled());
+    const query = vi.mocked(authClient.admin.listUsers).mock.calls[0][0].query;
+    expect(query).toMatchObject({
+      limit: ROSTER_PAGE_SIZE,
+      offset: 0,
+      filterField: "isAnonymous",
+      filterValue: "false",
+      filterOperator: "eq",
+    });
+    // No search params when searchString is empty
+    expect(query).not.toHaveProperty("searchValue");
   });
 
-  it("filters out anonymous users from a stringified response", async () => {
-    const users = [betterAuthUser(MOCK_USERS.dj1), ANONYMOUS_USER];
-    vi.mocked(authClient.admin.listUsers).mockResolvedValue({
-      data: JSON.stringify({ users, total: 2 }),
-      error: null,
+  it("passes search params when searchString is set", async () => {
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse([]));
+
+    const { store, wrapper } = createWrapper();
+    renderHook(() => useAccountListResults(), { wrapper });
+
+    // Wait for initial fetch
+    await waitFor(() => expect(authClient.admin.listUsers).toHaveBeenCalledTimes(1));
+
+    // Dispatch search and advance debounce timer
+    act(() => {
+      store.dispatch(adminSlice.actions.setSearchString("Juana"));
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
     });
 
-    const { result } = renderHook(() => useAccountListResults(), { wrapper: createWrapper() });
+    await waitFor(() => expect(authClient.admin.listUsers).toHaveBeenCalledTimes(2));
+    const query = vi.mocked(authClient.admin.listUsers).mock.calls[1][0].query;
+    expect(query).toMatchObject({
+      searchValue: "Juana",
+      searchField: "name",
+      searchOperator: "contains",
+    });
+  });
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.data).toHaveLength(1);
-    expect(result.current.data[0].email).toBe(MOCK_USERS.dj1.email);
+  it("computes offset from page", async () => {
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse([]));
+
+    const { store, wrapper } = createWrapper();
+    renderHook(() => useAccountListResults(), { wrapper });
+
+    await waitFor(() => expect(authClient.admin.listUsers).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      store.dispatch(adminSlice.actions.setPage(2));
+    });
+
+    await waitFor(() => expect(authClient.admin.listUsers).toHaveBeenCalledTimes(2));
+    const query = vi.mocked(authClient.admin.listUsers).mock.calls[1][0].query;
+    expect(query.offset).toBe(2 * ROSTER_PAGE_SIZE);
   });
 
   it("sets error state when the SDK returns an error", async () => {
@@ -154,7 +196,8 @@ describe("useAccountListResults", () => {
       error: { message: "Unauthorized", status: 401, statusText: "Unauthorized" },
     });
 
-    const { result } = renderHook(() => useAccountListResults(), { wrapper: createWrapper() });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountListResults(), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.isError).toBe(true);
@@ -167,7 +210,8 @@ describe("useAccountListResults", () => {
       error: null,
     });
 
-    const { result } = renderHook(() => useAccountListResults(), { wrapper: createWrapper() });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountListResults(), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.isError).toBe(false);

--- a/src/hooks/adminHooks.ts
+++ b/src/hooks/adminHooks.ts
@@ -1,10 +1,11 @@
 import { authClient } from "@/lib/features/authentication/client";
 import { adminSlice } from "@/lib/features/admin/frontend";
-import { useAppSelector } from "@/lib/hooks";
+import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { convertBetterAuthToAccountResult, BetterAuthUser } from "@/lib/features/admin/conversions-better-auth";
-import { Account } from "@/lib/features/admin/types";
-import { useMemo, useEffect, useState, useCallback } from "react";
+import { Account, ROSTER_PAGE_SIZE } from "@/lib/features/admin/types";
+import { useEffect, useState, useCallback } from "react";
 import { throwIfBetterAuthError } from "@/src/utilities/throwIfBetterAuthError";
+import { useDebouncedValue } from "@/src/hooks/useDebouncedValue";
 
 /**
  * Get the organization ID from environment variable
@@ -34,7 +35,10 @@ export const useAccountListResults = () => {
   const [isError, setIsError] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
+  const dispatch = useAppDispatch();
   const searchString = useAppSelector(adminSlice.selectors.getSearchString);
+  const page = useAppSelector(adminSlice.selectors.getPage);
+  const debouncedSearch = useDebouncedValue(searchString, 300);
 
   const fetchAccounts = useCallback(async () => {
     setIsLoading(true);
@@ -42,13 +46,22 @@ export const useAccountListResults = () => {
     setError(null);
 
     try {
-      // Fetch all users
-      const result = await authClient.admin.listUsers({
-        query: {
-          limit: 1000,
-          offset: 0,
-        },
-      });
+      // Build server-side query with filtering and pagination
+      const query: Record<string, unknown> = {
+        limit: ROSTER_PAGE_SIZE,
+        offset: page * ROSTER_PAGE_SIZE,
+        filterField: "isAnonymous",
+        filterValue: "false",
+        filterOperator: "eq",
+      };
+
+      if (debouncedSearch.length > 0) {
+        query.searchValue = debouncedSearch;
+        query.searchField = "name";
+        query.searchOperator = "contains";
+      }
+
+      const result = await authClient.admin.listUsers({ query });
 
       throwIfBetterAuthError(result, "Failed to fetch users");
 
@@ -69,11 +82,8 @@ export const useAccountListResults = () => {
         responseData = JSON.parse(responseData as string);
       }
 
-      // Filter out anonymous users (created by the anonymous auth plugin for unauthenticated visitors)
-      const parsed = responseData as { users?: { isAnonymous?: boolean }[] };
-      const users = (parsed?.users || []).filter(
-        (user) => !user.isAnonymous
-      );
+      const parsed = responseData as { users?: unknown[]; total?: number };
+      const users = parsed?.users || [];
 
       // Fetch organization members to get accurate roles
       let memberRoleMap = new Map<string, string>();
@@ -105,38 +115,21 @@ export const useAccountListResults = () => {
         return convertBetterAuthToAccountResult(betterAuthUser);
       });
       setAccounts(convertedAccounts);
+      dispatch(adminSlice.actions.setTotalAccounts(parsed?.total ?? 0));
     } catch (err) {
       setIsError(true);
       setError(err instanceof Error ? err : new Error(String(err)));
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [debouncedSearch, page, dispatch]);
 
   useEffect(() => {
     fetchAccounts();
   }, [fetchAccounts]);
 
-  const filteredData = useMemo(() => {
-    if (searchString.length > 0) {
-      return (
-        accounts.filter(
-          (account) =>
-            account.userName
-              .toLowerCase()
-              .includes(searchString.toLowerCase()) ||
-            account.realName
-              .toLowerCase()
-              .includes(searchString.toLowerCase()) ||
-            (account.djName?.toLowerCase().includes(searchString.toLowerCase()) ?? false)
-        ) ?? []
-      );
-    }
-    return accounts ?? [];
-  }, [accounts, searchString]);
-
   return {
-    data: filteredData,
+    data: accounts,
     isLoading,
     isError,
     error,


### PR DESCRIPTION
## Summary

- Move admin roster from client-side fetch-all (limit: 1000) to server-side filtering, search, and pagination using better-auth `listUsers` query params
- Anonymous users excluded server-side via `filterField: "isAnonymous"` instead of client-side `.filter()`
- Search uses `searchField: "name"` with `contains` operator, debounced at 300ms (placeholder updated to "Search by Name" to reflect server-side scope)
- Offset-based pagination with `ROSTER_PAGE_SIZE = 50` and Previous/Next controls shown when results span multiple pages

Closes #362

## Known limitations

- Search only covers the `name` field — better-auth `listUsers` doesn't support searching `username` or `djName` server-side
- CSV export is now page-scoped (exports the current page, not all users)

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run test:run` — all 2403 tests pass (171 files)
- [ ] Manual test against local backend:
  - Roster loads first 50 users with "Page 1 of N"
  - Next/Previous buttons paginate correctly
  - Typing in search box debounces and fetches matching results
  - Clearing search returns to full paginated list
  - Creating/deleting a user refreshes the current page
  - Anonymous users are excluded from the roster