### PR TITLE
Migrate Previous Sets pagination to cursor / nextCursor

### DIFF
--- a/lib/features/playlist-search/api.ts
+++ b/lib/features/playlist-search/api.ts
@@ -5,17 +5,50 @@ import type {
   PlaylistSearchResponse,
 } from "@wxyc/shared";
 
+// Local extensions until @wxyc/shared adds cursor pagination to api.yaml.
+// Backend-Service /flowsheet/search accepts cursor and returns nextCursor;
+// see docs/playlist-search/README.md step 3 in that repo. page is optional
+// here because cursor mode does not use it (and the backend defaults page
+// to 0 when missing); offset-mode callers can still supply it.
+export type PlaylistSearchParamsWithCursor = Omit<
+  PlaylistSearchParams,
+  "page"
+> & {
+  page?: number;
+  cursor?: string;
+};
+
+export type PlaylistSearchResponseWithCursor = PlaylistSearchResponse & {
+  nextCursor?: string;
+};
+
 export const playlistSearchApi = createApi({
   reducerPath: "playlistSearchApi",
   baseQuery: backendBaseQuery("flowsheet"),
   endpoints: (builder) => ({
-    searchPlaylists: builder.query<PlaylistSearchResponse, PlaylistSearchParams>({
-      query: ({ q, page = 0, limit = 50, sort = "date", order = "desc" }) => ({
+    searchPlaylists: builder.query<
+      PlaylistSearchResponseWithCursor,
+      PlaylistSearchParamsWithCursor
+    >({
+      query: ({
+        q,
+        page = 0,
+        limit = 50,
+        sort = "date",
+        order = "desc",
+        cursor,
+      }) => ({
         url: "/search",
-        params: { q, page, limit, sort, order },
+        // Only forward cursor when defined — sending cursor=undefined would
+        // serialize as the literal string "undefined".
+        params:
+          cursor !== undefined
+            ? { q, page, limit, sort, order, cursor }
+            : { q, page, limit, sort, order },
       }),
     }),
   }),
 });
 
-export const { useSearchPlaylistsQuery, useLazySearchPlaylistsQuery } = playlistSearchApi;
+export const { useSearchPlaylistsQuery, useLazySearchPlaylistsQuery } =
+  playlistSearchApi;

--- a/lib/features/playlist-search/frontend.ts
+++ b/lib/features/playlist-search/frontend.ts
@@ -6,7 +6,15 @@ type SortField = PlaylistSearchParams["sort"];
 type SortOrder = PlaylistSearchParams["order"];
 type Operator = "AND" | "OR" | "NOT";
 
-export type SearchField = "all" | "artist" | "song" | "album" | "label" | "dj" | "date" | "dateRange";
+export type SearchField =
+  | "all"
+  | "artist"
+  | "song"
+  | "album"
+  | "label"
+  | "dj"
+  | "date"
+  | "dateRange";
 
 export type SearchRow = {
   id: string;
@@ -14,14 +22,17 @@ export type SearchRow = {
   field: SearchField;
   value: string;
   valueTo?: string; // For date range "to" value
-  exact: boolean;   // Exact phrase match
+  exact: boolean; // Exact phrase match
 };
 
 export type PlaylistSearchState = {
   rows: SearchRow[];
   sortBy: SortField;
   sortOrder: SortOrder;
-  page: number;
+  // Cursor for the next page to fetch. null = first page (start from the
+  // most recent entries). The hook reads nextCursor from the previous
+  // response and dispatches advanceCursor(nextCursor) on infinite-scroll.
+  cursor: string | null;
 };
 
 const createInitialRow = (): SearchRow => ({
@@ -36,7 +47,7 @@ const initialState: PlaylistSearchState = {
   rows: [createInitialRow()],
   sortBy: "date",
   sortOrder: "desc",
-  page: 0,
+  cursor: null,
 };
 
 export const playlistSearchSlice = createAppSlice({
@@ -51,15 +62,18 @@ export const playlistSearchSlice = createAppSlice({
     },
     removeRow: (state, action: PayloadAction<string>) => {
       if (state.rows.length > 1) {
-        state.rows = state.rows.filter(r => r.id !== action.payload);
-        state.page = 0;
+        state.rows = state.rows.filter((r) => r.id !== action.payload);
+        state.cursor = null;
       }
     },
-    updateRow: (state, action: PayloadAction<{ id: string; updates: Partial<SearchRow> }>) => {
-      const row = state.rows.find(r => r.id === action.payload.id);
+    updateRow: (
+      state,
+      action: PayloadAction<{ id: string; updates: Partial<SearchRow> }>,
+    ) => {
+      const row = state.rows.find((r) => r.id === action.payload.id);
       if (row) {
         Object.assign(row, action.payload.updates);
-        state.page = 0;
+        state.cursor = null;
       }
     },
     setSort: (state, action: PayloadAction<SortField>) => {
@@ -69,13 +83,13 @@ export const playlistSearchSlice = createAppSlice({
         state.sortBy = action.payload;
         state.sortOrder = "desc";
       }
-      state.page = 0;
+      state.cursor = null;
     },
-    nextPage: (state) => {
-      state.page += 1;
+    advanceCursor: (state, action: PayloadAction<string>) => {
+      state.cursor = action.payload;
     },
-    resetPage: (state) => {
-      state.page = 0;
+    resetCursor: (state) => {
+      state.cursor = null;
     },
     reset: () => initialState,
   },
@@ -83,6 +97,6 @@ export const playlistSearchSlice = createAppSlice({
     getRows: (state) => state.rows,
     getSortBy: (state) => state.sortBy,
     getSortOrder: (state) => state.sortOrder,
-    getPage: (state) => state.page,
+    getCursor: (state) => state.cursor,
   },
 });

--- a/src/hooks/playlistSearchHooks.test.ts
+++ b/src/hooks/playlistSearchHooks.test.ts
@@ -7,16 +7,17 @@ import { playlistSearchSlice } from "@/lib/features/playlist-search/frontend";
 
 const mockTrigger = vi.fn();
 const mockQueryState = {
-  data: undefined as unknown,
+  data: undefined as
+    | { results: { id: number }[]; total: number; nextCursor?: string }
+    | undefined,
   isFetching: false,
   isError: false,
 };
 
 vi.mock("@/lib/features/playlist-search/api", async () => {
-  const actual =
-    await vi.importActual<typeof import("@/lib/features/playlist-search/api")>(
-      "@/lib/features/playlist-search/api"
-    );
+  const actual = await vi.importActual<
+    typeof import("@/lib/features/playlist-search/api")
+  >("@/lib/features/playlist-search/api");
   return {
     ...actual,
     useLazySearchPlaylistsQuery: () =>
@@ -53,7 +54,7 @@ describe("usePlaylistSearch", () => {
 
       await waitFor(() => expect(mockTrigger).toHaveBeenCalled());
       expect(mockTrigger).toHaveBeenCalledWith(
-        expect.objectContaining({ q: "", page: 0 })
+        expect.objectContaining({ q: "", cursor: undefined }),
       );
     });
 
@@ -72,13 +73,13 @@ describe("usePlaylistSearch", () => {
           playlistSearchSlice.actions.updateRow({
             id: rowId,
             updates: { value: "autechre" },
-          })
+          }),
         );
       });
       await waitFor(() =>
         expect(mockTrigger).toHaveBeenCalledWith(
-          expect.objectContaining({ q: "autechre" })
-        )
+          expect.objectContaining({ q: "autechre" }),
+        ),
       );
 
       // User clears it
@@ -87,7 +88,7 @@ describe("usePlaylistSearch", () => {
           playlistSearchSlice.actions.updateRow({
             id: rowId,
             updates: { value: "" },
-          })
+          }),
         );
       });
       await waitFor(() => {
@@ -112,7 +113,7 @@ describe("usePlaylistSearch", () => {
           playlistSearchSlice.actions.updateRow({
             id: rowId,
             updates: { value: "a" },
-          })
+          }),
         );
       });
 
@@ -134,15 +135,118 @@ describe("usePlaylistSearch", () => {
           playlistSearchSlice.actions.updateRow({
             id: rowId,
             updates: { value: "au" },
-          })
+          }),
         );
       });
 
       await waitFor(() =>
         expect(mockTrigger).toHaveBeenCalledWith(
-          expect.objectContaining({ q: "au" })
-        )
+          expect.objectContaining({ q: "au" }),
+        ),
       );
+    });
+  });
+
+  describe("cursor pagination", () => {
+    it("hasMore is true when the response includes a nextCursor", async () => {
+      const { wrapper } = createWrapper();
+      mockQueryState.data = {
+        results: [],
+        total: 1000,
+        nextCursor: "2024-06-15T14:30:00.000Z_42",
+      };
+
+      const { result } = renderHook(() => usePlaylistSearch(), { wrapper });
+
+      await waitFor(() => expect(result.current.hasMore).toBe(true));
+    });
+
+    it("hasMore is false when the response has no nextCursor", async () => {
+      const { wrapper } = createWrapper();
+      mockQueryState.data = { results: [], total: 5 };
+
+      const { result } = renderHook(() => usePlaylistSearch(), { wrapper });
+
+      await waitFor(() => expect(result.current.hasMore).toBe(false));
+    });
+
+    it("loadNextPage advances the cursor to nextCursor and re-fires", async () => {
+      const { store, wrapper } = createWrapper();
+      mockQueryState.data = {
+        results: [{ id: 1 }],
+        total: 1000,
+        nextCursor: "2024-06-15T14:30:00.000Z_42",
+      };
+
+      const { result } = renderHook(() => usePlaylistSearch(), { wrapper });
+
+      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+
+      act(() => {
+        result.current.loadNextPage();
+      });
+
+      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(2));
+      expect(mockTrigger.mock.calls[1][0]).toEqual(
+        expect.objectContaining({ cursor: "2024-06-15T14:30:00.000Z_42" }),
+      );
+      expect(store.getState().playlistSearch.cursor).toBe(
+        "2024-06-15T14:30:00.000Z_42",
+      );
+    });
+
+    it("loadNextPage is a no-op when no nextCursor is available", async () => {
+      const { wrapper } = createWrapper();
+      mockQueryState.data = { results: [{ id: 1 }], total: 1 };
+
+      const { result } = renderHook(() => usePlaylistSearch(), { wrapper });
+
+      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+
+      act(() => {
+        result.current.loadNextPage();
+      });
+
+      // Wait long enough for any spurious effect to fire
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(mockTrigger).toHaveBeenCalledTimes(1);
+    });
+
+    it("editing a row resets the cursor and refetches from the start", async () => {
+      const { store, wrapper } = createWrapper();
+      const rowId = store.getState().playlistSearch.rows[0].id;
+
+      // Simulate having paged once already
+      act(() => {
+        store.dispatch(
+          playlistSearchSlice.actions.advanceCursor(
+            "2024-06-15T14:30:00.000Z_42",
+          ),
+        );
+      });
+
+      renderHook(() => usePlaylistSearch(), { wrapper });
+
+      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+      expect(mockTrigger.mock.calls[0][0]).toEqual(
+        expect.objectContaining({ cursor: "2024-06-15T14:30:00.000Z_42" }),
+      );
+
+      // User edits the search → cursor resets
+      act(() => {
+        store.dispatch(
+          playlistSearchSlice.actions.updateRow({
+            id: rowId,
+            updates: { value: "autechre" },
+          }),
+        );
+      });
+
+      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(2));
+      expect(mockTrigger.mock.calls[1][0]).toEqual(
+        expect.objectContaining({ q: "autechre", cursor: undefined }),
+      );
+      expect(store.getState().playlistSearch.cursor).toBeNull();
     });
   });
 });

