### PR TITLE
Open major-version Dependabot bumps as individual PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,12 +15,18 @@ updates:
           - "@wxyc/shared"
       dev-dependencies:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
         exclude-patterns:
           - "better-auth"
           - "@better-auth/*"
           - "@wxyc/shared"
       production-dependencies:
         dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
         exclude-patterns:
           - "better-auth"
           - "@better-auth/*"


### PR DESCRIPTION
Limit the `dev-dependencies` and `production-dependencies` groups to `minor` and `patch` bumps so each major-version upgrade lands as its own reviewable PR. Without this, a single grouped PR (e.g. #386: React 18→19, MUI 6→9, jose 5→6, sonner 1→2 all together) becomes hard to review, and any single migration that needs code changes blocks the rest.

`better-auth` and `@wxyc/shared` keep their existing groups (those track packages we explicitly want bumped together regardless of severity).

## Test plan
- [ ] Wait for the next scheduled Dependabot run (or trigger one) and confirm that previously-grouped major bumps are now opened as individual PRs.