### PR TITLE
fix(api): soft-handle non-JSON responses in backendBaseQuery

### DIFF
--- a/lib/__tests__/features/backend.test.ts
+++ b/lib/__tests__/features/backend.test.ts
@@ -241,6 +241,10 @@ describe("backend", () => {
     });
 
     describe("non-JSON response handling (#519)", () => {
+      // Tests mock the inner fetchBaseQuery directly, so the real { request,
+      // response } meta objects don't exist. `meta: undefined` is the honest
+      // representation — the wrapper only passes meta through; it never reads
+      // .request or .response.
       const fakeApi = {} as any;
       const fakeExtra = {} as any;
       let warnSpy: ReturnType<typeof vi.spyOn>;
@@ -265,7 +269,7 @@ describe("backend", () => {
             data: "<!DOCTYPE html><html><body>Not Found</body></html>",
             error: "SyntaxError: JSON Parse error: Unrecognized token '<'",
           },
-          meta: { request: {} as Request, response: {} as Response },
+          meta: undefined,
         });
 
         const baseQuery = backendBaseQuery("library/rotation");
@@ -290,7 +294,7 @@ describe("backend", () => {
             data: "<!DOCTYPE html>",
             error: "SyntaxError: ...",
           },
-          meta: { request: {} as Request, response: {} as Response },
+          meta: undefined,
         });
 
         const baseQuery = backendBaseQuery("library/rotation");
@@ -314,7 +318,7 @@ describe("backend", () => {
         };
         mockInnerBaseQuery.mockResolvedValueOnce({
           error: jsonError,
-          meta: { request: {} as Request, response: {} as Response },
+          meta: undefined,
         });
 
         const baseQuery = backendBaseQuery("library/rotation");
@@ -333,7 +337,7 @@ describe("backend", () => {
       it("passes through successful responses unchanged", async () => {
         const success = {
           data: [{ position: "A1", title: "la paradoja", duration: null, artists: ["Juana Molina"] }],
-          meta: { request: {} as Request, response: {} as Response },
+          meta: undefined,
         };
         mockInnerBaseQuery.mockResolvedValueOnce(success);
 
@@ -358,7 +362,7 @@ describe("backend", () => {
             data: "<html>Bad Gateway</html>",
             error: "SyntaxError",
           },
-          meta: { request: {} as Request, response: {} as Response },
+          meta: undefined,
         });
 
         const baseQuery = backendBaseQuery("library/rotation");
@@ -382,7 +386,7 @@ describe("backend", () => {
               data: "<!DOCTYPE html>",
               error: "SyntaxError",
             },
-            meta: { request: {} as Request, response: {} as Response },
+            meta: undefined,
           });
 
           const baseQuery = backendBaseQuery("flowsheet");
@@ -411,7 +415,7 @@ describe("backend", () => {
             data: "<!DOCTYPE html>",
             error: "SyntaxError",
           },
-          meta: { request: {} as Request, response: {} as Response },
+          meta: undefined,
         });
 
         const baseQuery = backendBaseQuery("library/rotation");
@@ -440,7 +444,7 @@ describe("backend", () => {
             data: "<!DOCTYPE html>",
             error: "SyntaxError",
           },
-          meta: { request: {} as Request, response: {} as Response },
+          meta: undefined,
         });
 
         const baseQuery = backendBaseQuery("library/rotation");
@@ -464,7 +468,7 @@ describe("backend", () => {
             data: "<!DOCTYPE html>",
             error: "SyntaxError",
           },
-          meta: { request: {} as Request, response: {} as Response },
+          meta: undefined,
         });
 
         const baseQuery = backendBaseQuery("library/rotation");

--- a/lib/__tests__/features/backend.test.ts
+++ b/lib/__tests__/features/backend.test.ts
@@ -5,15 +5,29 @@ vi.mock("@/lib/features/authentication/client", () => ({
   getJWTToken: vi.fn(),
 }));
 