--- a/src/hooks/playlistSearchHooks.ts
+++ b/src/hooks/playlistSearchHooks.ts
@@ -1,7 +1,10 @@
 "use client";
 
 import { useLazySearchPlaylistsQuery } from "@/lib/features/playlist-search/api";
-import { playlistSearchSlice, SearchRow } from "@/lib/features/playlist-search/frontend";
+import {
+  playlistSearchSlice,
+  SearchRow,
+} from "@/lib/features/playlist-search/frontend";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useCallback, useEffect, useRef, useMemo } from "react";
 import type { PlaylistSearchResult } from "@wxyc/shared";
@@ -44,7 +47,8 @@ function buildQuery(rows: SearchRow[]): string {
       term = `"${term}"`;
     }
 
-    const fieldPrefix = row.field === "all" ? "" : (fieldPrefixes[row.field] || "");
+    const fieldPrefix =
+      row.field === "all" ? "" : fieldPrefixes[row.field] || "";
     const fullTerm = `${fieldPrefix}${term}`;
 
     // First row doesn't have an operator prefix
@@ -64,7 +68,7 @@ export function usePlaylistSearch() {
   const rows = useAppSelector(playlistSearchSlice.selectors.getRows);
   const sortBy = useAppSelector(playlistSearchSlice.selectors.getSortBy);
   const sortOrder = useAppSelector(playlistSearchSlice.selectors.getSortOrder);
-  const page = useAppSelector(playlistSearchSlice.selectors.getPage);
+  const cursor = useAppSelector(playlistSearchSlice.selectors.getCursor);
 
   const effectiveQuery = useMemo(() => buildQuery(rows), [rows]);
 
@@ -73,8 +77,12 @@ export function usePlaylistSearch() {
   // null sentinel = "never fired" — distinguishes initial mount from a
   // user-cleared empty query so the on-mount empty-q request still goes out.
   const lastFiredQueryRef = useRef<string | null>(null);
-  const lastFiredParamsRef = useRef<{ page: number; sortBy: string; sortOrder: string }>({
-    page: 0,
+  const lastFiredParamsRef = useRef<{
+    cursor: string | null;
+    sortBy: string;
+    sortOrder: string;
+  }>({
+    cursor: null,
     sortBy: "date",
     sortOrder: "desc",
   });
@@ -83,7 +91,8 @@ export function usePlaylistSearch() {
   const accumulatedResultsRef = useRef<PlaylistSearchResult[]>([]);
   const lastQueryForAccumulationRef = useRef<string>("");
 
-  const [trigger, { data, isFetching, isError }] = useLazySearchPlaylistsQuery();
+  const [trigger, { data, isFetching, isError }] =
+    useLazySearchPlaylistsQuery();
 
   // Reset accumulated results when query or sort changes
   useEffect(() => {
@@ -94,19 +103,25 @@ export function usePlaylistSearch() {
     }
   }, [effectiveQuery, sortBy, sortOrder]);
 
-  // Accumulate results when new data arrives
+  // Accumulate results when new data arrives. cursor === null means "first
+  // page" so we replace; otherwise we append (deduping by id) since the
+  // user is paginating.
   useEffect(() => {
     if (data?.results) {
-      if (page === 0) {
+      if (cursor === null) {
         accumulatedResultsRef.current = data.results;
       } else {
-        // Append new results, avoiding duplicates by ID
-        const existingIds = new Set(accumulatedResultsRef.current.map(r => r.id));
-        const newResults = data.results.filter(r => !existingIds.has(r.id));
-        accumulatedResultsRef.current = [...accumulatedResultsRef.current, ...newResults];
+        const existingIds = new Set(
+          accumulatedResultsRef.current.map((r) => r.id),
+        );
+        const newResults = data.results.filter((r) => !existingIds.has(r.id));
+        accumulatedResultsRef.current = [
+          ...accumulatedResultsRef.current,
+          ...newResults,
+        ];
       }
     }
-  }, [data, page]);
+  }, [data, cursor]);
 
   // Fire search when query changes (response-based throttling)
   useEffect(() => {
@@ -121,7 +136,7 @@ export function usePlaylistSearch() {
     }
 
     const paramsChanged =
-      page !== lastFiredParamsRef.current.page ||
+      cursor !== lastFiredParamsRef.current.cursor ||
       sortBy !== lastFiredParamsRef.current.sortBy ||
       sortOrder !== lastFiredParamsRef.current.sortOrder;
 
@@ -131,73 +146,90 @@ export function usePlaylistSearch() {
     } else if (effectiveQuery !== lastFiredQueryRef.current || paramsChanged) {
       // No request in flight and query/params changed - fire immediately
       lastFiredQueryRef.current = effectiveQuery;
-      lastFiredParamsRef.current = { page, sortBy, sortOrder };
+      lastFiredParamsRef.current = { cursor, sortBy, sortOrder };
       pendingQueryRef.current = null;
-      trigger({ q: effectiveQuery, page, limit: LIMIT, sort: sortBy, order: sortOrder });
+      trigger({
+        q: effectiveQuery,
+        limit: LIMIT,
+        sort: sortBy,
+        order: sortOrder,
+        cursor: cursor ?? undefined,
+      });
     }
-  }, [effectiveQuery, page, sortBy, sortOrder, isFetching, trigger]);
+  }, [effectiveQuery, cursor, sortBy, sortOrder, isFetching, trigger]);
 
   // When request completes, check if there's a pending query
   useEffect(() => {
-    if (!isFetching && pendingQueryRef.current && pendingQueryRef.current !== lastFiredQueryRef.current) {
+    if (
+      !isFetching &&
+      pendingQueryRef.current &&
+      pendingQueryRef.current !== lastFiredQueryRef.current
+    ) {
       const pending = pendingQueryRef.current;
       lastFiredQueryRef.current = pending;
-      lastFiredParamsRef.current = { page, sortBy, sortOrder };
+      lastFiredParamsRef.current = { cursor, sortBy, sortOrder };
       pendingQueryRef.current = null;
-      trigger({ q: pending, page, limit: LIMIT, sort: sortBy, order: sortOrder });
+      trigger({
+        q: pending,
+        limit: LIMIT,
+        sort: sortBy,
+        order: sortOrder,
+        cursor: cursor ?? undefined,
+      });
     }
-  }, [isFetching, page, sortBy, sortOrder, trigger]);
+  }, [isFetching, cursor, sortBy, sortOrder, trigger]);
 
   // Actions
   const addRow = useCallback(
     () => dispatch(playlistSearchSlice.actions.addRow()),
-    [dispatch]
+    [dispatch],
   );
 
   const removeRow = useCallback(
     (id: string) => dispatch(playlistSearchSlice.actions.removeRow(id)),
-    [dispatch]
+    [dispatch],
   );
 
   const updateRow = useCallback(
     (id: string, updates: Partial<SearchRow>) =>
       dispatch(playlistSearchSlice.actions.updateRow({ id, updates })),
-    [dispatch]
+    [dispatch],
   );
 
   const handleSort = useCallback(
-    (field: "date" | "artist" | "song" | "dj") => dispatch(playlistSearchSlice.actions.setSort(field)),
-    [dispatch]
+    (field: "date" | "artist" | "song" | "dj") =>
+      dispatch(playlistSearchSlice.actions.setSort(field)),
+    [dispatch],
   );
 
-  const loadNextPage = useCallback(
-    () => dispatch(playlistSearchSlice.actions.nextPage()),
-    [dispatch]
-  );
+  // Load the next page by advancing the cursor to whatever the last response
+  // returned. No-op when no nextCursor is available (last page or response
+  // not yet arrived).
+  const loadNextPage = useCallback(() => {
+    if (data?.nextCursor) {
+      dispatch(playlistSearchSlice.actions.advanceCursor(data.nextCursor));
+    }
+  }, [dispatch, data?.nextCursor]);
 
-  const reset = useCallback(
-    () => {
-      accumulatedResultsRef.current = [];
-      lastQueryForAccumulationRef.current = "";
-      dispatch(playlistSearchSlice.actions.reset());
-    },
-    [dispatch]
-  );
+  const reset = useCallback(() => {
+    accumulatedResultsRef.current = [];
+    lastQueryForAccumulationRef.current = "";
+    dispatch(playlistSearchSlice.actions.reset());
+  }, [dispatch]);
 
-  const hasMore = data ? page < data.totalPages - 1 : false;
+  const hasMore = data?.nextCursor !== undefined;
 
   return {
     // State
     rows,
     sortBy,
     sortOrder,
-    page,
+    cursor,
     effectiveQuery,
 
     // Results
     results: accumulatedResultsRef.current,
     total: data?.total ?? 0,
-    totalPages: data?.totalPages ?? 0,
     hasMore,
 
     // Loading states


### PR DESCRIPTION
## Summary

- Replaces page-based pagination state with a cursor in the playlist-search slice and threads it through `usePlaylistSearch`.
- Hook reads `cursor` from state, sends it on each trigger, dispatches `advanceCursor(data.nextCursor)` on `loadNextPage`. Editing a row, removing a row, or changing sort all reset the cursor to null so the next request starts from the most recent entries.
- `hasMore` is now derived from `data?.nextCursor` presence rather than computed from `totalPages`. Accumulation distinguishes "first page" (replace) from "subsequent page" (append, dedupe by id) by checking `cursor === null` instead of `page === 0`.
- Locally extends `PlaylistSearchParams` / `PlaylistSearchResponse` to add `cursor` / `nextCursor` until `@wxyc/shared` is updated. Tracked as a follow-up.

Pairs with WXYC/Backend-Service#473 (already merged + deployed). The offset shape still works on the backend, so this is a non-breaking client migration.

## Test plan

- [x] Existing 4 hook tests updated and pass with the new request shape
- [x] 5 new hook tests cover cursor pagination behavior: `hasMore` from `nextCursor`, `loadNextPage` advancing the cursor and re-firing, `loadNextPage` no-op when no `nextCursor`, and edit-row resetting the cursor
- [x] `npx tsc --noEmit` clean
- [x] Full vitest suite (2,560 tests) passes
- [x] `npx prettier --check` clean on touched files
- [ ] Manually verify in browser: load `/dashboard/playlists`, scroll to bottom, confirm next page loads with the same UX as before
- [ ] Verify clearing the search input goes back to recent tracks (no broken pagination state)

Closes #470