### PR TITLE
Fix flaky E2E goLive/leave timeouts

### DIFF
--- a/e2e/pages/flowsheet.page.ts
+++ b/e2e/pages/flowsheet.page.ts
@@ -90,7 +90,18 @@ export class FlowsheetPage {
     // Wait for the button to be enabled and not loading
     await expect(this.goLiveButton).toBeEnabled({ timeout: 10000 });
     await this.page.waitForTimeout(300); // Let prior mutations settle
+    // Listen for the join mutation response BEFORE clicking so we don't
+    // miss a fast reply. Without this, slow CI runners can fail: the
+    // optimistic cache update fires synchronously, but React may not
+    // flush the re-render before Playwright's assertion polls, or the
+    // backend may reject and the optimistic patch rolls back.
+    const joinResponse = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/flowsheet/join") && resp.status() === 200,
+      { timeout: 15000 }
+    );
     await this.goLiveButton.click();
+    await joinResponse;
     await expect(this.liveStatus).toContainText("On Air", { timeout: 10000 });
     // Wait for search inputs to become enabled (live state propagates)
     await expect(this.songInput).toBeEnabled({ timeout: 5000 });
@@ -110,7 +121,13 @@ export class FlowsheetPage {
   async leave(): Promise<void> {
     await expect(this.goLiveButton).toBeEnabled({ timeout: 10000 });
     await this.page.waitForTimeout(300);
+    const endResponse = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/flowsheet/end") && resp.status() === 200,
+      { timeout: 15000 }
+    );
     await this.goLiveButton.click();
+    await endResponse;
     await expect(this.liveStatus).toContainText("Off Air", { timeout: 10000 });
   }
 


### PR DESCRIPTION
## Summary

- Wait for the `POST /flowsheet/join` and `POST /flowsheet/end` mutation responses in the `goLive()` and `leave()` page object methods before asserting on the DOM text.
- Previously, these methods clicked the button and immediately asserted that the status text had changed. On slow CI runners, the React render cycle could lag behind the optimistic RTK Query cache update, or a failed backend response could roll it back — both causing the 10s assertion timeout to fire.
- The same `waitForResponse`-before-click pattern is already used successfully in `addTrack()` and the reload step within `goLive()`.

Closes #439

## Test plan

- [ ] E2E suite passes locally (`npm run test:e2e`)
- [ ] CI E2E workflow passes — the entry-caching and library-search-proxy specs no longer flake on the go-live step