### PR TITLE
Classic catalog: render EXCLUSIVE capsule on non-streaming releases

### DIFF
--- a/src/components/experiences/classic/catalog/SearchResults.tsx
+++ b/src/components/experiences/classic/catalog/SearchResults.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { useSearchCatalogQuery } from "@/lib/features/catalog/api";
 import { useAppSelector } from "@/lib/hooks";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
+import { Capsule } from "@/src/components/experiences/classic/flowsheet/Capsule";
 
 export default function SearchResults() {
   const searchParams = useSearchParams();
@@ -69,7 +70,15 @@ export default function SearchResults() {
           {results.map((result) => (
             <tr key={result.id} className="text">
               <td align="left">{result.album_artist ? "Various Artists" : result.artist.name}</td>
-              <td align="left">{result.title}</td>
+              <td align="left">
+                {result.title}
+                {result.on_streaming === false && (
+                  <>
+                    {" "}
+                    <Capsule variant="exclusive" label="EXCLUSIVE" />
+                  </>
+                )}
+              </td>
               <td align="left">{result.format}</td>
               <td align="left">
                 {result.artist.lettercode} {result.entry}

--- a/src/components/experiences/classic/catalog/__tests__/SearchResults.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchResults.test.tsx
@@ -54,3 +54,56 @@ describe("Classic SearchResults Various Artists display", () => {
     expect(screen.queryByText("Various Artists")).toBeNull();
   });
 });
+
+describe("Classic SearchResults EXCLUSIVE capsule", () => {
+  it("should render the EXCLUSIVE capsule on rows where on_streaming === false", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Chuquimamani-Condori", lettercode: "EL", numbercode: 12 }),
+      title: "Edits",
+      on_streaming: false,
+    });
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [album],
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithProviders(<SearchResults />);
+
+    expect(screen.getByText("EXCLUSIVE")).toBeDefined();
+  });
+
+  it("should NOT render the EXCLUSIVE capsule on rows where on_streaming === true", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Juana Molina", lettercode: "RO", numbercode: 34 }),
+      title: "DOGA",
+      on_streaming: true,
+    });
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [album],
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithProviders(<SearchResults />);
+
+    expect(screen.queryByText("EXCLUSIVE")).toBeNull();
+  });
+
+  it("should NOT render the EXCLUSIVE capsule on rows where on_streaming === undefined (unknown != off-streaming)", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Jessica Pratt", lettercode: "RO", numbercode: 55 }),
+      title: "On Your Own Love Again",
+      // on_streaming intentionally undefined — createTestAlbum's default
+    });
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [album],
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithProviders(<SearchResults />);
+
+    expect(screen.queryByText("EXCLUSIVE")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Renders an EXCLUSIVE capsule (purple `#7B2D8E`, white text) on Classic-mode card-catalog search result rows where `album.on_streaming === false`, matching tubafrenzy commit 37a4ace1 (`webapps/wxycdb/.../card-catalog-search.QDFFMJYO.js` `buildResultRow`). The capsule renders inline, trailing the album title in the same `<td>`.
- Reuses the `Capsule` component from PR 1 (`src/components/experiences/classic/flowsheet/Capsule.tsx`, `variant="exclusive"`) — no duplication, no new CSS (`.classic-capsule--exclusive` already exists in `src/styles/classic/capsules.css`).
- `undefined` and `true` both suppress the capsule. `undefined` is intentionally treated as "unknown", not "off-streaming".

Closes #514. Part of umbrella #511 (Classic-mode tubafrenzy UI sync, Jan–May 2026).

## Stacked-PR note

The base branch for this PR is **`classic-port/pr1-capsule-column`** (umbrella's PR 1), NOT `main`. PR 1 must merge first. GitHub will show only the catalog changes in the diff and the base will auto-rebase onto `main` once PR 1 lands.

## Test plan

- [x] `npx vitest run src/components/experiences/classic/catalog/` — 5/5 passing (2 existing + 3 new)
- [x] `npx vitest run src/components/experiences/classic/` — 71/71 passing across all Classic suites
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke-test in `dev`: search the catalog with a string that returns a known `on_streaming=false` release; verify the EXCLUSIVE capsule appears trailing the album title.
- [ ] Smoke-test the negative case: ensure rows for streaming releases (and rows where `on_streaming` is unknown) render without the capsule.