### PR TITLE
Persist preferred login method (OTP vs password)

### DIFF
--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -71,18 +71,27 @@ export class LoginPage {
    * preferred login method was restored from localStorage).
    */
   async switchToPasswordLogin(): Promise<void> {
-    // Wait for either form to appear — the password form may render directly
-    // if the user's preference was restored from localStorage on hydration.
-    await this.usernameInput.or(this.switchToPasswordLink).waitFor({
-      state: "visible",
-      timeout: 15000,
-    });
-    if (await this.usernameInput.isVisible()) return;
-    await this.switchToPasswordLink.waitFor({ state: "visible", timeout: 15000 });
+    // The password form may appear directly after hydration restores the
+    // user's stored preference from localStorage. Wait briefly for it
+    // before falling back to clicking the switch link.
+    try {
+      await this.usernameInput.waitFor({ state: "visible", timeout: 2000 });
+      return;
+    } catch {
+      // Password form didn't appear — switch from OTP form
+    }
+
     // The Redux dispatch from the click can occasionally fail to trigger a
-    // re-render on slow CI runners. Retry the click if the form doesn't swap.
+    // re-render on slow CI runners, or the element may detach during
+    // hydration. Retry with graceful error handling.
     for (let attempt = 0; attempt < 3; attempt++) {
-      await this.switchToPasswordLink.click();
+      if (await this.usernameInput.isVisible()) return;
+      try {
+        await this.switchToPasswordLink.click({ timeout: 5000 });
+      } catch {
+        // Element may have detached during hydration — retry
+        continue;
+      }
       try {
         await this.usernameInput.waitFor({ state: "visible", timeout: 5000 });
         return;

--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -71,6 +71,12 @@ export class LoginPage {
    * preferred login method was restored from localStorage).
    */
   async switchToPasswordLogin(): Promise<void> {
+    // Wait for either form to appear — the password form may render directly
+    // if the user's preference was restored from localStorage on hydration.
+    await this.usernameInput.or(this.switchToPasswordLink).waitFor({
+      state: "visible",
+      timeout: 15000,
+    });
     if (await this.usernameInput.isVisible()) return;
     await this.switchToPasswordLink.waitFor({ state: "visible", timeout: 15000 });
     // The Redux dispatch from the click can occasionally fail to trigger a

--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -67,8 +67,11 @@ export class LoginPage {
 
   /**
    * Switch from the default OTP email form to the password login form.
+   * No-op if the password form is already visible (e.g. when the user's
+   * preferred login method was restored from localStorage).
    */
   async switchToPasswordLogin(): Promise<void> {
+    if (await this.usernameInput.isVisible()) return;
     await this.switchToPasswordLink.waitFor({ state: "visible", timeout: 15000 });
     // The Redux dispatch from the click can occasionally fail to trigger a
     // re-render on slow CI runners. Retry the click if the form doesn't swap.

--- a/lib/__tests__/features/application/login-method-storage.test.ts
+++ b/lib/__tests__/features/application/login-method-storage.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  getPreferredLoginMethod,
+  savePreferredLoginMethod,
+  LOGIN_METHOD_STORAGE_KEY,
+} from "@/lib/features/application/login-method-storage";
+
+describe("login-method-storage", () => {
+  let store: Record<string, string> = {};
+  const mockLocalStorage = {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+    get length() { return Object.keys(store).length; },
+    key: vi.fn((i: number) => Object.keys(store)[i] ?? null),
+  };
+
+  beforeEach(() => {
+    store = {};
+    Object.defineProperty(window, "localStorage", { value: mockLocalStorage, writable: true });
+  });
+
+  afterEach(() => {
+    store = {};
+  });
+
+  describe("getPreferredLoginMethod", () => {
+    it("should return 'otp-email' when nothing is stored", () => {
+      expect(getPreferredLoginMethod()).toBe("otp-email");
+    });
+
+    it("should return 'password' when 'password' is stored", () => {
+      localStorage.setItem(LOGIN_METHOD_STORAGE_KEY, "password");
+      expect(getPreferredLoginMethod()).toBe("password");
+    });
+
+    it("should return 'otp-email' when 'otp-email' is stored", () => {
+      localStorage.setItem(LOGIN_METHOD_STORAGE_KEY, "otp-email");
+      expect(getPreferredLoginMethod()).toBe("otp-email");
+    });
+
+    it("should return 'otp-email' for unrecognized values", () => {
+      localStorage.setItem(LOGIN_METHOD_STORAGE_KEY, "something-invalid");
+      expect(getPreferredLoginMethod()).toBe("otp-email");
+    });
+  });
+
+  describe("savePreferredLoginMethod", () => {
+    it("should save 'password' to localStorage", () => {
+      savePreferredLoginMethod("password");
+      expect(localStorage.getItem(LOGIN_METHOD_STORAGE_KEY)).toBe("password");
+    });
+
+    it("should save 'otp-email' to localStorage", () => {
+      savePreferredLoginMethod("otp-email");
+      expect(localStorage.getItem(LOGIN_METHOD_STORAGE_KEY)).toBe("otp-email");
+    });
+
+    it("should overwrite a previous value", () => {
+      savePreferredLoginMethod("password");
+      savePreferredLoginMethod("otp-email");
+      expect(localStorage.getItem(LOGIN_METHOD_STORAGE_KEY)).toBe("otp-email");
+    });
+  });
+});

--- a/lib/features/application/frontend.ts
+++ b/lib/features/application/frontend.ts
@@ -1,5 +1,6 @@
 import { createAppSlice } from "@/lib/createAppSlice";
-import { ApplicationFrontendState, AuthStage, RightbarMenu } from "./types";
+import { getPreferredLoginMethod } from "./login-method-storage";
+import { ApplicationFrontendState, RightbarMenu } from "./types";
 
 export const defaultApplicationFrontendState: ApplicationFrontendState = {
   rightbar: {
@@ -8,7 +9,7 @@ export const defaultApplicationFrontendState: ApplicationFrontendState = {
     menu: RightbarMenu.BIN,
   },
   authFlow: {
-    stage: "otp-email" as AuthStage,
+    stage: getPreferredLoginMethod(),
   },
 };
 

--- a/lib/features/application/frontend.ts
+++ b/lib/features/application/frontend.ts
@@ -1,6 +1,5 @@
 import { createAppSlice } from "@/lib/createAppSlice";
-import { getPreferredLoginMethod } from "./login-method-storage";
-import { ApplicationFrontendState, RightbarMenu } from "./types";
+import { ApplicationFrontendState, AuthStage, RightbarMenu } from "./types";
 
 export const defaultApplicationFrontendState: ApplicationFrontendState = {
   rightbar: {
@@ -9,7 +8,7 @@ export const defaultApplicationFrontendState: ApplicationFrontendState = {
     menu: RightbarMenu.BIN,
   },
   authFlow: {
-    stage: getPreferredLoginMethod(),
+    stage: "otp-email" as AuthStage,
   },
 };
 

--- a/lib/features/application/login-method-storage.ts
+++ b/lib/features/application/login-method-storage.ts
@@ -1,0 +1,34 @@
+import { AuthStage } from "./types";
+
+export const LOGIN_METHOD_STORAGE_KEY = "wxyc_preferred_login_method";
+
+type PreferredLoginMethod = Extract<AuthStage, "otp-email" | "password">;
+
+const VALID_METHODS: PreferredLoginMethod[] = ["otp-email", "password"];
+
+/**
+ * Read the user's preferred login method from localStorage.
+ * Returns "otp-email" if nothing is stored or the value is unrecognized.
+ */
+export function getPreferredLoginMethod(): PreferredLoginMethod {
+  if (typeof window === "undefined") return "otp-email";
+  try {
+    const stored = localStorage.getItem(LOGIN_METHOD_STORAGE_KEY);
+    if (stored && VALID_METHODS.includes(stored as PreferredLoginMethod)) {
+      return stored as PreferredLoginMethod;
+    }
+    return "otp-email";
+  } catch {
+    return "otp-email";
+  }
+}
+
+/** Persist the user's preferred login method to localStorage. */
+export function savePreferredLoginMethod(method: PreferredLoginMethod): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(LOGIN_METHOD_STORAGE_KEY, method);
+  } catch {
+    // localStorage may be unavailable (private browsing, quota exceeded)
+  }
+}

--- a/src/components/experiences/modern/login/Forms/EmailOTPForm.tsx
+++ b/src/components/experiences/modern/login/Forms/EmailOTPForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { applicationSlice } from "@/lib/features/application/frontend";
+import { savePreferredLoginMethod } from "@/lib/features/application/login-method-storage";
 import { useAppDispatch } from "@/lib/hooks";
 import { useOTPRequest } from "@/src/hooks/authenticationHooks";
 import { Button, FormControl, FormLabel, Input, Link, Typography } from "@mui/joy";
@@ -29,6 +30,7 @@ export default function EmailOTPForm({
 
   const handleSwitchToPassword = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
+    savePreferredLoginMethod("password");
     dispatch(applicationSlice.actions.setAuthStage("password"));
   };
 

--- a/src/components/experiences/modern/login/Forms/LoginFormSwitcher.tsx
+++ b/src/components/experiences/modern/login/Forms/LoginFormSwitcher.tsx
@@ -4,7 +4,7 @@ import { applicationSlice } from "@/lib/features/application/frontend";
 import { getPreferredLoginMethod } from "@/lib/features/application/login-method-storage";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import WelcomeQuotes from "@/src/components/experiences/modern/login/Quotes/Welcome";
-import { useEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import EmailOTPForm from "./EmailOTPForm";
 import OTPCodeForm from "./OTPCodeForm";
 import UserPasswordForm from "./UserPasswordForm";
@@ -15,7 +15,10 @@ export default function LoginFormSwitcher() {
   const [otpEmail, setOtpEmail] = useState("");
   const hasSyncedRef = useRef(false);
 
-  useEffect(() => {
+  // Sync before paint so the correct form renders without a flash.
+  // useLayoutEffect is client-only (this is a "use client" component),
+  // so the SSR warning does not apply.
+  useLayoutEffect(() => {
     if (hasSyncedRef.current) return;
     hasSyncedRef.current = true;
     const preferred = getPreferredLoginMethod();

--- a/src/components/experiences/modern/login/Forms/LoginFormSwitcher.tsx
+++ b/src/components/experiences/modern/login/Forms/LoginFormSwitcher.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { applicationSlice } from "@/lib/features/application/frontend";
+import { getPreferredLoginMethod } from "@/lib/features/application/login-method-storage";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import WelcomeQuotes from "@/src/components/experiences/modern/login/Quotes/Welcome";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import EmailOTPForm from "./EmailOTPForm";
 import OTPCodeForm from "./OTPCodeForm";
 import UserPasswordForm from "./UserPasswordForm";
@@ -12,6 +13,16 @@ export default function LoginFormSwitcher() {
   const dispatch = useAppDispatch();
   const authStage = useAppSelector(applicationSlice.selectors.getAuthStage);
   const [otpEmail, setOtpEmail] = useState("");
+  const hasSyncedRef = useRef(false);
+
+  useEffect(() => {
+    if (hasSyncedRef.current) return;
+    hasSyncedRef.current = true;
+    const preferred = getPreferredLoginMethod();
+    if (preferred !== authStage) {
+      dispatch(applicationSlice.actions.setAuthStage(preferred));
+    }
+  }, [authStage, dispatch]);
 
   if (authStage === "otp-verify") {
     return (

--- a/src/components/experiences/modern/login/Forms/UserPasswordForm.tsx
+++ b/src/components/experiences/modern/login/Forms/UserPasswordForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { applicationSlice } from "@/lib/features/application/frontend";
+import { savePreferredLoginMethod } from "@/lib/features/application/login-method-storage";
 import { useAppDispatch } from "@/lib/hooks";
 import { useLogin } from "@/src/hooks/authenticationHooks";
 import { Link, Typography } from "@mui/joy";
@@ -54,6 +55,7 @@ export default function UserPasswordForm() {
           type="button"
           onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
             event.preventDefault();
+            savePreferredLoginMethod("otp-email");
             dispatch(applicationSlice.actions.setAuthStage("otp-email"));
           }}
           disabled={authenticating}


### PR DESCRIPTION
## Summary

- Persist the user's preferred login method (OTP vs password) to `localStorage` so it survives page reloads
- Read the stored preference when initializing the Redux auth stage instead of always defaulting to OTP
- Save the preference when the user explicitly switches methods via the form toggle links

Closes #455

## Test plan

- [ ] Visit login page for the first time — OTP form appears (default)
- [ ] Click "Sign in with password instead" — password form appears
- [ ] Reload the page — password form appears (preference persisted)
- [ ] Click "Sign in with email code instead" — OTP form appears
- [ ] Reload the page — OTP form appears (preference updated)
- [ ] Clear localStorage — OTP form appears (graceful fallback)