### PR TITLE
Cache dj-site build and Playwright browsers in E2E workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -117,6 +117,7 @@ jobs:
           EOF
 
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
@@ -130,9 +131,21 @@ jobs:
           (cd dj-site && npm ci) &
           wait
 
+      - name: Cache dj-site build
+        id: nextjs-build-cache
+        uses: actions/cache@v4
+        with:
+          path: dj-site/.next
+          key: e2e-nextjs-${{ hashFiles('dj-site/package-lock.json') }}-${{ hashFiles('dj-site/next.config.*') }}-${{ hashFiles('dj-site/app/**', 'dj-site/src/**', 'dj-site/lib/**') }}
+          restore-keys: |
+            e2e-nextjs-${{ hashFiles('dj-site/package-lock.json') }}-${{ hashFiles('dj-site/next.config.*') }}-
+            e2e-nextjs-${{ hashFiles('dj-site/package-lock.json') }}-
+
       - name: Build and start services
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NEXTJS_BUILD_CACHE_HIT: ${{ steps.nextjs-build-cache.outputs.cache-hit }}
+          PLAYWRIGHT_CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
         run: |
           # Backend track: build -> init-db -> start services -> seed users
           (
@@ -165,16 +178,29 @@ jobs:
           ) &
           PID_BACKEND=$!
 
-          # Frontend track: install Playwright + build dj-site (concurrent)
-          (cd dj-site && npx playwright install --with-deps chromium) &
-          PID_PW=$!
-          (cd dj-site && npm run build) &
-          PID_BUILD=$!
+          # Playwright track: skip install if browser binary is already cached.
+          # On cache hit the binary exists at ~/.cache/ms-playwright. The --with-deps
+          # flag installs system fonts via apt-get (~25s); ubuntu-latest already has
+          # the critical system libraries Chromium needs (libX11, libnss3, etc.).
+          if [ "$PLAYWRIGHT_CACHE_HIT" = "true" ]; then
+            echo "Playwright browser cache hit — skipping install"
+          else
+            (cd dj-site && npx playwright install --with-deps chromium) &
+            PID_PW=$!
+          fi
 
-          # Wait for all tracks -- fail if any fails
+          # dj-site build track: skip if exact cache hit on .next/
+          if [ "$NEXTJS_BUILD_CACHE_HIT" = "true" ]; then
+            echo "dj-site build cache hit — skipping build"
+          else
+            (cd dj-site && npm run build) &
+            PID_BUILD=$!
+          fi
+
+          # Wait for all tracks — fail if any fails
           wait $PID_BACKEND || exit 1
-          wait $PID_PW || exit 1
-          wait $PID_BUILD || exit 1
+          if [ -n "$PID_PW" ]; then wait $PID_PW || exit 1; fi
+          if [ -n "$PID_BUILD" ]; then wait $PID_BUILD || exit 1; fi
 
       - name: Start dj-site
         working-directory: dj-site

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,7 +288,7 @@ PRs that only change non-code files (docs, scripts, etc.) skip CI entirely via p
 
 ### E2E (`.github/workflows/e2e-tests.yml`)
 
-Runs on push to `main` and on PRs that touch app code. Spins up Backend-Service with Docker Compose (PostgreSQL + auth + backend), builds dj-site, runs Playwright tests. PRs that only change unit tests, test utilities, or non-app config skip E2E via path filters.
+Runs on push to `main` and on PRs that touch app code. Spins up Backend-Service with Docker Compose (PostgreSQL + auth + backend), builds dj-site, runs Playwright tests. PRs that only change unit tests, test utilities, or non-app config skip E2E via path filters. The workflow caches the dj-site `.next/` build output and Playwright browser binaries to reduce setup time. On cache hit, both the Next.js build and Playwright install are skipped entirely. Cache keys include `package-lock.json`, `next.config.*`, and app source files, so dependency or source changes invalidate the cache correctly.
 
 ### Deployment
 

