### PR TITLE
fix(rotation): add artist override input in rotation entry mode

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -1,29 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ReactElement } from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
-import { CssVarsProvider } from "@mui/joy/styles";
+import { fireEvent, screen } from "@testing-library/react";
+import {
+  renderWithProviders,
+  createTestAlbum,
+  createTestArtist,
+} from "@/lib/test-utils";
+import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import RotationEntryFields from "./RotationEntryFields";
-import { createTestAlbum, createTestArtist } from "@/lib/test-utils/fixtures";
 
-const renderWithMuiProvider = (ui: ReactElement) =>
-  render(<CssVarsProvider>{ui}</CssVarsProvider>);
-
-// State shared across mocks so individual tests can drive behaviour
-const mockDispatch = vi.fn();
+// `useFlowsheetSearch` fans out into many RTK Query hooks (live show control,
+// bin search, catalog search, rotation search, LML). Mocking it isolates
+// RotationEntryFields at the unit-test tier — without it the test would need
+// MSW handlers for the full search surface. Real Redux still drives the
+// dispatches we care about (asserted below); only the hook's read-side is
+// mocked so we can drive the visible input value and capture writes.
+const setSearchPropertyMock = vi.fn<(name: string, value: string) => void>();
 let mockSearchQuery: Record<string, string> = {
   artist: "",
   song: "",
   album: "",
   label: "",
 };
-let mockRotationData: ReturnType<typeof createTestAlbum>[] = [];
-let mockTracksData: { position: string; title: string; duration: string | null; artists: string[] }[] | undefined = undefined;
-let mockTracksLoading = false;
-
-vi.mock("@/lib/hooks", () => ({
-  useAppDispatch: () => mockDispatch,
-  useAppSelector: () => undefined,
-}));
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
   useFlowsheetSearch: () => ({
@@ -31,31 +28,43 @@ vi.mock("@/src/hooks/flowsheetHooks", () => ({
     getDisplayValue: (name: string) => mockSearchQuery[name] ?? "",
     setSearchProperty: (name: string, value: string) => {
       mockSearchQuery[name] = value;
+      setSearchPropertyMock(name, value);
     },
     selectedIndex: 0,
     selectedEntry: null,
   }),
 }));
 
-vi.mock("@/lib/features/rotation/api", () => ({
-  useGetRotationQuery: () => ({ data: mockRotationData }),
-  useGetRotationTracksQuery: () => ({ data: mockTracksData, isLoading: mockTracksLoading }),
-}));
+// Rotation API: kept mocked at the hook level so the test doesn't need MSW
+// handlers for `/library/rotation` and `/library/rotation/:id/tracks`. The
+// hook contract is small enough to mock directly.
+let mockRotationData: ReturnType<typeof createTestAlbum>[] = [];
+let mockTracksData:
+  | { position: string; title: string; duration: string | null; artists: string[] }[]
+  | undefined = undefined;
+let mockTracksLoading = false;
 
