### PR TITLE
Fix roster admin operations failing on missing org env var

### DIFF
--- a/app/dashboard/@modern/admin/roster/page.tsx
+++ b/app/dashboard/@modern/admin/roster/page.tsx
@@ -12,14 +12,15 @@ export const metadata: Metadata = {
 export default async function AdminPage() {
   const session = await requireAuth();
   await requireRole(session, Authorization.SM);
-  
+
   const user = await getUserFromSession(session);
-  
+  const organizationSlug = process.env.NEXT_PUBLIC_APP_ORGANIZATION || "";
+
   return (
     <>
       <PageHeader title="DJ Roster" />
       <>
-        <RosterTable user={user} />
+        <RosterTable user={user} organizationSlug={organizationSlug} />
       </>
     </>
   );

--- a/lib/__tests__/features/authentication/organization-utils.test.ts
+++ b/lib/__tests__/features/authentication/organization-utils.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/lib/test-utils/msw/server";
 
 // Mock server auth client
 const mockListMembers = vi.fn();
@@ -20,6 +22,7 @@ vi.mock("@/lib/features/authentication/client", () => ({
       getFullOrganization: (options: any) => mockGetFullOrganization(options),
     },
   },
+  authBaseURL: "https://api.wxyc.org/auth",
 }));
 
 // Mock fetch for organization slug resolution (used by server-side tests)
