### PR TITLE
Remove duplicate invite email from account provisioning

### DIFF
--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -101,23 +101,7 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
           throw new Error(errorData?.message || errorData?.error || `Failed to create user (${response.status})`);
         }
 
-        toast.success(`Account created successfully for ${newAccount.username}`);
-
-        // Send invite email (verification magic link) to the new user
-        try {
-          await fetch(`${authBaseURL}/send-verification-email`, {
-            method: "POST",
-            credentials: "omit",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              email: newAccount.email,
-              callbackURL: "/login",
-            }),
-          });
-          toast.success(`Invite email sent to ${newAccount.email}`);
-        } catch {
-          toast.warning("Account created but invite email could not be sent.");
-        }
+        toast.success(`Account created for ${newAccount.username} — setup email sent to ${newAccount.email}`);
 
         dispatch(adminSlice.actions.setAdding(false));
         dispatch(adminSlice.actions.reset());


### PR DESCRIPTION
## Summary

- Remove the frontend's `POST /auth/send-verification-email` call after account creation in `RosterTable.tsx`
- The Backend-Service `provision-user` endpoint now handles sending the welcome email server-side with a proper password reset token (WXYC/Backend-Service#459)
- Without this fix, new DJs receive two emails: one correct (with token) and one broken (bare `/login` URL)

## Test plan

- [x] Typecheck clean
- [ ] Create a new account via the DJ Roster panel and verify only one email is received with a working setup link