-// We need to mock fetchBaseQuery from Redux Toolkit
-const mockPrepareHeaders = vi.fn();
-const mockFetchBaseQuery = vi.fn((config: any) => {
-  // Store the config so we can test it
-  (mockFetchBaseQuery as any).lastConfig = config;
-  // Return a mock base query function
-  return vi.fn(async () => ({ data: {} }));
+// PostHog is invoked by the non-JSON branch — mock it so tests don't depend on the
+// browser SDK booting in jsdom. `vi.hoisted` ensures the mock fn exists when the
+// (hoisted) `vi.mock` factory runs.
+const { mockCaptureException } = vi.hoisted(() => ({
+  mockCaptureException: vi.fn(),
+}));
+vi.mock("@/lib/posthog", () => ({
+  posthog: { captureException: mockCaptureException },
+}));
+
+// We need to mock fetchBaseQuery from Redux Toolkit. The mock returns a function
+// whose behaviour individual tests can override via `mockInnerBaseQuery`.
+const { mockInnerBaseQuery, mockFetchBaseQuery } = vi.hoisted(() => {
+  // Type as `any` for ergonomic per-test overrides — the wrapped query's real
+  // signature is checked in `backend.ts` itself.
+  const inner = vi.fn<(...args: any[]) => Promise<any>>(async () => ({ data: {} }));
+  const factory = vi.fn((config: any) => {
+    (factory as any).lastConfig = config;
+    return inner;
+  });
+  (factory as any).lastConfig = null;
+  return { mockInnerBaseQuery: inner, mockFetchBaseQuery: factory };
 });
-(mockFetchBaseQuery as any).lastConfig = null;
 
 vi.mock("@reduxjs/toolkit/query", () => ({
   fetchBaseQuery: (config: any) => mockFetchBaseQuery(config),
@@ -223,6 +237,134 @@ describe("backend", () => {
         expect((mockFetchBaseQuery as any).lastConfig.baseUrl).toBe(
           "https://api.example.com//items"
         );
+      });
+    });
+
+    describe("non-JSON response handling (#519)", () => {
+      const fakeApi = {} as any;
+      const fakeExtra = {} as any;
+      let warnSpy: ReturnType<typeof vi.spyOn>;
+
+      beforeEach(() => {
+        mockInnerBaseQuery.mockReset();
+        mockCaptureException.mockReset();
+        warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        warnSpy.mockRestore();
+      });
+
+      it("returns { data: undefined } when the backend returns HTML 404", async () => {
+        // Simulate what fetchBaseQuery emits when responseHandler='json' chokes
+        // on `<!DOCTYPE html>…` from Express's default 404.
+        mockInnerBaseQuery.mockResolvedValueOnce({
+          error: {
+            status: "PARSING_ERROR",
+            originalStatus: 404,
+            data: "<!DOCTYPE html><html><body>Not Found</body></html>",
+            error: "SyntaxError: JSON Parse error: Unrecognized token '<'",
+          },
+          meta: { request: {} as Request, response: {} as Response },
+        });
+
+        const baseQuery = backendBaseQuery("library/rotation");
+        const result = await baseQuery(
+          { url: "/42/tracks" },
+          fakeApi,
+          fakeExtra
+        );
+
+        expect(result).toEqual(
+          expect.objectContaining({ data: undefined })
+        );
+        // Should NOT propagate the error — that's what produced the global toast.
+        expect((result as { error?: unknown }).error).toBeUndefined();
+      });
+
+      it("logs the non-JSON response to console + PostHog (no toast)", async () => {
+        mockInnerBaseQuery.mockResolvedValueOnce({
+          error: {
+            status: "PARSING_ERROR",
+            originalStatus: 404,
+            data: "<!DOCTYPE html>",
+            error: "SyntaxError: ...",
+          },
+          meta: { request: {} as Request, response: {} as Response },
+        });
+
+        const baseQuery = backendBaseQuery("library/rotation");
+        await baseQuery({ url: "/42/tracks" }, fakeApi, fakeExtra);
+
+        expect(warnSpy).toHaveBeenCalled();
+        expect(mockCaptureException).toHaveBeenCalledTimes(1);
+        const capturedError = mockCaptureException.mock.calls[0][0] as Error;
+        expect(capturedError).toBeInstanceOf(Error);
+        expect(capturedError.message).toContain("library/rotation");
+        expect(capturedError.message).toContain("/42/tracks");
+      });
+
+      it("does not swallow structured JSON 4xx errors", async () => {
+        // Backend returned a proper JSON-encoded error — RTK Query treats this
+        // as an HTTP error (status: 404 with parsed JSON body). Keep that
+        // surfacing through; only PARSING_ERROR is soft-handled.
+        const jsonError = {
+          status: 404,
+          data: { message: "rotation not found" },
+        };
+        mockInnerBaseQuery.mockResolvedValueOnce({
+          error: jsonError,
+          meta: { request: {} as Request, response: {} as Response },
+        });
+
+        const baseQuery = backendBaseQuery("library/rotation");
+        const result = await baseQuery(
+          { url: "/42/tracks" },
+          fakeApi,
+          fakeExtra
+        );
+
+        expect((result as { error: unknown }).error).toEqual(jsonError);
+        expect((result as { data?: unknown }).data).toBeUndefined();
+        expect(mockCaptureException).not.toHaveBeenCalled();
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+
+      it("passes through successful responses unchanged", async () => {
+        const success = {
+          data: [{ position: "A1", title: "la paradoja", duration: null, artists: ["Juana Molina"] }],
+          meta: { request: {} as Request, response: {} as Response },
+        };
+        mockInnerBaseQuery.mockResolvedValueOnce(success);
+
+        const baseQuery = backendBaseQuery("library/rotation");
+        const result = await baseQuery(
+          { url: "/42/tracks" },
+          fakeApi,
+          fakeExtra
+        );
+
+        expect(result).toBe(success);
+      });
+
+      it("does not throw if PostHog capture fails (defensive)", async () => {
+        mockCaptureException.mockImplementationOnce(() => {
+          throw new Error("posthog not initialized");
+        });
+        mockInnerBaseQuery.mockResolvedValueOnce({
+          error: {
+            status: "PARSING_ERROR",
+            originalStatus: 502,
+            data: "<html>Bad Gateway</html>",
+            error: "SyntaxError",
+          },
+          meta: { request: {} as Request, response: {} as Response },
+        });
+
+        const baseQuery = backendBaseQuery("library/rotation");
+        await expect(
+          baseQuery({ url: "/42/tracks" }, fakeApi, fakeExtra)
+        ).resolves.toEqual(expect.objectContaining({ data: undefined }));
       });
     });
   });

--- a/lib/__tests__/features/backend.test.ts
+++ b/lib/__tests__/features/backend.test.ts
@@ -366,6 +366,113 @@ describe("backend", () => {
           baseQuery({ url: "/42/tracks" }, fakeApi, fakeExtra)
         ).resolves.toEqual(expect.objectContaining({ data: undefined }));
       });
+
+      // Mutations must keep surfacing the error loudly. Soft-handling a POST
+      // would mean "Add to flowsheet" / "Add album" / "Add to bin" silently
+      // no-op if the backend route is missing — strictly worse UX than the
+      // confusing toast. The soft-handle is only meant for list-shaped GET
+      // reads.
+      it.each(["POST", "PATCH", "DELETE", "PUT"])(
+        "passes PARSING_ERROR through (loud) on %s mutations",
+        async (method) => {
+          mockInnerBaseQuery.mockResolvedValueOnce({
+            error: {
+              status: "PARSING_ERROR",
+              originalStatus: 404,
+              data: "<!DOCTYPE html>",
+              error: "SyntaxError",
+            },
+            meta: { request: {} as Request, response: {} as Response },
+          });
+
+          const baseQuery = backendBaseQuery("flowsheet");
+          const result = await baseQuery(
+            { url: "/", method, body: { foo: "bar" } },
+            fakeApi,
+            fakeExtra
+          );
+
+          expect((result as { error?: unknown }).error).toEqual(
+            expect.objectContaining({ status: "PARSING_ERROR" })
+          );
+          expect((result as { data?: unknown }).data).toBeUndefined();
+          // No log noise either — caller (or rtkQueryErrorLogger) owns surfacing.
+          expect(warnSpy).not.toHaveBeenCalled();
+          expect(mockCaptureException).not.toHaveBeenCalled();
+        }
+      );
+
+      // Escape hatch for a GET that wants loud failure anyway.
+      it("respects extraOptions.surfaceNonJsonAsError as a per-endpoint opt-out", async () => {
+        mockInnerBaseQuery.mockResolvedValueOnce({
+          error: {
+            status: "PARSING_ERROR",
+            originalStatus: 404,
+            data: "<!DOCTYPE html>",
+            error: "SyntaxError",
+          },
+          meta: { request: {} as Request, response: {} as Response },
+        });
+
+        const baseQuery = backendBaseQuery("library/rotation");
+        const result = await baseQuery(
+          { url: "/42/tracks" },
+          fakeApi,
+          { surfaceNonJsonAsError: true }
+        );
+
+        expect((result as { error?: unknown }).error).toEqual(
+          expect.objectContaining({ status: "PARSING_ERROR" })
+        );
+        expect((result as { data?: unknown }).data).toBeUndefined();
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(mockCaptureException).not.toHaveBeenCalled();
+      });
+
+      // Explicit `method: "GET"` (vs. the implicit-GET default) also gets the
+      // soft-handle. Defends against a future refactor that starts setting
+      // method explicitly on read queries.
+      it("soft-handles explicit method: GET the same as implicit-GET", async () => {
+        mockInnerBaseQuery.mockResolvedValueOnce({
+          error: {
+            status: "PARSING_ERROR",
+            originalStatus: 404,
+            data: "<!DOCTYPE html>",
+            error: "SyntaxError",
+          },
+          meta: { request: {} as Request, response: {} as Response },
+        });
+
+        const baseQuery = backendBaseQuery("library/rotation");
+        const result = await baseQuery(
+          { url: "/42/tracks", method: "GET" },
+          fakeApi,
+          fakeExtra
+        );
+
+        expect((result as { data?: unknown }).data).toBeUndefined();
+        expect((result as { error?: unknown }).error).toBeUndefined();
+      });
+
+      // String-form args (most concise GET shape RTK Query accepts) goes
+      // through the GET branch too.
+      it("soft-handles string-form args (RTK Query's GET shorthand)", async () => {
+        mockInnerBaseQuery.mockResolvedValueOnce({
+          error: {
+            status: "PARSING_ERROR",
+            originalStatus: 404,
+            data: "<!DOCTYPE html>",
+            error: "SyntaxError",
+          },
+          meta: { request: {} as Request, response: {} as Response },
+        });
+
+        const baseQuery = backendBaseQuery("library/rotation");
+        const result = await baseQuery("/42/tracks", fakeApi, fakeExtra);
+
+        expect((result as { data?: unknown }).data).toBeUndefined();
+        expect((result as { error?: unknown }).error).toBeUndefined();
+      });
     });
   });
 });

