### PR TITLE
classic catalog: Browse Exclusive Albums button + Exclusive filter chip

### DIFF
--- a/src/components/experiences/classic/catalog/Layout/Main.tsx
+++ b/src/components/experiences/classic/catalog/Layout/Main.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import "@/src/styles/classic/wxyc.css";
+import "@/src/styles/classic/filter-chip.css";
 import Navigation from "../../Navigation";
 
 export default function Main({

--- a/src/components/experiences/classic/catalog/SearchForm.tsx
+++ b/src/components/experiences/classic/catalog/SearchForm.tsx
@@ -17,6 +17,13 @@ export default function SearchForm() {
     if (query) {
       dispatch(catalogSlice.actions.setSearchQuery(query));
     }
+    // Rehydrate the Exclusive filter from the URL so reload / direct nav to
+    // /dashboard/catalog?exclusive=true keeps the filter applied. We
+    // explicitly only flip to ON here — we don't toggle off on absence,
+    // since the user may have set the filter via the in-page chip.
+    if (searchParams.get("exclusive") === "true") {
+      dispatch(catalogSlice.actions.setExclusiveFilter(true));
+    }
   }, [searchParams, dispatch]);
 
   useEffect(() => {

--- a/src/components/experiences/classic/catalog/SearchForm.tsx
+++ b/src/components/experiences/classic/catalog/SearchForm.tsx
@@ -10,6 +10,7 @@ export default function SearchForm() {
   const searchParams = useSearchParams();
   const dispatch = useAppDispatch();
   const searchQuery = useAppSelector(catalogSlice.selectors.getSearchQuery);
+  const exclusive = useAppSelector(catalogSlice.selectors.getExclusiveFilter);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -36,13 +37,20 @@ export default function SearchForm() {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
     const searchString = formData.get("searchString") as string;
-    
+    const params = new URLSearchParams();
+
     if (searchString && searchString.trim()) {
       dispatch(catalogSlice.actions.setSearchQuery(searchString.trim()));
-      router.push(`/dashboard/catalog?searchString=${encodeURIComponent(searchString.trim())}`);
-    } else {
-      router.push(`/dashboard/catalog`);
+      params.set("searchString", searchString.trim());
     }
+    // Preserve the Exclusive filter in the URL so the active state survives
+    // submitting a free-text query while the chip is on.
+    if (exclusive) {
+      params.set("exclusive", "true");
+    }
+
+    const qs = params.toString();
+    router.push(qs ? `/dashboard/catalog?${qs}` : `/dashboard/catalog`);
   };
 
   return (
@@ -101,7 +109,6 @@ export default function SearchForm() {
                 <td align="center">
                   <button
                     type="button"
-                    className="classic-browse-exclusive"
                     onClick={() => {
                       dispatch(catalogSlice.actions.setSearchQuery(""));
                       dispatch(catalogSlice.actions.setExclusiveFilter(true));

--- a/src/components/experiences/classic/catalog/SearchForm.tsx
+++ b/src/components/experiences/classic/catalog/SearchForm.tsx
@@ -92,6 +92,24 @@ export default function SearchForm() {
               </tr>
               <tr>
                 <td align="center">
+                  <button
+                    type="button"
+                    className="classic-browse-exclusive"
+                    onClick={() => {
+                      dispatch(catalogSlice.actions.setSearchQuery(""));
+                      dispatch(catalogSlice.actions.setExclusiveFilter(true));
+                      if (inputRef.current) {
+                        inputRef.current.value = "";
+                      }
+                      router.push(`/dashboard/catalog?exclusive=true`);
+                    }}
+                  >
+                    Browse Exclusive Albums
+                  </button>
+                </td>
+              </tr>
+              <tr>
+                <td align="center">
                   <span className="text">56,000+ total releases in this database.</span>
                 </td>
               </tr>

--- a/src/components/experiences/classic/catalog/SearchResults.tsx
+++ b/src/components/experiences/classic/catalog/SearchResults.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useSearchCatalogQuery } from "@/lib/features/catalog/api";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 import { Capsule } from "@/src/components/experiences/classic/flowsheet/Capsule";
-import "@/src/styles/classic/filter-chip.css";
 
 export default function SearchResults() {
   const dispatch = useAppDispatch();
+  const router = useRouter();
   const searchParams = useSearchParams();
   const searchQuery = useAppSelector(catalogSlice.selectors.getSearchQuery);
   const exclusive = useAppSelector(catalogSlice.selectors.getExclusiveFilter);
@@ -43,7 +43,20 @@ export default function SearchResults() {
           type="button"
           className="classic-filter-chip__dismiss"
           aria-label="Remove Exclusive filter"
-          onClick={() => dispatch(catalogSlice.actions.setExclusiveFilter(false))}
+          onClick={() => {
+            dispatch(catalogSlice.actions.setExclusiveFilter(false));
+            // Keep URL and slice in agreement: strip `?exclusive=true` so a
+            // reload after dismiss doesn't re-apply the filter via SearchForm's
+            // rehydration effect.
+            const params = new URLSearchParams(
+              Array.from(searchParams.entries())
+            );
+            params.delete("exclusive");
+            const qs = params.toString();
+            router.replace(
+              qs ? `/dashboard/catalog?${qs}` : `/dashboard/catalog`
+            );
+          }}
         >
           &times;
         </button>

--- a/src/components/experiences/classic/catalog/SearchResults.tsx
+++ b/src/components/experiences/classic/catalog/SearchResults.tsx
@@ -2,33 +2,59 @@
 
 import { useSearchParams } from "next/navigation";
 import { useSearchCatalogQuery } from "@/lib/features/catalog/api";
-import { useAppSelector } from "@/lib/hooks";
+import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 import { Capsule } from "@/src/components/experiences/classic/flowsheet/Capsule";
+import "@/src/styles/classic/filter-chip.css";
 
 export default function SearchResults() {
+  const dispatch = useAppDispatch();
   const searchParams = useSearchParams();
   const searchQuery = useAppSelector(catalogSlice.selectors.getSearchQuery);
+  const exclusive = useAppSelector(catalogSlice.selectors.getExclusiveFilter);
   const searchString = searchParams.get("searchString") || searchQuery;
+  const hasQuery = !!searchString && searchString.trim().length > 0;
+  // Either a free-text query OR the Exclusive filter constitutes a search.
+  // Skip only when neither is active so we don't fire empty requests.
+  const skip = !hasQuery && !exclusive;
 
   const { data: results, isLoading, error } = useSearchCatalogQuery(
     {
-      artist_name: searchString || undefined,
-      album_title: searchString || undefined,
+      artist_name: hasQuery ? searchString : undefined,
+      album_title: hasQuery ? searchString : undefined,
       n: 50,
+      on_streaming: exclusive ? false : undefined,
     },
-    {
-      skip: !searchString || searchString.trim().length === 0,
-    }
+    { skip }
   );
 
-  if (!searchString || searchString.trim().length === 0) {
+  if (skip) {
     return null;
   }
+
+  const filterChips = exclusive ? (
+    <div className="classic-filter-chips">
+      <span
+        className="classic-filter-chip classic-filter-chip--exclusive"
+        data-testid="classic-filter-chip-exclusive"
+      >
+        <span className="classic-filter-chip__label">Exclusive</span>
+        <button
+          type="button"
+          className="classic-filter-chip__dismiss"
+          aria-label="Remove Exclusive filter"
+          onClick={() => dispatch(catalogSlice.actions.setExclusiveFilter(false))}
+        >
+          &times;
+        </button>
+      </span>
+    </div>
+  ) : null;
 
   if (isLoading) {
     return (
       <div style={{ textAlign: "center" }} className="text">
+        {filterChips}
         <p>Loading search results...</p>
       </div>
     );
@@ -37,21 +63,27 @@ export default function SearchResults() {
   if (error) {
     return (
       <div style={{ textAlign: "center" }} className="text">
+        {filterChips}
         <p>Error loading search results. Please try again.</p>
       </div>
     );
   }
 
   if (!results || results.length === 0) {
+    const emptyContext = hasQuery
+      ? `No results found for "${searchString}"`
+      : "No exclusive albums found";
     return (
       <div style={{ textAlign: "center" }} className="text">
-        <p>No results found for &quot;{searchString}&quot;</p>
+        {filterChips}
+        <p>{emptyContext}</p>
       </div>
     );
   }
 
   return (
     <div style={{ textAlign: "center" }}>
+      {filterChips}
       <table
         cellPadding={4}
         cellSpacing={2}

--- a/src/components/experiences/classic/catalog/__tests__/SearchForm.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchForm.test.tsx
@@ -65,4 +65,34 @@ describe("Classic catalog SearchForm — Browse Exclusive Albums", () => {
       catalogSlice.selectors.getExclusiveFilter(store.getState())
     ).toBe(false);
   });
+
+  it("preserves ?exclusive=true on submit when the Exclusive filter is on", async () => {
+    mockPush.mockClear();
+    const { user, store } = renderWithProviders(<SearchForm />);
+    store.dispatch(catalogSlice.actions.setExclusiveFilter(true));
+    const input = screen.getByRole("textbox");
+    await user.type(input, "polvo");
+    const submit = screen.getByRole("button", {
+      name: /search the wxyc library/i,
+    });
+    await user.click(submit);
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    const pushedUrl = mockPush.mock.calls[0][0] as string;
+    expect(pushedUrl).toContain("searchString=polvo");
+    expect(pushedUrl).toContain("exclusive=true");
+  });
+
+  it("omits exclusive=true on submit when the Exclusive filter is off", async () => {
+    mockPush.mockClear();
+    const { user } = renderWithProviders(<SearchForm />);
+    const input = screen.getByRole("textbox");
+    await user.type(input, "polvo");
+    const submit = screen.getByRole("button", {
+      name: /search the wxyc library/i,
+    });
+    await user.click(submit);
+    const pushedUrl = mockPush.mock.calls[0][0] as string;
+    expect(pushedUrl).toContain("searchString=polvo");
+    expect(pushedUrl).not.toContain("exclusive=true");
+  });
 });

--- a/src/components/experiences/classic/catalog/__tests__/SearchForm.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchForm.test.tsx
@@ -1,15 +1,21 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/lib/test-utils/render";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 
 const mockPush = vi.fn();
+let mockSearchParams = new URLSearchParams("");
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
-  useSearchParams: () => new URLSearchParams(""),
+  useSearchParams: () => mockSearchParams,
 }));
 
 import SearchForm from "../SearchForm";
+
+beforeEach(() => {
+  mockPush.mockClear();
+  mockSearchParams = new URLSearchParams("");
+});
 
 describe("Classic catalog SearchForm — Browse Exclusive Albums", () => {
   it("renders a 'Browse Exclusive Albums' button", () => {
@@ -43,5 +49,20 @@ describe("Classic catalog SearchForm — Browse Exclusive Albums", () => {
     expect(
       catalogSlice.selectors.getSearchQuery(store.getState())
     ).toBe("");
+  });
+
+  it("rehydrates the Exclusive filter from ?exclusive=true on mount", () => {
+    mockSearchParams = new URLSearchParams("exclusive=true");
+    const { store } = renderWithProviders(<SearchForm />);
+    expect(
+      catalogSlice.selectors.getExclusiveFilter(store.getState())
+    ).toBe(true);
+  });
+
+  it("does NOT touch the Exclusive filter when ?exclusive is absent", () => {
+    const { store } = renderWithProviders(<SearchForm />);
+    expect(
+      catalogSlice.selectors.getExclusiveFilter(store.getState())
+    ).toBe(false);
   });
 });

--- a/src/components/experiences/classic/catalog/__tests__/SearchForm.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchForm.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import { catalogSlice } from "@/lib/features/catalog/frontend";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+import SearchForm from "../SearchForm";
+
+describe("Classic catalog SearchForm — Browse Exclusive Albums", () => {
+  it("renders a 'Browse Exclusive Albums' button", () => {
+    renderWithProviders(<SearchForm />);
+    expect(
+      screen.getByRole("button", { name: /browse exclusive albums/i })
+    ).toBeDefined();
+  });
+
+  it("clicking the button sets the exclusive filter and navigates to ?exclusive=true", async () => {
+    mockPush.mockClear();
+    const { user, store } = renderWithProviders(<SearchForm />);
+    const button = screen.getByRole("button", {
+      name: /browse exclusive albums/i,
+    });
+    await user.click(button);
+    expect(
+      catalogSlice.selectors.getExclusiveFilter(store.getState())
+    ).toBe(true);
+    expect(mockPush).toHaveBeenCalledWith(
+      "/dashboard/catalog?exclusive=true"
+    );
+  });
+
+  it("clears the search query when entering exclusive-browse mode", async () => {
+    const { user, store } = renderWithProviders(<SearchForm />);
+    store.dispatch(catalogSlice.actions.setSearchQuery("polvo"));
+    await user.click(
+      screen.getByRole("button", { name: /browse exclusive albums/i })
+    );
+    expect(
+      catalogSlice.selectors.getSearchQuery(store.getState())
+    ).toBe("");
+  });
+});

--- a/src/components/experiences/classic/catalog/__tests__/SearchResults.exclusive.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchResults.exclusive.test.tsx
@@ -8,9 +8,11 @@ import { createTestAlbum, createTestArtist } from "@/lib/test-utils";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 
 const mockSearchCatalogQuery = vi.fn();
+const mockReplace = vi.fn();
 const mockSearchParams = new URLSearchParams("");
 
 vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
   useSearchParams: () => mockSearchParams,
 }));
 
@@ -29,6 +31,7 @@ import SearchResults from "../SearchResults";
 
 beforeEach(() => {
   mockSearchCatalogQuery.mockReset();
+  mockReplace.mockReset();
   Array.from(mockSearchParams.keys()).forEach((k) =>
     mockSearchParams.delete(k)
   );
@@ -109,5 +112,41 @@ describe("Classic catalog SearchResults — Exclusive filter", () => {
     expect(
       catalogSlice.selectors.getExclusiveFilter(store.getState())
     ).toBe(false);
+  });
+
+  it("clicking the chip dismiss strips ?exclusive=true from the URL", async () => {
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    mockSearchParams.set("exclusive", "true");
+    const store = storeWithExclusive();
+    const { user } = renderWithProviders(<SearchResults />, { store });
+    await user.click(
+      screen.getByRole("button", { name: /remove exclusive filter/i })
+    );
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+    const replacedUrl = mockReplace.mock.calls[0][0] as string;
+    expect(replacedUrl).not.toContain("exclusive=true");
+    expect(replacedUrl).toBe("/dashboard/catalog");
+  });
+
+  it("chip dismiss preserves other params (e.g. searchString)", async () => {
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    mockSearchParams.set("exclusive", "true");
+    mockSearchParams.set("searchString", "polvo");
+    const store = storeWithExclusive();
+    const { user } = renderWithProviders(<SearchResults />, { store });
+    await user.click(
+      screen.getByRole("button", { name: /remove exclusive filter/i })
+    );
+    const replacedUrl = mockReplace.mock.calls[0][0] as string;
+    expect(replacedUrl).toContain("searchString=polvo");
+    expect(replacedUrl).not.toContain("exclusive=true");
   });
 });

--- a/src/components/experiences/classic/catalog/__tests__/SearchResults.exclusive.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchResults.exclusive.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import {
+  renderWithProviders,
+  createTestStore,
+} from "@/lib/test-utils/render";
+import { createTestAlbum, createTestArtist } from "@/lib/test-utils";
+import { catalogSlice } from "@/lib/features/catalog/frontend";
+
+const mockSearchCatalogQuery = vi.fn();
+const mockSearchParams = new URLSearchParams("");
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/lib/features/catalog/api")
+  >();
+  return {
+    ...actual,
+    useSearchCatalogQuery: (...args: unknown[]) =>
+      mockSearchCatalogQuery(...args),
+  };
+});
+
+import SearchResults from "../SearchResults";
+
+beforeEach(() => {
+  mockSearchCatalogQuery.mockReset();
+  Array.from(mockSearchParams.keys()).forEach((k) =>
+    mockSearchParams.delete(k)
+  );
+});
+
+function storeWithExclusive() {
+  const store = createTestStore();
+  store.dispatch(catalogSlice.actions.setExclusiveFilter(true));
+  return store;
+}
+
+describe("Classic catalog SearchResults — Exclusive filter", () => {
+  it("does NOT fire the search when neither query nor exclusive filter is set", () => {
+    mockSearchCatalogQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: undefined,
+    });
+    renderWithProviders(<SearchResults />);
+    const [, options] = mockSearchCatalogQuery.mock.calls[0] ?? [];
+    expect(options?.skip).toBe(true);
+  });
+
+  it("fires the search with on_streaming=false when exclusive filter is on (no query)", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({
+        name: "Stereolab",
+        lettercode: "RO",
+        numbercode: 87,
+      }),
+      title: "Aluminum Tunes",
+      on_streaming: false,
+    });
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [album],
+      isLoading: false,
+      error: undefined,
+    });
+    renderWithProviders(<SearchResults />, { store: storeWithExclusive() });
+    const [params, options] = mockSearchCatalogQuery.mock.calls.at(-1) ?? [];
+    expect(params).toMatchObject({ on_streaming: false });
+    expect(options?.skip).toBe(false);
+  });
+
+  it("renders the Exclusive filter chip when the filter is on", () => {
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    renderWithProviders(<SearchResults />, { store: storeWithExclusive() });
+    expect(screen.getByTestId("classic-filter-chip-exclusive")).toBeDefined();
+  });
+
+  it("does NOT render the Exclusive filter chip when the filter is off", () => {
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    renderWithProviders(<SearchResults />);
+    expect(
+      screen.queryByTestId("classic-filter-chip-exclusive")
+    ).toBeNull();
+  });
+
+  it("clicking the chip dismiss clears the exclusive filter", async () => {
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: undefined,
+    });
+    const store = storeWithExclusive();
+    const { user } = renderWithProviders(<SearchResults />, { store });
+    await user.click(
+      screen.getByRole("button", { name: /remove exclusive filter/i })
+    );
+    expect(
+      catalogSlice.selectors.getExclusiveFilter(store.getState())
+    ).toBe(false);
+  });
+});

