### PR TITLE
Add bulk CSV import for account creation

### DIFF
--- a/src/components/experiences/modern/admin/roster/ImportCSVModal.test.tsx
+++ b/src/components/experiences/modern/admin/roster/ImportCSVModal.test.tsx
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import ImportCSVModal from "./ImportCSVModal";
+
+// Mock the auth client
+vi.mock("@/lib/features/authentication/client", () => ({
+  authBaseURL: "http://localhost:8082/auth",
+}));
+
+// Mock sonner toast
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock shared validation
+vi.mock("@wxyc/shared/validation", () => ({
+  isValidEmail: (email: string) => {
+    if (typeof email !== "string") return false;
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  },
+}));
+
+const validCSV = [
+  "Name,Username,DJ Name,Email",
+  "Juana Molina,jmolina,DJ Juana,juana@wxyc.org",
+  "Cat Power,cpower,DJ Cat,cat@wxyc.org",
+].join("\n");
+
+const csvWithErrors = [
+  "Name,Username,DJ Name,Email",
+  "Juana Molina,jmolina,DJ Juana,juana@wxyc.org",
+  ",,DJ Bad,not-an-email",
+].join("\n");
+
+function createCSVFile(content: string, name = "roster.csv"): File {
+  return new File([content], name, { type: "text/csv" });
+}
+
+describe("ImportCSVModal", () => {
+  const defaultProps = {
+    open: true,
+    onClose: vi.fn(),
+    onComplete: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD", "temppass123");
+    vi.stubEnv("NEXT_PUBLIC_APP_ORGANIZATION", "wxyc");
+    global.fetch = vi.fn();
+  });
+
+  describe("rendering", () => {
+    it("should render the modal when open", () => {
+      renderWithProviders(<ImportCSVModal {...defaultProps} />);
+
+      expect(screen.getByText("Import DJs from CSV")).toBeInTheDocument();
+    });
+
+    it("should not render when closed", () => {
+      renderWithProviders(<ImportCSVModal {...defaultProps} open={false} />);
+
+      expect(screen.queryByText("Import DJs from CSV")).not.toBeInTheDocument();
+    });
+
+    it("should show file input in upload state", () => {
+      renderWithProviders(<ImportCSVModal {...defaultProps} />);
+
+      expect(screen.getByText(/drop a CSV file|click to browse/i)).toBeInTheDocument();
+    });
+
+    it("should show download template link", () => {
+      renderWithProviders(<ImportCSVModal {...defaultProps} />);
+
+      expect(screen.getByText(/download template/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("file upload", () => {
+    it("should transition to preview state after valid file upload", async () => {
+      const { user } = renderWithProviders(<ImportCSVModal {...defaultProps} />);
+      const fileInput = screen.getByTestId("csv-file-input");
+
+      await user.upload(fileInput, createCSVFile(validCSV));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Found 2 accounts/)).toBeInTheDocument();
+      });
+    });
+
+    it("should show parsed rows in preview table", async () => {
+      const { user } = renderWithProviders(<ImportCSVModal {...defaultProps} />);
+      const fileInput = screen.getByTestId("csv-file-input");
+
+      await user.upload(fileInput, createCSVFile(validCSV));
+
+      await waitFor(() => {
+        expect(screen.getByText("Juana Molina")).toBeInTheDocument();
+        expect(screen.getByText("Cat Power")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("preview state", () => {
+    async function renderWithPreview(csv = validCSV) {
+      const result = renderWithProviders(<ImportCSVModal {...defaultProps} />);
+      const fileInput = screen.getByTestId("csv-file-input");
+
+      await result.user.upload(fileInput, createCSVFile(csv));
+      await waitFor(() => {
+        expect(screen.getByText(/Found \d+ account/)).toBeInTheDocument();
+      });
+
+      return result;
+    }
+
+    it("should show validation errors inline", async () => {
+      await renderWithPreview(csvWithErrors);
+
+      await waitFor(() => {
+        expect(screen.getByText(/1 with errors/)).toBeInTheDocument();
+      });
+    });
+
+    it("should show role selector defaulting to DJ", async () => {
+      await renderWithPreview();
+
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
+
+    it("should show create button with valid row count", async () => {
+      await renderWithPreview();
+
+      expect(screen.getByRole("button", { name: /Create 2 Accounts/ })).toBeInTheDocument();
+    });
+
+    it("should exclude invalid rows from create button count", async () => {
+      await renderWithPreview(csvWithErrors);
+
+      expect(screen.getByRole("button", { name: /Create 1 Account/ })).toBeInTheDocument();
+    });
+
+    it("should disable create button when all rows have errors", async () => {
+      const allBadCSV = "Name,DJ Name,Email\n,,\n,,";
+      await renderWithPreview(allBadCSV);
+
+      const button = screen.getByRole("button", { name: /Create 0 Accounts/ });
+      expect(button).toBeDisabled();
+    });
+
+    it("should call onClose when Cancel is clicked", async () => {
+      const onClose = vi.fn();
+      const result = renderWithProviders(
+        <ImportCSVModal {...defaultProps} onClose={onClose} />
+      );
+      const fileInput = screen.getByTestId("csv-file-input");
+      await result.user.upload(fileInput, createCSVFile(validCSV));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Found 2 accounts/)).toBeInTheDocument();
+      });
+
+      await result.user.click(screen.getByRole("button", { name: "Cancel" }));
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe("import and results", () => {
+    async function renderAndStartImport(csv = validCSV) {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: "new-user-id" }),
+      });
+
+      const result = renderWithProviders(<ImportCSVModal {...defaultProps} />);
+      const fileInput = screen.getByTestId("csv-file-input");
+      await result.user.upload(fileInput, createCSVFile(csv));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Found \d+ account/)).toBeInTheDocument();
+      });
+
+      await result.user.click(screen.getByRole("button", { name: /Create \d+ Account/ }));
+
+      return result;
+    }
+
+    it("should call provision-user for each valid row", async () => {
+      await renderAndStartImport();
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:8082/auth/admin/provision-user",
+        expect.objectContaining({
+          method: "POST",
+          credentials: "include",
+          body: expect.stringContaining("juana@wxyc.org"),
+        }),
+      );
+    });
+
+    it("should show results summary after import completes", async () => {
+      await renderAndStartImport();
+
+      await waitFor(() => {
+        expect(screen.getByText(/Created 2 of 2 accounts/)).toBeInTheDocument();
+      });
+    });
+
+    it("should show Done button in results state", async () => {
+      await renderAndStartImport();
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+      });
+    });
+
+    it("should call onComplete when Done is clicked", async () => {
+      const onComplete = vi.fn();
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: "new-user-id" }),
+      });
+
+      const { user } = renderWithProviders(
+        <ImportCSVModal {...defaultProps} onComplete={onComplete} />
+      );
+      const fileInput = screen.getByTestId("csv-file-input");
+      await user.upload(fileInput, createCSVFile(validCSV));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Found 2 accounts/)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /Create 2 Accounts/ }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: "Done" }));
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    it("should handle API failures per row and show in results", async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 409,
+          json: async () => ({ message: "Email already exists" }),
+        });
+
+      const { user } = renderWithProviders(<ImportCSVModal {...defaultProps} />);
+      const fileInput = screen.getByTestId("csv-file-input");
+      await user.upload(fileInput, createCSVFile(validCSV));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Found 2 accounts/)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /Create 2 Accounts/ }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Created 1 of 2 accounts/)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/Email already exists/)).toBeInTheDocument();
+    });
+
+    it("should skip rows with validation errors during import", async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const { user } = renderWithProviders(<ImportCSVModal {...defaultProps} />);
+      const fileInput = screen.getByTestId("csv-file-input");
+      await user.upload(fileInput, createCSVFile(csvWithErrors));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Found 2 accounts/)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /Create 1 Account/ }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Created 1 of 1/)).toBeInTheDocument();
+      });
+
+      // Only one valid row should have been sent
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/experiences/modern/admin/roster/ImportCSVModal.tsx
+++ b/src/components/experiences/modern/admin/roster/ImportCSVModal.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { authBaseURL } from "@/lib/features/authentication/client";
+import { Authorization } from "@/lib/features/admin/types";
+import { authorizationToRole } from "@/lib/features/authentication/types";
+import { CheckCircle, Error as ErrorIcon, Upload } from "@mui/icons-material";
+import {
+  Button,
+  Chip,
+  DialogContent,
+  DialogTitle,
+  LinearProgress,
+  Modal,
+  ModalClose,
+  ModalDialog,
+  Option,
+  Select,
+  Stack,
+  Table,
+  Typography,
+} from "@mui/joy";
+import { useCallback, useRef, useState } from "react";
+import { toast } from "sonner";
+import { parseCSVImport, CSVImportRow, CSVRowError } from "./csvImport";
+
+type ImportCSVModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onComplete: () => void;
+};
+
+type ModalState = "upload" | "preview" | "importing" | "results";
+
+type ImportResult = {
+  row: CSVImportRow;
+  success: boolean;
+  error?: string;
+};
+
+const CSV_TEMPLATE = "Name,Username,DJ Name,Email\n";
+
+function downloadTemplate() {
+  const blob = new Blob([CSV_TEMPLATE], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.setAttribute("href", url);
+  link.setAttribute("style", "display: none");
+  link.setAttribute("download", "dj-import-template.csv");
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export default function ImportCSVModal({ open, onClose, onComplete }: ImportCSVModalProps) {
+  const [state, setState] = useState<ModalState>("upload");
+  const [rows, setRows] = useState<CSVImportRow[]>([]);
+  const [errors, setErrors] = useState<CSVRowError[]>([]);
+  const [authorization, setAuthorization] = useState<Authorization>(Authorization.DJ);
+  const [importProgress, setImportProgress] = useState(0);
+  const [importResults, setImportResults] = useState<ImportResult[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const validRowCount = rows.filter((_, i) => !errors.some((e) => e.row === i + 1)).length;
+  const successCount = importResults.filter((r) => r.success).length;
+
+  const handleClose = () => {
+    setState("upload");
+    setRows([]);
+    setErrors([]);
+    setAuthorization(Authorization.DJ);
+    setImportProgress(0);
+    setImportResults([]);
+    onClose();
+  };
+
+  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const text = event.target?.result as string;
+      const result = parseCSVImport(text);
+      setRows(result.rows);
+      setErrors(result.errors);
+      setState("preview");
+    };
+    reader.readAsText(file);
+  }, []);
+
+  const handleImport = useCallback(async () => {
+    setState("importing");
+    setImportProgress(0);
+    setImportResults([]);
+
+    const tempPassword = String(process.env.NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD || "");
+    const organizationSlug = process.env.NEXT_PUBLIC_APP_ORGANIZATION || "";
+    const role = authorizationToRole(authorization);
+
+    // Filter to only valid rows
+    const validRows = rows.filter((_, i) => !errors.some((e) => e.row === i + 1));
+    const results: ImportResult[] = [];
+
+    for (let i = 0; i < validRows.length; i++) {
+      const row = validRows[i];
+
+      try {
+        const response = await fetch(`${authBaseURL}/admin/provision-user`, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: row.email,
+            username: row.username,
+            password: tempPassword,
+            name: row.name,
+            organizationSlug,
+            role,
+            realName: row.name,
+            djName: row.djName,
+          }),
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => null);
+          throw new Error(errorData?.message || errorData?.error || `Failed (${response.status})`);
+        }
+
+        results.push({ row, success: true });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : "Failed to create account";
+        results.push({ row, success: false, error: errorMessage });
+      }
+
+      setImportProgress(((i + 1) / validRows.length) * 100);
+      setImportResults([...results]);
+    }
+
+    setState("results");
+
+    const successCount = results.filter((r) => r.success).length;
+    if (successCount === validRows.length) {
+      toast.success(`Created ${successCount} account${successCount !== 1 ? "s" : ""}`);
+    } else {
+      toast.error(`Created ${successCount} of ${validRows.length} accounts — some failed`);
+    }
+  }, [rows, errors, authorization]);
+
+  const handleDone = () => {
+    onComplete();
+    setState("upload");
+    setRows([]);
+    setErrors([]);
+    setImportProgress(0);
+    setImportResults([]);
+  };
+
+  return (
+    <Modal open={open} onClose={handleClose}>
+      <ModalDialog
+        variant="outlined"
+        sx={{ maxWidth: 700, width: "100%", borderRadius: "md" }}
+      >
+        <ModalClose />
+        <DialogTitle>
+          <Stack direction="row" alignItems="center" gap={1}>
+            <Upload />
+            Import DJs from CSV
+          </Stack>
+        </DialogTitle>
+        <DialogContent>
+          {state === "upload" && (
+            <Stack spacing={2}>
+              <Typography level="body-sm">
+                Upload a CSV file with columns: Name, Username (optional), DJ Name, Email
+              </Typography>
+              <label
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  padding: "2rem",
+                  border: "2px dashed var(--joy-palette-neutral-outlinedBorder)",
+                  borderRadius: "var(--joy-radius-md)",
+                  cursor: "pointer",
+                  textAlign: "center",
+                }}
+              >
+                <Upload sx={{ fontSize: 40, mb: 1, color: "neutral.500" }} />
+                <Typography level="body-md">
+                  Drop a CSV file here or click to browse
+                </Typography>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".csv"
+                  onChange={handleFileChange}
+                  style={{ display: "none" }}
+                  data-testid="csv-file-input"
+                />
+              </label>
+              <Button
+                variant="plain"
+                color="neutral"
+                size="sm"
+                onClick={downloadTemplate}
+              >
+                Download template
+              </Button>
+            </Stack>
+          )}
+
+          {state === "preview" && (
+            <Stack spacing={2}>
+              <Typography level="body-sm">
+                Found {rows.length} account{rows.length !== 1 ? "s" : ""} to create
+                {errors.length > 0 && ` (${errors.length > 0 ? rows.filter((_, i) => errors.some((e) => e.row === i + 1)).length : 0} with errors)`}
+              </Typography>
+              <div style={{ maxHeight: 300, overflow: "auto" }}>
+                <Table size="sm" stripe="odd">
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>Username</th>
+                      <th>DJ Name</th>
+                      <th>Email</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rows.map((row, i) => {
+                      const rowErrors = errors.filter((e) => e.row === i + 1);
+                      return (
+                        <tr key={i}>
+                          <td>{row.name || <Typography color="danger">—</Typography>}</td>
+                          <td>{row.username}</td>
+                          <td>{row.djName || <Typography color="danger">—</Typography>}</td>
+                          <td>{row.email || <Typography color="danger">—</Typography>}</td>
+                          <td>
+                            {rowErrors.length > 0 ? (
+                              <Chip color="danger" size="sm" variant="soft">
+                                {rowErrors.map((e) => e.message).join("; ")}
+                              </Chip>
+                            ) : (
+                              <CheckCircle color="success" fontSize="small" />
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </Table>
+              </div>
+              <Stack direction="row" spacing={2} alignItems="center">
+                <Typography level="body-sm">Role:</Typography>
+                <Select
+                  size="sm"
+                  color="success"
+                  value={authorization}
+                  onChange={(_, value) => {
+                    if (value !== null) setAuthorization(value as Authorization);
+                  }}
+                >
+                  <Option value={Authorization.NO}>Member</Option>
+                  <Option value={Authorization.DJ}>DJ</Option>
+                  <Option value={Authorization.MD}>Music Director</Option>
+                  <Option value={Authorization.SM}>Station Manager</Option>
+                </Select>
+              </Stack>
+              <Stack direction="row" spacing={1} justifyContent="flex-end">
+                <Button variant="plain" color="neutral" onClick={handleClose}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="solid"
+                  color="success"
+                  disabled={validRowCount === 0}
+                  onClick={handleImport}
+                >
+                  Create {validRowCount} Account{validRowCount !== 1 ? "s" : ""}
+                </Button>
+              </Stack>
+            </Stack>
+          )}
+
+          {state === "importing" && (
+            <Stack spacing={2}>
+              <LinearProgress
+                determinate
+                value={importProgress}
+                color="success"
+                sx={{ my: 1 }}
+              />
+              <Typography level="body-sm" textAlign="center">
+                Creating account {Math.min(importResults.length + 1, validRowCount)} of {validRowCount}...
+              </Typography>
+            </Stack>
+          )}
+
+          {state === "results" && (
+            <Stack spacing={2}>
+              <Typography level="title-md">
+                Created {successCount} of {importResults.length} account{importResults.length !== 1 ? "s" : ""}
+              </Typography>
+              {importResults.some((r) => !r.success) && (
+                <div style={{ maxHeight: 200, overflow: "auto" }}>
+                  <Table size="sm">
+                    <thead>
+                      <tr>
+                        <th>Name</th>
+                        <th>Email</th>
+                        <th>Error</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {importResults
+                        .filter((r) => !r.success)
+                        .map((r, i) => (
+                          <tr key={i}>
+                            <td>{r.row.name}</td>
+                            <td>{r.row.email}</td>
+                            <td>
+                              <Typography color="danger" level="body-sm">
+                                {r.error}
+                              </Typography>
+                            </td>
+                          </tr>
+                        ))}
+                    </tbody>
+                  </Table>
+                </div>
+              )}
+              <Stack direction="row" justifyContent="flex-end">
+                <Button variant="solid" color="success" onClick={handleDone}>
+                  Done
+                </Button>
+              </Stack>
+            </Stack>
+          )}
+        </DialogContent>
+      </ModalDialog>
+    </Modal>
+  );
+}

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -6,7 +6,7 @@ import { NewAccountParams, Authorization, ROSTER_PAGE_SIZE } from "@/lib/feature
 import { User, authorizationToRole } from "@/lib/features/authentication/types";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useAccountListResults } from "@/src/hooks/adminHooks";
-import { Add, GppBad, KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
+import { Add, GppBad, KeyboardArrowLeft, KeyboardArrowRight, Upload } from "@mui/icons-material";
 import {
   Button,
   CircularProgress,
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 import { AccountEntry } from "./AccountEntry";
 import AccountSearchForm from "./AccountSearchForm";
 import ExportDJsButton from "./ExportCSV";
+import ImportCSVModal from "./ImportCSVModal";
 import NewAccountForm from "./NewAccountForm";
 
 export default function RosterTable({ user }: { user: User }) {
@@ -28,6 +29,7 @@ export default function RosterTable({ user }: { user: User }) {
 
   const [isCreating, setIsCreating] = useState(false);
   const [createError, setCreateError] = useState<Error | null>(null);
+  const [importModalOpen, setImportModalOpen] = useState(false);
 
   const dispatch = useAppDispatch();
   const isAdding = useAppSelector(adminSlice.selectors.getAdding);
@@ -146,6 +148,16 @@ export default function RosterTable({ user }: { user: User }) {
           }}
         >
           <ExportDJsButton />
+          <Button
+            variant="outlined"
+            color="success"
+            size="sm"
+            disabled={!canCreateUser}
+            startDecorator={<Upload />}
+            onClick={() => setImportModalOpen(true)}
+          >
+            Import CSV
+          </Button>
           <Button
             variant="solid"
             color={"success"}
@@ -273,6 +285,14 @@ export default function RosterTable({ user }: { user: User }) {
           </Stack>
         )}
       </form>
+      <ImportCSVModal
+        open={importModalOpen}
+        onClose={() => setImportModalOpen(false)}
+        onComplete={() => {
+          setImportModalOpen(false);
+          refetch();
+        }}
+      />
     </Sheet>
   );
 }

--- a/src/components/experiences/modern/admin/roster/csvImport.test.ts
+++ b/src/components/experiences/modern/admin/roster/csvImport.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect } from "vitest";
+import { parseCSVText, parseCSVImport, sanitizeCSVField, deriveUsername } from "./csvImport";
+
+describe("sanitizeCSVField", () => {
+  it("should strip leading = character", () => {
+    expect(sanitizeCSVField("=SUM(A1)")).toBe("SUM(A1)");
+  });
+
+  it("should strip leading + character", () => {
+    expect(sanitizeCSVField("+cmd")).toBe("cmd");
+  });
+
+  it("should strip leading - character", () => {
+    expect(sanitizeCSVField("-cmd")).toBe("cmd");
+  });
+
+  it("should strip leading @ character", () => {
+    expect(sanitizeCSVField("@mention")).toBe("mention");
+  });
+
+  it("should leave normal strings unchanged", () => {
+    expect(sanitizeCSVField("Juana Molina")).toBe("Juana Molina");
+  });
+
+  it("should handle empty string", () => {
+    expect(sanitizeCSVField("")).toBe("");
+  });
+
+  it("should trim whitespace", () => {
+    expect(sanitizeCSVField("  Stereolab  ")).toBe("Stereolab");
+  });
+
+  it("should strip formula prefix then trim", () => {
+    expect(sanitizeCSVField("= dangerous ")).toBe("dangerous");
+  });
+});
+
+describe("deriveUsername", () => {
+  it("should extract local part from email", () => {
+    expect(deriveUsername("jmolina@unc.edu")).toBe("jmolina");
+  });
+
+  it("should handle email with dots in local part", () => {
+    expect(deriveUsername("j.molina@unc.edu")).toBe("j.molina");
+  });
+
+  it("should handle email with plus in local part", () => {
+    expect(deriveUsername("jmolina+test@unc.edu")).toBe("jmolina+test");
+  });
+});
+
+describe("parseCSVText", () => {
+  it("should parse basic comma-separated values", () => {
+    const result = parseCSVText("a,b,c\n1,2,3");
+    expect(result).toEqual([["a", "b", "c"], ["1", "2", "3"]]);
+  });
+
+  it("should handle quoted fields containing commas", () => {
+    const result = parseCSVText('a,"b,c",d');
+    expect(result).toEqual([["a", "b,c", "d"]]);
+  });
+
+  it("should handle escaped double quotes inside quoted fields", () => {
+    const result = parseCSVText('a,"say ""hello""",c');
+    expect(result).toEqual([["a", 'say "hello"', "c"]]);
+  });
+
+  it("should handle empty fields", () => {
+    const result = parseCSVText("a,,c");
+    expect(result).toEqual([["a", "", "c"]]);
+  });
+
+  it("should handle CRLF line endings", () => {
+    const result = parseCSVText("a,b\r\n1,2");
+    expect(result).toEqual([["a", "b"], ["1", "2"]]);
+  });
+
+  it("should handle trailing newline without producing empty row", () => {
+    const result = parseCSVText("a,b\n1,2\n");
+    expect(result).toEqual([["a", "b"], ["1", "2"]]);
+  });
+
+  it("should handle single row (header only)", () => {
+    const result = parseCSVText("Name,Email");
+    expect(result).toEqual([["Name", "Email"]]);
+  });
+
+  it("should handle newlines inside quoted fields", () => {
+    const result = parseCSVText('a,"line1\nline2",c');
+    expect(result).toEqual([["a", "line1\nline2", "c"]]);
+  });
+
+  it("should handle empty input", () => {
+    const result = parseCSVText("");
+    expect(result).toEqual([]);
+  });
+});
+
+describe("parseCSVImport", () => {
+  const validCSV = [
+    "Name,Username,DJ Name,Email",
+    "Juana Molina,jmolina,DJ Juana,juana@wxyc.org",
+    "Cat Power,cpower,DJ Cat,cat@wxyc.org",
+  ].join("\n");
+
+  it("should parse valid CSV with all fields", () => {
+    const result = parseCSVImport(validCSV);
+
+    expect(result.rows).toEqual([
+      { name: "Juana Molina", username: "jmolina", djName: "DJ Juana", email: "juana@wxyc.org" },
+      { name: "Cat Power", username: "cpower", djName: "DJ Cat", email: "cat@wxyc.org" },
+    ]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("should derive username from email when username is empty", () => {
+    const csv = "Name,Username,DJ Name,Email\nJuana Molina,,DJ Juana,juana@wxyc.org";
+    const result = parseCSVImport(csv);
+
+    expect(result.rows[0].username).toBe("juana");
+    expect(result.errors).toEqual([]);
+  });
+
+  it("should derive username from email when username column is absent", () => {
+    const csv = "Name,DJ Name,Email\nJuana Molina,DJ Juana,juana@wxyc.org";
+    const result = parseCSVImport(csv);
+
+    expect(result.rows[0].username).toBe("juana");
+    expect(result.errors).toEqual([]);
+  });
+
+  describe("header matching", () => {
+    it.each([
+      ["Name", "name"],
+      ["First and Last Name", "first and last name"],
+      ["Full Name", "full name"],
+      ["FULL NAME", "full name (uppercase)"],
+    ])("should match name column header: %s", (header) => {
+      const csv = `${header},DJ Name,Email\nJuana Molina,DJ Juana,juana@wxyc.org`;
+      const result = parseCSVImport(csv);
+
+      expect(result.rows[0].name).toBe("Juana Molina");
+    });
+
+    it.each([
+      ["DJ Name", "dj name"],
+      ["DJ_Name", "dj_name"],
+      ["djname", "djname"],
+      ["Dj Name", "Dj Name"],
+    ])("should match DJ name column header: %s", (header) => {
+      const csv = `Name,${header},Email\nJuana Molina,DJ Juana,juana@wxyc.org`;
+      const result = parseCSVImport(csv);
+
+      expect(result.rows[0].djName).toBe("DJ Juana");
+    });
+
+    it.each([
+      ["Email", "email"],
+      ["EMAIL", "email (uppercase)"],
+      ["email address", "email address"],
+      ["Email Address", "Email Address"],
+    ])("should match email column header: %s", (header) => {
+      const csv = `Name,DJ Name,${header}\nJuana Molina,DJ Juana,juana@wxyc.org`;
+      const result = parseCSVImport(csv);
+
+      expect(result.rows[0].email).toBe("juana@wxyc.org");
+    });
+
+    it.each([
+      ["Username", "username"],
+      ["USERNAME", "username (uppercase)"],
+      ["User Name", "user name"],
+      ["Username (Optional)", "Username (Optional)"],
+    ])("should match username column header: %s", (header) => {
+      const csv = `Name,${header},DJ Name,Email\nJuana Molina,jmolina,DJ Juana,juana@wxyc.org`;
+      const result = parseCSVImport(csv);
+
+      expect(result.rows[0].username).toBe("jmolina");
+    });
+  });
+
+  describe("validation", () => {
+    it("should report error when name is empty", () => {
+      const csv = "Name,DJ Name,Email\n,DJ Juana,juana@wxyc.org";
+      const result = parseCSVImport(csv);
+
+      expect(result.errors).toEqual([
+        expect.objectContaining({ row: 1, field: "name" }),
+      ]);
+    });
+
+    it("should report error when DJ name is empty", () => {
+      const csv = "Name,DJ Name,Email\nJuana Molina,,juana@wxyc.org";
+      const result = parseCSVImport(csv);
+
+      expect(result.errors).toEqual([
+        expect.objectContaining({ row: 1, field: "djName" }),
+      ]);
+    });
+
+    it("should report error when email is empty", () => {
+      const csv = "Name,DJ Name,Email\nJuana Molina,DJ Juana,";
+      const result = parseCSVImport(csv);
+
+      expect(result.errors).toEqual([
+        expect.objectContaining({ row: 1, field: "email" }),
+      ]);
+    });
+
+    it("should report error for invalid email format", () => {
+      const csv = "Name,DJ Name,Email\nJuana Molina,DJ Juana,not-an-email";
+      const result = parseCSVImport(csv);
+
+      expect(result.errors).toEqual([
+        expect.objectContaining({ row: 1, field: "email", message: expect.stringContaining("invalid") }),
+      ]);
+    });
+
+    it("should detect duplicate emails across rows", () => {
+      const csv = [
+        "Name,DJ Name,Email",
+        "Juana Molina,DJ Juana,juana@wxyc.org",
+        "Cat Power,DJ Cat,juana@wxyc.org",
+      ].join("\n");
+      const result = parseCSVImport(csv);
+
+      expect(result.errors).toEqual([
+        expect.objectContaining({ row: 2, field: "email", message: expect.stringContaining("Duplicate") }),
+      ]);
+    });
+
+    it("should report multiple errors on the same row", () => {
+      const csv = "Name,DJ Name,Email\n,,";
+      const result = parseCSVImport(csv);
+
+      expect(result.errors.length).toBeGreaterThanOrEqual(3);
+      expect(result.errors.every((e) => e.row === 1)).toBe(true);
+    });
+
+    it("should still include rows with errors in the rows array", () => {
+      const csv = "Name,DJ Name,Email\n,DJ Juana,juana@wxyc.org";
+      const result = parseCSVImport(csv);
+
+      expect(result.rows).toHaveLength(1);
+      expect(result.rows[0].djName).toBe("DJ Juana");
+    });
+  });
+
+  it("should strip formula-injection prefixes from field values", () => {
+    const csv = "Name,DJ Name,Email\n=Juana Molina,+DJ Juana,juana@wxyc.org";
+    const result = parseCSVImport(csv);
+
+    expect(result.rows[0].name).toBe("Juana Molina");
+    expect(result.rows[0].djName).toBe("DJ Juana");
+  });
+
+  it("should return empty rows for header-only CSV", () => {
+    const csv = "Name,DJ Name,Email";
+    const result = parseCSVImport(csv);
+
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("should ignore extra columns", () => {
+    const csv = "Name,DJ Name,Email,Favorite Color\nJuana Molina,DJ Juana,juana@wxyc.org,Blue";
+    const result = parseCSVImport(csv);
+
+    expect(result.rows[0]).toEqual({
+      name: "Juana Molina",
+      username: "juana",
+      djName: "DJ Juana",
+      email: "juana@wxyc.org",
+    });
+  });
+
+  it("should report error when required header columns are missing", () => {
+    const csv = "Name,Email\nJuana Molina,juana@wxyc.org";
+    const result = parseCSVImport(csv);
+
+    expect(result.errors).toEqual([
+      expect.objectContaining({ row: 0, field: "header", message: expect.stringContaining("DJ Name") }),
+    ]);
+    expect(result.rows).toEqual([]);
+  });
+});

--- a/src/components/experiences/modern/admin/roster/csvImport.ts
+++ b/src/components/experiences/modern/admin/roster/csvImport.ts
@@ -1,0 +1,191 @@
+import { isValidEmail } from "@wxyc/shared/validation";
+
+export type CSVImportRow = {
+  name: string;
+  username: string;
+  djName: string;
+  email: string;
+};
+
+export type CSVRowError = {
+  row: number;
+  field: string;
+  message: string;
+};
+
+export type CSVParseResult = {
+  rows: CSVImportRow[];
+  errors: CSVRowError[];
+};
+
+const FORMULA_PREFIXES = ["=", "+", "-", "@"];
+
+/**
+ * Strip formula-injection prefixes and trim whitespace.
+ */
+export function sanitizeCSVField(field: string): string {
+  let result = field;
+  if (result.length > 0 && FORMULA_PREFIXES.some((p) => result.startsWith(p))) {
+    result = result.slice(1);
+  }
+  return result.trim();
+}
+
+/**
+ * Derive a username from an email address (local part before @).
+ */
+export function deriveUsername(email: string): string {
+  return email.split("@")[0];
+}
+
+/**
+ * Parse raw CSV text into a 2D array of strings.
+ * Handles quoted fields, escaped quotes (""), newlines inside quotes, CRLF/LF.
+ */
+export function parseCSVText(text: string): string[][] {
+  if (text.length === 0) return [];
+
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentField = "";
+  let inQuotes = false;
+  let i = 0;
+
+  while (i < text.length) {
+    const char = text[i];
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (i + 1 < text.length && text[i + 1] === '"') {
+          // Escaped quote
+          currentField += '"';
+          i += 2;
+        } else {
+          // End of quoted field
+          inQuotes = false;
+          i++;
+        }
+      } else {
+        currentField += char;
+        i++;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+        i++;
+      } else if (char === ",") {
+        currentRow.push(currentField);
+        currentField = "";
+        i++;
+      } else if (char === "\r") {
+        // CRLF or bare CR
+        currentRow.push(currentField);
+        currentField = "";
+        rows.push(currentRow);
+        currentRow = [];
+        i++;
+        if (i < text.length && text[i] === "\n") {
+          i++;
+        }
+      } else if (char === "\n") {
+        currentRow.push(currentField);
+        currentField = "";
+        rows.push(currentRow);
+        currentRow = [];
+        i++;
+      } else {
+        currentField += char;
+        i++;
+      }
+    }
+  }
+
+  // Flush the last field/row (unless we just finished a newline)
+  if (currentField.length > 0 || currentRow.length > 0) {
+    currentRow.push(currentField);
+    rows.push(currentRow);
+  }
+
+  return rows;
+}
+
+// Header aliases for flexible column matching (all lowercase)
+const NAME_ALIASES = ["name", "first and last name", "full name"];
+const USERNAME_ALIASES = ["username", "user name", "username (optional)"];
+const DJ_NAME_ALIASES = ["dj name", "dj_name", "djname"];
+const EMAIL_ALIASES = ["email", "email address"];
+
+function findColumnIndex(headers: string[], aliases: string[]): number {
+  return headers.findIndex((h) => aliases.includes(h.toLowerCase().trim()));
+}
+
+/**
+ * Parse CSV text into structured import rows with validation.
+ * Returns all rows (including invalid ones) and a list of errors.
+ */
+export function parseCSVImport(text: string): CSVParseResult {
+  const rawRows = parseCSVText(text);
+  if (rawRows.length === 0) return { rows: [], errors: [] };
+
+  const headers = rawRows[0];
+  const nameIdx = findColumnIndex(headers, NAME_ALIASES);
+  const usernameIdx = findColumnIndex(headers, USERNAME_ALIASES);
+  const djNameIdx = findColumnIndex(headers, DJ_NAME_ALIASES);
+  const emailIdx = findColumnIndex(headers, EMAIL_ALIASES);
+
+  // Check for required headers
+  const missingHeaders: string[] = [];
+  if (nameIdx === -1) missingHeaders.push("Name");
+  if (djNameIdx === -1) missingHeaders.push("DJ Name");
+  if (emailIdx === -1) missingHeaders.push("Email");
+
+  if (missingHeaders.length > 0) {
+    return {
+      rows: [],
+      errors: [{
+        row: 0,
+        field: "header",
+        message: `Missing required columns: ${missingHeaders.join(", ")}`,
+      }],
+    };
+  }
+
+  const rows: CSVImportRow[] = [];
+  const errors: CSVRowError[] = [];
+  const seenEmails = new Set<string>();
+
+  for (let i = 1; i < rawRows.length; i++) {
+    const raw = rawRows[i];
+    const rowNum = i; // 1-indexed (row 1 = first data row)
+
+    const name = sanitizeCSVField(raw[nameIdx] ?? "");
+    const rawUsername = usernameIdx !== -1 ? sanitizeCSVField(raw[usernameIdx] ?? "") : "";
+    const djName = sanitizeCSVField(raw[djNameIdx] ?? "");
+    const email = sanitizeCSVField(raw[emailIdx] ?? "");
+
+    const username = rawUsername || (email ? deriveUsername(email) : "");
+
+    // Validate
+    if (!name) {
+      errors.push({ row: rowNum, field: "name", message: "Name is required" });
+    }
+    if (!djName) {
+      errors.push({ row: rowNum, field: "djName", message: "DJ Name is required" });
+    }
+    if (!email) {
+      errors.push({ row: rowNum, field: "email", message: "Email is required" });
+    } else if (!isValidEmail(email)) {
+      errors.push({ row: rowNum, field: "email", message: "Email address is invalid" });
+    } else {
+      const emailLower = email.toLowerCase();
+      if (seenEmails.has(emailLower)) {
+        errors.push({ row: rowNum, field: "email", message: `Duplicate email: ${email}` });
+      }
+      seenEmails.add(emailLower);
+    }
+
+    rows.push({ name, username, djName, email });
+  }
+
+  return { rows, errors };
+}


### PR DESCRIPTION
## Summary

- Add "Import CSV" button to the roster admin toolbar for bulk-creating DJ accounts from a CSV file
- CSV parser handles quoted fields, formula-injection sanitization, flexible header matching, email validation, duplicate detection, and username derivation from email
- Import modal with upload → preview → importing → results flow, sequential account creation with progress feedback

Closes #430

## Test plan

- [x] 50 unit tests for CSV parsing (edge cases, header matching, validation)
- [x] 18 component tests for the import modal (rendering, upload, preview, import, error handling)
- [x] Existing roster tests still pass (101 total across 5 files)
- [x] TypeScript compiles cleanly
- [ ] Manual test: upload a CSV via the roster page, verify preview and account creation