### PR TITLE
Fix blank page at /dashboard for authenticated users

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default function DashboardPage() {
-  redirect("/dashboard/flowsheet");
-}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,9 @@ export const metadata: Metadata = {
 export default async function HomePage() {
   const session = await getServerSession();
   if (session) {
-    redirect("/dashboard");
+    redirect(
+      process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/flowsheet"
+    );
   }
   return (
     <WXYCPage>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,19 @@ const nextConfig = {
   outputFileTracingRoot: import.meta.dirname,
   // Required for OpenNext Cloudflare
   output: "standalone",
+  async redirects() {
+    return [
+      {
+        // The dashboard layout uses parallel routes and doesn't render the
+        // children slot, so app/dashboard/page.tsx's redirect() never fires.
+        // Handle it here instead.
+        source: "/dashboard",
+        destination:
+          process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/flowsheet",
+        permanent: false,
+      },
+    ];
+  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## Summary

- Redirect authenticated users from `/` directly to `/dashboard/flowsheet` instead of `/dashboard`, which rendered blank
- Add `redirects()` config in `next.config.mjs` to catch direct navigation to `/dashboard`
- Remove dead `app/dashboard/page.tsx` whose `redirect()` could never fire

Closes #387

## Root Cause

The dashboard layout uses parallel routes (`@classic`, `@modern`, `@information`) and never renders the implicit `children` slot. The `redirect()` in `app/dashboard/page.tsx` was never executed because the component was never rendered. The parallel route defaults all return `null`, producing a blank page.

## Test plan

- [ ] Visit `dj.wxyc.org/` while authenticated — should land on `/dashboard/flowsheet`
- [ ] Navigate directly to `dj.wxyc.org/dashboard` — should redirect to `/dashboard/flowsheet`
- [ ] Visit `dj.wxyc.org/` while unauthenticated — should see the welcome page with login button
- [ ] Verify `/dashboard/flowsheet`, `/dashboard/catalog` still work as expected