### PR TITLE
Fix infinite spinner on catalog page after a search returns

### DIFF
--- a/src/hooks/__tests__/catalogResults.test.tsx
+++ b/src/hooks/__tests__/catalogResults.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
 import React, { type PropsWithChildren } from "react";
 import { Provider } from "react-redux";
 import { CssVarsProvider } from "@mui/joy/styles";
@@ -7,11 +7,26 @@ import { makeStore } from "@/lib/store";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 import type { SearchCatalogQueryParams } from "@/lib/features/catalog/types";
 
-// Capture args passed to useSearchCatalogQuery on each call
+type QueryResult = {
+  data: unknown;
+  isFetching: boolean;
+  isLoading: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+};
+
 const searchCatalogCalls: Array<{
   args: SearchCatalogQueryParams;
   options: { skip: boolean };
 }> = [];
+
+let nextQueryResult: QueryResult = {
+  data: undefined,
+  isFetching: false,
+  isLoading: false,
+  isSuccess: false,
+  isError: false,
+};
 
 vi.mock("@/lib/features/catalog/api", () => ({
   catalogApi: {
@@ -30,12 +45,7 @@ vi.mock("@/lib/features/catalog/api", () => ({
     options: { skip: boolean }
   ) => {
     searchCatalogCalls.push({ args, options });
-    return {
-      data: undefined,
-      isLoading: false,
-      isSuccess: false,
-      isError: false,
-    };
+    return nextQueryResult;
   },
 }));
 
@@ -45,35 +55,94 @@ vi.mock("../authenticationHooks", () => ({
 
 import { useCatalogResults } from "../catalogHooks";
 
+function Wrapper({
+  store,
+}: {
+  store: ReturnType<typeof makeStore>;
+}): (props: PropsWithChildren) => React.ReactElement {
+  return ({ children }) => (
+    <Provider store={store}>
+      <CssVarsProvider>{children}</CssVarsProvider>
+    </Provider>
+  );
+}
+
 describe("useCatalogResults", () => {
   beforeEach(() => {
     searchCatalogCalls.length = 0;
+    nextQueryResult = {
+      data: undefined,
+      isFetching: false,
+      isLoading: false,
+      isSuccess: false,
+      isError: false,
+    };
   });
 
   it("should pass valid query params on mount when searchString persists from a previous visit", () => {
     const store = makeStore();
-
-    // Simulate Redux state persisted from a previous catalog search
     store.dispatch(catalogSlice.actions.setSearchQuery("Autechre"));
 
-    function Wrapper({ children }: PropsWithChildren) {
-      return (
-        <Provider store={store}>
-          <CssVarsProvider>{children}</CssVarsProvider>
-        </Provider>
-      );
-    }
+    renderHook(() => useCatalogResults(), { wrapper: Wrapper({ store }) });
 
-    renderHook(() => useCatalogResults(), { wrapper: Wrapper });
-
-    // On the first render, useSearchCatalogQuery is called.
-    // With searchString="Autechre" (persisted), skip should be false.
-    // The query args should have valid artist_name/album_title (not undefined),
-    // because sending undefined params causes a 400 from the backend (?n=10 only).
     const firstCall = searchCatalogCalls[0];
-
     expect(firstCall.options.skip).toBe(false);
     expect(firstCall.args.artist_name).not.toBeUndefined();
     expect(firstCall.args.album_title).not.toBeUndefined();
+  });
+
+  describe("loading state", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should not show loading when searchString is below the minimum", () => {
+      const store = makeStore();
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: Wrapper({ store }),
+      });
+
+      expect(result.current.loading).toBe(false);
+
+      act(() => {
+        store.dispatch(catalogSlice.actions.setSearchQuery("a"));
+      });
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+
+      expect(result.current.loading).toBe(false);
+    });
+
+    it("should not stay stuck on loading after a successful query when persisted searchString triggers an immediate fetch", () => {
+      const store = makeStore();
+      store.dispatch(catalogSlice.actions.setSearchQuery("Autechre"));
+
+      // Simulate the query already having succeeded by the time the hook mounts
+      // (cache hit from a prior session) — isFetching=false, data populated.
+      nextQueryResult = {
+        data: [],
+        isFetching: false,
+        isLoading: false,
+        isSuccess: true,
+        isError: false,
+      };
+
+      const { result } = renderHook(() => useCatalogResults(), {
+        wrapper: Wrapper({ store }),
+      });
+
+      expect(result.current.loading).toBe(false);
+
+      // Advance past the previous debounce window — loading must not flip true.
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.loading).toBe(false);
+    });
   });
 });

