### PR TITLE
Replace fragile getFullOrganization calls with resolve-organization endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,7 @@ Cloudflare Pages via OpenNext. Build: `npm run build:opennext`. Deploy: `npm run
 - **No ESLint/Prettier config**: No formatter or linter configuration files exist at the project level. Follow existing code style
 - **Strict TypeScript**: `strict: true` in tsconfig
 - **Onboarding completeness**: Tracked via the `hasCompletedOnboarding` boolean on the user record, not by presence of profile fields (`realName`/`djName`). This allows admins to pre-fill profile fields when creating accounts without bypassing onboarding. The `isUserIncomplete()` function in `server-utils.ts` checks this flag; `getIncompleteUserAttributes()` still inspects `realName`/`djName` to determine which form fields to render during onboarding.
+- **Admin org resolution**: Admin pages (roster, role management) resolve the org slug to its UUID via `resolveOrganizationIdAdmin()` in `lib/features/authentication/organization-utils.ts`. This calls `GET /auth/admin/resolve-organization` on Backend-Service instead of the fragile `getFullOrganization` SDK method. The result is cached for the page session.
 
 ## Related Repos
 

--- a/lib/__tests__/features/authentication/organization-utils.test.ts
+++ b/lib/__tests__/features/authentication/organization-utils.test.ts
@@ -22,9 +22,9 @@ vi.mock("@/lib/features/authentication/client", () => ({
   },
 }));
 
-// Mock fetch for organization slug resolution
+// Mock fetch for organization slug resolution (used by server-side tests)
 const mockFetch = vi.fn();
-global.fetch = mockFetch;
+vi.stubGlobal("fetch", mockFetch);
 
 import {
   getAppOrganizationId,
@@ -349,4 +349,5 @@ describe("organization-utils", () => {
       expect(result).toBeUndefined();
     });
   });
+
 });

--- a/lib/features/authentication/organization-utils.ts
+++ b/lib/features/authentication/organization-utils.ts
@@ -1,6 +1,41 @@
-import { authClient } from "./client";
+import { authClient, authBaseURL } from "./client";
 import { getAppOrganizationId, getAppOrganizationIdClient } from "./organization-config";
 import { WXYCRole } from "./types";
+
+/**
+ * Module-level cache for the organization ID resolved via the admin endpoint.
+ * The slug-to-ID mapping is stable (WXYC has a single org) so no TTL is needed.
+ * Resets on page reload.
+ */
+let cachedAdminOrgId: string | null = null;
+
+/**
+ * Resolve the configured organization slug to its UUID via the admin endpoint.
+ * Caches the result for the page session. For use in admin contexts only (roster,
+ * role management) — requires the current user to have an admin session.
+ *
+ * @returns The organization UUID, or null if the slug is not configured or resolution fails.
+ */
+export async function resolveOrganizationIdAdmin(): Promise<string | null> {
+  if (cachedAdminOrgId) return cachedAdminOrgId;
+
+  const slug = process.env.NEXT_PUBLIC_APP_ORGANIZATION;
+  if (!slug) return null;
+
+  try {
+    const response = await fetch(
+      `${authBaseURL}/admin/resolve-organization?slug=${encodeURIComponent(slug)}`,
+      { credentials: "include" }
+    );
+
+    if (!response.ok) return null;
+    const data = await response.json();
+    cachedAdminOrgId = data.id;
+    return cachedAdminOrgId;
+  } catch {
+    return null;
+  }
+}
 
 // Re-export for existing consumers
 export { getAppOrganizationId, getAppOrganizationIdClient };

--- a/src/components/experiences/modern/admin/roster/AccountEntry.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEntry.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { authClient } from "@/lib/features/authentication/client";
-import { getAppOrganizationIdClient } from "@/lib/features/authentication/organization-utils";
+import { resolveOrganizationIdAdmin } from "@/lib/features/authentication/organization-utils";
 import {
   Account,
   Authorization,
@@ -179,29 +179,14 @@ export const AccountEntry = ({
   };
 
   /**
-   * Resolve organization slug to organization ID
+   * Resolve organization slug to organization ID via the admin endpoint.
    */
   const resolveOrganizationId = async (): Promise<string> => {
-    // Use NEXT_PUBLIC_APP_ORGANIZATION directly - inlined at build time by Next.js
-    const orgSlugOrId = process.env.NEXT_PUBLIC_APP_ORGANIZATION || getAppOrganizationIdClient();
-
-    if (!orgSlugOrId) {
-      throw new Error("Organization not configured (NEXT_PUBLIC_APP_ORGANIZATION not set)");
+    const orgId = await resolveOrganizationIdAdmin();
+    if (!orgId) {
+      throw new Error("Organization not configured");
     }
-
-    // Try to resolve slug to ID
-    const orgResult = await authClient.organization.getFullOrganization({
-      query: {
-        organizationSlug: orgSlugOrId,
-      },
-    });
-
-    if (orgResult.data?.id) {
-      return orgResult.data.id;
-    }
-
-    // If slug lookup fails, assume it's already an ID
-    return orgSlugOrId;
+    return orgId;
   };
 
   /**

--- a/src/hooks/adminHooks.test.ts
+++ b/src/hooks/adminHooks.test.ts
@@ -14,10 +14,15 @@ vi.mock("@/lib/features/authentication/client", () => ({
       listUsers: vi.fn(),
     },
     organization: {
-      getFullOrganization: vi.fn(),
       listMembers: vi.fn(),
     },
   },
+}));
+
+// Mock the organization-utils module for resolveOrganizationIdAdmin
+const mockResolveOrganizationIdAdmin = vi.fn();
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  resolveOrganizationIdAdmin: (...args: unknown[]) => mockResolveOrganizationIdAdmin(...args),
 }));
 
 import { authClient } from "@/lib/features/authentication/client";
@@ -216,5 +221,44 @@ describe("useAccountListResults", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.isError).toBe(false);
     expect(result.current.data).toHaveLength(0);
+  });
+
+  it("merges org member roles when resolveOrganizationIdAdmin returns an ID", async () => {
+    const users = [betterAuthUser(MOCK_USERS.dj1, { role: "user" })];
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
+    mockResolveOrganizationIdAdmin.mockResolvedValue("org-uuid-123");
+    vi.mocked(authClient.organization.listMembers).mockResolvedValue({
+      data: {
+        members: [{ userId: MOCK_USERS.dj1.id, role: "musicDirector" }],
+      },
+      error: null,
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountListResults(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data[0].authorization).toBe(Authorization.MD);
+    expect(authClient.organization.listMembers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ organizationId: "org-uuid-123" }),
+      })
+    );
+  });
+
+  it("loads accounts without org role overrides when resolveOrganizationIdAdmin returns null", async () => {
+    const users = [betterAuthUser(MOCK_USERS.dj1)];
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
+    mockResolveOrganizationIdAdmin.mockResolvedValue(null);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountListResults(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data).toHaveLength(1);
+    // Falls back to user-level role
+    expect(result.current.data[0].authorization).toBe(Authorization.DJ);
+    expect(authClient.organization.listMembers).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/adminHooks.ts
+++ b/src/hooks/adminHooks.ts
@@ -3,31 +3,10 @@ import { adminSlice } from "@/lib/features/admin/frontend";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { convertBetterAuthToAccountResult, BetterAuthUser } from "@/lib/features/admin/conversions-better-auth";
 import { Account, ROSTER_PAGE_SIZE } from "@/lib/features/admin/types";
+import { resolveOrganizationIdAdmin } from "@/lib/features/authentication/organization-utils";
 import { useEffect, useState, useCallback } from "react";
 import { throwIfBetterAuthError } from "@/src/utilities/throwIfBetterAuthError";
 import { useDebouncedValue } from "@/src/hooks/useDebouncedValue";
-
-/**
- * Get the organization ID from environment variable
- */
-async function getOrganizationId(): Promise<string | null> {
-  const orgSlugOrId = process.env.NEXT_PUBLIC_APP_ORGANIZATION;
-  if (!orgSlugOrId) {
-    return null;
-  }
-
-  const orgResult = await authClient.organization.getFullOrganization({
-    query: {
-      organizationSlug: orgSlugOrId,
-    },
-  });
-
-  if (orgResult.data?.id) {
-    return orgResult.data.id;
-  }
-
-  return orgSlugOrId;
-}
 
 export const useAccountListResults = () => {
   const [accounts, setAccounts] = useState<Account[]>([]);
@@ -87,7 +66,7 @@ export const useAccountListResults = () => {
 
       // Fetch organization members to get accurate roles
       let memberRoleMap = new Map<string, string>();
-      const organizationId = await getOrganizationId();
+      const organizationId = await resolveOrganizationIdAdmin();
 
       if (organizationId) {
         const membersResult = await authClient.organization.listMembers({


### PR DESCRIPTION
## Summary

- Add `resolveOrganizationIdAdmin()` to `organization-utils.ts` — calls `GET /auth/admin/resolve-organization` on Backend-Service, caches the result for the page session
- Replace `getOrganizationId()` in `adminHooks.ts` with the shared utility
- Replace `resolveOrganizationId()` in `AccountEntry.tsx` with the shared utility
- Add unit tests for org role merging and null-org graceful degradation

Closes #420

## Context

After #415 replaced user creation with `provision-user`, two admin call sites still used `getFullOrganization` to resolve the org slug. That SDK method requires `orgSessionMiddleware` and silently falls back to the raw slug on failure, causing `listMembers`/`updateMemberRole` to fail with `ORGANIZATION_NOT_FOUND`.

## Dependencies

WXYC/Backend-Service#422 must merge first — the `resolve-organization` endpoint this PR depends on. The dj-site E2E tests check out Backend-Service from `main`, so E2E will fail until the backend PR is merged.

## Test plan

- [x] TypeScript type check passes
- [x] All 2455 unit tests pass (including 2 new org resolution tests)
- [ ] E2E tests pass (requires WXYC/Backend-Service#422 on `main` first)