### PR TITLE
Display Various Artists for compilations in album detail view

### DIFF
--- a/app/dashboard/@information/(.)album/components/AlbumCard.test.tsx
+++ b/app/dashboard/@information/(.)album/components/AlbumCard.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import {
+  renderWithProviders,
+  createTestAlbum,
+  createTestArtist,
+} from "@/lib/test-utils";
+import AlbumCard from "./AlbumCard";
+
+vi.mock("./DiscogsMarkupRenderer", () => ({
+  default: () => <span>mocked bio</span>,
+}));
+
+vi.mock("./LibraryStatus", () => ({
+  default: () => <span>mocked status</span>,
+}));
+
+vi.mock("./StreamingLinks", () => ({
+  default: () => null,
+}));
+
+vi.mock("./Tracklist", () => ({
+  default: () => null,
+}));
+
+const defaultProps = {
+  artworkUrl: "https://example.com/cover.jpg",
+  metadata: null,
+  metadataLoading: false,
+  artistBio: null,
+  bioTokens: null,
+  artistWikipediaUrl: null,
+};
+
+describe("AlbumCard Various Artists display", () => {
+  it("should display 'Various Artists' in the title when album_artist is set", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Autechre", lettercode: "EL", numbercode: 5 }),
+      album_artist: "Autechre",
+      title: "All Tomorrow's Parties",
+    });
+
+    renderWithProviders(<AlbumCard album={album} {...defaultProps} />);
+
+    expect(screen.getByText(/Various Artists/)).toBeInTheDocument();
+  });
+
+  it("should display album_artist as subtext when set", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Autechre", lettercode: "EL", numbercode: 5 }),
+      album_artist: "Autechre",
+      title: "All Tomorrow's Parties",
+    });
+
+    renderWithProviders(<AlbumCard album={album} {...defaultProps} />);
+
+    expect(screen.getByText("Autechre")).toBeInTheDocument();
+  });
+
+  it("should display artist name normally when album_artist is not set", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Stereolab", lettercode: "RO", numbercode: 87 }),
+      title: "Aluminum Tunes",
+    });
+
+    renderWithProviders(<AlbumCard album={album} {...defaultProps} />);
+
+    expect(screen.getByText(/Stereolab/)).toBeInTheDocument();
+    expect(screen.queryByText("Various Artists")).not.toBeInTheDocument();
+  });
+
+  it("should use album_artist for 'About' section heading when set", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Autechre", lettercode: "EL", numbercode: 5 }),
+      album_artist: "Autechre",
+      title: "All Tomorrow's Parties",
+    });
+
+    renderWithProviders(
+      <AlbumCard
+        album={album}
+        {...defaultProps}
+        artistBio="Autechre are an English electronic music duo."
+      />
+    );
+
+    expect(screen.getByText(/About Autechre/)).toBeInTheDocument();
+  });
+});

--- a/app/dashboard/@information/(.)album/components/AlbumCard.tsx
+++ b/app/dashboard/@information/(.)album/components/AlbumCard.tsx
@@ -77,8 +77,13 @@ export default function AlbumCard({
           />
           <Stack sx={{ minWidth: 0, justifyContent: "center" }}>
             <Typography level="title-lg" sx={{ mb: 0.5 }}>
-              {album.artist.name} &bull; {album.title}
+              {album.album_artist ? "Various Artists" : album.artist.name} &bull; {album.title}
             </Typography>
+            {album.album_artist && (
+              <Typography level="body-sm" sx={{ mb: 0.5 }}>
+                {album.album_artist}
+              </Typography>
+            )}
             <Stack
               direction="row"
               spacing={1}
@@ -117,7 +122,7 @@ export default function AlbumCard({
           <>
             <Divider sx={{ my: 1 }} />
             <Typography level="title-sm" sx={{ mb: 0.5 }}>
-              About {album.artist.name}
+              About {album.album_artist ?? album.artist.name}
               {artistWikipediaUrl && (
                 <Link
                   href={artistWikipediaUrl}


### PR DESCRIPTION
## Summary

- Show "Various Artists" in the album detail card title when `album_artist` is set, with the album artist shown as subtext
- Use `album_artist` for the "About" section heading so the bio attribution is correct

Follow-up to #426 which fixed the same issue in the card catalog search results.

Closes #425

## Test plan

- [x] Displays "Various Artists" in title when `album_artist` is set
- [x] Displays album_artist as subtext when set
- [x] Displays artist name normally when `album_artist` is not set
- [x] "About" section heading uses album_artist when set
- [x] Full suite: 2462 tests pass
- [x] TypeScript strict mode passes