--- a/lib/__tests__/features/admin/conversions-better-auth.test.ts
+++ b/lib/__tests__/features/admin/conversions-better-auth.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  convertBetterAuthToAccountResult,
+  BetterAuthUser,
+} from "@/lib/features/admin/conversions-better-auth";
+import { AdminAuthenticationStatus, Authorization } from "@/lib/features/admin/types";
+
+function createTestBetterAuthUser(
+  overrides: Partial<BetterAuthUser> = {}
+): BetterAuthUser {
+  return {
+    id: "user-1",
+    email: "test@wxyc.org",
+    name: "Test User",
+    username: "testuser",
+    emailVerified: true,
+    role: "dj",
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+    ...overrides,
+  };
+}
+
+describe("convertBetterAuthToAccountResult", () => {
+  it("should map hasCompletedOnboarding: true", () => {
+    const user = createTestBetterAuthUser({ hasCompletedOnboarding: true });
+    const account = convertBetterAuthToAccountResult(user);
+    expect(account.hasCompletedOnboarding).toBe(true);
+  });
+
+  it("should map hasCompletedOnboarding: false", () => {
+    const user = createTestBetterAuthUser({ hasCompletedOnboarding: false });
+    const account = convertBetterAuthToAccountResult(user);
+    expect(account.hasCompletedOnboarding).toBe(false);
+  });
+
+  it("should default hasCompletedOnboarding to false when undefined", () => {
+    const user = createTestBetterAuthUser({ hasCompletedOnboarding: undefined });
+    const account = convertBetterAuthToAccountResult(user);
+    expect(account.hasCompletedOnboarding).toBe(false);
+  });
+
+  it("should map basic user fields", () => {
+    const user = createTestBetterAuthUser({
+      username: "djcat",
+      realName: "Cat Power",
+      djName: "DJ Cat",
+      email: "cat@wxyc.org",
+    });
+    const account = convertBetterAuthToAccountResult(user);
+    expect(account.userName).toBe("djcat");
+    expect(account.realName).toBe("Cat Power");
+    expect(account.djName).toBe("DJ Cat");
+    expect(account.email).toBe("cat@wxyc.org");
+  });
+
+  it("should map role to authorization", () => {
+    const user = createTestBetterAuthUser({ role: "stationManager" });
+    const account = convertBetterAuthToAccountResult(user);
+    expect(account.authorization).toBe(Authorization.SM);
+  });
+
+  it("should map emailVerified to authType", () => {
+    const unverified = createTestBetterAuthUser({ emailVerified: false });
+    expect(convertBetterAuthToAccountResult(unverified).authType).toBe(
+      AdminAuthenticationStatus.New
+    );
+
+    const verified = createTestBetterAuthUser({ emailVerified: true });
+    expect(convertBetterAuthToAccountResult(verified).authType).toBe(
+      AdminAuthenticationStatus.Confirmed
+    );
+  });
+});

--- a/lib/features/admin/conversions-better-auth.ts
+++ b/lib/features/admin/conversions-better-auth.ts
@@ -17,6 +17,8 @@ export type BetterAuthUser = {
   banReason?: string;
   /** Cross-cutting capabilities independent of role hierarchy */
   capabilities?: string[];
+  /** Whether the user has completed the onboarding flow */
+  hasCompletedOnboarding?: boolean;
 };
 
 /**
@@ -36,6 +38,7 @@ export function convertBetterAuthToAccountResult(
       : AdminAuthenticationStatus.New,
     email: user.email,
     capabilities: user.capabilities ?? [],
+    hasCompletedOnboarding: user.hasCompletedOnboarding ?? false,
   };
 }
 

--- a/lib/features/admin/types.ts
+++ b/lib/features/admin/types.ts
@@ -24,6 +24,8 @@ export type Account = {
   email?: string;
   /** Cross-cutting capabilities independent of role hierarchy */
   capabilities?: string[];
