### PR TITLE
Add album detail features: artwork, tracklist, streaming links, library status

### DIFF
--- a/app/dashboard/@information/(.)album/[id]/page.tsx
+++ b/app/dashboard/@information/(.)album/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useGetInformationQuery } from "@/lib/features/catalog/api";
 import { AlbumEntry } from "@/lib/features/catalog/types";
+import { useAlbumArtwork } from "@/lib/features/metadata/hooks";
 import { Modal } from "@mui/joy";
 import { useParams, useRouter } from "next/navigation";
 import AlbumCard from "../components/AlbumCard";
@@ -13,13 +14,18 @@ export default function AlbumPopup() {
 
   const params = useParams<{ id: string }>();
 
-  const { data, isLoading, isSuccess, isError } = useGetInformationQuery(
+  const { data, isLoading, isError } = useGetInformationQuery(
     {
       album_id: Number(params.id),
     },
     {
       skip: params.id === undefined || params.id === null,
     }
+  );
+
+  const { artworkUrl, metadata } = useAlbumArtwork(
+    data?.artist.name,
+    data?.title,
   );
 
   return (
@@ -38,7 +44,11 @@ export default function AlbumPopup() {
       ) : isError || !data ? (
         <AlbumErrorCard />
       ) : (
-        <AlbumCard album={data as AlbumEntry} />
+        <AlbumCard
+          album={data as AlbumEntry}
+          artworkUrl={artworkUrl}
+          metadata={metadata}
+        />
       )}
     </Modal>
   );

--- a/app/dashboard/@information/(.)album/[id]/page.tsx
+++ b/app/dashboard/@information/(.)album/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useGetInformationQuery } from "@/lib/features/catalog/api";
 import { AlbumEntry } from "@/lib/features/catalog/types";
-import { useAlbumArtwork } from "@/lib/features/metadata/hooks";
+import { useAlbumArtwork, useArtistMetadata } from "@/lib/features/metadata/hooks";
 import { Modal } from "@mui/joy";
 import { useParams, useRouter } from "next/navigation";
 import AlbumCard from "../components/AlbumCard";
@@ -23,10 +23,12 @@ export default function AlbumPopup() {
     }
   );
 
