### PR TITLE
Fix goLive/leave response filter to prevent false timeouts

### DIFF
--- a/e2e/pages/flowsheet.page.ts
+++ b/e2e/pages/flowsheet.page.ts
@@ -90,18 +90,27 @@ export class FlowsheetPage {
     // Wait for the button to be enabled and not loading
     await expect(this.goLiveButton).toBeEnabled({ timeout: 10000 });
     await this.page.waitForTimeout(300); // Let prior mutations settle
-    // Listen for the join mutation response BEFORE clicking so we don't
-    // miss a fast reply. Without this, slow CI runners can fail: the
-    // optimistic cache update fires synchronously, but React may not
-    // flush the re-render before Playwright's assertion polls, or the
-    // backend may reject and the optimistic patch rolls back.
-    const joinResponse = this.page.waitForResponse(
+    // Listen for the mutation response BEFORE clicking so we don't miss
+    // a fast reply. Without this, slow CI runners can fail: the optimistic
+    // cache update fires synchronously, but React may not flush the
+    // re-render before Playwright's assertion polls, or the backend may
+    // reject and the optimistic patch rolls back.
+    //
+    // We match any POST to /flowsheet/ (not just /join with status 200)
+    // because the live toggle shares a single button — if a prior serial
+    // test left the DJ live and the whoIsLive query hasn't resolved yet,
+    // the beforeEach status check may misread "Off Air" and call goLive(),
+    // but by the time we click the component's live state may have flipped,
+    // sending POST /end instead of /join. Matching broadly lets the DOM
+    // assertion below be the real verification.
+    const mutationResponse = this.page.waitForResponse(
       (resp) =>
-        resp.url().includes("/flowsheet/join") && resp.status() === 200,
+        resp.url().includes("/flowsheet/") &&
+        resp.request().method() === "POST",
       { timeout: 15000 }
     );
     await this.goLiveButton.click();
-    await joinResponse;
+    await mutationResponse;
     await expect(this.liveStatus).toContainText("On Air", { timeout: 10000 });
     // Wait for search inputs to become enabled (live state propagates)
     await expect(this.songInput).toBeEnabled({ timeout: 5000 });
@@ -121,13 +130,14 @@ export class FlowsheetPage {
   async leave(): Promise<void> {
     await expect(this.goLiveButton).toBeEnabled({ timeout: 10000 });
     await this.page.waitForTimeout(300);
-    const endResponse = this.page.waitForResponse(
+    const mutationResponse = this.page.waitForResponse(
       (resp) =>
-        resp.url().includes("/flowsheet/end") && resp.status() === 200,
+        resp.url().includes("/flowsheet/") &&
+        resp.request().method() === "POST",
       { timeout: 15000 }
     );
     await this.goLiveButton.click();
-    await endResponse;
+    await mutationResponse;
     await expect(this.liveStatus).toContainText("Off Air", { timeout: 10000 });
   }
 

--- a/e2e/pages/flowsheet.page.ts
+++ b/e2e/pages/flowsheet.page.ts
@@ -90,28 +90,34 @@ export class FlowsheetPage {
     // Wait for the button to be enabled and not loading
     await expect(this.goLiveButton).toBeEnabled({ timeout: 10000 });
     await this.page.waitForTimeout(300); // Let prior mutations settle
-    // Listen for the mutation response BEFORE clicking so we don't miss
-    // a fast reply. Without this, slow CI runners can fail: the optimistic
-    // cache update fires synchronously, but React may not flush the
-    // re-render before Playwright's assertion polls, or the backend may
-    // reject and the optimistic patch rolls back.
-    //
-    // We match any POST to /flowsheet/ (not just /join with status 200)
-    // because the live toggle shares a single button — if a prior serial
-    // test left the DJ live and the whoIsLive query hasn't resolved yet,
-    // the beforeEach status check may misread "Off Air" and call goLive(),
-    // but by the time we click the component's live state may have flipped,
-    // sending POST /end instead of /join. Matching broadly lets the DOM
-    // assertion below be the real verification.
-    const mutationResponse = this.page.waitForResponse(
-      (resp) =>
-        resp.url().includes("/flowsheet/") &&
-        resp.request().method() === "POST",
-      { timeout: 15000 }
+
+    // Re-check status after the settle window. The whoIsLive query may
+    // have resolved since the caller checked, flipping the component's
+    // live state to true. Clicking while live would toggle us OFF air
+    // (the button dispatches leaveShow instead of joinShow).
+    const alreadyLive = (await this.liveStatus.textContent())?.includes(
+      "On Air"
     );
-    await this.goLiveButton.click();
-    await mutationResponse;
-    await expect(this.liveStatus).toContainText("On Air", { timeout: 10000 });
+
+    if (!alreadyLive) {
+      // Listen for the mutation response BEFORE clicking so we don't miss
+      // a fast reply. Without this, slow CI runners can fail: the optimistic
+      // cache update fires synchronously, but React may not flush the
+      // re-render before Playwright's assertion polls, or the backend may
+      // reject and the optimistic patch rolls back.
+      const mutationResponse = this.page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/flowsheet/") &&
+          resp.request().method() === "POST",
+        { timeout: 15000 }
+      );
+      await this.goLiveButton.click();
+      await mutationResponse;
+      await expect(this.liveStatus).toContainText("On Air", {
+        timeout: 10000,
+      });
+    }
+
     // Wait for search inputs to become enabled (live state propagates)
     await expect(this.songInput).toBeEnabled({ timeout: 5000 });
     // Reload and wait for the flowsheet API to respond with data, confirming


### PR DESCRIPTION
## Summary

- Broadens the `waitForResponse` filter in `goLive()` and `leave()` to match any `POST` to `/flowsheet/` instead of requiring a specific endpoint (`/join` or `/end`) with status 200.
- The previous filter (from #440) caused a new failure mode: if the backend returns non-200, or if a race between the `beforeEach` status check and the component's `live` state causes the click to dispatch the opposite mutation (`POST /end` instead of `/join`), the listener never fires and the test times out.
- The DOM assertion (`toContainText("On Air")`) that follows the response wait is the real verification of the expected state.

Follow-up to #440, continues fix for #439.

## Test plan

- [ ] E2E suite passes in CI — the entry-caching and library-search-proxy specs no longer flake on the go-live step