--- a/src/components/experiences/classic/catalog/__tests__/SearchResults.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchResults.test.tsx
@@ -6,6 +6,7 @@ import { renderWithProviders } from "@/lib/test-utils/render";
 const mockSearchCatalogQuery = vi.fn();
 
 vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
   useSearchParams: () => new URLSearchParams("searchString=test"),
 }));
 

--- a/src/styles/classic/filter-chip.css
+++ b/src/styles/classic/filter-chip.css
@@ -1,0 +1,40 @@
+/* Classic catalog filter chip — shown when the Exclusive filter is active. */
+
+.classic-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+  justify-content: center;
+  padding: 0.5em 0;
+}
+
+.classic-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 2px 4px 2px 8px;
+  border-radius: 12px;
+  font-family: Verdana, Geneva, Arial, Helvetica, sans-serif;
+  font-size: 0.75em;
+  font-weight: bold;
+  color: #FFFFFF;
+  line-height: 1.4;
+}
+
+.classic-filter-chip--exclusive {
+  background-color: #7B2D8E;
+}
+
+.classic-filter-chip__dismiss {
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font-size: 1.2em;
+  line-height: 1;
+  padding: 0 4px;
+  cursor: pointer;
+}
+
+.classic-filter-chip__dismiss:hover {
+  opacity: 0.75;
+}


