### PR TITLE
Combine Code and Format into a single catalog column

### DIFF
--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -114,13 +114,6 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
           >
             {album.artist.genre}
           </Chip>
-          <Typography level="body-sm" noWrap>
-            {album.artist.lettercode} {album.artist.numbercode}/{album.entry}
-          </Typography>
-        </Stack>
-      </td>
-      <td>
-        <Stack gap={0.5}>
           <Chip
             variant="soft"
             size="sm"
@@ -143,6 +136,9 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
               WXYC EXCLUSIVE
             </Chip>
           )}
+          <Typography level="body-sm" noWrap>
+            {album.artist.lettercode} {album.artist.numbercode}/{album.entry}
+          </Typography>
         </Stack>
       </td>
       <td>

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -46,7 +46,7 @@ export default function Results({
           "& tbody tr > *:last-child": {
             position: "sticky",
             right: 0,
-            bgcolor: "var(--joy-palette-background-surface, #fff)",
+            bgcolor: "var(--joy-palette-background-surface)",
           },
           "& tbody tr:hover > *:last-child": {
             bgcolor: "var(--TableRow-hoverBackground)",
@@ -81,19 +81,16 @@ export default function Results({
               />
             </th>
             <th style={{ width: 50, padding: 12 }}></th>
-            <th style={{ width: 220, padding: 12 }}>
+            <th style={{ width: 180, padding: 12 }}>
               <TableHeader textValue="Artist" />
             </th>
-            <th style={{ width: 220, padding: 12 }}>
+            <th style={{ width: 180, padding: 12 }}>
               <TableHeader textValue="Title" />
             </th>
-            <th style={{ width: 130, padding: 12 }}>
+            <th style={{ width: 280, padding: 12 }}>
               <TableHeader textValue="Code" />
             </th>
-            <th style={{ width: 70, padding: 12 }}>
-              <TableHeader textValue="Format" />
-            </th>
-            <th style={{ width: 60, padding: 12 }}>
+            <th style={{ width: 80, padding: 12 }}>
               <TableHeader textValue="Plays" />
             </th>
             <th style={{ width: 120, padding: 12 }}></th>
@@ -103,7 +100,7 @@ export default function Results({
           {loading ? (
             <tr style={{ background: "transparent" }}>
               <td
-                colSpan={8}
+                colSpan={7}
                 style={{
                   textAlign: "center",
                   paddingTop: "3rem",
@@ -121,7 +118,7 @@ export default function Results({
 
           {!loading && !reachedEndForQuery && (
             <tr>
-              <td colSpan={8} style={{ textAlign: "center" }}>
+              <td colSpan={7} style={{ textAlign: "center" }}>
                 <Button
                   variant="solid"
                   color="primary"


### PR DESCRIPTION
## Summary

- Merge the separate Code and Format columns in the card catalog table into a single Code column showing `[genre chip] [format chip] [library code]` inline.
- Widen the combined column so the library code is no longer truncated.
- Remove the hardcoded `#fff` fallback on the sticky action buttons column so it respects the theme background in dark mode.

## Test plan

- [ ] Open the card catalog and verify the Code column displays genre, format, and library code inline
- [ ] Verify the library code (e.g., `AU O8/1`) is fully visible and not truncated
- [ ] Verify the action buttons column (info, add to queue, bin) has no white background in dark mode
- [ ] Verify albums with "WXYC EXCLUSIVE" chip still display it correctly in the combined column
- [ ] Verify the Plays column header is fully visible