### PR TITLE
Fix addToFlowsheet mutation hang with empty cache

### DIFF
--- a/e2e/pages/flowsheet.page.ts
+++ b/e2e/pages/flowsheet.page.ts
@@ -9,6 +9,7 @@ import { Page, Locator, expect } from "@playwright/test";
  */
 export class FlowsheetPage {
   readonly page: Page;
+  private entriesResponsePromise: Promise<unknown> | null = null;
 
   // Search form
   readonly searchForm: Locator;
@@ -73,6 +74,15 @@ export class FlowsheetPage {
   // --- Navigation ---
 
   async goto(): Promise<void> {
+    // Listen for the initial entries GET BEFORE navigating so we don't miss
+    // it — same pattern as the response wait in goLive() below.
+    this.entriesResponsePromise = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/flowsheet/") &&
+        resp.request().method() === "GET" &&
+        resp.status() === 200,
+      { timeout: 30000 }
+    );
     await this.page.goto("/dashboard/flowsheet");
     await this.page.waitForLoadState("domcontentloaded");
   }
@@ -80,8 +90,12 @@ export class FlowsheetPage {
   async waitForEntriesLoaded(): Promise<void> {
     // Wait for the Go Live button to be visible (page has rendered)
     await this.goLiveButton.waitFor({ state: "visible", timeout: 10000 });
-    // Brief pause for RTK Query to settle initial fetches
-    await this.page.waitForTimeout(500);
+    // Wait for the getInfiniteEntries response captured before navigation.
+    // This guarantees the RTK Query cache is populated before tests submit.
+    if (this.entriesResponsePromise) {
+      await this.entriesResponsePromise;
+      this.entriesResponsePromise = null;
+    }
   }
 
   // --- Go Live / Leave ---

--- a/e2e/pages/flowsheet.page.ts
+++ b/e2e/pages/flowsheet.page.ts
@@ -74,11 +74,13 @@ export class FlowsheetPage {
   // --- Navigation ---
 
   async goto(): Promise<void> {
-    // Listen for the initial entries GET BEFORE navigating so we don't miss
-    // it — same pattern as the response wait in goLive() below.
+    // Listen for the page-0 entries GET BEFORE navigating so we don't miss
+    // it. Filter on "page=" to avoid resolving on whoIsLive or getNowPlaying
+    // responses that share the /flowsheet/ prefix.
     this.entriesResponsePromise = this.page.waitForResponse(
       (resp) =>
         resp.url().includes("/flowsheet/") &&
+        resp.url().includes("page=") &&
         resp.request().method() === "GET" &&
         resp.status() === 200,
       { timeout: 30000 }

--- a/e2e/tests/flowsheet/entry-caching.spec.ts
+++ b/e2e/tests/flowsheet/entry-caching.spec.ts
@@ -116,13 +116,7 @@ test.describe("Flowsheet Entry Caching", () => {
   // 4. Slow network conditions (optimistic update)
   // ---------------------------------------------------------------
   test.describe("4. Slow network", () => {
-    // FIXME(#433): The optimistic entry never appears in the DOM under a
-    // delayed POST. The onQueryStarted callback may not fire if the infinite
-    // query cache hasn't populated by the time the mutation runs — the
-    // waitForEntriesLoaded() page object method only checks for the Go Live
-    // button, not the actual query data. Needs investigation into the RTK
-    // Query lifecycle ordering in CI.
-    test.fixme("entry appears immediately under throttled network", async ({
+    test("entry appears immediately under throttled network", async ({
       page,
     }) => {
       const trackName = `Optimistic ${ts}`;
@@ -172,11 +166,7 @@ test.describe("Flowsheet Entry Caching", () => {
   // 5. Page load timing
   // ---------------------------------------------------------------
   test.describe("5. Page load timing", () => {
-    // FIXME(#433): The addTrack mutation never resolves when submitting
-    // before entries finish loading. The entries cache is empty so the
-    // mutation falls through to invalidateTags, but the refetch may
-    // conflict with the still-delayed initial GET. Needs investigation.
-    test.fixme("can add track before entry list fully loads", async ({ page }) => {
+    test("can add track before entry list fully loads", async ({ page }) => {
       // URL predicate that matches only the page-0 entries GET, not POSTs
       const isPage0 = (url: URL) =>
         url.pathname.endsWith("/flowsheet/") &&
@@ -264,10 +254,7 @@ test.describe("Flowsheet Entry Caching", () => {
   // 7. Multiple tabs
   // ---------------------------------------------------------------
   test.describe("7. Multiple tabs", () => {
-    // FIXME(#433): Same mutation-resolution issue as tests 4/5/9 — the
-    // addTrack call hangs after 20+ DB entries. New browser contexts start
-    // with empty caches that must be populated before the mutation fires.
-    test.fixme("entry added in one tab appears in another after refresh", async ({
+    test("entry added in one tab appears in another after refresh", async ({
       browser,
     }) => {
       test.slow(); // Multi-context test needs extra time
@@ -342,11 +329,7 @@ test.describe("Flowsheet Entry Caching", () => {
   // 9. Rapid input (last — does not block other tests if it fails)
   // ---------------------------------------------------------------
   test.describe("9. Rapid input", () => {
-    // FIXME(#433): After 14+ cached entries, the first addTrack in this loop
-    // times out waiting for the form to clear. The sort-order fix (#444)
-    // corrected optimistic entry positioning but this test has a separate
-    // mutation-resolution issue — the POST appears to never complete in CI.
-    test.fixme("quick successive adds maintain order with no duplicates", async ({
+    test("quick successive adds maintain order with no duplicates", async ({
       page,
     }) => {
       test.slow(); // Rapid adds need extra time budget

--- a/e2e/tests/flowsheet/entry-caching.spec.ts
+++ b/e2e/tests/flowsheet/entry-caching.spec.ts
@@ -137,6 +137,7 @@ test.describe("Flowsheet Entry Caching", () => {
       await flowsheet.fillSearchForm({
         song: trackName,
         artist: "Optimistic Artist",
+        album: "Optimistic Album",
       });
       await flowsheet.submitViaEnter();
 
@@ -190,7 +191,7 @@ test.describe("Flowsheet Entry Caching", () => {
       await expect(flowsheet.songInput).toBeEnabled({ timeout: 10000 });
 
       const trackName = `Eager ${ts}`;
-      await flowsheet.addTrack({ song: trackName, artist: "Eager Artist" });
+      await flowsheet.addTrack({ song: trackName, artist: "Eager Artist", album: "Eager Album" });
 
       // After the delayed entries load completes, the track should be visible
       await page.unroute(isPage0);
@@ -284,7 +285,7 @@ test.describe("Flowsheet Entry Caching", () => {
 
         // Add a track in tab 1
         const trackName = `Cross Tab ${ts}`;
-        await fs1.addTrack({ song: trackName, artist: "Cross Tab Artist" });
+        await fs1.addTrack({ song: trackName, artist: "Cross Tab Artist", album: "Cross Tab Album" });
 
         // Tab 1 should show it immediately
         await fs1.expectEntryWithText(trackName);
@@ -344,7 +345,7 @@ test.describe("Flowsheet Entry Caching", () => {
       // Fire adds using Enter key (bypasses searchOpen check in button onClick)
       for (const name of trackNames) {
         await flowsheet.addTrack(
-          { song: name, artist: "Rapid Artist" },
+          { song: name, artist: "Rapid Artist", album: "Rapid Album" },
           "enter"
         );
       }

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -185,11 +185,12 @@ export const flowsheetApi = createApi({
           };
           const cached =
             flowsheetApi.endpoints.getInfiniteEntries.select(undefined)(root);
-          const hadCachedList = cached?.data != null;
 
           let tempId: number | undefined;
           let patchResult: { undo: () => void } | undefined;
 
+          // Optimistic entry only when the cache already has pages —
+          // buildOptimisticEntry needs existing data for play_order and show_id.
           if (cached?.data?.pages?.length) {
             const { entry, tempId: tid } = buildOptimisticEntry(
               arg,
@@ -209,23 +210,22 @@ export const flowsheetApi = createApi({
 
           try {
             const { data } = await queryFulfilled;
-            if (hadCachedList) {
-              dispatch(
-                flowsheetApi.util.updateQueryData(
-                  "getInfiniteEntries",
-                  undefined,
-                  (draft) => {
-                    if (tempId !== undefined) {
-                      replaceEntryIdAllPages(draft, tempId, data);
-                    } else {
-                      insertEntrySortedFirstPage(draft, data);
-                    }
+            // Always insert the server response directly. When the cache is
+            // uninitialized, updateQueryData is a no-op and the in-flight
+            // initial GET will return with the new entry included.
+            dispatch(
+              flowsheetApi.util.updateQueryData(
+                "getInfiniteEntries",
+                undefined,
+                (draft) => {
+                  if (tempId !== undefined) {
+                    replaceEntryIdAllPages(draft, tempId, data);
+                  } else {
+                    insertEntrySortedFirstPage(draft, data);
                   }
-                )
-              );
-            } else {
-              dispatch(flowsheetApi.util.invalidateTags(["Flowsheet"]));
-            }
+                }
+              )
+            );
           } catch (err) {
             flowsheetMutationCatch("addToFlowsheet", err);
             patchResult?.undo();


### PR DESCRIPTION
## Summary

- Remove the `invalidateTags(["Flowsheet"])` fallback in `addToFlowsheet`'s `onQueryStarted` callback that raced with the in-flight initial `getInfiniteEntries` GET when the cache was empty, causing the mutation to never resolve
- Fix the E2E page object's `waitForEntriesLoaded()` to await the actual entries GET response instead of a 500ms heuristic
- Enable 4 previously-fixme'd E2E tests: slow network (#4), page load timing (#5), multiple tabs (#7), rapid input (#9)

## Root cause

When the infinite query cache was uninitialized (user submits before entries load), `onQueryStarted` dispatched `invalidateTags(["Flowsheet"])` which triggered a refetch that raced with the still-in-flight initial GET. This caused unpredictable behavior in RTK Query 2.11.x that prevented the mutation from resolving cleanly.

The fix always uses `updateQueryData` to insert the server response directly. When the cache is uninitialized, `updateQueryData` is a no-op, and the in-flight initial GET returns with the new entry included since the POST already committed.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] 2549 unit tests pass (`npm run test:run`)
- [ ] E2E tests pass with 4 formerly-fixme'd tests enabled (CI)

Closes #433