### PR TITLE
Show onboarding status indicator in admin roster

### DIFF
--- a/lib/__tests__/features/admin/conversions-better-auth.test.ts
+++ b/lib/__tests__/features/admin/conversions-better-auth.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  convertBetterAuthToAccountResult,
+  BetterAuthUser,
+} from "@/lib/features/admin/conversions-better-auth";
+import { AdminAuthenticationStatus, Authorization } from "@/lib/features/admin/types";
+
+function createTestBetterAuthUser(
+  overrides: Partial<BetterAuthUser> = {}
+): BetterAuthUser {
+  return {
+    id: "user-1",
+    email: "test@wxyc.org",
+    name: "Test User",
+    username: "testuser",
+    emailVerified: true,
+    role: "dj",
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+    ...overrides,
+  };
+}
+
+describe("convertBetterAuthToAccountResult", () => {
+  it("should map hasCompletedOnboarding: true", () => {
+    const user = createTestBetterAuthUser({ hasCompletedOnboarding: true });
+    const account = convertBetterAuthToAccountResult(user);
+    expect(account.hasCompletedOnboarding).toBe(true);
+  });
+
+  it("should map hasCompletedOnboarding: false", () => {
+    const user = createTestBetterAuthUser({ hasCompletedOnboarding: false });
+    const account = convertBetterAuthToAccountResult(user);
+    expect(account.hasCompletedOnboarding).toBe(false);
+  });
+
+  it("should default hasCompletedOnboarding to false when undefined", () => {
+    const user = createTestBetterAuthUser({ hasCompletedOnboarding: undefined });
+    const account = convertBetterAuthToAccountResult(user);
+    expect(account.hasCompletedOnboarding).toBe(false);
+  });
+
+  it("should map basic user fields", () => {
+    const user = createTestBetterAuthUser({
+      username: "djcat",
+      realName: "Cat Power",
+      djName: "DJ Cat",
+      email: "cat@wxyc.org",
+    });
+    const account = convertBetterAuthToAccountResult(user);
+    expect(account.userName).toBe("djcat");
+    expect(account.realName).toBe("Cat Power");
+    expect(account.djName).toBe("DJ Cat");
+    expect(account.email).toBe("cat@wxyc.org");
+  });
+
+  it("should map role to authorization", () => {
+    const user = createTestBetterAuthUser({ role: "stationManager" });
+    const account = convertBetterAuthToAccountResult(user);
+    expect(account.authorization).toBe(Authorization.SM);
+  });
+
+  it("should map emailVerified to authType", () => {
+    const unverified = createTestBetterAuthUser({ emailVerified: false });
+    expect(convertBetterAuthToAccountResult(unverified).authType).toBe(
+      AdminAuthenticationStatus.New
+    );
+
+    const verified = createTestBetterAuthUser({ emailVerified: true });
+    expect(convertBetterAuthToAccountResult(verified).authType).toBe(
+      AdminAuthenticationStatus.Confirmed
+    );
+  });
+});

--- a/lib/features/admin/conversions-better-auth.ts
+++ b/lib/features/admin/conversions-better-auth.ts
@@ -17,6 +17,8 @@ export type BetterAuthUser = {
   banReason?: string;
   /** Cross-cutting capabilities independent of role hierarchy */
   capabilities?: string[];
+  /** Whether the user has completed the onboarding flow */
+  hasCompletedOnboarding?: boolean;
 };
 
 /**
@@ -36,6 +38,7 @@ export function convertBetterAuthToAccountResult(
       : AdminAuthenticationStatus.New,
     email: user.email,
     capabilities: user.capabilities ?? [],
+    hasCompletedOnboarding: user.hasCompletedOnboarding ?? false,
   };
 }
 

--- a/lib/features/admin/types.ts
+++ b/lib/features/admin/types.ts
@@ -24,6 +24,8 @@ export type Account = {
   email?: string;
   /** Cross-cutting capabilities independent of role hierarchy */
   capabilities?: string[];
