### PR TITLE
Bump @wxyc/shared to ^1.3.0 (catalog-track-search E7-4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "catalog-track-search-shared-v1.3.0",
+  "name": "catalog-artwork",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "catalog-artwork",
+  "name": "catalog-track-search-shared-v1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,7 +14,7 @@
         "@opennextjs/cloudflare": "^1.10.1",
         "@reduxjs/toolkit": "^2.2.0",
         "@uidotdev/usehooks": "^2.4.1",
-        "@wxyc/shared": "^0.5.1",
+        "@wxyc/shared": "^1.3.0",
         "better-auth": "^1.6.9",
         "cookie": "^1.0.2",
         "jose": "^5.9.6",
@@ -48,6 +48,9 @@
         "typescript": "^5.3.3",
         "vitest": "^4.0.18",
         "wrangler": "^4.42.2"
+      },
+      "engines": {
+        "node": "24.x"
       },
       "optionalDependencies": {
         "@ast-grep/napi-darwin-arm64": "^0.35.0",
@@ -14001,12 +14004,15 @@
       }
     },
     "node_modules/@wxyc/shared": {
-      "version": "0.5.1",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/0.5.1/1c9488fcfae4f6ddda64249c13801a8cbb91e338",
-      "integrity": "sha512-1SMVavd0Q3AFggKwRTa8vLZSY5CdbIRJGGhI4Kl7fScfANhusZwUaeAOYgUCPN7jOwQSstLQ0qpI+YAhVEnf3g==",
+      "version": "1.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.3.0/921aeb6e4fed2d130c7ac13e032740f1cb2d82ab",
+      "integrity": "sha512-StZ0DDuRcogWO4tD9PM2sd42inlYVb1RAo0wzUO3kj3l0HQh/p93PD6YbkEaKoiWJMxWRzPzSimsZvMdkM9KzQ==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=24"
       },
       "peerDependencies": {
         "better-auth": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@opennextjs/cloudflare": "^1.10.1",
     "@reduxjs/toolkit": "^2.2.0",
     "@uidotdev/usehooks": "^2.4.1",
-    "@wxyc/shared": "^0.5.1",
+    "@wxyc/shared": "^1.3.0",
     "better-auth": "^1.6.9",
     "cookie": "^1.0.2",
     "jose": "^5.9.6",


### PR DESCRIPTION
## Summary

Bumps `@wxyc/shared` from `^0.5.1` to `^1.3.0`, picking up the catalog-track-search E7-1 contract additions plus eight months of accumulated schema work between 0.5.1 and 1.3.0.

## Why a 0.x → 1.x jump

The `@wxyc/shared@1.3.0` package version was chosen explicitly to align the npm version with `api.yaml info.version` (the wxyc-shared E7-1 bump aligned both at `1.3.0` — see WXYC/wxyc-shared#117 / #113). It is not a redesign — the cumulative `api.yaml` delta from `0.5.1` to `1.3.0` is additive in every direction:

- **New schemas added**: `TrackMatchSource`, `TrackMatchHint`, `HealthCheckResponse`, `ReadinessResponse`, identity-block schemas, charset-torture corpus contracts
- **New optional fields**: `matched_via`, `track_position`, plus all identity-block additions
- **No removals**: no schemas, fields, or enum members removed
- **No narrowings**: no required-fields added, no type changes, no enum value renames

## What dj-site uses from `@wxyc/shared`

The 22 import sites consume: `BinLibraryDetails`, `PlaylistSearchParams`, `PlaylistSearchResult`, `AlbumSearchResult`, `FlowsheetEntryType`, `FlowsheetSongEntry`, `RotationBin`, `Authorization`, `WXYCRole`, and `isValidEmail`. All ten of these compile cleanly against 1.3.0 with zero source edits — the consumed surface is unchanged across the 0.5.1 → 1.3.0 range.

## Test plan

- [x] `npm install --ignore-scripts` resolves `@wxyc/shared@1.3.0` in `package-lock.json`
- [x] `npx tsc --noEmit` clean (strict mode)
- [x] `npm run test:run` — 2699 tests pass, 186 files, 0 failures
- [x] `npm run build` (Next.js production build) clean
- [x] No `.ts` / `.tsx` source edits

## Note on the second commit

The second commit (`fix: restore package-lock.json name field`) reverts a worktree-path artifact — when `npm install` runs from a freshly-checked-out worktree without a `name` field in `package.json`, npm uses the directory name. Restored to `"catalog-artwork"` to match main and stop the field from churning across worktrees.

Closes #503.

## Related

- Parent epic: WXYC/wxyc-shared#110 (E7)
- Blocked by: WXYC/wxyc-shared#113 (E7-2, merged) — `@wxyc/shared@1.3.0` published to GitHub Packages
- Sibling consumer bumps: WXYC/Backend-Service#848 (E7-3), WXYC/library-metadata-lookup#310 (E7-5, merged)