### PR TITLE
Fix NowPlaying audio stream buffering on mount

### DIFF
--- a/e2e/pages/now-playing.page.ts
+++ b/e2e/pages/now-playing.page.ts
@@ -1,0 +1,108 @@
+import { Page, Locator, expect } from "@playwright/test";
+
+const AUDIO_STREAM_URL = "audio-mp3.ibiblio.org";
+
+/**
+ * Page Object Model for the NowPlaying widget
+ *
+ * The NowPlaying widget appears in the Rightbar on dashboard pages.
+ * It contains an audio player for the live WXYC stream and displays
+ * the currently playing track.
+ */
+export class NowPlayingPage {
+  readonly page: Page;
+
+  // Audio element
+  readonly audioElement: Locator;
+
+  // Playback controls
+  readonly playButton: Locator;
+  readonly pauseButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    // Audio
+    this.audioElement = page.locator("#now-playing-music");
+
+    // Controls (same button, different aria-label based on state)
+    this.playButton = page.getByRole("button", { name: "Play audio" });
+    this.pauseButton = page.getByRole("button", { name: "Pause audio" });
+  }
+
+  // --- Audio stream routing ---
+
+  /**
+   * Block audio stream requests so tests don't download audio in CI.
+   * Must be called before navigating to a page with the NowPlaying widget.
+   */
+  async blockAudioStream(): Promise<void> {
+    await this.page.route(`**/${AUDIO_STREAM_URL}/**`, (route) => route.abort());
+  }
+
+  /**
+   * Collect audio stream request URLs for assertion.
+   * Returns the array that will be populated as requests are made.
+   * Must be called before navigating to a page with the NowPlaying widget.
+   */
+  trackAudioRequests(): string[] {
+    const requests: string[] = [];
+    this.page.on("request", (req) => {
+      if (req.url().includes(AUDIO_STREAM_URL)) {
+        requests.push(req.url());
+      }
+    });
+    return requests;
+  }
+
+  // --- Playback actions ---
+
+  /**
+   * Click play and simulate successful playback.
+   *
+   * In headless Chromium the actual audio.play() fails because there's
+   * no real audio device / the stream is blocked. Dispatching a synthetic
+   * `play` event flips the React isPlaying state so the pause button
+   * appears, matching real-browser behavior.
+   */
+  async play(): Promise<void> {
+    await this.playButton.click();
+    await this.simulateAudioEvent("play");
+  }
+
+  /**
+   * Click pause and simulate the pause event.
+   *
+   * audio.pause() on an element that was never truly playing won't fire
+   * a native pause event. The synthetic event keeps the React state in
+   * sync with the DOM.
+   */
+  async stop(): Promise<void> {
+    await this.pauseButton.waitFor({ state: "visible" });
+    await this.pauseButton.click();
+    await this.simulateAudioEvent("pause");
+  }
+
+  // --- Assertions ---
+
+  async expectNoSrc(): Promise<void> {
+    const src = await this.audioElement.getAttribute("src");
+    expect(src).toBeNull();
+  }
+
+  async expectStreamSrc(): Promise<void> {
+    await expect(this.audioElement).toHaveAttribute("src", /audio-mp3\.ibiblio\.org/);
+  }
+
+  async expectPreloadNone(): Promise<void> {
+    await expect(this.audioElement).toHaveAttribute("preload", "none");
+  }
+
+  // --- Internals ---
+
+  private async simulateAudioEvent(event: "play" | "pause"): Promise<void> {
+    await this.page.evaluate((evt) => {
+      document.querySelector("#now-playing-music")?.dispatchEvent(new Event(evt));
+    }, event);
+  }
+}

