### PR TITLE
feat(admin): add Station Manager catalog intake UI

### DIFF
--- a/app/dashboard/@modern/admin/catalog/page.tsx
+++ b/app/dashboard/@modern/admin/catalog/page.tsx
@@ -1,0 +1,22 @@
+import { requireAuth, requireRole } from "@/lib/features/authentication/server-utils";
+import { Authorization } from "@/lib/features/admin/types";
+import PageHeader from "@/src/components/experiences/modern/Header/PageHeader";
+import AdminCatalogForm from "@/src/components/experiences/modern/admin/catalog/AdminCatalogForm";
+import { Metadata } from "next";
+import { getPageTitle } from "@/lib/utils/page-title";
+
+export const metadata: Metadata = {
+  title: getPageTitle("Add to catalog"),
+};
+
+export default async function AdminCatalogPage() {
+  const session = await requireAuth();
+  await requireRole(session, Authorization.SM);
+
+  return (
+    <>
+      <PageHeader title="Add to catalog" />
+      <AdminCatalogForm />
+    </>
+  );
+}

--- a/e2e/pages/dashboard.page.ts
+++ b/e2e/pages/dashboard.page.ts
@@ -11,6 +11,7 @@ export class DashboardPage {
   readonly catalogLink: Locator;
   readonly adminLink: Locator;
   readonly rosterLink: Locator;
+  readonly catalogAdminLink: Locator;
   readonly logoutForm: Locator;
   readonly logoutButton: Locator;
 
@@ -32,6 +33,7 @@ export class DashboardPage {
     this.catalogLink = page.locator('a[href="/dashboard/catalog"]');
     this.adminLink = page.locator('a[href*="/dashboard/admin"]');
     this.rosterLink = page.locator('a[href="/dashboard/admin/roster"]');
+    this.catalogAdminLink = page.locator('a[href="/dashboard/admin/catalog"]');
 
     // Log out button is in a form in the sidebar - it's an IconButton with type="submit"
     // Select specifically the submit button inside a form (the logout button)
@@ -71,6 +73,12 @@ export class DashboardPage {
   async gotoAdminRoster(): Promise<void> {
     await this.page.goto("/dashboard/admin/roster");
     await this.page.waitForLoadState("domcontentloaded");
+  }
+
+  async gotoAdminCatalog(): Promise<void> {
+    await this.page.goto("/dashboard/admin/catalog");
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.page.waitForTimeout(500);
   }
 
   async navigateToFlowsheet(): Promise<void> {
@@ -123,6 +131,10 @@ export class DashboardPage {
 
   async expectOnAdminRoster(): Promise<void> {
     await expect(this.page).toHaveURL(/.*\/dashboard\/admin\/roster.*/);
+  }
+
+  async expectOnAdminCatalog(): Promise<void> {
+    await expect(this.page).toHaveURL(/.*\/dashboard\/admin\/catalog.*/);
   }
 
   async expectRedirectedToLogin(): Promise<void> {

--- a/e2e/tests/rbac/role-access.spec.ts
+++ b/e2e/tests/rbac/role-access.spec.ts
@@ -31,6 +31,11 @@ test.describe("Role-Based Access Control", () => {
       await dashboardPage.expectRedirectedToDefaultDashboard();
     });
 
+    test("should be redirected from admin catalog page", async ({ page }) => {
+      await dashboardPage.gotoAdminCatalog();
+      await dashboardPage.expectRedirectedToDefaultDashboard();
+    });
+
     test("should not see admin navigation link", async ({ page }) => {
       await dashboardPage.waitForPageLoad();
       // Admin roster link should not be visible for DJ users
@@ -60,6 +65,11 @@ test.describe("Role-Based Access Control", () => {
       // MD should also be redirected (roster requires SM)
       await dashboardPage.expectRedirectedToDefaultDashboard();
     });
+
+    test("should be redirected from admin catalog page", async ({ page }) => {
+      await dashboardPage.gotoAdminCatalog();
+      await dashboardPage.expectRedirectedToDefaultDashboard();
+    });
   });
 
   test.describe("Station Manager Access", () => {
@@ -83,6 +93,11 @@ test.describe("Role-Based Access Control", () => {
       await dashboardPage.gotoAdminRoster();
       // SM should have full access
       await dashboardPage.expectOnAdminRoster();
+    });
+
+    test("should access admin catalog page", async ({ page }) => {
+      await dashboardPage.gotoAdminCatalog();
+      await dashboardPage.expectOnAdminCatalog();
     });
 
     test("should see DJ Roster page header", async ({ page }) => {
@@ -109,6 +124,11 @@ test.describe("Role-Based Access Control", () => {
     test("should be redirected from admin pages", async ({ page }) => {
       await dashboardPage.gotoAdminRoster();
       // Member should be redirected to default dashboard
+      await dashboardPage.expectRedirectedToDefaultDashboard();
+    });
+
+    test("should be redirected from admin catalog page", async ({ page }) => {
+      await dashboardPage.gotoAdminCatalog();
       await dashboardPage.expectRedirectedToDefaultDashboard();
     });
 

--- a/lib/__tests__/features/catalog/api.test.tsx
+++ b/lib/__tests__/features/catalog/api.test.tsx
@@ -19,7 +19,7 @@ vi.mock("@/lib/features/authentication/client", () => ({
 
 describe("catalogApi", () => {
   describeApi(catalogApi, {
-    queries: ["searchCatalog", "getInformation", "getFormats", "getGenres"],
+    queries: ["searchCatalog", "getInformation", "getFormats", "getGenres", "peekArtistCode"],
     mutations: ["addAlbum", "addArtist", "addFormat", "addGenre"],
     reducerPath: "catalogApi",
   });

--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -15,7 +15,7 @@ import { Rotation } from "@/lib/features/rotation/types";
 
 describe("catalogApi", () => {
   describeApi(catalogApi, {
-    queries: ["searchCatalog", "getInformation", "getFormats", "getGenres"],
+    queries: ["searchCatalog", "getInformation", "getFormats", "getGenres", "peekArtistCode"],
     mutations: ["addAlbum", "addArtist", "addFormat", "addGenre", "markMissing", "markFound"],
     reducerPath: "catalogApi",
   });

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -2,11 +2,17 @@ import { createApi } from "@reduxjs/toolkit/query/react";
 import { backendBaseQuery } from "../backend";
 import { convertToAlbumEntry } from "./conversions";
 import {
+  AddAlbumRequestBody,
+  AddArtistRequestBody,
+  AddFormatRequestBody,
+  AddGenreRequestBody,
   AlbumEntry,
-  AlbumParams,
   AlbumSearchResultJSON,
   AlbumRequestParams,
-  ArtistParams,
+  LibraryFormatRow,
+  LibraryGenreRow,
+  PeekArtistCodeQuery,
+  PeekArtistCodeResponse,
   SearchCatalogQueryParams,
 } from "./types";
 
@@ -23,18 +29,27 @@ export const catalogApi = createApi({
       transformResponse: (response: AlbumSearchResultJSON[]) =>
         response.map(convertToAlbumEntry),
     }),
-    addAlbum: builder.mutation<any, AlbumParams>({
-      query: (album) => ({
+    addAlbum: builder.mutation<{ id: number } & Record<string, unknown>, AddAlbumRequestBody>({
+      query: (body) => ({
         url: "/",
         method: "POST",
-        body: album,
+        body,
       }),
     }),
-    addArtist: builder.mutation<any, ArtistParams>({
-      query: (artist) => ({
+    addArtist: builder.mutation<
+      { id: number; code_number?: number; genre_id?: number } & Record<string, unknown>,
+      AddArtistRequestBody
+    >({
+      query: (body) => ({
         url: "/artists",
         method: "POST",
-        body: artist,
+        body,
+      }),
+    }),
+    peekArtistCode: builder.query<PeekArtistCodeResponse, PeekArtistCodeQuery>({
+      query: ({ code_letters, genre_id }) => ({
+        url: "/artists/peek-code",
+        params: { code_letters, genre_id },
       }),
     }),
     getInformation: builder.query<AlbumEntry, AlbumRequestParams>({
@@ -69,28 +84,28 @@ export const catalogApi = createApi({
         { type: "AlbumDetail", id: albumId },
       ],
     }),
-    getFormats: builder.query<any, void>({
+    getFormats: builder.query<LibraryFormatRow[], void>({
       query: () => ({
         url: "/formats",
       }),
     }),
-    addFormat: builder.mutation<any, string>({
-      query: (format) => ({
+    addFormat: builder.mutation<LibraryFormatRow, AddFormatRequestBody>({
+      query: (body) => ({
         url: "/formats",
         method: "POST",
-        body: format,
+        body,
       }),
     }),
-    getGenres: builder.query<any, void>({
+    getGenres: builder.query<LibraryGenreRow[], void>({
       query: () => ({
         url: "/genres",
       }),
     }),
-    addGenre: builder.mutation<any, string>({
-      query: (genre) => ({
+    addGenre: builder.mutation<LibraryGenreRow, AddGenreRequestBody>({
+      query: (body) => ({
         url: "/genres",
         method: "POST",
-        body: genre,
+        body,
       }),
     }),
   }),
@@ -100,6 +115,7 @@ export const {
   useSearchCatalogQuery,
   useAddAlbumMutation,
   useAddArtistMutation,
+  useLazyPeekArtistCodeQuery,
   useGetInformationQuery,
   useGetFormatsQuery,
   useAddFormatMutation,

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -18,26 +18,74 @@ export type SearchCatalogQueryParams = {
   on_streaming?: boolean;
 };
 
-export type AlbumParams = {
+/**
+ * POST /library — matches Backend-Service `NewAlbumRequest` (JSON uses numbers for ids).
+ */
+export type AddAlbumRequestBody = {
   album_title: string;
-  artist_name: string | undefined;
-  artist_id: string | undefined;
   label: string;
-  genre_id: string;
-  format_id: string;
-  disc_quantity: number | undefined;
-  alternate_artist_name: string | undefined;
+  genre_id: number;
+  format_id: number;
+  artist_name?: string;
+  artist_id?: number;
+  alternate_artist_name?: string;
+  disc_quantity?: number;
+  label_id?: number;
+};
+
+/**
+ * POST /library/artists
+ */
+export type AddArtistRequestBody = {
+  artist_name: string;
+  code_letters: string;
+  genre_id: number;
+  code_number: number;
+  alphabetical_name?: string;
+};
+
+export type PeekArtistCodeQuery = {
+  code_letters: string;
+  genre_id: number;
+};
+
+export type PeekArtistCodeResponse = {
+  next_code_number: number;
+};
+
+export type LibraryFormatRow = {
+  id: number;
+  format_name: string;
+  add_date?: string;
+};
+
+export type LibraryGenreRow = {
+  id: number;
+  genre_name: string;
+  description?: string | null;
+  plays?: number;
+  add_date?: string;
+  last_modified?: string;
+};
+
+export type AddFormatRequestBody = {
+  name: string;
+};
+
+export type AddGenreRequestBody = {
+  name: string;
+  description: string;
 };
 
 export type AlbumRequestParams = {
   album_id: number;
 };
 
-export type ArtistParams = {
-  artist_name: string;
-  code_letters: string;
-  genre_id: string;
-};
+/** @deprecated use AddAlbumRequestBody */
+export type AlbumParams = AddAlbumRequestBody;
+
+/** @deprecated use AddArtistRequestBody */
+export type ArtistParams = AddArtistRequestBody;
 
 export type AlbumEntry = {
   id: number;

--- a/src/components/experiences/modern/Leftbar/Leftbar.test.tsx
+++ b/src/components/experiences/modern/Leftbar/Leftbar.test.tsx
@@ -103,6 +103,7 @@ vi.mock("@mui/icons-material/Storage", () => ({
 
 vi.mock("@mui/icons-material", () => ({
   EditCalendar: () => <svg data-testid="edit-calendar-icon" />,
+  LibraryAdd: () => <svg data-testid="library-add-icon" />,
   ManageAccounts: () => <svg data-testid="manage-accounts-icon" />,
 }));
 
@@ -175,6 +176,9 @@ describe("Leftbar", () => {
       screen.queryByTestId("leftbar-link--dashboard-admin-roster")
     ).not.toBeInTheDocument();
     expect(
+      screen.queryByTestId("leftbar-link--dashboard-admin-catalog")
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByTestId("leftbar-link--dashboard-admin-schedule")
     ).not.toBeInTheDocument();
   });
@@ -194,6 +198,9 @@ describe("Leftbar", () => {
     // MD users should see admin links
     expect(
       screen.getByTestId("leftbar-link--dashboard-admin-roster")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("leftbar-link--dashboard-admin-catalog")
     ).toBeInTheDocument();
     expect(
       screen.getByTestId("leftbar-link--dashboard-admin-schedule")
@@ -216,6 +223,9 @@ describe("Leftbar", () => {
     expect(
       screen.getByTestId("leftbar-link--dashboard-admin-roster")
     ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("leftbar-link--dashboard-admin-catalog")
+    ).toBeInTheDocument();
   });
 
   it("should disable roster link for MD authority (below SM)", async () => {
@@ -234,6 +244,10 @@ describe("Leftbar", () => {
       "leftbar-link--dashboard-admin-roster"
     );
     expect(rosterLink).toHaveAttribute("data-disabled", "true");
+    const catalogLink = screen.getByTestId(
+      "leftbar-link--dashboard-admin-catalog"
+    );
+    expect(catalogLink).toHaveAttribute("data-disabled", "true");
   });
 
   it("should enable roster link for SM authority", async () => {
@@ -252,6 +266,10 @@ describe("Leftbar", () => {
       "leftbar-link--dashboard-admin-roster"
     );
     expect(rosterLink).toHaveAttribute("data-disabled", "false");
+    const catalogLink = screen.getByTestId(
+      "leftbar-link--dashboard-admin-catalog"
+    );
+    expect(catalogLink).toHaveAttribute("data-disabled", "false");
   });
 
   it("should always disable schedule link", async () => {
@@ -329,6 +347,21 @@ describe("Leftbar", () => {
     render(Component);
 
     expect(screen.getByTestId("manage-accounts-icon")).toBeInTheDocument();
+  });
+
+  it("should render library add icon for catalog admin link when visible", async () => {
+    const { getUserFromSession } = await import(
+      "@/lib/features/authentication/server-utils"
+    );
+    vi.mocked(getUserFromSession).mockResolvedValue({
+      ...mockUser,
+      authority: Authorization.SM,
+    });
+
+    const Component = await Leftbar();
+    render(Component);
+
+    expect(screen.getByTestId("library-add-icon")).toBeInTheDocument();
   });
 
   it("should render edit calendar icon for schedule link when visible", async () => {

--- a/src/components/experiences/modern/Leftbar/Leftbar.tsx
+++ b/src/components/experiences/modern/Leftbar/Leftbar.tsx
@@ -1,6 +1,6 @@
 import { Authorization } from "@/lib/features/admin/types";
 import { requireAuth, getUserFromSession } from "@/lib/features/authentication/server-utils";
-import { EditCalendar, ManageAccounts } from "@mui/icons-material";
+import { EditCalendar, LibraryAdd, ManageAccounts } from "@mui/icons-material";
 import AlbumIcon from "@mui/icons-material/Album";
 import StorageIcon from "@mui/icons-material/Storage";
 import Divider from "@mui/joy/Divider";
@@ -38,6 +38,13 @@ export default async function Leftbar(): Promise<JSX.Element> {
               disabled={user.authority < Authorization.SM}
             >
               <ManageAccounts />
+            </LeftbarLink>
+            <LeftbarLink
+              path="/dashboard/admin/catalog"
+              title="Add to catalog"
+              disabled={user.authority < Authorization.SM}
+            >
+              <LibraryAdd />
             </LeftbarLink>
             <LeftbarLink
               path="/dashboard/admin/schedule"

--- a/src/components/experiences/modern/admin/catalog/AdminCatalogForm.tsx
+++ b/src/components/experiences/modern/admin/catalog/AdminCatalogForm.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import {
+  useAddAlbumMutation,
+  useAddArtistMutation,
+  useGetFormatsQuery,
+  useGetGenresQuery,
+  useGetInformationQuery,
+  useLazyPeekArtistCodeQuery,
+} from "@/lib/features/catalog/api";
+import type { AddAlbumRequestBody } from "@/lib/features/catalog/types";
+import CatalogEntryPreview from "./CatalogEntryPreview";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Button,
+  Divider,
+  FormControl,
+  FormLabel,
+  Input,
+  Option,
+  Select,
+  Stack,
+  Typography,
+} from "@mui/joy";
+import { ExpandMore } from "@mui/icons-material";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export default function AdminCatalogForm() {
+  const { data: genres, isLoading: genresLoading } = useGetGenresQuery();
+  const { data: formats, isLoading: formatsLoading } = useGetFormatsQuery();
+
+  const [addAlbum, { isLoading: addingAlbum }] = useAddAlbumMutation();
+  const [addArtist, { isLoading: addingArtist }] = useAddArtistMutation();
+  const [peekTrigger] = useLazyPeekArtistCodeQuery();
+
+  const [genreId, setGenreId] = useState("");
+  const [formatId, setFormatId] = useState("");
+  const [albumTitle, setAlbumTitle] = useState("");
+  const [label, setLabel] = useState("");
+  const [artistName, setArtistName] = useState("");
+  const [alternateArtist, setAlternateArtist] = useState("");
+  const [discQuantity, setDiscQuantity] = useState("1");
+
+  const [codeLetters, setCodeLetters] = useState("");
+  const [codeNumber, setCodeNumber] = useState("");
+  const [newArtistName, setNewArtistName] = useState("");
+  const [alphabeticalName, setAlphabeticalName] = useState("");
+
+  const [resolvedArtistId, setResolvedArtistId] = useState<number | null>(null);
+  const [previewAlbumId, setPreviewAlbumId] = useState<number | null>(null);
+
+  const { data: previewEntry } = useGetInformationQuery(
+    { album_id: previewAlbumId! },
+    { skip: previewAlbumId === null }
+  );
+
+  const onSuggestArtistCode = async () => {
+    const gid = Number(genreId);
+    const letters = codeLetters.trim().toUpperCase();
+    if (!letters || !Number.isFinite(gid)) {
+      toast.error("Enter code letters and select a genre first.");
+      return;
+    }
+    try {
+      const res = await peekTrigger({
+        code_letters: letters,
+        genre_id: gid,
+      }).unwrap();
+      setCodeNumber(String(res.next_code_number));
+      toast.success(`Suggested artist #${res.next_code_number}`);
+    } catch {
+      toast.error("Could not peek next artist code.");
+    }
+  };
+
+  const onCreateArtist = async () => {
+    const gid = Number(genreId);
+    const num = Number(codeNumber);
+    const name = newArtistName.trim();
+    const letters = codeLetters.trim().toUpperCase();
+    if (!name || !letters || !Number.isFinite(gid) || !Number.isFinite(num)) {
+      toast.error("Fill artist name, code letters, genre, and artist #.");
+      return;
+    }
+    try {
+      const created = await addArtist({
+        artist_name: name,
+        alphabetical_name: alphabeticalName.trim() || undefined,
+        code_letters: letters,
+        genre_id: gid,
+        code_number: num,
+      }).unwrap();
+      const id = (created as { id?: number }).id;
+      if (typeof id === "number") {
+        setResolvedArtistId(id);
+        setArtistName(name);
+        toast.success("Artist created. You can add the album below.");
+      }
+    } catch (err: unknown) {
+      const e = err as { status?: number; data?: { message?: string; artist?: { id: number } } };
+      if (e?.status === 409 && e?.data?.artist?.id) {
+        setResolvedArtistId(e.data.artist.id);
+        setArtistName(newArtistName.trim());
+        toast.info(
+          "That artist code already exists — using the existing artist record."
+        );
+        return;
+      }
+      const msg = e?.data?.message || "Could not create artist.";
+      toast.error(msg);
+    }
+  };
+
+  const onAddAlbum = async () => {
+    const gid = Number(genreId);
+    const fid = Number(formatId);
+    const dq = Math.max(1, parseInt(discQuantity, 10) || 1);
+    const title = albumTitle.trim();
+    const lab = label.trim();
+
+    if (!title || !lab || !Number.isFinite(gid) || !Number.isFinite(fid)) {
+      toast.error("Album title, label, genre, and format are required.");
+      return;
+    }
+    if (resolvedArtistId == null && !artistName.trim()) {
+      toast.error("Enter an artist name (existing library artist) or create a new artist first.");
+      return;
+    }
+
+    try {
+      const body: AddAlbumRequestBody = {
+        album_title: title,
+        label: lab,
+        genre_id: gid,
+        format_id: fid,
+        disc_quantity: dq,
+      };
+      if (alternateArtist.trim()) {
+        body.alternate_artist_name = alternateArtist.trim();
+      }
+      if (resolvedArtistId != null) {
+        body.artist_id = resolvedArtistId;
+      } else {
+        body.artist_name = artistName.trim();
+      }
+
+      const inserted = await addAlbum(body).unwrap();
+      const aid = (inserted as { id?: number }).id;
+      if (typeof aid === "number") {
+        setPreviewAlbumId(aid);
+        toast.success("Album added to the catalog.");
+      }
+    } catch (err: unknown) {
+      const e = err as { data?: { message?: string } };
+      toast.error(e?.data?.message || "Could not add album.");
+    }
+  };
+
+  const clearArtistResolution = () => {
+    setResolvedArtistId(null);
+  };
+
+  return (
+    <Stack spacing={2} sx={{ maxWidth: 720 }}>
+      <Typography level="body-md">
+        Add albums to the card catalog. The catalog code (genre, letter code, artist
+        number, album number) is assigned by the library when you save. Choose format
+        and disc count to match vinyl/CD and multi-disc releases.
+      </Typography>
+
+      <Accordion defaultExpanded={false}>
+        <AccordionSummary indicator={<ExpandMore />}>
+          <Typography level="title-md">Register a new artist (optional)</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Stack spacing={2}>
+            <Typography level="body-sm" sx={{ color: "text.secondary" }}>
+              Use this when the artist does not exist in the genre yet. You need the
+              letter code (e.g. RO) and the next artist number — use &quot;Suggest next
+              #&quot; after picking genre and letters.
+            </Typography>
+            <FormControl>
+              <FormLabel>Code letters</FormLabel>
+              <Input
+                value={codeLetters}
+                onChange={(e) => setCodeLetters(e.target.value)}
+                placeholder="e.g. RO"
+              />
+            </FormControl>
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+              <FormControl sx={{ flex: 1 }}>
+                <FormLabel>Artist #</FormLabel>
+                <Input
+                  value={codeNumber}
+                  onChange={(e) => setCodeNumber(e.target.value)}
+                  placeholder="number"
+                />
+              </FormControl>
+              <Button
+                variant="outlined"
+                onClick={onSuggestArtistCode}
+                sx={{ alignSelf: { sm: "flex-end" }, mt: { sm: 2.5 } }}
+              >
+                Suggest next #
+              </Button>
+            </Stack>
+            <FormControl>
+              <FormLabel>New artist name</FormLabel>
+              <Input
+                value={newArtistName}
+                onChange={(e) => setNewArtistName(e.target.value)}
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel>Alphabetical sort name (optional)</FormLabel>
+              <Input
+                value={alphabeticalName}
+                onChange={(e) => setAlphabeticalName(e.target.value)}
+              />
+            </FormControl>
+            <Button
+              loading={addingArtist}
+              onClick={onCreateArtist}
+              variant="soft"
+            >
+              Create artist
+            </Button>
+          </Stack>
+        </AccordionDetails>
+      </Accordion>
+
+      <Divider />
+
+      <Typography level="title-lg">Album</Typography>
+
+      <Stack spacing={2}>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
+          <FormControl sx={{ flex: 1 }} required>
+            <FormLabel>Genre</FormLabel>
+            <Select
+              placeholder="Choose genre"
+              value={genreId}
+              onChange={(_, v) => {
+                setGenreId(v as string);
+                clearArtistResolution();
+              }}
+              disabled={genresLoading}
+            >
+              <Option value="">Choose genre</Option>
+              {genres?.map((g) => (
+                <Option key={g.id} value={String(g.id)}>
+                  {g.genre_name}
+                </Option>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl sx={{ flex: 1 }} required>
+            <FormLabel>Format</FormLabel>
+            <Select
+              placeholder="Choose format"
+              value={formatId}
+              onChange={(_, v) => setFormatId(v as string)}
+              disabled={formatsLoading}
+            >
+              <Option value="">Choose format</Option>
+              {formats?.map((f) => (
+                <Option key={f.id} value={String(f.id)}>
+                  {f.format_name}
+                </Option>
+              ))}
+            </Select>
+          </FormControl>
+        </Stack>
+
+        <FormControl required>
+          <FormLabel>Album title</FormLabel>
+          <Input
+            value={albumTitle}
+            onChange={(e) => setAlbumTitle(e.target.value)}
+          />
+        </FormControl>
+
+        <FormControl required>
+          <FormLabel>Label</FormLabel>
+          <Input value={label} onChange={(e) => setLabel(e.target.value)} />
+        </FormControl>
+
+        <FormControl>
+          <FormLabel>
+            Artist name{" "}
+            {resolvedArtistId != null && (
+              <Typography component="span" level="body-xs" sx={{ color: "success.600" }}>
+                (linked to new artist id {resolvedArtistId})
+              </Typography>
+            )}
+          </FormLabel>
+          <Input
+            value={artistName}
+            onChange={(e) => {
+              setArtistName(e.target.value);
+              clearArtistResolution();
+            }}
+            placeholder="Must match an existing artist in this genre, unless you created one above"
+          />
+        </FormControl>
+
+        <FormControl>
+          <FormLabel>Alternate artist display (optional)</FormLabel>
+          <Input
+            value={alternateArtist}
+            onChange={(e) => setAlternateArtist(e.target.value)}
+          />
+        </FormControl>
+
+        <FormControl>
+          <FormLabel>Disc quantity</FormLabel>
+          <Input
+            type="number"
+            slotProps={{ input: { min: 1 } }}
+            value={discQuantity}
+            onChange={(e) => setDiscQuantity(e.target.value)}
+          />
+        </FormControl>
+
+        <Button loading={addingAlbum} onClick={onAddAlbum}>
+          Add album to catalog
+        </Button>
+      </Stack>
+
+      {previewEntry && previewAlbumId !== null && (
+        <Stack spacing={1} sx={{ mt: 2 }}>
+          <Typography level="title-md">Preview (library encoding)</Typography>
+          <CatalogEntryPreview entry={previewEntry} />
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/experiences/modern/admin/catalog/CatalogEntryPreview.tsx
+++ b/src/components/experiences/modern/admin/catalog/CatalogEntryPreview.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { AlbumEntry } from "@/lib/features/catalog/types";
+import { Chip, ColorPaletteProp, Stack, Typography } from "@mui/joy";
+
+/**
+ * Read-only catalog row matching flowsheet CODE / vinyl chip presentation.
+ */
+export default function CatalogEntryPreview({ entry }: { entry: AlbumEntry }) {
+  return (
+    <Stack
+      direction="row"
+      justifyContent="space-between"
+      data-testid="catalog-entry-preview"
+      sx={{
+        p: 1,
+        borderRadius: "sm",
+        bgcolor: "background.level1",
+        border: "1px solid",
+        borderColor: "divider",
+      }}
+    >
+      <Stack direction="column" sx={{ flex: 1, minWidth: 0, px: 1 }}>
+        <Typography level="body-xs" sx={{ mb: -0.5, color: "text.tertiary" }}>
+          CODE
+        </Typography>
+        <Typography
+          component="div"
+          sx={{
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            fontFamily: "monospace",
+            fontSize: "1rem",
+          }}
+        >
+          {entry.artist.genre} {entry.artist.lettercode} {entry.artist.numbercode}/
+          {entry.entry}
+          <Chip
+            variant="soft"
+            size="sm"
+            color={
+              (String(entry.format).toLowerCase().includes("vinyl")
+                ? "primary"
+                : "info") as ColorPaletteProp
+            }
+            sx={{ ml: 2 }}
+          >
+            {String(entry.format).toLowerCase().includes("vinyl") ? "vinyl" : "cd"}
+          </Chip>
+          {entry.on_streaming === false && (
+            <Chip
+              variant="soft"
+              size="sm"
+              sx={{
+                ml: 1,
+                backgroundColor: "#7B2D8E",
+                color: "#fff",
+                fontWeight: "bold",
+                fontSize: "0.6rem",
+              }}
+            >
+              EXCLUSIVE
+            </Chip>
+          )}
+        </Typography>
+      </Stack>
+      <Stack direction="column" sx={{ flex: 1, minWidth: 0, px: 1 }}>
+        <Typography level="body-xs" sx={{ mb: -0.5, color: "text.tertiary" }}>
+          ARTIST
+        </Typography>
+        <Typography sx={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+          {entry.artist.name || "Unknown"}
+        </Typography>
+      </Stack>
+      <Stack direction="column" sx={{ flex: 1, minWidth: 0, px: 1 }}>
+        <Typography level="body-xs" sx={{ mb: -0.5, color: "text.tertiary" }}>
+          ALBUM
+        </Typography>
+        <Typography sx={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+          {entry.title || "Unknown"}
+        </Typography>
+      </Stack>
+      <Stack direction="column" sx={{ flex: 1, minWidth: 0, px: 1 }}>
+        <Typography level="body-xs" sx={{ mb: -0.5, color: "text.tertiary" }}>
+          LABEL
+        </Typography>
+        <Typography sx={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+          {entry.label || "Unknown"}
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary

Adds an **Add to catalog** admin flow for Station Managers: optional **new artist** registration (peek next artist #, create artist), then **add album** with genre, format, label, disc quantity, and alternate artist. After a successful insert, loads **`GET /library/info`** and shows a **CODE / vinyl | cd** preview aligned with flowsheet search styling.

## API layer (`catalogApi`)

- **`peekArtistCode`** → `GET /library/artists/peek-code` via **`useLazyPeekArtistCodeQuery`**
- Request bodies aligned with Backend-Service: **`AddAlbumRequestBody`**, **`AddArtistRequestBody`** (includes **`code_number`**), **`AddFormatRequestBody`**, **`AddGenreRequestBody`** (`name` + **`description`**)
- Typed **`getFormats`** / **`getGenres`** responses

## Routes / UX

- **`/dashboard/admin/catalog`** — **`requireRole(SM)`**, sidebar link **Add to catalog** (same SM gate as DJ Roster)

## Tests

- Leftbar unit tests + RBAC e2e paths for admin catalog (DJ / MD / member redirect; SM access)

## Notes

- Edit/remove catalog rows still require backend support; this PR is **add + preview** only.
