### PR TITLE
Fix onboarding bypass when admin pre-fills profile fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,7 @@ Cloudflare Pages via OpenNext. Build: `npm run build:opennext`. Deploy: `npm run
 - **Experiences**: Two UI themes (modern/classic). Classic theme views prefixed with `CLASSIC_`. The experience system uses a registry pattern (`lib/features/experiences/registry.ts`)
 - **No ESLint/Prettier config**: No formatter or linter configuration files exist at the project level. Follow existing code style
 - **Strict TypeScript**: `strict: true` in tsconfig
+- **Onboarding completeness**: Tracked via the `hasCompletedOnboarding` boolean on the user record, not by presence of profile fields (`realName`/`djName`). This allows admins to pre-fill profile fields when creating accounts without bypassing onboarding. The `isUserIncomplete()` function in `server-utils.ts` checks this flag; `getIncompleteUserAttributes()` still inspects `realName`/`djName` to determine which form fields to render during onboarding.
 
 ## Related Repos
 

--- a/e2e/pages/onboarding.page.ts
+++ b/e2e/pages/onboarding.page.ts
@@ -74,6 +74,18 @@ export class OnboardingPage {
     await this.submitForm();
   }
 
+  /**
+   * Complete onboarding for users whose profile is already filled (admin-created).
+   * Only password fields are shown on the form.
+   */
+  async completePasswordOnlyOnboarding(password: string): Promise<void> {
+    await this.passwordInput.waitFor({ state: "visible", timeout: 10000 });
+    await this.passwordInput.fill(password);
+    await this.confirmPasswordInput.fill(password);
+    await expect(this.submitButton).toBeEnabled({ timeout: 5000 });
+    await this.submitButton.click();
+  }
+
   async goBackToLogin(): Promise<void> {
     await this.backButton.click();
     await this.page.waitForURL("**/login**");

--- a/e2e/tests/admin/admin-password-reset.spec.ts
+++ b/e2e/tests/admin/admin-password-reset.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, TEST_USERS, TEMP_PASSWORD } from "../../fixtures/auth.fix
 import { DashboardPage } from "../../pages/dashboard.page";
 import { RosterPage } from "../../pages/roster.page";
 import { LoginPage } from "../../pages/login.page";
+import { OnboardingPage } from "../../pages/onboarding.page";
 import path from "path";
 
 const authDir = path.join(__dirname, "../../.auth");
@@ -245,6 +246,7 @@ test.describe("Password Reset for Different User States", () => {
     await userContext.clearCookies();
 
     const userLoginPage = new LoginPage(userPage);
+    const userOnboarding = new OnboardingPage(userPage);
     const userDashboard = new DashboardPage(userPage);
 
     await userLoginPage.goto();
@@ -256,8 +258,15 @@ test.describe("Password Reset for Different User States", () => {
 
     await userLoginPage.login(username, TEMP_PASSWORD);
 
-    // User has complete profile, should go to dashboard
-    await userLoginPage.waitForRedirectToDashboard();
+    // Admin-created users have hasCompletedOnboarding=false and are
+    // redirected to onboarding to set their own password
+    await userLoginPage.waitForRedirectToOnboarding();
+
+    // Complete onboarding (profile is pre-filled, only password needed)
+    await userOnboarding.completePasswordOnlyOnboarding("NewPassword1");
+
+    // After onboarding, user reaches the dashboard
+    await userOnboarding.expectRedirectToDashboard();
     await userDashboard.expectOnDashboard();
 
     // Cleanup

--- a/e2e/tests/admin/user-creation.spec.ts
+++ b/e2e/tests/admin/user-creation.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, TEST_USERS, TEMP_PASSWORD } from "../../fixtures/auth.fix
 import { DashboardPage } from "../../pages/dashboard.page";
 import { RosterPage } from "../../pages/roster.page";
 import { LoginPage } from "../../pages/login.page";
+import { OnboardingPage } from "../../pages/onboarding.page";
 import path from "path";
 
 const authDir = path.join(__dirname, "../../.auth");
@@ -293,6 +294,7 @@ test.describe("New User Can Login", () => {
     await newUserContext.clearCookies();
 
     const newUserLoginPage = new LoginPage(newUserPage);
+    const newUserOnboarding = new OnboardingPage(newUserPage);
     const newUserDashboard = new DashboardPage(newUserPage);
 
     // Login as the newly created user with the temp password
@@ -305,26 +307,15 @@ test.describe("New User Can Login", () => {
 
     await newUserLoginPage.login(username, TEMP_PASSWORD);
 
-    // Wait for either success (redirect to dashboard/onboarding) or error
-    // Give more time for the auth server to respond
-    await Promise.race([
-      newUserPage.waitForURL((url) => url.pathname.includes("/dashboard") || url.pathname.includes("/onboarding"), { timeout: 15000 }),
-      newUserLoginPage.expectErrorToast().then(() => {
-        throw new Error("Login failed with error toast");
-      }),
-    ]).catch(async (err) => {
-      // Take a screenshot for debugging
-      const url = newUserPage.url();
-      console.log(`Login redirect failed. Current URL: ${url}`);
-      // Check for error toast
-      const errorToast = newUserPage.locator('[data-sonner-toast][data-type="error"]');
-      if (await errorToast.isVisible()) {
-        const errorText = await errorToast.textContent();
-        console.log(`Error toast: ${errorText}`);
-      }
-      throw err;
-    });
+    // Admin-created users have hasCompletedOnboarding=false and are
+    // redirected to onboarding to set their own password
+    await newUserLoginPage.waitForRedirectToOnboarding();
 
+    // Complete onboarding (profile is pre-filled, only password needed)
+    await newUserOnboarding.completePasswordOnlyOnboarding("NewPassword1");
+
+    // After onboarding, user reaches the dashboard
+    await newUserOnboarding.expectRedirectToDashboard();
     await newUserDashboard.expectOnDashboard();
 
     // Cleanup

--- a/e2e/tests/admin/user-deletion.spec.ts
+++ b/e2e/tests/admin/user-deletion.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, TEST_USERS, TEMP_PASSWORD } from "../../fixtures/auth.fix
 import { DashboardPage } from "../../pages/dashboard.page";
 import { RosterPage } from "../../pages/roster.page";
 import { LoginPage } from "../../pages/login.page";
+import { OnboardingPage } from "../../pages/onboarding.page";
 import path from "path";
 
 const authDir = path.join(__dirname, "../../.auth");
@@ -178,12 +179,16 @@ test.describe("User Deletion Session Invalidation", () => {
     await adminPage.waitForTimeout(1000);
 
     // New user logs in with temp password
+    const userOnboarding = new OnboardingPage(userPage);
     await userLoginPage.goto();
     await userPage.waitForLoadState("domcontentloaded");
     await userLoginPage.login(username, TEMP_PASSWORD);
 
-    // User has complete profile, should go to dashboard
-    await userLoginPage.waitForRedirectToDashboard();
+    // Admin-created users have hasCompletedOnboarding=false and must
+    // complete onboarding before reaching the dashboard
+    await userLoginPage.waitForRedirectToOnboarding();
+    await userOnboarding.completePasswordOnlyOnboarding("NewPassword1");
+    await userOnboarding.expectRedirectToDashboard();
     await userDashboard.expectOnDashboard();
 
     // Admin deletes the user

--- a/e2e/tests/onboarding/new-user.spec.ts
+++ b/e2e/tests/onboarding/new-user.spec.ts
@@ -213,13 +213,14 @@ test.describe("New User Onboarding", () => {
       const username = `onboard_${Date.now()}`;
       const email = `${username}@test.wxyc.org`;
 
-      // Create user with complete profile (realName provided, djName defaults to "Anonymous")
-      // Note: Admin-created users are typically "complete" and go directly to dashboard
+      // Create user with complete profile (realName and djName provided by admin).
+      // Admin-created users still have hasCompletedOnboarding=false and must
+      // go through onboarding to set their own password.
       await rosterPage.createAccount({
         realName: "Onboard Test",
         username,
         email,
-        djName: "New DJ", // Provide djName to make user complete
+        djName: "New DJ",
         role: "dj",
       });
 
@@ -230,14 +231,21 @@ test.describe("New User Onboarding", () => {
       const userContext = await browser.newContext({ baseURL });
       const userPage = await userContext.newPage();
       const userLoginPage = new LoginPage(userPage);
+      const userOnboarding = new OnboardingPage(userPage);
       const userDashboard = new DashboardPage(userPage);
 
       await userLoginPage.goto();
       await userPage.waitForLoadState("domcontentloaded");
       await userLoginPage.login(username, TEMP_PASSWORD);
 
-      // User has complete profile (admin provided realName and djName), goes to dashboard
-      await userLoginPage.waitForRedirectToDashboard();
+      // User is redirected to onboarding to set their own password
+      await userLoginPage.waitForRedirectToOnboarding();
+
+      // Profile fields are pre-filled, only password is required
+      await userOnboarding.completePasswordOnlyOnboarding("NewPassword1");
+
+      // After onboarding, user is redirected to dashboard
+      await userOnboarding.expectRedirectToDashboard();
       await userDashboard.expectOnDashboard();
 
       // Cleanup
@@ -249,7 +257,7 @@ test.describe("New User Onboarding", () => {
 
 test.describe("Complete User Bypass", () => {
   test("should not redirect complete user to onboarding", async ({ page }) => {
-    // Complete users (with realName and djName) should go directly to dashboard
+    // Users with hasCompletedOnboarding=true should go directly to dashboard
     const loginPage = new LoginPage(page);
     const dashboardPage = new DashboardPage(page);
 

--- a/lib/__tests__/features/authentication/server-utils.test.ts
+++ b/lib/__tests__/features/authentication/server-utils.test.ts
@@ -155,10 +155,28 @@ describe("server-utils", () => {
       expect(mockRedirect).toHaveBeenCalledWith("/login?incomplete=true");
     });
 
-    it("should not redirect incomplete users when realName is not in session", async () => {
-      // Simulate a session where better-auth didn't include realName at all
+    it("should redirect when hasCompletedOnboarding is false even with all profile fields filled", async () => {
+      const session = createTestBetterAuthSession({
+        user: {
+          id: "test-id",
+          email: "test@wxyc.org",
+          name: "test",
+          emailVerified: true,
+          realName: "Valid Name",
+          djName: "DJ Test",
+          hasCompletedOnboarding: false,
+        },
+      });
+      mockGetSession.mockResolvedValue({ data: session, error: null });
+
+      await expect(requireAuth()).rejects.toThrow("REDIRECT:/login?incomplete=true");
+      expect(mockRedirect).toHaveBeenCalledWith("/login?incomplete=true");
+    });
+
+    it("should not redirect when hasCompletedOnboarding is not in session", async () => {
+      // Simulate a session where better-auth didn't include hasCompletedOnboarding at all
       const session = createTestBetterAuthSession();
-      delete (session.user as any).realName;
+      delete (session.user as any).hasCompletedOnboarding;
       mockGetSession.mockResolvedValue({ data: session, error: null });
 
       const result = await requireAuth();
@@ -285,7 +303,7 @@ describe("server-utils", () => {
   });
 
   describe("isUserIncomplete", () => {
-    it("should return false for complete user", () => {
+    it("should return false for complete user with hasCompletedOnboarding true", () => {
       const session = createTestBetterAuthSession();
 
       const result = isUserIncomplete(session);
@@ -293,7 +311,7 @@ describe("server-utils", () => {
       expect(result).toBe(false);
     });
 
-    it("should return true when realName is missing", () => {
+    it("should return true when hasCompletedOnboarding is false", () => {
       const session = createTestIncompleteSession(["realName"]);
 
       const result = isUserIncomplete(session);
@@ -301,15 +319,25 @@ describe("server-utils", () => {
       expect(result).toBe(true);
     });
 
-    it("should return true when only djName is missing", () => {
-      const session = createTestIncompleteSession(["djName"]);
+    it("should return true when hasCompletedOnboarding is false even if all fields filled", () => {
+      const session = createTestBetterAuthSession({
+        user: {
+          id: "test-id",
+          email: "test@wxyc.org",
+          name: "test",
+          emailVerified: true,
+          realName: "Valid Name",
+          djName: "DJ Test",
+          hasCompletedOnboarding: false,
+        },
+      });
 
       const result = isUserIncomplete(session);
 
       expect(result).toBe(true);
     });
 
-    it("should return true when realName is empty string", () => {
+    it("should return false when hasCompletedOnboarding is true even if realName is empty", () => {
       const session = createTestBetterAuthSession({
         user: {
           id: "test-id",
@@ -318,29 +346,13 @@ describe("server-utils", () => {
           emailVerified: true,
           realName: "",
           djName: "DJ Test",
+          hasCompletedOnboarding: true,
         },
       });
 
       const result = isUserIncomplete(session);
 
-      expect(result).toBe(true);
-    });
-
-    it("should return true when realName is whitespace only", () => {
-      const session = createTestBetterAuthSession({
-        user: {
-          id: "test-id",
-          email: "test@wxyc.org",
-          name: "test",
-          emailVerified: true,
-          realName: "   ",
-          djName: "DJ Test",
-        },
-      });
-
-      const result = isUserIncomplete(session);
-
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
   });
 

--- a/lib/__tests__/features/authentication/user-completeness.test.ts
+++ b/lib/__tests__/features/authentication/user-completeness.test.ts
@@ -24,70 +24,19 @@ import {
 } from "@/lib/test-utils";
 
 describe("isUserIncomplete", () => {
-  it("should return false for complete user", () => {
+  it("should return false for complete user with hasCompletedOnboarding true", () => {
     const session = createTestBetterAuthSession();
 
     expect(isUserIncomplete(session)).toBe(false);
   });
 
-  it("should return true when realName is missing", () => {
+  it("should return true when hasCompletedOnboarding is false", () => {
     const session = createTestIncompleteSession(["realName"]);
 
     expect(isUserIncomplete(session)).toBe(true);
   });
 
-  it("should return true when djName is missing", () => {
-    const session = createTestIncompleteSession(["djName"]);
-
-    expect(isUserIncomplete(session)).toBe(true);
-  });
-
-  it("should return true when realName is empty string", () => {
-    const session = createTestBetterAuthSession({
-      user: {
-        id: "test-id",
-        email: "test@wxyc.org",
-        name: "test",
-        emailVerified: true,
-        realName: "",
-        djName: "DJ Test",
-      },
-    });
-
-    expect(isUserIncomplete(session)).toBe(true);
-  });
-
-  it("should return true when realName is whitespace only", () => {
-    const session = createTestBetterAuthSession({
-      user: {
-        id: "test-id",
-        email: "test@wxyc.org",
-        name: "test",
-        emailVerified: true,
-        realName: "   ",
-        djName: "DJ Test",
-      },
-    });
-
-    expect(isUserIncomplete(session)).toBe(true);
-  });
-
-  it("should return true when djName is whitespace only", () => {
-    const session = createTestBetterAuthSession({
-      user: {
-        id: "test-id",
-        email: "test@wxyc.org",
-        name: "test",
-        emailVerified: true,
-        realName: "Valid Name",
-        djName: "   ",
-      },
-    });
-
-    expect(isUserIncomplete(session)).toBe(true);
-  });
-
-  it("should return false when both names have valid values", () => {
+  it("should return true when hasCompletedOnboarding is false even if all profile fields are filled", () => {
     const session = createTestBetterAuthSession({
       user: {
         id: "test-id",
@@ -96,14 +45,41 @@ describe("isUserIncomplete", () => {
         emailVerified: true,
         realName: "Valid Real Name",
         djName: "Valid DJ Name",
+        hasCompletedOnboarding: false,
+      },
+    });
+
+    expect(isUserIncomplete(session)).toBe(true);
+  });
+
+  it("should return false when hasCompletedOnboarding is true even if realName is empty", () => {
+    const session = createTestBetterAuthSession({
+      user: {
+        id: "test-id",
+        email: "test@wxyc.org",
+        name: "test",
+        emailVerified: true,
+        realName: "",
+        djName: "DJ Test",
+        hasCompletedOnboarding: true,
       },
     });
 
     expect(isUserIncomplete(session)).toBe(false);
   });
 
-  it("should return true when both names are missing", () => {
-    const session = createTestIncompleteSession(["realName", "djName"]);
+  it("should return true when hasCompletedOnboarding is undefined", () => {
+    const session = createTestBetterAuthSession({
+      user: {
+        id: "test-id",
+        email: "test@wxyc.org",
+        name: "test",
+        emailVerified: true,
+        realName: "Valid Name",
+        djName: "DJ Test",
+        hasCompletedOnboarding: undefined,
+      },
+    });
 
     expect(isUserIncomplete(session)).toBe(true);
   });

--- a/lib/__tests__/features/authentication/user-completeness.test.ts
+++ b/lib/__tests__/features/authentication/user-completeness.test.ts
@@ -68,7 +68,7 @@ describe("isUserIncomplete", () => {
     expect(isUserIncomplete(session)).toBe(false);
   });
 
-  it("should return true when hasCompletedOnboarding is undefined", () => {
+  it("should return false when hasCompletedOnboarding is undefined (backward compat)", () => {
     const session = createTestBetterAuthSession({
       user: {
         id: "test-id",
@@ -81,7 +81,7 @@ describe("isUserIncomplete", () => {
       },
     });
 
-    expect(isUserIncomplete(session)).toBe(true);
+    expect(isUserIncomplete(session)).toBe(false);
   });
 });
 

--- a/lib/__tests__/features/authentication/utilities.test.ts
+++ b/lib/__tests__/features/authentication/utilities.test.ts
@@ -102,7 +102,7 @@ describe("authentication utilities", () => {
       expect((result as any).requiredAttributes).toContain("djName");
     });
 
-    it("should treat empty string realName as incomplete", () => {
+    it("should treat empty string realName as incomplete when hasCompletedOnboarding is false", () => {
       const session = createTestBetterAuthSession({
         user: {
           id: "test-id",
@@ -111,10 +111,45 @@ describe("authentication utilities", () => {
           emailVerified: true,
           realName: "   ",
           djName: "DJ Test",
+          hasCompletedOnboarding: false,
         },
       });
       const result = betterAuthSessionToAuthenticationData(session);
       expect((result as any).requiredAttributes).toContain("realName");
+    });
+
+    it("should return IncompleteUser when hasCompletedOnboarding is false even with all fields present", () => {
+      const session = createTestBetterAuthSession({
+        user: {
+          id: "test-id",
+          email: "test@wxyc.org",
+          name: "testuser",
+          emailVerified: true,
+          realName: "Valid Name",
+          djName: "DJ Test",
+          hasCompletedOnboarding: false,
+        },
+      });
+      const result = betterAuthSessionToAuthenticationData(session);
+      expect((result as any).requiredAttributes).toBeDefined();
+      expect((result as any).requiredAttributes).toEqual([]);
+    });
+
+    it("should return AuthenticatedUser when hasCompletedOnboarding is true even if djName is empty", () => {
+      const session = createTestBetterAuthSession({
+        user: {
+          id: "test-id",
+          email: "test@wxyc.org",
+          name: "testuser",
+          emailVerified: true,
+          realName: "Valid Name",
+          djName: "",
+          hasCompletedOnboarding: true,
+        },
+      });
+      const result = betterAuthSessionToAuthenticationData(session);
+      expect((result as any).user).toBeDefined();
+      expect((result as any).user.realName).toBe("Valid Name");
     });
 
     it("should map stationManager role to SM Authorization", () => {

--- a/lib/features/authentication/server-utils.ts
+++ b/lib/features/authentication/server-utils.ts
@@ -56,10 +56,10 @@ export async function requireAuth(): Promise<BetterAuthSession> {
     redirect("/login?error=email-not-verified");
   }
 
-  // Redirect incomplete users (missing realName) back to login for onboarding.
-  // Only check if realName is explicitly present as a key in the user object
+  // Redirect incomplete users back to login for onboarding.
+  // Only check if hasCompletedOnboarding is explicitly present as a key in the user object
   // (better-auth includes additional fields when configured).
-  if ("realName" in session.user && isUserIncomplete(session)) {
+  if ("hasCompletedOnboarding" in session.user && isUserIncomplete(session)) {
     redirect("/login?incomplete=true");
   }
 
@@ -135,13 +135,12 @@ export async function requireRole(session: BetterAuthSession, requiredRole: Auth
 }
 
 /**
- * Check if user is incomplete (missing required fields: realName or djName)
+ * Check if user has not completed onboarding (setting their own password and confirming profile).
+ * Uses the explicit hasCompletedOnboarding flag rather than inspecting profile fields,
+ * so admins can pre-fill realName/djName without bypassing onboarding.
  */
 export function isUserIncomplete(session: BetterAuthSession): boolean {
-  const realName = session.user.realName;
-  const djName = session.user.djName;
-
-  return !realName || realName.trim() === "" || !djName || djName.trim() === "";
+  return !session.user.hasCompletedOnboarding;
 }
 
 /**

--- a/lib/features/authentication/server-utils.ts
+++ b/lib/features/authentication/server-utils.ts
@@ -140,7 +140,7 @@ export async function requireRole(session: BetterAuthSession, requiredRole: Auth
  * so admins can pre-fill realName/djName without bypassing onboarding.
  */
 export function isUserIncomplete(session: BetterAuthSession): boolean {
-  return !session.user.hasCompletedOnboarding;
+  return session.user.hasCompletedOnboarding === false;
 }
 
 /**

--- a/lib/features/authentication/utilities.ts
+++ b/lib/features/authentication/utilities.ts
@@ -35,6 +35,7 @@ export type BetterAuthSession = {
     banned?: boolean;
     banReason?: string | null;
     banExpires?: Date | null;
+    hasCompletedOnboarding?: boolean;
     displayUsername?: string | null;
     image?: string | null;
     // Organization member data (if using organizationClient)
@@ -104,17 +105,16 @@ export function betterAuthSessionToAuthenticationData(
 
   const username = session.user.username || session.user.name;
 
-  // Check if user is incomplete (missing required fields: realName or djName)
-  const missingAttributes: (keyof VerifiedData)[] = [];
-  if (!session.user.realName || session.user.realName.trim() === "") {
-    missingAttributes.push("realName");
-  }
-  if (!session.user.djName || session.user.djName.trim() === "") {
-    missingAttributes.push("djName");
-  }
-
-  // If user is missing required fields, return IncompleteUser
-  if (missingAttributes.length > 0) {
+  // Check onboarding status using the explicit flag
+  if (!session.user.hasCompletedOnboarding) {
+    // Compute which profile fields are still missing for the onboarding form
+    const missingAttributes: (keyof VerifiedData)[] = [];
+    if (!session.user.realName || session.user.realName.trim() === "") {
+      missingAttributes.push("realName");
+    }
+    if (!session.user.djName || session.user.djName.trim() === "") {
+      missingAttributes.push("djName");
+    }
     return {
       username,
       requiredAttributes: missingAttributes,
@@ -201,17 +201,16 @@ export async function betterAuthSessionToAuthenticationDataAsync(
 
   const username = session.user.username || session.user.name;
 
-  // Check if user is incomplete (missing required fields: realName or djName)
-  const missingAttributes: (keyof VerifiedData)[] = [];
-  if (!session.user.realName || session.user.realName.trim() === "") {
-    missingAttributes.push("realName");
-  }
-  if (!session.user.djName || session.user.djName.trim() === "") {
-    missingAttributes.push("djName");
-  }
-
-  // If user is missing required fields, return IncompleteUser
-  if (missingAttributes.length > 0) {
+  // Check onboarding status using the explicit flag
+  if (!session.user.hasCompletedOnboarding) {
+    // Compute which profile fields are still missing for the onboarding form
+    const missingAttributes: (keyof VerifiedData)[] = [];
+    if (!session.user.realName || session.user.realName.trim() === "") {
+      missingAttributes.push("realName");
+    }
+    if (!session.user.djName || session.user.djName.trim() === "") {
+      missingAttributes.push("djName");
+    }
     return {
       username,
       requiredAttributes: missingAttributes,

--- a/lib/features/authentication/utilities.ts
+++ b/lib/features/authentication/utilities.ts
@@ -105,8 +105,9 @@ export function betterAuthSessionToAuthenticationData(
 
   const username = session.user.username || session.user.name;
 
-  // Check onboarding status using the explicit flag
-  if (!session.user.hasCompletedOnboarding) {
+  // Check onboarding status using the explicit flag.
+  // Use strict === false so that undefined (field absent from backend) is treated as complete.
+  if (session.user.hasCompletedOnboarding === false) {
     // Compute which profile fields are still missing for the onboarding form
     const missingAttributes: (keyof VerifiedData)[] = [];
     if (!session.user.realName || session.user.realName.trim() === "") {
@@ -201,8 +202,9 @@ export async function betterAuthSessionToAuthenticationDataAsync(
 
   const username = session.user.username || session.user.name;
 
-  // Check onboarding status using the explicit flag
-  if (!session.user.hasCompletedOnboarding) {
+  // Check onboarding status using the explicit flag.
+  // Use strict === false so that undefined (field absent from backend) is treated as complete.
+  if (session.user.hasCompletedOnboarding === false) {
     // Compute which profile fields are still missing for the onboarding form
     const missingAttributes: (keyof VerifiedData)[] = [];
     if (!session.user.realName || session.user.realName.trim() === "") {

--- a/lib/test-utils/fixtures.ts
+++ b/lib/test-utils/fixtures.ts
@@ -360,6 +360,7 @@ export function createTestBetterAuthSession(
       emailVerified: true,
       realName: "Test User",
       djName: "DJ Test",
+      hasCompletedOnboarding: true,
       role: "dj",
       createdAt: new Date("2024-01-01"),
       updatedAt: new Date("2024-01-01"),
@@ -379,6 +380,8 @@ export function createTestIncompleteSession(
   missingFields: ("realName" | "djName")[] = ["realName", "djName"]
 ): BetterAuthSession {
   const session = createTestBetterAuthSession();
+
+  session.user.hasCompletedOnboarding = false;
 
   if (missingFields.includes("realName")) {
     session.user.realName = undefined;

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import React from "react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { authenticationSlice } from "@/lib/features/authentication/frontend";
+
+// Mock next/navigation
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    refresh: mockRefresh,
+  }),
+}));
+
+// Mock sonner
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock authClient
+const mockUpdateUser = vi.fn();
+const mockChangePassword = vi.fn();
+const mockGetSession = vi.fn();
+const mockSignInUsername = vi.fn();
+const mockSignInEmailOtp = vi.fn();
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: {
+    updateUser: (...args: any[]) => mockUpdateUser(...args),
+    changePassword: (...args: any[]) => mockChangePassword(...args),
+    getSession: (...args: any[]) => mockGetSession(...args),
+    signIn: {
+      username: (...args: any[]) => mockSignInUsername(...args),
+      emailOtp: (...args: any[]) => mockSignInEmailOtp(...args),
+    },
+    signOut: vi.fn(),
+  },
+}));
+
+// Mock throwIfBetterAuthError
+vi.mock("@/src/utilities/throwIfBetterAuthError", () => ({
+  throwIfBetterAuthError: vi.fn(),
+}));
+
+// Mock applicationHooks
+vi.mock("./applicationHooks", () => ({
+  resetApplication: vi.fn(),
+}));
+
+function createTestStore() {
+  return configureStore({
+    reducer: {
+      authentication: authenticationSlice.reducer,
+    },
+  });
+}
+
+function createWrapper() {
+  const store = createTestStore();
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(Provider, { store, children });
+  };
+}
+
+describe("authenticationHooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD = "temp123";
+    process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE = "/dashboard/flowsheet";
+  });
+
+  describe("useLogin", () => {
+    it("should redirect to incomplete when hasCompletedOnboarding is false", async () => {
+      mockSignInUsername.mockResolvedValue({
+        data: {
+          user: {
+            id: "user-1",
+            realName: "Test User",
+            djName: "DJ Test",
+            hasCompletedOnboarding: false,
+          },
+        },
+      });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "testdj" },
+          password: { value: "password123" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleLogin(form);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/login?incomplete=true");
+    });
+
+    it("should redirect to dashboard when hasCompletedOnboarding is true", async () => {
+      mockSignInUsername.mockResolvedValue({
+        data: {
+          user: {
+            id: "user-1",
+            realName: "Test User",
+            djName: "DJ Test",
+            hasCompletedOnboarding: true,
+          },
+        },
+      });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "testdj" },
+          password: { value: "password123" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleLogin(form);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
+    });
+  });
+
+  describe("useNewUser", () => {
+    it("should include hasCompletedOnboarding: true in updateUser call", async () => {
+      mockGetSession.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+      });
+      mockUpdateUser.mockResolvedValue({ data: {} });
+      mockChangePassword.mockResolvedValue({ data: {} });
+
+      const { useNewUser } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useNewUser(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "testdj" },
+          password: { value: "NewPassword1" },
+          realName: { value: "Real Name" },
+          djName: { value: "DJ Name" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleNewUser(form);
+      });
+
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        hasCompletedOnboarding: true,
+        realName: "Real Name",
+        djName: "DJ Name",
+      });
+    });
+
+    it("should set hasCompletedOnboarding even when profile fields are already filled", async () => {
+      mockGetSession.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+      });
+      mockUpdateUser.mockResolvedValue({ data: {} });
+      mockChangePassword.mockResolvedValue({ data: {} });
+
+      const { useNewUser } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useNewUser(), { wrapper: createWrapper() });
+
+      // Simulate form where realName/djName inputs don't exist (admin pre-filled them)
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "testdj" },
+          password: { value: "NewPassword1" },
+          realName: undefined,
+          djName: undefined,
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleNewUser(form);
+      });
+
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        hasCompletedOnboarding: true,
+      });
+    });
+  });
+});

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -134,6 +134,36 @@ describe("authenticationHooks", () => {
 
       expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
     });
+
+    it("should redirect to dashboard when hasCompletedOnboarding is undefined (backward compat)", async () => {
+      mockSignInUsername.mockResolvedValue({
+        data: {
+          user: {
+            id: "user-1",
+            realName: "Test User",
+            djName: "DJ Test",
+            // hasCompletedOnboarding not present — backend hasn't been updated yet
+          },
+        },
+      });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "testdj" },
+          password: { value: "password123" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleLogin(form);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
+    });
   });
 
   describe("useNewUser", () => {

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -53,7 +53,7 @@ export const useLogin = () => {
       toast.success("Login successful");
 
       const user = (result as any).data?.user;
-      if (user && !user.realName) {
+      if (user && !user.hasCompletedOnboarding) {
         router.push("/login?incomplete=true");
       } else {
         router.push(dashboardHome);
@@ -127,7 +127,7 @@ export const useOTPVerify = () => {
       const dashboardHome = String(process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/catalog");
 
       const user = (result as any).data?.user;
-      if (user && !user.realName) {
+      if (user && !user.hasCompletedOnboarding) {
         router.push("/login?incomplete=true");
       } else {
         router.push(dashboardHome);
@@ -270,7 +270,7 @@ export const useNewUser = () => {
         throw new Error("You must be authenticated to update your profile");
       }
 
-      const updateRequest: any = {};
+      const updateRequest: any = { hasCompletedOnboarding: true };
       if (params.realName) {
         updateRequest.realName = params.realName;
       }

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -53,7 +53,7 @@ export const useLogin = () => {
       toast.success("Login successful");
 
       const user = (result as any).data?.user;
-      if (user && !user.hasCompletedOnboarding) {
+      if (user && user.hasCompletedOnboarding === false) {
         router.push("/login?incomplete=true");
       } else {
         router.push(dashboardHome);
@@ -127,7 +127,7 @@ export const useOTPVerify = () => {
       const dashboardHome = String(process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/catalog");
 
       const user = (result as any).data?.user;
-      if (user && !user.hasCompletedOnboarding) {
+      if (user && user.hasCompletedOnboarding === false) {
         router.push("/login?incomplete=true");
       } else {
         router.push(dashboardHome);


### PR DESCRIPTION
## Summary

- Replace `realName`/`djName` presence checks with explicit `hasCompletedOnboarding` flag from user record
- `isUserIncomplete()` now checks `!hasCompletedOnboarding` instead of inspecting profile fields
- `useLogin()`, `useOTPVerify()` check the flag for post-login routing
- `useNewUser()` sets `hasCompletedOnboarding: true` on onboarding completion
- `getIncompleteUserAttributes()` unchanged — still determines which form fields to render

Closes #380

Depends on WXYC/Backend-Service#388

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm run test:run` passes (2405 tests)
- [ ] Admin creates account with pre-filled `realName`/`djName` → new user signs in via OTP → routed to onboarding (password fields only) → sets password → `hasCompletedOnboarding` set to `true` → dashboard
- [ ] Existing users with complete profiles can sign in normally
- [ ] Deploy after WXYC/Backend-Service#388