### PR TITLE
Fix show start/end entries not rendering

### DIFF
--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -313,6 +313,56 @@ describe("flowsheet conversions", () => {
         expect(result.day).toBe("Unknown");
         expect(result.time).toBe("Unknown");
       });
+
+      it("should handle show_start without dj_name by falling back to artist_name", () => {
+        const entry = {
+          ...createTestV2ShowStartEntry(),
+          dj_name: undefined,
+          artist_name: "DJ Houndstooth",
+        } as any;
+        const result = convertV2Entry(entry) as FlowsheetShowBlockEntry;
+
+        expect(result.dj_name).toBe("DJ Houndstooth");
+        expect(result.isStart).toBe(true);
+      });
+
+      it("should handle show_end without dj_name by falling back to artist_name", () => {
+        const entry = {
+          ...createTestV2ShowEndEntry(),
+          dj_name: undefined,
+          artist_name: "DJ Mouseness",
+        } as any;
+        const result = convertV2Entry(entry) as FlowsheetShowBlockEntry;
+
+        expect(result.dj_name).toBe("DJ Mouseness");
+        expect(result.isStart).toBe(false);
+      });
+
+      it("should handle show_start without timestamp by falling back to add_time", () => {
+        const entry = {
+          ...createTestV2ShowStartEntry(),
+          timestamp: undefined,
+          add_time: "2026-04-24T16:03:38.067Z",
+        } as any;
+        const result = convertV2Entry(entry) as FlowsheetShowBlockEntry;
+
+        expect(result.dj_name).toBeTruthy();
+        expect(result.isStart).toBe(true);
+        expect(result.day).not.toBe("Unknown");
+        expect(result.time).not.toBe("Unknown");
+      });
+
+      it("should handle show_start with neither dj_name nor artist_name", () => {
+        const entry = {
+          ...createTestV2ShowStartEntry(),
+          dj_name: undefined,
+          artist_name: undefined,
+        } as any;
+        const result = convertV2Entry(entry) as FlowsheetShowBlockEntry;
+
+        expect(result.dj_name).toBe("");
+        expect(result.isStart).toBe(true);
+      });
     });
 
     describe("convertV2FlowsheetResponse", () => {

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -96,10 +96,13 @@ export function convertV2Entry(entry: FlowsheetV2EntryJSON): FlowsheetEntry {
       };
 
     case "show_start": {
-      const { day, time } = parseTimestamp(entry.timestamp);
+      const { day, time } =
+        entry.timestamp !== undefined
+          ? parseTimestamp(entry.timestamp)
+          : formatAddTime(entry.add_time);
       return {
         ...base,
-        dj_name: entry.dj_name,
+        dj_name: entry.dj_name ?? (entry as any).artist_name ?? "",
         isStart: true,
         day,
         time,
@@ -107,10 +110,13 @@ export function convertV2Entry(entry: FlowsheetV2EntryJSON): FlowsheetEntry {
     }
 
     case "show_end": {
-      const { day, time } = parseTimestamp(entry.timestamp);
+      const { day, time } =
+        entry.timestamp !== undefined
+          ? parseTimestamp(entry.timestamp)
+          : formatAddTime(entry.add_time);
       return {
         ...base,
-        dj_name: entry.dj_name,
+        dj_name: entry.dj_name ?? (entry as any).artist_name ?? "",
         isStart: false,
         day,
         time,


### PR DESCRIPTION
## Summary

- Fall back to `artist_name` when `dj_name` is missing on show start/end entries
- Fall back to `formatAddTime(add_time)` when `timestamp` is `undefined`
- Preserves existing behavior for V2 responses and empty string timestamps

Closes #461

## Test plan

- [x] 4 new conversion tests pass (artist_name fallback, add_time fallback, both missing)
- [x] All 40 conversion tests pass
- [x] Full test suite: 2558 pass, 2 pre-existing failures (login component, unrelated)
- [ ] Verify on dj.wxyc.org: show start/end entries display with DJ name and timestamp