--- a/e2e/tests/flowsheet/audio-stream.spec.ts
+++ b/e2e/tests/flowsheet/audio-stream.spec.ts
@@ -46,7 +46,7 @@ test.describe("NowPlaying audio stream", () => {
   });
 
   test("should set src on play and remove it on stop", async ({ page }) => {
-    // Block the actual stream request so the test doesn't hang downloading audio
+    // Block the actual stream so we don't download audio in CI
     await page.route(`**/${AUDIO_STREAM_URL}/**`, (route) => route.abort());
 
     await page.goto("/dashboard/flowsheet");
@@ -58,15 +58,22 @@ test.describe("NowPlaying audio stream", () => {
     // Before play: no src
     expect(await audio.getAttribute("src")).toBeNull();
 
-    // Click play — src should be set
+    // Click play — src should be set on the audio element
     await playButton.click();
     await expect(audio).toHaveAttribute("src", /audio-mp3\.ibiblio\.org/);
 
-    // Click pause/stop — src should be removed
+    // The actual audio.play() fails because we aborted the route, so
+    // isPlaying never becomes true and the button stays "Play audio".
+    // Manually fire the play event to simulate successful playback so
+    // the React state flips and the button becomes "Pause audio".
+    await page.evaluate(() => {
+      const el = document.querySelector("#now-playing-music");
+      el?.dispatchEvent(new Event("play"));
+    });
+
+    // Now click pause — src should be removed
     const pauseButton = page.getByRole("button", { name: "Pause audio" });
     await pauseButton.click();
-
-    // After stop: src should be cleared
     await expect(audio).not.toHaveAttribute("src");
   });
 
@@ -78,9 +85,15 @@ test.describe("NowPlaying audio stream", () => {
 
     const audio = page.locator("#now-playing-music");
 
-    // Play → stop
+    // Play → verify src set
     await page.getByRole("button", { name: "Play audio" }).click();
     await expect(audio).toHaveAttribute("src", /audio-mp3\.ibiblio\.org/);
+
+    // Simulate successful playback, then stop
+    await page.evaluate(() => {
+      const el = document.querySelector("#now-playing-music");
+      el?.dispatchEvent(new Event("play"));
+    });
     await page.getByRole("button", { name: "Pause audio" }).click();
     await expect(audio).not.toHaveAttribute("src");
 

--- a/e2e/tests/flowsheet/audio-stream.spec.ts
+++ b/e2e/tests/flowsheet/audio-stream.spec.ts
@@ -4,6 +4,20 @@ import path from "path";
 const authDir = path.join(__dirname, "../../.auth");
 const AUDIO_STREAM_URL = "audio-mp3.ibiblio.org";
 
+/** Dispatch a synthetic play event so React flips isPlaying to true. */
+async function simulatePlay(page: import("@playwright/test").Page) {
+  await page.evaluate(() => {
+    document.querySelector("#now-playing-music")?.dispatchEvent(new Event("play"));
+  });
+}
+
+/** Dispatch a synthetic pause event so React flips isPlaying to false. */
+async function simulatePause(page: import("@playwright/test").Page) {
+  await page.evaluate(() => {
+    document.querySelector("#now-playing-music")?.dispatchEvent(new Event("pause"));
+  });
+}
+
 /**
  * NowPlaying Audio Stream E2E Tests
  *
@@ -64,16 +78,13 @@ test.describe("NowPlaying audio stream", () => {
 
     // The actual audio.play() fails because we aborted the route, so
     // isPlaying never becomes true and the button stays "Play audio".
-    // Manually fire the play event to simulate successful playback so
-    // the React state flips and the button becomes "Pause audio".
-    await page.evaluate(() => {
-      const el = document.querySelector("#now-playing-music");
-      el?.dispatchEvent(new Event("play"));
-    });
+    // Dispatch synthetic play/pause events to drive the React state
+    // through the full play → stop cycle.
+    await simulatePlay(page);
 
-    // Now click pause — src should be removed
     const pauseButton = page.getByRole("button", { name: "Pause audio" });
     await pauseButton.click();
+    await simulatePause(page);
     await expect(audio).not.toHaveAttribute("src");
   });
 
@@ -89,12 +100,10 @@ test.describe("NowPlaying audio stream", () => {
     await page.getByRole("button", { name: "Play audio" }).click();
     await expect(audio).toHaveAttribute("src", /audio-mp3\.ibiblio\.org/);
 
-    // Simulate successful playback, then stop
-    await page.evaluate(() => {
-      const el = document.querySelector("#now-playing-music");
-      el?.dispatchEvent(new Event("play"));
-    });
+    // Stop
+    await simulatePlay(page);
     await page.getByRole("button", { name: "Pause audio" }).click();
+    await simulatePause(page);
     await expect(audio).not.toHaveAttribute("src");
 
     // Play again — should reconnect

--- a/e2e/tests/flowsheet/audio-stream.spec.ts
+++ b/e2e/tests/flowsheet/audio-stream.spec.ts
@@ -1,22 +1,8 @@
 import { test, expect } from "../../fixtures/auth.fixture";
+import { NowPlayingPage } from "../../pages/now-playing.page";
 import path from "path";
 
 const authDir = path.join(__dirname, "../../.auth");
-const AUDIO_STREAM_URL = "audio-mp3.ibiblio.org";
-
-/** Dispatch a synthetic play event so React flips isPlaying to true. */
-async function simulatePlay(page: import("@playwright/test").Page) {
-  await page.evaluate(() => {
-    document.querySelector("#now-playing-music")?.dispatchEvent(new Event("play"));
-  });
-}
-
-/** Dispatch a synthetic pause event so React flips isPlaying to false. */
-async function simulatePause(page: import("@playwright/test").Page) {
-  await page.evaluate(() => {
-    document.querySelector("#now-playing-music")?.dispatchEvent(new Event("pause"));
-  });
-}
 
 /**
  * NowPlaying Audio Stream E2E Tests
@@ -31,83 +17,58 @@ test.describe("NowPlaying audio stream", () => {
   test.use({ storageState: path.join(authDir, "dj2.json") });
 
   test("should not fetch audio stream on page load", async ({ page }) => {
-    const audioRequests: string[] = [];
-    page.on("request", (req) => {
-      if (req.url().includes(AUDIO_STREAM_URL)) {
-        audioRequests.push(req.url());
-      }
-    });
+    const nowPlaying = new NowPlayingPage(page);
+    const requests = nowPlaying.trackAudioRequests();
 
     await page.goto("/dashboard/flowsheet");
     await page.waitForLoadState("domcontentloaded");
     // Wait long enough for any preload to have started
     await page.waitForTimeout(2000);
 
-    expect(audioRequests).toHaveLength(0);
+    expect(requests).toHaveLength(0);
   });
 
-  test("should have audio element with no src and preload=none", async ({
-    page,
-  }) => {
+  test("should have audio element with no src and preload=none", async ({ page }) => {
+    const nowPlaying = new NowPlayingPage(page);
+
     await page.goto("/dashboard/flowsheet");
     await page.waitForLoadState("domcontentloaded");
 
-    const audio = page.locator("#now-playing-music");
-    await expect(audio).toHaveAttribute("preload", "none");
-    // The audio element should not have a src attribute at all
-    const src = await audio.getAttribute("src");
-    expect(src).toBeNull();
+    await nowPlaying.expectPreloadNone();
+    await nowPlaying.expectNoSrc();
   });
 
   test("should set src on play and remove it on stop", async ({ page }) => {
-    // Block the actual stream so we don't download audio in CI
-    await page.route(`**/${AUDIO_STREAM_URL}/**`, (route) => route.abort());
+    const nowPlaying = new NowPlayingPage(page);
+    await nowPlaying.blockAudioStream();
 
     await page.goto("/dashboard/flowsheet");
     await page.waitForLoadState("domcontentloaded");
 
-    const audio = page.locator("#now-playing-music");
-    const playButton = page.getByRole("button", { name: "Play audio" });
+    await nowPlaying.expectNoSrc();
 
-    // Before play: no src
-    expect(await audio.getAttribute("src")).toBeNull();
+    await nowPlaying.play();
+    await nowPlaying.expectStreamSrc();
 
-    // Click play — src should be set on the audio element
-    await playButton.click();
-    await expect(audio).toHaveAttribute("src", /audio-mp3\.ibiblio\.org/);
-
-    // The actual audio.play() fails because we aborted the route, so
-    // isPlaying never becomes true and the button stays "Play audio".
-    // Dispatch synthetic play/pause events to drive the React state
-    // through the full play → stop cycle.
-    await simulatePlay(page);
-
-    const pauseButton = page.getByRole("button", { name: "Pause audio" });
-    await pauseButton.click();
-    await simulatePause(page);
-    await expect(audio).not.toHaveAttribute("src");
+    await nowPlaying.stop();
+    await nowPlaying.expectNoSrc();
   });
 
   test("should reconnect stream on second play", async ({ page }) => {
-    await page.route(`**/${AUDIO_STREAM_URL}/**`, (route) => route.abort());
+    const nowPlaying = new NowPlayingPage(page);
+    await nowPlaying.blockAudioStream();
 
     await page.goto("/dashboard/flowsheet");
     await page.waitForLoadState("domcontentloaded");
 
-    const audio = page.locator("#now-playing-music");
-
-    // Play → verify src set
-    await page.getByRole("button", { name: "Play audio" }).click();
-    await expect(audio).toHaveAttribute("src", /audio-mp3\.ibiblio\.org/);
-
-    // Stop
-    await simulatePlay(page);
-    await page.getByRole("button", { name: "Pause audio" }).click();
-    await simulatePause(page);
-    await expect(audio).not.toHaveAttribute("src");
+    // Play → stop
+    await nowPlaying.play();
+    await nowPlaying.expectStreamSrc();
+    await nowPlaying.stop();
+    await nowPlaying.expectNoSrc();
 
     // Play again — should reconnect
-    await page.getByRole("button", { name: "Play audio" }).click();
-    await expect(audio).toHaveAttribute("src", /audio-mp3\.ibiblio\.org/);
+    await nowPlaying.play();
+    await nowPlaying.expectStreamSrc();
   });
 });

--- a/e2e/tests/flowsheet/audio-stream.spec.ts
+++ b/e2e/tests/flowsheet/audio-stream.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "../../fixtures/auth.fixture";
+import path from "path";
+
+const authDir = path.join(__dirname, "../../.auth");
+const AUDIO_STREAM_URL = "audio-mp3.ibiblio.org";
+
+/**
+ * NowPlaying Audio Stream E2E Tests
+ *
+ * Verifies that the live MP3 stream is not buffered until the user
+ * explicitly presses play, and that stopping fully tears down the
+ * connection.
+ *
+ * See: https://github.com/WXYC/dj-site/issues/374
+ */
+test.describe("NowPlaying audio stream", () => {
+  test.use({ storageState: path.join(authDir, "dj2.json") });
+
+  test("should not fetch audio stream on page load", async ({ page }) => {
+    const audioRequests: string[] = [];
+    page.on("request", (req) => {
+      if (req.url().includes(AUDIO_STREAM_URL)) {
+        audioRequests.push(req.url());
+      }
+    });
+
+    await page.goto("/dashboard/flowsheet");
+    await page.waitForLoadState("domcontentloaded");
+    // Wait long enough for any preload to have started
+    await page.waitForTimeout(2000);
+
+    expect(audioRequests).toHaveLength(0);
+  });
+
+  test("should have audio element with no src and preload=none", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard/flowsheet");
+    await page.waitForLoadState("domcontentloaded");
+
+    const audio = page.locator("#now-playing-music");
+    await expect(audio).toHaveAttribute("preload", "none");
+    // The audio element should not have a src attribute at all
+    const src = await audio.getAttribute("src");
+    expect(src).toBeNull();
+  });
+
+  test("should set src on play and remove it on stop", async ({ page }) => {
+    // Block the actual stream request so the test doesn't hang downloading audio
+    await page.route(`**/${AUDIO_STREAM_URL}/**`, (route) => route.abort());
+
+    await page.goto("/dashboard/flowsheet");
+    await page.waitForLoadState("domcontentloaded");
+
+    const audio = page.locator("#now-playing-music");
+    const playButton = page.getByRole("button", { name: "Play audio" });
+
+    // Before play: no src
+    expect(await audio.getAttribute("src")).toBeNull();
+
+    // Click play — src should be set
+    await playButton.click();
+    await expect(audio).toHaveAttribute("src", /audio-mp3\.ibiblio\.org/);
+
+    // Click pause/stop — src should be removed
+    const pauseButton = page.getByRole("button", { name: "Pause audio" });
+    await pauseButton.click();
+
+    // After stop: src should be cleared
+    await expect(audio).not.toHaveAttribute("src");
+  });
+
+  test("should reconnect stream on second play", async ({ page }) => {
+    await page.route(`**/${AUDIO_STREAM_URL}/**`, (route) => route.abort());
+
+    await page.goto("/dashboard/flowsheet");
+    await page.waitForLoadState("domcontentloaded");
+
+    const audio = page.locator("#now-playing-music");
+
+    // Play → stop
+    await page.getByRole("button", { name: "Play audio" }).click();
+    await expect(audio).toHaveAttribute("src", /audio-mp3\.ibiblio\.org/);
+    await page.getByRole("button", { name: "Pause audio" }).click();
+    await expect(audio).not.toHaveAttribute("src");
+
+    // Play again — should reconnect
+    await page.getByRole("button", { name: "Play audio" }).click();
+    await expect(audio).toHaveAttribute("src", /audio-mp3\.ibiblio\.org/);
+  });
+});

--- a/src/widgets/NowPlaying/index.tsx
+++ b/src/widgets/NowPlaying/index.tsx
@@ -110,11 +110,12 @@ export default function NowPlaying({ mini = false }: NowPlayingWidgetProps) {
         cancelAnimationFrame(animationFrameRef.current);
       }
 
-      // Pause and cleanup audio
+      // Pause and tear down stream connection
       const audio = audioRef.current;
       if (audio) {
         audio.pause();
-        audio.src = "";
+        audio.removeAttribute("src");
+        audio.load();
       }
 
       // Close audio context

--- a/src/widgets/NowPlaying/index.tsx
+++ b/src/widgets/NowPlaying/index.tsx
@@ -92,7 +92,10 @@ export default function NowPlaying({ mini = false }: NowPlayingWidgetProps) {
 
     if (isPlaying) {
       audio.pause();
+      audio.removeAttribute("src");
+      audio.load();
     } else {
+      audio.src = AUDIO_SRC;
       audio.play().catch((error) => {
         console.error("Failed to play audio:", error);
       });
@@ -132,7 +135,7 @@ export default function NowPlaying({ mini = false }: NowPlayingWidgetProps) {
         id="now-playing-music"
         crossOrigin="anonymous"
         ref={audioRef}
-        src={AUDIO_SRC}
+        preload="none"
         playsInline
         style={{ display: "none" }}
       />


### PR DESCRIPTION
## Summary

- Remove static `src` from the `<audio>` element so the live Icecast MP3 stream isn't buffered on page load
- Add `preload="none"` and set `src` dynamically only when the user presses play
- On stop, clear `src` and call `load()` to fully tear down the stream connection

Closes #374

## Test plan

- [ ] Load `/dashboard/flowsheet` and verify no audio network requests appear in DevTools until play is pressed
- [ ] Press play — stream should start and audio visualizer should work
- [ ] Press stop — verify the network connection to `audio-mp3.ibiblio.org` is closed (not just paused)
- [ ] Press play again — stream should reconnect and play normally
- [ ] Verify NowPlaying unit tests pass (28 tests)