### PR TITLE
Move roster DJ editing controls to modal

### DIFF
--- a/e2e/pages/roster.page.ts
+++ b/e2e/pages/roster.page.ts
@@ -277,7 +277,7 @@ export class RosterPage {
     await this.openEditModal(username);
     const { delete: deleteBtn } = this.getModalActionButtons();
     await deleteBtn.waitFor({ state: "visible", timeout: 5000 });
-    await deleteBtn.click({ force: true });
+    await deleteBtn.evaluate((el) => (el as HTMLElement).click());
   }
 
   async resetUserPassword(username: string): Promise<void> {
@@ -285,7 +285,7 @@ export class RosterPage {
     const { resetPassword } = this.getModalActionButtons();
     await resetPassword.waitFor({ state: "visible", timeout: 5000 });
     await this.page.waitForTimeout(300);
-    await resetPassword.click({ force: true });
+    await resetPassword.evaluate((el) => (el as HTMLElement).click());
   }
 
   /**
@@ -480,7 +480,8 @@ export class RosterPage {
    */
   async confirmEmailChange(username: string): Promise<void> {
     const saveButton = this.getEmailConfirmButton(username);
-    await saveButton.click({ force: true });
+    await saveButton.waitFor({ state: "visible", timeout: 5000 });
+    await saveButton.evaluate((el) => (el as HTMLElement).click());
   }
 
   /**

--- a/e2e/pages/roster.page.ts
+++ b/e2e/pages/roster.page.ts
@@ -77,7 +77,7 @@ export class RosterPage {
 
     // Edit modal — MUI Joy ModalDialog
     this.editModal = page.locator('[role="dialog"]');
-    this.editModalClose = this.editModal.locator('button[aria-label="Close"]');
+    this.editModalClose = this.editModal.locator('.MuiModalClose-root');
   }
 
   async goto(): Promise<void> {
@@ -362,21 +362,20 @@ export class RosterPage {
 
   async expectSuccessToast(message?: string): Promise<void> {
     if (message) {
-      // Wait for a toast containing the specific message
       const specificToast = this.page.locator(`[data-sonner-toast][data-type="success"]:has-text("${message}")`);
       await expect(specificToast).toBeVisible({ timeout: 10000 });
     } else {
-      await expect(this.successToast).toBeVisible({ timeout: 10000 });
+      // Use .first() to avoid strict mode violations when multiple success toasts are visible
+      await expect(this.successToast.first()).toBeVisible({ timeout: 10000 });
     }
   }
 
   async expectErrorToast(message?: string): Promise<void> {
     if (message) {
-      // Wait for a toast containing the specific message
       const specificToast = this.page.locator(`[data-sonner-toast][data-type="error"]:has-text("${message}")`);
       await expect(specificToast).toBeVisible({ timeout: 10000 });
     } else {
-      await expect(this.errorToast).toBeVisible({ timeout: 10000 });
+      await expect(this.errorToast.first()).toBeVisible({ timeout: 10000 });
     }
   }
 

--- a/e2e/pages/roster.page.ts
+++ b/e2e/pages/roster.page.ts
@@ -191,7 +191,8 @@ export class RosterPage {
    * Close the edit modal.
    */
   async closeEditModal(): Promise<void> {
-    await this.editModalClose.click();
+    // Use force click to bypass MUI overlay elements that intercept pointer events
+    await this.editModalClose.click({ force: true });
     await this.editModal.waitFor({ state: "hidden", timeout: 5000 });
   }
 

--- a/e2e/pages/roster.page.ts
+++ b/e2e/pages/roster.page.ts
@@ -191,8 +191,9 @@ export class RosterPage {
    * Close the edit modal.
    */
   async closeEditModal(): Promise<void> {
-    // Use force click to bypass MUI overlay elements that intercept pointer events
-    await this.editModalClose.click({ force: true });
+    // Press Escape to close the modal — more reliable than clicking the close
+    // button, which can be intercepted by MUI overlay elements
+    await this.page.keyboard.press("Escape");
     await this.editModal.waitFor({ state: "hidden", timeout: 5000 });
   }
 

--- a/e2e/pages/roster.page.ts
+++ b/e2e/pages/roster.page.ts
@@ -36,6 +36,10 @@ export class RosterPage {
   readonly successToast: Locator;
   readonly errorToast: Locator;
 
+  // Edit modal
+  readonly editModal: Locator;
+  readonly editModalClose: Locator;
+
   constructor(page: Page) {
     this.page = page;
 
@@ -70,6 +74,10 @@ export class RosterPage {
     // Toasts
     this.successToast = page.locator('[data-sonner-toast][data-type="success"]');
     this.errorToast = page.locator('[data-sonner-toast][data-type="error"]');
+
+    // Edit modal — MUI Joy ModalDialog
+    this.editModal = page.locator('[role="dialog"]');
+    this.editModalClose = this.editModal.locator('button[aria-label="Close"]');
   }
 
   async goto(): Promise<void> {
@@ -157,26 +165,68 @@ export class RosterPage {
     return this.page.locator(`tr:has-text("${username}")`);
   }
 
+  // ---------------------------------------------------------------------------
+  // Edit modal helpers
+  // ---------------------------------------------------------------------------
+
   /**
-   * Get the role select dropdown for a user row.
-   * MUI Joy Select renders a button[role="combobox"].
+   * Get the settings button for a user row (opens the edit modal).
    */
-  getRoleSelect(username: string): Locator {
+  getEditButton(username: string): Locator {
     const row = this.getUserRow(username);
-    return row.locator('[role="combobox"]').first();
+    return row.locator("td").last().locator("button");
   }
 
   /**
-   * Set a user's role via the select dropdown.
-   * @param username - The username of the user row
+   * Open the edit modal for a user.
+   */
+  async openEditModal(username: string): Promise<void> {
+    const editBtn = this.getEditButton(username);
+    await editBtn.waitFor({ state: "visible", timeout: 5000 });
+    await editBtn.click();
+    await this.editModal.waitFor({ state: "visible", timeout: 5000 });
+  }
+
+  /**
+   * Close the edit modal.
+   */
+  async closeEditModal(): Promise<void> {
+    await this.editModalClose.click();
+    await this.editModal.waitFor({ state: "hidden", timeout: 5000 });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Role management (via edit modal)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Get the role select dropdown inside the edit modal.
+   */
+  getModalRoleSelect(): Locator {
+    return this.editModal.locator('[role="combobox"]').first();
+  }
+
+  /**
+   * Get the role select dropdown for a user row (display-only chip).
+   * For backward compatibility with assertion methods.
+   */
+  getRoleSelect(username: string): Locator {
+    return this.getModalRoleSelect();
+  }
+
+  /**
+   * Set a user's role via the edit modal.
+   * @param username - The username of the user
    * @param roleLabel - Display label: "Member", "DJ", "Music Director", or "Station Manager"
    */
   async setUserRole(username: string, roleLabel: string): Promise<void> {
-    const select = this.getRoleSelect(username);
+    await this.openEditModal(username);
+    const select = this.getModalRoleSelect();
     await select.waitFor({ state: "visible", timeout: 5000 });
     await select.click();
     await this.page.getByRole("option", { name: roleLabel }).click();
     await this.page.waitForTimeout(1000);
+    await this.closeEditModal();
   }
 
   /** Wrapper for backward compatibility */
@@ -199,36 +249,40 @@ export class RosterPage {
     await this.setUserRole(username, "DJ");
   }
 
+  // ---------------------------------------------------------------------------
+  // Action buttons (inside edit modal)
+  // ---------------------------------------------------------------------------
+
   /**
-   * Get action buttons for a user row
-   * The buttons are IconButtons in a Stack - reset password is first, delete is last
+   * Get action buttons inside the edit modal.
    */
-  getActionButtons(username: string): { resetPassword: Locator; delete: Locator } {
-    const row = this.getUserRow(username);
-    // The buttons are in the last cell (td) of the row, in a Stack
-    const actionCell = row.locator("td").last();
-    const buttons = actionCell.locator("button");
+  getModalActionButtons(): { resetPassword: Locator; delete: Locator } {
     return {
-      resetPassword: buttons.first(),
-      delete: buttons.last(),
+      resetPassword: this.editModal.locator('button:has-text("Reset Password")'),
+      delete: this.editModal.locator('button:has-text("Delete Account")'),
     };
   }
 
+  /**
+   * Get action buttons for a user row — opens the modal first.
+   * @deprecated Use openEditModal() + getModalActionButtons() directly.
+   */
+  getActionButtons(username: string): { resetPassword: Locator; delete: Locator } {
+    return this.getModalActionButtons();
+  }
+
   async deleteUser(username: string): Promise<void> {
-    const { delete: deleteBtn } = this.getActionButtons(username);
-    // Wait for button to be visible and enabled
+    await this.openEditModal(username);
+    const { delete: deleteBtn } = this.getModalActionButtons();
     await deleteBtn.waitFor({ state: "visible", timeout: 5000 });
-    // Use regular click to properly trigger dialog interception
     await deleteBtn.click();
   }
 
   async resetUserPassword(username: string): Promise<void> {
-    const { resetPassword } = this.getActionButtons(username);
-    // Wait for button to be visible and enabled
+    await this.openEditModal(username);
+    const { resetPassword } = this.getModalActionButtons();
     await resetPassword.waitFor({ state: "visible", timeout: 5000 });
-    // Small delay to ensure button is interactive
     await this.page.waitForTimeout(300);
-    // Use force click to bypass any overlays (like Tooltips)
     await resetPassword.click({ force: true });
   }
 
@@ -327,29 +381,37 @@ export class RosterPage {
   }
 
   /**
-   * Assert the role select dropdown is disabled for a user (e.g., self-modification prevention)
+   * Assert the role select dropdown is disabled for a user (via edit modal)
    */
   async expectRoleSelectDisabled(username: string): Promise<void> {
-    const select = this.getRoleSelect(username);
+    await this.openEditModal(username);
+    const select = this.getModalRoleSelect();
     await expect(select).toBeDisabled();
+    await this.closeEditModal();
   }
 
   /**
-   * Assert the role select shows a specific role label for a user
+   * Assert the role shows a specific label for a user (via the chip in the table row)
    */
   async expectUserRole(username: string, roleLabel: string): Promise<void> {
-    const select = this.getRoleSelect(username);
-    await expect(select).toContainText(roleLabel, { timeout: 10000 });
+    const row = this.getUserRow(username);
+    // The role is displayed as a Chip in the first cell
+    const roleChip = row.locator("td").first().locator(".MuiChip-root").first();
+    await expect(roleChip).toContainText(roleLabel, { timeout: 10000 });
   }
 
   async expectDeleteButtonDisabled(username: string): Promise<void> {
-    const { delete: deleteBtn } = this.getActionButtons(username);
+    await this.openEditModal(username);
+    const { delete: deleteBtn } = this.getModalActionButtons();
     await expect(deleteBtn).toBeDisabled();
+    await this.closeEditModal();
   }
 
   async expectResetPasswordButtonDisabled(username: string): Promise<void> {
-    const { resetPassword } = this.getActionButtons(username);
+    await this.openEditModal(username);
+    const { resetPassword } = this.getModalActionButtons();
     await expect(resetPassword).toBeDisabled();
+    await this.closeEditModal();
   }
 
   async getUserCount(): Promise<number> {
@@ -359,80 +421,72 @@ export class RosterPage {
     return Math.max(0, count - 1);
   }
 
+  // ---------------------------------------------------------------------------
+  // Email editing (via edit modal)
+  // ---------------------------------------------------------------------------
+
   /**
-   * Get the email edit button for a user row
+   * Get the email edit button for a user row.
+   * With the modal refactor, email editing is inside the modal.
+   * This opens the modal and returns the email input.
    */
   getEmailEditButton(username: string): Locator {
-    const row = this.getUserRow(username);
-    // The email cell has a Stack with the email text and an edit button
-    // Find the cell containing the email, then get the button inside it
-    return row.locator("td").nth(4).locator("button");
+    // The "edit" button is now the settings button on the row
+    return this.getEditButton(username);
   }
 
   /**
-   * Get the email input field when editing
+   * Get the email input field inside the edit modal
+   */
+  getModalEmailInput(): Locator {
+    return this.editModal.locator('input[type="email"]');
+  }
+
+  /**
+   * Get the email input field when editing (alias for modal version)
    */
   getEmailInput(username: string): Locator {
-    const row = this.getUserRow(username);
-    return row.locator("td").nth(4).locator("input");
+    return this.getModalEmailInput();
   }
 
   /**
-   * Get the confirm button when editing email
+   * Get the save button for email changes in the modal
    */
   getEmailConfirmButton(username: string): Locator {
-    const row = this.getUserRow(username);
-    // The confirm button is the first button in the email cell (green checkmark)
-    return row.locator("td").nth(4).locator("button").first();
+    return this.editModal.locator('button:has-text("Save")');
   }
 
   /**
-   * Get the cancel button when editing email
-   */
-  getEmailCancelButton(username: string): Locator {
-    const row = this.getUserRow(username);
-    // The cancel button is the second button in the email cell
-    return row.locator("td").nth(4).locator("button").nth(1);
-  }
-
-  /**
-   * Start editing a user's email
+   * Start editing a user's email by opening the modal
    */
   async startEditEmail(username: string): Promise<void> {
-    const editButton = this.getEmailEditButton(username);
-    await editButton.waitFor({ state: "visible", timeout: 5000 });
-    // Use JavaScript click to bypass MUI Chips in adjacent cells that intercept pointer events
-    await editButton.evaluate((el) => (el as HTMLElement).click());
-    // Wait for input to appear
-    await this.getEmailInput(username).waitFor({ state: "visible", timeout: 5000 });
+    await this.openEditModal(username);
+    await this.getModalEmailInput().waitFor({ state: "visible", timeout: 5000 });
   }
 
   /**
-   * Update a user's email (full flow)
+   * Update a user's email (full flow inside modal)
    */
   async updateUserEmail(username: string, newEmail: string): Promise<void> {
     await this.startEditEmail(username);
-    const emailInput = this.getEmailInput(username);
+    const emailInput = this.getModalEmailInput();
     await emailInput.clear();
     await emailInput.fill(newEmail);
   }
 
   /**
-   * Confirm the email change
+   * Confirm the email change (click Save in the modal)
    */
   async confirmEmailChange(username: string): Promise<void> {
-    const confirmButton = this.getEmailConfirmButton(username);
-    // Use JavaScript click to bypass MUI Chips in adjacent cells that intercept pointer events
-    await confirmButton.evaluate((el) => (el as HTMLElement).click());
+    const saveButton = this.getEmailConfirmButton(username);
+    await saveButton.click();
   }
 
   /**
-   * Cancel the email change
+   * Cancel the email change (close the modal without saving)
    */
   async cancelEmailChange(username: string): Promise<void> {
-    const cancelButton = this.getEmailCancelButton(username);
-    // Use JavaScript click to bypass MUI Chips in adjacent cells that intercept pointer events
-    await cancelButton.evaluate((el) => (el as HTMLElement).click());
+    await this.closeEditModal();
   }
 
   /**
@@ -445,14 +499,12 @@ export class RosterPage {
   }
 
   /**
-   * Get the current email displayed for a user
+   * Get the current email displayed for a user from the table row
    */
   async getUserEmail(username: string): Promise<string> {
     const row = this.getUserRow(username);
     const emailCell = row.locator("td").nth(4);
-    // Get the text content, filtering out any button text
-    const emailSpan = emailCell.locator("span").first();
-    return (await emailSpan.textContent()) || "";
+    return ((await emailCell.textContent()) || "").trim();
   }
 
   /**

--- a/e2e/pages/roster.page.ts
+++ b/e2e/pages/roster.page.ts
@@ -277,7 +277,7 @@ export class RosterPage {
     await this.openEditModal(username);
     const { delete: deleteBtn } = this.getModalActionButtons();
     await deleteBtn.waitFor({ state: "visible", timeout: 5000 });
-    await deleteBtn.click();
+    await deleteBtn.click({ force: true });
   }
 
   async resetUserPassword(username: string): Promise<void> {
@@ -480,7 +480,7 @@ export class RosterPage {
    */
   async confirmEmailChange(username: string): Promise<void> {
     const saveButton = this.getEmailConfirmButton(username);
-    await saveButton.click();
+    await saveButton.click({ force: true });
   }
 
   /**

--- a/e2e/tests/admin/admin-email-change.spec.ts
+++ b/e2e/tests/admin/admin-email-change.spec.ts
@@ -21,33 +21,23 @@ test.describe("Admin Email Change", () => {
     await rosterPage.waitForTableLoaded();
   });
 
-  test("should display edit button for user emails", async () => {
-    // The dj1 user should have an edit button
-    const editButton = rosterPage.getEmailEditButton(TEST_USERS.dj1.username);
+  test("should display edit button for user", async () => {
+    // The dj1 user should have an edit (settings) button
+    const editButton = rosterPage.getEditButton(TEST_USERS.dj1.username);
     await expect(editButton).toBeVisible();
   });
 
-  test("should not display edit button for own email", async () => {
-    // Station manager should not have edit button for their own email
-    const editButton = rosterPage.getEmailEditButton(TEST_USERS.stationManager.username);
-    await expect(editButton).not.toBeVisible();
-  });
-
-  test("should show inline edit mode when clicking edit button", async () => {
+  test("should show email input in edit modal", async () => {
     await rosterPage.startEditEmail(TEST_USERS.dj1.username);
 
     // Should show input field
     const emailInput = rosterPage.getEmailInput(TEST_USERS.dj1.username);
     await expect(emailInput).toBeVisible();
 
-    // Should show confirm and cancel buttons
-    const confirmButton = rosterPage.getEmailConfirmButton(TEST_USERS.dj1.username);
-    const cancelButton = rosterPage.getEmailCancelButton(TEST_USERS.dj1.username);
-    await expect(confirmButton).toBeVisible();
-    await expect(cancelButton).toBeVisible();
+    await rosterPage.closeEditModal();
   });
 
-  test("should cancel email edit when clicking cancel button", async () => {
+  test("should cancel email edit when closing modal", async () => {
     const originalEmail = await rosterPage.getUserEmail(TEST_USERS.dj1.username);
 
     await rosterPage.startEditEmail(TEST_USERS.dj1.username);
@@ -57,7 +47,7 @@ test.describe("Admin Email Change", () => {
     await emailInput.clear();
     await emailInput.fill("changed@example.com");
 
-    // Cancel
+    // Close modal without saving
     await rosterPage.cancelEmailChange(TEST_USERS.dj1.username);
 
     // Email should be unchanged
@@ -244,10 +234,8 @@ test.describe("Admin Email Change - Error Handling", () => {
     // Wait for dialog to be processed
     await page.waitForTimeout(500);
 
-    // Original email should still be there (edit mode might still be open though)
-    // Cancel to exit edit mode using the page object method (uses JS click
-    // to bypass MUI Chips that intercept pointer events)
-    await rosterPage.cancelEmailChange(TEST_USERS.dj1.username);
+    // Close modal without saving
+    await rosterPage.closeEditModal();
 
     await rosterPage.expectUserEmail(TEST_USERS.dj1.username, originalEmail);
   });

--- a/src/components/experiences/modern/admin/roster/AccountEditModal.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEditModal.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import { authClient } from "@/lib/features/authentication/client";
+import { resolveOrganizationIdAdmin } from "@/lib/features/authentication/organization-utils";
+import {
+  Account,
+  Authorization,
+} from "@/lib/features/admin/types";
+import {
+  AUTHORIZATION_LABELS,
+  authorizationToRole,
+} from "@/lib/features/authentication/types";
+import { DeleteForever, Edit, Language, SyncLock } from "@mui/icons-material";
+import {
+  Button,
+  Chip,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  FormLabel,
+  Input,
+  Modal,
+  ModalClose,
+  ModalDialog,
+  Option,
+  Select,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/joy";
+import { useState } from "react";
+import { toast } from "sonner";
+
+const CAPABILITIES = ["editor", "webmaster"] as const;
+type Capability = (typeof CAPABILITIES)[number];
+
+type AccountEditModalProps = {
+  open: boolean;
+  onClose: () => void;
+  account: Account;
+  isSelf: boolean;
+  onAccountChange?: () => Promise<void>;
+  organizationSlug: string;
+};
+
+export default function AccountEditModal({
+  open,
+  onClose,
+  account,
+  isSelf,
+  onAccountChange,
+  organizationSlug,
+}: AccountEditModalProps) {
+  const [isPromoting, setIsPromoting] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isUpdatingCapabilities, setIsUpdatingCapabilities] = useState(false);
+  const [isUpdatingEmail, setIsUpdatingEmail] = useState(false);
+  const [newEmail, setNewEmail] = useState(account.email ?? "");
+
+  const userCapabilities = (account.capabilities ?? []) as Capability[];
+
+  const resolveUserId = async () => {
+    if (account.id) {
+      return account.id;
+    }
+
+    const listResult = await authClient.admin.listUsers({
+      query: {
+        searchValue: account.email || account.userName,
+        searchField: account.email ? "email" : "name",
+        limit: 1,
+      },
+    });
+
+    if (
+      listResult.error ||
+      !listResult.data?.users ||
+      listResult.data.users.length === 0
+    ) {
+      throw new Error(`User with username ${account.userName} not found`);
+    }
+
+    return listResult.data.users[0].id;
+  };
+
+  const resolveOrganizationId = async (): Promise<string> => {
+    const orgId = await resolveOrganizationIdAdmin(organizationSlug);
+    if (!orgId) {
+      throw new Error("Organization not configured");
+    }
+    return orgId;
+  };
+
+  const resolveMemberId = async (userId: string, organizationId: string): Promise<string> => {
+    const result = await authClient.organization.listMembers({
+      query: {
+        organizationId,
+        filterField: "userId",
+        filterOperator: "eq",
+        filterValue: userId,
+        limit: 1,
+      },
+    });
+
+    if (result.error) {
+      throw new Error(result.error.message || "Failed to fetch member");
+    }
+
+    const member = result.data?.members?.find((m: { userId: string }) => m.userId === userId);
+    if (!member) {
+      throw new Error("User is not a member of the organization");
+    }
+
+    return member.id;
+  };
+
+  const updateOrganizationRole = async (
+    userId: string,
+    newRole: "member" | "dj" | "musicDirector" | "stationManager"
+  ) => {
+    const organizationId = await resolveOrganizationId();
+    const memberId = await resolveMemberId(userId, organizationId);
+
+    const result = await authClient.organization.updateMemberRole({
+      memberId,
+      organizationId,
+      role: newRole,
+    });
+
+    if (result.error) {
+      throw new Error(result.error.message || "Failed to update role");
+    }
+
+    return result;
+  };
+
+  const updateCapabilities = async (newCapabilities: Capability[]) => {
+    const userId = await resolveUserId();
+
+    const result = await (authClient.admin as any).updateUser({
+      userId,
+      data: { capabilities: newCapabilities },
+    });
+
+    if (result.error) {
+      throw new Error(result.error.message || "Failed to update capabilities");
+    }
+
+    return result.data;
+  };
+
+  const handleRoleChange = async (newAuth: Authorization) => {
+    if (newAuth === account.authorization) return;
+
+    const newRole = authorizationToRole(newAuth);
+    const label = AUTHORIZATION_LABELS[newAuth];
+
+    if (!confirm(`Are you sure you want to change ${account.realName}'s role to ${label}?`)) {
+      return;
+    }
+
+    setIsPromoting(true);
+    try {
+      const targetUserId = await resolveUserId();
+      await updateOrganizationRole(targetUserId, newRole);
+      toast.success(`${account.realName}'s role updated to ${label}`);
+      if (onAccountChange) {
+        await onAccountChange();
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to update role";
+      if (errorMessage.trim().length > 0) {
+        toast.error(errorMessage);
+      }
+    } finally {
+      setIsPromoting(false);
+    }
+  };
+
+  const handleCapabilityToggle = async (capability: Capability) => {
+    const hasCapability = userCapabilities.includes(capability);
+    const newCapabilities = hasCapability
+      ? userCapabilities.filter((c) => c !== capability)
+      : [...userCapabilities, capability];
+
+    const action = hasCapability ? "remove" : "grant";
+    const confirmMessage = `Are you sure you want to ${action} the "${capability}" capability ${hasCapability ? "from" : "to"} ${account.realName}?`;
+
+    if (!confirm(confirmMessage)) {
+      return;
+    }
+
+    setIsUpdatingCapabilities(true);
+    try {
+      await updateCapabilities(newCapabilities);
+      toast.success(
+        `${capability} capability ${hasCapability ? "removed from" : "granted to"} ${account.realName}`
+      );
+      if (onAccountChange) {
+        await onAccountChange();
+      }
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Failed to update capabilities";
+      toast.error(errorMessage);
+    } finally {
+      setIsUpdatingCapabilities(false);
+    }
+  };
+
+  const handleEmailUpdate = async () => {
+    if (!newEmail || newEmail === account.email) {
+      return;
+    }
+
+    const confirmed = confirm(
+      `Are you sure you want to change ${account.realName}'s email to ${newEmail}? This will take effect immediately without verification.`
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    setIsUpdatingEmail(true);
+    try {
+      const targetUserId = await resolveUserId();
+
+      const result = await authClient.admin.updateUser({
+        userId: targetUserId,
+        data: { email: newEmail, emailVerified: true },
+      });
+
+      if (result.error) {
+        throw new Error(result.error.message || "Failed to update email");
+      }
+
+      toast.success(`Email updated to ${newEmail}`);
+      if (onAccountChange) {
+        await onAccountChange();
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to update email";
+      toast.error(errorMessage);
+    } finally {
+      setIsUpdatingEmail(false);
+    }
+  };
+
+  const handlePasswordReset = async () => {
+    if (!confirm("Are you sure you want to reset this user's password?")) {
+      return;
+    }
+
+    setIsResetting(true);
+    try {
+      const targetUserId = await resolveUserId();
+
+      const tempPassword =
+        process.env.NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD || crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+
+      const result = await authClient.admin.setUserPassword({
+        userId: targetUserId,
+        newPassword: tempPassword,
+      });
+
+      if (result.error) {
+        throw new Error(result.error.message || "Failed to reset password");
+      }
+
+      toast.success(`Password reset successfully. Temporary password: ${tempPassword}`, {
+        duration: 10000,
+      });
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to reset password";
+      if (errorMessage.trim().length > 0) {
+        toast.error(errorMessage);
+      }
+    } finally {
+      setIsResetting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!confirm(`Are you sure you want to delete ${account.realName}'s account?`)) {
+      return;
+    }
+
+    setIsDeleting(true);
+    try {
+      const targetUserId = await resolveUserId();
+
+      const result = await authClient.admin.removeUser({
+        userId: targetUserId,
+      });
+
+      if (result.error) {
+        throw new Error(result.error.message || "Failed to delete user");
+      }
+
+      toast.success(`${account.realName}'s account deleted successfully`);
+      onClose();
+      if (onAccountChange) {
+        await onAccountChange();
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to delete account";
+      if (errorMessage.trim().length > 0) {
+        toast.error(errorMessage);
+      }
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const displayName = account.realName || account.userName;
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <ModalDialog variant="outlined" sx={{ maxWidth: 480, width: "100%" }}>
+        <ModalClose />
+        <DialogTitle>
+          {displayName}
+          {account.djName && (
+            <Typography level="body-sm" sx={{ ml: 1 }}>
+              DJ {account.djName}
+            </Typography>
+          )}
+        </DialogTitle>
+        <DialogContent>
+          <Stack spacing={2.5} sx={{ mt: 1 }}>
+            {/* Role */}
+            <FormControl>
+              <FormLabel>Role</FormLabel>
+              <Select
+                size="sm"
+                color="success"
+                value={account.authorization}
+                disabled={isSelf || isPromoting}
+                onChange={(_, newValue) => {
+                  if (newValue !== null) handleRoleChange(newValue as Authorization);
+                }}
+                slotProps={{ button: { sx: { whiteSpace: "nowrap" } } }}
+              >
+                <Option value={Authorization.NO}>Member</Option>
+                <Option value={Authorization.DJ}>DJ</Option>
+                <Option value={Authorization.MD}>Music Director</Option>
+                <Option value={Authorization.SM}>Station Manager</Option>
+              </Select>
+              {isSelf && (
+                <Typography level="body-xs" sx={{ mt: 0.5 }}>
+                  You cannot change your own role.
+                </Typography>
+              )}
+            </FormControl>
+
+            {/* Capabilities */}
+            <FormControl>
+              <FormLabel>Capabilities</FormLabel>
+              <Stack direction="row" spacing={1}>
+                <Tooltip
+                  title={
+                    isSelf
+                      ? "You cannot modify your own capabilities"
+                      : userCapabilities.includes("editor")
+                        ? "Remove editor capability"
+                        : "Grant editor capability (allows website editing)"
+                  }
+                  arrow
+                  placement="top"
+                  variant="outlined"
+                  size="sm"
+                >
+                  <Chip
+                    variant={userCapabilities.includes("editor") ? "solid" : "outlined"}
+                    color={userCapabilities.includes("editor") ? "success" : "neutral"}
+                    size="md"
+                    startDecorator={<Edit sx={{ fontSize: 16 }} />}
+                    onClick={() => !isSelf && handleCapabilityToggle("editor")}
+                    disabled={isSelf || isUpdatingCapabilities}
+                    sx={{
+                      cursor: isSelf ? "not-allowed" : "pointer",
+                      opacity: isUpdatingCapabilities ? 0.5 : 1,
+                    }}
+                  >
+                    Editor
+                  </Chip>
+                </Tooltip>
+                <Tooltip
+                  title={
+                    isSelf
+                      ? "You cannot modify your own capabilities"
+                      : userCapabilities.includes("webmaster")
+                        ? "Remove webmaster capability"
+                        : "Grant webmaster capability (can delegate editor)"
+                  }
+                  arrow
+                  placement="top"
+                  variant="outlined"
+                  size="sm"
+                >
+                  <Chip
+                    variant={userCapabilities.includes("webmaster") ? "solid" : "outlined"}
+                    color={userCapabilities.includes("webmaster") ? "primary" : "neutral"}
+                    size="md"
+                    startDecorator={<Language sx={{ fontSize: 16 }} />}
+                    onClick={() => !isSelf && handleCapabilityToggle("webmaster")}
+                    disabled={isSelf || isUpdatingCapabilities}
+                    sx={{
+                      cursor: isSelf ? "not-allowed" : "pointer",
+                      opacity: isUpdatingCapabilities ? 0.5 : 1,
+                    }}
+                  >
+                    Webmaster
+                  </Chip>
+                </Tooltip>
+              </Stack>
+            </FormControl>
+
+            {/* Email */}
+            <FormControl>
+              <FormLabel>Email</FormLabel>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Input
+                  size="sm"
+                  type="email"
+                  value={newEmail}
+                  onChange={(e) => setNewEmail(e.target.value)}
+                  disabled={isSelf || isUpdatingEmail}
+                  sx={{ flex: 1 }}
+                />
+                {!isSelf && newEmail !== account.email && (
+                  <Button
+                    size="sm"
+                    color="success"
+                    variant="solid"
+                    loading={isUpdatingEmail}
+                    onClick={handleEmailUpdate}
+                  >
+                    Save
+                  </Button>
+                )}
+              </Stack>
+            </FormControl>
+
+            <Divider />
+
+            {/* Danger zone */}
+            <Stack spacing={1.5}>
+              <Typography level="title-sm">Account Actions</Typography>
+              <Stack direction="row" spacing={1}>
+                <Button
+                  size="sm"
+                  color="success"
+                  variant="solid"
+                  startDecorator={<SyncLock />}
+                  disabled={isSelf || isResetting}
+                  loading={isResetting}
+                  onClick={handlePasswordReset}
+                >
+                  Reset Password
+                </Button>
+                <Button
+                  size="sm"
+                  color="danger"
+                  variant="outlined"
+                  startDecorator={<DeleteForever />}
+                  disabled={isSelf || isDeleting}
+                  loading={isDeleting}
+                  onClick={handleDelete}
+                >
+                  Delete Account
+                </Button>
+              </Stack>
+              {isSelf && (
+                <Typography level="body-xs">
+                  You cannot reset your own password or delete your own account from here.
+                </Typography>
+              )}
+            </Stack>
+          </Stack>
+        </DialogContent>
+      </ModalDialog>
+    </Modal>
+  );
+}

--- a/src/components/experiences/modern/admin/roster/AccountEditModal.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEditModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { authClient } from "@/lib/features/authentication/client";
+import { authBaseURL, authClient } from "@/lib/features/authentication/client";
 import { resolveOrganizationIdAdmin } from "@/lib/features/authentication/organization-utils";
 import {
   Account,
@@ -10,7 +10,7 @@ import {
   AUTHORIZATION_LABELS,
   authorizationToRole,
 } from "@/lib/features/authentication/types";
-import { DeleteForever, Edit, Language, SyncLock } from "@mui/icons-material";
+import { DeleteForever, Edit, Language, Send, SyncLock } from "@mui/icons-material";
 import {
   Button,
   Chip,
@@ -57,9 +57,11 @@ export default function AccountEditModal({
   const [isDeleting, setIsDeleting] = useState(false);
   const [isUpdatingCapabilities, setIsUpdatingCapabilities] = useState(false);
   const [isUpdatingEmail, setIsUpdatingEmail] = useState(false);
+  const [isSendingEmail, setIsSendingEmail] = useState(false);
   const [newEmail, setNewEmail] = useState(account.email ?? "");
 
   const userCapabilities = (account.capabilities ?? []) as Capability[];
+  const isIncomplete = account.hasCompletedOnboarding === false;
 
   const resolveUserId = async () => {
     if (account.id) {
@@ -314,6 +316,76 @@ export default function AccountEditModal({
     }
   };
 
+  const handleSendInvite = async () => {
+    if (!account.email) {
+      toast.error("No email address on file.");
+      return;
+    }
+
+    setIsSendingEmail(true);
+    try {
+      const targetUserId = await resolveUserId();
+
+      // Un-verify the email so the verification endpoint will send a new email
+      await authClient.admin.updateUser({
+        userId: targetUserId,
+        data: { emailVerified: false },
+      });
+
+      const response = await fetch(`${authBaseURL}/send-verification-email`, {
+        method: "POST",
+        credentials: "omit",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: account.email,
+          callbackURL: "/login",
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to send invite email");
+      }
+
+      toast.success(`Invite email sent to ${account.email}`);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to send invite email";
+      toast.error(errorMessage);
+    } finally {
+      setIsSendingEmail(false);
+    }
+  };
+
+  const handleSendPasswordReset = async () => {
+    if (!account.email) {
+      toast.error("No email address on file.");
+      return;
+    }
+
+    setIsSendingEmail(true);
+    try {
+      const redirectTo =
+        typeof window !== "undefined"
+          ? `${window.location.origin}/login`
+          : undefined;
+
+      const result = await authClient.requestPasswordReset({
+        email: account.email,
+        redirectTo,
+      });
+
+      if ((result as any).error) {
+        throw new Error((result as any).error.message || "Failed to send password reset");
+      }
+
+      toast.success(`Password reset email sent to ${account.email}`);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to send password reset email";
+      toast.error(errorMessage);
+    } finally {
+      setIsSendingEmail(false);
+    }
+  };
+
   const displayName = account.realName || account.userName;
 
   return (
@@ -446,10 +518,23 @@ export default function AccountEditModal({
 
             <Divider />
 
-            {/* Danger zone */}
+            {/* Account actions */}
             <Stack spacing={1.5}>
               <Typography level="title-sm">Account Actions</Typography>
-              <Stack direction="row" spacing={1}>
+              <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap", gap: 1 }}>
+                {!isSelf && (
+                  <Button
+                    size="sm"
+                    color="primary"
+                    variant="solid"
+                    startDecorator={<Send />}
+                    disabled={isSendingEmail}
+                    loading={isSendingEmail}
+                    onClick={isIncomplete ? handleSendInvite : handleSendPasswordReset}
+                  >
+                    {isIncomplete ? "Send Invite" : "Send Password Reset"}
+                  </Button>
+                )}
                 <Button
                   size="sm"
                   color="success"
@@ -475,7 +560,7 @@ export default function AccountEditModal({
               </Stack>
               {isSelf && (
                 <Typography level="body-xs">
-                  You cannot reset your own password or delete your own account from here.
+                  You cannot modify your own account from here.
                 </Typography>
               )}
             </Stack>

--- a/src/components/experiences/modern/admin/roster/AccountEntry.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEntry.tsx
@@ -1,28 +1,20 @@
 "use client";
 
-import { authClient } from "@/lib/features/authentication/client";
-import { resolveOrganizationIdAdmin } from "@/lib/features/authentication/organization-utils";
 import {
   Account,
-  Authorization,
 } from "@/lib/features/admin/types";
 import {
   AUTHORIZATION_LABELS,
-  authorizationToRole,
 } from "@/lib/features/authentication/types";
-import { Check, Close, DeleteForever, Edit, Language, SyncLock } from "@mui/icons-material";
+import { Edit, Language, Settings } from "@mui/icons-material";
 import {
   Chip,
-  FormControl,
   IconButton,
-  Input,
-  Option,
-  Select,
   Stack,
   Tooltip,
 } from "@mui/joy";
 import { useState } from "react";
-import { toast } from "sonner";
+import AccountEditModal from "./AccountEditModal";
 
 const CAPABILITIES = ["editor", "webmaster"] as const;
 type Capability = (typeof CAPABILITIES)[number];
@@ -38,510 +30,99 @@ export const AccountEntry = ({
   onAccountChange?: () => Promise<void>;
   organizationSlug: string;
 }) => {
-  const [isPromoting, setIsPromoting] = useState(false);
-  const [isResetting, setIsResetting] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [isUpdatingCapabilities, setIsUpdatingCapabilities] = useState(false);
-  const [isEditingEmail, setIsEditingEmail] = useState(false);
-  const [isUpdatingEmail, setIsUpdatingEmail] = useState(false);
-  const [newEmail, setNewEmail] = useState(account.email);
-  const [promoteError, setPromoteError] = useState<Error | null>(null);
-  const [resetError, setResetError] = useState<Error | null>(null);
-  const [deleteError, setDeleteError] = useState<Error | null>(null);
+  const [editModalOpen, setEditModalOpen] = useState(false);
 
   const userCapabilities = (account.capabilities ?? []) as Capability[];
 
-  /**
-   * Update user capabilities via better-auth admin API directly.
-   * The backend is the authority on whether the caller has permission.
-   */
-  const updateCapabilities = async (newCapabilities: Capability[]) => {
-    const userId = await resolveUserId();
-
-    const result = await (authClient.admin as any).updateUser({
-      userId,
-      data: { capabilities: newCapabilities },
-    });
-
-    if (result.error) {
-      throw new Error(result.error.message || "Failed to update capabilities");
-    }
-
-    return result.data;
-  };
-
-  /**
-   * Handle admin email update (bypasses verification)
-   */
-  const handleEmailUpdate = async () => {
-    if (!newEmail || newEmail === account.email) {
-      setIsEditingEmail(false);
-      return;
-    }
-
-    const confirmed = confirm(
-      `Are you sure you want to change ${account.realName}'s email to ${newEmail}? This will take effect immediately without verification.`
-    );
-
-    if (!confirmed) {
-      return;
-    }
-
-    setIsUpdatingEmail(true);
-    try {
-      const targetUserId = await resolveUserId();
-
-      const result = await authClient.admin.updateUser({
-        userId: targetUserId,
-        data: { email: newEmail, emailVerified: true },
-      });
-
-      if (result.error) {
-        throw new Error(result.error.message || "Failed to update email");
-      }
-
-      toast.success(`Email updated to ${newEmail}`);
-      setIsEditingEmail(false);
-      if (onAccountChange) {
-        await onAccountChange();
-      }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "Failed to update email";
-      toast.error(errorMessage);
-    } finally {
-      setIsUpdatingEmail(false);
-    }
-  };
-
-  /**
-   * Toggle a capability on/off for the user
-   */
-  const handleCapabilityToggle = async (capability: Capability) => {
-    const hasCapability = userCapabilities.includes(capability);
-    const newCapabilities = hasCapability
-      ? userCapabilities.filter((c) => c !== capability)
-      : [...userCapabilities, capability];
-
-    const action = hasCapability ? "remove" : "grant";
-    const confirmMessage = `Are you sure you want to ${action} the "${capability}" capability ${hasCapability ? "from" : "to"} ${account.realName}?`;
-
-    if (!confirm(confirmMessage)) {
-      return;
-    }
-
-    setIsUpdatingCapabilities(true);
-    try {
-      await updateCapabilities(newCapabilities);
-      toast.success(
-        `${capability} capability ${hasCapability ? "removed from" : "granted to"} ${account.realName}`
-      );
-      if (onAccountChange) {
-        await onAccountChange();
-      }
-    } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : "Failed to update capabilities";
-      toast.error(errorMessage);
-    } finally {
-      setIsUpdatingCapabilities(false);
-    }
-  };
-
-  /**
-   * Change the user's role via the organization membership API
-   */
-  const handleRoleChange = async (newAuth: Authorization) => {
-    if (newAuth === account.authorization) return;
-
-    const newRole = authorizationToRole(newAuth);
-    const label = AUTHORIZATION_LABELS[newAuth];
-
-    if (!confirm(`Are you sure you want to change ${account.realName}'s role to ${label}?`)) {
-      return;
-    }
-
-    setIsPromoting(true);
-    setPromoteError(null);
-    try {
-      const targetUserId = await resolveUserId();
-      await updateOrganizationRole(targetUserId, newRole);
-      toast.success(`${account.realName}'s role updated to ${label}`);
-      if (onAccountChange) {
-        await onAccountChange();
-      }
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "Failed to update role";
-      setPromoteError(err instanceof Error ? err : new Error(errorMessage));
-      if (errorMessage.trim().length > 0) {
-        toast.error(errorMessage);
-      }
-    } finally {
-      setIsPromoting(false);
-    }
-  };
-
-  /**
-   * Resolve organization slug to organization ID via the admin endpoint.
-   */
-  const resolveOrganizationId = async (): Promise<string> => {
-    const orgId = await resolveOrganizationIdAdmin(organizationSlug);
-    if (!orgId) {
-      throw new Error("Organization not configured");
-    }
-    return orgId;
-  };
-
-  /**
-   * Get the member ID for a user in the organization
-   */
-  const resolveMemberId = async (userId: string, organizationId: string): Promise<string> => {
-    const result = await authClient.organization.listMembers({
-      query: {
-        organizationId,
-        filterField: "userId",
-        filterOperator: "eq",
-        filterValue: userId,
-        limit: 1,
-      },
-    });
-
-    if (result.error) {
-      throw new Error(result.error.message || "Failed to fetch member");
-    }
-
-    const member = result.data?.members?.find((m: { userId: string }) => m.userId === userId);
-    if (!member) {
-      throw new Error("User is not a member of the organization");
-    }
-
-    return member.id;
-  };
-
-  /**
-   * Update user's role in the organization
-   */
-  const updateOrganizationRole = async (
-    userId: string,
-    newRole: "member" | "dj" | "musicDirector" | "stationManager"
-  ) => {
-    const organizationId = await resolveOrganizationId();
-    const memberId = await resolveMemberId(userId, organizationId);
-
-    const result = await authClient.organization.updateMemberRole({
-      memberId,
-      organizationId,
-      role: newRole,
-    });
-
-    if (result.error) {
-      throw new Error(result.error.message || "Failed to update role");
-    }
-
-    return result;
-  };
-
-  const resolveUserId = async () => {
-    if (account.id) {
-      return account.id;
-    }
-
-    const listResult = await authClient.admin.listUsers({
-      query: {
-        searchValue: account.email || account.userName,
-        searchField: account.email ? "email" : "name",
-        limit: 1,
-      },
-    });
-
-    if (
-      listResult.error ||
-      !listResult.data?.users ||
-      listResult.data.users.length === 0
-    ) {
-      throw new Error(`User with username ${account.userName} not found`);
-    }
-
-    return listResult.data.users[0].id;
-  };
-
   return (
-    <tr>
-      <td style={{ verticalAlign: "middle" }}>
-        <Stack spacing={0.5}>
-          <FormControl size="sm">
-            <Select
+    <>
+      <tr>
+        <td style={{ verticalAlign: "middle" }}>
+          <Stack spacing={0.5}>
+            <Chip
               size="sm"
+              variant="soft"
               color="success"
-              value={account.authorization}
-              disabled={isSelf || isPromoting}
-              onChange={(_, newValue) => {
-                if (newValue !== null) handleRoleChange(newValue as Authorization);
-              }}
-              slotProps={{ button: { sx: { whiteSpace: "nowrap" } } }}
             >
-              <Option value={Authorization.NO}>Member</Option>
-              <Option value={Authorization.DJ}>DJ</Option>
-              <Option value={Authorization.MD}>Music Director</Option>
-              <Option value={Authorization.SM}>Station Manager</Option>
-            </Select>
-          </FormControl>
-          <Stack direction="row" spacing={0.5}>
-            <Tooltip
-              title={
-                isSelf
-                  ? "You cannot modify your own capabilities"
-                  : userCapabilities.includes("editor")
-                    ? "Remove editor capability"
-                    : "Grant editor capability (allows website editing)"
-              }
-              arrow
-              placement="top"
-              variant="outlined"
-              size="sm"
-            >
-              <Chip
-                variant={userCapabilities.includes("editor") ? "solid" : "outlined"}
-                color={userCapabilities.includes("editor") ? "success" : "neutral"}
-                size="sm"
-                startDecorator={<Edit sx={{ fontSize: 14 }} />}
-                onClick={() => !isSelf && handleCapabilityToggle("editor")}
-                disabled={isSelf || isUpdatingCapabilities}
-                sx={{
-                  cursor: isSelf ? "not-allowed" : "pointer",
-                  opacity: isUpdatingCapabilities ? 0.5 : 1,
-                }}
-              >
-                Editor
-              </Chip>
-            </Tooltip>
-            <Tooltip
-              title={
-                isSelf
-                  ? "You cannot modify your own capabilities"
-                  : userCapabilities.includes("webmaster")
-                    ? "Remove webmaster capability"
-                    : "Grant webmaster capability (can delegate editor)"
-              }
-              arrow
-              placement="top"
-              variant="outlined"
-              size="sm"
-            >
-              <Chip
-                variant={userCapabilities.includes("webmaster") ? "solid" : "outlined"}
-                color={userCapabilities.includes("webmaster") ? "primary" : "neutral"}
-                size="sm"
-                startDecorator={<Language sx={{ fontSize: 14 }} />}
-                onClick={() => !isSelf && handleCapabilityToggle("webmaster")}
-                disabled={isSelf || isUpdatingCapabilities}
-                sx={{
-                  cursor: isSelf ? "not-allowed" : "pointer",
-                  opacity: isUpdatingCapabilities ? 0.5 : 1,
-                }}
-              >
-                Webmaster
-              </Chip>
-            </Tooltip>
+              {AUTHORIZATION_LABELS[account.authorization]}
+            </Chip>
+            {userCapabilities.length > 0 && (
+              <Stack direction="row" spacing={0.5}>
+                {userCapabilities.includes("editor") && (
+                  <Chip
+                    variant="solid"
+                    color="success"
+                    size="sm"
+                    startDecorator={<Edit sx={{ fontSize: 14 }} />}
+                  >
+                    Editor
+                  </Chip>
+                )}
+                {userCapabilities.includes("webmaster") && (
+                  <Chip
+                    variant="solid"
+                    color="primary"
+                    size="sm"
+                    startDecorator={<Language sx={{ fontSize: 14 }} />}
+                  >
+                    Webmaster
+                  </Chip>
+                )}
+              </Stack>
+            )}
           </Stack>
-        </Stack>
-      </td>
-      <td>
-        <Stack direction="row" spacing={0.5} alignItems="center">
-          <span>{account.realName}</span>
-          {account.hasCompletedOnboarding === false && (
-            <Tooltip
-              title="Has not completed onboarding"
-              arrow
-              placement="top"
-              variant="outlined"
-              size="sm"
-            >
-              <Chip variant="soft" color="warning" size="sm">
-                New
-              </Chip>
-            </Tooltip>
-          )}
-        </Stack>
-      </td>
-      <td>{account.userName}</td>
-      <td>
-        {account.djName && account.djName.length > 0 && "DJ"} {account.djName ?? ""}
-      </td>
-      <td>
-        {isEditingEmail ? (
+        </td>
+        <td>
           <Stack direction="row" spacing={0.5} alignItems="center">
-            <Input
-              size="sm"
-              value={newEmail}
-              onChange={(e) => setNewEmail(e.target.value)}
-              sx={{ minWidth: 200 }}
-              disabled={isUpdatingEmail}
-            />
-            <IconButton
-              size="sm"
-              color="success"
-              onClick={handleEmailUpdate}
-              loading={isUpdatingEmail}
-            >
-              <Check />
-            </IconButton>
-            <IconButton
-              size="sm"
-              color="neutral"
-              onClick={() => {
-                setIsEditingEmail(false);
-                setNewEmail(account.email);
-              }}
-              disabled={isUpdatingEmail}
-            >
-              <Close />
-            </IconButton>
-          </Stack>
-        ) : (
-          <Stack direction="row" spacing={0.5} alignItems="center">
-            <span>{account.email}</span>
-            {!isSelf && (
+            <span>{account.realName}</span>
+            {account.hasCompletedOnboarding === false && (
               <Tooltip
-                title={`Edit ${account.realName}'s email`}
+                title="Has not completed onboarding"
                 arrow
                 placement="top"
                 variant="outlined"
                 size="sm"
               >
-                <IconButton
-                  size="sm"
-                  variant="plain"
-                  onClick={() => setIsEditingEmail(true)}
-                >
-                  <Edit />
-                </IconButton>
+                <Chip variant="soft" color="warning" size="sm">
+                  New
+                </Chip>
               </Tooltip>
             )}
           </Stack>
-        )}
-      </td>
-      <td>
-        <Stack direction="row" spacing={0.5}>
+        </td>
+        <td>{account.userName}</td>
+        <td>
+          {account.djName && account.djName.length > 0 && "DJ"} {account.djName ?? ""}
+        </td>
+        <td>{account.email}</td>
+        <td>
           <Tooltip
-            title={`Reset ${account.realName}${
-              account.realName.length > 0 ? "'s" : ""
-            } Password`}
-            arrow={true}
+            title={`Edit ${account.realName || account.userName}`}
+            arrow
             placement="top"
             variant="outlined"
             size="sm"
           >
             <IconButton
-              color={"success"}
+              color="success"
               variant="solid"
               size="sm"
-              disabled={isSelf || isResetting}
-              loading={isResetting}
-              onClick={async () => {
-                if (
-                  confirm(
-                    "Are you sure you want to reset this user's password?"
-                  )
-                ) {
-                  setIsResetting(true);
-                  setResetError(null);
-                  try {
-                    const targetUserId = await resolveUserId();
-
-                    // Use the configured onboarding temp password so the admin
-                    // can share the known password with the user
-                    const tempPassword =
-                      process.env.NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD || crypto.randomUUID().replace(/-/g, "").slice(0, 16);
-
-                    // Use dedicated setUserPassword endpoint which only updates
-                    // the password hash on the account table, without touching user fields
-                    const result = await authClient.admin.setUserPassword({
-                      userId: targetUserId,
-                      newPassword: tempPassword,
-                    });
-
-                    if (result.error) {
-                      throw new Error(result.error.message || "Failed to reset password");
-                    }
-
-                    toast.success(`Password reset successfully. Temporary password: ${tempPassword}`, {
-                      duration: 10000, // Show longer so admin can copy password
-                    });
-                  } catch (err) {
-                    const errorMessage = err instanceof Error ? err.message : "Failed to reset password";
-                    setResetError(err instanceof Error ? err : new Error(errorMessage));
-                    if (errorMessage.trim().length > 0) {
-                      toast.error(errorMessage);
-                    }
-                  } finally {
-                    setIsResetting(false);
-                  }
-                }
-              }}
+              onClick={() => setEditModalOpen(true)}
+              aria-label={`Edit ${account.realName || account.userName}`}
             >
-              <SyncLock />
+              <Settings />
             </IconButton>
           </Tooltip>
-          <Tooltip
-            title={
-              !isSelf
-                ? `Delete ${account.realName}${
-                    account.realName.length > 0 ? "'s" : ""
-                  } Profile`
-                : `You cannot delete yourself!`
-            }
-            arrow={true}
-            placement="top"
-            variant="outlined"
-            size="sm"
-          >
-            <IconButton
-              color="warning"
-              variant="outlined"
-              size="sm"
-              disabled={isSelf || isDeleting}
-              loading={isDeleting}
-              onClick={async () => {
-                if (
-                  confirm(
-                    `Are you sure you want to delete ${account.realName}'s account?`
-                  )
-                ) {
-                  setIsDeleting(true);
-                  setDeleteError(null);
-                  try {
-                    const targetUserId = await resolveUserId();
-
-                    // Delete user via better-auth admin API
-                    const result = await authClient.admin.removeUser({
-                      userId: targetUserId,
-                    });
-
-                    if (result.error) {
-                      throw new Error(result.error.message || "Failed to delete user");
-                    }
-
-                    toast.success(`${account.realName}'s account deleted successfully`);
-                    if (onAccountChange) {
-                      await onAccountChange();
-                    }
-                  } catch (err) {
-                    const errorMessage = err instanceof Error ? err.message : "Failed to delete account";
-                    setDeleteError(err instanceof Error ? err : new Error(errorMessage));
-                    if (errorMessage.trim().length > 0) {
-                      toast.error(errorMessage);
-                    }
-                  } finally {
-                    setIsDeleting(false);
-                  }
-                }
-              }}
-            >
-              <DeleteForever />
-            </IconButton>
-          </Tooltip>
-        </Stack>
-      </td>
-    </tr>
+        </td>
+      </tr>
+      <AccountEditModal
+        open={editModalOpen}
+        onClose={() => setEditModalOpen(false)}
+        account={account}
+        isSelf={isSelf}
+        onAccountChange={onAccountChange}
+        organizationSlug={organizationSlug}
+      />
+    </>
   );
 };

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { authBaseURL } from "@/lib/features/authentication/client";
+import { authBaseURL, authClient } from "@/lib/features/authentication/client";
 import { adminSlice } from "@/lib/features/admin/frontend";
 import { NewAccountParams, Authorization, ROSTER_PAGE_SIZE } from "@/lib/features/admin/types";
 import { User, authorizationToRole } from "@/lib/features/authentication/types";
@@ -102,6 +102,22 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
         }
 
         toast.success(`Account created successfully for ${newAccount.username}`);
+
+        // Send invite email (verification magic link) to the new user
+        try {
+          await fetch(`${authBaseURL}/send-verification-email`, {
+            method: "POST",
+            credentials: "omit",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email: newAccount.email,
+              callbackURL: "/login",
+            }),
+          });
+          toast.success(`Invite email sent to ${newAccount.email}`);
+        } catch {
+          toast.warning("Account created but invite email could not be sent.");
+        }
 
         dispatch(adminSlice.actions.setAdding(false));
         dispatch(adminSlice.actions.reset());

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -128,7 +128,7 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
         height: "100%",
         overflow: "auto",
         bgcolor: "transparent",
-        "--Table-lastColumnWidth": "120px",
+        "--Table-lastColumnWidth": "60px",
       }}
     >
       <Stack
@@ -182,7 +182,7 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
         >
           <thead>
             <tr>
-              <th style={{ minWidth: "180px" }}>Permissions</th>
+              <th style={{ minWidth: "120px" }}>Role</th>
               <th style={{ minWidth: "100px" }}>Name</th>
               <th style={{ minWidth: "100px" }}>Username</th>
               <th style={{ minWidth: "100px" }}>DJ Name</th>


### PR DESCRIPTION
## Summary

- Extracts all inline editing controls (role, capabilities, email, password reset, delete) from `AccountEntry` table rows into a new `AccountEditModal`
- Table rows are now display-only with a single settings button to open the modal
- All admin functionality, confirmations, and API interactions preserved

Closes #450

## Test plan

- [ ] Verify roster table displays DJ info correctly (role chip, capability badges, name, username, DJ name, email)
- [ ] Click settings button on a DJ row and verify modal opens with correct data
- [ ] Change a DJ's role via the modal dropdown
- [ ] Toggle Editor and Webmaster capabilities
- [ ] Edit a DJ's email and save
- [ ] Reset a DJ's password
- [ ] Delete a DJ's account
- [ ] Verify self-edit protections (controls disabled for own account, explanatory text shown)
- [ ] Verify "New" chip still appears for users who haven't completed onboarding