### PR TITLE
Add Dependabot config, update @wxyc/shared to ^0.4.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      better-auth:
+        patterns:
+          - "better-auth"
+          - "@better-auth/*"
+      wxyc-shared:
+        patterns:
+          - "@wxyc/shared"
+      dev-dependencies:
+        dependency-type: "development"
+        exclude-patterns:
+          - "better-auth"
+          - "@better-auth/*"
+          - "@wxyc/shared"
+      production-dependencies:
+        dependency-type: "production"
+        exclude-patterns:
+          - "better-auth"
+          - "@better-auth/*"
+          - "@wxyc/shared"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "replace-artwork-with-metadata-proxy",
+  "name": "dep-sync",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,7 +14,7 @@
         "@opennextjs/cloudflare": "^1.10.1",
         "@reduxjs/toolkit": "^2.2.0",
         "@uidotdev/usehooks": "^2.4.1",
-        "@wxyc/shared": "^0.3.0",
+        "@wxyc/shared": "^0.4.0",
         "better-auth": "^1.5.6",
         "cookie": "^1.0.2",
         "jose": "^5.9.6",
@@ -14115,16 +14115,16 @@
       }
     },
     "node_modules/@wxyc/shared": {
-      "version": "0.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.3.0/860f0669f9bf2a86889d6a88c39fc8e2637d215d",
-      "integrity": "sha512-CwrneM/No/jjo8Q2vK6zi9FQlOoxoh/RIJAXSpIZxCnNJEqjJXoMWIKu9X26HxB4re4EbAbvuKNZ3qH4QyZAPw==",
+      "version": "0.4.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.4.0/88a8a2128fc917acd3d0882094e4a7f1a1a8a566",
+      "integrity": "sha512-5HIyILNJXVpE/wkdBDWEAvFUA5sbhK2z+l6fUZxprRSE6O7oB5JuV/4IoXnpKV+9lZJB0TMruwKvgMMHpG6SUA==",
       "license": "MIT",
       "dependencies": {
-        "better-auth": "^1.4.9",
         "date-fns": "^4.1.0"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "better-auth": "^1.5.0",
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/abort-controller": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@opennextjs/cloudflare": "^1.10.1",
     "@reduxjs/toolkit": "^2.2.0",
     "@uidotdev/usehooks": "^2.4.1",
-    "@wxyc/shared": "^0.3.0",
+    "@wxyc/shared": "^0.4.0",
     "better-auth": "^1.5.6",
     "cookie": "^1.0.2",
     "jose": "^5.9.6",


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` with weekly update schedule and dedicated groups for `better-auth` and `@wxyc/shared`
- Update `@wxyc/shared` from `^0.3.0` to `^0.4.0` in `package.json`

## Context

Part 3 of the dependency sync strategy described in WXYC/Backend-Service#362. Depends on WXYC/wxyc-shared#47 being merged and `v0.4.0` tagged/published before the `@wxyc/shared` version can resolve. The Dependabot config takes effect immediately on merge.

### Dependabot groups

| Group | Packages | Purpose |
|-------|----------|---------|
| `better-auth` | `better-auth`, `@better-auth/*` | Coordinated auth library updates |
| `wxyc-shared` | `@wxyc/shared` | Shared package updates |
| `dev-dependencies` | All other dev deps | Grouped dev dependency updates |
| `production-dependencies` | All other prod deps | Grouped production updates |

## Test plan

- [x] Dependabot YAML is valid
- [ ] CI passes
- [ ] After WXYC/wxyc-shared#47 merges: `npm install` resolves `@wxyc/shared@^0.4.0`, run `npm test`
- [ ] After merge: verify Dependabot appears in repo Settings > Code security