--- a/src/hooks/catalogHooks.ts
+++ b/src/hooks/catalogHooks.ts
@@ -28,7 +28,7 @@ import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { FlowsheetQuery } from "@/lib/features/flowsheet/types";
 import { useGetRotationQuery } from "@/lib/features/rotation/api";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuthentication } from "./authenticationHooks";
 import { filterBySearchTerms } from "@/src/utilities/filterBySearchTerms";
 
@@ -122,53 +122,51 @@ export const useCatalogResults = () => {
     );
   const loadMore = () => dispatch(catalogSlice.actions.loadMore());
 
-  const [loading, setLoading] = useState(false);
+  const [debouncing, setDebouncing] = useState(false);
   const [reachedEndForQuery, setReachedEndForQuery] = useState(false);
-  const [queryTimeout, setQueryTimeout] = useState<
-    NodeJS.Timeout | undefined
-  >();
 
+  const isFirstRender = useRef(true);
   useEffect(() => {
-    clearTimeout(queryTimeout);
-    setQueryTimeout(
-      setTimeout(() => {
-        setLoading(true);
-        clearSelection();
-        setFormattedQuery(formatCatalogSearchQuery(searchIn, searchString, n, exclusive));
-      }, 500)
-    );
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    setDebouncing(true);
+    const timer = setTimeout(() => {
+      clearSelection();
+      setFormattedQuery(
+        formatCatalogSearchQuery(searchIn, searchString, n, exclusive)
+      );
+      setDebouncing(false);
+    }, 500);
+    return () => clearTimeout(timer);
   }, [searchIn, searchString, n, exclusive]);
 
   useEffect(() => {
     setReachedEndForQuery(false);
   }, [searchIn, searchString]);
 
-  const { data, isLoading, isSuccess, isError } = useSearchCatalogQuery(
-    formattedQuery,
-    {
-      skip:
-        authenticating ||
-        !authenticated ||
-        searchString.length < MIN_SEARCH_LENGTH,
-    }
-  );
+  const { data, isFetching } = useSearchCatalogQuery(formattedQuery, {
+    skip:
+      authenticating ||
+      !authenticated ||
+      searchString.length < MIN_SEARCH_LENGTH,
+  });
 
-  // Calculate loading state during render - simpler than separate useEffect
   const combinedLoading = useMemo(() => {
-    return isLoading || loading;
-  }, [isLoading, loading]);
+    if (searchString.length < MIN_SEARCH_LENGTH) return false;
+    return debouncing || isFetching;
+  }, [debouncing, isFetching, searchString.length]);
 
   const [lastData, setLastData] = useState(0);
   useEffect(() => {
-    if (isSuccess || isError) {
-      setLoading(false);
-    }
-    if (data?.length === lastData) {
+    if (data === undefined) return;
+    if (data.length === lastData) {
       setReachedEndForQuery(true);
     } else {
-      setLastData(data?.length ?? 0);
+      setLastData(data.length);
     }
-  }, [data, isSuccess, isError, lastData]);
+  }, [data, lastData]);
 
   return {
     data,


### PR DESCRIPTION
Closes #473

## Summary

- Replace the manual `loading` flag in `useCatalogResults` with derived state (`debouncing || isFetching`, gated on `searchString.length >= MIN_SEARCH_LENGTH`) so the spinner can no longer get stuck on after the 500ms debounce timeout fires while the query is a cache hit (or is skipped).
- Skip the debounce on first render so the lazy-initialized `formattedQuery` still fires immediately when Redux already has a persisted searchString — preserving the behavior added in 57cae87.

## Why the spinner could get stuck

The previous implementation kept `loading` in component state, set true by a 500ms timeout and reset to false only when the RTK Query result's `isSuccess`/`isError` flipped. Two cases left it stuck:

1. **Persisted searchString.** Lazy init starts the query immediately on mount. If it completes before the 500ms timeout fires, the timeout then re-sets `formattedQuery` to the same args. RTK Query returns the cached result without changing `data`/`isSuccess`/`isError`, the dependent effect does not rerun, and `loading` stays true.
2. **Empty/short searchString.** The query is skipped, so `isSuccess`/`isError` never fire. The timeout still sets `loading=true` with no path back to false.

Deriving `loading` from `debouncing` + `isFetching` (and ignoring it entirely below the minimum search length) eliminates both cases.

## Test plan

- [x] Added a regression test that simulates a persisted searchString with the query already succeeded (cache hit) and asserts `loading` stays false across the 500ms window.
- [x] Added a test that types a 1-character query and asserts `loading` stays false past the debounce window.
- [x] `npx vitest run` (full suite, 2557 tests) passes locally.
- [x] `npx tsc --noEmit` passes locally.
- [ ] Manual verification on dj.wxyc.org/dashboard/catalog: navigate to catalog with a previously persisted search, confirm spinner clears once results land.