### PR TITLE
classic previous sets: replace Modern delegation with Classic-styled playlist archive

### DIFF
--- a/app/dashboard/@classic/playlists/__tests__/page.test.tsx
+++ b/app/dashboard/@classic/playlists/__tests__/page.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import * as ClassicPlaylistsPageModule from "../page";
+
+// The Classic Previous Sets page must NOT import from
+// src/components/experiences/modern/ (per the tubafrenzy-sync plan PR 4).
+describe("Classic /dashboard/playlists page", () => {
+  it("exports a default React component", () => {
+    expect(typeof ClassicPlaylistsPageModule.default).toBe("function");
+  });
+
+  it("has a Next.js Metadata export with the Previous Sets title", () => {
+    expect(ClassicPlaylistsPageModule.metadata).toBeDefined();
+    expect(ClassicPlaylistsPageModule.metadata.title).toMatch(
+      /previous sets/i
+    );
+  });
+});

--- a/app/dashboard/@classic/playlists/page.tsx
+++ b/app/dashboard/@classic/playlists/page.tsx
@@ -1,11 +1,11 @@
 import { Metadata } from "next";
 import { getPageTitle } from "@/lib/utils/page-title";
-import PlaylistSearchContainer from "@/src/components/experiences/modern/playlist-search/PlaylistSearchContainer";
+import { PreviousSetsContainer } from "@/src/components/experiences/classic/playlists";
 
 export const metadata: Metadata = {
   title: getPageTitle("Previous Sets"),
 };
 
 export default function ClassicPreviousSetsPage() {
-  return <PlaylistSearchContainer />;
+  return <PreviousSetsContainer />;
 }

