### PR TITLE
classic flowsheet: REQUEST/ROTATION/EXCLUSIVE capsule column

### DIFF
--- a/src/components/experiences/classic/flowsheet/Capsule.tsx
+++ b/src/components/experiences/classic/flowsheet/Capsule.tsx
@@ -1,4 +1,3 @@
-import type { Rotation } from "@/lib/features/rotation/types";
 import type { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
 import "@/src/styles/classic/capsules.css";
 
@@ -30,7 +29,7 @@ export function capsulesForSongEntry(entry: FlowsheetSongEntry): CapsuleSpec[] {
   if (entry.rotation) {
     out.push({
       variant: "rotation",
-      label: `ROTATION ${entry.rotation as Rotation}`,
+      label: `ROTATION ${entry.rotation}`,
     });
   }
   if (entry.on_streaming === false) {

--- a/src/components/experiences/classic/flowsheet/Capsule.tsx
+++ b/src/components/experiences/classic/flowsheet/Capsule.tsx
@@ -1,0 +1,40 @@
+import type { Rotation } from "@/lib/features/rotation/types";
+import type { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
+import "@/src/styles/classic/capsules.css";
+
+export type CapsuleVariant = "request" | "rotation" | "exclusive";
+
+export function Capsule({
+  variant,
+  label,
+}: {
+  variant: CapsuleVariant;
+  label: string;
+}) {
+  return (
+    <span className={`classic-capsule classic-capsule--${variant}`}>
+      {label}
+    </span>
+  );
+}
+
+type CapsuleSpec = { variant: CapsuleVariant; label: string };
+
+// Capsules render in priority order: REQUEST → ROTATION → EXCLUSIVE.
+// Mirrors tubafrenzy's `flowsheetRadioShowModify.jsp` capsule ordering.
+export function capsulesForSongEntry(entry: FlowsheetSongEntry): CapsuleSpec[] {
+  const out: CapsuleSpec[] = [];
+  if (entry.request_flag) {
+    out.push({ variant: "request", label: "REQUEST" });
+  }
+  if (entry.rotation) {
+    out.push({
+      variant: "rotation",
+      label: `ROTATION ${entry.rotation as Rotation}`,
+    });
+  }
+  if (entry.on_streaming === false) {
+    out.push({ variant: "exclusive", label: "EXCLUSIVE" });
+  }
+  return out;
+}

--- a/src/components/experiences/classic/flowsheet/EntryRow.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryRow.tsx
@@ -8,6 +8,7 @@ import {
   isFlowsheetStartShowEntry,
   isFlowsheetEndShowEntry,
 } from "@/lib/features/flowsheet/types";
+import { Capsule, capsulesForSongEntry } from "./Capsule";
 
 export default function EntryRow({
   entry,
@@ -30,10 +31,14 @@ export default function EntryRow({
 }) {
   const fontSizeClass = `fontSize${fontSize}`;
 
+  // Markers (talkset / breakpoint / start / end of show) span the full table.
+  // Column count after capsule consolidation: 1 (indicators) + 4 (artist/song/release/label)
+  // + 2 (move up/down) + 1 (edit/delete) = 8 columns. Header text spans the first 5
+  // (indicators + 4 data) and the row's trailing 3 columns stay empty.
   if (isFlowsheetTalksetEntry(entry)) {
     return (
       <tr style={{ backgroundColor: "#BBBBBB" }} className={`flowsheetEntryData ${fontSizeClass}`}>
-        <td colSpan={6} align="center" className="redlabel">
+        <td colSpan={5} align="center" className="redlabel">
           talkset
         </td>
         <td colSpan={3}>&nbsp;</td>
@@ -44,7 +49,7 @@ export default function EntryRow({
   if (isFlowsheetBreakpointEntry(entry)) {
     return (
       <tr style={{ backgroundColor: "#444444" }} className={`flowsheetEntryData ${fontSizeClass}`}>
-        <td colSpan={6} align="left" className="littlegreenlabel">
+        <td colSpan={5} align="left" className="littlegreenlabel">
           {entry.message}
         </td>
         <td colSpan={3}>&nbsp;</td>
@@ -55,7 +60,7 @@ export default function EntryRow({
   if (isFlowsheetStartShowEntry(entry)) {
     return (
       <tr style={{ backgroundColor: "#444444" }} className={`flowsheetEntryData ${fontSizeClass}`}>
-        <td colSpan={6} align="left" className="littlegreenlabel">
+        <td colSpan={5} align="left" className="littlegreenlabel">
           Start: {entry.dj_name}
         </td>
         <td colSpan={3}>&nbsp;</td>
@@ -66,7 +71,7 @@ export default function EntryRow({
   if (isFlowsheetEndShowEntry(entry)) {
     return (
       <tr style={{ backgroundColor: "#444444" }} className={`flowsheetEntryData ${fontSizeClass}`}>
-        <td colSpan={6} align="left" className="littlegreenlabel">
+        <td colSpan={5} align="left" className="littlegreenlabel">
           End: {entry.dj_name}
         </td>
         <td colSpan={3}>&nbsp;</td>
@@ -75,14 +80,16 @@ export default function EntryRow({
   }
 
   if (isFlowsheetSongEntry(entry)) {
-    const rotationIndicator = entry.rotation ? "*" : "";
-    const requestIndicator = entry.request_flag ? "*" : "";
     const hasComposer = false; // BMI composer info not in current type
+    const capsules = capsulesForSongEntry(entry);
 
     return (
       <tr style={{ backgroundColor: "#F3F3F3" }} className={`flowsheetEntryData ${fontSizeClass}`}>
-        <td align="center">{rotationIndicator}</td>
-        <td align="center">{requestIndicator}</td>
+        <td align="center">
+          {capsules.map((c) => (
+            <Capsule key={c.variant} variant={c.variant} label={c.label} />
+          ))}
+        </td>
         <td align="left">{entry.artist_name}</td>
         <td align="left">
           {entry.track_title}

--- a/src/components/experiences/classic/flowsheet/EntryTable.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryTable.tsx
@@ -28,8 +28,7 @@ export default function EntryTable({
       <table cellPadding={4} cellSpacing={2} border={0} style={{ width: "100%" }}>
         <thead>
           <tr>
-            <th>Playlist</th>
-            <th>Req.</th>
+            <th>Indicators</th>
             <th style={{ width: "25%" }}>Artist</th>
             <th>Song</th>
             <th>Release</th>
@@ -59,7 +58,7 @@ export default function EntryTable({
             ))
           ) : (
             <tr>
-              <td align="center" className="text" colSpan={9}>
+              <td align="center" className="text" colSpan={8}>
                 There are currently no entries on this flowsheet.
               </td>
             </tr>
@@ -69,12 +68,12 @@ export default function EntryTable({
       <table cellPadding={4} cellSpacing={2} border={0} style={{ width: "100%" }}>
         <tbody>
           <tr style={{ backgroundColor: "#FFFFFF" }}>
-            <td colSpan={6} align="center" className="redlabel">
+            <td colSpan={5} align="center" className="redlabel">
               &nbsp;
             </td>
           </tr>
           <tr style={{ backgroundColor: "#FFFFFF" }}>
-            <td colSpan={6} align="center" className="redlabel">
+            <td colSpan={5} align="center" className="redlabel">
               <a
                 href="#"
                 onClick={(e) => {

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import { createTestFlowsheetEntry } from "@/lib/test-utils";
+import { Rotation } from "@/lib/features/rotation/types";
+import type { FlowsheetEntry } from "@/lib/features/flowsheet/types";
+import EntryRow from "../EntryRow";
+
+// renderInTable wraps EntryRow in a <table><tbody> so the row's <td> elements
+// are mounted in a valid layout context (RTL otherwise warns).
+function renderRow(props: {
+  entry: FlowsheetEntry;
+  index?: number;
+  totalEntries?: number;
+}) {
+  return renderWithProviders(
+    <table>
+      <tbody>
+        <EntryRow
+          entry={props.entry}
+          index={props.index ?? 1}
+          totalEntries={props.totalEntries ?? 3}
+          fontSize={3}
+          onEdit={() => {}}
+          onDelete={() => {}}
+          onMoveUp={() => {}}
+          onMoveDown={() => {}}
+        />
+      </tbody>
+    </table>
+  );
+}
+
+describe("Classic EntryRow capsule indicators", () => {
+  it("renders a REQUEST capsule when request_flag=true", () => {
+    const entry = createTestFlowsheetEntry({ request_flag: true });
+    renderRow({ entry });
+    expect(screen.getByText("REQUEST")).toBeDefined();
+  });
+
+  it("does not render any capsule when no flags are set", () => {
+    const entry = createTestFlowsheetEntry({
+      request_flag: false,
+      rotation: undefined,
+      on_streaming: undefined,
+    });
+    renderRow({ entry });
+    expect(screen.queryByText("REQUEST")).toBeNull();
+    expect(screen.queryByText(/^ROTATION /)).toBeNull();
+    expect(screen.queryByText("EXCLUSIVE")).toBeNull();
+  });
+
+  it.each([
+    [Rotation.H, "ROTATION H"],
+    [Rotation.M, "ROTATION M"],
+    [Rotation.L, "ROTATION L"],
+    [Rotation.S, "ROTATION S"],
+  ])("renders a %s rotation capsule as %s", (rotation, label) => {
+    const entry = createTestFlowsheetEntry({ rotation });
+    renderRow({ entry });
+    expect(screen.getByText(label)).toBeDefined();
+  });
+
+  it("renders an EXCLUSIVE capsule when on_streaming=false", () => {
+    const entry = createTestFlowsheetEntry({ on_streaming: false });
+    renderRow({ entry });
+    expect(screen.getByText("EXCLUSIVE")).toBeDefined();
+  });
+
+  it("does not render EXCLUSIVE when on_streaming=true", () => {
+    const entry = createTestFlowsheetEntry({ on_streaming: true });
+    renderRow({ entry });
+    expect(screen.queryByText("EXCLUSIVE")).toBeNull();
+  });
+
+  it("renders REQUEST, ROTATION, and EXCLUSIVE together in that priority order", () => {
+    const entry = createTestFlowsheetEntry({
+      request_flag: true,
+      rotation: Rotation.H,
+      on_streaming: false,
+    });
+    renderRow({ entry });
+    const request = screen.getByText("REQUEST");
+    const rotation = screen.getByText("ROTATION H");
+    const exclusive = screen.getByText("EXCLUSIVE");
+    // DOM order matches priority order.
+    const order = [request, rotation, exclusive].map((el) =>
+      Array.from(document.body.querySelectorAll(".classic-capsule")).indexOf(el)
+    );
+    expect(order).toEqual([0, 1, 2]);
+  });
+
+  it("renders the indicators inside a single leftmost <td> cell", () => {
+    const entry = createTestFlowsheetEntry({ request_flag: true });
+    const { container } = renderRow({ entry });
+    const firstCell = container.querySelector("tr > td:first-child");
+    expect(firstCell).not.toBeNull();
+    expect(firstCell!.querySelector(".classic-capsule")).not.toBeNull();
+  });
+});

--- a/src/styles/classic/capsules.css
+++ b/src/styles/classic/capsules.css
@@ -29,8 +29,5 @@
   background-color: #7B2D8E;
 }
 
-html[data-experience="classic"][data-joy-color-scheme="dark"] .classic-capsule {
-  /* Capsule backgrounds are saturated enough to stay legible in dark mode;
-     no overrides needed today. Keep this selector so future dark-mode tuning
-     has an obvious anchor. */
-}
+/* Capsule backgrounds are saturated enough to stay legible in Classic's
+   dark color scheme; no dark-mode overrides needed today. */

--- a/src/styles/classic/capsules.css
+++ b/src/styles/classic/capsules.css
@@ -1,0 +1,36 @@
+/* Tubafrenzy parity: REQUEST / ROTATION X / EXCLUSIVE capsule badges.
+   Colors mirror tubafrenzy's wxyc.css: #CC0000 (request), #555 (rotation), #7B2D8E (exclusive). */
+
+.classic-capsule {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-family: Verdana, Geneva, Arial, Helvetica, sans-serif;
+  font-size: 0.7em;
+  font-weight: bold;
+  color: #FFFFFF;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.classic-capsule + .classic-capsule {
+  margin-left: 4px;
+}
+
+.classic-capsule--request {
+  background-color: #CC0000;
+}
+
+.classic-capsule--rotation {
+  background-color: #555555;
+}
+
+.classic-capsule--exclusive {
+  background-color: #7B2D8E;
+}
+
+html[data-experience="classic"][data-joy-color-scheme="dark"] .classic-capsule {
+  /* Capsule backgrounds are saturated enough to stay legible in dark mode;
+     no overrides needed today. Keep this selector so future dark-mode tuning
+     has an obvious anchor. */
+}


### PR DESCRIPTION
## Summary

- Replace the two leftmost asterisk columns (`Playlist *` / `Req *`) on the Classic live flowsheet with a single **Indicators** column rendering one or more capsule badges per row: `REQUEST` (red), `ROTATION X` where `X ∈ {H,M,L,S}` (gray), `EXCLUSIVE` (purple).
- Multiple capsules stack in priority order **REQUEST → ROTATION → EXCLUSIVE**, matching tubafrenzy.
- Driven entirely off existing `FlowsheetSongBase` fields (`request_flag`, `rotation`, `on_streaming`) — no data-model change.

Tracking parent: #511.

Closes #512.

## DJ smoke checklist

The DJ can still:
- [ ] See request flagging on a row (now as a red REQUEST capsule instead of a `*` in Req column).
- [ ] See rotation flagging on a row (now as a gray ROTATION X capsule instead of a `*` in Playlist column).
- [ ] Add a track / edit / delete / move up / move down (these affordances untouched in this PR — column count drops from 9 to 8 but no row actions changed).
- [ ] Sign off / end the show (also untouched).
- [ ] Read the talkset / breakpoint / start-of-show / end-of-show marker rows (`colSpan` rebalanced from 9 to 8 — visually identical).

## Test plan

- [x] `npx vitest run src/components/experiences/classic/flowsheet/` — 10 new tests pass.
- [x] `npx vitest run` full suite — 2709 existing tests still pass.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: open `/dashboard/flowsheet` in Classic mode and confirm capsules render correctly for a row with request, rotation, and exclusive flags. (No backing dev server in this PR run; manual smoke deferred to local + staging.)