### PR TITLE
ci: finish supply-chain hardening (charset-corpus-drift permissions + gha/v1) + add runbook

### DIFF
--- a/.github/workflows/charset-corpus-drift.yml
+++ b/.github/workflows/charset-corpus-drift.yml
@@ -12,11 +12,19 @@ on:
   schedule:
     - cron: "17 8 * * 1"
 
+# Workflow-level GITHUB_TOKEN scope. The reusable workflow runs
+# `npm pack @wxyc/shared` against npm.pkg.github.com using the token
+# forwarded as `npm-token`, which needs packages:read.
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   drift:
-    uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@main
+    uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@gha/v1
     with:
       pinned-sha256: 75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a
       package-version: "0.10.0"
+      wxyc-shared-ref: gha/v1
     secrets:
       npm-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,21 @@ Runs on push to `main` and on PRs that touch app code. Spins up Backend-Service 
 
 Cloudflare Pages via OpenNext. Build: `npm run build:opennext`. Deploy: `npm run deploy` (Wrangler).
 
+### CI pin maintenance
+
+Two classes of pin in `.github/workflows/*.yml` exist for supply-chain reasons (mirrors WXYC/request-o-matic#124's free-tier hardening; see WXYC/wiki#67 for the org-wide rollout). They will bit-rot and need occasional bumps:
+
+- **Workflow-level `permissions:`** scoped to the minimum each workflow needs:
+  - `ci.yml`, `e2e-tests.yml`: `contents: read` (no GITHUB_TOKEN writes; Cloudflare deploy is owned by the Cloudflare Pages GitHub App, not this workflow).
+  - `charset-corpus-drift.yml`: `contents: read` plus `packages: read` (the reusable workflow pulls `@wxyc/shared` from `npm.pkg.github.com`).
+  - `cloudflare-deploy-status.yml`: `issues: write` only — it doesn't `actions/checkout` (just hits the Cloudflare API and creates / updates a GitHub issue), so it doesn't need `contents: read`. Don't add `contents: read` defensively; the minimal grant is the point.
+  Failure mode is silent — a job that needs a missing scope (e.g. `pull-requests: write`) fails its API call but the workflow stays green. When adding a step that needs to comment on PRs, push tags, mint releases, etc., explicitly grant the scope at the **job** level (or widen the workflow-level floor only if every job in the file needs it).
+- **Reusable-workflow refs pinned to `@gha/v1`**, not `@main` — `WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@gha/v1` (in `charset-corpus-drift.yml`). The publishing repo treats `gha/v1` as a moving major tag — re-pointed forward on non-breaking changes, frozen on breaking changes (which get a fresh `gha/v2`). Don't downgrade to `@main`; if a `gha/v2` migration arrives, follow the procedure at the top of `WXYC/wxyc-shared/CLAUDE.md` "Tag Stability Policy".
+
+Run `actionlint .github/workflows/*.yml` locally before pushing workflow changes; it validates `permissions:` syntax, action-version pins, and shell-script blocks (via shellcheck), and catches the silent-mistake class of errors above before CI does.
+
+Item 4 of #124 (Railway CLI pin) does not apply — dj-site deploys to Cloudflare Pages.
+
 ## Code Conventions
 
 - **Path alias**: `@/` maps to project root (e.g., `@/lib/features/flowsheet/types`)


### PR DESCRIPTION
## Summary

Two changes:

1. **`.github/workflows/charset-corpus-drift.yml`** — add workflow-level `permissions: contents: read + packages: read` (the latter is required for the reusable workflow's `npm pack @wxyc/shared` against `npm.pkg.github.com`), and bump the `WXYC/wxyc-shared` reusable-workflow ref from `@main` to `@gha/v1` (with the `wxyc-shared-ref: gha/v1` input matching LML's idiom). The other 3 dj-site workflows had explicit permissions in `d1bd805`, but this one was missed.
2. **`CLAUDE.md` `## CI/CD`** — new `### CI pin maintenance` subsection covering the per-workflow permissions matrix (4 workflows, 3 distinct profiles), the `@gha/v1` reusable-workflow ref, the deliberate minimalism of `cloudflare-deploy-status.yml`'s `issues: write`-only block (which a defensive editor might "fix" by adding `contents: read`), and `actionlint` as the local pre-flight.

Item 4 of #124 (Railway CLI pin) is N/A — dj-site deploys to Cloudflare Pages.

## Motivation

WXYC/wiki#67 tracks the org-wide replication of WXYC/request-o-matic#124's free-tier supply-chain hardening. dj-site was mostly mechanically done (3 of 4 workflows had explicit `permissions:` after `d1bd805`), but `charset-corpus-drift.yml` had no `permissions:` block AND still floated on `@main` for the reusable workflow ref — both real gaps, not just doc gaps. The new runbook documents the rationale so the next maintainer doesn't add `contents: read` defensively to `cloudflare-deploy-status.yml` (which would break nothing but pollutes the minimal-grant principle).

Closes #525. Part of WXYC/wiki#67.

## Test plan

- [x] `actionlint .github/workflows/charset-corpus-drift.yml` clean.
- [x] `actionlint .github/workflows/*.yml` produces no NEW issues. (Pre-existing SC2086 / SC2129 / SC2046 info/warning-level shellcheck warnings in `cloudflare-deploy-status.yml` and `e2e-tests.yml` are out of scope.)
- [ ] Markdown rendering: confirm new `### CI pin maintenance` subsection appears under `## CI/CD` between `### Deployment` and `## Code Conventions`.
- [ ] CI green — including the `Charset Corpus Drift` workflow itself, which now resolves `@gha/v1` instead of `@main`.

## Related

- WXYC/wiki#67 — org-wide tracker
- WXYC/request-o-matic#124 — pattern source
- WXYC/request-o-matic#139 — rom-side runbook PR
- WXYC/library-metadata-lookup#331, WXYC/semantic-index#317, WXYC/Backend-Service#868 — sibling runbook PRs (parallel)