-vi.mock("@/lib/features/flowsheet/frontend", () => ({
-  flowsheetSlice: {
-    actions: {
-      setSearchProperty: (payload: { name: string; value: string }) => ({
-        type: "flowsheet/setSearchProperty",
-        payload,
-      }),
-      setRotationMetadata: (payload: unknown) => ({
-        type: "flowsheet/setRotationMetadata",
-        payload,
-      }),
-    },
-  },
-}));
+// Partial mock: lib/store.ts imports `rotationApi` from this module for the
+// real store setup that renderWithProviders wires up. importOriginal keeps
+// that export intact while overriding the two query hooks the component uses.
+vi.mock("@/lib/features/rotation/api", async () => {
+  // Keep rotationApi intact — lib/store.ts consumes it for the real store
+  // that renderWithProviders wires up. Override only the two query hooks
+  // the component reads. Returning a minimal {data, isLoading} subset (vs.
+  // the full UseQueryHookResult) is fine because the component never reads
+  // refetch / fulfilledTimeStamp / etc.
+  const actual = await vi.importActual<typeof import("@/lib/features/rotation/api")>(
+    "@/lib/features/rotation/api"
+  );
+  return {
+    ...actual,
+    useGetRotationQuery: () => ({ data: mockRotationData }),
+    useGetRotationTracksQuery: () => ({
+      data: mockTracksData,
+      isLoading: mockTracksLoading,
+    }),
+  };
+});
 
 const lightningBoltOoioo = createTestAlbum({
   id: 7,
@@ -65,6 +74,14 @@ const lightningBoltOoioo = createTestAlbum({
   rotation_id: 42,
   rotation_bin: "H",
 });
+
+const selectBinAndRelease = () => {
+  fireEvent.click(screen.getByRole("radio", { name: "H" }));
+  fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+  fireEvent.click(
+    screen.getByTestId(`rotation-release-option-${lightningBoltOoioo.id}`)
+  );
+};
 
 describe("RotationEntryFields", () => {
   beforeEach(() => {
@@ -76,18 +93,14 @@ describe("RotationEntryFields", () => {
   });
 
   it("does not render the artist input before a release is selected", () => {
-    renderWithMuiProvider(<RotationEntryFields disabled={false} />);
-    expect(screen.queryByTestId("flowsheet-search-artist")).not.toBeInTheDocument();
+    renderWithProviders(<RotationEntryFields disabled={false} />);
+    expect(
+      screen.queryByTestId("flowsheet-search-artist")
+    ).not.toBeInTheDocument();
   });
 
-  const selectBinAndRelease = () => {
-    fireEvent.click(screen.getByRole("radio", { name: "H" }));
-    fireEvent.click(screen.getByTestId("rotation-release-trigger"));
-    fireEvent.click(screen.getByTestId(`rotation-release-option-${lightningBoltOoioo.id}`));
-  };
-
   it("renders an editable artist input once a release is selected", () => {
-    renderWithMuiProvider(<RotationEntryFields disabled={false} />);
+    renderWithProviders(<RotationEntryFields disabled={false} />);
     selectBinAndRelease();
 
     const artistInput = screen.getByTestId("flowsheet-search-artist");
@@ -96,26 +109,44 @@ describe("RotationEntryFields", () => {
   });
 
   it("seeds the artist input with the release's primary artist", () => {
-    renderWithMuiProvider(<RotationEntryFields disabled={false} />);
+    // Assert against the *real* action creator so the test catches drift if
+    // the slice ever renames the action or reshapes the payload.
+    const { store } = renderWithProviders(
+      <RotationEntryFields disabled={false} />
+    );
+    const dispatchSpy = vi.spyOn(store, "dispatch");
+
     selectBinAndRelease();
 
-    // handleSelectRelease dispatches setSearchProperty with the release artist.
-    expect(mockDispatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "flowsheet/setSearchProperty",
-        payload: { name: "artist", value: "OOIOO" },
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      flowsheetSlice.actions.setSearchProperty({
+        name: "artist",
+        value: "OOIOO",
       })
     );
   });
 
   it("lets the DJ override the seeded artist (split release case)", () => {
-    renderWithMuiProvider(<RotationEntryFields disabled={false} />);
+    renderWithProviders(<RotationEntryFields disabled={false} />);
     selectBinAndRelease();
 
-    const artistInput = screen.getByTestId("flowsheet-search-artist") as HTMLInputElement;
+    const artistInput = screen.getByTestId("flowsheet-search-artist");
     fireEvent.change(artistInput, { target: { value: "Lightning Bolt" } });
 
-    // The mocked setSearchProperty stores via the same shape as the real hook.
-    expect(mockSearchQuery.artist).toBe("Lightning Bolt");
+    expect(setSearchPropertyMock).toHaveBeenCalledWith(
+      "artist",
+      "Lightning Bolt"
+    );
+  });
+
+  it("propagates the disabled prop to the artist input", () => {
+    const { rerender } = renderWithProviders(
+      <RotationEntryFields disabled={false} />
+    );
+    selectBinAndRelease();
+    expect(screen.getByTestId("flowsheet-search-artist")).not.toBeDisabled();
+
+    rerender(<RotationEntryFields disabled={true} />);
+    expect(screen.getByTestId("flowsheet-search-artist")).toBeDisabled();
   });
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ReactElement } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CssVarsProvider } from "@mui/joy/styles";
+import RotationEntryFields from "./RotationEntryFields";
+import { createTestAlbum, createTestArtist } from "@/lib/test-utils/fixtures";
+
+const renderWithMuiProvider = (ui: ReactElement) =>
+  render(<CssVarsProvider>{ui}</CssVarsProvider>);
+
+// State shared across mocks so individual tests can drive behaviour
+const mockDispatch = vi.fn();
+let mockSearchQuery: Record<string, string> = {
+  artist: "",
+  song: "",
+  album: "",
+  label: "",
+};
+let mockRotationData: ReturnType<typeof createTestAlbum>[] = [];
+let mockTracksData: { position: string; title: string; duration: string | null; artists: string[] }[] | undefined = undefined;
+let mockTracksLoading = false;
+
+vi.mock("@/lib/hooks", () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: () => undefined,
+}));
+
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useFlowsheetSearch: () => ({
+    setSearchOpen: vi.fn(),
+    getDisplayValue: (name: string) => mockSearchQuery[name] ?? "",
+    setSearchProperty: (name: string, value: string) => {
+      mockSearchQuery[name] = value;
+    },
+    selectedIndex: 0,
+    selectedEntry: null,
+  }),
+}));
+
+vi.mock("@/lib/features/rotation/api", () => ({
+  useGetRotationQuery: () => ({ data: mockRotationData }),
+  useGetRotationTracksQuery: () => ({ data: mockTracksData, isLoading: mockTracksLoading }),
+}));
+
+vi.mock("@/lib/features/flowsheet/frontend", () => ({
+  flowsheetSlice: {
+    actions: {
+      setSearchProperty: (payload: { name: string; value: string }) => ({
+        type: "flowsheet/setSearchProperty",
+        payload,
+      }),
+      setRotationMetadata: (payload: unknown) => ({
+        type: "flowsheet/setRotationMetadata",
+        payload,
+      }),
+    },
+  },
+}));
+
+const lightningBoltOoioo = createTestAlbum({
+  id: 7,
+  title: "OOIOO / Lightning Bolt Split",
+  artist: createTestArtist({ name: "OOIOO" }),
+  label: "Load Records",
+  rotation_id: 42,
+  rotation_bin: "H",
+});
+
+describe("RotationEntryFields", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchQuery = { artist: "", song: "", album: "", label: "" };
+    mockRotationData = [lightningBoltOoioo];
+    mockTracksData = undefined;
+    mockTracksLoading = false;
+  });
+
+  it("does not render the artist input before a release is selected", () => {
+    renderWithMuiProvider(<RotationEntryFields disabled={false} />);
+    expect(screen.queryByTestId("flowsheet-search-artist")).not.toBeInTheDocument();
+  });
+
+  const selectBinAndRelease = () => {
+    fireEvent.click(screen.getByRole("radio", { name: "H" }));
+    fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+    fireEvent.click(screen.getByTestId(`rotation-release-option-${lightningBoltOoioo.id}`));
+  };
+
+  it("renders an editable artist input once a release is selected", () => {
+    renderWithMuiProvider(<RotationEntryFields disabled={false} />);
+    selectBinAndRelease();
+
+    const artistInput = screen.getByTestId("flowsheet-search-artist");
+    expect(artistInput).toBeInTheDocument();
+    expect(artistInput).not.toHaveAttribute("readonly");
+  });
+
+  it("seeds the artist input with the release's primary artist", () => {
+    renderWithMuiProvider(<RotationEntryFields disabled={false} />);
+    selectBinAndRelease();
+
+    // handleSelectRelease dispatches setSearchProperty with the release artist.
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "flowsheet/setSearchProperty",
+        payload: { name: "artist", value: "OOIOO" },
+      })
+    );
+  });
+
+  it("lets the DJ override the seeded artist (split release case)", () => {
+    renderWithMuiProvider(<RotationEntryFields disabled={false} />);
+    selectBinAndRelease();
+
+    const artistInput = screen.getByTestId("flowsheet-search-artist") as HTMLInputElement;
+    fireEvent.change(artistInput, { target: { value: "Lightning Bolt" } });
+
+    // The mocked setSearchProperty stores via the same shape as the real hook.
+    expect(mockSearchQuery.artist).toBe("Lightning Bolt");
+  });
+});

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -127,6 +127,17 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
           suppressHydrationWarning
         />
       )}
+      {selectedRelease && (
+        <>
+          <Divider orientation="vertical" />
+          <FlowsheetSearchInput
+            name="artist"
+            disabled={disabled}
+            required
+            suppressHydrationWarning
+          />
+        </>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary

- Renders an editable `FlowsheetSearchInput name="artist"` in `RotationEntryFields` once a release is selected. Defaults to the release's primary artist (already seeded via `setSearchProperty` in `handleSelectRelease`), but DJs can override for split releases (e.g. OOIOO / Lightning Bolt) or mis-credited rotation entries.
- Because `selectedIndex` stays at `0` in rotation mode, the readonly-when-result-selected logic in `FlowsheetSearchInput` does not engage — the field is free-form, matching what the legacy tubafrenzy flowsheet does after WXYC/tubafrenzy#365.
- Adds a new ` RotationEntryFields.test.tsx` covering: input absent before release selection; input present + editable after; default seeded from the release artist; override flows through to the search query.

Closes #518

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx`
- [x] `npx vitest run --changed origin/main` (mirrors CI scoping)
- [ ] Manual: enter rotation mode, pick a bin and release, override the artist, submit — verify the override (not the release artist) lands in the flowsheet entry.