### PR TITLE
fix: improve onboarding UX and make DJ Name optional

### DIFF
--- a/app/login/@modern/@newuser/page.tsx
+++ b/app/login/@modern/@newuser/page.tsx
@@ -2,8 +2,6 @@ import { IncompleteUser } from "@/lib/features/authentication/types";
 import { createServerSideProps } from "@/lib/features/session";
 import AuthBackButton from "@/src/components/experiences/modern/login/Forms/AuthBackButton";
 import NewUserForm from "@/src/components/experiences/modern/login/Forms/NewUserForm";
-import HoldOnQuotes from "@/src/components/experiences/modern/login/Quotes/HoldOn";
-
 export default async function NewUserPage() {
   const resetData = (await createServerSideProps())
     .authentication as IncompleteUser;
@@ -11,7 +9,6 @@ export default async function NewUserPage() {
   return (
     <>
       <AuthBackButton text="Login with a different account" />
-      <HoldOnQuotes />
       <NewUserForm {...resetData} />
     </>
   );

--- a/lib/__tests__/features/authentication/server-utils.test.ts
+++ b/lib/__tests__/features/authentication/server-utils.test.ts
@@ -374,22 +374,22 @@ describe("server-utils", () => {
       expect(result).not.toContain("djName");
     });
 
-    it("should return djName when only djName is missing", () => {
+    it("should not return djName when only djName is missing (djName is optional)", () => {
       const session = createTestIncompleteSession(["djName"]);
 
       const result = getIncompleteUserAttributes(session);
 
-      expect(result).toContain("djName");
+      expect(result).not.toContain("djName");
       expect(result).not.toContain("realName");
     });
 
-    it("should return both realName and djName when both are missing", () => {
+    it("should return only realName when both realName and djName are missing (djName is optional)", () => {
       const session = createTestIncompleteSession(["realName", "djName"]);
 
       const result = getIncompleteUserAttributes(session);
 
       expect(result).toContain("realName");
-      expect(result).toContain("djName");
+      expect(result).not.toContain("djName");
     });
 
     it("should detect empty string realName as missing", () => {

--- a/lib/__tests__/features/authentication/user-completeness.test.ts
+++ b/lib/__tests__/features/authentication/user-completeness.test.ts
@@ -101,25 +101,25 @@ describe("getIncompleteUserAttributes", () => {
     expect(result).not.toContain("djName");
   });
 
-  it("should return djName when missing", () => {
+  it("should not return djName when missing (djName is optional)", () => {
     const session = createTestIncompleteSession(["djName"]);
 
     const result = getIncompleteUserAttributes(session);
 
-    expect(result).toContain("djName");
+    expect(result).not.toContain("djName");
     expect(result).not.toContain("realName");
   });
 
-  it("should return both when both are missing", () => {
+  it("should return only realName when both are missing (djName is optional)", () => {
     const session = createTestIncompleteSession(["realName", "djName"]);
 
     const result = getIncompleteUserAttributes(session);
 
     expect(result).toContain("realName");
-    expect(result).toContain("djName");
+    expect(result).not.toContain("djName");
   });
 
-  it("should detect empty string as missing", () => {
+  it("should detect empty string realName as missing but not djName (djName is optional)", () => {
     const session = createTestBetterAuthSession({
       user: {
         id: "test-id",
@@ -134,10 +134,10 @@ describe("getIncompleteUserAttributes", () => {
     const result = getIncompleteUserAttributes(session);
 
     expect(result).toContain("realName");
-    expect(result).toContain("djName");
+    expect(result).not.toContain("djName");
   });
 
-  it("should detect whitespace-only strings as missing", () => {
+  it("should detect whitespace-only realName as missing but not djName (djName is optional)", () => {
     const session = createTestBetterAuthSession({
       user: {
         id: "test-id",
@@ -152,6 +152,6 @@ describe("getIncompleteUserAttributes", () => {
     const result = getIncompleteUserAttributes(session);
 
     expect(result).toContain("realName");
-    expect(result).toContain("djName");
+    expect(result).not.toContain("djName");
   });
 });

--- a/lib/__tests__/features/authentication/utilities.test.ts
+++ b/lib/__tests__/features/authentication/utilities.test.ts
@@ -89,17 +89,17 @@ describe("authentication utilities", () => {
       expect((result as any).requiredAttributes).toContain("realName");
     });
 
-    it("should identify incomplete users missing djName", () => {
+    it("should not include djName in required attributes (it is optional)", () => {
       const session = createTestIncompleteSession(["djName"]);
       const result = betterAuthSessionToAuthenticationData(session);
-      expect((result as any).requiredAttributes).toContain("djName");
+      expect((result as any).requiredAttributes).not.toContain("djName");
     });
 
-    it("should identify incomplete users missing both realName and djName", () => {
+    it("should only include realName when both realName and djName are missing", () => {
       const session = createTestIncompleteSession(["realName", "djName"]);
       const result = betterAuthSessionToAuthenticationData(session);
       expect((result as any).requiredAttributes).toContain("realName");
-      expect((result as any).requiredAttributes).toContain("djName");
+      expect((result as any).requiredAttributes).not.toContain("djName");
     });
 
     it("should treat empty string realName as incomplete when hasCompletedOnboarding is false", () => {

--- a/lib/features/authentication/server-utils.ts
+++ b/lib/features/authentication/server-utils.ts
@@ -153,9 +153,7 @@ export function getIncompleteUserAttributes(session: BetterAuthSession): (keyof 
     missingAttributes.push("realName");
   }
 
-  if (!session.user.djName || session.user.djName.trim() === "") {
-    missingAttributes.push("djName");
-  }
+  // djName is optional — not included in required attributes
 
   return missingAttributes;
 }

--- a/lib/features/authentication/utilities.ts
+++ b/lib/features/authentication/utilities.ts
@@ -113,9 +113,7 @@ export function betterAuthSessionToAuthenticationData(
     if (!session.user.realName || session.user.realName.trim() === "") {
       missingAttributes.push("realName");
     }
-    if (!session.user.djName || session.user.djName.trim() === "") {
-      missingAttributes.push("djName");
-    }
+    // djName is optional — not included in required attributes
     return {
       username,
       requiredAttributes: missingAttributes,
@@ -210,9 +208,7 @@ export async function betterAuthSessionToAuthenticationDataAsync(
     if (!session.user.realName || session.user.realName.trim() === "") {
       missingAttributes.push("realName");
     }
-    if (!session.user.djName || session.user.djName.trim() === "") {
-      missingAttributes.push("djName");
-    }
+    // djName is optional — not included in required attributes
     return {
       username,
       requiredAttributes: missingAttributes,

--- a/src/Layout/Background.tsx
+++ b/src/Layout/Background.tsx
@@ -39,7 +39,7 @@ export function BackgroundBox({ children }: { children: ReactNode }) {
         transitionDelay: "calc(var(--Transition-duration) + 0.1s)",
         position: "relative",
         zIndex: 1,
-        height: "100%",
+        minHeight: "100%",
         display: "flex",
         justifyContent: "flex-end",
         backdropFilter: "blur(4px)",

--- a/src/Layout/Header.tsx
+++ b/src/Layout/Header.tsx
@@ -21,12 +21,11 @@ export default function Header() {
     >
       <Box
         sx={{
-          height: "clamp(2rem, 10vw, 7rem)",
+          width: 150,
+          mx: "auto",
         }}
       >
         <Logo />
-      </Box>
-      <Box>
       </Box>
     </Box>
   );

--- a/src/Layout/WXYCPage.tsx
+++ b/src/Layout/WXYCPage.tsx
@@ -10,7 +10,7 @@ export default function WXYCPage({
   children: React.ReactNode;
 }) {
   return (
-    <Box sx={{ height: "100%" }} className="ignoreClassic">
+    <Box sx={{ minHeight: "100%" }} className="ignoreClassic">
       <BackgroundBox>
         <Header />
         <Main>{children}</Main>

--- a/src/components/experiences/modern/Leftbar/LeftbarLink.test.tsx
+++ b/src/components/experiences/modern/Leftbar/LeftbarLink.test.tsx
@@ -42,19 +42,20 @@ describe("LeftbarLink", () => {
     expect(screen.getByTestId("icon")).toBeInTheDocument();
   });
 
-  it("should be disabled when disabled prop is true", () => {
+  it("should not render as a link when disabled", () => {
     render(
       <LeftbarLink path="/dashboard/catalog" title="Catalog" disabled={true}>
         <span>Icon</span>
       </LeftbarLink>
     );
 
-    const link = screen.getByRole("link");
-    expect(link).toHaveAttribute("aria-disabled", "true");
-    expect(link).toHaveStyle({ pointerEvents: "none" });
+    // When disabled, ListItemButton does not get component: Link, so it renders as a button
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("aria-disabled", "true");
   });
 
-  it("should be enabled when disabled prop is false", () => {
+  it("should render as a link when not disabled", () => {
     render(
       <LeftbarLink path="/dashboard/catalog" title="Catalog" disabled={false}>
         <span>Icon</span>
@@ -62,8 +63,7 @@ describe("LeftbarLink", () => {
     );
 
     const link = screen.getByRole("link");
-    expect(link).toHaveAttribute("aria-disabled", "false");
-    expect(link).toHaveStyle({ pointerEvents: "auto" });
+    expect(link).toHaveAttribute("href", "/dashboard/catalog");
   });
 
   it("should show solid variant when path matches current pathname", async () => {
@@ -76,9 +76,9 @@ describe("LeftbarLink", () => {
       </LeftbarLink>
     );
 
-    // The ListItemButton should have solid variant when path matches
-    const button = screen.getByRole("button");
-    expect(button).toHaveClass("MuiListItemButton-variantSolid");
+    // The ListItemButton renders as a link when not disabled
+    const link = screen.getByRole("link");
+    expect(link).toHaveClass("MuiListItemButton-variantSolid");
   });
 
   it("should show plain variant when path does not match current pathname", async () => {
@@ -91,9 +91,9 @@ describe("LeftbarLink", () => {
       </LeftbarLink>
     );
 
-    // The ListItemButton should have plain variant when path doesn't match
-    const button = screen.getByRole("button");
-    expect(button).toHaveClass("MuiListItemButton-variantPlain");
+    // The ListItemButton renders as a link when not disabled
+    const link = screen.getByRole("link");
+    expect(link).toHaveClass("MuiListItemButton-variantPlain");
   });
 
   it("should render tooltip with title", () => {
@@ -103,7 +103,7 @@ describe("LeftbarLink", () => {
       </LeftbarLink>
     );
 
-    // Tooltip title is not directly visible but is in the DOM
-    expect(screen.getByRole("button")).toBeInTheDocument();
+    // The ListItemButton renders as a link when not disabled
+    expect(screen.getByRole("link")).toBeInTheDocument();
   });
 });

--- a/src/components/experiences/modern/Leftbar/LeftbarLink.tsx
+++ b/src/components/experiences/modern/Leftbar/LeftbarLink.tsx
@@ -14,26 +14,22 @@ export default function LeftbarLink(props: LeftbarLinkProps): JSX.Element {
   const pathname = usePathname();
 
   return (
-    <Link
-      aria-disabled={props.disabled}
-      href={props.path}
-      prefetch={props.disabled ? false : undefined}
-      style={{
-        pointerEvents: props.disabled ? "none" : "auto",
-      }}
-    >
-      <ListItem>
-        <Tooltip
-          title={props.title}
-          arrow={true}
-          placement="right"
-          size="sm"
-          variant="outlined"
+    <ListItem>
+      <Tooltip
+        title={props.title}
+        arrow={true}
+        placement="right"
+        size="sm"
+        variant="outlined"
+      >
+        <ListItemButton
+          disabled={props.disabled}
+          variant={pathname === props.path ? "solid" : "plain"}
+          {...(!props.disabled && {
+            component: Link,
+            href: props.path,
+          })}
         >
-          <ListItemButton
-            disabled={props.disabled}
-            variant={pathname === props.path ? "solid" : "plain"}
-          >
             <Badge
               anchorOrigin={{
                 vertical: "top",
@@ -48,6 +44,5 @@ export default function LeftbarLink(props: LeftbarLinkProps): JSX.Element {
           </ListItemButton>
         </Tooltip>
       </ListItem>
-    </Link>
   );
 }

--- a/src/components/experiences/modern/login/Forms/NewUserForm.tsx
+++ b/src/components/experiences/modern/login/Forms/NewUserForm.tsx
@@ -9,7 +9,7 @@ import {
 import { useAppDispatch } from "@/lib/hooks";
 import { useNewUser } from "@/src/hooks/authenticationHooks";
 import { isStrongPassword } from "@/src/utilities/passwordValidation";
-import { Typography } from "@mui/joy";
+import { FormControl, FormLabel, Input, Typography } from "@mui/joy";
 import { useEffect, useState } from "react";
 import RequiredBox from "./Fields/RequiredBox";
 import { ValidatedSubmitButton } from "./Fields/ValidatedSubmitButton";
@@ -50,6 +50,14 @@ export default function NewUserForm({
           disabled={authenticating}
         />
       ))}
+      <FormControl>
+        <FormLabel>DJ Name (optional)</FormLabel>
+        <Input
+          name="djName"
+          placeholder="DJ Name"
+          disabled={authenticating}
+        />
+      </FormControl>
       <RequiredBox
         name="password"
         title="New Password"

--- a/src/components/experiences/modern/login/Forms/OnboardingForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/OnboardingForm.test.tsx
@@ -73,7 +73,7 @@ describe("OnboardingForm", () => {
     expect(screen.getByText("Real Name")).toBeInTheDocument();
   });
 
-  it("should render DJ name input", () => {
+  it("should render DJ name input as optional", () => {
     const Wrapper = createWrapper();
     render(
       <Wrapper>
@@ -81,7 +81,7 @@ describe("OnboardingForm", () => {
       </Wrapper>
     );
 
-    expect(screen.getByText("DJ Name")).toBeInTheDocument();
+    expect(screen.getByText("DJ Name (optional)")).toBeInTheDocument();
   });
 
   it("should render password input with requirements", () => {
@@ -150,6 +150,6 @@ describe("OnboardingForm", () => {
 
     // Form should render with provided values
     expect(screen.getByText("Real Name")).toBeInTheDocument();
-    expect(screen.getByText("DJ Name")).toBeInTheDocument();
+    expect(screen.getByText("DJ Name (optional)")).toBeInTheDocument();
   });
 });

--- a/src/components/experiences/modern/login/Forms/OnboardingForm.tsx
+++ b/src/components/experiences/modern/login/Forms/OnboardingForm.tsx
@@ -56,7 +56,7 @@ export default function OnboardingForm({
         initialValue={realName}
       />
       <FormControl>
-        <FormLabel>DJ Name</FormLabel>
+        <FormLabel>DJ Name (optional)</FormLabel>
         <Input
           name="djName"
           placeholder="DJ Name"

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -11,6 +11,7 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
     include: ["**/*.test.{ts,tsx}"],
+    exclude: ["node_modules", ".claude/**"],
     globals: true,
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

- Make DJ Name an optional field during onboarding (labeled "(optional)" instead of required with asterisk)
- Fix login/onboarding page layout so the form and submit button are always visible without scrolling (`height` -> `minHeight`)
- Remove the "Hold On..." quote banner from the onboarding form to reduce vertical space
- Center and resize the WXYC logo on login pages (one-third of form width)
- Show tooltips on disabled sidebar links (moved Link inside ListItemButton instead of wrapping)
- Exclude `.claude/` directory from vitest test discovery to prevent worktree files from being picked up

## Test plan

- [x] All 2471 unit tests pass (15 tests updated to match new behavior)
- [ ] Manual test: log in as `test_incomplete` / `temppass123`, verify onboarding form shows DJ Name as optional
- [ ] Manual test: verify submit button is visible without scrolling on the onboarding page
- [ ] Manual test: hover over disabled "Previous Sets" sidebar link, verify tooltip appears
- [ ] Manual test: verify login page logo is centered and appropriately sized

Closes #418