### PR TITLE
classic flowsheet: restyle talkset, breakpoint, and show-delimiter marker rows

### DIFF
--- a/src/components/experiences/classic/flowsheet/EntryRow.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryRow.tsx
@@ -9,7 +9,9 @@ import {
   isFlowsheetEndShowEntry,
 } from "@/lib/features/flowsheet/types";
 import { Capsule, capsulesForSongEntry } from "./Capsule";
+import { formatShortDate, formatShortTime } from "./marker-format";
 import "@/src/styles/classic/segue.css";
+import "@/src/styles/classic/markers.css";
 
 export default function EntryRow({
   entry,
@@ -44,8 +46,8 @@ export default function EntryRow({
   // (indicators + 4 data) and the row's trailing 3 columns stay empty.
   if (isFlowsheetTalksetEntry(entry)) {
     return (
-      <tr style={{ backgroundColor: "#BBBBBB" }} className={`flowsheetEntryData ${fontSizeClass}`}>
-        <td colSpan={5} align="center" className="redlabel">
+      <tr className={`flowsheetEntryData classic-marker-talkset ${fontSizeClass}`}>
+        <td colSpan={5} align="center">
           talkset
         </td>
         <td colSpan={3}>&nbsp;</td>
@@ -55,9 +57,9 @@ export default function EntryRow({
 
   if (isFlowsheetBreakpointEntry(entry)) {
     return (
-      <tr style={{ backgroundColor: "#444444" }} className={`flowsheetEntryData ${fontSizeClass}`}>
-        <td colSpan={5} align="left" className="littlegreenlabel">
-          {entry.message}
+      <tr className={`flowsheetEntryData classic-marker-breakpoint ${fontSizeClass}`}>
+        <td colSpan={5} align="center">
+          {formatShortTime(entry.time)} breakpoint
         </td>
         <td colSpan={3}>&nbsp;</td>
       </tr>
@@ -66,9 +68,10 @@ export default function EntryRow({
 
   if (isFlowsheetStartShowEntry(entry)) {
     return (
-      <tr style={{ backgroundColor: "#444444" }} className={`flowsheetEntryData ${fontSizeClass}`}>
-        <td colSpan={5} align="left" className="littlegreenlabel">
-          Start: {entry.dj_name}
+      <tr className={`flowsheetEntryData classic-marker-breakpoint ${fontSizeClass}`}>
+        <td colSpan={5} align="center">
+          Start of show — {entry.dj_name} @ {formatShortDate(entry.day)}{" "}
+          {formatShortTime(entry.time)}
         </td>
         <td colSpan={3}>&nbsp;</td>
       </tr>
@@ -77,9 +80,10 @@ export default function EntryRow({
 
   if (isFlowsheetEndShowEntry(entry)) {
     return (
-      <tr style={{ backgroundColor: "#444444" }} className={`flowsheetEntryData ${fontSizeClass}`}>
-        <td colSpan={5} align="left" className="littlegreenlabel">
-          End: {entry.dj_name}
+      <tr className={`flowsheetEntryData classic-marker-breakpoint ${fontSizeClass}`}>
+        <td colSpan={5} align="center">
+          End of show — {entry.dj_name} @ {formatShortDate(entry.day)}{" "}
+          {formatShortTime(entry.time)}
         </td>
         <td colSpan={3}>&nbsp;</td>
       </tr>

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
@@ -130,3 +130,162 @@ describe("Classic EntryRow segue indicator", () => {
     expect(container.querySelector("tr.classic-segue")).toBeNull();
   });
 });
+
+describe("Classic EntryRow markers", () => {
+  describe("talkset", () => {
+    const talksetEntry = {
+      id: 1,
+      show_id: 1,
+      play_order: 1,
+      message: "Talkset - station ID",
+    };
+
+    it("renders the lowercase word 'talkset' centered", () => {
+      const { container } = renderRow({ entry: talksetEntry });
+      const cell = container.querySelector("tr > td:first-child");
+      expect(cell).not.toBeNull();
+      expect(cell!.textContent).toBe("talkset");
+      expect(cell!.getAttribute("align")).toBe("center");
+    });
+
+    it("uses the classic-marker-talkset class on its row (background #BBBBBB)", () => {
+      const { container } = renderRow({ entry: talksetEntry });
+      const row = container.querySelector("tr");
+      expect(row).not.toBeNull();
+      expect(row!.classList.contains("classic-marker-talkset")).toBe(true);
+    });
+
+    it("does NOT use the legacy redlabel class on its cell", () => {
+      const { container } = renderRow({ entry: talksetEntry });
+      expect(container.querySelector(".redlabel")).toBeNull();
+    });
+  });
+
+  describe("breakpoint", () => {
+    const breakpointEntry = {
+      id: 2,
+      show_id: 1,
+      play_order: 2,
+      message: "Breakpoint - 5:00 PM",
+      day: "11/14/2023",
+      time: "5:00:00 PM",
+    };
+
+    it("renders '{h:mm a} breakpoint' (no seconds, lowercase suffix)", () => {
+      const { container } = renderRow({ entry: breakpointEntry });
+      const cell = container.querySelector("tr > td:first-child");
+      expect(cell).not.toBeNull();
+      expect(cell!.textContent).toBe("5:00 PM breakpoint");
+    });
+
+    it("renders content centered", () => {
+      const { container } = renderRow({ entry: breakpointEntry });
+      const cell = container.querySelector("tr > td:first-child");
+      expect(cell!.getAttribute("align")).toBe("center");
+    });
+
+    it("uses the classic-marker-breakpoint class on its row", () => {
+      const { container } = renderRow({ entry: breakpointEntry });
+      const row = container.querySelector("tr");
+      expect(row!.classList.contains("classic-marker-breakpoint")).toBe(true);
+    });
+
+    it("does NOT use the legacy littlegreenlabel class on its cell", () => {
+      const { container } = renderRow({ entry: breakpointEntry });
+      expect(container.querySelector(".littlegreenlabel")).toBeNull();
+    });
+  });
+
+  describe("start of show", () => {
+    const startEntry = {
+      id: 3,
+      show_id: 1,
+      play_order: 3,
+      dj_name: "DJ Cool",
+      isStart: true,
+      day: "11/14/2023",
+      time: "5:13:00 PM",
+    };
+
+    it("renders 'Start of show — {dj_name} @ {M/d/yy} {h:mm a}'", () => {
+      const { container } = renderRow({ entry: startEntry });
+      const cell = container.querySelector("tr > td:first-child");
+      expect(cell!.textContent).toBe(
+        "Start of show — DJ Cool @ 11/14/23 5:13 PM"
+      );
+    });
+
+    it("uses the classic-marker-breakpoint class on its row (shared #444 styling)", () => {
+      const { container } = renderRow({ entry: startEntry });
+      const row = container.querySelector("tr");
+      expect(row!.classList.contains("classic-marker-breakpoint")).toBe(true);
+    });
+  });
+
+  describe("end of show", () => {
+    const endEntry = {
+      id: 4,
+      show_id: 1,
+      play_order: 4,
+      dj_name: "DJ Cool",
+      isStart: false,
+      day: "11/14/2023",
+      time: "5:13:00 PM",
+    };
+
+    it("renders 'End of show — {dj_name} @ {M/d/yy} {h:mm a}'", () => {
+      const { container } = renderRow({ entry: endEntry });
+      const cell = container.querySelector("tr > td:first-child");
+      expect(cell!.textContent).toBe(
+        "End of show — DJ Cool @ 11/14/23 5:13 PM"
+      );
+    });
+
+    it("uses the classic-marker-breakpoint class on its row (shared #444 styling)", () => {
+      const { container } = renderRow({ entry: endEntry });
+      const row = container.querySelector("tr");
+      expect(row!.classList.contains("classic-marker-breakpoint")).toBe(true);
+    });
+  });
+
+  it.each([
+    ["11/14/2023", "5:13:00 PM", "11/14/23 5:13 PM"],
+    ["1/3/2024", "12:05:00 AM", "1/3/24 12:05 AM"],
+    ["12/31/2099", "11:59:59 PM", "12/31/99 11:59 PM"],
+  ])(
+    "formats day=%s + time=%s as '%s' in show-block markers",
+    (day, time, expected) => {
+      const { container } = renderRow({
+        entry: {
+          id: 5,
+          show_id: 1,
+          play_order: 5,
+          dj_name: "DJ Test",
+          isStart: true,
+          day,
+          time,
+        },
+      });
+      const cell = container.querySelector("tr > td:first-child");
+      expect(cell!.textContent).toBe(`Start of show — DJ Test @ ${expected}`);
+    }
+  );
+
+  it("falls back to the raw day/time strings when they don't match the expected pattern", () => {
+    const { container } = renderRow({
+      entry: {
+        id: 6,
+        show_id: 1,
+        play_order: 6,
+        dj_name: "DJ Test",
+        isStart: true,
+        day: "Unknown",
+        time: "Unknown",
+      },
+    });
+    const cell = container.querySelector("tr > td:first-child");
+    expect(cell!.textContent).toBe(
+      "Start of show — DJ Test @ Unknown Unknown"
+    );
+  });
+});

--- a/src/components/experiences/classic/flowsheet/marker-format.ts
+++ b/src/components/experiences/classic/flowsheet/marker-format.ts
@@ -1,0 +1,23 @@
+// Shortens day/time strings produced by `formatAddTime()` in
+// `lib/features/flowsheet/conversions.ts` to the tubafrenzy display form:
+//   day: "11/14/2023"   -> "11/14/23"
+//   time: "5:13:00 PM"  -> "5:13 PM"
+// Returns the input unchanged when it doesn't match the expected pattern,
+// so unknown / placeholder values pass through.
+
+const DAY_PATTERN = /^(\d{1,2})\/(\d{1,2})\/(\d{2})(\d{2})$/;
+const TIME_PATTERN = /^(\d{1,2}:\d{2}):\d{2}\s+(AM|PM)$/i;
+
+export function formatShortDate(day: string): string {
+  const match = day.match(DAY_PATTERN);
+  if (!match) return day;
+  const [, month, date, , yy] = match;
+  return `${month}/${date}/${yy}`;
+}
+
+export function formatShortTime(time: string): string {
+  const match = time.match(TIME_PATTERN);
+  if (!match) return time;
+  const [, hm, ampm] = match;
+  return `${hm} ${ampm.toUpperCase()}`;
+}

--- a/src/styles/classic/markers.css
+++ b/src/styles/classic/markers.css
@@ -1,0 +1,21 @@
+/* Tubafrenzy parity: marker row styling for talkset / breakpoint / show-delimiter
+   rows. Drops the legacy `.redlabel` / `.littlegreenlabel` classes in favor of
+   row-level classes that own background + text color together. */
+
+.classic-marker-talkset {
+  background-color: #BBBBBB;
+}
+
+.classic-marker-talkset > td {
+  font-weight: bold;
+  color: #000000;
+}
+
+.classic-marker-breakpoint {
+  background-color: #444444;
+}
+
+.classic-marker-breakpoint > td {
+  font-weight: bold;
+  color: #FFFFFF;
+}


### PR DESCRIPTION
Closes #528.

## Summary

- Talkset rows drop the legacy `.redlabel` class and render plain centered `talkset` against `#BBBBBB`.
- Breakpoint rows lose `.littlegreenlabel`, switch to centered alignment, and read `{h:mm a} breakpoint` (lowercase suffix, no seconds) on `#444` with white text.
- Start / end-of-show rows pick up the same `#444` row styling and now read `Start of show — {dj_name} @ {M/d/yy} {h:mm a}` / `End of show — …` rather than the previous `Start: {dj_name}` / `End: {dj_name}`.
- `formatShortDate` / `formatShortTime` (new co-located `marker-format.ts`) strip seconds + the century from the strings produced by `formatAddTime()` in `lib/features/flowsheet/conversions.ts`. Unparseable input falls through unchanged so `"Unknown"` placeholders still render.
- Row-level classes (`.classic-marker-talkset`, `.classic-marker-breakpoint`) own background + text color together in a new `src/styles/classic/markers.css`. The legacy `.redlabel` / `.littlegreenlabel` classes stay in place for non-flowsheet consumers.

## Tubafrenzy reference

Commit `718c9840` + `flowsheetRadioShowModify.jsp:185-199`, `FlowsheetEntry.getShowDelimiterDisplay()`.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run` — 2747 / 2747 pass (14 new tests under `Classic EntryRow markers`)
- [x] `npm run build` — production build green
- [ ] Manual: dev server + visually inspect a talkset / breakpoint / start / end row on the Classic flowsheet

## Related

- Umbrella: #511
- Predecessors: #512 (capsule column), #516 (segue indicator)