### PR TITLE
Fix flowsheet entry ordering across show boundaries

### DIFF
--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -366,9 +366,7 @@ describe("flowsheet conversions", () => {
     });
 
     describe("convertV2FlowsheetResponse", () => {
-      it("should convert and sort entries by play_order descending", () => {
-        // Input unsorted: [id=1/po=99, id=3/po=1, id=2/po=50]
-        // After play_order DESC: [id=1 (po=99), id=2 (po=50), id=3 (po=1)]
+      it("should convert and sort entries by id descending", () => {
         const entries = [
           createTestV2TrackEntry({ id: 1, play_order: 99 }),
           createTestV2TrackEntry({ id: 3, play_order: 1 }),
@@ -376,9 +374,7 @@ describe("flowsheet conversions", () => {
         ];
         const result = convertV2FlowsheetResponse(entries);
 
-        expect(result[0].id).toBe(1);
-        expect(result[1].id).toBe(2);
-        expect(result[2].id).toBe(3);
+        expect(result.map((e) => e.id)).toEqual([3, 2, 1]);
       });
 
       it("should handle empty array", () => {
@@ -386,7 +382,7 @@ describe("flowsheet conversions", () => {
         expect(result).toEqual([]);
       });
 
-      it("should handle mixed entry types sorted by play_order descending", () => {
+      it("should handle mixed entry types sorted by id descending", () => {
         const entries = [
           createTestV2ShowStartEntry({ id: 1, play_order: 1 }),
           createTestV2TrackEntry({ id: 2, play_order: 2 }),
@@ -399,6 +395,21 @@ describe("flowsheet conversions", () => {
         expect(result).toHaveLength(5);
         expect(result[0].id).toBe(5);
         expect(result[4].id).toBe(1);
+      });
+
+      it("should sort correctly across shows where play_order resets", () => {
+        // Current show: ids 100-102, play_orders 1-3
+        // Previous show: ids 90-92, play_orders 10-12
+        // play_order DESC would wrongly put 92 (po=12) before 102 (po=3)
+        const entries = [
+          createTestV2TrackEntry({ id: 102, play_order: 3 }),
+          createTestV2TrackEntry({ id: 92, play_order: 12 }),
+          createTestV2TrackEntry({ id: 101, play_order: 2 }),
+          createTestV2TrackEntry({ id: 91, play_order: 11 }),
+        ];
+        const result = convertV2FlowsheetResponse(entries);
+
+        expect(result.map((e) => e.id)).toEqual([102, 101, 92, 91]);
       });
     });
 

--- a/lib/__tests__/features/flowsheet/infinite-cache.test.ts
+++ b/lib/__tests__/features/flowsheet/infinite-cache.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import type { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
 import {
   buildOptimisticEntry,
+  compareEntriesNewestFirst,
   insertEntrySortedFirstPage,
   maxPlayOrder,
   primaryShowId,
@@ -27,6 +28,50 @@ function song(
   };
 }
 
+describe("compareEntriesNewestFirst", () => {
+  it("should sort real entries by id descending (higher id = newer)", () => {
+    const entries = [song(5, 1, 1), song(10, 2, 1), song(1, 3, 1)];
+    entries.sort(compareEntriesNewestFirst);
+    expect(entries.map((e) => e.id)).toEqual([10, 5, 1]);
+  });
+
+  it("should sort correctly across shows where play_order resets", () => {
+    // Current show: play_orders 1-3, ids 100-102
+    // Previous show: play_orders 10-12, ids 90-92
+    // play_order DESC would wrongly put previous show first
+    const entries = [
+      song(102, 3, 2), // current show
+      song(101, 2, 2),
+      song(100, 1, 2),
+      song(92, 12, 1), // previous show
+      song(91, 11, 1),
+      song(90, 10, 1),
+    ];
+    entries.sort(compareEntriesNewestFirst);
+    expect(entries.map((e) => e.id)).toEqual([102, 101, 100, 92, 91, 90]);
+  });
+
+  it("should place optimistic temp entries (negative ids) before real entries", () => {
+    const entries = [song(50, 10, 1), song(-1719148800000, 11, 1)];
+    entries.sort(compareEntriesNewestFirst);
+    expect(entries[0].id).toBe(-1719148800000);
+    expect(entries[1].id).toBe(50);
+  });
+
+  it("should sort multiple temp entries with more-negative first (more recent)", () => {
+    const older = song(-1000000, 11, 1);
+    const newer = song(-2000000, 12, 1); // more negative = created later
+    const entries = [older, newer];
+    entries.sort(compareEntriesNewestFirst);
+    expect(entries[0].id).toBe(-2000000);
+    expect(entries[1].id).toBe(-1000000);
+  });
+
+  it("should return 0 for entries with the same id", () => {
+    expect(compareEntriesNewestFirst(song(5, 1, 1), song(5, 1, 1))).toBe(0);
+  });
+});
+
 describe("infinite-cache", () => {
   it("maxPlayOrder and primaryShowId read pages", () => {
     const draft = {
@@ -40,27 +85,35 @@ describe("infinite-cache", () => {
     expect(primaryShowId(draft)).toBe(5);
   });
 
-  it("insertEntrySortedFirstPage keeps descending play_order on page 0", () => {
-    // id order (10, 8, 99) differs from play_order order (20, 15, 10)
-    // to prove the sort key is play_order, not id
+  it("insertEntrySortedFirstPage keeps descending id on page 0", () => {
     const draft = {
       pages: [[song(10, 20, 1), song(8, 10, 1)]],
       pageParams: [0],
     };
-    insertEntrySortedFirstPage(draft, song(99, 15, 1));
-    expect(draft.pages[0].map((e) => e.play_order)).toEqual([20, 15, 10]);
-    expect(draft.pages[0].map((e) => e.id)).toEqual([10, 99, 8]);
+    insertEntrySortedFirstPage(draft, song(9, 15, 1));
+    expect(draft.pages[0].map((e) => e.id)).toEqual([10, 9, 8]);
   });
 
-  it("insertEntrySortedFirstPage positions optimistic entry (negative id) at top by play_order", () => {
+  it("insertEntrySortedFirstPage positions optimistic entry (negative id) at top", () => {
     const draft = {
       pages: [[song(50, 10, 1), song(49, 9, 1)]],
       pageParams: [0],
     };
-    // Optimistic entry: very negative id, but play_order = 11 (maxPlayOrder + 1)
     insertEntrySortedFirstPage(draft, song(-1719148800000, 11, 1));
-    expect(draft.pages[0].map((e) => e.play_order)).toEqual([11, 10, 9]);
     expect(draft.pages[0][0].id).toBe(-1719148800000);
+    expect(draft.pages[0].map((e) => e.id)).toEqual([-1719148800000, 50, 49]);
+  });
+
+  it("insertEntrySortedFirstPage handles cross-show entries correctly", () => {
+    // Page 0 has entries from two shows: current (ids 100-102, play_orders 1-3)
+    // and previous (ids 90-92, play_orders 10-12).
+    // A new entry (id 103) should go to the top regardless of play_order.
+    const draft = {
+      pages: [[song(102, 3, 2), song(101, 2, 2), song(92, 12, 1), song(91, 11, 1)]],
+      pageParams: [0],
+    };
+    insertEntrySortedFirstPage(draft, song(103, 4, 2));
+    expect(draft.pages[0].map((e) => e.id)).toEqual([103, 102, 101, 92, 91]);
   });
 
   it("insertEntrySortedFirstPage initializes empty cache", () => {
@@ -79,18 +132,15 @@ describe("infinite-cache", () => {
     expect(draft.pages[1]).toHaveLength(0);
   });
 
-  it("replaceEntryIdAllPages maintains play_order sort after replacement", () => {
-    // Temp entry at the END — simulates where id-based sorting would place
-    // an optimistic entry with a very negative id
+  it("replaceEntryIdAllPages maintains id-descending sort after replacement", () => {
+    // Temp entry at the top (optimistic entries sort first by compareEntriesNewestFirst)
     const draft = {
-      pages: [[song(50, 10, 1), song(49, 9, 1), song(-1719148800000, 11, 1)]],
+      pages: [[song(-1719148800000, 11, 1), song(50, 10, 1), song(49, 9, 1)]],
       pageParams: [0],
     };
     const server = song(51, 11, 1);
     replaceEntryIdAllPages(draft, -1719148800000, server);
-    // Server entry should be re-sorted to position 0 (highest play_order)
     expect(draft.pages[0].map((e) => e.id)).toEqual([51, 50, 49]);
-    expect(draft.pages[0].map((e) => e.play_order)).toEqual([11, 10, 9]);
   });
 
   it("replaceEntryIdAllPages inserts when temp entry is not found", () => {
@@ -100,8 +150,7 @@ describe("infinite-cache", () => {
     };
     const server = song(51, 11, 1);
     replaceEntryIdAllPages(draft, -999, server);
-    expect(draft.pages[0].map((e) => e.play_order)).toEqual([11, 10, 9]);
-    expect(draft.pages[0][0].id).toBe(51);
+    expect(draft.pages[0].map((e) => e.id)).toEqual([51, 50, 49]);
   });
 
   it("swapPlayOrdersForSwitch swaps play_order between two entries", () => {

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -182,5 +182,5 @@ export function convertV2FlowsheetResponse(
 ): FlowsheetEntry[] {
   return entries
     .map(convertV2Entry)
-    .sort((a, b) => b.play_order - a.play_order);
+    .sort((a, b) => b.id - a.id);
 }

--- a/lib/features/flowsheet/infinite-cache.ts
+++ b/lib/features/flowsheet/infinite-cache.ts
@@ -83,7 +83,22 @@ export function buildOptimisticEntry(
   return { entry, tempId };
 }
 
-/** Insert so `pages[0]` stays sorted by `play_order` descending (newest first). */
+/**
+ * Sort comparator for FlowsheetEntry: newest-first (descending).
+ * Uses `id` as the global sort key since it's monotonically increasing across
+ * all shows, unlike `play_order` which resets per show. Optimistic temp entries
+ * (negative IDs from `nextOptimisticTempId`) always sort before real entries
+ * since they represent the most recent additions.
+ */
+export function compareEntriesNewestFirst(a: FlowsheetEntry, b: FlowsheetEntry): number {
+  const aTemp = a.id < 0;
+  const bTemp = b.id < 0;
+  if (aTemp !== bTemp) return aTemp ? -1 : 1;
+  if (aTemp) return a.id - b.id; // more negative = newer (larger Date.now())
+  return b.id - a.id;
+}
+
+/** Insert so `pages[0]` stays sorted by id descending (newest first). */
 export function insertEntrySortedFirstPage(
   draft: InfiniteEntriesDraft,
   entry: FlowsheetEntry
@@ -94,7 +109,7 @@ export function insertEntrySortedFirstPage(
     return;
   }
   const page0 = draft.pages[0];
-  const idx = page0.findIndex((e) => e.play_order < entry.play_order);
+  const idx = page0.findIndex((e) => compareEntriesNewestFirst(entry, e) < 0);
   if (idx === -1) {
     page0.push(entry);
   } else {

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/features/flowsheet/api";
 import { convertQueryToSubmission } from "@/lib/features/flowsheet/conversions";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { compareEntriesNewestFirst } from "@/lib/features/flowsheet/infinite-cache";
 import { partitionFlowsheetEntries } from "@/lib/features/flowsheet/partition";
 import {
   FlowsheetEntry,
@@ -79,9 +80,7 @@ export const useShowControl = () => {
     if (!infiniteData?.pages) return [];
     const map = new Map<number, FlowsheetEntry>();
     infiniteData.pages.flat().forEach((entry) => map.set(entry.id, entry));
-    return Array.from(map.values()).sort(
-      (a, b) => b.play_order - a.play_order
-    );
+    return Array.from(map.values()).sort(compareEntriesNewestFirst);
   }, [infiniteData?.pages]);
 
   // Calculate derived state during render - no useState/useEffect needed
@@ -249,9 +248,7 @@ export const useFlowsheet = () => {
     if (!infiniteData?.pages) return [];
     const map = new Map<number, FlowsheetEntry>();
     infiniteData.pages.flat().forEach((entry) => map.set(entry.id, entry));
-    return Array.from(map.values()).sort(
-      (a, b) => b.play_order - a.play_order
-    );
+    return Array.from(map.values()).sort(compareEntriesNewestFirst);
   }, [infiniteData?.pages]);
 
   const [addToFlowsheet] = useAddToFlowsheetMutation();


### PR DESCRIPTION
## Summary

- Replace `play_order DESC` sorting with `id DESC` sorting for flowsheet entries. `play_order` resets per show, causing previous show entries to intermix with current show entries. Entry IDs are globally monotonic and always reflect chronological order.
- Add `compareEntriesNewestFirst` comparator that handles optimistic temp entries (negative IDs) by always placing them first, preserving correct positioning during optimistic updates.
- Update all four sort sites: API response transform, cache insertion, and both presentation-layer dedup memos.

Closes #464

## Test plan

- [x] All 2567 unit tests pass
- [x] TypeScript type check clean
- [x] Production build succeeds
- [ ] Verify on dj.wxyc.org that entries display in correct chronological order across show boundaries
- [ ] Verify optimistic entry positioning still works (new entries appear at top immediately)