### PR TITLE
feat: add Previous Sets dashboard page

### DIFF
--- a/app/dashboard/@classic/playlists/page.tsx
+++ b/app/dashboard/@classic/playlists/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from "next";
+import { getPageTitle } from "@/lib/utils/page-title";
+import PlaylistSearchContainer from "@/src/components/experiences/modern/playlist-search/PlaylistSearchContainer";
+
+export const metadata: Metadata = {
+  title: getPageTitle("Previous Sets"),
+};
+
+export default function ClassicPreviousSetsPage() {
+  return <PlaylistSearchContainer />;
+}

--- a/app/dashboard/@modern/playlists/page.tsx
+++ b/app/dashboard/@modern/playlists/page.tsx
@@ -1,0 +1,19 @@
+import PageHeader from "@/src/components/experiences/modern/Header/PageHeader";
+import SearchBar from "@/src/components/experiences/modern/previous-sets/Search/SearchBar";
+import Results from "@/src/components/experiences/modern/previous-sets/Results/Results";
+import { Metadata } from "next";
+import { getPageTitle } from "@/lib/utils/page-title";
+
+export const metadata: Metadata = {
+  title: getPageTitle("Previous Sets"),
+};
+
+export default function PreviousSetsPage() {
+  return (
+    <>
+      <PageHeader title="Previous Sets" />
+      <SearchBar />
+      <Results />
+    </>
+  );
+}

