### PR TITLE
Fix null crash on /flowsheet/latest

### DIFF
--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -44,12 +44,12 @@ export const flowsheetApi = createApi({
   baseQuery: backendBaseQuery("flowsheet"),
   tagTypes: ["NowPlaying", "WhoIsLive", "Flowsheet"],
   endpoints: (builder) => ({
-    getNowPlaying: builder.query<FlowsheetEntry, void>({
+    getNowPlaying: builder.query<FlowsheetEntry | null, void>({
       query: () => ({
         url: "/latest",
       }),
-      transformResponse: (response: FlowsheetV2EntryJSON) =>
-        convertV2Entry(response),
+      transformResponse: (response: FlowsheetV2EntryJSON | null) =>
+        response ? convertV2Entry(response) : null,
       providesTags: ["NowPlaying"],
     }),
     getInfiniteEntries: builder.infiniteQuery<


### PR DESCRIPTION
## Summary

- Guard against null response from `GET /flowsheet/latest` in the `getNowPlaying` RTK Query endpoint.
- When the backend returns no data (empty database, no active show), the transform now returns `null` instead of crashing on `entry.id`.
- The only consumer (`NowPlaying` widget) already handles null via `??` coalescing.

Companion backend PR: WXYC/Backend-Service (changes `/flowsheet/latest` to return 204 No Content instead of `200 null`).

## Test plan

- [ ] Start with a fresh database (no shows, no entries) and verify the flowsheet page loads without a `TypeError: null is not an object` console error
- [ ] Start a show, add entries, and verify the Now Playing widget still displays correctly