### PR TITLE
Display Various Artists for compilations in card catalog

### DIFF
--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -177,6 +177,30 @@ describe("convertToAlbumEntry", () => {
     ]
   );
 
+  describeConversionWithAssertions(
+    "album_artist (compilation handling)",
+    convertToAlbumEntry,
+    [
+      {
+        name: "should pass through album_artist when present",
+        input: createTestAlbumSearchResult({
+          artist_name: "Autechre",
+          album_artist: "Autechre",
+        }),
+        assertions: (result) => {
+          expect(result.album_artist).toBe("Autechre");
+        },
+      },
+      {
+        name: "should default album_artist to undefined when absent",
+        input: createTestAlbumSearchResult(),
+        assertions: (result) => {
+          expect(result.album_artist).toBeUndefined();
+        },
+      },
+    ]
+  );
+
   describe("bug fixes", () => {
     it("should not set artist.id to the album id", () => {
       const searchResult = createTestAlbumSearchResult({

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -26,6 +26,7 @@ export function convertToAlbumEntry(
     entry: response.code_number ?? 0,
     format: (response.format_name as Format) ?? "Unknown",
     alternate_artist: "",
+    album_artist: isSearchResult(response) ? response.album_artist : undefined,
     rotation_bin: isSearchResult(response)
       ? (response.rotation_bin as Rotation)
       : undefined,

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -46,6 +46,7 @@ export type AlbumEntry = {
   entry: number;
   format: Format;
   alternate_artist: string | undefined;
+  album_artist?: string;
   rotation_bin: Rotation | undefined;
   rotation_id: number | undefined;
   plays: number | undefined;

--- a/src/components/experiences/classic/catalog/SearchResults.tsx
+++ b/src/components/experiences/classic/catalog/SearchResults.tsx
@@ -68,7 +68,7 @@ export default function SearchResults() {
         <tbody>
           {results.map((result) => (
             <tr key={result.id} className="text">
-              <td align="left">{result.artist.name}</td>
+              <td align="left">{result.album_artist ? "Various Artists" : result.artist.name}</td>
               <td align="left">{result.title}</td>
               <td align="left">{result.format}</td>
               <td align="left">

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -90,9 +90,11 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
               level="body-sm"
               textColor="text.primary"
             >
-              {album.artist.name}
+              {album.album_artist ? "Various Artists" : album.artist.name}
             </Typography>
-            <Typography level="body-sm">{album.alternate_artist}</Typography>
+            <Typography level="body-sm">
+              {album.album_artist ?? album.alternate_artist}
+            </Typography>
           </div>
         </Box>
       </td>

--- a/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { createTestAlbum } from "@/lib/test-utils";
+import { createTestAlbum, createTestArtist } from "@/lib/test-utils";
 import { renderWithProviders } from "@/lib/test-utils/render";
 
 vi.mock("next/navigation", () => ({
@@ -125,6 +125,61 @@ describe("CatalogResult WXYC Exclusive badge", () => {
     );
 
     expect(screen.queryByText("WXYC EXCLUSIVE")).toBeNull();
+  });
+});
+
+describe("CatalogResult Various Artists display", () => {
+  it("should display 'Various Artists' when album_artist is set", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Autechre", lettercode: "EL", numbercode: 5 }),
+      album_artist: "Autechre",
+      title: "All Tomorrow's Parties",
+    });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByText("Various Artists")).toBeDefined();
+  });
+
+  it("should display the album_artist as subtext when set", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Autechre", lettercode: "EL", numbercode: 5 }),
+      album_artist: "Autechre",
+      title: "All Tomorrow's Parties",
+    });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByText("Autechre")).toBeDefined();
+  });
+
+  it("should display artist name normally when album_artist is not set", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Stereolab", lettercode: "RO", numbercode: 87 }),
+    });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByText("Stereolab")).toBeDefined();
+    expect(screen.queryByText("Various Artists")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Thread `album_artist` from API response through to catalog display components
- Show "Various Artists" as primary artist when `album_artist` is set, with the album artist as subtext
- Fix applies to both modern and classic theme catalog views

Closes #425

## Test plan

- [x] Conversion: `album_artist` passes through when present, defaults to undefined when absent
- [x] Component: displays "Various Artists" when `album_artist` is set
- [x] Component: displays album_artist value as subtext
- [x] Component: displays artist name normally when no `album_artist`
- [x] Full suite: 2458 tests pass
- [x] TypeScript strict mode passes