### PR TITLE
fix: treat addMember failure as fatal during account creation

### DIFF
--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -139,10 +139,16 @@ export default function RosterTable({ user }: { user: User }) {
           }
         }
 
-        // Add user to the organization with the appropriate role
+        // Add user to the organization with the appropriate role.
+        // This MUST succeed — without org membership the user can't have
+        // their role managed, so treat failure as a fatal error.
         const organizationId = await getOrganizationId();
 
-        if (organizationId && result.data?.user?.id) {
+        if (!organizationId) {
+          throw new Error("Organization not configured. User was created but cannot be managed without an organization.");
+        }
+
+        if (result.data?.user?.id) {
           // Type assertion needed - addMember is provided by organizationClient but not fully typed
           const addMemberResult = await (authClient.organization as typeof authClient.organization & {
             addMember: (params: { userId: string; organizationId: string; role: string }) => Promise<{ error?: { message?: string } }>
@@ -153,12 +159,8 @@ export default function RosterTable({ user }: { user: User }) {
           });
 
           if (addMemberResult.error) {
-            console.error("Failed to add user to organization:", addMemberResult.error);
-            // Don't fail the whole operation, but log the warning
-            toast.warning("User created but could not be added to organization. Role management may not work.");
+            throw new Error(addMemberResult.error.message || "Failed to add user to organization. Role management will not work.");
           }
-        } else if (!organizationId) {
-          console.warn("Organization ID not configured, user created without organization membership");
         }
 
         toast.success(`Account created successfully for ${newAccount.username}`);

--- a/src/components/experiences/modern/admin/roster/__tests__/RosterTable.test.tsx
+++ b/src/components/experiences/modern/admin/roster/__tests__/RosterTable.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithProviders, createTestUser } from "@/lib/test-utils";
+import { Authorization } from "@/lib/features/admin/types";
+import { adminSlice } from "@/lib/features/admin/frontend";
+import { makeStore } from "@/lib/store";
+
+const mockCreateUser = vi.fn();
+const mockUpdateUser = vi.fn();
+const mockAddMember = vi.fn();
+const mockGetFullOrganization = vi.fn();
+const mockRefetch = vi.fn();
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: {
+    admin: {
+      createUser: (...args: unknown[]) => mockCreateUser(...args),
+      listUsers: vi.fn().mockResolvedValue({ data: { users: [], total: 0 } }),
+      updateUser: (...args: unknown[]) => mockUpdateUser(...args),
+    },
+    organization: {
+      getFullOrganization: (...args: unknown[]) => mockGetFullOrganization(...args),
+      addMember: (...args: unknown[]) => mockAddMember(...args),
+      listMembers: vi.fn().mockResolvedValue({ data: { members: [] } }),
+    },
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@/src/hooks/adminHooks", () => ({
+  useAccountListResults: () => ({
+    data: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: mockRefetch,
+  }),
+}));
+
+import { toast } from "sonner";
+import RosterTable from "../RosterTable";
+
+const stationManager = createTestUser({
+  username: "test_sm",
+  authority: Authorization.SM,
+});
+
+describe("RosterTable account creation", () => {
+  let store: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = makeStore();
+
+    // Default: organization resolves successfully
+    mockGetFullOrganization.mockResolvedValue({
+      data: { id: "test-org-id" },
+    });
+
+    // Default: createUser succeeds
+    mockCreateUser.mockResolvedValue({
+      data: { user: { id: "new-user-id" } },
+    });
+
+    // Default: updateUser (email verification) succeeds
+    mockUpdateUser.mockResolvedValue({ data: {} });
+
+    // Default: refetch resolves
+    mockRefetch.mockResolvedValue(undefined);
+
+    // Set NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD for the component
+    vi.stubEnv("NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD", "temppass123");
+    vi.stubEnv("NEXT_PUBLIC_APP_ORGANIZATION", "test-org");
+  });
+
+  async function openFormAndSubmit(user: ReturnType<typeof renderWithProviders>["user"]) {
+    // Open the new account form
+    store.dispatch(adminSlice.actions.setAdding(true));
+
+    // Wait for the form to render
+    const nameInput = await screen.findByPlaceholderText("Name");
+    const usernameInput = screen.getByPlaceholderText("Username");
+    const emailInput = screen.getByPlaceholderText("Email");
+    const saveButton = screen.getByRole("button", { name: /save/i });
+
+    await user.type(nameInput, "Juana Molina");
+    await user.type(usernameInput, "jmolina");
+    await user.type(emailInput, "jmolina@wxyc.org");
+    await user.click(saveButton);
+  }
+
+  it("should show error toast when addMember fails", async () => {
+    mockAddMember.mockResolvedValue({
+      error: { message: "User could not be added to organization" },
+    });
+
+    const { user } = renderWithProviders(<RosterTable user={stationManager} />, { store });
+    await openFormAndSubmit(user);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("should show success toast when addMember succeeds", async () => {
+    mockAddMember.mockResolvedValue({ data: { id: "member-id" } });
+
+    const { user } = renderWithProviders(<RosterTable user={stationManager} />, { store });
+    await openFormAndSubmit(user);
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        expect.stringContaining("jmolina")
+      );
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("should show error toast when organization ID is not configured", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_ORGANIZATION", "");
+    mockGetFullOrganization.mockResolvedValue({ data: null });
+
+    const { user } = renderWithProviders(<RosterTable user={stationManager} />, { store });
+    await openFormAndSubmit(user);
+
+    await waitFor(() => {
+      // Without an organization, addMember is skipped — but the user is created
+      // without org membership, which means role management won't work.
+      // The current behavior shows success, but this should be an error.
+      expect(toast.error).toHaveBeenCalled();
+    });
+
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #409

## Summary

- Make `addMember()` failure throw instead of showing a warning toast that gets immediately covered by the success toast
- Make missing organization ID throw instead of silently creating users without org membership
- Add unit tests for account creation error handling (`RosterTable.test.tsx`)

## Context

When an admin creates a new user through the roster, `addMember()` failure was silently swallowed — the admin saw "Account created successfully" but the user wasn't added to the organization. This meant role changes, email updates, and other admin operations would silently fail because `resolveMemberId()` couldn't find the user in the organization member list.

Discovered while investigating E2E failures in #394 — role-modification tests that create temp users and then change their roles would see no success toast after the role change.

## Test plan

- [ ] Unit tests pass: `npx vitest run src/components/experiences/modern/admin/roster/__tests__/RosterTable.test.tsx`
- [ ] Full test suite passes: `npm run test:run`
- [ ] Manual: create a user in the roster — verify success toast appears
- [ ] Manual: if `addMember` fails (e.g., disconnect backend mid-request) — verify error toast appears instead of success