### PR TITLE
Let DJs edit auto-filled fields in flowsheet search bar without losing siblings

### DIFF
--- a/lib/__tests__/features/flowsheet/flowsheet.test.ts
+++ b/lib/__tests__/features/flowsheet/flowsheet.test.ts
@@ -82,6 +82,49 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       const result = harness().reduce(actions.setSelectedResult(3));
       expect(result.search.selectedResult).toBe(3);
     });
+
+    describe("freezeSelectionToQuery", () => {
+      it("should copy the selected entry's fields into the query and deselect", () => {
+        const result = harness().chain(
+          actions.setSearchProperty({ name: "song", value: "la paradoja" }),
+          actions.setSelectedResult(2),
+          actions.freezeSelectionToQuery({
+            artist: "Juana Molina",
+            album: "DOGA",
+            label: "Sonamos",
+            album_id: 42,
+          })
+        );
+
+        expect(result.search.query.artist).toBe("Juana Molina");
+        expect(result.search.query.album).toBe("DOGA");
+        expect(result.search.query.label).toBe("Sonamos");
+        expect(result.search.query.album_id).toBe(42);
+        expect(result.search.selectedResult).toBe(0);
+        // Unrelated fields are not touched
+        expect(result.search.query.song).toBe("la paradoja");
+      });
+
+      it("should clear album_id when not provided", () => {
+        const seeded = harness().reduce(
+          actions.freezeSelectionToQuery({
+            artist: "Stereolab",
+            album: "Aluminum Tunes",
+            label: "Duophonic",
+            album_id: 7,
+          })
+        );
+        const result = harness().reduce(
+          actions.freezeSelectionToQuery({
+            artist: "Cat Power",
+            album: "Moon Pix",
+            label: "Matador Records",
+          }),
+          seeded
+        );
+        expect(result.search.query.album_id).toBeUndefined();
+      });
+    });
   });
 
   describe("queue actions", () => {

--- a/lib/__tests__/features/flowsheet/flowsheet.test.ts
+++ b/lib/__tests__/features/flowsheet/flowsheet.test.ts
@@ -124,6 +124,43 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         );
         expect(result.search.query.album_id).toBeUndefined();
       });
