### PR TITLE
Send invite magic link on account creation and add resend button

### DIFF
--- a/src/components/experiences/modern/admin/roster/AccountEditModal.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEditModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { authClient } from "@/lib/features/authentication/client";
+import { authBaseURL, authClient } from "@/lib/features/authentication/client";
 import { resolveOrganizationIdAdmin } from "@/lib/features/authentication/organization-utils";
 import {
   Account,
@@ -10,7 +10,7 @@ import {
   AUTHORIZATION_LABELS,
   authorizationToRole,
 } from "@/lib/features/authentication/types";
-import { DeleteForever, Edit, Language, SyncLock } from "@mui/icons-material";
+import { DeleteForever, Edit, Language, Send, SyncLock } from "@mui/icons-material";
 import {
   Button,
   Chip,
@@ -57,9 +57,11 @@ export default function AccountEditModal({
   const [isDeleting, setIsDeleting] = useState(false);
   const [isUpdatingCapabilities, setIsUpdatingCapabilities] = useState(false);
   const [isUpdatingEmail, setIsUpdatingEmail] = useState(false);
+  const [isSendingEmail, setIsSendingEmail] = useState(false);
   const [newEmail, setNewEmail] = useState(account.email ?? "");
 
   const userCapabilities = (account.capabilities ?? []) as Capability[];
+  const isIncomplete = account.hasCompletedOnboarding === false;
 
   const resolveUserId = async () => {
     if (account.id) {
@@ -314,6 +316,76 @@ export default function AccountEditModal({
     }
   };
 
+  const handleSendInvite = async () => {
+    if (!account.email) {
+      toast.error("No email address on file.");
+      return;
+    }
+
+    setIsSendingEmail(true);
+    try {
+      const targetUserId = await resolveUserId();
+
+      // Un-verify the email so the verification endpoint will send a new email
+      await authClient.admin.updateUser({
+        userId: targetUserId,
+        data: { emailVerified: false },
+      });
+
+      const response = await fetch(`${authBaseURL}/send-verification-email`, {
+        method: "POST",
+        credentials: "omit",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: account.email,
+          callbackURL: "/login",
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to send invite email");
+      }
+
+      toast.success(`Invite email sent to ${account.email}`);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to send invite email";
+      toast.error(errorMessage);
+    } finally {
+      setIsSendingEmail(false);
+    }
+  };
+
+  const handleSendPasswordReset = async () => {
+    if (!account.email) {
+      toast.error("No email address on file.");
+      return;
+    }
+
+    setIsSendingEmail(true);
+    try {
+      const redirectTo =
+        typeof window !== "undefined"
+          ? `${window.location.origin}/login`
+          : undefined;
+
+      const result = await authClient.requestPasswordReset({
+        email: account.email,
+        redirectTo,
+      });
+
+      if ((result as any).error) {
+        throw new Error((result as any).error.message || "Failed to send password reset");
+      }
+
+      toast.success(`Password reset email sent to ${account.email}`);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to send password reset email";
+      toast.error(errorMessage);
+    } finally {
+      setIsSendingEmail(false);
+    }
+  };
+
   const displayName = account.realName || account.userName;
 
   return (
@@ -446,10 +518,23 @@ export default function AccountEditModal({
 
             <Divider />
 
-            {/* Danger zone */}
+            {/* Account actions */}
             <Stack spacing={1.5}>
               <Typography level="title-sm">Account Actions</Typography>
-              <Stack direction="row" spacing={1}>
+              <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap", gap: 1 }}>
+                {!isSelf && (
+                  <Button
+                    size="sm"
+                    color="primary"
+                    variant="solid"
+                    startDecorator={<Send />}
+                    disabled={isSendingEmail}
+                    loading={isSendingEmail}
+                    onClick={isIncomplete ? handleSendInvite : handleSendPasswordReset}
+                  >
+                    {isIncomplete ? "Send Invite" : "Send Password Reset"}
+                  </Button>
+                )}
                 <Button
                   size="sm"
                   color="success"
@@ -475,7 +560,7 @@ export default function AccountEditModal({
               </Stack>
               {isSelf && (
                 <Typography level="body-xs">
-                  You cannot reset your own password or delete your own account from here.
+                  You cannot modify your own account from here.
                 </Typography>
               )}
             </Stack>

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { authBaseURL } from "@/lib/features/authentication/client";
+import { authBaseURL, authClient } from "@/lib/features/authentication/client";
 import { adminSlice } from "@/lib/features/admin/frontend";
 import { NewAccountParams, Authorization, ROSTER_PAGE_SIZE } from "@/lib/features/admin/types";
 import { User, authorizationToRole } from "@/lib/features/authentication/types";
@@ -102,6 +102,22 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
         }
 
         toast.success(`Account created successfully for ${newAccount.username}`);
+
+        // Send invite email (verification magic link) to the new user
+        try {
+          await fetch(`${authBaseURL}/send-verification-email`, {
+            method: "POST",
+            credentials: "omit",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email: newAccount.email,
+              callbackURL: "/login",
+            }),
+          });
+          toast.success(`Invite email sent to ${newAccount.email}`);
+        } catch {
+          toast.warning("Account created but invite email could not be sent.");
+        }
 
         dispatch(adminSlice.actions.setAdding(false));
         dispatch(adminSlice.actions.reset());


### PR DESCRIPTION
## Summary

- After creating a new DJ account, automatically send a verification magic link email that takes the user directly to onboarding
- Add "Send Invite" button in the edit modal for incomplete users (resends the magic link)
- Add "Send Password Reset" button in the edit modal for complete users (forgot password flow)

Closes #452

## Test plan

- [ ] Create a new DJ account and verify an invite email is sent
- [ ] Click the magic link in the invite email and verify it auto-signs in and shows onboarding
- [ ] Open the edit modal for an incomplete user and verify "Send Invite" button appears
- [ ] Click "Send Invite" and verify a new magic link email is sent
- [ ] Open the edit modal for a complete user and verify "Send Password Reset" button appears
- [ ] Click "Send Password Reset" and verify a password reset email is sent
- [ ] Verify the send buttons are hidden when viewing your own account