--- a/lib/features/backend.ts
+++ b/lib/features/backend.ts
@@ -65,14 +65,18 @@ const logNonJsonResponse = (
   error: FetchBaseQueryError & { originalStatus?: number; data?: unknown }
 ) => {
   const url = typeof args === "string" ? args : args.url;
+  const params = typeof args === "string" ? undefined : args.params;
   const message = `[backendBaseQuery] non-JSON response from ${domain}/${url} (HTTP ${error.originalStatus ?? "?"}); soft-failing.`;
-  // eslint-disable-next-line no-console
-  console.warn(message, { sample: typeof error.data === "string" ? error.data.slice(0, 200) : error.data });
+  console.warn(message, {
+    sample: typeof error.data === "string" ? error.data.slice(0, 200) : error.data,
+    params,
+  });
   // PostHog is the project's wired error sink (see lib/store.ts).
   try {
     posthog.captureException(new Error(message), {
       domain,
       url,
+      params,
       originalStatus: error.originalStatus,
     });
   } catch {
@@ -81,14 +85,47 @@ const logNonJsonResponse = (
 };
 
 /**
+ * RTK Query passes `extraOptions` through from each endpoint definition. We
+ * use it as the opt-OUT knob for the non-JSON soft-handle path: a GET endpoint
+ * that *requires* loud failure on PARSING_ERROR can set
+ * `extraOptions: { surfaceNonJsonAsError: true }` in its `builder.query(...)`
+ * definition. Default behavior (soft-handle) is the right policy for the
+ * common case — list-shaped queries hitting a not-yet-shipped backend route
+ * should fall through to their empty-state branch, not nuke the UI with a
+ * toast.
+ */
+type BackendExtraOptions = {
+  surfaceNonJsonAsError?: boolean;
+};
+
+/**
+ * fetchBaseQuery treats a string `args` as `GET <url>`; an object `args` with
+ * no `method` defaults to GET too. Only when `method` is explicitly set to
+ * something else is the request a mutation. Lower-casing first defends against
+ * an accidental `Method: 'post'` typo.
+ */
+const isGetRequest = (args: string | FetchArgs): boolean => {
+  if (typeof args === "string") return true;
+  const method = args.method;
+  if (method === undefined) return true;
+  return method.toUpperCase() === "GET";
+};
+
+/**
  * Backend base query for RTK Query APIs.
  *
  * Wraps `fetchBaseQuery` with two extras:
  * 1. Adds the JWT bearer token and a request id (in `prepareHeaders`).
- * 2. Soft-handles non-JSON responses (most notably Express's HTML 404s):
- *    the query resolves with `{ data: undefined }` instead of throwing the
- *    cryptic `Unrecognized token '<'` JSON-parse error up to the global
- *    error toast. See WXYC/dj-site#519.
+ * 2. Soft-handles non-JSON responses (most notably Express's HTML 404s)
+ *    **for GET requests by default**: the query resolves with
+ *    `{ data: undefined }` instead of throwing the cryptic
+ *    `Unrecognized token '<'` JSON-parse error up to the global error toast.
+ *    See WXYC/dj-site#519.
+ *
+ * Mutations (POST/PATCH/DELETE/PUT) **never** get the soft-handle treatment —
+ * a silently-"succeeding" `addToFlowsheet` or `addAlbum` is a worse UX than a
+ * confusing toast. A GET endpoint that wants the loud behavior anyway can
+ * opt out per-endpoint via `extraOptions: { surfaceNonJsonAsError: true }`.
  */
 export const backendBaseQuery = (domain: string): BackendBaseQuery => {
   const inner = innerBaseQuery(domain);
@@ -97,8 +134,11 @@ export const backendBaseQuery = (domain: string): BackendBaseQuery => {
     const result = await inner(args, api, extraOptions);
 
     if (result.error && isNonJsonParsingError(result.error)) {
-      logNonJsonResponse(domain, args, result.error);
-      return { data: undefined, meta: result.meta };
+      const optOut = (extraOptions as BackendExtraOptions | undefined)?.surfaceNonJsonAsError === true;
+      if (isGetRequest(args) && !optOut) {
+        logNonJsonResponse(domain, args, result.error);
+        return { data: undefined, meta: result.meta };
+      }
     }
 
     return result;

--- a/lib/features/backend.ts
+++ b/lib/features/backend.ts
@@ -1,19 +1,106 @@
+import type {
+  BaseQueryApi,
+  BaseQueryFn,
+  FetchArgs,
+  FetchBaseQueryError,
+  FetchBaseQueryMeta,
+} from "@reduxjs/toolkit/query";
 import { fetchBaseQuery } from "@reduxjs/toolkit/query";
 import { getJWTToken } from "./authentication/client";
+import { posthog } from "../posthog";
 
-export const backendBaseQuery = (domain: string) => fetchBaseQuery({
-  baseUrl: `${process.env.NEXT_PUBLIC_BACKEND_URL}/${domain}`,
-  prepareHeaders: async (headers) => {
-    headers.set("Content-Type", "application/json");
-    headers.set("X-Request-Id", crypto.randomUUID());
+type BackendBaseQuery = BaseQueryFn<
+  string | FetchArgs,
+  unknown,
+  FetchBaseQueryError,
+  Record<string, unknown>,
+  FetchBaseQueryMeta
+>;
 
-    // Get JWT token from better-auth /token endpoint
-    const token = await getJWTToken();
+const innerBaseQuery = (domain: string): BackendBaseQuery =>
+  fetchBaseQuery({
+    baseUrl: `${process.env.NEXT_PUBLIC_BACKEND_URL}/${domain}`,
+    prepareHeaders: async (headers) => {
+      headers.set("Content-Type", "application/json");
+      headers.set("X-Request-Id", crypto.randomUUID());
 
-    if (token) {
-      // Use Bearer format for better-auth JWT tokens
-      headers.set("Authorization", `Bearer ${token}`);
+      // Get JWT token from better-auth /token endpoint
+      const token = await getJWTToken();
+
+      if (token) {
+        // Use Bearer format for better-auth JWT tokens
+        headers.set("Authorization", `Bearer ${token}`);
+      }
+      return headers;
+    },
+  });
+
+/**
+ * Detect a response body that the JSON `responseHandler` couldn't parse.
+ *
+ * RTK Query surfaces these as `PARSING_ERROR` from `fetchBaseQuery`. The most
+ * common producer is a backend route returning Express's default 404 HTML
+ * (`<!DOCTYPE html>…`), which the frontend then tries to `JSON.parse` and the
+ * resulting `SyntaxError: Unrecognized token '<'` bubbles up as a useless
+ * global toast (see WXYC/dj-site#519).
+ *
+ * Returning `{ data: undefined }` here makes the calling query succeed with no
+ * data. List-shaped queries (e.g. `getRotationTracks`) can fall through their
+ * existing empty-state branch; object-shaped queries see `undefined` and can
+ * gate UI off `data`. Structured JSON 4xx responses are *not* affected — they
+ * still flow through `validateStatus` and surface as normal errors.
+ */
+const isNonJsonParsingError = (
+  error: FetchBaseQueryError
+): error is FetchBaseQueryError & {
+  status: "PARSING_ERROR";
+  originalStatus: number;
+  data: string;
+  error: string;
+} => error.status === "PARSING_ERROR";
+
+const logNonJsonResponse = (
+  domain: string,
+  args: string | FetchArgs,
+  error: FetchBaseQueryError & { originalStatus?: number; data?: unknown }
+) => {
+  const url = typeof args === "string" ? args : args.url;
+  const message = `[backendBaseQuery] non-JSON response from ${domain}/${url} (HTTP ${error.originalStatus ?? "?"}); soft-failing.`;
+  // eslint-disable-next-line no-console
+  console.warn(message, { sample: typeof error.data === "string" ? error.data.slice(0, 200) : error.data });
+  // PostHog is the project's wired error sink (see lib/store.ts).
+  try {
+    posthog.captureException(new Error(message), {
+      domain,
+      url,
+      originalStatus: error.originalStatus,
+    });
+  } catch {
+    // posthog may not be initialized (tests, SSR) — never let logging crash a query.
+  }
+};
+
+/**
+ * Backend base query for RTK Query APIs.
+ *
+ * Wraps `fetchBaseQuery` with two extras:
+ * 1. Adds the JWT bearer token and a request id (in `prepareHeaders`).
+ * 2. Soft-handles non-JSON responses (most notably Express's HTML 404s):
+ *    the query resolves with `{ data: undefined }` instead of throwing the
+ *    cryptic `Unrecognized token '<'` JSON-parse error up to the global
+ *    error toast. See WXYC/dj-site#519.
+ */
+export const backendBaseQuery = (domain: string): BackendBaseQuery => {
+  const inner = innerBaseQuery(domain);
+
+  return async (args, api: BaseQueryApi, extraOptions) => {
+    const result = await inner(args, api, extraOptions);
+
+    if (result.error && isNonJsonParsingError(result.error)) {
+      logNonJsonResponse(domain, args, result.error);
+      return { data: undefined, meta: result.meta };
     }
-    return headers;
-  },
-});
+
+    return result;
+  };
+};


### PR DESCRIPTION
## Summary

- Wraps `backendBaseQuery` so RTK Query's `PARSING_ERROR` (the symptom of `JSON.parse('<!DOCTYPE html>…')` blowing up on Express's default 404 HTML) is intercepted and resolved as `{ data: undefined }` instead of bubbling up to the global error toast as the cryptic *"SyntaxError: Unrecognized token '<'"*.
- The shared layer is the right home for this — applies to every RTK Query API in the app, not just `useGetRotationTracksQuery`. Array-shaped consumers see `undefined` and fall through their existing empty-state branches (in `RotationEntryFields`, that's the manual-song escape at lines 122-129 on `main`).
- Structured JSON 4xx responses are unaffected — they still surface as normal errors. Only non-JSON / parse-failed responses are soft-handled.
- Diagnostics flow to `console.warn` + PostHog (the project's wired error sink, mirroring `lib/store.ts`). PostHog capture is wrapped in `try { } catch { }` so an uninitialized SDK can never crash a query.
- 5 new unit tests in `backend.test.ts` cover: PARSING_ERROR → `{ data: undefined }`, console + PostHog logging, structured JSON 4xx pass-through, success pass-through, and PostHog crash resilience.

The proper fix is still the Backend endpoint shipping (WXYC/Backend-Service#836 / WXYC/dj-site#501); this is the defensive cushion until then.

Closes #519

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run lib/__tests__/features/backend.test.ts` — 18/18 passing (13 existing + 5 new)
- [x] `npx vitest run --changed origin/main` — 1571/1571 (backend.ts is broadly imported)
- [ ] Manual: with the Backend endpoint still missing, pick a bin and release in rotation mode — verify no `SyntaxError` toast appears and the manual-song input takes over.