### PR TITLE
Bump @wxyc/shared to 0.4.1 and remove on_streaming type cast

### DIFF
--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -92,7 +92,7 @@ export function convertV2Entry(entry: FlowsheetV2EntryJSON): FlowsheetEntry {
         album_id: entry.album_id ?? undefined,
         rotation_id: entry.rotation_id ?? undefined,
         rotation: entry.rotation_bin as Rotation,
-        on_streaming: (entry as Record<string, unknown>).on_streaming as boolean | undefined,
+        on_streaming: entry.on_streaming ?? undefined,
       };
 
     case "show_start": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dep-sync",
+  "name": "dj-site-bump-shared",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,7 +14,7 @@
         "@opennextjs/cloudflare": "^1.10.1",
         "@reduxjs/toolkit": "^2.2.0",
         "@uidotdev/usehooks": "^2.4.1",
-        "@wxyc/shared": "^0.4.0",
+        "@wxyc/shared": "^0.4.1",
         "better-auth": "^1.5.6",
         "cookie": "^1.0.2",
         "jose": "^5.9.6",
@@ -14115,9 +14115,9 @@
       }
     },
     "node_modules/@wxyc/shared": {
-      "version": "0.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.4.0/88a8a2128fc917acd3d0882094e4a7f1a1a8a566",
-      "integrity": "sha512-5HIyILNJXVpE/wkdBDWEAvFUA5sbhK2z+l6fUZxprRSE6O7oB5JuV/4IoXnpKV+9lZJB0TMruwKvgMMHpG6SUA==",
+      "version": "0.4.1",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.4.1/fe101dc724909afe304c8fa67fc270ac6e72aced",
+      "integrity": "sha512-8WWjkkGfIabef6xO+NkcTCYIDFS8j5HOhkYvTsjCZDyyhQC5k3XMki6GFSAyxaYAIe66F9fl22lxJYizkns1cw==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@opennextjs/cloudflare": "^1.10.1",
     "@reduxjs/toolkit": "^2.2.0",
     "@uidotdev/usehooks": "^2.4.1",
-    "@wxyc/shared": "^0.4.0",
+    "@wxyc/shared": "^0.4.1",
     "better-auth": "^1.5.6",
     "cookie": "^1.0.2",
     "jose": "^5.9.6",


### PR DESCRIPTION
## Summary

- Bump `@wxyc/shared` from 0.4.0 to 0.4.1 (adds `on_streaming` to `FlowsheetV2TrackEntry`)
- Replace unsafe `Record<string, unknown>` cast with direct property access in flowsheet conversions

## Test plan

- [x] Typecheck passes
- [x] All 2507 tests pass