+
+      it("should round-trip rotation_id and rotation_bin", () => {
+        const result = harness().reduce(
+          actions.freezeSelectionToQuery({
+            artist: "Juana Molina",
+            album: "DOGA",
+            label: "Sonamos",
+            album_id: 42,
+            rotation_id: 99,
+            rotation_bin: "H",
+          })
+        );
+        expect(result.search.query.rotation_id).toBe(99);
+        expect(result.search.query.rotation_bin).toBe("H");
+      });
+
+      it("should clear rotation_id and rotation_bin when not provided", () => {
+        const seeded = harness().reduce(
+          actions.freezeSelectionToQuery({
+            artist: "Stereolab",
+            album: "Aluminum Tunes",
+            label: "Duophonic",
+            rotation_id: 5,
+            rotation_bin: "M",
+          })
+        );
+        const result = harness().reduce(
+          actions.freezeSelectionToQuery({
+            artist: "Cat Power",
+            album: "Moon Pix",
+            label: "Matador Records",
+          }),
+          seeded
+        );
+        expect(result.search.query.rotation_id).toBeUndefined();
+        expect(result.search.query.rotation_bin).toBeUndefined();
+      });
     });
   });
 

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -76,12 +76,16 @@ export const flowsheetSlice = createAppSlice({
         album: string;
         label: string;
         album_id?: number;
+        rotation_id?: number;
+        rotation_bin?: Rotation;
       }>
     ) => {
       state.search.query.artist = action.payload.artist;
       state.search.query.album = action.payload.album;
       state.search.query.label = action.payload.label;
       state.search.query.album_id = action.payload.album_id;
+      state.search.query.rotation_id = action.payload.rotation_id;
+      state.search.query.rotation_bin = action.payload.rotation_bin;
       state.search.selectedResult = 0;
     },
     toggleRequest: (state) => {

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -65,6 +65,25 @@ export const flowsheetSlice = createAppSlice({
     ) => {
       state.search.query[action.payload.name] = action.payload.value;
     },
+    /**
+     * Copy a selected search result's fields into the live search query and
+     * deselect it, so the user can edit one field without losing the others.
+     */
+    freezeSelectionToQuery: (
+      state,
+      action: PayloadAction<{
+        artist: string;
+        album: string;
+        label: string;
+        album_id?: number;
+      }>
+    ) => {
+      state.search.query.artist = action.payload.artist;
+      state.search.query.album = action.payload.album;
+      state.search.query.label = action.payload.label;
+      state.search.query.album_id = action.payload.album_id;
+      state.search.selectedResult = 0;
+    },
     toggleRequest: (state) => {
       state.search.query.request = !state.search.query.request;
     },

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.test.tsx
@@ -168,8 +168,48 @@ describe("FlowsheetSearchInput", () => {
         album: "DOGA",
         label: "Sonamos",
         album_id: 42,
+        rotation_id: undefined,
+        rotation_bin: undefined,
       });
       expect(mockSetSearchProperty).toHaveBeenCalledWith("artist", "Juana M");
+    });
+
+    it("should preserve rotation_id and rotation_bin from a rotation/bin selection", async () => {
+      const { useFlowsheetSearch } = await import(
+        "@/src/hooks/flowsheetHooks"
+      );
+      vi.mocked(useFlowsheetSearch).mockReturnValue({
+        getDisplayValue: (name: string) =>
+          name === "artist" ? "Juana Molina" : "",
+        setSearchProperty: mockSetSearchProperty,
+        selectedIndex: 1,
+        selectedEntry: {
+          id: 42,
+          artist: { name: "Juana Molina" },
+          title: "DOGA",
+          label: "Sonamos",
+          rotation_id: 7,
+          rotation_bin: "H",
+        },
+      } as any);
+      const { flowsheetSlice } = await import(
+        "@/lib/features/flowsheet/frontend"
+      );
+
+      render(<FlowsheetSearchInput name="artist" />);
+
+      fireEvent.change(screen.getByRole("textbox"), {
+        target: { value: "Juana M" },
+      });
+
+      expect(flowsheetSlice.actions.freezeSelectionToQuery).toHaveBeenCalledWith({
+        artist: "Juana Molina",
+        album: "DOGA",
+        label: "Sonamos",
+        album_id: 42,
+        rotation_id: 7,
+        rotation_bin: "H",
+      });
     });
 
     it("should not block keystrokes when auto-filled", async () => {

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.test.tsx
@@ -2,16 +2,31 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import FlowsheetSearchInput from "./FlowsheetSearchInput";
 
-// Mock hooks
 const mockSetSearchProperty = vi.fn();
+const mockDispatch = vi.fn();
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
   useFlowsheetSearch: vi.fn(() => ({
-    getDisplayValue: (name: string) => "",
+    getDisplayValue: (_name: string) => "",
     setSearchProperty: mockSetSearchProperty,
     selectedIndex: 0,
     selectedEntry: null,
   })),
+}));
+
+vi.mock("@/lib/hooks", () => ({
+  useAppDispatch: () => mockDispatch,
+}));
+
+vi.mock("@/lib/features/flowsheet/frontend", () => ({
+  flowsheetSlice: {
+    actions: {
+      freezeSelectionToQuery: vi.fn((payload) => ({
+        type: "freezeSelectionToQuery",
+        payload,
+      })),
+    },
+  },
 }));
 
 vi.mock("@/src/utilities/stringutilities", () => ({
@@ -40,15 +55,15 @@ describe("FlowsheetSearchInput", () => {
     render(<FlowsheetSearchInput name="artist" />);
 
     const input = screen.getByRole("textbox");
-    fireEvent.change(input, { target: { value: "Test Artist" } });
+    fireEvent.change(input, { target: { value: "Juana Molina" } });
 
-    expect(mockSetSearchProperty).toHaveBeenCalledWith("artist", "Test Artist");
+    expect(mockSetSearchProperty).toHaveBeenCalledWith("artist", "Juana Molina");
   });
 
   it("should display value from getDisplayValue", async () => {
     const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
     vi.mocked(useFlowsheetSearch).mockReturnValue({
-      getDisplayValue: () => "Existing Value",
+      getDisplayValue: () => "DOGA",
       setSearchProperty: mockSetSearchProperty,
       selectedIndex: 0,
       selectedEntry: null,
@@ -57,41 +72,7 @@ describe("FlowsheetSearchInput", () => {
     render(<FlowsheetSearchInput name="album" />);
 
     const input = screen.getByRole("textbox");
-    expect(input).toHaveValue("Existing Value");
-  });
-
-  it("should be readonly when field is auto-filled", async () => {
-    const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useFlowsheetSearch).mockReturnValue({
-      getDisplayValue: () => "Auto-filled value",
-      setSearchProperty: mockSetSearchProperty,
-      selectedIndex: 1,
-      selectedEntry: {
-        artist: { name: "Test Artist" },
-      },
-    } as any);
-
-    render(<FlowsheetSearchInput name="artist" />);
-
-    const input = screen.getByRole("textbox");
-    expect(input).toHaveAttribute("readonly");
-  });
-
-  it("should not be readonly for song field even when selected", async () => {
-    const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useFlowsheetSearch).mockReturnValue({
-      getDisplayValue: () => "Song title",
-      setSearchProperty: mockSetSearchProperty,
-      selectedIndex: 1,
-      selectedEntry: {
-        title: "Test Album",
-      },
-    } as any);
-
-    render(<FlowsheetSearchInput name="song" />);
-
-    const input = screen.getByRole("textbox");
-    expect(input).not.toHaveAttribute("readonly");
+    expect(input).toHaveValue("DOGA");
   });
 
   it("should stop click propagation", () => {
@@ -135,177 +116,74 @@ describe("FlowsheetSearchInput", () => {
     expect(input).toHaveAttribute("data-custom", "value");
   });
 
-  it("should be readonly when album field is auto-filled", async () => {
-    const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useFlowsheetSearch).mockReturnValue({
-      getDisplayValue: () => "Auto-filled Album",
-      setSearchProperty: mockSetSearchProperty,
-      selectedIndex: 1,
-      selectedEntry: {
-        title: "Test Album Title",
-      },
-    } as any);
+  describe("editing an auto-filled field", () => {
+    async function selectResult() {
+      const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
+      vi.mocked(useFlowsheetSearch).mockReturnValue({
+        getDisplayValue: (name: string) => {
+          switch (name) {
+            case "artist":
+              return "Juana Molina";
+            case "album":
+              return "DOGA";
+            case "label":
+              return "Sonamos";
+            default:
+              return "";
+          }
+        },
+        setSearchProperty: mockSetSearchProperty,
+        selectedIndex: 1,
+        selectedEntry: {
+          id: 42,
+          artist: { name: "Juana Molina" },
+          title: "DOGA",
+          label: "Sonamos",
+        },
+      } as any);
+    }
 
-    render(<FlowsheetSearchInput name="album" />);
+    it("should not be readonly so the user can edit on click", async () => {
+      await selectResult();
 
-    const input = screen.getByRole("textbox");
-    expect(input).toHaveAttribute("readonly");
-  });
+      render(<FlowsheetSearchInput name="artist" />);
 
-  it("should be readonly when label field is auto-filled", async () => {
-    const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useFlowsheetSearch).mockReturnValue({
-      getDisplayValue: () => "Auto-filled Label",
-      setSearchProperty: mockSetSearchProperty,
-      selectedIndex: 1,
-      selectedEntry: {
-        label: "Test Label",
-      },
-    } as any);
+      const input = screen.getByRole("textbox");
+      expect(input).not.toHaveAttribute("readonly");
+    });
 
-    render(<FlowsheetSearchInput name="label" />);
+    it("should freeze the selected entry's fields into the query before applying the edit", async () => {
+      await selectResult();
+      const { flowsheetSlice } = await import(
+        "@/lib/features/flowsheet/frontend"
+      );
 
-    const input = screen.getByRole("textbox");
-    expect(input).toHaveAttribute("readonly");
-  });
+      render(<FlowsheetSearchInput name="artist" />);
 
-  it("should prevent keydown when auto-filled except Tab, Shift, and Enter", async () => {
-    const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useFlowsheetSearch).mockReturnValue({
-      getDisplayValue: () => "Auto-filled value",
-      setSearchProperty: mockSetSearchProperty,
-      selectedIndex: 1,
-      selectedEntry: {
-        artist: { name: "Test Artist" },
-      },
-    } as any);
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "Juana M" } });
 
-    render(<FlowsheetSearchInput name="artist" />);
+      expect(flowsheetSlice.actions.freezeSelectionToQuery).toHaveBeenCalledWith({
+        artist: "Juana Molina",
+        album: "DOGA",
+        label: "Sonamos",
+        album_id: 42,
+      });
+      expect(mockSetSearchProperty).toHaveBeenCalledWith("artist", "Juana M");
+    });
 
-    const input = screen.getByRole("textbox");
+    it("should not block keystrokes when auto-filled", async () => {
+      await selectResult();
 
-    // Regular key should be prevented
-    const letterEvent = fireEvent.keyDown(input, { key: 'a' });
-    expect(letterEvent).toBe(false); // preventDefault was called
+      render(<FlowsheetSearchInput name="artist" />);
 
-    // Tab should not be prevented
-    const tabEvent = fireEvent.keyDown(input, { key: 'Tab' });
-    expect(tabEvent).toBe(true); // default not prevented
+      const input = screen.getByRole("textbox");
 
-    // Shift should not be prevented
-    const shiftEvent = fireEvent.keyDown(input, { key: 'Shift' });
-    expect(shiftEvent).toBe(true);
-
-    expect(input).toHaveAttribute("readonly");
-  });
-
-  it("should not prevent Enter keydown when auto-filled so form submission works", async () => {
-    const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useFlowsheetSearch).mockReturnValue({
-      getDisplayValue: () => "Auto-filled value",
-      setSearchProperty: mockSetSearchProperty,
-      selectedIndex: 1,
-      selectedEntry: {
-        artist: { name: "Test Artist" },
-      },
-    } as any);
-
-    render(<FlowsheetSearchInput name="artist" />);
-
-    const input = screen.getByRole("textbox");
-
-    // Enter should not be prevented — it must propagate for form submission
-    const enterEvent = fireEvent.keyDown(input, { key: 'Enter' });
-    expect(enterEvent).toBe(true);
-  });
-
-  it("should not call setSearchProperty when auto-filled", async () => {
-    const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useFlowsheetSearch).mockReturnValue({
-      getDisplayValue: () => "Auto-filled value",
-      setSearchProperty: mockSetSearchProperty,
-      selectedIndex: 1,
-      selectedEntry: {
-        artist: { name: "Test Artist" },
-      },
-    } as any);
-
-    render(<FlowsheetSearchInput name="artist" />);
-
-    const input = screen.getByRole("textbox");
-    fireEvent.change(input, { target: { value: "New Value" } });
-
-    // Should not be called because field is auto-filled
-    expect(mockSetSearchProperty).not.toHaveBeenCalled();
-  });
-
-  it("should apply auto-fill styles when field is auto-filled", async () => {
-    const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useFlowsheetSearch).mockReturnValue({
-      getDisplayValue: () => "Auto-filled value",
-      setSearchProperty: mockSetSearchProperty,
-      selectedIndex: 1,
-      selectedEntry: {
-        artist: { name: "Test Artist" },
-      },
-    } as any);
-
-    render(<FlowsheetSearchInput name="artist" />);
-
-    const input = screen.getByRole("textbox");
-    expect(input).toHaveStyle({ cursor: "not-allowed", opacity: "0.6" });
-  });
-
-  it("should not be readonly when selectedEntry has no value for field", async () => {
-    const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useFlowsheetSearch).mockReturnValue({
-      getDisplayValue: () => "",
-      setSearchProperty: mockSetSearchProperty,
-      selectedIndex: 1,
-      selectedEntry: {
-        // No artist name
-        artist: null,
-      },
-    } as any);
-
-    render(<FlowsheetSearchInput name="artist" />);
-
-    const input = screen.getByRole("textbox");
-    expect(input).not.toHaveAttribute("readonly");
-  });
-
-  it("should not be readonly when album field has no title", async () => {
-    const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useFlowsheetSearch).mockReturnValue({
-      getDisplayValue: () => "",
-      setSearchProperty: mockSetSearchProperty,
-      selectedIndex: 1,
-      selectedEntry: {
-        title: "", // empty title
-      },
-    } as any);
-
-    render(<FlowsheetSearchInput name="album" />);
-
-    const input = screen.getByRole("textbox");
-    expect(input).not.toHaveAttribute("readonly");
-  });
-
-  it("should not be readonly when label field has no label", async () => {
-    const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useFlowsheetSearch).mockReturnValue({
-      getDisplayValue: () => "",
-      setSearchProperty: mockSetSearchProperty,
-      selectedIndex: 1,
-      selectedEntry: {
-        label: null,
-      },
-    } as any);
-
-    render(<FlowsheetSearchInput name="label" />);
-
-    const input = screen.getByRole("textbox");
-    expect(input).not.toHaveAttribute("readonly");
+      // None of these should be prevented now — typing thaws the selection.
+      expect(fireEvent.keyDown(input, { key: "a" })).toBe(true);
+      expect(fireEvent.keyDown(input, { key: "Backspace" })).toBe(true);
+      expect(fireEvent.keyDown(input, { key: "Enter" })).toBe(true);
+    });
   });
 
   describe("ghost text", () => {
@@ -343,11 +221,11 @@ describe("FlowsheetSearchInput", () => {
     it("should not render ghost text when field is auto-filled", async () => {
       const { useFlowsheetSearch } = await import("@/src/hooks/flowsheetHooks");
       vi.mocked(useFlowsheetSearch).mockReturnValue({
-        getDisplayValue: () => "Auto-filled value",
+        getDisplayValue: () => "Juana Molina",
         setSearchProperty: mockSetSearchProperty,
         selectedIndex: 1,
         selectedEntry: {
-          artist: { name: "Test Artist" },
+          artist: { name: "Juana Molina" },
         },
       } as any);
 

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { FlowsheetSearchProperty } from "@/lib/features/flowsheet/types";
+import { useAppDispatch } from "@/lib/hooks";
 import { useFlowsheetSearch } from "@/src/hooks/flowsheetHooks";
 import { toTitleCase } from "@/src/utilities/stringutilities";
 import { InputHTMLAttributes, Ref } from "react";
@@ -25,10 +27,11 @@ export default function FlowsheetSearchInput({
 }: FlowsheetSearchInputProps) {
   const { getDisplayValue, setSearchProperty, selectedIndex, selectedEntry } =
     useFlowsheetSearch();
+  const dispatch = useAppDispatch();
 
   const displayValue = getDisplayValue(name);
 
-  // Check if field is auto-filled from the selected entry
+  // Whether this field's value is currently sourced from a selected result.
   let isAutoFilled = false;
   if (selectedIndex > 0 && name !== "song" && selectedEntry) {
     switch (name) {
@@ -43,6 +46,20 @@ export default function FlowsheetSearchInput({
         break;
     }
   }
+
+  // Freeze the selected entry's fields into the live query and deselect, so
+  // editing one field doesn't blank out the others that came from the result.
+  const thawSelection = () => {
+    if (!selectedEntry) return;
+    dispatch(
+      flowsheetSlice.actions.freezeSelectionToQuery({
+        artist: selectedEntry.artist?.name ?? "",
+        album: selectedEntry.title ?? "",
+        label: selectedEntry.label ?? "",
+        album_id: selectedEntry.id ?? undefined,
+      })
+    );
+  };
 
   const hasGhost = !isAutoFilled && Boolean(ghostSuffix);
 
@@ -90,15 +107,12 @@ export default function FlowsheetSearchInput({
         value={displayValue}
         autoComplete="off"
         onChange={(e) => {
-          if (!isAutoFilled) {
-            setSearchProperty(name, e.target.value);
+          if (isAutoFilled) {
+            thawSelection();
           }
+          setSearchProperty(name, e.target.value);
         }}
         onKeyDown={(e) => {
-          if (isAutoFilled && e.key !== "Tab" && e.key !== "Shift" && e.key !== "Enter") {
-            e.preventDefault();
-            return;
-          }
           // Accept ghost text on Tab
           if (e.key === "Tab" && hasGhost && onAcceptGhost) {
             e.preventDefault();
@@ -106,17 +120,9 @@ export default function FlowsheetSearchInput({
           }
         }}
         onClick={(e) => e.stopPropagation()}
-        readOnly={isAutoFilled}
         disabled={Boolean(props.disabled)}
         {...props}
-        style={{
-          ...externalStyle,
-          cursor: isAutoFilled ? "not-allowed" : externalStyle?.cursor,
-          opacity: isAutoFilled ? 0.6 : externalStyle?.opacity,
-          backgroundColor: isAutoFilled
-            ? "rgba(0, 0, 0, 0.05)"
-            : externalStyle?.backgroundColor,
-        }}
+        style={externalStyle}
       />
     </div>
   );

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchInput.tsx
@@ -57,6 +57,8 @@ export default function FlowsheetSearchInput({
         album: selectedEntry.title ?? "",
         label: selectedEntry.label ?? "",
         album_id: selectedEntry.id ?? undefined,
+        rotation_id: selectedEntry.rotation_id ?? undefined,
+        rotation_bin: selectedEntry.rotation_bin ?? undefined,
       })
     );
   };


### PR DESCRIPTION
## Summary

- Picking a search result populated the artist/album/label display from the selected entry, but those values never landed in `searchQuery`. The fields were `readOnly` with key events blocked, so the only way to edit the artist was to arrow-up off the result — which reverted the display to the empty `searchQuery` and visibly cleared album/label.
- New `freezeSelectionToQuery` reducer copies the selected entry's `{artist, album, label, album_id}` into the live query and clears `selectedResult`. `FlowsheetSearchInput` runs it on first keystroke when the field is auto-filled, then applies the edit through the existing `setSearchProperty` path.
- The readOnly attribute, the non-Tab/Shift/Enter keydown blocker, and the disabled-style overrides go away since editing is now the supported path.

Closes #509.

## Test plan

- [ ] Pick a search result, then type into the artist field — typed value lands in artist, album / label / album_id remain populated, selected-result highlight clears.
- [ ] Same flow editing album: artist / label / album_id are preserved.
- [ ] Submit after a thaw — the resulting flowsheet entry has the typed artist with the previously-selected album_id.
- [ ] Backspace and arrow keys behave normally inside auto-filled fields.
- [ ] `npx tsc --noEmit` clean, `npx vitest run` 2693/2693 passing locally.