### PR DESCRIPTION
Closes #532.

## Summary

- Adds a "Browse Exclusive Albums" button under the Classic catalog search input. Clicking it clears the text query, sets `catalogSlice.search.exclusive=true`, and navigates to `/dashboard/catalog?exclusive=true`.
- `SearchForm`'s existing `useEffect` (which rehydrates `?searchString` into the slice) now also rehydrates `?exclusive=true` so a refresh / direct link keeps the filter applied.
- `SearchResults` no longer skips when the search string is empty if the exclusive filter is on. The RTK Query forwards `on_streaming: false` whenever the filter is on.
- A purple `.classic-filter-chip` ("Exclusive ×") renders above the result table when the filter is active. The dismiss button (aria-labelled "Remove Exclusive filter") flips the slice back to off.
- Empty-state copy is filter-aware: "No exclusive albums found" vs the existing "No results found for X".

## Backend

`GET /library` already accepts `on_streaming` — no Backend-Service change. The `wxyc-shared/api.yaml` spec is missing the parameter and should be patched in a separate doc-only PR (filed as a follow-up).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run` — 2785 / 2785 pass (12 new tests across 2 files, including URL-rehydration)
- [x] `npm run build` — production build green
- [ ] Manual: dev server + visit `/dashboard/catalog` in Classic mode; click Browse Exclusive Albums; confirm only exclusive releases render with a dismissable chip; refresh page and confirm filter persists

## Related

- Umbrella: #511
- Predecessors: #512 (capsule column), #514 (EXCLUSIVE on individual rows)