### PR TITLE
Catalog search UI improvements

### DIFF
--- a/lib/__tests__/features/bin/conversions.test.ts
+++ b/lib/__tests__/features/bin/conversions.test.ts
@@ -129,10 +129,10 @@ describe("bin conversions", () => {
       expect(result.add_date).toBeUndefined();
     });
 
-    it("should default plays to 0", () => {
+    it("should keep plays undefined for bin responses", () => {
       const response = createTestBinResponse();
       const result = convertToAlbumEntry(response);
-      expect(result.plays).toBe(0);
+      expect(result.plays).toBeUndefined();
     });
 
     it("should set rotation_id to undefined", () => {

--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -64,10 +64,10 @@ describe("convertToAlbumEntry", () => {
         },
       },
       {
-        name: "should default plays to 0 when undefined",
+        name: "should keep plays undefined when not provided",
         input: createTestAlbumSearchResult({ plays: undefined }),
         assertions: (result) => {
-          expect(result.plays).toBe(0);
+          expect(result.plays).toBeUndefined();
         },
       },
       {
@@ -155,7 +155,7 @@ describe("convertToAlbumEntry", () => {
           expect(result.rotation_bin).toBeUndefined();
           expect(result.rotation_id).toBeUndefined();
           expect(result.add_date).toBeUndefined();
-          expect(result.plays).toBe(0);
+          expect(result.plays).toBeUndefined();
         },
       },
     ]

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -30,7 +30,7 @@ export function convertToAlbumEntry(
       ? (response.rotation_bin as Rotation)
       : undefined,
     add_date: isSearchResult(response) ? response.add_date : undefined,
-    plays: (isSearchResult(response) ? response.plays : undefined) ?? 0,
+    plays: isSearchResult(response) ? response.plays : undefined,
     label: response.label ?? "",
     rotation_id: isSearchResult(response) ? response.rotation_id : undefined,
     on_streaming: isSearchResult(response) ? (response as Record<string, unknown>).on_streaming as boolean | undefined : undefined,

--- a/src/components/experiences/modern/catalog/ArtistAvatar.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAvatar.tsx
@@ -25,7 +25,7 @@ export const ROTATION_STYLES: { [id in Rotation]: ColorPaletteProp } = {
   S: "neutral",
 };
 
-const GENRE_COLORS: { [id in Genre]: ColorPaletteProp } = {
+export const GENRE_COLORS: { [id in Genre]: ColorPaletteProp } = {
   Rock: "primary",
   Blues: "success",
   Electronic: "success",
@@ -38,7 +38,7 @@ const GENRE_COLORS: { [id in Genre]: ColorPaletteProp } = {
   Unknown: "neutral",
 };
 
-const GENRE_VARIANTS: { [id in Genre]: VariantProp } = {
+export const GENRE_VARIANTS: { [id in Genre]: VariantProp } = {
   Rock: "solid",
   Electronic: "solid",
   Hiphop: "soft",

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -1,21 +1,22 @@
 "use client";
 
-import { AlbumEntry } from "@/lib/features/catalog/types";
+import { AlbumEntry, Genre } from "@/lib/features/catalog/types";
 import Box from "@mui/joy/Box";
 import Checkbox from "@mui/joy/Checkbox";
 import Chip from "@mui/joy/Chip";
 import IconButton from "@mui/joy/IconButton";
 import Typography from "@mui/joy/Typography";
 
+import { Album as AlbumIcon } from "@mui/icons-material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
-import { Stack, Tooltip } from "@mui/joy";
+import { Avatar, Stack, Tooltip } from "@mui/joy";
 
 import { useCatalogSearch } from "@/src/hooks/catalogHooks";
 import { QueueMusic } from "@mui/icons-material";
-import Link from "next/link";
-import { ArtistAvatar } from "../ArtistAvatar";
 import { useQueue, useShowControl } from "@/src/hooks/flowsheetHooks";
+import { useRouter } from "next/navigation";
+import { GENRE_COLORS, GENRE_VARIANTS } from "../ArtistAvatar";
 import AddRemoveBin from "./AddRemoveBin";
 import { convertBinToQueue } from "@/lib/features/bin/conversions";
 import { toast } from "sonner";
@@ -23,12 +24,23 @@ import { toast } from "sonner";
 export default function CatalogResult({ album }: { album: AlbumEntry }) {
   const { live } = useShowControl();
   const { addToQueue } = useQueue();
+  const router = useRouter();
 
   const { selected, setSelection, orderBy } = useCatalogSearch();
 
+  const genreColor = GENRE_COLORS[(album.artist.genre as Genre) ?? "Unknown"] ?? "neutral";
+  const genreVariant = GENRE_VARIANTS[(album.artist.genre as Genre) ?? "Unknown"] ?? "soft";
+
   return (
-    <tr key={album.id}>
-      <td style={{ textAlign: "center" }}>
+    <tr
+      key={album.id}
+      onClick={() => router.push(`/dashboard/album/${album.id}`)}
+      style={{ cursor: "pointer" }}
+    >
+      <td
+        style={{ textAlign: "center" }}
+        onClick={(e) => e.stopPropagation()}
+      >
         <Checkbox
           checked={selected.includes(album.id)}
           color={selected.includes(album.id) ? "primary" : undefined}
@@ -44,12 +56,17 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
         />
       </td>
       <td>
-        <ArtistAvatar
-          entry={album.entry}
-          artist={album.artist}
-          format={album.format}
-          rotation={album.rotation_bin}
-        />
+        <Avatar
+          variant="soft"
+          color={genreColor}
+          sx={{
+            width: 40,
+            height: 40,
+            borderRadius: "sm",
+          }}
+        >
+          <AlbumIcon />
+        </Avatar>
       </td>
       <td>
         <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
@@ -75,55 +92,67 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
         </Typography>
       </td>
       <td>
-        <Typography level="body-xs">{album.artist.genre}</Typography>
-        <Typography level="body-md">
-          {album.artist.lettercode} {album.artist.numbercode}/{album.entry}
-        </Typography>
+        <Stack direction="row" gap={0.75} alignItems="center" flexWrap="nowrap">
+          <Chip
+            variant={genreVariant}
+            color={genreColor}
+            size="sm"
+          >
+            {album.artist.genre}
+          </Chip>
+          <Typography level="body-sm" noWrap>
+            {album.artist.lettercode} {album.artist.numbercode}/{album.entry}
+          </Typography>
+        </Stack>
       </td>
       <td>
-        <Chip
-          variant="soft"
-          size="sm"
-          color={album.format.includes("Vinyl") ? "primary" : "warning"}
-        >
-          {album.format}
-        </Chip>
-        {album.on_streaming === false && (
+        <Stack gap={0.5}>
           <Chip
             variant="soft"
             size="sm"
-            sx={{
-              ml: 0.5,
-              backgroundColor: "#7B2D8E",
-              color: "#fff",
-              fontWeight: "bold",
-              fontSize: "0.65rem",
-              letterSpacing: "0.5px",
-            }}
+            color={album.format.includes("Vinyl") ? "primary" : "warning"}
           >
-            WXYC EXCLUSIVE
+            {album.format}
           </Chip>
-        )}
+          {album.on_streaming === false && (
+            <Chip
+              variant="soft"
+              size="sm"
+              sx={{
+                backgroundColor: "#7B2D8E",
+                color: "#fff",
+                fontWeight: "bold",
+                fontSize: "0.65rem",
+                letterSpacing: "0.5px",
+              }}
+            >
+              WXYC EXCLUSIVE
+            </Chip>
+          )}
+        </Stack>
       </td>
-      <td>{album.plays ?? 0}</td>
       <td>
+        <Typography level="body-sm">
+          {album.plays != null && album.plays > 0 ? album.plays : "—"}
+        </Typography>
+      </td>
+      <td onClick={(e) => e.stopPropagation()}>
         <Stack direction="row" gap={0.25}>
           <Tooltip variant="outlined" size="sm" title="More information">
-            <Link href={`/dashboard/album/${album.id}`}>
-              <IconButton
-                aria-label="More information"
-                variant="soft"
-                color="neutral"
-                size="sm"
-              >
-                <InfoOutlinedIcon />
-              </IconButton>
-            </Link>
+            <IconButton
+              aria-label="More information"
+              variant="plain"
+              color="neutral"
+              size="sm"
+              onClick={() => router.push(`/dashboard/album/${album.id}`)}
+            >
+              <InfoOutlinedIcon />
+            </IconButton>
           </Tooltip>
           {live && (
             <Tooltip title="Add to Queue" variant="outlined" size="sm">
               <IconButton
-                variant="soft"
+                variant="plain"
                 color="neutral"
                 size="sm"
                 onClick={() => {

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -38,10 +38,18 @@ export default function Results({
           "--Table-headerUnderlineThickness": "1px",
           "--TableRow-hoverBackground": (theme) =>
             theme.vars.palette.background.level1,
-          "& tr > *:last-child": {
+          "& thead tr > *:last-child": {
             position: "sticky",
             right: 0,
             bgcolor: "var(--TableCell-headBackground)",
+          },
+          "& tbody tr > *:last-child": {
+            position: "sticky",
+            right: 0,
+            bgcolor: "var(--joy-palette-background-surface, #fff)",
+          },
+          "& tbody tr:hover > *:last-child": {
+            bgcolor: "var(--TableRow-hoverBackground)",
           },
         }}
       >
@@ -79,7 +87,7 @@ export default function Results({
             <th style={{ width: 220, padding: 12 }}>
               <TableHeader textValue="Title" />
             </th>
-            <th style={{ width: 60, padding: 12 }}>
+            <th style={{ width: 130, padding: 12 }}>
               <TableHeader textValue="Code" />
             </th>
             <th style={{ width: 70, padding: 12 }}>

--- a/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
@@ -47,7 +47,7 @@ describe("CatalogResult plays column (Bug 12)", () => {
     expect(playsCell).toBeDefined();
   });
 
-  it("should display 0 when plays is 0", () => {
+  it("should display dash when plays is 0", () => {
     const album = createTestAlbum({ plays: 0 });
 
     renderWithProviders(
@@ -60,12 +60,12 @@ describe("CatalogResult plays column (Bug 12)", () => {
 
     const cells = document.querySelectorAll("td");
     const playsCell = Array.from(cells).find(
-      (cell) => cell.textContent?.trim() === "0"
+      (cell) => cell.textContent?.trim() === "—"
     );
     expect(playsCell).toBeDefined();
   });
 
-  it("should display 0 when plays is undefined", () => {
+  it("should display dash when plays is undefined", () => {
     const album = createTestAlbum({ plays: undefined });
 
     renderWithProviders(
@@ -78,7 +78,7 @@ describe("CatalogResult plays column (Bug 12)", () => {
 
     const cells = document.querySelectorAll("td");
     const playsCell = Array.from(cells).find(
-      (cell) => cell.textContent?.trim() === "0"
+      (cell) => cell.textContent?.trim() === "—"
     );
     expect(playsCell).toBeDefined();
   });


### PR DESCRIPTION
## Summary

- Replace the complex ArtistAvatar (library code circle) with a genre-colored album placeholder — the code is already shown in its own column. Actual album artwork depends on Backend-Service#403.
- Genre label in the Code column is now a colored chip capsule matching the avatar genre colors, displayed inline with the library code
- Code column widened from 60px to 130px so genre chip and code fit on one line
- Format and WXYC EXCLUSIVE chips stacked vertically to prevent overflow into adjacent columns
- Action buttons (info, queue, bin) switched from `variant="soft"` to `variant="plain"` to remove grey backgrounds
- Sticky actions column fixed: body rows now use surface background instead of header background
- Rows are clickable to open the album info page; checkbox and action buttons use stopPropagation
- Plays column shows "—" instead of a misleading 0 when the backend doesn't return play data (Backend-Service#406)

## Test plan

- [x] TypeScript compiles with no errors in changed files
- [x] All 52 catalog tests pass
- [ ] Visual verification: genre chip displays inline with library code in Code column
- [ ] Visual verification: WXYC EXCLUSIVE stacks below format chip without overflow
- [ ] Visual verification: action buttons have no grey background
- [ ] Visual verification: clicking a row navigates to album info; clicking checkbox/buttons does not