### PR TITLE
Enable entry-caching E2E tests

### DIFF
--- a/e2e/pages/flowsheet.page.ts
+++ b/e2e/pages/flowsheet.page.ts
@@ -169,6 +169,12 @@ export class FlowsheetPage {
     method: "button" | "enter" = "button"
   ): Promise<void> {
     await this.fillSearchForm(data);
+    // Register response listener BEFORE submitting so we don't miss the POST
+    // if it completes while we're waiting for the form to clear.
+    const responsePromise = this.page.waitForResponse(
+      (r) => r.url().includes("/flowsheet") && r.request().method() === "POST" && r.status() < 300,
+      { timeout: 15000 }
+    );
     if (method === "button") {
       await this.submitViaButton();
     } else {
@@ -179,11 +185,7 @@ export class FlowsheetPage {
     // was initiated (though not necessarily that the response has arrived).
     await expect(this.songInput).toHaveValue("", { timeout: 10000 });
     // Wait for the POST response to confirm the entry is persisted on the server.
-    // Without this, expectEntryWithText could race ahead of the mutation.
-    await this.page.waitForResponse(
-      (r) => r.url().includes("/flowsheet") && r.request().method() === "POST" && r.status() < 300,
-      { timeout: 10000 }
-    );
+    await responsePromise;
   }
 
   // --- Entry locators ---

--- a/e2e/tests/flowsheet/entry-caching.spec.ts
+++ b/e2e/tests/flowsheet/entry-caching.spec.ts
@@ -53,11 +53,7 @@ test.describe("Flowsheet Entry Caching", () => {
   // 1. Basic add behavior
   // ---------------------------------------------------------------
   test.describe("1. Basic add behavior", () => {
-    // FIXME: RTK Query infiniteQuery tag invalidation refetches fresh data
-    // from the server but does not update the rendered entry list. The entry
-    // is persisted (POST 201) and returned by the API, but the component
-    // keeps rendering stale cached pages. See PR #306.
-    test.fixme("should add entry via submit button click", async ({ page }) => {
+    test("should add entry via submit button click", async ({ page }) => {
       const trackName = `Button Add ${ts}`;
 
       await flowsheet.addTrack(
@@ -68,7 +64,7 @@ test.describe("Flowsheet Entry Caching", () => {
       await flowsheet.expectEntryWithText(trackName);
     });
 
-    test.fixme("should add entry via Enter key", async ({ page }) => {
+    test("should add entry via Enter key", async ({ page }) => {
       const trackName = `Enter Add ${ts}`;
 
       await flowsheet.addTrack(
@@ -84,7 +80,7 @@ test.describe("Flowsheet Entry Caching", () => {
   // 2. Consistency across multiple attempts
   // ---------------------------------------------------------------
   test.describe("2. Consistency", () => {
-    test.fixme("all tracks appear after adding 12 entries", async ({ page }) => {
+    test("all tracks appear after adding 12 entries", async ({ page }) => {
       test.slow(); // This test adds many entries
 
       const trackCount = 12;
@@ -116,7 +112,7 @@ test.describe("Flowsheet Entry Caching", () => {
     // hang after many entries accumulate in the cache. Investigate as a follow-up
     // to PR #306 -- the mutation's onQueryStarted may have a race condition with
     // the infinite query cache when pages.length > 1.
-    test.fixme("quick successive adds maintain order with no duplicates", async ({
+    test("quick successive adds maintain order with no duplicates", async ({
       page,
     }) => {
       test.slow(); // Rapid adds need extra time budget
@@ -172,7 +168,7 @@ test.describe("Flowsheet Entry Caching", () => {
     // submission when POST is delayed. Investigate whether onQueryStarted's
     // buildOptimisticEntry + insertEntrySortedFirstPage actually runs before
     // the route interception delays the network request.
-    test.fixme("entry appears immediately under throttled network", async ({
+    test("entry appears immediately under throttled network", async ({
       page,
     }) => {
       const trackName = `Optimistic ${ts}`;
@@ -225,7 +221,7 @@ test.describe("Flowsheet Entry Caching", () => {
   test.describe("5. Page load timing", () => {
     // TODO: The entries GET delay route may be intercepting the flowsheet POST
     // as well, causing the add mutation to hang. Needs URL pattern refinement.
-    test.fixme("can add track before entry list fully loads", async ({ page }) => {
+    test("can add track before entry list fully loads", async ({ page }) => {
       // Set up a route to delay entries loading BEFORE navigating
       await page.route("**/flowsheet/?page=0**", async (route) => {
         if (route.request().method() === "GET") {
@@ -256,7 +252,7 @@ test.describe("Flowsheet Entry Caching", () => {
   // 6. Edit behavior
   // ---------------------------------------------------------------
   test.describe("6. Edit behavior", () => {
-    test.fixme("edit appears immediately and persists after refresh", async ({
+    test("edit appears immediately and persists after refresh", async ({
       page,
     }) => {
       const originalTitle = `Editable ${ts}`;
@@ -310,7 +306,7 @@ test.describe("Flowsheet Entry Caching", () => {
   test.describe("7. Multiple tabs", () => {
     // TODO: Same add-mutation hang as rapid/slow-network tests. New browser
     // contexts start with empty cache; after 20+ DB entries the mutation hangs.
-    test.fixme("entry added in one tab appears in another after refresh", async ({
+    test("entry added in one tab appears in another after refresh", async ({
       browser,
     }) => {
       test.slow(); // Multi-context test needs extra time
@@ -361,7 +357,7 @@ test.describe("Flowsheet Entry Caching", () => {
   // 8. Live / Go Live interaction
   // ---------------------------------------------------------------
   test.describe("8. Live toggle interaction", () => {
-    test.fixme("can add track immediately after going live", async ({ page }) => {
+    test("can add track immediately after going live", async ({ page }) => {
       // Leave first so we can test the go-live -> add flow
       await flowsheet.leave();
       isLive = false;

--- a/e2e/tests/flowsheet/entry-caching.spec.ts
+++ b/e2e/tests/flowsheet/entry-caching.spec.ts
@@ -22,16 +22,18 @@ test.describe("Flowsheet Entry Caching", () => {
   test.setTimeout(60_000);
 
   let flowsheet: FlowsheetPage;
-  let isLive = false;
   const ts = Date.now();
 
   test.beforeEach(async ({ page }) => {
     flowsheet = new FlowsheetPage(page);
     await flowsheet.goto();
     await flowsheet.waitForEntriesLoaded();
-    if (!isLive) {
+    // Check actual page state rather than a module-level flag, which desyncs
+    // when Playwright retries the serial suite in a fresh worker while the DJ
+    // is still live server-side from the previous attempt.
+    const status = await flowsheet.liveStatus.textContent({ timeout: 3000 }).catch(() => "");
+    if (!status?.includes("On Air")) {
       await flowsheet.goLive();
-      isLive = true;
     }
   });
 
@@ -108,11 +110,10 @@ test.describe("Flowsheet Entry Caching", () => {
   // 3. Rapid input
   // ---------------------------------------------------------------
   test.describe("3. Rapid input", () => {
-    // TODO: This test surfaces a potential issue where addToFlowsheet mutations
-    // hang after many entries accumulate in the cache. Investigate as a follow-up
-    // to PR #306 -- the mutation's onQueryStarted may have a race condition with
+    // FIXME: addToFlowsheet mutations hang after many entries accumulate in
+    // the cache. The mutation's onQueryStarted may have a race condition with
     // the infinite query cache when pages.length > 1.
-    test("quick successive adds maintain order with no duplicates", async ({
+    test.fixme("quick successive adds maintain order with no duplicates", async ({
       page,
     }) => {
       test.slow(); // Rapid adds need extra time budget
@@ -164,11 +165,11 @@ test.describe("Flowsheet Entry Caching", () => {
   // 4. Slow network conditions (optimistic update)
   // ---------------------------------------------------------------
   test.describe("4. Slow network", () => {
-    // TODO: Optimistic entry does not appear in entry list within 2s of
+    // FIXME: Optimistic entry does not appear in entry list within 2s of
     // submission when POST is delayed. Investigate whether onQueryStarted's
     // buildOptimisticEntry + insertEntrySortedFirstPage actually runs before
     // the route interception delays the network request.
-    test("entry appears immediately under throttled network", async ({
+    test.fixme("entry appears immediately under throttled network", async ({
       page,
     }) => {
       const trackName = `Optimistic ${ts}`;
@@ -219,9 +220,9 @@ test.describe("Flowsheet Entry Caching", () => {
   // 5. Page load timing
   // ---------------------------------------------------------------
   test.describe("5. Page load timing", () => {
-    // TODO: The entries GET delay route may be intercepting the flowsheet POST
+    // FIXME: The entries GET delay route may be intercepting the flowsheet POST
     // as well, causing the add mutation to hang. Needs URL pattern refinement.
-    test("can add track before entry list fully loads", async ({ page }) => {
+    test.fixme("can add track before entry list fully loads", async ({ page }) => {
       // Set up a route to delay entries loading BEFORE navigating
       await page.route("**/flowsheet/?page=0**", async (route) => {
         if (route.request().method() === "GET") {
@@ -304,9 +305,9 @@ test.describe("Flowsheet Entry Caching", () => {
   // 7. Multiple tabs
   // ---------------------------------------------------------------
   test.describe("7. Multiple tabs", () => {
-    // TODO: Same add-mutation hang as rapid/slow-network tests. New browser
+    // FIXME: Same add-mutation hang as rapid/slow-network tests. New browser
     // contexts start with empty cache; after 20+ DB entries the mutation hangs.
-    test("entry added in one tab appears in another after refresh", async ({
+    test.fixme("entry added in one tab appears in another after refresh", async ({
       browser,
     }) => {
       test.slow(); // Multi-context test needs extra time
@@ -360,12 +361,10 @@ test.describe("Flowsheet Entry Caching", () => {
     test("can add track immediately after going live", async ({ page }) => {
       // Leave first so we can test the go-live -> add flow
       await flowsheet.leave();
-      isLive = false;
       await flowsheet.expectOffAir();
 
       // Go live and immediately add a track
       await flowsheet.goLive();
-      isLive = true;
 
       const trackName = `Post-Live ${ts}`;
       await flowsheet.addTrack({

--- a/e2e/tests/flowsheet/library-search-proxy.spec.ts
+++ b/e2e/tests/flowsheet/library-search-proxy.spec.ts
@@ -16,8 +16,10 @@ const authDir = path.join(__dirname, "../../.auth");
  * tests use serial mode and go live in the first test.
  */
 test.describe("Library Search Proxy", () => {
-  // Use dj2 to avoid session conflicts with auth tests that use dj.json
-  test.use({ storageState: path.join(authDir, "dj2.json") });
+  // Use musicDirector to avoid live-state conflicts with entry-caching tests
+  // (which toggle dj2 live/off-air) and session conflicts with auth tests
+  // (which invalidate dj.json).
+  test.use({ storageState: path.join(authDir, "musicDirector.json") });
   test.describe.configure({ mode: "serial" });
   test.setTimeout(60_000);
 
@@ -36,7 +38,7 @@ test.describe("Library Search Proxy", () => {
 
   test.afterAll(async ({ browser }) => {
     const context = await browser.newContext({
-      storageState: path.join(authDir, "dj2.json"),
+      storageState: path.join(authDir, "musicDirector.json"),
       baseURL: process.env.E2E_BASE_URL || "http://localhost:3000",
     });
     const page = await context.newPage();


### PR DESCRIPTION
## Summary

- Enables 5 of 9 entry-caching E2E tests (1, 2, 6, 8, and the basic add tests) now that the infiniteQuery cache fix (#306) has merged
- Keeps tests 3, 4, 5, 7 as `.fixme()` — they have separate known issues (mutation hang with large cache, optimistic updates, route interception patterns) unrelated to the #306 cache fix
- Fixes `addTrack` page object race condition: registers `waitForResponse` before submission so the POST response can't be missed
- Fixes parallel safety: moves `library-search-proxy.spec.ts` from `dj2.json` to `musicDirector.json` to avoid live-state conflicts with entry-caching (which toggles dj2 live/off-air)
- Fixes `isLive` desync on retry: replaces module-level flag with actual page state check, preventing `goLive()` from toggling an already-live DJ off-air when Playwright retries in a fresh worker

## Parallel safety verification

- **Session isolation**: entry-caching uses `dj2.json`; `auth/logout.spec.ts` uses `dj.json` — no session conflict
- **Live-state isolation**: `library-search-proxy` moved to `musicDirector.json` — no live toggle conflict with entry-caching's dj2
- **Other `dj2.json` consumers**: `role-access`, `album-detail`, `audio-stream` are read-only — no flowsheet mutation or live-state conflict
- **Serial mode**: Tests within entry-caching run serially (shared show state), which is correct
- **Cleanup**: `afterAll` calls `ensureOffAir()` to leave dj2 off-air for subsequent test files

Closes #422

## Test plan

- [x] E2E CI passes with 5 tests enabled and 4 remaining fixme
- [x] No flaky failures from parallel test files using `dj2.json`
- [x] `library-search-proxy` passes with `musicDirector.json`