+  /** Whether the user has completed the onboarding flow */
+  hasCompletedOnboarding?: boolean;
 };
 
 export type NewAccountParams = {

--- a/lib/test-utils/fixtures.ts
+++ b/lib/test-utils/fixtures.ts
@@ -477,6 +477,7 @@ export function createTestAccountResult(
     authorization: Authorization.DJ,
     authType: AdminAuthenticationStatus.Confirmed,
     email: "test@wxyc.org",
+    hasCompletedOnboarding: true,
     ...overrides,
   };
 }

--- a/src/components/experiences/modern/admin/roster/AccountEntry.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEntry.tsx
@@ -358,7 +358,24 @@ export const AccountEntry = ({
           </Stack>
         </Stack>
       </td>
-      <td>{account.realName}</td>
+      <td>
+        <Stack direction="row" spacing={0.5} alignItems="center">
+          <span>{account.realName}</span>
+          {account.hasCompletedOnboarding === false && (
+            <Tooltip
+              title="Has not completed onboarding"
+              arrow
+              placement="top"
+              variant="outlined"
+              size="sm"
+            >
+              <Chip variant="soft" color="warning" size="sm">
+                New
+              </Chip>
+            </Tooltip>
+          )}
+        </Stack>
+      </td>
       <td>{account.userName}</td>
       <td>
         {account.djName && account.djName.length > 0 && "DJ"} {account.djName ?? ""}

--- a/src/components/experiences/modern/admin/roster/__tests__/AccountEntry.test.tsx
+++ b/src/components/experiences/modern/admin/roster/__tests__/AccountEntry.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { AccountEntry } from "../AccountEntry";
+import { renderWithProviders, createTestAccountResult } from "@/lib/test-utils";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: {
+    admin: { listUsers: vi.fn(), updateUser: vi.fn(), removeUser: vi.fn(), setUserPassword: vi.fn() },
+    organization: { getFullOrganization: vi.fn(), listMembers: vi.fn(), updateMemberRole: vi.fn() },
+  },
+  authBaseURL: "http://localhost:8082/auth",
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  getAppOrganizationIdClient: vi.fn(() => "test-org"),
+}));
+
+function renderAccountEntry(overrides: Parameters<typeof createTestAccountResult>[0] = {}) {
+  const account = createTestAccountResult(overrides);
+  return renderWithProviders(
+    <table>
+      <tbody>
+        <AccountEntry account={account} isSelf={false} />
+      </tbody>
+    </table>
+  );
+}
+
+describe("AccountEntry onboarding indicator", () => {
+  it("should show 'New' chip when user has not completed onboarding", () => {
+    renderAccountEntry({ hasCompletedOnboarding: false });
+
+    expect(screen.getByText("New")).toBeInTheDocument();
+  });
+
+  it("should not show 'New' chip when user has completed onboarding", () => {
+    renderAccountEntry({ hasCompletedOnboarding: true });
+
+    expect(screen.queryByText("New")).not.toBeInTheDocument();
+  });
+
+  it("should not show 'New' chip when hasCompletedOnboarding is undefined", () => {
+    renderAccountEntry({ hasCompletedOnboarding: undefined });
+
+    expect(screen.queryByText("New")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Cache the full `.next/` build output in E2E, skipping `npm run build` entirely on exact cache hit
- Skip Playwright `install --with-deps` when browser binary is already cached, eliminating ~25s of `apt-get`
- Conditional PID-based wait logic handles skipped tracks cleanly

Closes #437

## Test plan

- [ ] First E2E run: same timing (cold cache), post-step shows "Cache saved" for both new entries
- [ ] Re-run via `gh workflow run e2e-tests.yml`: "Cache restored" for Playwright and `.next/`, build step drops to ~32s
- [ ] Push a source change: Playwright cache hit, `.next/` partial hit (restore-key), Turbopack incremental build
- [ ] All E2E tests pass (confirms cached `.next/` output is valid for `npm run start`)