### PR TITLE
Validate usernames in the admin Add DJ form

### DIFF
--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -19,6 +19,7 @@ import {
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { onRosterInvalidated } from "@/lib/features/admin/roster-events";
+import { getUsernameError } from "@/src/utilities/usernameValidation";
 import { AccountEntry } from "./AccountEntry";
 import AccountSearchForm from "./AccountSearchForm";
 import ExportDJsButton from "./ExportCSV";
@@ -80,6 +81,11 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
           temporaryPassword: tempPassword,
           authorization: authorizationOfNewAccount,
         };
+
+        const usernameError = getUsernameError(newAccount.username);
+        if (usernameError) {
+          throw new Error(usernameError);
+        }
 
         const role = authorizationToRole(authorizationOfNewAccount);
 

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -19,6 +19,7 @@ import {
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { onRosterInvalidated } from "@/lib/features/admin/roster-events";
+import { getUsernameError } from "@/src/utilities/usernameValidation";
 import { AccountEntry } from "./AccountEntry";
 import AccountSearchForm from "./AccountSearchForm";
 import ExportDJsButton from "./ExportCSV";
@@ -71,6 +72,11 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
           email: formData.get("email") as string,
           authorization: authorizationOfNewAccount,
         };
+
+        const usernameError = getUsernameError(newAccount.username);
+        if (usernameError) {
+          throw new Error(usernameError);
+        }
 
         const role = authorizationToRole(authorizationOfNewAccount);
 

--- a/src/utilities/usernameValidation.test.ts
+++ b/src/utilities/usernameValidation.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  getUsernameError,
+  MAX_USERNAME_LENGTH,
+  MIN_USERNAME_LENGTH,
+} from "./usernameValidation";
+
+describe("getUsernameError", () => {
+  describe("valid usernames", () => {
+    it.each([
+      ["lowercase", "billb"],
+      ["mixed case", "BillB"],
+      ["with underscore", "bill_b"],
+      ["with dot", "bill.b"],
+      ["digits only", "12345"],
+      ["minimum length", "a".repeat(MIN_USERNAME_LENGTH)],
+      ["maximum length", "a".repeat(MAX_USERNAME_LENGTH)],
+    ])('should accept %s ("%s")', (_label, input) => {
+      expect(getUsernameError(input)).toBeNull();
+    });
+  });
+
+  describe("rejected usernames", () => {
+    it("should reject internal whitespace", () => {
+      expect(getUsernameError("bill b")).toMatch(/no spaces/i);
+    });
+
+    it.each([
+      ["dash", "bill-b"],
+      ["at", "bill@b"],
+      ["apostrophe", "bill's"],
+      ["unicode", "billé"],
+    ])("should reject %s", (_label, input) => {
+      expect(getUsernameError(input)).toMatch(/letters/i);
+    });
+
+    it("should reject empty string with too-short message", () => {
+      expect(getUsernameError("")).toMatch(/at least 3/);
+    });
+
+    it("should reject MIN-1 with too-short message", () => {
+      expect(getUsernameError("a".repeat(MIN_USERNAME_LENGTH - 1))).toMatch(
+        /at least 3/
+      );
+    });
+
+    it("should reject MAX+1 with too-long message", () => {
+      expect(getUsernameError("a".repeat(MAX_USERNAME_LENGTH + 1))).toMatch(
+        /at most 30/
+      );
+    });
+  });
+});

--- a/src/utilities/usernameValidation.ts
+++ b/src/utilities/usernameValidation.ts
@@ -1,0 +1,25 @@
+/**
+ * Username validation that mirrors better-auth's username plugin defaults
+ * (see Backend-Service `shared/authentication/src/auth.username.ts`).
+ *
+ * The canonical check runs server-side in `provisionUser()`. This client-side
+ * copy exists so the admin "Add DJ" form can fail fast with a friendly
+ * message instead of round-tripping a 400.
+ */
+
+export const USERNAME_REGEX = /^[a-zA-Z0-9_.]+$/;
+export const MIN_USERNAME_LENGTH = 3;
+export const MAX_USERNAME_LENGTH = 30;
+
+export function getUsernameError(username: string): string | null {
+  if (username.length < MIN_USERNAME_LENGTH) {
+    return `Username must be at least ${MIN_USERNAME_LENGTH} characters.`;
+  }
+  if (username.length > MAX_USERNAME_LENGTH) {
+    return `Username must be at most ${MAX_USERNAME_LENGTH} characters.`;
+  }
+  if (!USERNAME_REGEX.test(username)) {
+    return 'Username may only contain letters, numbers, underscores, and dots (no spaces).';
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- Companion to WXYC/Backend-Service#732. The server-side change rejects bad usernames at provision time; this PR makes the admin "Add DJ" form fail fast with a friendly inline error before the network round-trip, instead of waiting for the 400.
- New `src/utilities/usernameValidation.ts` mirrors the Backend-Service validator's regex and length bounds. Returns a user-facing string or `null`. Comment in the file points to the canonical server-side module so any future divergence is intentional.
- `RosterTable.tsx`'s `handleAddAccount` runs the validator on the username field and `throw`s if it returns a string — the existing `catch` already turns this into a toast and inline error.
- Skipped: per-row pre-validation in `ImportCSVModal`. The server side rejects bad rows with the same message and the modal already displays per-row server errors. Adding client-side row checks duplicates scope without value.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run test:run` — 2543 passing (15 new cases on the validator)
- [x] `npm run build`
- [ ] CI green
- [ ] Manual: open the roster admin page, type "bill b" as username, click Save; expect inline error + toast "Username may only contain letters, numbers, underscores, and dots (no spaces)." and no network call to `/admin/provision-user`.

Closes #483