### PR TITLE
Adopt shared generateUsername() in onboarding redirect tests

### DIFF
--- a/e2e/tests/admin/admin-password-reset.spec.ts
+++ b/e2e/tests/admin/admin-password-reset.spec.ts
@@ -3,6 +3,7 @@ import { DashboardPage } from "../../pages/dashboard.page";
 import { RosterPage } from "../../pages/roster.page";
 import { LoginPage } from "../../pages/login.page";
 import { OnboardingPage } from "../../pages/onboarding.page";
+import { generateUsername, generateEmail } from "../../helpers/test-data";
 import path from "path";
 
 const authDir = path.join(__dirname, "../../.auth");
@@ -212,8 +213,8 @@ test.describe("Password Reset for Different User States", () => {
     const rosterPage = new RosterPage(page);
 
     // Create a new user (who will be "New" / unconfirmed) with complete profile
-    const username = `unconfirmed_${Date.now()}`;
-    const email = `${username}@test.wxyc.org`;
+    const username = generateUsername("unconfirmed");
+    const email = generateEmail(username);
 
     await dashboardPage.gotoAdminRoster();
     await rosterPage.waitForTableLoaded();
@@ -227,7 +228,7 @@ test.describe("Password Reset for Different User States", () => {
     });
 
     await rosterPage.expectSuccessToast();
-    await page.waitForTimeout(1000);
+    await rosterPage.waitForDataRefresh();
 
     // Reset password for the new (unconfirmed) user
     // Note: The reset button should work for new users too since they need to set up their account

--- a/e2e/tests/admin/user-deletion.spec.ts
+++ b/e2e/tests/admin/user-deletion.spec.ts
@@ -181,8 +181,8 @@ test.describe("User Deletion Session Invalidation", () => {
     await adminDashboard.gotoAdminRoster();
     await adminRosterPage.waitForTableLoaded();
 
-    const username = `session_test_${Date.now()}`;
-    const email = `${username}@test.wxyc.org`;
+    const username = generateUsername("session");
+    const email = generateEmail(username);
 
     await adminRosterPage.createAccount({
       realName: "Session Test User",
@@ -193,7 +193,7 @@ test.describe("User Deletion Session Invalidation", () => {
     });
 
     await adminRosterPage.expectSuccessToast();
-    await adminPage.waitForTimeout(1000);
+    await adminRosterPage.waitForDataRefresh();
 
     // New user logs in with temp password
     const userOnboarding = new OnboardingPage(userPage);

--- a/e2e/tests/onboarding/new-user.spec.ts
+++ b/e2e/tests/onboarding/new-user.spec.ts
@@ -3,6 +3,7 @@ import { LoginPage } from "../../pages/login.page";
 import { DashboardPage } from "../../pages/dashboard.page";
 import { OnboardingPage } from "../../pages/onboarding.page";
 import { RosterPage } from "../../pages/roster.page";
+import { generateUsername, generateEmail } from "../../helpers/test-data";
 
 test.describe("New User Onboarding", () => {
   // Onboarding tests do manual logins and must run sequentially
@@ -210,8 +211,8 @@ test.describe("New User Onboarding", () => {
       const rosterPage = new RosterPage(adminPage);
       await rosterPage.waitForTableLoaded();
 
-      const username = `onboard_${Date.now()}`;
-      const email = `${username}@test.wxyc.org`;
+      const username = generateUsername("onboard");
+      const email = generateEmail(username);
 
       // Create user with complete profile (realName and djName provided by admin).
       // Admin-created users still have hasCompletedOnboarding=false and must
@@ -225,7 +226,7 @@ test.describe("New User Onboarding", () => {
       });
 
       await rosterPage.expectSuccessToast();
-      await adminPage.waitForTimeout(1000);
+      await rosterPage.waitForDataRefresh();
 
       // New user logs in with temp password
       const userContext = await browser.newContext({ baseURL });


### PR DESCRIPTION
## Summary

- Replace inline `Date.now()` username patterns in three E2E test files with the shared `generateUsername()` helper from `e2e/helpers/test-data`
- The shorter base-36 output format (~28 chars vs ~37 chars) avoids the onboarding redirect timeouts observed with the previous longer format
- Replace `waitForTimeout(1000)` with `waitForDataRefresh()` for consistency

Stacks on top of #403. Part of #394 (Stream 5).

## Test plan

- [ ] Run `npx playwright test e2e/tests/admin/admin-password-reset.spec.ts --project=chromium` — onboarding redirect test passes
- [ ] Run `npx playwright test e2e/tests/admin/user-deletion.spec.ts --project=chromium` — session invalidation test passes
- [ ] Run `npx playwright test e2e/tests/onboarding/new-user.spec.ts --project=chromium` — admin-created user onboarding test passes
- [ ] Run full E2E suite — no regressions