--- a/lib/features/playlist-search/frontend.ts
+++ b/lib/features/playlist-search/frontend.ts
@@ -18,9 +18,12 @@ export type SearchRow = {
 
 export type SearchMode = "simple" | "advanced";
 
+export type SimpleSearchField = "all" | "artist" | "song" | "album" | "label" | "dj";
+
 export type PlaylistSearchState = {
   mode: SearchMode;
   simpleQuery: string;
+  searchField: SimpleSearchField;
   advancedRows: SearchRow[];
   sortBy: SortField;
   sortOrder: SortOrder;
@@ -38,6 +41,7 @@ const createInitialRow = (): SearchRow => ({
 const initialState: PlaylistSearchState = {
   mode: "simple",
   simpleQuery: "",
+  searchField: "all",
   advancedRows: [createInitialRow()],
   sortBy: "date",
   sortOrder: "desc",
@@ -54,6 +58,10 @@ export const playlistSearchSlice = createAppSlice({
     },
     setSimpleQuery: (state, action: PayloadAction<string>) => {
       state.simpleQuery = action.payload;
+      state.page = 0;
+    },
+    setSearchField: (state, action: PayloadAction<SimpleSearchField>) => {
+      state.searchField = action.payload;
       state.page = 0;
     },
     addRow: (state) => {
@@ -92,6 +100,7 @@ export const playlistSearchSlice = createAppSlice({
   selectors: {
     getMode: (state) => state.mode,
     getSimpleQuery: (state) => state.simpleQuery,
+    getSearchField: (state) => state.searchField,
     getAdvancedRows: (state) => state.advancedRows,
     getSortBy: (state) => state.sortBy,
     getSortOrder: (state) => state.sortOrder,

--- a/lib/test-utils/msw/handlers.ts
+++ b/lib/test-utils/msw/handlers.ts
@@ -36,6 +36,11 @@ export const handlers = [
     return HttpResponse.json([]);
   }),
 
+  // Playlist search API handlers
+  http.get(`${BACKEND_URL}/flowsheet/search`, () => {
+    return HttpResponse.json({ results: [], total: 0, page: 0, totalPages: 0 });
+  }),
+
   // Rotation API handlers
   http.get(`${BACKEND_URL}/rotation/`, () => {
     return HttpResponse.json([]);

--- a/src/components/experiences/modern/Leftbar/Leftbar.test.tsx
+++ b/src/components/experiences/modern/Leftbar/Leftbar.test.tsx
@@ -127,7 +127,7 @@ describe("Leftbar", () => {
     expect(screen.getByTestId("flowsheet-link")).toBeInTheDocument();
   });
 
-  it("should render previous sets link as disabled", async () => {
+  it("should render previous sets link as enabled", async () => {
     const Component = await Leftbar();
     render(Component);
 
@@ -135,7 +135,7 @@ describe("Leftbar", () => {
       "leftbar-link--dashboard-playlists"
     );
     expect(playlistsLink).toBeInTheDocument();
-    expect(playlistsLink).toHaveAttribute("data-disabled", "true");
+    expect(playlistsLink).not.toHaveAttribute("data-disabled", "true");
     expect(screen.getByText("Previous Sets")).toBeInTheDocument();
   });
 

--- a/src/components/experiences/modern/Leftbar/Leftbar.tsx
+++ b/src/components/experiences/modern/Leftbar/Leftbar.tsx
@@ -26,7 +26,6 @@ export default async function Leftbar(): Promise<JSX.Element> {
         <LeftbarLink
           path="/dashboard/playlists"
           title="Previous Sets"
-          disabled={true}
         >
           <StorageIcon />
         </LeftbarLink>

--- a/src/components/experiences/modern/previous-sets/Results/Results.tsx
+++ b/src/components/experiences/modern/previous-sets/Results/Results.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { usePlaylistSearch } from "@/src/hooks/playlistSearchHooks";
+import type { PlaylistSearchParams } from "@wxyc/shared/dtos";
+import { ArrowDownward, ArrowUpward } from "@mui/icons-material";
+import { Box, CircularProgress, Table, Typography } from "@mui/joy";
+import { useEffect, useRef } from "react";
+import ResultsContainer from "./ResultsContainer";
+
+function SortableHeader({
+  field,
+  label,
+  currentSort,
+  currentOrder,
+  onSort,
+}: {
+  field: "date" | "artist" | "song" | "dj";
+  label: string;
+  currentSort: PlaylistSearchParams["sort"];
+  currentOrder: "asc" | "desc";
+  onSort: (field: "date" | "artist" | "song" | "dj") => void;
+}) {
+  const isActive = currentSort === field;
+
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        cursor: "pointer",
+        userSelect: "none",
+        "&:hover": { color: "primary.plainColor" },
+      }}
+      onClick={() => onSort(field)}
+    >
+      {label}
+      {isActive && (
+        <Box component="span" sx={{ ml: 0.5, display: "flex" }}>
+          {currentOrder === "asc" ? (
+            <ArrowUpward sx={{ fontSize: 16 }} />
+          ) : (
+            <ArrowDownward sx={{ fontSize: 16 }} />
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function Results() {
+  const {
+    results,
+    total,
+    hasMore,
+    isLoading,
+    sortBy,
+    sortOrder,
+    handleSort,
+    loadNextPage,
+    effectiveQuery,
+  } = usePlaylistSearch();
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Infinite scroll
+  useEffect(() => {
+    const scroller = scrollRef.current;
+    if (!scroller) return;
+
+    const onScroll = () => {
+      const scrolledToBottom =
+        scroller.scrollHeight <=
+        scroller.scrollTop + scroller.clientHeight + 100;
+
+      if (scrolledToBottom && !isLoading && hasMore) {
+        loadNextPage();
+      }
+    };
+
+    scroller.addEventListener("scroll", onScroll);
+    return () => scroller.removeEventListener("scroll", onScroll);
+  }, [isLoading, hasMore, loadNextPage]);
+
+  const hasQuery = effectiveQuery.length >= 2;
+
+  return (
+    <ResultsContainer>
+      <Box
+        ref={scrollRef}
+        sx={{
+          maxHeight: "calc(100vh - 240px)",
+          overflowY: "auto",
+        }}
+      >
+        <Table
+          aria-label="playlist search results"
+          stickyHeader
+          hoverRow
+          sx={{
+            "--TableCell-headBackground": (theme) =>
+              theme.vars.palette.background.level1,
+            "--Table-headerUnderlineThickness": "1px",
+            "--TableRow-hoverBackground": (theme) =>
+              theme.vars.palette.background.level1,
+          }}
+        >
+          <thead>
+            <tr>
+              <th style={{ width: 160, padding: 12 }}>
+                <SortableHeader
+                  field="date"
+                  label="Date"
+                  currentSort={sortBy}
+                  currentOrder={sortOrder}
+                  onSort={handleSort}
+                />
+              </th>
+              <th style={{ width: 180, padding: 12 }}>
+                <SortableHeader
+                  field="artist"
+                  label="Artist"
+                  currentSort={sortBy}
+                  currentOrder={sortOrder}
+                  onSort={handleSort}
+                />
+              </th>
+              <th style={{ width: 200, padding: 12 }}>
+                <SortableHeader
+                  field="song"
+                  label="Song"
+                  currentSort={sortBy}
+                  currentOrder={sortOrder}
+                  onSort={handleSort}
+                />
+              </th>
+              <th style={{ width: 180, padding: 12 }}>Release</th>
+              <th style={{ width: 140, padding: 12 }}>Label</th>
+              <th style={{ width: 120, padding: 12 }}>
+                <SortableHeader
+                  field="dj"
+                  label="DJ"
+                  currentSort={sortBy}
+                  currentOrder={sortOrder}
+                  onSort={handleSort}
+                />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading && results.length === 0 ? (
+              <tr style={{ background: "transparent" }}>
+                <td
+                  colSpan={6}
+                  style={{
+                    textAlign: "center",
+                    paddingTop: "3rem",
+                    background: "transparent",
+                  }}
+                >
+                  <CircularProgress color="primary" size="md" />
+                </td>
+              </tr>
+            ) : (
+              results.map((result) => (
+                <tr key={result.id}>
+                  <td>
+                    <Typography level="body-sm" sx={{ color: "text.secondary" }}>
+                      {formatDate(new Date(result.play_date))}
+                    </Typography>
+                  </td>
+                  <td>
+                    <Typography level="body-sm" fontWeight="md">
+                      {result.artist_name}
+                    </Typography>
+                  </td>
+                  <td>
+                    <Typography level="body-sm">
+                      {result.track_title}
+                    </Typography>
+                  </td>
+                  <td>
+                    <Typography level="body-sm" sx={{ color: "text.secondary" }}>
+                      {result.album_title}
+                    </Typography>
+                  </td>
+                  <td>
+                    <Typography level="body-sm" sx={{ color: "text.tertiary" }}>
+                      {result.record_label}
+                    </Typography>
+                  </td>
+                  <td>
+                    <Typography level="body-sm">
+                      {result.dj_name}
+                    </Typography>
+                  </td>
+                </tr>
+              ))
+            )}
+
+            {isLoading && results.length > 0 && (
+              <tr style={{ background: "transparent" }}>
+                <td
+                  colSpan={6}
+                  style={{ textAlign: "center", padding: "1rem" }}
+                >
+                  <CircularProgress color="primary" size="sm" />
+                </td>
+              </tr>
+            )}
+
+            {hasQuery && !isLoading && results.length === 0 && (
+              <tr style={{ background: "transparent" }}>
+                <td
+                  colSpan={6}
+                  style={{ textAlign: "center", paddingTop: "2rem" }}
+                >
+                  <Typography level="body-sm" sx={{ color: "text.secondary" }}>
+                    No results found
+                  </Typography>
+                </td>
+              </tr>
+            )}
+
+            {!isLoading && !hasMore && results.length > 0 && (
+              <tr style={{ background: "transparent" }}>
+                <td
+                  colSpan={6}
+                  style={{ textAlign: "center", padding: "1rem" }}
+                >
+                  <Typography level="body-xs" sx={{ color: "text.tertiary" }}>
+                    {total.toLocaleString()} results
+                  </Typography>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </Table>
+      </Box>
+    </ResultsContainer>
+  );
+}

--- a/src/components/experiences/modern/previous-sets/Results/ResultsContainer.tsx
+++ b/src/components/experiences/modern/previous-sets/Results/ResultsContainer.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Logo from "@/src/components/shared/Branding/Logo";
+import { usePlaylistSearch } from "@/src/hooks/playlistSearchHooks";
+import { Box, Sheet, Typography } from "@mui/joy";
+
+export default function ResultsContainer({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { effectiveQuery } = usePlaylistSearch();
+  const hasQuery = effectiveQuery.length >= 2;
+
+  return (
+    <Sheet
+      variant="outlined"
+      sx={{
+        width: "100%",
+        borderRadius: "md",
+        flex: 1,
+        overflow: hasQuery ? "auto" : "hidden",
+        minHeight: 0,
+      }}
+    >
+      <Box
+        sx={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          zIndex: 999,
+          backdropFilter: hasQuery ? "blur(0)" : "blur(1rem)",
+          borderRadius: "lg",
+          pointerEvents: hasQuery ? "none" : "auto",
+          transition: "backdrop-filter 0.2s",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Box
+          sx={{
+            height: "80%",
+            opacity: hasQuery ? 0 : 1,
+            transition: "opacity 0.2s",
+            pb: 2,
+          }}
+        >
+          <Logo color="primary" />
+          <Typography
+            color="primary"
+            level="body-lg"
+            sx={{ textAlign: "center" }}
+          >
+            Start typing in the search bar above to explore previous sets!
+          </Typography>
+        </Box>
+      </Box>
+      {children}
+    </Sheet>
+  );
+}

--- a/src/components/experiences/modern/previous-sets/Search/Filters.tsx
+++ b/src/components/experiences/modern/previous-sets/Search/Filters.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { SimpleSearchField } from "@/lib/features/playlist-search/frontend";
+import { usePlaylistSearch } from "@/src/hooks/playlistSearchHooks";
+import { FormControl, FormLabel, Option, Select } from "@mui/joy";
+import React from "react";
+
+const SEARCH_FIELD_OPTIONS: { value: SimpleSearchField; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "artist", label: "Artist" },
+  { value: "song", label: "Song" },
+  { value: "album", label: "Album" },
+  { value: "label", label: "Label" },
+  { value: "dj", label: "DJ" },
+];
+
+export default function Filters() {
+  const { searchField, setSearchField, sortBy, sortOrder, handleSort } =
+    usePlaylistSearch();
+
+  const sortValue = `${sortBy}-${sortOrder}`;
+
+  const handleSortChange = (_: unknown, value: string | null) => {
+    if (!value) return;
+    const [field] = value.split("-") as ["date" | "artist" | "song" | "dj"];
+    // Toggle sort — if same field, it flips order; if different, sets desc
+    handleSort(field);
+  };
+
+  return (
+    <React.Fragment>
+      <FormControl size="sm" sx={{ flex: 1 }}>
+        <FormLabel>Search In</FormLabel>
+        <Select
+          color="primary"
+          placeholder="All"
+          value={searchField}
+          slotProps={{ button: { sx: { whiteSpace: "nowrap" } } }}
+          onChange={(_, newValue) =>
+            setSearchField((newValue as SimpleSearchField) || "all")
+          }
+        >
+          {SEARCH_FIELD_OPTIONS.map((opt) => (
+            <Option key={opt.value} value={opt.value}>
+              {opt.label}
+            </Option>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl size="sm" sx={{ flex: 1 }}>
+        <FormLabel>Sort By</FormLabel>
+        <Select
+          color="primary"
+          value={sortValue}
+          slotProps={{ button: { sx: { whiteSpace: "nowrap" } } }}
+          onChange={handleSortChange}
+        >
+          <Option value="date-desc">Date (Newest)</Option>
+          <Option value="date-asc">Date (Oldest)</Option>
+          <Option value="artist-desc">Artist (Z-A)</Option>
+          <Option value="artist-asc">Artist (A-Z)</Option>
+          <Option value="dj-desc">DJ (Z-A)</Option>
+          <Option value="dj-asc">DJ (A-Z)</Option>
+        </Select>
+      </FormControl>
+    </React.Fragment>
+  );
+}

--- a/src/components/experiences/modern/previous-sets/Search/SearchBar.tsx
+++ b/src/components/experiences/modern/previous-sets/Search/SearchBar.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { usePlaylistSearch } from "@/src/hooks/playlistSearchHooks";
+import PlaylistAdvancedSearch from "@/src/components/experiences/modern/playlist-search/PlaylistAdvancedSearch";
+import { Cancel, Troubleshoot, Tune } from "@mui/icons-material";
+import { Box, FormControl, FormLabel, IconButton, Input, Tooltip } from "@mui/joy";
+import Filters from "./Filters";
+
+export default function SearchBar() {
+  const {
+    mode,
+    setMode,
+    simpleQuery,
+    setSimpleQuery,
+    advancedRows,
+    addRow,
+    removeRow,
+    updateRow,
+    isLoading,
+  } = usePlaylistSearch();
+
+  const isAdvanced = mode === "advanced";
+
+  return (
+    <Box sx={{ py: 2 }}>
+      <Box
+        sx={{
+          borderRadius: "sm",
+          display: { xs: "none", sm: "flex" },
+          flexWrap: "wrap",
+          gap: 1.5,
+          "& > *": {
+            minWidth: { xs: "180px", md: "200px" },
+          },
+        }}
+      >
+        {!isAdvanced && (
+          <FormControl
+            sx={{ flex: 1, flexBasis: { xs: "100%", lg: "50%" } }}
+            size="sm"
+          >
+            <FormLabel>Search previous sets</FormLabel>
+            <Input
+              color="primary"
+              placeholder="Search"
+              startDecorator={<Troubleshoot />}
+              endDecorator={
+                simpleQuery !== "" ? (
+                  <IconButton
+                    variant="plain"
+                    color="primary"
+                    onClick={() => setSimpleQuery("")}
+                  >
+                    <Cancel />
+                  </IconButton>
+                ) : undefined
+              }
+              value={simpleQuery}
+              onChange={(e) => setSimpleQuery(e.target.value)}
+            />
+          </FormControl>
+        )}
+
+        {!isAdvanced && <Filters />}
+
+        <FormControl
+          size="sm"
+          sx={{ flex: "none", justifyContent: "flex-end" }}
+        >
+          <Tooltip
+            title={isAdvanced ? "Simple Search" : "Advanced Search"}
+            placement="top"
+            size="sm"
+          >
+            <IconButton
+              variant={isAdvanced ? "solid" : "outlined"}
+              color="primary"
+              onClick={() => setMode(isAdvanced ? "simple" : "advanced")}
+            >
+              <Tune />
+            </IconButton>
+          </Tooltip>
+        </FormControl>
+      </Box>
+
+      {isAdvanced && (
+        <Box sx={{ mt: 2 }}>
+          <PlaylistAdvancedSearch
+            rows={advancedRows}
+            onAddRow={addRow}
+            onRemoveRow={removeRow}
+            onUpdateRow={updateRow}
+            isLoading={isLoading}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/hooks/playlistSearchHooks.ts
+++ b/src/hooks/playlistSearchHooks.ts
@@ -1,13 +1,24 @@
 "use client";
 
 import { useLazySearchPlaylistsQuery } from "@/lib/features/playlist-search/api";
-import { playlistSearchSlice, SearchRow } from "@/lib/features/playlist-search/frontend";
+import { playlistSearchSlice, SearchRow, SimpleSearchField } from "@/lib/features/playlist-search/frontend";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useCallback, useEffect, useRef, useMemo } from "react";
 import type { PlaylistSearchResult } from "@wxyc/shared";
 
 const MIN_QUERY_LENGTH = 2;
 const LIMIT = 50;
+
+/** Field-specific prefixes for backend query parsing. */
+const fieldPrefixes: Record<string, string> = {
+  artist: "artist:",
+  song: "song:",
+  album: "album:",
+  label: "label:",
+  dj: "dj:",
+  date: "date:",
+  dateRange: "dateRange:",
+};
 
 /**
  * Build a query string from advanced search rows.
@@ -21,17 +32,6 @@ function buildAdvancedQuery(rows: SearchRow[]): string {
     if (!row.value.trim()) continue;
 
     let term = row.value.trim();
-
-    // Handle field-specific prefixes for backend parsing
-    const fieldPrefixes: Record<string, string> = {
-      artist: "artist:",
-      song: "song:",
-      album: "album:",
-      label: "label:",
-      dj: "dj:",
-      date: "date:",
-      dateRange: "dateRange:",
-    };
 
     // Format the value based on field type
     if (row.field === "dateRange" && row.valueTo) {
@@ -63,6 +63,7 @@ export function usePlaylistSearch() {
   const mode = useAppSelector(playlistSearchSlice.selectors.getMode);
   const simpleQuery = useAppSelector(playlistSearchSlice.selectors.getSimpleQuery);
   const advancedRows = useAppSelector(playlistSearchSlice.selectors.getAdvancedRows);
+  const searchField = useAppSelector(playlistSearchSlice.selectors.getSearchField);
   const sortBy = useAppSelector(playlistSearchSlice.selectors.getSortBy);
   const sortOrder = useAppSelector(playlistSearchSlice.selectors.getSortOrder);
   const page = useAppSelector(playlistSearchSlice.selectors.getPage);
@@ -70,10 +71,13 @@ export function usePlaylistSearch() {
   // Build the effective query based on mode
   const effectiveQuery = useMemo(() => {
     if (mode === "simple") {
-      return simpleQuery;
+      const q = simpleQuery.trim();
+      if (!q || searchField === "all") return q;
+      const prefix = fieldPrefixes[searchField];
+      return prefix ? `${prefix}${q}` : q;
     }
     return buildAdvancedQuery(advancedRows);
-  }, [mode, simpleQuery, advancedRows]);
+  }, [mode, simpleQuery, searchField, advancedRows]);
 
   // Track pending query to fire after current request completes
   const pendingQueryRef = useRef<string | null>(null);
@@ -159,6 +163,11 @@ export function usePlaylistSearch() {
     [dispatch]
   );
 
+  const setSearchField = useCallback(
+    (field: SimpleSearchField) => dispatch(playlistSearchSlice.actions.setSearchField(field)),
+    [dispatch]
+  );
+
   const addRow = useCallback(
     () => dispatch(playlistSearchSlice.actions.addRow()),
     [dispatch]
@@ -200,6 +209,7 @@ export function usePlaylistSearch() {
     // State
     mode,
     simpleQuery,
+    searchField,
     advancedRows,
     sortBy,
     sortOrder,
@@ -220,6 +230,7 @@ export function usePlaylistSearch() {
     // Actions
     setMode,
     setSimpleQuery,
+    setSearchField,
     addRow,
     removeRow,
     updateRow,


### PR DESCRIPTION
## Summary

- Add `/dashboard/playlists` page with playlist archive search matching the catalog/flowsheet design language
- Single search bar with "Search In" field filter, sort controls, and Advanced Search toggle
- Sortable results table with infinite scroll
- Enable the "Previous Sets" sidebar link
- Extend `playlistSearchSlice` with `searchField` state for field-scoped search
- Add MSW mock for `GET /flowsheet/search`

Reuses existing `playlistSearchApi`, `PlaylistAdvancedSearch`, and `PlaylistSearchRow` components.

**Note**: Results will be empty until the `GET /flowsheet/search` backend endpoint is built in Backend-Service. The API contract is defined by `@wxyc/shared` types.

## Test plan

- [x] All 2526 unit tests pass
- [x] TypeScript compiles cleanly
- [ ] Navigate to Previous Sets via sidebar — page renders with search bar and empty results container
- [ ] Type a search query — loading spinner appears (MSW returns empty results)
- [ ] Toggle Advanced Search — multi-row query builder appears
- [ ] Change "Search In" filter — verify field prefix is applied
- [ ] Verify card catalog and flowsheet still work as before

Closes #434