### PR TITLE
Add exclusive filter to catalog search and EXCLUSIVE badge to flowsheet entries

### DIFF
--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -178,6 +178,25 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
     });
   });
 
+  describe("exclusive filter actions", () => {
+    it("should set exclusive filter to true", () => {
+      const result = harness().reduce(actions.setExclusiveFilter(true));
+      expect(result.search.exclusive).toBe(true);
+    });
+
+    it("should set exclusive filter back to false", () => {
+      const result = harness().chain(
+        actions.setExclusiveFilter(true),
+        actions.setExclusiveFilter(false)
+      );
+      expect(result.search.exclusive).toBe(false);
+    });
+
+    it("should default exclusive to false", () => {
+      expect(harness().initialState.search.exclusive).toBe(false);
+    });
+  });
+
   describe("selection actions", () => {
     it("should set selection", () => {
       const result = harness().reduce(actions.setSelection([1, 2, 3]));
@@ -290,6 +309,13 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       const { dispatch, select } = harness().withStore();
       dispatch(actions.setSearchGenre("Rock"));
       expect(select(catalogSlice.selectors.getSearchGenre)).toBe("Rock");
+    });
+
+    it("should select exclusive filter", () => {
+      const { dispatch, select } = harness().withStore();
+      expect(select(catalogSlice.selectors.getExclusiveFilter)).toBe(false);
+      dispatch(actions.setExclusiveFilter(true));
+      expect(select(catalogSlice.selectors.getExclusiveFilter)).toBe(true);
     });
 
     it("should select mobile search open state", () => {

--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -166,6 +166,27 @@ describe("flowsheet conversions", () => {
         expect(result.record_label).toBe("");
       });
 
+      it("should convert on_streaming: false on track entries", () => {
+        const entry = createTestV2TrackEntry({ on_streaming: false } as any);
+        const result = convertV2Entry(entry) as FlowsheetSongEntry;
+
+        expect(result.on_streaming).toBe(false);
+      });
+
+      it("should convert on_streaming: true on track entries", () => {
+        const entry = createTestV2TrackEntry({ on_streaming: true } as any);
+        const result = convertV2Entry(entry) as FlowsheetSongEntry;
+
+        expect(result.on_streaming).toBe(true);
+      });
+
+      it("should default on_streaming to undefined when absent", () => {
+        const entry = createTestV2TrackEntry();
+        const result = convertV2Entry(entry) as FlowsheetSongEntry;
+
+        expect(result.on_streaming).toBeUndefined();
+      });
+
       it("should preserve rotation data on track entries", () => {
         const entry = createTestV2TrackEntry({
           rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -16,9 +16,9 @@ export const catalogApi = createApi({
   tagTypes: ["Rotation"],
   endpoints: (builder) => ({
     searchCatalog: builder.query<AlbumEntry[], SearchCatalogQueryParams>({
-      query: ({ artist_name, album_title, n }) => ({
+      query: ({ artist_name, album_title, n, on_streaming }) => ({
         url: "/",
-        params: { artist_name, album_title, n },
+        params: { artist_name, album_title, n, on_streaming },
       }),
       transformResponse: (response: AlbumSearchResultJSON[]) =>
         response.map(convertToAlbumEntry),

--- a/lib/features/catalog/frontend.ts
+++ b/lib/features/catalog/frontend.ts
@@ -6,6 +6,7 @@ export const defaultCatalogFrontendState: CatalogFrontendState = {
     in: "All",
     query: "",
     genre: "All",
+    exclusive: false,
     mobileOpen: false,
     params: {
       n: 10,
@@ -31,6 +32,9 @@ export const catalogSlice = createAppSlice({
     },
     setSearchGenre: (state, action) => {
       state.search.genre = action.payload;
+    },
+    setExclusiveFilter: (state, action) => {
+      state.search.exclusive = action.payload;
     },
     openMobileSearch: (state) => {
       state.search.mobileOpen = true;
@@ -68,6 +72,7 @@ export const catalogSlice = createAppSlice({
     getSearchParams: (state) => state.search.params,
     getSearchIn: (state) => state.search.in,
     getSearchGenre: (state) => state.search.genre,
+    getExclusiveFilter: (state) => state.search.exclusive,
     isMobileSearchOpen: (state) => state.search.mobileOpen,
     getSelected: (state) => state.results.selected,
   },

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -15,6 +15,7 @@ export type SearchCatalogQueryParams = {
   artist_name: string | undefined;
   album_title: string | undefined;
   n: number | undefined;
+  on_streaming?: boolean;
 };
 
 export type AlbumParams = {
@@ -70,6 +71,7 @@ export type CatalogSearchState = {
   query: string;
   in: SearchIn;
   genre: Genre | "All";
+  exclusive: boolean;
   mobileOpen: boolean;
   params: {
     n: number;

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -92,6 +92,7 @@ export function convertV2Entry(entry: FlowsheetV2EntryJSON): FlowsheetEntry {
         album_id: entry.album_id ?? undefined,
         rotation_id: entry.rotation_id ?? undefined,
         rotation: entry.rotation_bin as Rotation,
+        on_streaming: (entry as Record<string, unknown>).on_streaming as boolean | undefined ?? undefined,
       };
 
     case "show_start": {

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -92,7 +92,7 @@ export function convertV2Entry(entry: FlowsheetV2EntryJSON): FlowsheetEntry {
         album_id: entry.album_id ?? undefined,
         rotation_id: entry.rotation_id ?? undefined,
         rotation: entry.rotation_bin as Rotation,
-        on_streaming: (entry as Record<string, unknown>).on_streaming as boolean | undefined ?? undefined,
+        on_streaming: (entry as Record<string, unknown>).on_streaming as boolean | undefined,
       };
 
     case "show_start": {

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -57,6 +57,7 @@ export type FlowsheetSongBase = {
   album_id?: number;
   rotation_id?: number;
   rotation?: Rotation;
+  on_streaming?: boolean;
 };
 
 export type FlowsheetSongEntry = FlowsheetEntryBase & FlowsheetSongBase;

--- a/src/components/experiences/modern/catalog/Search/Filters.test.tsx
+++ b/src/components/experiences/modern/catalog/Search/Filters.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { Filters } from "./Filters";
+import {
+  createComponentHarnessWithQueries,
+  componentQueries,
+} from "@/lib/test-utils";
+import { catalogSlice } from "@/lib/features/catalog/frontend";
+import type { ColorPaletteProp } from "@mui/joy";
+
+const setup = createComponentHarnessWithQueries(
+  Filters,
+  { color: "primary" as ColorPaletteProp | undefined },
+  {
+    exclusiveCheckbox: componentQueries.byRole("checkbox", { name: "Exclusives Only" }),
+  }
+);
+
+describe("Filters", () => {
+  it("should render the Exclusives Only checkbox", () => {
+    const { exclusiveCheckbox } = setup();
+
+    expect(exclusiveCheckbox()).toBeInTheDocument();
+  });
+
+  it("should default exclusive checkbox to unchecked", () => {
+    const { exclusiveCheckbox } = setup();
+
+    expect(exclusiveCheckbox()).not.toBeChecked();
+  });
+
+  it("should toggle exclusive filter when checkbox is clicked", async () => {
+    const { exclusiveCheckbox, user, getState } = setup();
+
+    expect(catalogSlice.selectors.getExclusiveFilter(getState())).toBe(false);
+
+    await user.click(exclusiveCheckbox());
+
+    expect(exclusiveCheckbox()).toBeChecked();
+    expect(catalogSlice.selectors.getExclusiveFilter(getState())).toBe(true);
+  });
+
+  it("should uncheck exclusive filter when clicked again", async () => {
+    const { exclusiveCheckbox, user, getState } = setup();
+
+    await user.click(exclusiveCheckbox());
+    expect(catalogSlice.selectors.getExclusiveFilter(getState())).toBe(true);
+
+    await user.click(exclusiveCheckbox());
+    expect(exclusiveCheckbox()).not.toBeChecked();
+    expect(catalogSlice.selectors.getExclusiveFilter(getState())).toBe(false);
+  });
+
+  it("should render Search In and Genre selects", () => {
+    setup();
+
+    expect(screen.getByText("Search In")).toBeInTheDocument();
+    expect(screen.getByText("Genre")).toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/catalog/Search/Filters.tsx
+++ b/src/components/experiences/modern/catalog/Search/Filters.tsx
@@ -62,6 +62,10 @@ export const Filters = ({ color }: { color: ColorPaletteProp | undefined }) => {
                 backgroundColor: "#7B2D8E",
                 borderColor: "#7B2D8E",
               },
+              "&.Mui-checked:hover": {
+                backgroundColor: "#6a2479",
+                borderColor: "#6a2479",
+              },
             },
           }}
         />

--- a/src/components/experiences/modern/catalog/Search/Filters.tsx
+++ b/src/components/experiences/modern/catalog/Search/Filters.tsx
@@ -3,6 +3,7 @@
 import { Genre, SearchIn } from "@/lib/features/catalog/types";
 import { useCatalogSearch } from "@/src/hooks/catalogHooks";
 import {
+  Checkbox,
   ColorPaletteProp,
   FormControl,
   FormLabel,
@@ -12,7 +13,7 @@ import {
 import React from "react";
 
 export const Filters = ({ color }: { color: ColorPaletteProp | undefined }) => {
-  const { setSearchIn, setSearchGenre } = useCatalogSearch();
+  const { setSearchIn, setSearchGenre, exclusive, setExclusiveFilter } = useCatalogSearch();
 
   return (
     <React.Fragment>
@@ -49,6 +50,21 @@ export const Filters = ({ color }: { color: ColorPaletteProp | undefined }) => {
           <Option value="Classical">Classical</Option>
           <Option value="Soundtrack">Soundtrack</Option>
         </Select>
+      </FormControl>
+      <FormControl size="sm" sx={{ flex: "none", justifyContent: "flex-end" }}>
+        <Checkbox
+          label="Exclusives Only"
+          checked={exclusive}
+          onChange={(e) => setExclusiveFilter(e.target.checked)}
+          sx={{
+            "& .MuiCheckbox-checkbox": {
+              "&.Mui-checked": {
+                backgroundColor: "#7B2D8E",
+                borderColor: "#7B2D8E",
+              },
+            },
+          }}
+        />
       </FormControl>
     </React.Fragment>
   );

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
@@ -506,6 +506,42 @@ describe("SongEntry", () => {
     });
   });
 
+  describe("EXCLUSIVE chip", () => {
+    it("should render EXCLUSIVE chip when on_streaming is false", () => {
+      const exclusiveEntry = { ...mockEntry, on_streaming: false };
+
+      render(
+        <SongEntry entry={exclusiveEntry} playing={false} queue={false} />
+      );
+
+      expect(screen.getByText("EXCLUSIVE")).toBeInTheDocument();
+    });
+
+    it("should NOT render EXCLUSIVE chip when on_streaming is true", () => {
+      const streamingEntry = { ...mockEntry, on_streaming: true };
+
+      render(
+        <SongEntry entry={streamingEntry} playing={false} queue={false} />
+      );
+
+      expect(screen.queryByText("EXCLUSIVE")).not.toBeInTheDocument();
+    });
+
+    it("should NOT render EXCLUSIVE chip when on_streaming is undefined", () => {
+      const entryWithoutStreaming = { ...mockEntry, on_streaming: undefined };
+
+      render(
+        <SongEntry
+          entry={entryWithoutStreaming}
+          playing={false}
+          queue={false}
+        />
+      );
+
+      expect(screen.queryByText("EXCLUSIVE")).not.toBeInTheDocument();
+    });
+  });
+
   describe("Rotation badge", () => {
     it("should display rotation badge when rotation is present", () => {
       render(<SongEntry entry={mockEntry} playing={false} queue={false} />);

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
@@ -27,6 +27,7 @@ import {
   Badge,
   Box,
   Checkbox,
+  Chip,
   CircularProgress,
   IconButton,
   Stack,
@@ -218,6 +219,21 @@ export default function SongEntry({
           alignItems={"center"}
           spacing={0.5}
         >
+          {entry.on_streaming === false && (
+            <Chip
+              variant="soft"
+              size="sm"
+              sx={{
+                backgroundColor: "#7B2D8E",
+                color: "#fff",
+                fontWeight: "bold",
+                fontSize: "0.6rem",
+                letterSpacing: "0.5px",
+              }}
+            >
+              EXCLUSIVE
+            </Chip>
+          )}
           <Box
             sx={{
               display: "flex",

--- a/src/hooks/catalogHooks.test.ts
+++ b/src/hooks/catalogHooks.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { formatCatalogSearchQuery } from "./catalogHooks";
+
+describe("formatCatalogSearchQuery", () => {
+  describe("search in modes", () => {
+    it.each([
+      ["Albums", undefined, "test", 10],
+      ["Artists", "test", undefined, 10],
+      ["All", "test", "test", 10],
+    ] as const)(
+      "should format query for %s mode",
+      (searchIn, expectedArtist, expectedAlbum, expectedN) => {
+        const result = formatCatalogSearchQuery(searchIn, "test", 10);
+        expect(result.artist_name).toBe(expectedArtist);
+        expect(result.album_title).toBe(expectedAlbum);
+        expect(result.n).toBe(expectedN);
+      }
+    );
+  });
+
+  describe("exclusive filter", () => {
+    it("should not include on_streaming when exclusive is false", () => {
+      const result = formatCatalogSearchQuery("All", "test", 10, false);
+      expect(result.on_streaming).toBeUndefined();
+    });
+
+    it("should not include on_streaming when exclusive is omitted", () => {
+      const result = formatCatalogSearchQuery("All", "test", 10);
+      expect(result.on_streaming).toBeUndefined();
+    });
+
+    it("should include on_streaming: false when exclusive is true", () => {
+      const result = formatCatalogSearchQuery("All", "test", 10, true);
+      expect(result.on_streaming).toBe(false);
+    });
+
+    it.each(["Albums", "Artists", "All"] as const)(
+      "should include on_streaming: false for %s mode when exclusive is true",
+      (searchIn) => {
+        const result = formatCatalogSearchQuery(searchIn, "test", 10, true);
+        expect(result.on_streaming).toBe(false);
+      }
+    );
+  });
+});

--- a/src/hooks/catalogHooks.ts
+++ b/src/hooks/catalogHooks.ts
@@ -9,16 +9,20 @@ import {
 export function formatCatalogSearchQuery(
   searchIn: SearchIn,
   searchString: string,
-  n: number
+  n: number,
+  exclusive: boolean = false
 ): SearchCatalogQueryParams {
-  switch (searchIn) {
-    case "Albums":
-      return { artist_name: undefined, album_title: searchString, n };
-    case "Artists":
-      return { artist_name: searchString, album_title: undefined, n };
-    default:
-      return { artist_name: searchString, album_title: searchString, n };
-  }
+  const base = (() => {
+    switch (searchIn) {
+      case "Albums":
+        return { artist_name: undefined, album_title: searchString, n };
+      case "Artists":
+        return { artist_name: searchString, album_title: undefined, n };
+      default:
+        return { artist_name: searchString, album_title: searchString, n };
+    }
+  })();
+  return exclusive ? { ...base, on_streaming: false } : base;
 }
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { FlowsheetQuery } from "@/lib/features/flowsheet/types";
@@ -45,6 +49,10 @@ export const useCatalogSearch = () => {
     dispatch(catalogSlice.actions.setSelection(ids));
   const clearSelection = () => dispatch(catalogSlice.actions.clearSelection());
   const selected = useAppSelector(catalogSlice.selectors.getSelected);
+
+  const exclusive = useAppSelector(catalogSlice.selectors.getExclusiveFilter);
+  const setExclusiveFilter = (value: boolean) =>
+    dispatch(catalogSlice.actions.setExclusiveFilter(value));
 
   const { n, orderBy, orderDirection } = useAppSelector(
     catalogSlice.selectors.getSearchParams
@@ -82,6 +90,8 @@ export const useCatalogSearch = () => {
     setSelection,
     clearSelection,
     selected,
+    exclusive,
+    setExclusiveFilter,
     n,
   };
 };
@@ -105,6 +115,7 @@ export const useCatalogResults = () => {
   const { authenticating, authenticated } = useAuthentication();
 
   const searchIn = useAppSelector(catalogSlice.selectors.getSearchIn);
+  const exclusive = useAppSelector(catalogSlice.selectors.getExclusiveFilter);
   const [formattedQuery, setFormattedQuery] =
     useState<SearchCatalogQueryParams>({
       artist_name: undefined,
@@ -125,10 +136,10 @@ export const useCatalogResults = () => {
       setTimeout(() => {
         setLoading(true);
         clearSelection();
-        setFormattedQuery(formatCatalogSearchQuery(searchIn, searchString, n));
+        setFormattedQuery(formatCatalogSearchQuery(searchIn, searchString, n, exclusive));
       }, 500)
     );
-  }, [searchIn, searchString, n]);
+  }, [searchIn, searchString, n, exclusive]);
 
   useEffect(() => {
     setReachedEndForQuery(false);


### PR DESCRIPTION
## Summary

- Add "Exclusives Only" checkbox to catalog search filters, wired to `on_streaming=false` backend param
- Add compact purple EXCLUSIVE badge to live flowsheet entries in `SongEntry` when `on_streaming === false`
- Add `on_streaming` to `FlowsheetSongBase` type and V2 entry conversion
- Redux slice, hooks, and API updated for the exclusive filter state
- 24 new tests across slice, hooks, filters, conversions, and SongEntry

Closes #377

Depends on WXYC/wxyc-shared#55, WXYC/Backend-Service#386

## Test plan

- [x] All 2426 tests pass
- [x] Typecheck passes
- [ ] Verify catalog "Exclusives Only" checkbox filters results
- [ ] Verify EXCLUSIVE badge appears on flowsheet entries with `on_streaming === false`
- [ ] Verify badge hidden for `on_streaming === true` or `undefined`