### PR TITLE
Scope CI tests to changed code on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,18 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - 'app/**'
+      - 'src/**'
+      - 'lib/**'
+      - 'tests/**'
+      - 'public/**'
+      - '*.ts'
+      - '*.tsx'
+      - '*.mts'
+      - '*.json'
+      - '*.config.*'
+      - '.github/workflows/ci.yml'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -51,6 +63,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Fetch base branch for change detection
+        if: github.event_name == 'pull_request'
+        run: git fetch origin main --depth=1
+
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
@@ -63,7 +79,12 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Run unit tests
-        run: npx vitest run --shard=${{ matrix.shard }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            npx vitest run --changed origin/main --shard=${{ matrix.shard }}
+          else
+            npx vitest run --shard=${{ matrix.shard }}
+          fi
 
   build:
     name: Build

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,6 +5,18 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - 'app/**'
+      - 'src/**'
+      - 'lib/features/**'
+      - 'lib/store.ts'
+      - 'lib/hooks.ts'
+      - 'e2e/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'next.config.*'
+      - 'playwright.config.*'
+      - '.github/workflows/e2e-tests.yml'
   workflow_dispatch:
     inputs:
       backend_ref:


### PR DESCRIPTION
## Summary

- Add path filters to CI and E2E workflows so they skip entirely for non-code PR changes
- Use `vitest --changed origin/main` on PRs to only run tests affected by the diff
- Pushes to `main` still run the full test suite for regression coverage

Closes #416

## Test plan

- [x] Validated workflow YAML with `act -n` dry runs for all jobs
- [x] Verified `pull_request` event includes the "Fetch base branch" step and `--changed` flag
- [x] Verified `push` event skips the fetch step and runs full `vitest run`
- [ ] Merge a docs-only PR to confirm CI is skipped
- [ ] Merge a single-feature PR to confirm only affected tests run