### PR TITLE
Optimize CI: parallelize jobs, shard unit tests, fix deploy monitor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,23 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
+  NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:8082/auth
+  NEXT_PUBLIC_DASHBOARD_HOME_PAGE: /dashboard/flowsheet
+  NEXT_PUBLIC_VERSION: ci
+  NEXT_PUBLIC_DEFAULT_EXPERIENCE: modern
+  NEXT_PUBLIC_ENABLED_EXPERIENCES: modern,classic
+  NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING: "true"
+
 jobs:
-  lint-test-build:
-    name: Lint, Test & Build
+  typecheck:
+    name: Type Check
     runs-on: ubuntu-latest
-    env:
-      NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
-      NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:8082/auth
-      NEXT_PUBLIC_DASHBOARD_HOME_PAGE: /dashboard/flowsheet
-      NEXT_PUBLIC_VERSION: ci
-      NEXT_PUBLIC_DEFAULT_EXPERIENCE: modern
-      NEXT_PUBLIC_ENABLED_EXPERIENCES: modern,classic
-      NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -36,18 +41,56 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+  test:
+    name: Unit Tests (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1/3, 2/3, 3/3]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Run unit tests
-        run: npm run test:run
+        run: npx vitest run --shard=${{ matrix.shard }}
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}
+          restore-keys: nextjs-${{ hashFiles('package-lock.json') }}-
 
       - name: Build
         run: npm run build
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Upload coverage
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: coverage-report
-          path: coverage/
-          retention-days: 7

--- a/.github/workflows/cloudflare-deploy-status.yml
+++ b/.github/workflows/cloudflare-deploy-status.yml
@@ -2,7 +2,7 @@ name: Cloudflare Deployment Status Monitor
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions:
@@ -13,8 +13,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check required configuration
+        id: config
+        run: |
+          if [ -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ] || [ -z "${{ vars.CLOUDFLARE_ACCOUNT_ID }}" ]; then
+            echo "::warning::Skipping deployment check — CLOUDFLARE_API_TOKEN secret and/or CLOUDFLARE_ACCOUNT_ID variable not configured in repo settings."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Query Cloudflare API for latest production deployment
         id: query
+        if: steps.config.outputs.configured == 'true'
         run: |
           RESPONSE=$(curl -sf \
             -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
@@ -31,7 +42,7 @@ jobs:
           echo "commit_msg=$COMMIT_MSG" >> "$GITHUB_OUTPUT"
 
       - name: Handle deployment failure
-        if: steps.query.outputs.status == 'failure'
+        if: steps.config.outputs.configured == 'true' && steps.query.outputs.status == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOY_ID: ${{ steps.query.outputs.deploy_id }}
@@ -67,7 +78,7 @@ jobs:
           fi
 
       - name: Handle deployment recovery
-        if: steps.query.outputs.status == 'success'
+        if: steps.config.outputs.configured == 'true' && steps.query.outputs.status == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_SHA: ${{ steps.query.outputs.commit_sha }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,7 +2,7 @@ name: E2E Tests
 
 on:
   push:
-    branches: [main, new-authentication-provider]
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -11,6 +11,10 @@ on:
         description: 'Backend-Service branch/tag to use'
         required: false
         default: 'main'
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   # Frontend configuration


### PR DESCRIPTION
## Summary

- Split sequential CI into 3 parallel jobs (typecheck, 3 test shards, build) — wall clock ~8 min to ~3 min
- Add concurrency groups to CI and E2E workflows to cancel stale runs
- Fix Cloudflare deploy monitor: guard for missing secrets, reduce frequency from every 15 min to hourly
- Remove dead coverage upload and stale `new-authentication-provider` branch trigger

Closes #382

## Test plan

- [ ] Verify CI triggers 5 parallel jobs (typecheck, 3 test shards, build) and all pass
- [ ] Push a second commit quickly to verify concurrency group cancels the first CI run
- [ ] Verify Cloudflare monitor shows a warning annotation instead of failing when secrets are unconfigured
- [ ] Configure `CLOUDFLARE_API_TOKEN` secret and `CLOUDFLARE_ACCOUNT_ID` variable in repo settings to fully enable the monitor