### PR TITLE
ci: pin workflow-level GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ env:
   NEXT_PUBLIC_ENABLED_EXPERIENCES: modern,classic
   NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING: "true"
 
+# Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
+# comments on PRs, or creates releases; all writes to external services
+# use their own non-GITHUB_TOKEN secrets. contents:read is the safe floor.
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     name: Type Check

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,6 +48,12 @@ env:
   E2E_AUTH_PORT: 8084
   E2E_BACKEND_PORT: 8085
 
+# Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
+# comments on PRs, or creates releases; all writes to external services
+# use their own non-GITHUB_TOKEN secrets. contents:read is the safe floor.
+permissions:
+  contents: read
+
 jobs:
   e2e:
     name: E2E Tests


### PR DESCRIPTION
Closes #506.

Adds a top-level `permissions:` block to every workflow so the GITHUB_TOKEN runs with a least-privilege scope pinned in code, instead of inheriting whatever the repo-wide default happens to be.

- `ci.yml`: contents: read
- `e2e-tests.yml`: contents: read

Behavior-neutral today (no job writes via GITHUB_TOKEN beyond what the block grants) but pins the safe posture so future jobs can't silently inherit write scopes.

Part of the org-wide GitHub Actions hardening project (Phase 3).