### PR TITLE
classic catalog: render EXCLUSIVE capsule on non-streaming releases

### DIFF
--- a/src/components/experiences/classic/catalog/SearchResults.tsx
+++ b/src/components/experiences/classic/catalog/SearchResults.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { useSearchCatalogQuery } from "@/lib/features/catalog/api";
 import { useAppSelector } from "@/lib/hooks";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
+import { Capsule } from "@/src/components/experiences/classic/flowsheet/Capsule";
 
 export default function SearchResults() {
   const searchParams = useSearchParams();
@@ -69,7 +70,15 @@ export default function SearchResults() {
           {results.map((result) => (
             <tr key={result.id} className="text">
               <td align="left">{result.album_artist ? "Various Artists" : result.artist.name}</td>
-              <td align="left">{result.title}</td>
+              <td align="left">
+                {result.title}
+                {result.on_streaming === false && (
+                  <>
+                    {" "}
+                    <Capsule variant="exclusive" label="EXCLUSIVE" />
+                  </>
+                )}
+              </td>
               <td align="left">{result.format}</td>
               <td align="left">
                 {result.artist.lettercode} {result.entry}

--- a/src/components/experiences/classic/catalog/__tests__/SearchResults.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchResults.test.tsx
@@ -54,3 +54,56 @@ describe("Classic SearchResults Various Artists display", () => {
     expect(screen.queryByText("Various Artists")).toBeNull();
   });
 });
+
+describe("Classic SearchResults EXCLUSIVE capsule", () => {
+  it("should render the EXCLUSIVE capsule on rows where on_streaming === false", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Chuquimamani-Condori", lettercode: "EL", numbercode: 12 }),
+      title: "Edits",
+      on_streaming: false,
+    });
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [album],
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithProviders(<SearchResults />);
+
+    expect(screen.getByText("EXCLUSIVE")).toBeDefined();
+  });
+
+  it("should NOT render the EXCLUSIVE capsule on rows where on_streaming === true", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Juana Molina", lettercode: "RO", numbercode: 34 }),
+      title: "DOGA",
+      on_streaming: true,
+    });
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [album],
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithProviders(<SearchResults />);
+
+    expect(screen.queryByText("EXCLUSIVE")).toBeNull();
+  });
+
+  it("should NOT render the EXCLUSIVE capsule on rows where on_streaming === undefined (unknown != off-streaming)", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Jessica Pratt", lettercode: "RO", numbercode: 55 }),
+      title: "On Your Own Love Again",
+      // on_streaming intentionally undefined — createTestAlbum's default
+    });
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [album],
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithProviders(<SearchResults />);
+
+    expect(screen.queryByText("EXCLUSIVE")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Renders an EXCLUSIVE capsule (purple `#7B2D8E`, white text) on Classic-mode card-catalog search result rows where `album.on_streaming === false`, matching tubafrenzy commit 37a4ace1. The capsule renders inline, trailing the album title in the same `<td>`.
- Reuses the `Capsule` component from PR #513 (now merged) — no duplication, no new CSS.
- `undefined` and `true` both suppress the capsule. `undefined` is intentionally treated as "unknown", not "off-streaming".

Closes #514. Part of umbrella #511.

## Note on the PR history

Originally opened as #515 stacked on #513 (`classic-port/pr1-capsule-column`). When #513 merged with branch deletion, GitHub auto-closed the dependent PR. Re-opening here with the same head branch (`classic-port/pr5-catalog-exclusive`), now targeting `main`.

## Test plan

- [x] `npx vitest run src/components/experiences/classic/catalog/` — 5/5 passing
- [x] `npx vitest run src/components/experiences/classic/` — 71/71 passing
- [x] `npx tsc --noEmit` — clean