### PR TITLE
Fix catalog search firing with missing params on re-mount

### DIFF
--- a/src/hooks/__tests__/catalogResults.test.tsx
+++ b/src/hooks/__tests__/catalogResults.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import React, { type PropsWithChildren } from "react";
+import { Provider } from "react-redux";
+import { CssVarsProvider } from "@mui/joy/styles";
+import { makeStore } from "@/lib/store";
+import { catalogSlice } from "@/lib/features/catalog/frontend";
+import type { SearchCatalogQueryParams } from "@/lib/features/catalog/types";
+
+// Capture args passed to useSearchCatalogQuery on each call
+const searchCatalogCalls: Array<{
+  args: SearchCatalogQueryParams;
+  options: { skip: boolean };
+}> = [];
+
+vi.mock("@/lib/features/catalog/api", () => ({
+  catalogApi: {
+    reducerPath: "catalogApi",
+    reducer: (state = {}) => state,
+    middleware:
+      () =>
+      (next: (action: unknown) => unknown) =>
+      (action: unknown) =>
+        next(action),
+    endpoints: {},
+    util: { resetApiState: () => ({ type: "noop" }) },
+  },
+  useSearchCatalogQuery: (
+    args: SearchCatalogQueryParams,
+    options: { skip: boolean }
+  ) => {
+    searchCatalogCalls.push({ args, options });
+    return {
+      data: undefined,
+      isLoading: false,
+      isSuccess: false,
+      isError: false,
+    };
+  },
+}));
+
+vi.mock("../authenticationHooks", () => ({
+  useAuthentication: () => ({ authenticating: false, authenticated: true }),
+}));
+
+import { useCatalogResults } from "../catalogHooks";
+
+describe("useCatalogResults", () => {
+  beforeEach(() => {
+    searchCatalogCalls.length = 0;
+  });
+
+  it("should pass valid query params on mount when searchString persists from a previous visit", () => {
+    const store = makeStore();
+
+    // Simulate Redux state persisted from a previous catalog search
+    store.dispatch(catalogSlice.actions.setSearchQuery("Autechre"));
+
+    function Wrapper({ children }: PropsWithChildren) {
+      return (
+        <Provider store={store}>
+          <CssVarsProvider>{children}</CssVarsProvider>
+        </Provider>
+      );
+    }
+
+    renderHook(() => useCatalogResults(), { wrapper: Wrapper });
+
+    // On the first render, useSearchCatalogQuery is called.
+    // With searchString="Autechre" (persisted), skip should be false.
+    // The query args should have valid artist_name/album_title (not undefined),
+    // because sending undefined params causes a 400 from the backend (?n=10 only).
+    const firstCall = searchCatalogCalls[0];
+
+    expect(firstCall.options.skip).toBe(false);
+    expect(firstCall.args.artist_name).not.toBeUndefined();
+    expect(firstCall.args.album_title).not.toBeUndefined();
+  });
+});

--- a/src/hooks/catalogHooks.ts
+++ b/src/hooks/catalogHooks.ts
@@ -117,11 +117,9 @@ export const useCatalogResults = () => {
   const searchIn = useAppSelector(catalogSlice.selectors.getSearchIn);
   const exclusive = useAppSelector(catalogSlice.selectors.getExclusiveFilter);
   const [formattedQuery, setFormattedQuery] =
-    useState<SearchCatalogQueryParams>({
-      artist_name: undefined,
-      album_title: undefined,
-      n: 10,
-    });
+    useState<SearchCatalogQueryParams>(() =>
+      formatCatalogSearchQuery(searchIn, searchString, n, exclusive)
+    );
   const loadMore = () => dispatch(catalogSlice.actions.loadMore());
 
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
## Summary

- Fix 400 error toast ("Missing query parameter") that appears when navigating back to the catalog page after a previous search
- The `useCatalogResults` hook initialized `formattedQuery` with hardcoded `{ artist_name: undefined, album_title: undefined }`, but `searchString` persisted in Redux from the previous visit. On mount, the skip condition was false (non-empty searchString) so RTK Query fired with just `?n=10`, causing a 400
- Fix: initialize `formattedQuery` from the current Redux state via `formatCatalogSearchQuery()` so query args are always consistent with the skip condition

## Test plan

- [x] New test verifying query args have valid params when searchString is persisted
- [x] Full test suite passes (2559/2559, 2 pre-existing failures in LoginFormSwitcher)
- [x] Typecheck passes