### PR TITLE
Show album artwork in catalog search results

### DIFF
--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -96,6 +96,22 @@ describe("convertToAlbumEntry", () => {
           expect(result.date_found).toBeUndefined();
         },
       },
+      {
+        name: "should pass through artwork_url when present",
+        input: createTestAlbumSearchResult({
+          artwork_url: "https://i.discogs.com/confield.jpg",
+        } as any),
+        assertions: (result) => {
+          expect(result.artwork_url).toBe("https://i.discogs.com/confield.jpg");
+        },
+      },
+      {
+        name: "should default artwork_url to undefined",
+        input: createTestAlbumSearchResult(),
+        assertions: (result) => {
+          expect(result.artwork_url).toBeUndefined();
+        },
+      },
     ]
   );
 

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -36,6 +36,7 @@ export function convertToAlbumEntry(
     on_streaming: isSearchResult(response) ? (response as Record<string, unknown>).on_streaming as boolean | undefined : undefined,
     date_lost: isSearchResult(response) ? (response as Record<string, unknown>).date_lost as string | undefined : undefined,
     date_found: isSearchResult(response) ? (response as Record<string, unknown>).date_found as string | undefined : undefined,
+    artwork_url: isSearchResult(response) ? (response as Record<string, unknown>).artwork_url as string | null | undefined : undefined,
   };
 }
 

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -54,6 +54,7 @@ export type AlbumEntry = {
   on_streaming?: boolean;
   date_lost?: string;
   date_found?: string;
+  artwork_url?: string | null;
 };
 
 export type ArtistEntry = {

--- a/lib/test-utils/fixtures.ts
+++ b/lib/test-utils/fixtures.ts
@@ -185,6 +185,7 @@ export function createTestAlbum(overrides: Partial<AlbumEntry> = {}): AlbumEntry
     add_date: toDateString(TEST_TIMESTAMPS.ONE_WEEK_AGO),
     label: TEST_SEARCH_STRINGS.LABEL,
     on_streaming: undefined,
+    artwork_url: undefined,
     ...overrides,
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "lockfile-shared-041",
+  "name": "catalog-artwork",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,7 +14,7 @@
         "@opennextjs/cloudflare": "^1.10.1",
         "@reduxjs/toolkit": "^2.2.0",
         "@uidotdev/usehooks": "^2.4.1",
-        "@wxyc/shared": "^0.4.1",
+        "@wxyc/shared": "^0.5.1",
         "better-auth": "^1.5.6",
         "cookie": "^1.0.2",
         "jose": "^5.9.6",
@@ -14115,9 +14115,9 @@
       }
     },
     "node_modules/@wxyc/shared": {
-      "version": "0.4.1",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.4.1/fe101dc724909afe304c8fa67fc270ac6e72aced",
-      "integrity": "sha512-8WWjkkGfIabef6xO+NkcTCYIDFS8j5HOhkYvTsjCZDyyhQC5k3XMki6GFSAyxaYAIe66F9fl22lxJYizkns1cw==",
+      "version": "0.5.1",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.5.1/1c9488fcfae4f6ddda64249c13801a8cbb91e338",
+      "integrity": "sha512-1SMVavd0Q3AFggKwRTa8vLZSY5CdbIRJGGhI4Kl7fScfANhusZwUaeAOYgUCPN7jOwQSstLQ0qpI+YAhVEnf3g==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@opennextjs/cloudflare": "^1.10.1",
     "@reduxjs/toolkit": "^2.2.0",
     "@uidotdev/usehooks": "^2.4.1",
-    "@wxyc/shared": "^0.4.1",
+    "@wxyc/shared": "^0.5.1",
     "better-auth": "^1.5.6",
     "cookie": "^1.0.2",
     "jose": "^5.9.6",

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -56,17 +56,31 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
         />
       </td>
       <td>
-        <Avatar
-          variant="soft"
-          color={genreColor}
-          sx={{
-            width: 40,
-            height: 40,
-            borderRadius: "sm",
-          }}
-        >
-          <AlbumIcon />
-        </Avatar>
+        {album.artwork_url ? (
+          <Box
+            component="img"
+            src={album.artwork_url}
+            alt={`${album.artist.name} - ${album.title}`}
+            sx={{
+              width: 40,
+              height: 40,
+              borderRadius: "sm",
+              objectFit: "cover",
+            }}
+          />
+        ) : (
+          <Avatar
+            variant="soft"
+            color={genreColor}
+            sx={{
+              width: 40,
+              height: 40,
+              borderRadius: "sm",
+            }}
+          >
+            <AlbumIcon />
+          </Avatar>
+        )}
       </td>
       <td>
         <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>

--- a/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
@@ -127,3 +127,51 @@ describe("CatalogResult WXYC Exclusive badge", () => {
     expect(screen.queryByText("WXYC EXCLUSIVE")).toBeNull();
   });
 });
+
+describe("CatalogResult album artwork", () => {
+  it("should render album artwork when artwork_url is provided", () => {
+    const album = createTestAlbum({
+      artwork_url: "https://i.discogs.com/confield.jpg",
+    });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    const img = screen.getByAltText(`${album.artist.name} - ${album.title}`);
+    expect(img).toBeDefined();
+    expect(img.getAttribute("src")).toBe("https://i.discogs.com/confield.jpg");
+  });
+
+  it("should fall back to ArtistAvatar when artwork_url is null", () => {
+    const album = createTestAlbum({ artwork_url: null });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("should fall back to ArtistAvatar when artwork_url is undefined", () => {
+    const album = createTestAlbum({ artwork_url: undefined });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Upgrade `@wxyc/shared` to 0.5.1 (adds `artwork_url` to `AlbumSearchResult`)
- Add `artwork_url` to `AlbumEntry` type and pass it through `convertToAlbumEntry`
- Render Discogs album cover in catalog results when available, fall back to genre-colored icon
- 5 new tests (2 conversion, 3 component)

Closes #406

## Test plan

- [x] 2453 tests pass (`npm run test:run`)
- [x] Typecheck passes (`npx tsc --noEmit`)
- [ ] CI passes