@@ -30,6 +33,8 @@ import {
   getAppOrganizationId,
   getAppOrganizationIdClient,
   getUserRoleInOrganizationClient,
+  resolveOrganizationIdAdmin,
+  _resetOrgCacheForTesting,
 } from "@/lib/features/authentication/organization-utils";
 import {
   getUserRoleInOrganization,
@@ -110,6 +115,49 @@ describe("organization-utils", () => {
       const result = getAppOrganizationIdClient();
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe("resolveOrganizationIdAdmin", () => {
+    let receivedSlug: string | null = null;
+
+    beforeEach(() => {
+      _resetOrgCacheForTesting();
+      receivedSlug = null;
+      server.use(
+        http.get("https://api.wxyc.org/auth/admin/resolve-organization", ({ request }) => {
+          const url = new URL(request.url);
+          receivedSlug = url.searchParams.get("slug");
+          return HttpResponse.json({ id: `org-for-${receivedSlug}` });
+        })
+      );
+    });
+
+    it("should use slugOverride when provided, ignoring env var", async () => {
+      delete process.env.NEXT_PUBLIC_APP_ORGANIZATION;
+
+      const result = await resolveOrganizationIdAdmin("wxyc");
+
+      expect(result).toBe("org-for-wxyc");
+      expect(receivedSlug).toBe("wxyc");
+    });
+
+    it("should fall back to env var when no slugOverride is provided", async () => {
+      process.env.NEXT_PUBLIC_APP_ORGANIZATION = "wxyc-from-env";
+
+      const result = await resolveOrganizationIdAdmin();
+
+      expect(result).toBe("org-for-wxyc-from-env");
+      expect(receivedSlug).toBe("wxyc-from-env");
+    });
+
+    it("should return null when neither slugOverride nor env var is available", async () => {
+      delete process.env.NEXT_PUBLIC_APP_ORGANIZATION;
+
+      const result = await resolveOrganizationIdAdmin();
+
+      expect(result).toBeNull();
+      expect(receivedSlug).toBeNull();
     });
   });
 

--- a/lib/features/authentication/organization-utils.ts
+++ b/lib/features/authentication/organization-utils.ts
@@ -14,12 +14,14 @@ let cachedAdminOrgId: string | null = null;
  * Caches the result for the page session. For use in admin contexts only (roster,
  * role management) — requires the current user to have an admin session.
  *
+ * @param slugOverride - Explicit slug to use instead of the NEXT_PUBLIC_APP_ORGANIZATION env var.
+ *   Prefer passing this from a server component prop to avoid build-time inlining issues.
  * @returns The organization UUID, or null if the slug is not configured or resolution fails.
  */
-export async function resolveOrganizationIdAdmin(): Promise<string | null> {
+export async function resolveOrganizationIdAdmin(slugOverride?: string): Promise<string | null> {
   if (cachedAdminOrgId) return cachedAdminOrgId;
 
-  const slug = process.env.NEXT_PUBLIC_APP_ORGANIZATION;
+  const slug = slugOverride || process.env.NEXT_PUBLIC_APP_ORGANIZATION;
   if (!slug) return null;
 
   try {
@@ -161,4 +163,9 @@ export function normalizeRole(role: string): string {
   // For any other role string, return the original (mapRoleToAuthorization will handle it)
   // This includes better-auth default roles like "owner", "admin", "user"
   return role;
+}
+
+/** @internal — test-only cache reset */
+export function _resetOrgCacheForTesting() {
+  cachedAdminOrgId = null;
 }

--- a/src/components/experiences/modern/admin/roster/AccountEntry.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEntry.tsx
@@ -31,10 +31,12 @@ export const AccountEntry = ({
   account,
   isSelf,
   onAccountChange,
+  organizationSlug,
 }: {
   account: Account;
   isSelf: boolean;
   onAccountChange?: () => Promise<void>;
+  organizationSlug: string;
 }) => {
   const [isPromoting, setIsPromoting] = useState(false);
   const [isResetting, setIsResetting] = useState(false);
@@ -182,7 +184,7 @@ export const AccountEntry = ({
    * Resolve organization slug to organization ID via the admin endpoint.
    */
   const resolveOrganizationId = async (): Promise<string> => {
-    const orgId = await resolveOrganizationIdAdmin();
+    const orgId = await resolveOrganizationIdAdmin(organizationSlug);
     if (!orgId) {
       throw new Error("Organization not configured");
     }

--- a/src/components/experiences/modern/admin/roster/ImportCSVModal.test.tsx
+++ b/src/components/experiences/modern/admin/roster/ImportCSVModal.test.tsx
@@ -45,12 +45,12 @@ describe("ImportCSVModal", () => {
     open: true,
     onClose: vi.fn(),
     onComplete: vi.fn(),
+    organizationSlug: "wxyc",
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv("NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD", "temppass123");
-    vi.stubEnv("NEXT_PUBLIC_APP_ORGANIZATION", "wxyc");
     global.fetch = vi.fn();
   });
 
@@ -204,6 +204,19 @@ describe("ImportCSVModal", () => {
           body: expect.stringContaining("juana@wxyc.org"),
         }),
       );
+    });
+
+    it("should send organizationSlug from prop in the request body", async () => {
+      await renderAndStartImport();
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalled();
+      });
+
+      const body = JSON.parse(
+        (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body
+      );
+      expect(body.organizationSlug).toBe("wxyc");
     });
 
     it("should show results summary after import completes", async () => {

--- a/src/components/experiences/modern/admin/roster/ImportCSVModal.tsx
+++ b/src/components/experiences/modern/admin/roster/ImportCSVModal.tsx
@@ -27,6 +27,7 @@ type ImportCSVModalProps = {
   open: boolean;
   onClose: () => void;
   onComplete: () => void;
+  organizationSlug: string;
 };
 
 type ModalState = "upload" | "preview" | "importing" | "results";
@@ -52,7 +53,7 @@ function downloadTemplate() {
   URL.revokeObjectURL(url);
 }
 
-export default function ImportCSVModal({ open, onClose, onComplete }: ImportCSVModalProps) {
+export default function ImportCSVModal({ open, onClose, onComplete, organizationSlug }: ImportCSVModalProps) {
   const [state, setState] = useState<ModalState>("upload");
   const [rows, setRows] = useState<CSVImportRow[]>([]);
   const [errors, setErrors] = useState<CSVRowError[]>([]);
@@ -95,7 +96,6 @@ export default function ImportCSVModal({ open, onClose, onComplete }: ImportCSVM
     setImportResults([]);
 
     const tempPassword = String(process.env.NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD || "");
-    const organizationSlug = process.env.NEXT_PUBLIC_APP_ORGANIZATION || "";
     const role = authorizationToRole(authorization);
 
     // Filter to only valid rows

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -24,7 +24,7 @@ import ExportDJsButton from "./ExportCSV";
 import ImportCSVModal from "./ImportCSVModal";
 import NewAccountForm from "./NewAccountForm";
 
-export default function RosterTable({ user }: { user: User }) {
+export default function RosterTable({ user, organizationSlug }: { user: User; organizationSlug: string }) {
   const { data, isLoading, isError, error, refetch } = useAccountListResults();
 
   const [isCreating, setIsCreating] = useState(false);
@@ -63,9 +63,8 @@ export default function RosterTable({ user }: { user: User }) {
           throw new Error("Missing onboarding temp password configuration.");
         }
 
-        const organizationSlug = process.env.NEXT_PUBLIC_APP_ORGANIZATION;
         if (!organizationSlug) {
-          throw new Error("Organization not configured (NEXT_PUBLIC_APP_ORGANIZATION not set).");
+          throw new Error("Organization not configured.");
         }
 
         const newAccount: NewAccountParams = {
@@ -225,6 +224,7 @@ export default function RosterTable({ user }: { user: User }) {
                   account={dj}
                   isSelf={dj.userName === user.username}
                   onAccountChange={refetch}
+                  organizationSlug={organizationSlug}
                 />
               ))
             )}
@@ -292,6 +292,7 @@ export default function RosterTable({ user }: { user: User }) {
           setImportModalOpen(false);
           refetch();
         }}
+        organizationSlug={organizationSlug}
       />
     </Sheet>
   );

--- a/src/components/experiences/modern/admin/roster/__tests__/AccountEntry.test.tsx
+++ b/src/components/experiences/modern/admin/roster/__tests__/AccountEntry.test.tsx
@@ -13,14 +13,15 @@ vi.mock("@/lib/features/authentication/client", () => ({
 
 vi.mock("@/lib/features/authentication/organization-utils", () => ({
   getAppOrganizationIdClient: vi.fn(() => "test-org"),
+  resolveOrganizationIdAdmin: vi.fn(() => Promise.resolve("resolved-org-id")),
 }));
 
-function renderAccountEntry(overrides: Parameters<typeof createTestAccountResult>[0] = {}) {
+function renderAccountEntry(overrides: Parameters<typeof createTestAccountResult>[0] = {}, organizationSlug = "wxyc") {
   const account = createTestAccountResult(overrides);
   return renderWithProviders(
     <table>
       <tbody>
-        <AccountEntry account={account} isSelf={false} />
+        <AccountEntry account={account} isSelf={false} organizationSlug={organizationSlug} />
       </tbody>
     </table>
   );


### PR DESCRIPTION
## Summary

- Read NEXT_PUBLIC_APP_ORGANIZATION in the server component at runtime and pass it as a prop to client components, avoiding dependency on build-time env var inlining
- Add optional `slugOverride` parameter to `resolveOrganizationIdAdmin()` so callers can pass the slug explicitly
- Fix account creation (Add DJ), CSV import, and role change operations that were hard-failing when the env var wasn't inlined

Closes #446

## Test plan

- [x] TypeScript compiles with no errors
- [x] All 2547 unit tests pass
- [x] Production build succeeds
- [ ] CI passes (typecheck, tests, build)
- [ ] E2E passes (account creation exercises this code path)
- [ ] Cloudflare Pages deployment succeeds
- [ ] Verify Add DJ works in production