### PR TITLE
E2E parallel safety: remove serial blocks from role-modification and email-change tests

### DIFF
--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -194,4 +194,24 @@ export async function revokeUserSessions(sessionCookie: string): Promise<boolean
   }
 }
 
+/**
+ * Mark an admin-created user as having completed onboarding.
+ * Requires Backend-Service to be running with NODE_ENV !== 'production'.
+ */
+export async function confirmUser(userId: string): Promise<boolean> {
+  const baseUrl = await getAuthServiceBaseUrl();
+
+  try {
+    const response = await fetch(`${baseUrl}/auth/test/confirm-user`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId }),
+    });
+    return response.ok;
+  } catch (error) {
+    console.error("Failed to confirm user:", error);
+    return false;
+  }
+}
+
 export { expect };

--- a/e2e/helpers/test-data.ts
+++ b/e2e/helpers/test-data.ts
@@ -10,7 +10,9 @@
  * @param prefix - Short label identifying the test context (e.g. "user", "delete", "role", "email")
  */
 export function generateUsername(prefix = "e2e"): string {
-  return `e2e_${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+  // Base-36 timestamp (~8 chars) keeps output shorter (~20 chars total) to
+  // avoid onboarding redirect timeouts observed with longer username formats.
+  return `e2e_${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 5)}`;
 }
 
 /**

--- a/e2e/tests/admin/admin-email-change.spec.ts
+++ b/e2e/tests/admin/admin-email-change.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, TEST_USERS } from "../../fixtures/auth.fixture";
 import { RosterPage } from "../../pages/roster.page";
 import { DashboardPage } from "../../pages/dashboard.page";
+import { generateUsername, generateEmail } from "../../helpers/test-data";
 import path from "path";
 
 const authDir = path.join(__dirname, "../../.auth");
@@ -11,9 +12,6 @@ test.describe("Admin Email Change", () => {
 
   let rosterPage: RosterPage;
   let dashboardPage: DashboardPage;
-
-  // Serial mode: mutation tests change dj2's email
-  test.describe.configure({ mode: "serial" });
 
   test.beforeEach(async ({ page }) => {
     rosterPage = new RosterPage(page);
@@ -88,10 +86,23 @@ test.describe("Admin Email Change", () => {
     expect(dialogMessage).toContain("without verification");
   });
 
-  test("should update email immediately when confirmed", async ({ page }) => {
+  test("should update email immediately when confirmed", async () => {
+    // Create a temp user so we don't mutate shared seeded user state
+    const username = generateUsername("email");
+    const originalEmail = generateEmail(username);
+
+    await rosterPage.createAccount({
+      realName: "Email Update Test",
+      username,
+      email: originalEmail,
+    });
+
+    await rosterPage.expectSuccessToast();
+    await rosterPage.waitForDataRefresh();
+
     const newEmail = `admin_changed_${Date.now()}@wxyc.org`;
 
-    await rosterPage.updateEmailWithConfirm(TEST_USERS.dj2.username, newEmail);
+    await rosterPage.updateEmailWithConfirm(username, newEmail);
 
     // Should show success toast
     await rosterPage.expectSuccessToast(`Email updated to ${newEmail}`);
@@ -101,13 +112,25 @@ test.describe("Admin Email Change", () => {
   });
 
   test("should not require email verification for admin-changed emails", async () => {
+    // Create a temp user so we don't mutate shared seeded user state
+    const username = generateUsername("email");
+    const originalEmail = generateEmail(username);
+
+    await rosterPage.createAccount({
+      realName: "Email Verify Test",
+      username,
+      email: originalEmail,
+    });
+
+    await rosterPage.expectSuccessToast();
+    await rosterPage.waitForDataRefresh();
+
     // This test verifies that admin-changed emails don't require verification
     // by checking that emailVerified: true is set (observable through the user
     // being able to log in with the new email without verification)
-
     const newEmail = `admin_verified_${Date.now()}@wxyc.org`;
 
-    await rosterPage.updateEmailWithConfirm(TEST_USERS.dj2.username, newEmail);
+    await rosterPage.updateEmailWithConfirm(username, newEmail);
 
     await rosterPage.expectSuccessToast();
 

--- a/e2e/tests/admin/role-modification.spec.ts
+++ b/e2e/tests/admin/role-modification.spec.ts
@@ -24,15 +24,19 @@ test.describe("Admin Role Modification", () => {
   });
 
   test.describe("Promotion", () => {
-    // Role changes require confirmed (onboarded) users, so we use seeded users.
-    // Serial mode prevents concurrent mutation of shared user state.
-    test.describe.configure({ mode: "serial" });
-
     test("should promote DJ to Music Director", async () => {
-      const username = TEST_USERS.dj1.username;
+      const username = generateUsername("role");
+      const email = generateEmail(username);
 
-      const userRow = rosterPage.getUserRow(username);
-      await expect(userRow).toBeVisible({ timeout: 5000 });
+      await rosterPage.createAccount({
+        realName: "Promote DJ Test",
+        username,
+        email,
+        role: "dj",
+      });
+
+      await rosterPage.expectSuccessToast();
+      await rosterPage.waitForDataRefresh();
 
       // Accept confirmation dialog before clicking
       rosterPage.acceptConfirmDialog();
@@ -50,24 +54,19 @@ test.describe("Admin Role Modification", () => {
       await rosterPage.expectUserRole(username, "Music Director");
     });
 
-    test.afterEach(async () => {
-      // Reset test_dj1 back to DJ role if it was promoted
-      const username = TEST_USERS.dj1.username;
-      const select = rosterPage.getRoleSelect(username);
-      const currentText = await select.textContent();
-
-      if (currentText?.includes("Music Director")) {
-        rosterPage.acceptConfirmDialog();
-        await rosterPage.demoteFromMusicDirector(username);
-        await rosterPage.waitForDataRefresh();
-      }
-    });
-
     test("should promote Music Director to Station Manager", async () => {
-      const username = TEST_USERS.musicDirector.username;
+      const username = generateUsername("role");
+      const email = generateEmail(username);
 
-      const userRow = rosterPage.getUserRow(username);
-      await expect(userRow).toBeVisible({ timeout: 5000 });
+      await rosterPage.createAccount({
+        realName: "Promote MD Test",
+        username,
+        email,
+        role: "musicDirector",
+      });
+
+      await rosterPage.expectSuccessToast();
+      await rosterPage.waitForDataRefresh();
 
       // Accept confirmation dialog
       rosterPage.acceptConfirmDialog();
@@ -80,24 +79,23 @@ test.describe("Admin Role Modification", () => {
 
       // Verify role select now shows Station Manager
       await rosterPage.expectUserRole(username, "Station Manager");
-
-      // Demote back to MD to reset state
-      rosterPage.acceptConfirmDialog();
-      await rosterPage.demoteFromStationManager(username);
-      await rosterPage.waitForDataRefresh();
     });
   });
 
   test.describe("Demotion", () => {
-    // Role changes require confirmed (onboarded) users, so we use seeded users.
-    // Serial mode prevents concurrent mutation of shared user state.
-    test.describe.configure({ mode: "serial" });
-
     test("should demote Station Manager to Music Director", async () => {
-      const username = TEST_USERS.demotableSm.username;
+      const username = generateUsername("role");
+      const email = generateEmail(username);
 
-      const userRow = rosterPage.getUserRow(username);
-      await expect(userRow).toBeVisible({ timeout: 5000 });
+      await rosterPage.createAccount({
+        realName: "Demote SM Test",
+        username,
+        email,
+        role: "stationManager",
+      });
+
+      await rosterPage.expectSuccessToast();
+      await rosterPage.waitForDataRefresh();
 
       // Accept confirmation dialog
       rosterPage.acceptConfirmDialog();
@@ -110,30 +108,21 @@ test.describe("Admin Role Modification", () => {
 
       // Verify role select now shows Music Director
       await rosterPage.expectUserRole(username, "Music Director");
-
-      // Promote back to SM to reset state
-      rosterPage.acceptConfirmDialog();
-      await rosterPage.promoteToStationManager(username);
-      await rosterPage.waitForDataRefresh();
     });
 
-    test("should demote Music Director to DJ", async ({ page }) => {
-      const username = TEST_USERS.dj1.username;
+    test("should demote Music Director to DJ", async () => {
+      const username = generateUsername("role");
+      const email = generateEmail(username);
 
-      const userRow = rosterPage.getUserRow(username);
-      await expect(userRow).toBeVisible({ timeout: 5000 });
+      await rosterPage.createAccount({
+        realName: "Demote MD Test",
+        username,
+        email,
+        role: "musicDirector",
+      });
 
-      // First, ensure the user is MD (promote if needed)
-      const select = rosterPage.getRoleSelect(username);
-      const currentText = await select.textContent();
-      if (!currentText?.includes("Music Director")) {
-        rosterPage.acceptConfirmDialog();
-        await rosterPage.promoteToMusicDirector(username);
-        await rosterPage.waitForDataRefresh();
-        // Dismiss any toasts from the promotion step
-        await page.keyboard.press("Escape");
-        await page.waitForTimeout(500);
-      }
+      await rosterPage.expectSuccessToast();
+      await rosterPage.waitForDataRefresh();
 
       // Accept confirmation dialog for demotion
       rosterPage.acceptConfirmDialog();
@@ -285,11 +274,8 @@ test.describe("Admin Role Modification", () => {
 });
 
 test.describe("Role Change Persistence", () => {
-  // Uses seeded dj1 (confirmed user). Serial to prevent concurrent mutation.
-  test.describe.configure({ mode: "serial" });
-
   test("role change should persist after page refresh", async ({ page }) => {
-    // This test does a full login flow + multiple role changes + page reload,
+    // This test does a full login flow + account creation + role change + page reload,
     // so it needs more time than the default timeout.
     test.setTimeout(30000);
     const loginPage = new LoginPage(page);
@@ -303,24 +289,19 @@ test.describe("Role Change Persistence", () => {
     await dashboardPage.gotoAdminRoster();
     await rosterPage.waitForTableLoaded();
 
-    // Use existing seeded user who is already an organization member
-    const username = TEST_USERS.dj1.username;
+    // Create a temp user as DJ
+    const username = generateUsername("persist");
+    const email = generateEmail(username);
 
-    // Verify user row exists and role select is visible
-    await rosterPage.expectUserInRoster(username);
-    const select = rosterPage.getRoleSelect(username);
-    await expect(select).toBeVisible({ timeout: 5000 });
+    await rosterPage.createAccount({
+      realName: "Persist Test",
+      username,
+      email,
+      role: "dj",
+    });
 
-    // First ensure the user is a DJ (not MD) - demote if needed
-    const currentText = await select.textContent();
-    if (currentText?.includes("Music Director")) {
-      rosterPage.acceptConfirmDialog();
-      await rosterPage.demoteFromMusicDirector(username);
-      await rosterPage.waitForDataRefresh();
-      // Dismiss any toasts
-      await page.keyboard.press("Escape");
-      await page.waitForTimeout(500);
-    }
+    await rosterPage.expectSuccessToast();
+    await rosterPage.waitForDataRefresh();
 
     // Promote to MD
     rosterPage.acceptConfirmDialog();
@@ -336,11 +317,6 @@ test.describe("Role Change Persistence", () => {
 
     // Verify role select still shows Music Director after refresh
     await rosterPage.expectUserRole(username, "Music Director");
-
-    // Clean up: demote back to DJ
-    rosterPage.acceptConfirmDialog();
-    await rosterPage.demoteFromMusicDirector(username);
-    await rosterPage.waitForDataRefresh();
   });
 });
 


### PR DESCRIPTION
Closes #402

## Summary

- Convert Promotion, Demotion, and Persistence test blocks in `role-modification.spec.ts` from shared seeded users (`TEST_USERS.dj1`, `TEST_USERS.musicDirector`, `TEST_USERS.demotableSm`) to per-test temp users via `rosterPage.createAccount()`. These tests operate entirely from the admin's perspective — the temp user never logs in — so `hasCompletedOnboarding` is irrelevant.
- Convert the two mutating tests in `admin-email-change.spec.ts` from `TEST_USERS.dj2` to per-test temp users, removing serial mode.
- Shorten `generateUsername()` output in `e2e/helpers/test-data.ts` (base-36 timestamps) to avoid onboarding redirect timeouts observed with longer username formats.
- Add `confirmUser()` helper to `auth.fixture.ts` (calls `POST /auth/test/confirm-user` on Backend-Service) for future use in Stream 5.

## Test plan

- [ ] Run `npx playwright test e2e/tests/admin/role-modification.spec.ts --project=chromium --workers=3` — all tests pass in parallel
- [ ] Run `npx playwright test e2e/tests/admin/admin-email-change.spec.ts --project=chromium --workers=3` — all tests pass in parallel
- [ ] Run full E2E suite — no regressions
- [ ] Verify no `serial` annotations remain in role-modification Promotion/Demotion/Persistence or admin-email-change blocks