### PR TITLE
Route library search through Backend-Service proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,6 @@ Create `.env.local`:
 ```bash
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8080
 NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:8082/auth
-NEXT_PUBLIC_LML_URL=http://localhost:8000
 NEXT_PUBLIC_DASHBOARD_HOME_PAGE=/dashboard/flowsheet
 NEXT_PUBLIC_DEFAULT_EXPERIENCE=modern
 NEXT_PUBLIC_ENABLED_EXPERIENCES=modern,classic

--- a/e2e/tests/flowsheet/library-search-proxy.spec.ts
+++ b/e2e/tests/flowsheet/library-search-proxy.spec.ts
@@ -20,21 +20,20 @@ test.describe("Library Search Proxy", () => {
   test.beforeEach(async ({ page }) => {
     flowsheet = new FlowsheetPage(page);
     await flowsheet.goto();
-    await flowsheet.waitForEntriesLoaded();
+    // Wait for the search form to be visible — don't need Go Live or entries
+    await flowsheet.artistInput.waitFor({ state: "visible", timeout: 15000 });
   });
 
   test("search calls Backend-Service proxy with auth header", async ({
     page,
   }) => {
-    let capturedUrl: string | undefined;
-    let capturedAuthHeader: string | null | undefined;
+    // Set up route interception BEFORE typing to catch the request
+    const proxyRequestPromise = page.waitForRequest(
+      (req) => req.url().includes("/proxy/library/search"),
+      { timeout: 5000 }
+    );
 
-    // Intercept the proxy request and return a mock response
     await page.route("**/proxy/library/search**", async (route) => {
-      const request = route.request();
-      capturedUrl = request.url();
-      capturedAuthHeader = request.headers()["authorization"];
-
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -63,25 +62,26 @@ test.describe("Library Search Proxy", () => {
       });
     });
 
-    // Type enough to trigger the debounced search
+    // Type enough to trigger the debounced search (min 3 chars combined)
     await flowsheet.artistInput.click();
     await flowsheet.artistInput.fill("Stereolab");
     await flowsheet.albumInput.fill("Aluminum");
 
-    // Wait for the intercepted request
-    await page.waitForTimeout(500); // debounce is 350ms
+    // Wait for the proxy request to fire
+    const request = await proxyRequestPromise;
+    const url = request.url();
+    const authHeader = request.headers()["authorization"];
 
-    expect(capturedUrl).toBeDefined();
-    expect(capturedUrl).toContain("/proxy/library/search");
-    expect(capturedUrl).toContain("artist=Stereolab");
-    expect(capturedUrl).toContain("title=Aluminum");
-    expect(capturedAuthHeader).toMatch(/^Bearer .+/);
+    expect(url).toContain("/proxy/library/search");
+    expect(url).toContain("artist=Stereolab");
+    expect(url).toContain("title=Aluminum");
+    expect(authHeader).toMatch(/^Bearer .+/);
   });
 
   test("search does not call LML directly", async ({ page }) => {
     let lmlDirectCalled = false;
 
-    // Watch for any direct LML calls
+    // Watch for any direct LML calls (port 8000 = LML default)
     page.on("request", (request) => {
       const url = request.url();
       if (
@@ -92,7 +92,7 @@ test.describe("Library Search Proxy", () => {
       }
     });
 
-    // Intercept proxy calls so they don't fail
+    // Intercept proxy calls so they succeed
     await page.route("**/proxy/library/search**", (route) =>
       route.fulfill({
         status: 200,
@@ -105,7 +105,8 @@ test.describe("Library Search Proxy", () => {
     await flowsheet.artistInput.fill("Cat Power");
     await flowsheet.albumInput.fill("Moon Pix");
 
-    await page.waitForTimeout(500);
+    // Wait past debounce (350ms) + network roundtrip margin
+    await page.waitForTimeout(600);
 
     expect(lmlDirectCalled).toBe(false);
   });

--- a/e2e/tests/flowsheet/library-search-proxy.spec.ts
+++ b/e2e/tests/flowsheet/library-search-proxy.spec.ts
@@ -11,26 +11,49 @@ const authDir = path.join(__dirname, "../../.auth");
  * Backend-Service's GET /proxy/library/search instead of calling
  * LML directly. Uses route interception to verify the request
  * shape and auth headers without requiring LML to be running.
+ *
+ * The search form is only visible when the DJ is live, so these
+ * tests use serial mode and go live in the first test.
  */
 test.describe("Library Search Proxy", () => {
-  test.use({ storageState: path.join(authDir, "dj.json") });
+  // Use dj2 to avoid session conflicts with auth tests that use dj.json
+  test.use({ storageState: path.join(authDir, "dj2.json") });
+  test.describe.configure({ mode: "serial" });
+  test.setTimeout(60_000);
 
   let flowsheet: FlowsheetPage;
+  let isLive = false;
 
   test.beforeEach(async ({ page }) => {
     flowsheet = new FlowsheetPage(page);
     await flowsheet.goto();
-    // Wait for the search form to be visible — don't need Go Live or entries
-    await flowsheet.artistInput.waitFor({ state: "visible", timeout: 15000 });
+    await flowsheet.waitForEntriesLoaded();
+    if (!isLive) {
+      await flowsheet.goLive();
+      isLive = true;
+    }
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const context = await browser.newContext({
+      storageState: path.join(authDir, "dj2.json"),
+      baseURL: process.env.E2E_BASE_URL || "http://localhost:3000",
+    });
+    const page = await context.newPage();
+    const fs = new FlowsheetPage(page);
+    await fs.goto();
+    await fs.waitForEntriesLoaded();
+    await fs.ensureOffAir();
+    await context.close();
   });
 
   test("search calls Backend-Service proxy with auth header", async ({
     page,
   }) => {
-    // Set up route interception BEFORE typing to catch the request
+    // Set up route interception BEFORE typing
     const proxyRequestPromise = page.waitForRequest(
       (req) => req.url().includes("/proxy/library/search"),
-      { timeout: 5000 }
+      { timeout: 5000 },
     );
 
     await page.route("**/proxy/library/search**", async (route) => {
@@ -63,7 +86,6 @@ test.describe("Library Search Proxy", () => {
     });
 
     // Type enough to trigger the debounced search (min 3 chars combined)
-    await flowsheet.artistInput.click();
     await flowsheet.artistInput.fill("Stereolab");
     await flowsheet.albumInput.fill("Aluminum");
 
@@ -98,10 +120,9 @@ test.describe("Library Search Proxy", () => {
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({ results: [], total: 0, query: null }),
-      })
+      }),
     );
 
-    await flowsheet.artistInput.click();
     await flowsheet.artistInput.fill("Cat Power");
     await flowsheet.albumInput.fill("Moon Pix");
 

--- a/e2e/tests/flowsheet/library-search-proxy.spec.ts
+++ b/e2e/tests/flowsheet/library-search-proxy.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "../../fixtures/auth.fixture";
+import { FlowsheetPage } from "../../pages/flowsheet.page";
+import path from "path";
+
+const authDir = path.join(__dirname, "../../.auth");
+
+/**
+ * Library Search Proxy E2E Tests
+ *
+ * Verifies that dj-site routes library catalog searches through
+ * Backend-Service's GET /proxy/library/search instead of calling
+ * LML directly. Uses route interception to verify the request
+ * shape and auth headers without requiring LML to be running.
+ */
+test.describe("Library Search Proxy", () => {
+  test.use({ storageState: path.join(authDir, "dj.json") });
+
+  let flowsheet: FlowsheetPage;
+
+  test.beforeEach(async ({ page }) => {
+    flowsheet = new FlowsheetPage(page);
+    await flowsheet.goto();
+    await flowsheet.waitForEntriesLoaded();
+  });
+
+  test("search calls Backend-Service proxy with auth header", async ({
+    page,
+  }) => {
+    let capturedUrl: string | undefined;
+    let capturedAuthHeader: string | null | undefined;
+
+    // Intercept the proxy request and return a mock response
+    await page.route("**/proxy/library/search**", async (route) => {
+      const request = route.request();
+      capturedUrl = request.url();
+      capturedAuthHeader = request.headers()["authorization"];
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          results: [
+            {
+              id: 42,
+              title: "Aluminum Tunes",
+              artist: "Stereolab",
+              call_letters: "RO",
+              artist_call_number: 87,
+              release_call_number: 1,
+              genre: "Rock",
+              format: "CD",
+              alternate_artist_name: null,
+              label: "Duophonic",
+              on_streaming: true,
+              call_number: "Rock CD RO 87/1",
+              library_url:
+                "http://www.wxyc.info/wxycdb/libraryRelease?id=42",
+            },
+          ],
+          total: 1,
+          query: "Stereolab",
+        }),
+      });
+    });
+
+    // Type enough to trigger the debounced search
+    await flowsheet.artistInput.click();
+    await flowsheet.artistInput.fill("Stereolab");
+    await flowsheet.albumInput.fill("Aluminum");
+
+    // Wait for the intercepted request
+    await page.waitForTimeout(500); // debounce is 350ms
+
+    expect(capturedUrl).toBeDefined();
+    expect(capturedUrl).toContain("/proxy/library/search");
+    expect(capturedUrl).toContain("artist=Stereolab");
+    expect(capturedUrl).toContain("title=Aluminum");
+    expect(capturedAuthHeader).toMatch(/^Bearer .+/);
+  });
+
+  test("search does not call LML directly", async ({ page }) => {
+    let lmlDirectCalled = false;
+
+    // Watch for any direct LML calls
+    page.on("request", (request) => {
+      const url = request.url();
+      if (
+        url.includes(":8000/") &&
+        url.includes("/api/v1/library/search")
+      ) {
+        lmlDirectCalled = true;
+      }
+    });
+
+    // Intercept proxy calls so they don't fail
+    await page.route("**/proxy/library/search**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ results: [], total: 0, query: null }),
+      })
+    );
+
+    await flowsheet.artistInput.click();
+    await flowsheet.artistInput.fill("Cat Power");
+    await flowsheet.albumInput.fill("Moon Pix");
+
+    await page.waitForTimeout(500);
+
+    expect(lmlDirectCalled).toBe(false);
+  });
+});

--- a/src/hooks/lml/index.ts
+++ b/src/hooks/lml/index.ts
@@ -1,4 +1,4 @@
-export { getLmlBaseUrl } from "./lml-client";
+export { getLibrarySearchUrl } from "./lml-client";
 export { useLmlLibrarySearch } from "./useLmlLibrarySearch";
 export { convertLmlItemToAlbumEntry } from "./lml-conversions";
 export type { LmlLibraryItem, LmlLibrarySearchResponse } from "./types";

--- a/src/hooks/lml/lml-client.ts
+++ b/src/hooks/lml/lml-client.ts
@@ -1,3 +1,24 @@
-export function getLmlBaseUrl(): string {
-  return process.env.NEXT_PUBLIC_LML_URL || "http://localhost:8000";
+import { getJWTToken } from "@/lib/features/authentication/client";
+
+function getBackendBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8080";
+}
+
+/**
+ * Get the URL for the library search proxy endpoint on Backend-Service.
+ */
+export function getLibrarySearchUrl(): string {
+  return `${getBackendBaseUrl()}/proxy/library/search`;
+}
+
+/**
+ * Build headers for authenticated requests to Backend-Service.
+ * Reuses the JWT token cache from the auth client.
+ */
+export async function getAuthHeaders(): Promise<HeadersInit> {
+  const token = await getJWTToken();
+  if (token) {
+    return { Authorization: `Bearer ${token}` };
+  }
+  return {};
 }

--- a/src/hooks/lml/useLmlLibrarySearch.test.ts
+++ b/src/hooks/lml/useLmlLibrarySearch.test.ts
@@ -5,7 +5,13 @@ import { server, createTestLmlLibraryItem } from "@/lib/test-utils";
 import { useLmlLibrarySearch } from "./useLmlLibrarySearch";
 import type { LmlLibrarySearchResponse } from "./types";
 
-const LML_URL = process.env.NEXT_PUBLIC_LML_URL || "http://localhost:8000";
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue("test-jwt-token"),
+}));
+
+const BACKEND_URL =
+  process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8080";
+const PROXY_SEARCH_URL = `${BACKEND_URL}/proxy/library/search`;
 
 describe("useLmlLibrarySearch", () => {
   beforeEach(() => {
@@ -27,10 +33,10 @@ describe("useLmlLibrarySearch", () => {
     expect(result.current.isLoading).toBe(false);
   });
 
-  it("should send correct query params to LML", async () => {
+  it("should send correct query params to Backend-Service proxy", async () => {
     let capturedUrl: URL | undefined;
     server.use(
-      http.get(`${LML_URL}/api/v1/library/search`, ({ request }) => {
+      http.get(PROXY_SEARCH_URL, ({ request }) => {
         capturedUrl = new URL(request.url);
         return HttpResponse.json({
           results: [],
@@ -52,6 +58,29 @@ describe("useLmlLibrarySearch", () => {
     expect(capturedUrl!.searchParams.get("limit")).toBe("10");
   });
 
+  it("should include Authorization header", async () => {
+    let capturedHeaders: Headers | undefined;
+    server.use(
+      http.get(PROXY_SEARCH_URL, ({ request }) => {
+        capturedHeaders = request.headers;
+        return HttpResponse.json({
+          results: [],
+          total: 0,
+          query: null,
+        } satisfies LmlLibrarySearchResponse);
+      })
+    );
+
+    renderHook(() =>
+      useLmlLibrarySearch({ artist: "Stereolab", album: "Aluminum" })
+    );
+
+    await vi.advanceTimersByTimeAsync(400);
+    await waitFor(() => expect(capturedHeaders).toBeDefined());
+
+    expect(capturedHeaders!.get("Authorization")).toMatch(/^Bearer /);
+  });
+
   it("should convert results to AlbumEntry[]", async () => {
     const lmlItem = createTestLmlLibraryItem({
       id: 99,
@@ -65,7 +94,7 @@ describe("useLmlLibrarySearch", () => {
     });
 
     server.use(
-      http.get(`${LML_URL}/api/v1/library/search`, () => {
+      http.get(PROXY_SEARCH_URL, () => {
         return HttpResponse.json({
           results: [lmlItem],
           total: 1,
@@ -97,7 +126,7 @@ describe("useLmlLibrarySearch", () => {
 
   it("should return empty array on HTTP error", async () => {
     server.use(
-      http.get(`${LML_URL}/api/v1/library/search`, () => {
+      http.get(PROXY_SEARCH_URL, () => {
         return new HttpResponse(null, { status: 500 });
       })
     );
@@ -114,7 +143,7 @@ describe("useLmlLibrarySearch", () => {
 
   it("should return empty array on network error", async () => {
     server.use(
-      http.get(`${LML_URL}/api/v1/library/search`, () => {
+      http.get(PROXY_SEARCH_URL, () => {
         return HttpResponse.error();
       })
     );
@@ -132,7 +161,7 @@ describe("useLmlLibrarySearch", () => {
   it("should debounce requests", async () => {
     let callCount = 0;
     server.use(
-      http.get(`${LML_URL}/api/v1/library/search`, () => {
+      http.get(PROXY_SEARCH_URL, () => {
         callCount++;
         return HttpResponse.json({
           results: [],

--- a/src/hooks/lml/useLmlLibrarySearch.ts
+++ b/src/hooks/lml/useLmlLibrarySearch.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { AlbumEntry } from "@/lib/features/catalog/types";
-import { getLmlBaseUrl } from "./lml-client";
+import { getLibrarySearchUrl, getAuthHeaders } from "./lml-client";
 import { convertLmlItemToAlbumEntry } from "./lml-conversions";
 import type { LmlLibrarySearchResponse } from "./types";
 
@@ -11,7 +11,8 @@ const MIN_QUERY_LENGTH = 3;
 const RESULT_LIMIT = 10;
 
 /**
- * Debounced hook that searches the LML library API and returns `AlbumEntry[]`.
+ * Debounced hook that searches the library catalog via Backend-Service's
+ * proxy endpoint and returns `AlbumEntry[]`.
  * Designed to be called with the current flowsheet search query fields.
  * Gracefully returns an empty array on any error.
  */
@@ -47,9 +48,10 @@ export function useLmlLibrarySearch({
         if (album) params.set("title", album);
         params.set("limit", String(RESULT_LIMIT));
 
+        const headers = await getAuthHeaders();
         const response = await fetch(
-          `${getLmlBaseUrl()}/api/v1/library/search?${params}`,
-          { signal: controller.signal }
+          `${getLibrarySearchUrl()}?${params}`,
+          { signal: controller.signal, headers }
         );
 
         if (!response.ok) {


### PR DESCRIPTION
## Summary

- Switch library search from direct LML calls to Backend-Service's `GET /proxy/library/search`
- Add JWT auth header via the existing `getJWTToken()` auth client
- Remove `NEXT_PUBLIC_LML_URL` env var — all LML access now routes through Backend-Service
- Update all 7 hook tests to use the proxy URL and mock the auth token

Closes #396

## Test plan

- [x] 7 hook tests pass (URL, auth header, conversion, errors, debounce)
- [x] Full suite passes (2508 tests, 178 files)
- [x] Typecheck passes
- [ ] CI passes
- [ ] Manual: log in as DJ, verify flowsheet autocomplete returns library search results

🔗 Depends on WXYC/Backend-Service#405 deployed