-  const { artworkUrl, metadata } = useAlbumArtwork(
+  const { artworkUrl, isLoading: metadataLoading, metadata } = useAlbumArtwork(
     data?.artist.name,
     data?.title,
   );
+
+  const { artistMetadata } = useArtistMetadata(metadata?.discogsArtistId);
 
   return (
     <Modal
@@ -48,6 +50,9 @@ export default function AlbumPopup() {
           album={data as AlbumEntry}
           artworkUrl={artworkUrl}
           metadata={metadata}
+          metadataLoading={metadataLoading}
+          artistBio={artistMetadata?.bio ?? metadata?.artistBio ?? null}
+          artistWikipediaUrl={artistMetadata?.wikipediaUrl ?? metadata?.artistWikipediaUrl ?? null}
         />
       )}
     </Modal>

--- a/app/dashboard/@information/(.)album/components/AlbumCard.tsx
+++ b/app/dashboard/@information/(.)album/components/AlbumCard.tsx
@@ -1,36 +1,48 @@
 "use client";
 
 import { AlbumEntry } from "@/lib/features/catalog/types";
-
+import { AlbumMetadata } from "@/lib/features/metadata/types";
 import { ArtistAvatar } from "@/src/components/experiences/modern/catalog/ArtistAvatar";
 import {
   AspectRatio,
   Box,
-  Button,
   Card,
   CardContent,
   CardOverflow,
+  Chip,
   Divider,
+  Link,
   ModalClose,
   Stack,
   Typography,
 } from "@mui/joy";
-import { useEffect, useState } from "react";
+import LibraryStatus from "./LibraryStatus";
+import StreamingLinks from "./StreamingLinks";
+import Tracklist from "./Tracklist";
 
-export default function AlbumCard({ album }: { album: AlbumEntry }) {
-  const [image, setImage] = useState("");
+interface AlbumCardProps {
+  album: AlbumEntry;
+  artworkUrl: string;
+  metadata: AlbumMetadata | null;
+}
 
+export default function AlbumCard({
+  album,
+  artworkUrl,
+  metadata,
+}: AlbumCardProps) {
   return (
     <Card
       variant="outlined"
       sx={{
         width: "50%",
-        height: 500,
+        maxHeight: "80vh",
+        overflow: "auto",
       }}
     >
       <CardOverflow>
         <AspectRatio ratio="4">
-          <img src={image.length > 0 ? image : "/img/wxyc_dark.jpg"} />
+          <img src={artworkUrl} />
         </AspectRatio>
         <Box
           sx={{
@@ -44,7 +56,7 @@ export default function AlbumCard({ album }: { album: AlbumEntry }) {
             backdropFilter: "blur(0.2rem)",
             pointerEvents: "none",
           }}
-        ></Box>
+        />
         <Box
           sx={{
             position: "absolute",
@@ -56,7 +68,7 @@ export default function AlbumCard({ album }: { album: AlbumEntry }) {
             borderTopLeftRadius: "var(--CardOverflow-radius)",
             bgcolor: "rgba(0,0,0,0.5)",
           }}
-        ></Box>
+        />
         <Box
           sx={{
             position: "absolute",
@@ -98,7 +110,7 @@ export default function AlbumCard({ album }: { album: AlbumEntry }) {
             {album.title}
           </Typography>
         </Box>
-        <ModalClose variant="solid" />;
+        <ModalClose variant="solid" />
       </CardOverflow>
       <CardContent>
         <Stack
@@ -115,7 +127,35 @@ export default function AlbumCard({ album }: { album: AlbumEntry }) {
             &nbsp;&nbsp; • &nbsp;&nbsp; {album?.format ?? ""}
           </Typography>
         </Stack>
-        No Reviews Yet!
+        {metadata && (
+          <Stack direction="row" spacing={1} sx={{ mb: 1, flexWrap: "wrap", alignItems: "center" }}>
+            {metadata.label && (
+              <Typography level="body-sm">{metadata.label}</Typography>
+            )}
+            {metadata.label && metadata.releaseYear ? (
+              <Typography level="body-sm"> • </Typography>
+            ) : null}
+            {metadata.releaseYear ? (
+              <Typography level="body-sm">{metadata.releaseYear}</Typography>
+            ) : null}
+            {metadata.genres?.map((g) => (
+              <Chip key={g} size="sm" variant="soft">
+                {g}
+              </Chip>
+            ))}
+            {metadata.styles?.map((s) => (
+              <Chip key={s} size="sm" variant="outlined">
+                {s}
+              </Chip>
+            ))}
+          </Stack>
+        )}
+        <LibraryStatus album={album} />
+        <Box sx={{ mt: 1 }}>
+          <StreamingLinks metadata={metadata} />
+        </Box>
+        <Divider sx={{ my: 1 }} />
+        <Tracklist tracklist={metadata?.tracklist} />
       </CardContent>
       <CardOverflow
         variant="soft"
@@ -128,19 +168,36 @@ export default function AlbumCard({ album }: { album: AlbumEntry }) {
         }}
       >
         <Stack direction="row" spacing={1}>
-        <Typography
-          level="body-sm"
-          sx={{ fontWeight: "md", color: "text.secondary" }}
-        >
-          {album.plays ?? 0} plays
-        </Typography>
-        <Divider orientation="vertical" />
-        <Typography
-          level="body-sm"
-          sx={{ fontWeight: "md", color: "text.secondary" }}
-        >
-          Added {!album.add_date ? "Unknown Time" : new Date(album.add_date).toLocaleDateString()}
-        </Typography>
+          <Typography
+            level="body-sm"
+            sx={{ fontWeight: "md", color: "text.secondary" }}
+          >
+            {album.plays ?? 0} plays
+          </Typography>
+          <Divider orientation="vertical" />
+          <Typography
+            level="body-sm"
+            sx={{ fontWeight: "md", color: "text.secondary" }}
+          >
+            Added{" "}
+            {!album.add_date
+              ? "Unknown Time"
+              : new Date(album.add_date).toLocaleDateString()}
+          </Typography>
+          {metadata?.discogsUrl && (
+            <>
+              <Divider orientation="vertical" />
+              <Link
+                href={metadata.discogsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                level="body-sm"
+                sx={{ fontWeight: "md" }}
+              >
+                Discogs
+              </Link>
+            </>
+          )}
         </Stack>
       </CardOverflow>
     </Card>

--- a/app/dashboard/@information/(.)album/components/AlbumCard.tsx
+++ b/app/dashboard/@information/(.)album/components/AlbumCard.tsx
@@ -2,20 +2,21 @@
 
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { AlbumMetadata } from "@/lib/features/metadata/types";
-import { ArtistAvatar } from "@/src/components/experiences/modern/catalog/ArtistAvatar";
 import {
-  AspectRatio,
   Box,
   Card,
   CardContent,
   CardOverflow,
   Chip,
+  CircularProgress,
   Divider,
   Link,
   ModalClose,
   Stack,
   Typography,
 } from "@mui/joy";
+import { useRef, useState, useEffect } from "react";
+import DiscogsMarkup from "./DiscogsMarkupRenderer";
 import LibraryStatus from "./LibraryStatus";
 import StreamingLinks from "./StreamingLinks";
 import Tracklist from "./Tracklist";
@@ -24,13 +25,30 @@ interface AlbumCardProps {
   album: AlbumEntry;
   artworkUrl: string;
   metadata: AlbumMetadata | null;
+  metadataLoading: boolean;
+  artistBio: string | null;
+  artistWikipediaUrl: string | null;
 }
 
 export default function AlbumCard({
   album,
   artworkUrl,
   metadata,
+  metadataLoading,
+  artistBio,
+  artistWikipediaUrl,
 }: AlbumCardProps) {
+  const [bioExpanded, setBioExpanded] = useState(false);
+  const [bioOverflows, setBioOverflows] = useState(false);
+  const bioRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = bioRef.current;
+    if (el) {
+      setBioOverflows(el.scrollHeight > el.clientHeight);
+    }
+  }, [artistBio]);
+
   return (
     <Card
       variant="outlined"
@@ -40,122 +58,106 @@ export default function AlbumCard({
         overflow: "auto",
       }}
     >
-      <CardOverflow>
-        <AspectRatio ratio="4">
-          <img src={artworkUrl} />
-        </AspectRatio>
-        <Box
-          sx={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            width: "100%",
-            height: "100%",
-            borderTopRightRadius: "var(--CardOverflow-radius)",
-            borderTopLeftRadius: "var(--CardOverflow-radius)",
-            backdropFilter: "blur(0.2rem)",
-            pointerEvents: "none",
-          }}
-        />
-        <Box
-          sx={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            width: "100%",
-            height: "100%",
-            borderTopRightRadius: "var(--CardOverflow-radius)",
-            borderTopLeftRadius: "var(--CardOverflow-radius)",
-            bgcolor: "rgba(0,0,0,0.5)",
-          }}
-        />
-        <Box
-          sx={{
-            position: "absolute",
-            bottom: 3,
-            left: 0,
-            display: "flex",
-            alignItems: "flex-end",
-            justifyContent: "flex-start",
-          }}
-        >
-          <Box
-            sx={{
-              ml: 5,
-              width: 70,
-              "& > *": {
-                transform: "scale(1.8) translateY(13px)",
-              },
-            }}
-          >
-            <ArtistAvatar
-              artist={album.artist}
-              format={album.format}
-              entry={album.entry}
-              rotation={album.rotation_bin}
-            />
-          </Box>
-          <Typography
-            level="h3"
-            sx={{
-              overflow: "hidden",
-              lineHeight: "1.5em",
-              height: "3em",
-              pl: 3.2,
-              mb: -8.5,
-              textOverflow: "ellipsis",
-              maxWidth: "calc(100% - 40px)",
-            }}
-          >
-            {album.title}
-          </Typography>
-        </Box>
-        <ModalClose variant="solid" />
-      </CardOverflow>
+      <ModalClose variant="plain" sx={{ position: "absolute", top: 8, right: 8, zIndex: 1 }} />
       <CardContent>
-        <Stack
-          direction="row"
-          spacing={2}
-          sx={{
-            ml: 15,
-            mb: 1,
-          }}
-        >
-          <Typography level="body-lg">
-            {album.artist.name} &nbsp;&nbsp; • &nbsp;&nbsp; {album.artist.genre}{" "}
-            {album.artist.lettercode} {album.artist.numbercode}/{album.entry}{" "}
-            &nbsp;&nbsp; • &nbsp;&nbsp; {album?.format ?? ""}
-          </Typography>
-        </Stack>
-        {metadata && (
-          <Stack direction="row" spacing={1} sx={{ mb: 1, flexWrap: "wrap", alignItems: "center" }}>
-            {metadata.label && (
-              <Typography level="body-sm">{metadata.label}</Typography>
-            )}
-            {metadata.label && metadata.releaseYear ? (
-              <Typography level="body-sm"> • </Typography>
-            ) : null}
-            {metadata.releaseYear ? (
-              <Typography level="body-sm">{metadata.releaseYear}</Typography>
-            ) : null}
-            {metadata.genres?.map((g) => (
-              <Chip key={g} size="sm" variant="soft">
-                {g}
-              </Chip>
-            ))}
-            {metadata.styles?.map((s) => (
-              <Chip key={s} size="sm" variant="outlined">
-                {s}
-              </Chip>
-            ))}
+        <Stack direction="row" spacing={2} sx={{ mb: 1 }}>
+          <Box
+            component="img"
+            src={artworkUrl}
+            alt={`${album.title} cover`}
+            sx={{
+              width: 200,
+              height: 200,
+              objectFit: "cover",
+              borderRadius: "sm",
+              flexShrink: 0,
+            }}
+          />
+          <Stack sx={{ minWidth: 0, justifyContent: "center" }}>
+            <Typography level="title-lg" sx={{ mb: 0.5 }}>
+              {album.artist.name} &bull; {album.title}
+            </Typography>
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{ mb: 1, flexWrap: "wrap", alignItems: "center" }}
+            >
+              {metadata?.label && (
+                <Typography level="body-sm">{metadata.label}</Typography>
+              )}
+              {metadata?.label && metadata.releaseYear ? (
+                <Typography level="body-sm">&bull;</Typography>
+              ) : null}
+              {metadata?.releaseYear ? (
+                <Typography level="body-sm">{metadata.releaseYear}</Typography>
+              ) : null}
+              {!metadata && !metadataLoading && (
+                <Typography level="body-sm">
+                  {album.label || ""}{album.label ? " \u2022 " : ""}{album?.format ?? ""}
+                </Typography>
+              )}
+              {metadata?.genres?.map((g) => (
+                <Chip key={g} size="sm" variant="soft">
+                  {g}
+                </Chip>
+              ))}
+              {metadata?.styles?.map((s) => (
+                <Chip key={s} size="sm" variant="outlined">
+                  {s}
+                </Chip>
+              ))}
+            </Stack>
+            <LibraryStatus album={album} />
           </Stack>
+        </Stack>
+        <StreamingLinks metadata={metadata} />
+        {artistBio && (
+          <>
+            <Divider sx={{ my: 1 }} />
+            <Typography level="title-sm" sx={{ mb: 0.5 }}>
+              About {album.artist.name}
+              {artistWikipediaUrl && (
+                <Link
+                  href={artistWikipediaUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  level="body-xs"
+                  sx={{ ml: 1 }}
+                >
+                  Wikipedia
+                </Link>
+              )}
+            </Typography>
+            <Typography
+              ref={bioRef}
+              component="div"
+              level="body-sm"
+              sx={{
+                ...(!bioExpanded && { maxHeight: 80, overflow: "hidden" }),
+                color: "text.secondary",
+              }}
+            >
+              <DiscogsMarkup text={artistBio} />
+            </Typography>
+            {bioOverflows && !bioExpanded && (
+              <Link
+                component="button"
+                level="body-xs"
+                onClick={() => setBioExpanded(true)}
+              >
+                Read More
+              </Link>
+            )}
+          </>
         )}
-        <LibraryStatus album={album} />
-        <Box sx={{ mt: 1 }}>
-          <StreamingLinks metadata={metadata} />
-        </Box>
         <Divider sx={{ my: 1 }} />
-        <Tracklist tracklist={metadata?.tracklist} />
+        {metadataLoading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+            <CircularProgress size="sm" />
+          </Box>
+        ) : (
+          <Tracklist tracklist={metadata?.tracklist} />
+        )}
       </CardContent>
       <CardOverflow
         variant="soft"

--- a/app/dashboard/@information/(.)album/components/DiscogsMarkupRenderer.tsx
+++ b/app/dashboard/@information/(.)album/components/DiscogsMarkupRenderer.tsx
@@ -1,0 +1,82 @@
+import { Link } from "@mui/joy";
+import { type ReactNode } from "react";
+import { parseDiscogsMarkup, type ResolvedToken } from "./discogsMarkup";
+
+function renderToken(token: ResolvedToken, key: number): ReactNode {
+  switch (token.type) {
+    case "plainText":
+      return <span key={key}>{token.text}</span>;
+
+    case "artistLink":
+      return (
+        <Link
+          key={key}
+          href={token.url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {token.displayName}
+        </Link>
+      );
+
+    case "labelName":
+      return <span key={key}>{token.name}</span>;
+
+    case "releaseLink":
+      return (
+        <Link
+          key={key}
+          href={token.url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {token.title}
+        </Link>
+      );
+
+    case "masterLink":
+      return (
+        <Link
+          key={key}
+          href={token.url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {token.title}
+        </Link>
+      );
+
+    case "bold":
+      return <strong key={key}>{token.content}</strong>;
+
+    case "italic":
+      return <em key={key}>{token.content}</em>;
+
+    case "underline":
+      return (
+        <span key={key} style={{ textDecoration: "underline" }}>
+          {token.content}
+        </span>
+      );
+
+    case "urlLink":
+      return token.href ? (
+        <Link
+          key={key}
+          href={token.href}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {token.content}
+        </Link>
+      ) : (
+        <span key={key}>{token.content}</span>
+      );
+  }
+}
+
+/** Renders Discogs markup as React elements with links and formatting. */
+export default function DiscogsMarkup({ text }: { text: string }) {
+  const tokens = parseDiscogsMarkup(text);
+  return <>{tokens.map((token, i) => renderToken(token, i))}</>;
+}

--- a/app/dashboard/@information/(.)album/components/LibraryStatus.test.tsx
+++ b/app/dashboard/@information/(.)album/components/LibraryStatus.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import {
+  renderWithProviders,
+  createTestAlbum,
+  createTestArtist,
+} from "@/lib/test-utils";
+import LibraryStatus from "./LibraryStatus";
+
+const catPowerAlbum = () =>
+  createTestAlbum({
+    title: "Moon Pix",
+    artist: createTestArtist({
+      name: "Cat Power",
+      lettercode: "RO",
+      numbercode: 23,
+      genre: "Rock",
+    }),
+    label: "Matador Records",
+  });
+
+describe("LibraryStatus", () => {
+  it("shows 'In Library' chip when date_lost is undefined", () => {
+    const album = catPowerAlbum();
+
+    renderWithProviders(<LibraryStatus album={album} />);
+
+    expect(screen.getByText("In Library")).toBeInTheDocument();
+    expect(screen.getByText("Mark Missing")).toBeInTheDocument();
+  });
+
+  it("shows 'Missing since...' chip when date_lost is set and date_found is not", () => {
+    const album = catPowerAlbum();
+    album.date_lost = "2025-03-15";
+
+    renderWithProviders(<LibraryStatus album={album} />);
+
+    expect(
+      screen.getByText(
+        `Missing since ${new Date("2025-03-15").toLocaleDateString()}`,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Mark Found")).toBeInTheDocument();
+  });
+
+  it("shows 'In Library' when date_found is after date_lost", () => {
+    const album = catPowerAlbum();
+    album.date_lost = "2025-03-15";
+    album.date_found = "2025-04-01";
+
+    renderWithProviders(<LibraryStatus album={album} />);
+
+    expect(screen.getByText("In Library")).toBeInTheDocument();
+    expect(screen.getByText("Mark Missing")).toBeInTheDocument();
+  });
+
+  it("shows missing when date_found is before date_lost", () => {
+    const album = catPowerAlbum();
+    album.date_lost = "2025-04-10";
+    album.date_found = "2025-03-01";
+
+    renderWithProviders(<LibraryStatus album={album} />);
+
+    expect(
+      screen.getByText(
+        `Missing since ${new Date("2025-04-10").toLocaleDateString()}`,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Mark Found")).toBeInTheDocument();
+  });
+});

--- a/app/dashboard/@information/(.)album/components/LibraryStatus.tsx
+++ b/app/dashboard/@information/(.)album/components/LibraryStatus.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { AlbumEntry } from "@/lib/features/catalog/types";
+import {
+  useMarkFoundMutation,
+  useMarkMissingMutation,
+} from "@/lib/features/catalog/api";
+import { Button, Chip, Stack } from "@mui/joy";
+
+interface LibraryStatusProps {
+  album: AlbumEntry;
+}
+
+export default function LibraryStatus({ album }: LibraryStatusProps) {
+  const [markMissing] = useMarkMissingMutation();
+  const [markFound] = useMarkFoundMutation();
+
+  const isMissing =
+    album.date_lost &&
+    (!album.date_found ||
+      new Date(album.date_found) < new Date(album.date_lost));
+
+  if (isMissing) {
+    return (
+      <Stack direction="row" spacing={1} alignItems="center">
+        <Chip color="danger" size="sm">
+          Missing since {new Date(album.date_lost!).toLocaleDateString()}
+        </Chip>
+        <Button
+          size="sm"
+          variant="outlined"
+          color="success"
+          onClick={() => markFound({ albumId: album.id })}
+        >
+          Mark Found
+        </Button>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack direction="row" spacing={1} alignItems="center">
+      <Chip color="success" size="sm">
+        In Library
+      </Chip>
+      <Button
+        size="sm"
+        variant="outlined"
+        color="danger"
+        onClick={() => markMissing({ albumId: album.id })}
+      >
+        Mark Missing
+      </Button>
+    </Stack>
+  );
+}

--- a/app/dashboard/@information/(.)album/components/LibraryStatus.tsx
+++ b/app/dashboard/@information/(.)album/components/LibraryStatus.tsx
@@ -5,7 +5,7 @@ import {
   useMarkFoundMutation,
   useMarkMissingMutation,
 } from "@/lib/features/catalog/api";
-import { Button, Chip, Stack } from "@mui/joy";
+import { Chip, Stack } from "@mui/joy";
 
 interface LibraryStatusProps {
   album: AlbumEntry;
@@ -26,14 +26,15 @@ export default function LibraryStatus({ album }: LibraryStatusProps) {
         <Chip color="danger" size="sm">
           Missing since {new Date(album.date_lost!).toLocaleDateString()}
         </Chip>
-        <Button
+        <Chip
           size="sm"
           variant="outlined"
           color="success"
           onClick={() => markFound({ albumId: album.id })}
+          sx={{ cursor: "pointer" }}
         >
           Mark Found
-        </Button>
+        </Chip>
       </Stack>
     );
   }
@@ -43,14 +44,15 @@ export default function LibraryStatus({ album }: LibraryStatusProps) {
       <Chip color="success" size="sm">
         In Library
       </Chip>
-      <Button
+      <Chip
         size="sm"
         variant="outlined"
         color="danger"
         onClick={() => markMissing({ albumId: album.id })}
+        sx={{ cursor: "pointer" }}
       >
         Mark Missing
-      </Button>
+      </Chip>
     </Stack>
   );
 }

--- a/app/dashboard/@information/(.)album/components/StreamingLinks.test.tsx
+++ b/app/dashboard/@information/(.)album/components/StreamingLinks.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import StreamingLinks from "./StreamingLinks";
+import type { AlbumMetadata } from "@/lib/features/metadata/types";
+
+function createTestMetadata(
+  overrides: Partial<AlbumMetadata> = {},
+): AlbumMetadata {
+  return {
+    discogsReleaseId: 12345,
+    discogsUrl: "",
+    artworkUrl: "https://example.com/art.jpg",
+    releaseYear: 2023,
+    spotifyUrl: "",
+    appleMusicUrl: "",
+    youtubeMusicUrl: "",
+    bandcampUrl: "",
+    soundcloudUrl: "",
+    tracklist: [],
+    genres: ["Electronic"],
+    styles: ["Ambient"],
+    label: "Warp",
+    fullReleaseDate: "2023-05-01",
+    ...overrides,
+  };
+}
+
+describe("StreamingLinks", () => {
+  it("returns null when metadata is null", () => {
+    const { container } = render(<StreamingLinks metadata={null} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when all URLs are empty strings", () => {
+    const metadata = createTestMetadata();
+    const { container } = render(<StreamingLinks metadata={metadata} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders only chips for services with URLs", () => {
+    const metadata = createTestMetadata({
+      spotifyUrl: "https://open.spotify.com/album/abc",
+      bandcampUrl: "https://artist.bandcamp.com/album/xyz",
+    });
+
+    render(<StreamingLinks metadata={metadata} />);
+
+    expect(screen.getByText("Spotify")).toBeInTheDocument();
+    expect(screen.getByText("Bandcamp")).toBeInTheDocument();
+    expect(screen.queryByText("Apple Music")).not.toBeInTheDocument();
+    expect(screen.queryByText("YouTube")).not.toBeInTheDocument();
+    expect(screen.queryByText("SoundCloud")).not.toBeInTheDocument();
+    expect(screen.queryByText("Discogs")).not.toBeInTheDocument();
+  });
+
+  it("chips link to correct URLs with target=_blank", () => {
+    const metadata = createTestMetadata({
+      spotifyUrl: "https://open.spotify.com/album/abc",
+      discogsUrl: "https://www.discogs.com/release/12345",
+    });
+
+    render(<StreamingLinks metadata={metadata} />);
+
+    const spotifyLink = screen.getByText("Spotify").closest("a");
+    expect(spotifyLink).toHaveAttribute(
+      "href",
+      "https://open.spotify.com/album/abc",
+    );
+    expect(spotifyLink).toHaveAttribute("target", "_blank");
+
+    const discogsLink = screen.getByText("Discogs").closest("a");
+    expect(discogsLink).toHaveAttribute(
+      "href",
+      "https://www.discogs.com/release/12345",
+    );
+    expect(discogsLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders all services when all URLs are provided", () => {
+    const metadata = createTestMetadata({
+      spotifyUrl: "https://spotify.com",
+      appleMusicUrl: "https://music.apple.com",
+      youtubeMusicUrl: "https://music.youtube.com",
+      bandcampUrl: "https://bandcamp.com",
+      soundcloudUrl: "https://soundcloud.com",
+      discogsUrl: "https://discogs.com",
+    });
+
+    render(<StreamingLinks metadata={metadata} />);
+
+    expect(screen.getByText("Spotify")).toBeInTheDocument();
+    expect(screen.getByText("Apple Music")).toBeInTheDocument();
+    expect(screen.getByText("YouTube")).toBeInTheDocument();
+    expect(screen.getByText("Bandcamp")).toBeInTheDocument();
+    expect(screen.getByText("SoundCloud")).toBeInTheDocument();
+    expect(screen.getByText("Discogs")).toBeInTheDocument();
+  });
+});

--- a/app/dashboard/@information/(.)album/components/StreamingLinks.test.tsx
+++ b/app/dashboard/@information/(.)album/components/StreamingLinks.test.tsx
@@ -8,6 +8,7 @@ function createTestMetadata(
 ): AlbumMetadata {
   return {
     discogsReleaseId: 12345,
+    discogsArtistId: null,
     discogsUrl: "",
     artworkUrl: "https://example.com/art.jpg",
     releaseYear: 2023,

--- a/app/dashboard/@information/(.)album/components/StreamingLinks.tsx
+++ b/app/dashboard/@information/(.)album/components/StreamingLinks.tsx
@@ -1,0 +1,43 @@
+import { AlbumMetadata } from "@/lib/features/metadata/types";
+import { Chip, Stack } from "@mui/joy";
+
+interface StreamingLinksProps {
+  metadata: AlbumMetadata | null;
+}
+
+const SERVICES: { key: keyof AlbumMetadata; label: string }[] = [
+  { key: "spotifyUrl", label: "Spotify" },
+  { key: "appleMusicUrl", label: "Apple Music" },
+  { key: "youtubeMusicUrl", label: "YouTube" },
+  { key: "bandcampUrl", label: "Bandcamp" },
+  { key: "soundcloudUrl", label: "SoundCloud" },
+  { key: "discogsUrl", label: "Discogs" },
+];
+
+export default function StreamingLinks({ metadata }: StreamingLinksProps) {
+  if (!metadata) return null;
+
+  const links = SERVICES.filter(
+    (service) => metadata[service.key] as string,
+  );
+
+  if (links.length === 0) return null;
+
+  return (
+    <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap" }}>
+      {links.map((service) => (
+        <Chip
+          key={service.key}
+          variant="outlined"
+          size="sm"
+          component="a"
+          href={metadata[service.key] as string}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {service.label}
+        </Chip>
+      ))}
+    </Stack>
+  );
+}

--- a/app/dashboard/@information/(.)album/components/Tracklist.test.tsx
+++ b/app/dashboard/@information/(.)album/components/Tracklist.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Tracklist from "./Tracklist";
+
+describe("Tracklist", () => {
+  it("renders 'No tracklist available' when tracklist is undefined", () => {
+    render(<Tracklist tracklist={undefined} />);
+    expect(screen.getByText("No tracklist available")).toBeInTheDocument();
+  });
+
+  it("renders 'No tracklist available' when tracklist is empty", () => {
+    render(<Tracklist tracklist={[]} />);
+    expect(screen.getByText("No tracklist available")).toBeInTheDocument();
+  });
+
+  it("renders table with tracks when tracklist has entries", () => {
+    const tracklist = [
+      { position: "1", title: "la paradoja", duration: "4:32" },
+      { position: "2", title: "In a Sentimental Mood", duration: "5:27" },
+      { position: "3", title: "Call Your Name", duration: "3:15" },
+    ];
+
+    render(<Tracklist tracklist={tracklist} />);
+
+    expect(screen.getByText("#")).toBeInTheDocument();
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("Duration")).toBeInTheDocument();
+
+    expect(screen.getByText("la paradoja")).toBeInTheDocument();
+    expect(screen.getByText("4:32")).toBeInTheDocument();
+    expect(screen.getByText("In a Sentimental Mood")).toBeInTheDocument();
+    expect(screen.getByText("5:27")).toBeInTheDocument();
+    expect(screen.getByText("Call Your Name")).toBeInTheDocument();
+    expect(screen.getByText("3:15")).toBeInTheDocument();
+  });
+
+  it("renders correct number of rows", () => {
+    const tracklist = [
+      { position: "A1", title: "VI Scose Poise", duration: "6:10" },
+      { position: "A2", title: "Cfern", duration: "4:45" },
+    ];
+
+    render(<Tracklist tracklist={tracklist} />);
+
+    const rows = screen.getAllByRole("row");
+    // 1 header row + 2 data rows
+    expect(rows).toHaveLength(3);
+  });
+});

--- a/app/dashboard/@information/(.)album/components/Tracklist.tsx
+++ b/app/dashboard/@information/(.)album/components/Tracklist.tsx
@@ -1,0 +1,39 @@
+import { Table, Typography } from "@mui/joy";
+
+interface TracklistProps {
+  tracklist: { position: string; title: string; duration: string }[] | undefined;
+}
+
+export default function Tracklist({ tracklist }: TracklistProps) {
+  if (!tracklist || tracklist.length === 0) {
+    return (
+      <Typography
+        level="body-sm"
+        sx={{ color: "text.tertiary", fontStyle: "italic" }}
+      >
+        No tracklist available
+      </Typography>
+    );
+  }
+
+  return (
+    <Table size="sm" stripe="odd">
+      <thead>
+        <tr>
+          <th style={{ width: 40 }}>#</th>
+          <th>Title</th>
+          <th style={{ width: 80 }}>Duration</th>
+        </tr>
+      </thead>
+      <tbody>
+        {tracklist.map((track, index) => (
+          <tr key={index}>
+            <td>{track.position}</td>
+            <td>{track.title}</td>
+            <td>{track.duration}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+}

--- a/app/dashboard/@information/(.)album/components/discogsMarkup.test.ts
+++ b/app/dashboard/@information/(.)album/components/discogsMarkup.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect } from "vitest";
+import {
+  tokenize,
+  resolve,
+  parseDiscogsMarkup,
+  stripDisambiguationSuffix,
+  type ResolvedToken,
+} from "./discogsMarkup";
+
+/** Helper: extract display text from resolved tokens */
+function textContent(tokens: ResolvedToken[]): string {
+  return tokens
+    .map((t) => {
+      switch (t.type) {
+        case "plainText": return t.text;
+        case "artistLink": return t.displayName;
+        case "labelName": return t.name;
+        case "releaseLink": return t.title;
+        case "masterLink": return t.title;
+        case "bold": return t.content;
+        case "italic": return t.content;
+        case "underline": return t.content;
+        case "urlLink": return t.content;
+      }
+    })
+    .join("");
+}
+
+// MARK: - Artist Tag Tests
+
+describe("Artist Tag Tests", () => {
+  it("parses artist link with name", () => {
+    const result = parseDiscogsMarkup("[a=The Beatles]");
+    expect(textContent(result)).toBe("The Beatles");
+  });
+
+  it("parses artist link with special characters", () => {
+    const result = parseDiscogsMarkup("[a=Guns N' Roses]");
+    expect(textContent(result)).toBe("Guns N' Roses");
+  });
+
+  it("skips artist link by ID in sync mode", () => {
+    const result = parseDiscogsMarkup("[a12345]");
+    expect(textContent(result)).toBe("");
+  });
+
+  it("skips artist link with large ID", () => {
+    const result = parseDiscogsMarkup("[a9999999]");
+    expect(textContent(result)).toBe("");
+  });
+
+  it("preserves text around artist ID link", () => {
+    const result = parseDiscogsMarkup("See [a12345] for more");
+    expect(textContent(result)).toBe("See  for more");
+  });
+
+  it("artist link has correct URL", () => {
+    const result = parseDiscogsMarkup("[a=Test Artist]");
+    const artistToken = result.find((t) => t.type === "artistLink");
+    expect(artistToken).toBeDefined();
+    if (artistToken?.type === "artistLink") {
+      expect(artistToken.url).toContain("discogs.com/search");
+      expect(artistToken.url).toContain("type=artist");
+    }
+  });
+});
+
+// MARK: - Bold Tag Tests
+
+describe("Bold Tag Tests", () => {
+  it("parses bold text", () => {
+    const result = parseDiscogsMarkup("[b]bold text[/b]");
+    expect(textContent(result)).toBe("bold text");
+    expect(result).toContainEqual({ type: "bold", content: "bold text" });
+  });
+
+  it("parses bold text with surrounding content", () => {
+    const result = parseDiscogsMarkup("This is [b]bold[/b] text");
+    expect(textContent(result)).toBe("This is bold text");
+  });
+
+  it("skips orphaned bold closing tag", () => {
+    const result = parseDiscogsMarkup("text [/b] more");
+    expect(textContent(result)).toBe("text  more");
+  });
+
+  it("handles unclosed bold tag", () => {
+    const result = parseDiscogsMarkup("[b]no closing tag");
+    expect(textContent(result)).toBe("no closing tag");
+  });
+
+  it("handles empty bold content", () => {
+    const result = parseDiscogsMarkup("[b][/b]");
+    expect(textContent(result)).toBe("");
+  });
+});
+
+// MARK: - Italic Tag Tests
+
+describe("Italic Tag Tests", () => {
+  it("parses italic text", () => {
+    const result = parseDiscogsMarkup("[i]italic text[/i]");
+    expect(textContent(result)).toBe("italic text");
+    expect(result).toContainEqual({ type: "italic", content: "italic text" });
+  });
+
+  it("parses italic text with surrounding content", () => {
+    const result = parseDiscogsMarkup("This is [i]italic[/i] text");
+    expect(textContent(result)).toBe("This is italic text");
+  });
+
+  it("skips orphaned italic closing tag", () => {
+    const result = parseDiscogsMarkup("text [/i] more");
+    expect(textContent(result)).toBe("text  more");
+  });
+
+  it("handles unclosed italic tag", () => {
+    const result = parseDiscogsMarkup("[i]no closing tag");
+    expect(textContent(result)).toBe("no closing tag");
+  });
+});
+
+// MARK: - Underline Tag Tests
+
+describe("Underline Tag Tests", () => {
+  it("parses underlined text", () => {
+    const result = parseDiscogsMarkup("[u]underlined text[/u]");
+    expect(textContent(result)).toBe("underlined text");
+    expect(result).toContainEqual({ type: "underline", content: "underlined text" });
+  });
+
+  it("parses underline text with surrounding content", () => {
+    const result = parseDiscogsMarkup("This is [u]underlined[/u] text");
+    expect(textContent(result)).toBe("This is underlined text");
+  });
+
+  it("skips orphaned underline closing tag", () => {
+    const result = parseDiscogsMarkup("text [/u] more");
+    expect(textContent(result)).toBe("text  more");
+  });
+
+  it("handles unclosed underline tag", () => {
+    const result = parseDiscogsMarkup("[u]no closing tag");
+    expect(textContent(result)).toBe("no closing tag");
+  });
+});
+
+// MARK: - Label Tag Tests
+
+describe("Label Tag Tests", () => {
+  it("parses label link", () => {
+    const result = parseDiscogsMarkup("[l=Blue Note Records]");
+    expect(textContent(result)).toBe("Blue Note Records");
+  });
+
+  it("parses label link with special characters", () => {
+    const result = parseDiscogsMarkup("[l=4AD]");
+    expect(textContent(result)).toBe("4AD");
+  });
+
+  it("parses label link with surrounding text", () => {
+    const result = parseDiscogsMarkup("Released on [l=Motown] in 1965");
+    expect(textContent(result)).toBe("Released on Motown in 1965");
+  });
+});
+
+// MARK: - URL Tag Tests
+
+describe("URL Tag Tests", () => {
+  it("parses URL link", () => {
+    const result = parseDiscogsMarkup("[url=https://example.com]Click here[/url]");
+    expect(textContent(result)).toBe("Click here");
+    const urlToken = result.find((t) => t.type === "urlLink");
+    expect(urlToken).toBeDefined();
+    if (urlToken?.type === "urlLink") {
+      expect(urlToken.href).toBe("https://example.com");
+    }
+  });
+
+  it("handles URL without closing tag - shows URL", () => {
+    const result = parseDiscogsMarkup("[url=https://example.com]orphaned");
+    expect(textContent(result)).toBe("https://example.comorphaned");
+  });
+
+  it("handles invalid URL gracefully", () => {
+    const result = parseDiscogsMarkup("[url=not a valid url]text[/url]");
+    expect(textContent(result)).toBe("text");
+  });
+
+  it("parses URL with complex query string", () => {
+    const result = parseDiscogsMarkup(
+      "[url=https://example.com/path?query=value&other=123]Link[/url]",
+    );
+    expect(textContent(result)).toBe("Link");
+    const urlToken = result.find((t) => t.type === "urlLink");
+    if (urlToken?.type === "urlLink") {
+      expect(urlToken.href).toBe("https://example.com/path?query=value&other=123");
+    }
+  });
+});
+
+// MARK: - ID-based Tag Tests
+
+describe("ID-based Tag Tests", () => {
+  it("skips release link by ID in sync mode", () => {
+    expect(textContent(parseDiscogsMarkup("[r12345]"))).toBe("");
+  });
+
+  it("skips master link by ID in sync mode", () => {
+    expect(textContent(parseDiscogsMarkup("[m123]"))).toBe("");
+  });
+
+  it("skips release link by ID with equals sign", () => {
+    expect(textContent(parseDiscogsMarkup("[r=621811]"))).toBe("");
+  });
+
+  it("skips master link by ID with equals sign", () => {
+    expect(textContent(parseDiscogsMarkup("[m=199386]"))).toBe("");
+  });
+
+  it("preserves text around release ID", () => {
+    const result = parseDiscogsMarkup("See release [r99999] for details");
+    expect(textContent(result)).toBe("See release  for details");
+  });
+
+  it("preserves text around master ID", () => {
+    const result = parseDiscogsMarkup("Master [m456] version");
+    expect(textContent(result)).toBe("Master  version");
+  });
+});
+
+// MARK: - Edge Cases
+
+describe("Edge Cases", () => {
+  it("handles plain text without tags", () => {
+    const result = parseDiscogsMarkup("Just plain text with no formatting");
+    expect(textContent(result)).toBe("Just plain text with no formatting");
+  });
+
+  it("handles empty string", () => {
+    const result = parseDiscogsMarkup("");
+    expect(textContent(result)).toBe("");
+  });
+
+  it("handles multiple consecutive tags", () => {
+    const result = parseDiscogsMarkup("[a=Artist A][a=Artist B][a=Artist C]");
+    expect(textContent(result)).toBe("Artist AArtist BArtist C");
+  });
+
+  it("handles mixed tags and text", () => {
+    const result = parseDiscogsMarkup(
+      "Check out [a=The Beatles] on [l=Apple Records]!",
+    );
+    expect(textContent(result)).toBe("Check out The Beatles on Apple Records!");
+  });
+
+  it("handles nested formatting tags (raw content, no recursion)", () => {
+    const result = parseDiscogsMarkup("[b]bold [i]and italic[/i][/b]");
+    expect(textContent(result)).toBe("bold [i]and italic[/i]");
+  });
+
+  it("handles unclosed bracket", () => {
+    const result = parseDiscogsMarkup("Text with [unclosed bracket");
+    expect(textContent(result)).toBe("Text with [unclosed bracket");
+  });
+
+  it("handles unknown tags", () => {
+    const result = parseDiscogsMarkup("[unknown]text[/unknown]");
+    expect(textContent(result)).toBe("text");
+  });
+
+  it("handles real-world Discogs text", () => {
+    const result = parseDiscogsMarkup(
+      "Written by [a=John Lennon] and [a=Paul McCartney]. Released on [l=Apple Records] in 1969. See [r123456] for more info.",
+    );
+    expect(textContent(result)).toBe(
+      "Written by John Lennon and Paul McCartney. Released on Apple Records in 1969. See  for more info.",
+    );
+  });
+
+  it("handles text with only brackets", () => {
+    const result = parseDiscogsMarkup("[]");
+    expect(textContent(result)).toBe("");
+  });
+
+  it("handles deeply nested same-type tags", () => {
+    const result = parseDiscogsMarkup("[b]outer [b]inner[/b] outer[/b]");
+    expect(textContent(result)).toBe("outer [b]inner[/b] outer");
+  });
+
+  it("handles multiple different formatting in sequence", () => {
+    const result = parseDiscogsMarkup(
+      "[b]bold[/b] then [i]italic[/i] then [u]underline[/u]",
+    );
+    expect(textContent(result)).toBe("bold then italic then underline");
+  });
+
+  it("does not confuse url tag with u tag", () => {
+    const result = parseDiscogsMarkup("[url=https://example.com]link[/url]");
+    expect(textContent(result)).toBe("link");
+    const urlToken = result.find((t) => t.type === "urlLink");
+    expect(urlToken).toBeDefined();
+    if (urlToken?.type === "urlLink") {
+      expect(urlToken.href).toBeTruthy();
+    }
+  });
+});
+
+// MARK: - Token Type Verification
+
+describe("Token Type Verification", () => {
+  it("bold produces bold token", () => {
+    const result = parseDiscogsMarkup("[b]text[/b]");
+    expect(result.some((t) => t.type === "bold")).toBe(true);
+  });
+
+  it("italic produces italic token", () => {
+    const result = parseDiscogsMarkup("[i]text[/i]");
+    expect(result.some((t) => t.type === "italic")).toBe(true);
+  });
+
+  it("underline produces underline token", () => {
+    const result = parseDiscogsMarkup("[u]text[/u]");
+    expect(result.some((t) => t.type === "underline")).toBe(true);
+  });
+
+  it("URL produces urlLink token with href", () => {
+    const result = parseDiscogsMarkup("[url=https://test.com]link[/url]");
+    const urlToken = result.find((t) => t.type === "urlLink");
+    expect(urlToken).toBeDefined();
+    if (urlToken?.type === "urlLink") {
+      expect(urlToken.href).toBe("https://test.com");
+    }
+  });
+
+  it("plain text produces no special tokens", () => {
+    const result = parseDiscogsMarkup("plain text");
+    expect(result.every((t) => t.type === "plainText")).toBe(true);
+  });
+});
+
+// MARK: - Utility Tests
+
+describe("stripDisambiguationSuffix", () => {
+  it("removes numeric suffix", () => {
+    expect(stripDisambiguationSuffix("Artist (2)")).toBe("Artist");
+    expect(stripDisambiguationSuffix("Artist (123)")).toBe("Artist");
+  });
+
+  it("preserves non-numeric parentheses", () => {
+    expect(stripDisambiguationSuffix("Artist (Band)")).toBe("Artist (Band)");
+    expect(stripDisambiguationSuffix("Level 42")).toBe("Level 42");
+  });
+
+  it("handles no suffix", () => {
+    expect(stripDisambiguationSuffix("Artist")).toBe("Artist");
+  });
+
+  it("only strips trailing numeric parentheses", () => {
+    expect(stripDisambiguationSuffix("Blink-182")).toBe("Blink-182");
+    expect(stripDisambiguationSuffix("Test (Band)")).toBe("Test (Band)");
+  });
+});
+
+// MARK: - Tokenizer Unit Tests
+
+describe("tokenize", () => {
+  it("tokenizes plain text", () => {
+    const tokens = tokenize("hello world");
+    expect(tokens).toEqual([{ type: "plainText", text: "hello world" }]);
+  });
+
+  it("tokenizes artist name tag", () => {
+    const tokens = tokenize("[a=Autechre]");
+    expect(tokens).toEqual([{ type: "artistName", name: "Autechre" }]);
+  });
+
+  it("tokenizes artist ID tag", () => {
+    const tokens = tokenize("[a41]");
+    expect(tokens).toEqual([{ type: "artistId", id: 41 }]);
+  });
+
+  it("tokenizes mixed content", () => {
+    const tokens = tokenize("By [a=Rob Brown] and [a=Sean Booth]");
+    expect(tokens).toHaveLength(4);
+    expect(tokens[0]).toEqual({ type: "plainText", text: "By " });
+    expect(tokens[1]).toEqual({ type: "artistName", name: "Rob Brown" });
+    expect(tokens[2]).toEqual({ type: "plainText", text: " and " });
+    expect(tokens[3]).toEqual({ type: "artistName", name: "Sean Booth" });
+  });
+});
+
+// MARK: - Resolve Unit Tests
+
+describe("resolve", () => {
+  it("resolves artist name to artist link", () => {
+    const tokens = tokenize("[a=Autechre]");
+    const resolved = resolve(tokens);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].type).toBe("artistLink");
+    if (resolved[0].type === "artistLink") {
+      expect(resolved[0].displayName).toBe("Autechre");
+    }
+  });
+
+  it("strips disambiguation suffix from artist names", () => {
+    const tokens = tokenize("[a=Salamanda (8)]");
+    const resolved = resolve(tokens);
+    if (resolved[0].type === "artistLink") {
+      expect(resolved[0].displayName).toBe("Salamanda");
+    }
+  });
+
+  it("drops ID-only tokens in sync mode", () => {
+    const tokens = tokenize("[a41]");
+    const resolved = resolve(tokens);
+    expect(resolved).toHaveLength(0);
+  });
+});

--- a/app/dashboard/@information/(.)album/components/discogsMarkup.ts
+++ b/app/dashboard/@information/(.)album/components/discogsMarkup.ts
@@ -1,0 +1,264 @@
+/**
+ * Parses Discogs markup to structured tokens for rendering.
+ *
+ * Follows the same 3-phase architecture as the iOS DiscogsMarkupParser:
+ * 1. Tokenize — parse markup into a flat token list
+ * 2. Resolve — resolve ID-based tokens (sync mode skips them)
+ * 3. Render — convert tokens to a renderable format
+ *
+ * Supported formats:
+ * - `[a=Artist Name]` — artist link (displays the artist name)
+ * - `[a12345]` — artist link by ID (skipped in sync mode)
+ * - `[l=Label Name]` — label link (displays the label name)
+ * - `[b]text[/b]` — bold text
+ * - `[i]text[/i]` — italic text
+ * - `[u]text[/u]` — underlined text
+ * - `[url=http://example.com]Link Text[/url]` — URL link
+ * - `[r12345]` or `[r=12345]` — release link by ID (skipped in sync mode)
+ * - `[m123]` or `[m=123]` — master link by ID (skipped in sync mode)
+ */
+
+// MARK: - Token Types
+
+export type DiscogsToken =
+  | { type: "plainText"; text: string }
+  | { type: "artistName"; name: string }
+  | { type: "artistId"; id: number }
+  | { type: "releaseId"; id: number }
+  | { type: "masterId"; id: number }
+  | { type: "labelName"; name: string }
+  | { type: "bold"; content: string }
+  | { type: "italic"; content: string }
+  | { type: "underline"; content: string }
+  | { type: "url"; href: string; content: string };
+
+export type ResolvedToken =
+  | { type: "plainText"; text: string }
+  | { type: "artistLink"; displayName: string; url: string }
+  | { type: "labelName"; name: string }
+  | { type: "releaseLink"; title: string; url: string }
+  | { type: "masterLink"; title: string; url: string }
+  | { type: "bold"; content: string }
+  | { type: "italic"; content: string }
+  | { type: "underline"; content: string }
+  | { type: "urlLink"; href: string | null; content: string };
+
+// MARK: - Tag Patterns
+
+const ARTIST_NAME_PATTERN = /^a=(.+)$/;
+const ARTIST_ID_PATTERN = /^a(\d+)$/;
+const RELEASE_ID_PATTERN = /^r=?(\d+)$/;
+const MASTER_ID_PATTERN = /^m=?(\d+)$/;
+const LABEL_NAME_PATTERN = /^l=(.+)$/;
+const URL_OPEN_PATTERN = /^url=(.+)$/;
+const CLOSING_TAG_PATTERN = /^\/(.+)$/;
+
+// MARK: - Phase 1: Tokenize
+
+/**
+ * Finds a closing tag like [/tag] in the remaining text, handling same-type
+ * nesting via depth tracking. Returns the content between tags and the index
+ * after the closing tag, or null if not found.
+ */
+function findClosingTag(
+  text: string,
+  startIndex: number,
+  tag: string,
+): { content: string; endIndex: number } | null {
+  let searchStart = startIndex;
+  let depth = 1;
+
+  while (searchStart < text.length) {
+    const openBracket = text.indexOf("[", searchStart);
+    if (openBracket === -1) break;
+
+    const closeBracket = text.indexOf("]", openBracket);
+    if (closeBracket === -1) break;
+
+    const tagContent = text.slice(openBracket + 1, closeBracket);
+
+    if (tagContent === tag) {
+      depth += 1;
+    } else if (tagContent === `/${tag}`) {
+      depth -= 1;
+      if (depth === 0) {
+        const content = text.slice(startIndex, openBracket);
+        return { content, endIndex: closeBracket + 1 };
+      }
+    }
+
+    searchStart = closeBracket + 1;
+  }
+
+  return null;
+}
+
+export function tokenize(text: string): DiscogsToken[] {
+  const tokens: DiscogsToken[] = [];
+  let pos = 0;
+
+  while (pos < text.length) {
+    const bracketIndex = text.indexOf("[", pos);
+    if (bracketIndex === -1) {
+      tokens.push({ type: "plainText", text: text.slice(pos) });
+      break;
+    }
+
+    // Add plain text before the bracket
+    if (bracketIndex > pos) {
+      tokens.push({ type: "plainText", text: text.slice(pos, bracketIndex) });
+    }
+
+    // Find closing bracket
+    const closingBracket = text.indexOf("]", bracketIndex);
+    if (closingBracket === -1) {
+      tokens.push({ type: "plainText", text: text.slice(bracketIndex) });
+      break;
+    }
+
+    const tagContent = text.slice(bracketIndex + 1, closingBracket);
+    pos = closingBracket + 1;
+
+    if (tagContent.length === 0) continue;
+
+    // Classify the tag
+    const token = classifyTag(tagContent, text, pos);
+    if (token) {
+      tokens.push(token.token);
+      pos = token.newPos;
+    }
+    // Unknown/orphaned/empty tags are silently skipped
+  }
+
+  return tokens;
+}
+
+function classifyTag(
+  tag: string,
+  fullText: string,
+  posAfterTag: number,
+): { token: DiscogsToken; newPos: number } | null {
+  let match: RegExpMatchArray | null;
+
+  // Artist name: [a=Name]
+  match = tag.match(ARTIST_NAME_PATTERN);
+  if (match) {
+    return { token: { type: "artistName", name: match[1] }, newPos: posAfterTag };
+  }
+
+  // Artist ID: [a12345]
+  match = tag.match(ARTIST_ID_PATTERN);
+  if (match) {
+    return { token: { type: "artistId", id: parseInt(match[1], 10) }, newPos: posAfterTag };
+  }
+
+  // Release ID: [r12345] or [r=12345]
+  match = tag.match(RELEASE_ID_PATTERN);
+  if (match) {
+    return { token: { type: "releaseId", id: parseInt(match[1], 10) }, newPos: posAfterTag };
+  }
+
+  // Master ID: [m123] or [m=123]
+  match = tag.match(MASTER_ID_PATTERN);
+  if (match) {
+    return { token: { type: "masterId", id: parseInt(match[1], 10) }, newPos: posAfterTag };
+  }
+
+  // Label name: [l=Name]
+  match = tag.match(LABEL_NAME_PATTERN);
+  if (match) {
+    return { token: { type: "labelName", name: match[1] }, newPos: posAfterTag };
+  }
+
+  // URL: [url=...]...[/url]
+  match = tag.match(URL_OPEN_PATTERN);
+  if (match) {
+    const href = match[1];
+    const closing = findClosingTag(fullText, posAfterTag, "url");
+    if (closing) {
+      return {
+        token: { type: "url", href, content: closing.content },
+        newPos: closing.endIndex,
+      };
+    }
+    // No closing tag — show URL and remaining text combined
+    const remaining = fullText.slice(posAfterTag);
+    return {
+      token: { type: "plainText", text: href + remaining },
+      newPos: fullText.length,
+    };
+  }
+
+  // Formatting tags: [b]...[/b], [i]...[/i], [u]...[/u]
+  if (tag === "b" || tag === "i" || tag === "u") {
+    const closing = findClosingTag(fullText, posAfterTag, tag);
+    if (closing) {
+      const tokenType = tag === "b" ? "bold" : tag === "i" ? "italic" : "underline";
+      return {
+        token: { type: tokenType, content: closing.content },
+        newPos: closing.endIndex,
+      };
+    }
+    // Unclosed tag — skip the tag, content becomes plain text
+    return null;
+  }
+
+  // Orphaned closing tags — skip
+  if (CLOSING_TAG_PATTERN.test(tag)) {
+    return null;
+  }
+
+  // Unknown tag — skip
+  return null;
+}
+
+// MARK: - Phase 2: Resolve
+
+/** Removes Discogs disambiguation suffix like " (8)" from artist names. */
+export function stripDisambiguationSuffix(name: string): string {
+  return name.replace(/ \(\d+\)$/, "");
+}
+
+export function resolve(tokens: DiscogsToken[]): ResolvedToken[] {
+  return tokens.flatMap((token): ResolvedToken[] => {
+    switch (token.type) {
+      case "plainText":
+        return [{ type: "plainText", text: token.text }];
+
+      case "artistName": {
+        const displayName = stripDisambiguationSuffix(token.name);
+        const encoded = encodeURIComponent(token.name);
+        const url = `https://www.discogs.com/search/?q=${encoded}&type=artist`;
+        return [{ type: "artistLink", displayName, url }];
+      }
+
+      case "labelName":
+        return [{ type: "labelName", name: token.name }];
+
+      case "bold":
+        return [{ type: "bold", content: token.content }];
+
+      case "italic":
+        return [{ type: "italic", content: token.content }];
+
+      case "underline":
+        return [{ type: "underline", content: token.content }];
+
+      case "url":
+        return [{ type: "urlLink", href: token.href, content: token.content }];
+
+      // ID-based tokens are skipped in sync mode (no resolver)
+      case "artistId":
+      case "releaseId":
+      case "masterId":
+        return [];
+    }
+  });
+}
+
+// MARK: - Public API
+
+/** Parses Discogs markup and returns resolved tokens for rendering. */
+export function parseDiscogsMarkup(text: string): ResolvedToken[] {
+  return resolve(tokenize(text));
+}

--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -16,7 +16,7 @@ import { Rotation } from "@/lib/features/rotation/types";
 describe("catalogApi", () => {
   describeApi(catalogApi, {
     queries: ["searchCatalog", "getInformation", "getFormats", "getGenres"],
-    mutations: ["addAlbum", "addArtist", "addFormat", "addGenre"],
+    mutations: ["addAlbum", "addArtist", "addFormat", "addGenre", "markMissing", "markFound"],
     reducerPath: "catalogApi",
   });
 });
@@ -75,6 +75,25 @@ describe("convertToAlbumEntry", () => {
         input: createTestAlbumSearchResult({ add_date: "2024-06-08" }),
         assertions: (result) => {
           expect(result.add_date).toBe("2024-06-08");
+        },
+      },
+      {
+        name: "should pass through date_lost and date_found",
+        input: createTestAlbumSearchResult({
+          date_lost: "2025-01-15T00:00:00.000Z",
+          date_found: "2025-02-20T00:00:00.000Z",
+        } as any),
+        assertions: (result) => {
+          expect(result.date_lost).toBe("2025-01-15T00:00:00.000Z");
+          expect(result.date_found).toBe("2025-02-20T00:00:00.000Z");
+        },
+      },
+      {
+        name: "should default date_lost and date_found to undefined",
+        input: createTestAlbumSearchResult(),
+        assertions: (result) => {
+          expect(result.date_lost).toBeUndefined();
+          expect(result.date_found).toBeUndefined();
         },
       },
     ]

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -13,7 +13,7 @@ import {
 export const catalogApi = createApi({
   reducerPath: "catalogApi",
   baseQuery: backendBaseQuery("library"),
-  tagTypes: ["Rotation"],
+  tagTypes: ["Rotation", "AlbumDetail"],
   endpoints: (builder) => ({
     searchCatalog: builder.query<AlbumEntry[], SearchCatalogQueryParams>({
       query: ({ artist_name, album_title, n }) => ({
@@ -44,6 +44,30 @@ export const catalogApi = createApi({
       }),
       transformResponse: (response: AlbumSearchResultJSON) =>
         convertToAlbumEntry(response),
+      providesTags: (result) =>
+        result ? [{ type: "AlbumDetail", id: result.id }] : [],
+    }),
+    markMissing: builder.mutation<AlbumEntry, { albumId: number }>({
+      query: ({ albumId }) => ({
+        url: `/${albumId}/missing`,
+        method: "PATCH",
+      }),
+      transformResponse: (response: AlbumSearchResultJSON) =>
+        convertToAlbumEntry(response),
+      invalidatesTags: (_result, _error, { albumId }) => [
+        { type: "AlbumDetail", id: albumId },
+      ],
+    }),
+    markFound: builder.mutation<AlbumEntry, { albumId: number }>({
+      query: ({ albumId }) => ({
+        url: `/${albumId}/found`,
+        method: "PATCH",
+      }),
+      transformResponse: (response: AlbumSearchResultJSON) =>
+        convertToAlbumEntry(response),
+      invalidatesTags: (_result, _error, { albumId }) => [
+        { type: "AlbumDetail", id: albumId },
+      ],
     }),
     getFormats: builder.query<any, void>({
       query: () => ({
@@ -81,4 +105,6 @@ export const {
   useAddFormatMutation,
   useGetGenresQuery,
   useAddGenreMutation,
+  useMarkMissingMutation,
+  useMarkFoundMutation,
 } = catalogApi;

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -34,6 +34,8 @@ export function convertToAlbumEntry(
     label: response.label ?? "",
     rotation_id: isSearchResult(response) ? response.rotation_id : undefined,
     on_streaming: isSearchResult(response) ? (response as Record<string, unknown>).on_streaming as boolean | undefined : undefined,
+    date_lost: isSearchResult(response) ? (response as Record<string, unknown>).date_lost as string | undefined : undefined,
+    date_found: isSearchResult(response) ? (response as Record<string, unknown>).date_found as string | undefined : undefined,
   };
 }
 

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -51,6 +51,8 @@ export type AlbumEntry = {
   add_date: string | undefined;
   label: string;
   on_streaming?: boolean;
+  date_lost?: string;
+  date_found?: string;
 };
 
 export type ArtistEntry = {

--- a/lib/features/metadata/api.ts
+++ b/lib/features/metadata/api.ts
@@ -1,6 +1,6 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import { backendBaseQuery } from "../backend";
-import { AlbumMetadata, AlbumMetadataQueryParams } from "./types";
+import { AlbumMetadata, AlbumMetadataQueryParams, ArtistMetadata } from "./types";
 
 export const metadataApi = createApi({
   reducerPath: "metadataApi",
@@ -12,7 +12,13 @@ export const metadataApi = createApi({
         params: { artistName, releaseTitle, ...(trackTitle && { trackTitle }) },
       }),
     }),
+    getArtistMetadata: builder.query<ArtistMetadata, { artistId: number }>({
+      query: ({ artistId }) => ({
+        url: "/metadata/artist",
+        params: { artistId },
+      }),
+    }),
   }),
 });
 
-export const { useGetAlbumMetadataQuery } = metadataApi;
+export const { useGetAlbumMetadataQuery, useGetArtistMetadataQuery } = metadataApi;

--- a/lib/features/metadata/hooks.ts
+++ b/lib/features/metadata/hooks.ts
@@ -1,4 +1,4 @@
-import { useGetAlbumMetadataQuery } from "./api";
+import { useGetAlbumMetadataQuery, useGetArtistMetadataQuery } from "./api";
 
 const DEFAULT_ARTWORK_URL = "/img/cassette.png";
 
@@ -21,5 +21,23 @@ export function useAlbumArtwork(
     artworkUrl: data?.artworkUrl ?? DEFAULT_ARTWORK_URL,
     isLoading: !shouldSkip && isLoading,
     metadata: data ?? null,
+  };
+}
+
+/**
+ * Fetches artist metadata (bio, Wikipedia link) from the Backend-Service metadata proxy.
+ * Skips the query when `discogsArtistId` is falsy.
+ */
+export function useArtistMetadata(discogsArtistId: number | null | undefined) {
+  const shouldSkip = !discogsArtistId;
+
+  const { data, isLoading } = useGetArtistMetadataQuery(
+    { artistId: discogsArtistId! },
+    { skip: shouldSkip },
+  );
+
+  return {
+    artistMetadata: data ?? null,
+    isLoading: !shouldSkip && isLoading,
   };
 }

--- a/lib/features/metadata/types.ts
+++ b/lib/features/metadata/types.ts
@@ -1,5 +1,6 @@
 export interface AlbumMetadata {
   discogsReleaseId: number;
+  discogsArtistId: number | null;
   discogsUrl: string;
   artworkUrl: string;
   releaseYear: number;
@@ -13,6 +14,15 @@ export interface AlbumMetadata {
   styles: string[];
   label: string;
   fullReleaseDate: string;
+  artistBio?: string;
+  artistWikipediaUrl?: string;
+}
+
+export interface ArtistMetadata {
+  discogsArtistId: number;
+  bio: string | null;
+  wikipediaUrl: string | null;
+  imageUrl: string | null;
 }
 
 export interface AlbumMetadataQueryParams {


### PR DESCRIPTION
## Summary
- Redesign album detail modal with real Discogs artwork, tracklist table, streaming service links, genre/style chips, and library missing/found status
- Add `Tracklist`, `StreamingLinks`, and `LibraryStatus` sub-components
- Add `markMissing`/`markFound` mutations to `catalogApi` with `AlbumDetail` tag invalidation
- Wire up existing `useAlbumArtwork` hook for artwork and metadata

Closes #376

Depends on WXYC/Backend-Service#381 and WXYC/wxyc-shared#52.

## Test plan
- [x] Tracklist component: undefined, empty, and populated states
- [x] StreamingLinks component: null metadata, empty URLs, selective rendering
- [x] LibraryStatus component: in-library, missing, found-after-lost states
- [x] Conversion: `date_lost`/`date_found` pass-through
- [x] API harness: `markMissing`/`markFound` mutations registered
- [x] `npx tsc --noEmit` passes
- [x] `npm run test:run` — 2419 tests pass
- [ ] Manual: open album detail modal, verify artwork/tracklist/streaming links render