### PR TITLE
Show recent tracks on /dashboard/playlists by default

### DIFF
--- a/src/hooks/playlistSearchHooks.test.ts
+++ b/src/hooks/playlistSearchHooks.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import React from "react";
+import { Provider } from "react-redux";
+import { makeStore, AppStore } from "@/lib/store";
+import { playlistSearchSlice } from "@/lib/features/playlist-search/frontend";
+
+const mockTrigger = vi.fn();
+const mockQueryState = {
+  data: undefined as unknown,
+  isFetching: false,
+  isError: false,
+};
+
+vi.mock("@/lib/features/playlist-search/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/features/playlist-search/api")>(
+      "@/lib/features/playlist-search/api"
+    );
+  return {
+    ...actual,
+    useLazySearchPlaylistsQuery: () =>
+      [mockTrigger, mockQueryState] as unknown as ReturnType<
+        typeof actual.useLazySearchPlaylistsQuery
+      >,
+  };
+});
+
+import { usePlaylistSearch } from "./playlistSearchHooks";
+
+function createWrapper(store?: AppStore) {
+  const s = store ?? makeStore();
+  return {
+    store: s,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Provider, { store: s, children }),
+  };
+}
+
+beforeEach(() => {
+  mockTrigger.mockReset();
+  mockQueryState.data = undefined;
+  mockQueryState.isFetching = false;
+  mockQueryState.isError = false;
+});
+
+describe("usePlaylistSearch", () => {
+  describe("default-recent behavior", () => {
+    it("fires an empty-query request on mount so the page shows recent tracks", async () => {
+      const { wrapper } = createWrapper();
+
+      renderHook(() => usePlaylistSearch(), { wrapper });
+
+      await waitFor(() => expect(mockTrigger).toHaveBeenCalled());
+      expect(mockTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({ q: "", page: 0 })
+      );
+    });
+
+    it("re-fires the empty query when the user clears all rows back to default", async () => {
+      const { store, wrapper } = createWrapper();
+      const rowId = store.getState().playlistSearch.rows[0].id;
+
+      renderHook(() => usePlaylistSearch(), { wrapper });
+
+      // Initial empty fire
+      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+
+      // User types something
+      act(() => {
+        store.dispatch(
+          playlistSearchSlice.actions.updateRow({
+            id: rowId,
+            updates: { value: "autechre" },
+          })
+        );
+      });
+      await waitFor(() =>
+        expect(mockTrigger).toHaveBeenCalledWith(
+          expect.objectContaining({ q: "autechre" })
+        )
+      );
+
+      // User clears it
+      act(() => {
+        store.dispatch(
+          playlistSearchSlice.actions.updateRow({
+            id: rowId,
+            updates: { value: "" },
+          })
+        );
+      });
+      await waitFor(() => {
+        const lastCall = mockTrigger.mock.calls.at(-1);
+        expect(lastCall?.[0]).toEqual(expect.objectContaining({ q: "" }));
+      });
+    });
+  });
+
+  describe("partial-query debounce", () => {
+    it("does not fire while the user has typed only a single character", async () => {
+      const { store, wrapper } = createWrapper();
+      const rowId = store.getState().playlistSearch.rows[0].id;
+
+      renderHook(() => usePlaylistSearch(), { wrapper });
+
+      // Wait for the initial empty fire so we can isolate the next behavior
+      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+
+      act(() => {
+        store.dispatch(
+          playlistSearchSlice.actions.updateRow({
+            id: rowId,
+            updates: { value: "a" },
+          })
+        );
+      });
+
+      // Give effects a tick to settle, then assert no new call
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(mockTrigger).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires once the user types a second character", async () => {
+      const { store, wrapper } = createWrapper();
+      const rowId = store.getState().playlistSearch.rows[0].id;
+
+      renderHook(() => usePlaylistSearch(), { wrapper });
+
+      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+
+      act(() => {
+        store.dispatch(
+          playlistSearchSlice.actions.updateRow({
+            id: rowId,
+            updates: { value: "au" },
+          })
+        );
+      });
+
+      await waitFor(() =>
+        expect(mockTrigger).toHaveBeenCalledWith(
+          expect.objectContaining({ q: "au" })
+        )
+      );
+    });
+  });
+});

--- a/src/hooks/playlistSearchHooks.ts
+++ b/src/hooks/playlistSearchHooks.ts
@@ -70,7 +70,9 @@ export function usePlaylistSearch() {
 
   // Track pending query to fire after current request completes
   const pendingQueryRef = useRef<string | null>(null);
-  const lastFiredQueryRef = useRef<string>("");
+  // null sentinel = "never fired" — distinguishes initial mount from a
+  // user-cleared empty query so the on-mount empty-q request still goes out.
+  const lastFiredQueryRef = useRef<string | null>(null);
   const lastFiredParamsRef = useRef<{ page: number; sortBy: string; sortOrder: string }>({
     page: 0,
     sortBy: "date",
@@ -108,7 +110,12 @@ export function usePlaylistSearch() {
 
   // Fire search when query changes (response-based throttling)
   useEffect(() => {
-    if (effectiveQuery.length < MIN_QUERY_LENGTH) {
+    // Empty query is the "show recent tracks" default. Single-character
+    // partials still get debounced — wait for at least MIN_QUERY_LENGTH
+    // chars before issuing a substring match.
+    const isPartialQuery =
+      effectiveQuery.length > 0 && effectiveQuery.length < MIN_QUERY_LENGTH;
+    if (isPartialQuery) {
       pendingQueryRef.current = null;
       return;
     }


### PR DESCRIPTION
## Summary

- Lets `usePlaylistSearch` fire a request with `q: ''` when the search rows are empty so the Previous Sets page shows recent track entries on mount instead of an empty state.
- Keeps the single-character debounce (`length === 1` still skips); only `length === 0` is newly allowed through.
- Switches `lastFiredQueryRef` to a `null` sentinel so the initial empty query is not treated as "already fired" against its initial `""` value.
- Pairs with WXYC/Backend-Service#467, which relaxes the controller to accept missing or empty `q`. With migration `0050_flowsheet-track-add-time-idx.sql` already deployed, the empty-q path is a direct index scan over `(add_time DESC) WHERE entry_type='track'`.

## Test plan

- [x] New hook tests cover empty-on-mount, clear-back-to-empty, single-char debounce, and resume-on-second-character
- [x] `npx tsc --noEmit` clean
- [x] Full vitest suite passes (2,555 tests)
- [ ] After WXYC/Backend-Service#467 is deployed: load `/dashboard/playlists` in the browser and confirm recent tracks render without typing
- [ ] Confirm typing then clearing returns to recent tracks rather than an empty state

Closes #468