+  /** Whether the user has completed the onboarding flow */
+  hasCompletedOnboarding?: boolean;
 };
 
 export type NewAccountParams = {

--- a/lib/test-utils/fixtures.ts
+++ b/lib/test-utils/fixtures.ts
@@ -477,6 +477,7 @@ export function createTestAccountResult(
     authorization: Authorization.DJ,
     authType: AdminAuthenticationStatus.Confirmed,
     email: "test@wxyc.org",
+    hasCompletedOnboarding: true,
     ...overrides,
   };
 }

--- a/src/components/experiences/modern/admin/roster/AccountEntry.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEntry.tsx
@@ -358,7 +358,24 @@ export const AccountEntry = ({
           </Stack>
         </Stack>
       </td>
-      <td>{account.realName}</td>
+      <td>
+        <Stack direction="row" spacing={0.5} alignItems="center">
+          <span>{account.realName}</span>
+          {account.hasCompletedOnboarding === false && (
+            <Tooltip
+              title="Has not completed onboarding"
+              arrow
+              placement="top"
+              variant="outlined"
+              size="sm"
+            >
+              <Chip variant="soft" color="warning" size="sm">
+                New
+              </Chip>
+            </Tooltip>
+          )}
+        </Stack>
+      </td>
       <td>{account.userName}</td>
       <td>
         {account.djName && account.djName.length > 0 && "DJ"} {account.djName ?? ""}

--- a/src/components/experiences/modern/admin/roster/__tests__/AccountEntry.test.tsx
+++ b/src/components/experiences/modern/admin/roster/__tests__/AccountEntry.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { AccountEntry } from "../AccountEntry";
+import { renderWithProviders, createTestAccountResult } from "@/lib/test-utils";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: {
+    admin: { listUsers: vi.fn(), updateUser: vi.fn(), removeUser: vi.fn(), setUserPassword: vi.fn() },
+    organization: { getFullOrganization: vi.fn(), listMembers: vi.fn(), updateMemberRole: vi.fn() },
+  },
+  authBaseURL: "http://localhost:8082/auth",
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  getAppOrganizationIdClient: vi.fn(() => "test-org"),
+}));
+
+function renderAccountEntry(overrides: Parameters<typeof createTestAccountResult>[0] = {}) {
+  const account = createTestAccountResult(overrides);
+  return renderWithProviders(
+    <table>
+      <tbody>
+        <AccountEntry account={account} isSelf={false} />
+      </tbody>
+    </table>
+  );
+}
+
+describe("AccountEntry onboarding indicator", () => {
+  it("should show 'New' chip when user has not completed onboarding", () => {
+    renderAccountEntry({ hasCompletedOnboarding: false });
+
+    expect(screen.getByText("New")).toBeInTheDocument();
+  });
+
+  it("should not show 'New' chip when user has completed onboarding", () => {
+    renderAccountEntry({ hasCompletedOnboarding: true });
+
+    expect(screen.queryByText("New")).not.toBeInTheDocument();
+  });
+
+  it("should not show 'New' chip when hasCompletedOnboarding is undefined", () => {
+    renderAccountEntry({ hasCompletedOnboarding: undefined });
+
+    expect(screen.queryByText("New")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Add a "New" chip next to user names in the admin roster for users who haven't completed onboarding
- Plumb `hasCompletedOnboarding` through from the better-auth API response to the `Account` type and roster UI
- Add conversion and component tests

Closes #427

## Test plan

- [ ] Verify "New" chip appears next to names of users with `hasCompletedOnboarding: false`
- [ ] Verify no chip appears for users who have completed onboarding
- [ ] Verify tooltip reads "Has not completed onboarding" on hover
- [ ] Run `npx tsc --noEmit` — passes
- [ ] Run `npx vitest run --changed origin/main` — all 1491 tests pass