--- a/src/components/experiences/classic/flowsheet/Capsule.tsx
+++ b/src/components/experiences/classic/flowsheet/Capsule.tsx
@@ -1,4 +1,4 @@
-import type { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
+import type { Rotation } from "@/lib/features/rotation/types";
 import "@/src/styles/classic/capsules.css";
 
 export type CapsuleVariant = "request" | "rotation" | "exclusive";
@@ -19,9 +19,18 @@ export function Capsule({
 
 type CapsuleSpec = { variant: CapsuleVariant; label: string };
 
+// Minimal shape needed to compute capsules — kept structural so flowsheet
+// song entries and playlist-archive search results (and any future row
+// type that carries the same flags) can share `capsulesForSongEntry`.
+export type Capsulable = {
+  request_flag?: boolean;
+  rotation?: Rotation | null;
+  on_streaming?: boolean;
+};
+
 // Capsules render in priority order: REQUEST → ROTATION → EXCLUSIVE.
 // Mirrors tubafrenzy's `flowsheetRadioShowModify.jsp` capsule ordering.
-export function capsulesForSongEntry(entry: FlowsheetSongEntry): CapsuleSpec[] {
+export function capsulesForSongEntry(entry: Capsulable): CapsuleSpec[] {
   const out: CapsuleSpec[] = [];
   if (entry.request_flag) {
     out.push({ variant: "request", label: "REQUEST" });

--- a/src/components/experiences/classic/playlists/InfiniteScroll.tsx
+++ b/src/components/experiences/classic/playlists/InfiniteScroll.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+
+// Classic-flavored intersection-observer wrapper. Mirrors Modern's
+// `PlaylistInfiniteScroll` minus the MUI Joy chrome — pure HTML + the
+// Classic .text class for messaging.
+export default function InfiniteScroll({
+  children,
+  hasMore,
+  isLoading,
+  onLoadMore,
+}: {
+  children: ReactNode;
+  hasMore: boolean;
+  isLoading: boolean;
+  onLoadMore: () => void;
+}) {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const [entry] = entries;
+        if (entry.isIntersecting && hasMore && !isLoading) {
+          onLoadMore();
+        }
+      },
+      {
+        root: null,
+        rootMargin: "100px",
+        threshold: 0,
+      }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, isLoading, onLoadMore]);
+
+  return (
+    <div className="classic-previous-sets-scroll">
+      {children}
+      <div ref={sentinelRef} style={{ height: 1, width: "100%" }} />
+      {isLoading && (
+        <div
+          className="text"
+          style={{ textAlign: "center", padding: "1em" }}
+        >
+          Loading more results...
+        </div>
+      )}
+      {!hasMore && !isLoading && (
+        <div
+          className="smalltext"
+          style={{ textAlign: "center", padding: "0.5em", color: "#888" }}
+        >
+          End of results
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/experiences/classic/playlists/InfiniteScroll.tsx
+++ b/src/components/experiences/classic/playlists/InfiniteScroll.tsx
@@ -41,7 +41,7 @@ export default function InfiniteScroll({
   }, [hasMore, isLoading, onLoadMore]);
 
   return (
-    <div className="classic-previous-sets-scroll">
+    <div>
       {children}
       <div ref={sentinelRef} style={{ height: 1, width: "100%" }} />
       {isLoading && (

--- a/src/components/experiences/classic/playlists/PreviousSetsContainer.tsx
+++ b/src/components/experiences/classic/playlists/PreviousSetsContainer.tsx
@@ -21,7 +21,11 @@ export default function PreviousSetsContainer() {
     effectiveQuery,
   } = usePlaylistSearch();
 
-  const hasQuery = effectiveQuery.trim().length >= 2;
+  // Gate the results section on the same min-query threshold the hook uses
+  // (MIN_QUERY_LENGTH = 2) so this matches Modern's container and avoids
+  // surfacing the "Searching..." / "No results" copy for sub-threshold
+  // partial inputs.
+  const hasQuery = effectiveQuery.length >= 2;
 
   return (
     <div className="classic-previous-sets">
@@ -39,12 +43,16 @@ export default function PreviousSetsContainer() {
       <SearchForm />
 
       {hasQuery && (
-        <div className="classic-previous-sets-results">
+        <>
+          {/* Loading-text gating mirrors Modern's PlaylistSearchContainer:
+              while a request is in flight, always show "Searching..." rather
+              than stale "Found N results" / "No results found" copy that
+              would flash mid-query. */}
           <p
             className="text"
             style={{ textAlign: "center", padding: "0.5em" }}
           >
-            {isLoading && results.length === 0
+            {isLoading
               ? "Searching..."
               : total > 0
               ? `Found ${total.toLocaleString()} results`
@@ -69,7 +77,7 @@ export default function PreviousSetsContainer() {
               <ResultTable results={results as PreviousSetsResult[]} />
             </InfiniteScroll>
           )}
-        </div>
+        </>
       )}
     </div>
   );

--- a/src/components/experiences/classic/playlists/PreviousSetsContainer.tsx
+++ b/src/components/experiences/classic/playlists/PreviousSetsContainer.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { usePlaylistSearch } from "@/src/hooks/playlistSearchHooks";
+import SearchForm from "./SearchForm";
+import ResultTable from "./ResultTable";
+import InfiniteScroll from "./InfiniteScroll";
+import type { PreviousSetsResult } from "./ResultRow";
+import "@/src/styles/classic/previous-sets.css";
+
+// Top-level Classic "Previous Sets" surface. Mirrors tubafrenzy's
+// `public/searchPage.jsp` + `mostRecentEntries.jsp` shape: centered title,
+// single free-form search input, 5-col results table below.
+export default function PreviousSetsContainer() {
+  const {
+    results,
+    total,
+    hasMore,
+    isLoading,
+    isError,
+    loadNextPage,
+    effectiveQuery,
+  } = usePlaylistSearch();
+
+  const hasQuery = effectiveQuery.trim().length >= 2;
+
+  return (
+    <div className="classic-previous-sets">
+      <h2 className="bigblue" style={{ textAlign: "center" }}>
+        Playlist Archive
+      </h2>
+      <p
+        className="smalltext"
+        style={{ textAlign: "center", marginBottom: "1em" }}
+      >
+        Search through WXYC playlists from November 2004 to present. Use AND,
+        OR, NOT operators and quotes for exact phrases.
+      </p>
+
+      <SearchForm />
+
+      {hasQuery && (
+        <div className="classic-previous-sets-results">
+          <p
+            className="text"
+            style={{ textAlign: "center", padding: "0.5em" }}
+          >
+            {isLoading && results.length === 0
+              ? "Searching..."
+              : total > 0
+              ? `Found ${total.toLocaleString()} results`
+              : "No results found"}
+          </p>
+
+          {isError && (
+            <p
+              className="redlabel"
+              style={{ textAlign: "center", padding: "0.5em" }}
+            >
+              An error occurred while searching. Please try again.
+            </p>
+          )}
+
+          {results.length > 0 && (
+            <InfiniteScroll
+              hasMore={hasMore}
+              isLoading={isLoading}
+              onLoadMore={loadNextPage}
+            >
+              <ResultTable results={results as PreviousSetsResult[]} />
+            </InfiniteScroll>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/experiences/classic/playlists/PreviousSetsContainer.tsx
+++ b/src/components/experiences/classic/playlists/PreviousSetsContainer.tsx
@@ -4,7 +4,6 @@ import { usePlaylistSearch } from "@/src/hooks/playlistSearchHooks";
 import SearchForm from "./SearchForm";
 import ResultTable from "./ResultTable";
 import InfiniteScroll from "./InfiniteScroll";
-import type { PreviousSetsResult } from "./ResultRow";
 import "@/src/styles/classic/previous-sets.css";
 
 // Top-level Classic "Previous Sets" surface. Mirrors tubafrenzy's
@@ -74,7 +73,10 @@ export default function PreviousSetsContainer() {
               isLoading={isLoading}
               onLoadMore={loadNextPage}
             >
-              <ResultTable results={results as PreviousSetsResult[]} />
+              {/* PreviousSetsResult only adds optional fields on top of
+                  PlaylistSearchResult, so the wider hook return type is
+                  structurally assignable to the narrower table prop. */}
+              <ResultTable results={results} />
             </InfiniteScroll>
           )}
         </>

--- a/src/components/experiences/classic/playlists/ResultRow.tsx
+++ b/src/components/experiences/classic/playlists/ResultRow.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { PlaylistSearchResult } from "@wxyc/shared/dtos";
+import type { Rotation } from "@/lib/features/rotation/types";
+import { Capsule } from "@/src/components/experiences/classic/flowsheet/Capsule";
+import "@/src/styles/classic/segue.css";
+
+// PlaylistSearchResult plus the optional flags that drive capsules + segue.
+// Backend may not yet surface every flag on every result; the row simply
+// suppresses the capsule when the corresponding field is absent.
+export type PreviousSetsResult = PlaylistSearchResult & {
+  request_flag?: boolean;
+  rotation?: Rotation;
+  on_streaming?: boolean;
+  segue?: boolean;
+};
+
+type CapsuleVariant = "request" | "rotation" | "exclusive";
+type CapsuleSpec = { variant: CapsuleVariant; label: string };
+
+// Same priority order as `capsulesForSongEntry` in the flowsheet.
+function capsulesForResult(result: PreviousSetsResult): CapsuleSpec[] {
+  const out: CapsuleSpec[] = [];
+  if (result.request_flag) {
+    out.push({ variant: "request", label: "REQUEST" });
+  }
+  if (result.rotation) {
+    out.push({
+      variant: "rotation",
+      label: `ROTATION ${result.rotation}`,
+    });
+  }
+  if (result.on_streaming === false) {
+    out.push({ variant: "exclusive", label: "EXCLUSIVE" });
+  }
+  return out;
+}
+
+export default function ResultRow({
+  result,
+  nextIsTrack,
+}: {
+  result: PreviousSetsResult;
+  nextIsTrack: boolean;
+}) {
+  const capsules = capsulesForResult(result);
+  // Mirrors EntryRow's segue logic: a segue indicator only makes sense when
+  // the next visible row is also a track. Tubafrenzy expresses the same
+  // guard via `:has(+ tr.entry-row)`.
+  const showSegue = result.segue === true && nextIsTrack;
+  const className = showSegue ? "classic-segue" : undefined;
+
+  return (
+    <tr className={className} data-segue={showSegue ? "true" : undefined}>
+      <td align="center" style={{ width: "5%" }}>
+        {capsules.map((c) => (
+          <Capsule key={c.variant} variant={c.variant} label={c.label} />
+        ))}
+      </td>
+      <td align="left" style={{ width: "25%" }}>
+        {result.artist_name}
+      </td>
+      <td align="left">{result.track_title}</td>
+      <td align="left">{result.album_title}</td>
+      <td align="left">{result.record_label}</td>
+    </tr>
+  );
+}

--- a/src/components/experiences/classic/playlists/ResultRow.tsx
+++ b/src/components/experiences/classic/playlists/ResultRow.tsx
@@ -2,7 +2,10 @@
 
 import type { PlaylistSearchResult } from "@wxyc/shared/dtos";
 import type { Rotation } from "@/lib/features/rotation/types";
-import { Capsule } from "@/src/components/experiences/classic/flowsheet/Capsule";
+import {
+  Capsule,
+  capsulesForSongEntry,
+} from "@/src/components/experiences/classic/flowsheet/Capsule";
 import "@/src/styles/classic/segue.css";
 
 // PlaylistSearchResult plus the optional flags that drive capsules + segue.
@@ -15,39 +18,23 @@ export type PreviousSetsResult = PlaylistSearchResult & {
   segue?: boolean;
 };
 
-type CapsuleVariant = "request" | "rotation" | "exclusive";
-type CapsuleSpec = { variant: CapsuleVariant; label: string };
-
-// Same priority order as `capsulesForSongEntry` in the flowsheet.
-function capsulesForResult(result: PreviousSetsResult): CapsuleSpec[] {
-  const out: CapsuleSpec[] = [];
-  if (result.request_flag) {
-    out.push({ variant: "request", label: "REQUEST" });
-  }
-  if (result.rotation) {
-    out.push({
-      variant: "rotation",
-      label: `ROTATION ${result.rotation}`,
-    });
-  }
-  if (result.on_streaming === false) {
-    out.push({ variant: "exclusive", label: "EXCLUSIVE" });
-  }
-  return out;
-}
-
 export default function ResultRow({
   result,
-  nextIsTrack,
+  nextIsSong,
 }: {
   result: PreviousSetsResult;
-  nextIsTrack: boolean;
+  /** True if the next row in the table is also a song row. Mirrors
+   *  EntryRow's `nextIsSong` prop so the Classic segue contract stays
+   *  unified across flowsheet + playlist archive. */
+  nextIsSong: boolean;
 }) {
-  const capsules = capsulesForResult(result);
+  // Shared capsule resolver — same priority order (REQUEST → ROTATION →
+  // EXCLUSIVE) and label format as the flowsheet song row.
+  const capsules = capsulesForSongEntry(result);
   // Mirrors EntryRow's segue logic: a segue indicator only makes sense when
-  // the next visible row is also a track. Tubafrenzy expresses the same
+  // the next visible row is also a song row. Tubafrenzy expresses the same
   // guard via `:has(+ tr.entry-row)`.
-  const showSegue = result.segue === true && nextIsTrack;
+  const showSegue = result.segue === true && nextIsSong;
   const className = showSegue ? "classic-segue" : undefined;
 
   return (

--- a/src/components/experiences/classic/playlists/ResultTable.tsx
+++ b/src/components/experiences/classic/playlists/ResultTable.tsx
@@ -44,7 +44,7 @@ export default function ResultTable({
           <ResultRow
             key={result.id}
             result={result}
-            nextIsTrack={index < results.length - 1}
+            nextIsSong={index < results.length - 1}
           />
         ))}
       </tbody>

--- a/src/components/experiences/classic/playlists/ResultTable.tsx
+++ b/src/components/experiences/classic/playlists/ResultTable.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import ResultRow, { type PreviousSetsResult } from "./ResultRow";
+import "@/src/styles/classic/previous-sets.css";
+
+// 5-col previous-sets layout mirroring tubafrenzy's `mostRecentEntries.jsp`
+// + `public/flowsheetRadioShowDisplayPublic.jsp`:
+// Indicators · Artist · Song · Release · Label.
+export default function ResultTable({
+  results,
+}: {
+  results: PreviousSetsResult[];
+}) {
+  if (results.length === 0) {
+    return (
+      <div
+        className="classic-previous-sets-empty text"
+        style={{ textAlign: "center", padding: "1em" }}
+      >
+        No results found.
+      </div>
+    );
+  }
+
+  return (
+    <table
+      className="classic-previous-sets-table"
+      cellPadding={4}
+      cellSpacing={2}
+      border={0}
+      style={{ width: "100%" }}
+    >
+      <thead>
+        <tr>
+          <th style={{ width: "5%" }}>&nbsp;</th>
+          <th style={{ width: "25%" }}>Artist</th>
+          <th>Song</th>
+          <th>Release</th>
+          <th>Label</th>
+        </tr>
+      </thead>
+      <tbody>
+        {results.map((result, index) => (
+          <ResultRow
+            key={result.id}
+            result={result}
+            nextIsTrack={index < results.length - 1}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/experiences/classic/playlists/ResultTable.tsx
+++ b/src/components/experiences/classic/playlists/ResultTable.tsx
@@ -6,22 +6,15 @@ import "@/src/styles/classic/previous-sets.css";
 // 5-col previous-sets layout mirroring tubafrenzy's `mostRecentEntries.jsp`
 // + `public/flowsheetRadioShowDisplayPublic.jsp`:
 // Indicators · Artist · Song · Release · Label.
+//
+// Callers must gate on results.length > 0 — the table doesn't render its
+// own empty state. PreviousSetsContainer surfaces "No results found" copy
+// above the table, mirroring Modern's PlaylistSearchContainer.
 export default function ResultTable({
   results,
 }: {
   results: PreviousSetsResult[];
 }) {
-  if (results.length === 0) {
-    return (
-      <div
-        className="classic-previous-sets-empty text"
-        style={{ textAlign: "center", padding: "1em" }}
-      >
-        No results found.
-      </div>
-    );
-  }
-
   return (
     <table
       className="classic-previous-sets-table"

--- a/src/components/experiences/classic/playlists/SearchForm.tsx
+++ b/src/components/experiences/classic/playlists/SearchForm.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { usePlaylistSearch } from "@/src/hooks/playlistSearchHooks";
+import "@/src/styles/classic/previous-sets.css";
+
+// Classic free-form search input, mirroring tubafrenzy's
+// `public/searchPage.jsp`. Pipes the first (and only) search row's value
+// through `playlistSearchSlice` so the shared usePlaylistSearch hook fires
+// the search query reactively.
+export default function SearchForm() {
+  const { rows, updateRow } = usePlaylistSearch();
+  const row = rows[0];
+
+  return (
+    <div className="classic-previous-sets-search">
+      <input
+        type="text"
+        autoCorrect="off"
+        id="searchInput"
+        name="searchString"
+        value={row?.value ?? ""}
+        onChange={(e) => row && updateRow(row.id, { value: e.target.value })}
+        placeholder="Type to search..."
+        className="classic-previous-sets-search-input"
+      />
+    </div>
+  );
+}

--- a/src/components/experiences/classic/playlists/SearchForm.tsx
+++ b/src/components/experiences/classic/playlists/SearchForm.tsx
@@ -16,7 +16,6 @@ export default function SearchForm() {
       <input
         type="text"
         autoCorrect="off"
-        id="searchInput"
         name="searchString"
         value={row?.value ?? ""}
         onChange={(e) => row && updateRow(row.id, { value: e.target.value })}

--- a/src/components/experiences/classic/playlists/__tests__/PreviousSetsContainer.test.tsx
+++ b/src/components/experiences/classic/playlists/__tests__/PreviousSetsContainer.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import type { PlaylistSearchResult } from "@wxyc/shared/dtos";
+
+const mockTrigger = vi.fn();
+const mockQueryState = {
+  data: undefined as
+    | {
+        results: PlaylistSearchResult[];
+        total: number;
+        page: number;
+        totalPages: number;
+        nextCursor?: string;
+      }
+    | undefined,
+  isFetching: false,
+  isError: false,
+};
+
+vi.mock("@/lib/features/playlist-search/api", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/features/playlist-search/api")
+  >("@/lib/features/playlist-search/api");
+  return {
+    ...actual,
+    useLazySearchPlaylistsQuery: () =>
+      [mockTrigger, mockQueryState] as unknown as ReturnType<
+        typeof actual.useLazySearchPlaylistsQuery
+      >,
+  };
+});
+
+// Import after the mock is defined.
+import PreviousSetsContainer from "../PreviousSetsContainer";
+
+beforeEach(() => {
+  mockTrigger.mockReset();
+  mockQueryState.data = undefined;
+  mockQueryState.isFetching = false;
+  mockQueryState.isError = false;
+});
+
+describe("Classic Previous Sets PreviousSetsContainer", () => {
+  it("renders the Classic page title", () => {
+    renderWithProviders(<PreviousSetsContainer />);
+    expect(
+      screen.getByRole("heading", { name: /playlist archive/i })
+    ).toBeDefined();
+  });
+
+  it("renders a search input", () => {
+    renderWithProviders(<PreviousSetsContainer />);
+    expect(screen.getByPlaceholderText(/type to search/i)).toBeDefined();
+  });
+
+  it("does not render the results section before the user has typed", () => {
+    const { container } = renderWithProviders(<PreviousSetsContainer />);
+    expect(container.querySelector("table thead")).toBeNull();
+  });
+
+  it("renders the result table after the user types and data arrives", async () => {
+    const { user, rerender } = renderWithProviders(<PreviousSetsContainer />);
+    const input = screen.getByPlaceholderText(/type to search/i);
+    await user.type(input, "Juana");
+    // Land the response AFTER typing so the data effect ([data, cursor])
+    // fires its accumulator update — the reset effect (which clears on
+    // effectiveQuery change) doesn't fire again on this render.
+    mockQueryState.data = {
+      results: [
+        {
+          id: 1,
+          play_date: "2024-06-15T14:30:00.000Z",
+          artist_name: "Juana Molina",
+          track_title: "la paradoja",
+          album_title: "DOGA",
+          record_label: "Sonamos",
+          dj_name: "Test DJ",
+          show_id: 100,
+        },
+      ],
+      total: 1,
+      page: 0,
+      totalPages: 1,
+    };
+    rerender(<PreviousSetsContainer />); // data effect runs, populates ref
+    rerender(<PreviousSetsContainer />); // re-read ref into the DOM
+    await waitFor(() => {
+      expect(screen.getByText("Juana Molina")).toBeDefined();
+    });
+  });
+
+  it("shows an error message when the search request fails", async () => {
+    const { user, rerender } = renderWithProviders(<PreviousSetsContainer />);
+    await user.type(screen.getByPlaceholderText(/type to search/i), "Juana");
+    mockQueryState.isError = true;
+    rerender(<PreviousSetsContainer />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/an error occurred while searching/i)
+      ).toBeDefined();
+    });
+  });
+});

--- a/src/components/experiences/classic/playlists/__tests__/ResultRow.test.tsx
+++ b/src/components/experiences/classic/playlists/__tests__/ResultRow.test.tsx
@@ -17,13 +17,13 @@ const baseResult: PreviousSetsResult = {
 
 function renderRow(props: {
   result?: Partial<PreviousSetsResult>;
-  nextIsTrack?: boolean;
+  nextIsSong?: boolean;
 }) {
   const result = { ...baseResult, ...props.result };
   return renderWithProviders(
     <table>
       <tbody>
-        <ResultRow result={result} nextIsTrack={props.nextIsTrack ?? false} />
+        <ResultRow result={result} nextIsSong={props.nextIsSong ?? false} />
       </tbody>
     </table>
   );
@@ -81,20 +81,20 @@ describe("Classic Previous Sets ResultRow", () => {
     expect(capsules[2].textContent).toBe("EXCLUSIVE");
   });
 
-  it("renders the segue indicator when segue=true and the next row is a track", () => {
+  it("renders the segue indicator when segue=true and the next row is a song", () => {
     const { container } = renderRow({
       result: { segue: true },
-      nextIsTrack: true,
+      nextIsSong: true,
     });
     const row = container.querySelector("tr.classic-segue");
     expect(row).not.toBeNull();
     expect(row!.getAttribute("data-segue")).toBe("true");
   });
 
-  it("does NOT render the segue indicator when the next row is not a track", () => {
+  it("does NOT render the segue indicator when the next row is not a song", () => {
     const { container } = renderRow({
       result: { segue: true },
-      nextIsTrack: false,
+      nextIsSong: false,
     });
     expect(container.querySelector("tr.classic-segue")).toBeNull();
   });
@@ -102,7 +102,7 @@ describe("Classic Previous Sets ResultRow", () => {
   it("does NOT render the segue indicator when segue is undefined", () => {
     const { container } = renderRow({
       result: { segue: undefined },
-      nextIsTrack: true,
+      nextIsSong: true,
     });
     expect(container.querySelector("tr.classic-segue")).toBeNull();
   });

--- a/src/components/experiences/classic/playlists/__tests__/ResultRow.test.tsx
+++ b/src/components/experiences/classic/playlists/__tests__/ResultRow.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import { Rotation } from "@/lib/features/rotation/types";
+import ResultRow, { type PreviousSetsResult } from "../ResultRow";
+
+const baseResult: PreviousSetsResult = {
+  id: 1,
+  play_date: "2024-06-15T14:30:00.000Z",
+  artist_name: "Juana Molina",
+  track_title: "la paradoja",
+  album_title: "DOGA",
+  record_label: "Sonamos",
+  dj_name: "Test DJ",
+  show_id: 100,
+};
+
+function renderRow(props: {
+  result?: Partial<PreviousSetsResult>;
+  nextIsTrack?: boolean;
+}) {
+  const result = { ...baseResult, ...props.result };
+  return renderWithProviders(
+    <table>
+      <tbody>
+        <ResultRow result={result} nextIsTrack={props.nextIsTrack ?? false} />
+      </tbody>
+    </table>
+  );
+}
+
+describe("Classic Previous Sets ResultRow", () => {
+  it("renders the 4 data columns + leftmost indicator cell", () => {
+    const { container } = renderRow({});
+    const tds = container.querySelectorAll("tr > td");
+    expect(tds.length).toBe(5);
+    expect(tds[1].textContent).toBe("Juana Molina");
+    expect(tds[2].textContent).toBe("la paradoja");
+    expect(tds[3].textContent).toBe("DOGA");
+    expect(tds[4].textContent).toBe("Sonamos");
+  });
+
+  it("renders no capsules when no flags are set", () => {
+    const { container } = renderRow({});
+    expect(container.querySelector(".classic-capsule")).toBeNull();
+  });
+
+  it("renders a REQUEST capsule when request_flag=true", () => {
+    renderRow({ result: { request_flag: true } });
+    expect(screen.getByText("REQUEST")).toBeDefined();
+  });
+
+  it.each([
+    [Rotation.H, "ROTATION H"],
+    [Rotation.M, "ROTATION M"],
+    [Rotation.L, "ROTATION L"],
+    [Rotation.S, "ROTATION S"],
+  ])("renders %s rotation as %s", (rotation, label) => {
+    renderRow({ result: { rotation } });
+    expect(screen.getByText(label)).toBeDefined();
+  });
+
+  it("renders EXCLUSIVE when on_streaming=false", () => {
+    renderRow({ result: { on_streaming: false } });
+    expect(screen.getByText("EXCLUSIVE")).toBeDefined();
+  });
+
+  it("does NOT render EXCLUSIVE when on_streaming=true", () => {
+    renderRow({ result: { on_streaming: true } });
+    expect(screen.queryByText("EXCLUSIVE")).toBeNull();
+  });
+
+  it("renders all three capsules in priority order (REQUEST → ROTATION → EXCLUSIVE)", () => {
+    const { container } = renderRow({
+      result: { request_flag: true, rotation: Rotation.H, on_streaming: false },
+    });
+    const capsules = container.querySelectorAll(".classic-capsule");
+    expect(capsules.length).toBe(3);
+    expect(capsules[0].textContent).toBe("REQUEST");
+    expect(capsules[1].textContent).toBe("ROTATION H");
+    expect(capsules[2].textContent).toBe("EXCLUSIVE");
+  });
+
+  it("renders the segue indicator when segue=true and the next row is a track", () => {
+    const { container } = renderRow({
+      result: { segue: true },
+      nextIsTrack: true,
+    });
+    const row = container.querySelector("tr.classic-segue");
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute("data-segue")).toBe("true");
+  });
+
+  it("does NOT render the segue indicator when the next row is not a track", () => {
+    const { container } = renderRow({
+      result: { segue: true },
+      nextIsTrack: false,
+    });
+    expect(container.querySelector("tr.classic-segue")).toBeNull();
+  });
+
+  it("does NOT render the segue indicator when segue is undefined", () => {
+    const { container } = renderRow({
+      result: { segue: undefined },
+      nextIsTrack: true,
+    });
+    expect(container.querySelector("tr.classic-segue")).toBeNull();
+  });
+});

--- a/src/components/experiences/classic/playlists/__tests__/ResultTable.test.tsx
+++ b/src/components/experiences/classic/playlists/__tests__/ResultTable.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import ResultTable from "../ResultTable";
+import type { PreviousSetsResult } from "../ResultRow";
+
+const results: PreviousSetsResult[] = [
+  {
+    id: 1,
+    play_date: "2024-06-15T14:30:00.000Z",
+    artist_name: "Juana Molina",
+    track_title: "la paradoja",
+    album_title: "DOGA",
+    record_label: "Sonamos",
+    dj_name: "Test DJ",
+    show_id: 100,
+    segue: true,
+  },
+  {
+    id: 2,
+    play_date: "2024-06-15T14:33:00.000Z",
+    artist_name: "Jessica Pratt",
+    track_title: "Back, Baby",
+    album_title: "On Your Own Love Again",
+    record_label: "Drag City",
+    dj_name: "Test DJ",
+    show_id: 100,
+  },
+];
+
+describe("Classic Previous Sets ResultTable", () => {
+  it("renders a 5-column header (Indicators · Artist · Song · Release · Label)", () => {
+    const { container } = renderWithProviders(<ResultTable results={results} />);
+    const headers = container.querySelectorAll("thead th");
+    expect(headers.length).toBe(5);
+    expect(headers[1].textContent).toBe("Artist");
+    expect(headers[2].textContent).toBe("Song");
+    expect(headers[3].textContent).toBe("Release");
+    expect(headers[4].textContent).toBe("Label");
+  });
+
+  it("renders one row per result", () => {
+    const { container } = renderWithProviders(<ResultTable results={results} />);
+    const bodyRows = container.querySelectorAll("tbody tr");
+    expect(bodyRows.length).toBe(2);
+  });
+
+  it("renders the segue indicator on the first row when the next row is also a track", () => {
+    const { container } = renderWithProviders(<ResultTable results={results} />);
+    const segueRows = container.querySelectorAll("tr.classic-segue");
+    expect(segueRows.length).toBe(1);
+    // The segue row is the first result row (id=1) because the second result follows it.
+    expect(segueRows[0].getAttribute("data-segue")).toBe("true");
+  });
+
+  it("does NOT render any segue indicator when no row has segue=true", () => {
+    const noSegueResults = results.map((r) => ({ ...r, segue: false }));
+    const { container } = renderWithProviders(
+      <ResultTable results={noSegueResults} />
+    );
+    expect(container.querySelector("tr.classic-segue")).toBeNull();
+  });
+
+  it("renders an empty-state message when results is empty", () => {
+    const { container } = renderWithProviders(<ResultTable results={[]} />);
+    expect(container.textContent).toMatch(/no results/i);
+  });
+});

--- a/src/components/experiences/classic/playlists/__tests__/ResultTable.test.tsx
+++ b/src/components/experiences/classic/playlists/__tests__/ResultTable.test.tsx
@@ -60,8 +60,11 @@ describe("Classic Previous Sets ResultTable", () => {
     expect(container.querySelector("tr.classic-segue")).toBeNull();
   });
 
-  it("renders an empty-state message when results is empty", () => {
+  it("renders an empty <tbody> when results is empty (caller gates rendering)", () => {
+    // ResultTable does not own the empty-state message — its sole caller,
+    // PreviousSetsContainer, surfaces "No results found" copy and gates
+    // <ResultTable> on results.length > 0. Mirrors Modern's flow.
     const { container } = renderWithProviders(<ResultTable results={[]} />);
-    expect(container.textContent).toMatch(/no results/i);
+    expect(container.querySelectorAll("tbody tr").length).toBe(0);
   });
 });

--- a/src/components/experiences/classic/playlists/__tests__/ResultTable.test.tsx
+++ b/src/components/experiences/classic/playlists/__tests__/ResultTable.test.tsx
@@ -44,7 +44,7 @@ describe("Classic Previous Sets ResultTable", () => {
     expect(bodyRows.length).toBe(2);
   });
 
-  it("renders the segue indicator on the first row when the next row is also a track", () => {
+  it("renders the segue indicator on the first row when the next row is also a song", () => {
     const { container } = renderWithProviders(<ResultTable results={results} />);
     const segueRows = container.querySelectorAll("tr.classic-segue");
     expect(segueRows.length).toBe(1);

--- a/src/components/experiences/classic/playlists/__tests__/SearchForm.test.tsx
+++ b/src/components/experiences/classic/playlists/__tests__/SearchForm.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { screen, act } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import { playlistSearchSlice } from "@/lib/features/playlist-search/frontend";
+import SearchForm from "../SearchForm";
+
+describe("Classic Previous Sets SearchForm", () => {
+  it("renders a single free-form text input", () => {
+    renderWithProviders(<SearchForm />);
+    const input = screen.getByPlaceholderText(/type to search/i);
+    expect(input).toBeDefined();
+    expect(input.tagName).toBe("INPUT");
+    expect((input as HTMLInputElement).type).toBe("text");
+  });
+
+  it("updates the playlistSearch row when the user types", async () => {
+    const { user, store } = renderWithProviders(<SearchForm />);
+    const input = screen.getByPlaceholderText(/type to search/i);
+    await user.type(input, "polvo");
+    const rows = store.getState().playlistSearch.rows;
+    expect(rows[0].value).toBe("polvo");
+  });
+
+  it("renders the value from the slice", () => {
+    const { container, store } = renderWithProviders(<SearchForm />);
+    const rowId = store.getState().playlistSearch.rows[0].id;
+    act(() => {
+      store.dispatch(
+        playlistSearchSlice.actions.updateRow({
+          id: rowId,
+          updates: { value: "preloaded query" },
+        })
+      );
+    });
+    const input = container.querySelector(
+      "input[type='text']"
+    ) as HTMLInputElement;
+    expect(input.value).toBe("preloaded query");
+  });
+});

--- a/src/components/experiences/classic/playlists/index.ts
+++ b/src/components/experiences/classic/playlists/index.ts
@@ -1,0 +1,6 @@
+export { default as PreviousSetsContainer } from "./PreviousSetsContainer";
+export { default as SearchForm } from "./SearchForm";
+export { default as ResultTable } from "./ResultTable";
+export { default as ResultRow } from "./ResultRow";
+export { default as InfiniteScroll } from "./InfiniteScroll";
+export type { PreviousSetsResult } from "./ResultRow";

--- a/src/styles/classic/previous-sets.css
+++ b/src/styles/classic/previous-sets.css
@@ -1,0 +1,42 @@
+/* Classic "Previous Sets" (playlist archive) surface — visual parity with
+   tubafrenzy's public/searchPage.jsp + mostRecentEntries.jsp. */
+
+.classic-previous-sets {
+  padding: 1em;
+}
+
+.classic-previous-sets-search {
+  text-align: center;
+  padding: 0.5em 0 1em;
+}
+
+.classic-previous-sets-search-input {
+  width: 60%;
+  max-width: 600px;
+  padding: 4px 8px;
+  font-family: Verdana, Arial, Helvetica, sans-serif;
+  font-size: 1em;
+  border: 1px solid #999;
+}
+
+.classic-previous-sets-table {
+  border-collapse: collapse;
+}
+
+.classic-previous-sets-table thead th {
+  background-color: #DDDDDD;
+  border-bottom: 1px solid #999;
+  padding: 6px 4px;
+  font-family: Verdana, Arial, Helvetica, sans-serif;
+  font-size: 0.85em;
+  text-align: left;
+}
+
+.classic-previous-sets-table tbody tr:nth-child(even) {
+  background-color: #F8F8F8;
+}
+
+.classic-previous-sets-empty {
+  font-style: italic;
+  color: #666;
+}

--- a/src/styles/classic/previous-sets.css
+++ b/src/styles/classic/previous-sets.css
@@ -35,8 +35,3 @@
 .classic-previous-sets-table tbody tr:nth-child(even) {
   background-color: #F8F8F8;
 }
-
-.classic-previous-sets-empty {
-  font-style: italic;
-  color: #666;
-}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -39,3 +39,16 @@ global.ResizeObserver = class ResizeObserver {
   unobserve() {}
   disconnect() {}
 };
+
+// Mock IntersectionObserver for infinite-scroll components (jsdom lacks it).
+global.IntersectionObserver = class IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = "";
+  readonly thresholds: readonly number[] = [];
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+} as unknown as typeof IntersectionObserver;


### PR DESCRIPTION
Closes #530.

## Summary

- `app/dashboard/@classic/playlists/page.tsx` now mounts a new Classic `PreviousSetsContainer` instead of the Modern `PlaylistSearchContainer`. After this PR, no Classic page imports from `experiences/modern/`.
- Six new Classic components under `src/components/experiences/classic/playlists/` (container, search form, results table, row, infinite scroll, barrel) plus `src/styles/classic/previous-sets.css`.
- Reuses the shared `usePlaylistSearch` hook + `playlistSearchSlice` + RTK query API unchanged — no data-layer duplication.
- `ResultRow` accepts an extension type `PreviousSetsResult` so capsule + segue rendering is wired today and lights up once the backend surfaces `rotation` / `request_flag` / `segue` / `on_streaming` on `PlaylistSearchResult`.
- `IntersectionObserver` mocked in `vitest.setup.ts` (same pattern as the existing `ResizeObserver` mock) so the new infinite-scroll component is testable in jsdom.

## Tubafrenzy reference

`public/searchPage.jsp` (free-form input) + `mostRecentEntries.jsp` (5-col layout) + `public/flowsheetRadioShowDisplayPublic.jsp` (capsule + segue rules).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run` — 2760 / 2760 pass (28 new tests across 5 files)
- [x] `npm run build` — production build green
- [ ] Manual: dev server + visit `/dashboard/playlists` in Classic mode; type a query and confirm Classic-styled results render

## Out of scope (filed/file separately)

- Enriching `PlaylistSearchResult` so capsules have data to render
- Closed-show drill-through (`public/flowsheetRadioShowDisplayPublic.jsp` per-show layout)
- Advanced filters (date pickers, field selectors) in the Classic search form

## Related

- Umbrella: #511
- Predecessors: #512 (capsule column), #516 (segue indicator)