### PR TITLE
classic flowsheet: redesign EntryForm with Add a / From / Bin dropdowns

### DIFF
--- a/src/components/experiences/classic/flowsheet/EntryForm.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryForm.tsx
@@ -1,16 +1,25 @@
 "use client";
 
 import { FormEvent, useState, useEffect } from "react";
-import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import { useAppDispatch } from "@/lib/hooks";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { useAddToFlowsheetMutation } from "@/lib/features/flowsheet/api";
-import { convertQueryToSubmission } from "@/lib/features/flowsheet/conversions";
 import { useGetRotationQuery } from "@/lib/features/rotation/api";
 import { Rotation } from "@/lib/features/rotation/types";
-import { AlbumEntry } from "@/lib/features/catalog/types";
+import { FlowsheetEntryType } from "@wxyc/shared/dtos";
 
+type EntryType = "track" | "talkset" | "breakpoint";
 type ReleaseType = "rotationRelease" | "libraryRelease" | "otherRelease";
 type RotationType = "heavy" | "medium" | "light" | "singles";
+
+function formatBreakpointTime(): string {
+  const now = new Date();
+  const hour = now.getHours();
+  const minutes = now.getMinutes();
+  const ampm = hour >= 12 ? "PM" : "AM";
+  const displayHour = hour % 12 || 12;
+  return `${displayHour}:${minutes.toString().padStart(2, "0")} ${ampm}`;
+}
 
 export default function EntryForm({
   onSuccess,
@@ -20,9 +29,9 @@ export default function EntryForm({
   isLive?: boolean;
 }) {
   const dispatch = useAppDispatch();
-  const searchQuery = useAppSelector(flowsheetSlice.selectors.getSearchQuery);
   const [addToFlowsheet, { isLoading }] = useAddToFlowsheetMutation();
 
+  const [entryType, setEntryType] = useState<EntryType>("track");
   const [releaseType, setReleaseType] = useState<ReleaseType>("rotationRelease");
   const [rotationType, setRotationType] = useState<RotationType | "">("");
   const [selectedRotationId, setSelectedRotationId] = useState<number>(0);
@@ -32,7 +41,7 @@ export default function EntryForm({
   const [useArtistForComposer, setUseArtistForComposer] = useState(false);
   const [releaseTitle, setReleaseTitle] = useState("");
   const [labelName, setLabelName] = useState("");
-  const [requestAnswer, setRequestAnswer] = useState<"yes" | "no">("no");
+  const [requestFlag, setRequestFlag] = useState(false);
   const [segue, setSegue] = useState(false);
 
   const { data: rotationData } = useGetRotationQuery();
@@ -59,41 +68,64 @@ export default function EntryForm({
     }
   };
 
-  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const resetTrackFields = () => {
+    setArtistName("");
+    setSongTitle("");
+    setComposer("");
+    setReleaseTitle("");
+    setLabelName("");
+    setRequestFlag(false);
+    setSegue(false);
+    setSelectedRotationId(0);
+    setRotationType("");
+  };
 
-    let submissionData: any;
+  // The Add button is disabled (in track mode) until enough fields are present
+  // to make a meaningful submission: a song title plus either an artist name
+  // (Library/Other) or a selected rotation release (Rotation). Talkset and
+  // Breakpoint modes have no track to gate on, so they're always enabled.
+  const canSubmitTrack =
+    songTitle.trim().length > 0 &&
+    (releaseType === "rotationRelease"
+      ? selectedRotationId > 0
+      : artistName.trim().length > 0);
+  const canSubmit =
+    entryType === "track" ? canSubmitTrack : true;
 
-    if (releaseType === "rotationRelease" && selectedRotationId > 0) {
+  const handleSubmit = async (e?: FormEvent<HTMLFormElement>) => {
+    e?.preventDefault();
+    if (!canSubmit) return;
+
+    let submissionData: Parameters<typeof addToFlowsheet>[0];
+
+    if (entryType === "talkset") {
+      submissionData = {
+        message: "Talkset",
+        entry_type: FlowsheetEntryType.talkset,
+      };
+    } else if (entryType === "breakpoint") {
+      submissionData = {
+        message: `${formatBreakpointTime()} Breakpoint`,
+        entry_type: FlowsheetEntryType.breakpoint,
+      };
+    } else if (releaseType === "rotationRelease" && selectedRotationId > 0) {
       const release = rotationData?.find((r) => r.id === selectedRotationId);
       if (!release) return;
-
       submissionData = {
         album_id: release.id,
         track_title: songTitle,
         rotation_id: release.rotation_id,
-        request_flag: requestAnswer === "yes",
+        request_flag: requestFlag,
         segue,
         record_label: labelName || release.label,
-        play_freq: release.rotation_bin,
-      };
-    } else if (releaseType === "libraryRelease") {
-      // For library releases, we'd need album_id from search
-      // For now, treat as other release
-      submissionData = {
-        artist_name: artistName,
-        album_title: releaseTitle,
-        track_title: songTitle,
-        request_flag: requestAnswer === "yes",
-        segue,
-        record_label: labelName,
+        rotation_bin: release.rotation_bin,
       };
     } else {
       submissionData = {
         artist_name: artistName,
         album_title: releaseTitle,
         track_title: songTitle,
-        request_flag: requestAnswer === "yes",
+        request_flag: requestFlag,
         segue,
         record_label: labelName,
       };
@@ -101,16 +133,8 @@ export default function EntryForm({
 
     try {
       await addToFlowsheet(submissionData).unwrap();
-      // Reset form
-      setArtistName("");
-      setSongTitle("");
-      setComposer("");
-      setReleaseTitle("");
-      setLabelName("");
-      setRequestAnswer("no");
-      setSegue(false);
-      setSelectedRotationId(0);
-      setRotationType("");
+      resetTrackFields();
+      setEntryType("track");
       dispatch(flowsheetSlice.actions.resetSearch());
       onSuccess?.();
     } catch (error) {
@@ -119,314 +143,301 @@ export default function EntryForm({
   };
 
   return (
-    <form name="flowsheetEntry" method="POST" onSubmit={handleSubmit}>
-      <fieldset disabled={!isLive}>
-        <table cellPadding={2} align="center">
-          <tbody>
-            <tr>
-              <td colSpan={4} className="label" align="center">
-                Add a track from:&nbsp;&nbsp;&nbsp;
-                <input
-                  type="radio"
-                  name="releaseType"
-                  value="rotationRelease"
-                  checked={releaseType === "rotationRelease"}
-                  onChange={() => setReleaseType("rotationRelease")}
-                  disabled={!isLive}
-                />
-                &nbsp;Rotation&nbsp;
-                <input
-                  type="radio"
-                  name="releaseType"
-                  value="libraryRelease"
-                  checked={releaseType === "libraryRelease"}
-                  onChange={() => setReleaseType("libraryRelease")}
-                  disabled={!isLive}
-                />
-                &nbsp;WXYC Library&nbsp;
-                <input
-                  type="radio"
-                  name="releaseType"
-                  value="otherRelease"
-                  checked={releaseType === "otherRelease"}
-                  onChange={() => setReleaseType("otherRelease")}
-                  disabled={!isLive}
-                />
-                &nbsp;Other&nbsp;
-              </td>
-            </tr>
-          </tbody>
-        </table>
+    <>
+      <div style={{ textAlign: "center", marginBottom: "8px" }}>
+        <span className="label">Add a </span>
+        <select
+          name="addEntryType"
+          value={entryType}
+          onChange={(e) => setEntryType(e.target.value as EntryType)}
+          disabled={!isLive}
+        >
+          <option value="track">Track</option>
+          <option value="talkset">Talkset</option>
+          <option value="breakpoint">Breakpoint</option>
+        </select>
+        {entryType !== "track" && (
+          <>
+            &nbsp;
+            <button
+              type="button"
+              onClick={() => handleSubmit()}
+              disabled={!isLive || isLoading || !canSubmit}
+            >
+              Add
+            </button>
+          </>
+        )}
+      </div>
 
-      {releaseType === "rotationRelease" && (
-        <table cellPadding={5} align="center">
-          <tbody>
-            <tr>
-              <td id="rotationSelectionTD" className="redlabel" style={{ fontWeight: "bold" }}>
-              <input
-                type="radio"
-                name="rotationType"
-                value="heavy"
-                checked={rotationType === "heavy"}
-                onChange={() => setRotationType("heavy")}
+      {entryType === "track" && (
+        <form name="flowsheetEntry" method="POST" onSubmit={handleSubmit}>
+          <fieldset disabled={!isLive}>
+            <div style={{ textAlign: "center", margin: "8px 0" }}>
+              <span className="label">From </span>
+              <select
+                name="releaseType"
+                value={releaseType}
+                onChange={(e) => setReleaseType(e.target.value as ReleaseType)}
                 disabled={!isLive}
-              />
-              H&nbsp;
-              <input
-                type="radio"
-                name="rotationType"
-                value="medium"
-                checked={rotationType === "medium"}
-                onChange={() => setRotationType("medium")}
-                disabled={!isLive}
-              />
-              M&nbsp;
-              <input
-                type="radio"
-                name="rotationType"
-                value="light"
-                checked={rotationType === "light"}
-                onChange={() => setRotationType("light")}
-                disabled={!isLive}
-              />
-              L&nbsp;
-              <input
-                type="radio"
-                name="rotationType"
-                value="singles"
-                checked={rotationType === "singles"}
-                onChange={() => setRotationType("singles")}
-                disabled={!isLive}
-              />
-              S&nbsp;
-            </td>
-            <td id="releaseDropdownTD">
-              <div id="rotationInstructionsLabel" className="label">
-                (Choose 'H' for Heavy, 'M' for Medium, 'L' for Light, or 'S' for Singles)
-              </div>
-              {rotationType === "heavy" && (
-                <select
-                  name="heavyRelease"
-                  onChange={(e) =>
-                    handleRotationSelect("heavy", parseInt(e.target.value))
-                  }
-                  disabled={!isLive}
-                >
-                  <option value="0">
-                    ---------------- Choose one of the releases in Heavy Rotation
-                    ------------------
-                  </option>
-                  {heavyReleases.map((release) => (
-                    <option key={release.id} value={release.id}>
-                      {release.artist.name} - {release.title}
-                    </option>
-                  ))}
-                </select>
-              )}
-              {rotationType === "medium" && (
-                <select
-                  name="mediumRelease"
-                  onChange={(e) =>
-                    handleRotationSelect("medium", parseInt(e.target.value))
-                  }
-                  disabled={!isLive}
-                >
-                  <option value="0">
-                    ---------------- Choose one of the releases in Medium Rotation
-                    -----------------
-                  </option>
-                  {mediumReleases.map((release) => (
-                    <option key={release.id} value={release.id}>
-                      {release.artist.name} - {release.title}
-                    </option>
-                  ))}
-                </select>
-              )}
-              {rotationType === "light" && (
-                <select
-                  name="lightRelease"
-                  onChange={(e) =>
-                    handleRotationSelect("light", parseInt(e.target.value))
-                  }
-                  disabled={!isLive}
-                >
-                  <option value="0">
-                    ---------------- Choose one of the releases in Light Rotation
-                    ------------------
-                  </option>
-                  {lightReleases.map((release) => (
-                    <option key={release.id} value={release.id}>
-                      {release.artist.name} - {release.title}
-                    </option>
-                  ))}
-                </select>
-              )}
-              {rotationType === "singles" && (
-                <select
-                  name="singlesRelease"
-                  onChange={(e) =>
-                    handleRotationSelect("singles", parseInt(e.target.value))
-                  }
-                  disabled={!isLive}
-                >
-                  <option value="0">
-                    ---------------- Choose one of the releases in Singles Rotation
-                    ----------------
-                  </option>
-                  {singlesReleases.map((release) => (
-                    <option key={release.id} value={release.id}>
-                      {release.artist.name} - {release.title}
-                    </option>
-                  ))}
-                </select>
-              )}
-            </td>
-          </tr>
-          </tbody>
-        </table>
-      )}
+              >
+                <option value="rotationRelease">Rotation</option>
+                <option value="libraryRelease">WXYC Library</option>
+                <option value="otherRelease">Other</option>
+              </select>
+            </div>
 
-      <table cellPadding={2} align="center">
-        <tbody>
-          {releaseType !== "rotationRelease" && (
-            <tr id="artistTextboxRow">
-              <td className="redtitle" align="right">
-                ARTIST:
-              </td>
-              <td colSpan={3} className="redtitle" valign="top" align="left">
-                <input
-                  type="text"
-                  size={40}
-                  name="artistName"
-                  value={artistName}
-                  onChange={(e) => setArtistName(e.target.value)}
-                  disabled={!isLive}
-                />
-              </td>
-            </tr>
-          )}
-          <tr id="songTextboxRow">
-            <td className="redtitle" align="right">
-              SONG:
-            </td>
-            <td colSpan={3} className="redtitle" align="left" valign="top">
-              <input
-                type="text"
-                size={50}
-                name="songTitle"
-                value={songTitle}
-                onChange={(e) => setSongTitle(e.target.value)}
-                required
-                disabled={!isLive}
-              />
-            </td>
-          </tr>
-          {releaseType !== "rotationRelease" && (
-            <tr id="composerTextboxRow">
-              <td className="redtitle" align="right">
-                COMPOSER:
-              </td>
-              <td colSpan={2} className="redtitle" valign="top" align="left">
-                <input
-                  type="text"
-                  size={50}
-                  name="bmiComposer"
-                  value={composer}
-                  onChange={(e) => setComposer(e.target.value)}
-                  disabled={!isLive}
-                />
-                &nbsp;&nbsp;
-              </td>
-              <td className="label" valign="top">
-                <div id="autofillText" className="label">
-                  Auto-fill 'COMPOSER' field with 'ARTIST' field?
-                  <input
-                    type="checkbox"
-                    name="useArtistName"
-                    checked={useArtistForComposer}
-                    onChange={(e) => setUseArtistForComposer(e.target.checked)}
+            {releaseType === "rotationRelease" && (
+              <>
+                <div style={{ textAlign: "center", marginBottom: "6px" }}>
+                  <span className="label">Bin </span>
+                  <select
+                    name="rotationType"
+                    value={rotationType}
+                    onChange={(e) => {
+                      setRotationType(e.target.value as RotationType | "");
+                      setSelectedRotationId(0);
+                    }}
                     disabled={!isLive}
-                  />
+                  >
+                    <option value=""></option>
+                    <option value="heavy">Heavy</option>
+                    <option value="medium">Medium</option>
+                    <option value="light">Light</option>
+                    <option value="singles">Singles</option>
+                  </select>
                 </div>
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
-      <table cellPadding={2} align="center">
-        <tbody>
-          <tr id="regularReleaseRow">
-            <td colSpan={4} className="label">
-              <div id="rotationDisclaimer2" style={{ textAlign: "center" }}>
-                <span style={{ fontSize: "0.7em" }}>
-                  'Release' and 'Label' are optional fields but listeners may be
-                  interested in this information.
-                </span>
-              </div>
-              Release:&nbsp;
-              <input
-                type="text"
-                size={60}
-                name="releaseTitle"
-                value={releaseTitle}
-                onChange={(e) => setReleaseTitle(e.target.value)}
-                disabled={!isLive || (releaseType === "rotationRelease" && selectedRotationId > 0)}
-              />
-              &nbsp;&nbsp;&nbsp; Label:&nbsp;
-              <input
-                type="text"
-                size={25}
-                name="labelName"
-                value={labelName}
-                onChange={(e) => setLabelName(e.target.value)}
-                disabled={!isLive}
-              />
-              &nbsp;&nbsp;&nbsp;
-            </td>
-          </tr>
-          <tr id="requestSubmitRow">
-            <td colSpan={4} className="redlabel" style={{ textAlign: "center" }}>
-              Was this song a request?{" "}
-              <input
-                type="radio"
-                name="requestAnswer"
-                value="yes"
-                checked={requestAnswer === "yes"}
-                onChange={() => setRequestAnswer("yes")}
-                disabled={!isLive}
-              />
-              Yes &nbsp;
-              <input
-                type="radio"
-                name="requestAnswer"
-                value="no"
-                checked={requestAnswer === "no"}
-                onChange={() => setRequestAnswer("no")}
-                disabled={!isLive}
-              />
-              No &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-              <label>
-                <input
-                  type="checkbox"
-                  name="segueAnswer"
-                  checked={segue}
-                  onChange={(e) => setSegue(e.target.checked)}
-                  disabled={!isLive}
-                />{" "}
-                Segue
-              </label>
-              &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-              <input
-                type="submit"
-                id="submitButton"
-                value="  Add This Song To The Flowsheet  "
-                disabled={!isLive || isLoading || !songTitle.trim()}
-              />
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      </fieldset>
-    </form>
+                <div
+                  id="releaseDropdownTD"
+                  style={{ textAlign: "center", marginBottom: "8px" }}
+                >
+                  {rotationType === "heavy" && (
+                    <select
+                      name="heavyRelease"
+                      value={selectedRotationId}
+                      onChange={(e) =>
+                        handleRotationSelect("heavy", parseInt(e.target.value))
+                      }
+                      disabled={!isLive}
+                    >
+                      <option value="0">
+                        ---------------- Choose one of the releases in Heavy
+                        Rotation ------------------
+                      </option>
+                      {heavyReleases.map((release) => (
+                        <option key={release.id} value={release.id}>
+                          {release.artist.name} - {release.title}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                  {rotationType === "medium" && (
+                    <select
+                      name="mediumRelease"
+                      value={selectedRotationId}
+                      onChange={(e) =>
+                        handleRotationSelect("medium", parseInt(e.target.value))
+                      }
+                      disabled={!isLive}
+                    >
+                      <option value="0">
+                        ---------------- Choose one of the releases in Medium
+                        Rotation -----------------
+                      </option>
+                      {mediumReleases.map((release) => (
+                        <option key={release.id} value={release.id}>
+                          {release.artist.name} - {release.title}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                  {rotationType === "light" && (
+                    <select
+                      name="lightRelease"
+                      value={selectedRotationId}
+                      onChange={(e) =>
+                        handleRotationSelect("light", parseInt(e.target.value))
+                      }
+                      disabled={!isLive}
+                    >
+                      <option value="0">
+                        ---------------- Choose one of the releases in Light
+                        Rotation ------------------
+                      </option>
+                      {lightReleases.map((release) => (
+                        <option key={release.id} value={release.id}>
+                          {release.artist.name} - {release.title}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                  {rotationType === "singles" && (
+                    <select
+                      name="singlesRelease"
+                      value={selectedRotationId}
+                      onChange={(e) =>
+                        handleRotationSelect(
+                          "singles",
+                          parseInt(e.target.value)
+                        )
+                      }
+                      disabled={!isLive}
+                    >
+                      <option value="0">
+                        ---------------- Choose one of the releases in Singles
+                        Rotation ----------------
+                      </option>
+                      {singlesReleases.map((release) => (
+                        <option key={release.id} value={release.id}>
+                          {release.artist.name} - {release.title}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+              </>
+            )}
+
+            <table cellPadding={2} align="center">
+              <tbody>
+                {releaseType !== "rotationRelease" && (
+                  <tr id="artistTextboxRow">
+                    <td className="redtitle" align="right">
+                      ARTIST:
+                    </td>
+                    <td colSpan={3} className="redtitle" valign="top" align="left">
+                      <input
+                        type="text"
+                        size={40}
+                        name="artistName"
+                        value={artistName}
+                        onChange={(e) => setArtistName(e.target.value)}
+                        disabled={!isLive}
+                      />
+                    </td>
+                  </tr>
+                )}
+                <tr id="songTextboxRow">
+                  <td className="redtitle" align="right">
+                    SONG:
+                  </td>
+                  <td colSpan={3} className="redtitle" align="left" valign="top">
+                    <input
+                      type="text"
+                      size={50}
+                      name="songTitle"
+                      value={songTitle}
+                      onChange={(e) => setSongTitle(e.target.value)}
+                      required
+                      disabled={!isLive}
+                    />
+                  </td>
+                </tr>
+                {releaseType !== "rotationRelease" && (
+                  <tr id="composerTextboxRow">
+                    <td className="redtitle" align="right">
+                      COMPOSER:
+                    </td>
+                    <td colSpan={2} className="redtitle" valign="top" align="left">
+                      <input
+                        type="text"
+                        size={50}
+                        name="bmiComposer"
+                        value={composer}
+                        onChange={(e) => setComposer(e.target.value)}
+                        disabled={!isLive}
+                      />
+                      &nbsp;&nbsp;
+                    </td>
+                    <td className="label" valign="top">
+                      <div id="autofillText" className="label">
+                        Auto-fill 'COMPOSER' field with 'ARTIST' field?
+                        <input
+                          type="checkbox"
+                          name="useArtistName"
+                          checked={useArtistForComposer}
+                          onChange={(e) => setUseArtistForComposer(e.target.checked)}
+                          disabled={!isLive}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+
+            <table cellPadding={2} align="center">
+              <tbody>
+                <tr id="regularReleaseRow">
+                  <td colSpan={4} className="label">
+                    <div id="rotationDisclaimer2" style={{ textAlign: "center" }}>
+                      <span style={{ fontSize: "0.7em" }}>
+                        'Release' and 'Label' are optional fields but listeners
+                        may be interested in this information.
+                      </span>
+                    </div>
+                    Release:&nbsp;
+                    <input
+                      type="text"
+                      size={60}
+                      name="releaseTitle"
+                      value={releaseTitle}
+                      onChange={(e) => setReleaseTitle(e.target.value)}
+                      disabled={
+                        !isLive ||
+                        (releaseType === "rotationRelease" &&
+                          selectedRotationId > 0)
+                      }
+                    />
+                    &nbsp;&nbsp;&nbsp; Label:&nbsp;
+                    <input
+                      type="text"
+                      size={25}
+                      name="labelName"
+                      value={labelName}
+                      onChange={(e) => setLabelName(e.target.value)}
+                      disabled={!isLive}
+                    />
+                    &nbsp;&nbsp;&nbsp;
+                  </td>
+                </tr>
+                <tr id="requestSubmitRow">
+                  <td colSpan={4} className="redlabel" style={{ textAlign: "center" }}>
+                    <label>
+                      <input
+                        type="checkbox"
+                        name="requestAnswer"
+                        checked={requestFlag}
+                        onChange={(e) => setRequestFlag(e.target.checked)}
+                        disabled={!isLive}
+                      />{" "}
+                      Request
+                    </label>
+                    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                    <label>
+                      <input
+                        type="checkbox"
+                        name="segueAnswer"
+                        checked={segue}
+                        onChange={(e) => setSegue(e.target.checked)}
+                        disabled={!isLive}
+                      />{" "}
+                      Segue
+                    </label>
+                    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                    <input
+                      type="submit"
+                      id="submitButton"
+                      value="Add"
+                      disabled={!isLive || isLoading || !canSubmit}
+                    />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </fieldset>
+        </form>
+      )}
+    </>
   );
 }

--- a/src/components/experiences/classic/flowsheet/EntryForm.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryForm.tsx
@@ -121,6 +121,10 @@ export default function EntryForm({
         rotation_bin: release.rotation_bin,
       };
     } else {
+      // libraryRelease + otherRelease both fall through to the free-text
+      // submission path. Plumbing a real `library_album_id` for the Library
+      // case is tracked separately (the catalog-search picker lives in the
+      // Modern theme); the Classic port preserves prior behavior here.
       submissionData = {
         artist_name: artistName,
         album_title: releaseTitle,
@@ -143,36 +147,34 @@ export default function EntryForm({
   };
 
   return (
-    <>
-      <div style={{ textAlign: "center", marginBottom: "8px" }}>
-        <span className="label">Add a </span>
-        <select
-          name="addEntryType"
-          value={entryType}
-          onChange={(e) => setEntryType(e.target.value as EntryType)}
-          disabled={!isLive}
-        >
-          <option value="track">Track</option>
-          <option value="talkset">Talkset</option>
-          <option value="breakpoint">Breakpoint</option>
-        </select>
-        {entryType !== "track" && (
-          <>
-            &nbsp;
-            <button
-              type="button"
-              onClick={() => handleSubmit()}
-              disabled={!isLive || isLoading || !canSubmit}
-            >
-              Add
-            </button>
-          </>
-        )}
-      </div>
+    <form name="flowsheetEntry" method="POST" onSubmit={handleSubmit}>
+      <fieldset disabled={!isLive}>
+        <div style={{ textAlign: "center", marginBottom: "8px" }}>
+          <span className="label">Add a </span>
+          <select
+            name="addEntryType"
+            value={entryType}
+            onChange={(e) => setEntryType(e.target.value as EntryType)}
+            disabled={!isLive}
+          >
+            <option value="track">Track</option>
+            <option value="talkset">Talkset</option>
+            <option value="breakpoint">Breakpoint</option>
+          </select>
+          {entryType !== "track" && (
+            <>
+              &nbsp;
+              <input
+                type="submit"
+                value="Add"
+                disabled={!isLive || isLoading || !canSubmit}
+              />
+            </>
+          )}
+        </div>
 
-      {entryType === "track" && (
-        <form name="flowsheetEntry" method="POST" onSubmit={handleSubmit}>
-          <fieldset disabled={!isLive}>
+        {entryType === "track" && (
+          <>
             <div style={{ textAlign: "center", margin: "8px 0" }}>
               <span className="label">From </span>
               <select
@@ -200,7 +202,7 @@ export default function EntryForm({
                     }}
                     disabled={!isLive}
                   >
-                    <option value=""></option>
+                    <option value="">-- choose bin --</option>
                     <option value="heavy">Heavy</option>
                     <option value="medium">Medium</option>
                     <option value="light">Light</option>
@@ -328,7 +330,6 @@ export default function EntryForm({
                       name="songTitle"
                       value={songTitle}
                       onChange={(e) => setSongTitle(e.target.value)}
-                      required
                       disabled={!isLive}
                     />
                   </td>
@@ -435,9 +436,9 @@ export default function EntryForm({
                 </tr>
               </tbody>
             </table>
-          </fieldset>
-        </form>
-      )}
-    </>
+          </>
+        )}
+      </fieldset>
+    </form>
   );
 }

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryForm.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryForm.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { renderWithProviders } from "@/lib/test-utils/render";
+import {
+  createTestArtist,
+  createTestRotationAlbum,
+} from "@/lib/test-utils/fixtures";
+import { Rotation } from "@/lib/features/rotation/types";
 import { FlowsheetEntryType } from "@wxyc/shared/dtos";
 import EntryForm from "../EntryForm";
 
@@ -20,15 +25,17 @@ vi.mock("@/lib/features/flowsheet/api", async (importOriginal) => {
   };
 });
 
-// Rotation data is irrelevant for most tests; return an empty list by default.
-// Individual tests can override via vi.mocked() when they need fixtures.
+// Rotation data is fixture-controlled per test. Default is empty; tests that
+// exercise the rotation-release submission branch set `rotationDataMock` to a
+// list before rendering the form.
+let rotationDataMock: ReturnType<typeof createTestRotationAlbum>[] = [];
 vi.mock("@/lib/features/rotation/api", async (importOriginal) => {
   const actual = await importOriginal<
     typeof import("@/lib/features/rotation/api")
   >();
   return {
     ...actual,
-    useGetRotationQuery: () => ({ data: [] as never[] }),
+    useGetRotationQuery: () => ({ data: rotationDataMock }),
   };
 });
 
@@ -37,6 +44,7 @@ beforeEach(() => {
   // Default: addToFlowsheet returns a mock RTK Query result with .unwrap()
   // that resolves so the form's reset path doesn't throw.
   addToFlowsheetMock.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+  rotationDataMock = [];
 });
 
 /**
@@ -255,7 +263,7 @@ describe("Classic EntryForm — Submit disabled until track chosen", () => {
 });
 
 describe("Classic EntryForm — Bin dropdown (replaces H/M/L/S radios)", () => {
-  it("renders Bin as a select with Heavy/Medium/Light/Singles + empty option", () => {
+  it("renders Bin as a select with Heavy/Medium/Light/Singles + empty placeholder", () => {
     renderWithProviders(<EntryForm />);
     const bin = getNamedSelect("rotationType");
     const optionValues = Array.from(bin.options).map((o) => o.value);
@@ -265,5 +273,110 @@ describe("Classic EntryForm — Bin dropdown (replaces H/M/L/S radios)", () => {
     expect(
       document.querySelector('input[type="radio"][name="rotationType"]')
     ).toBeNull();
+  });
+
+  it("labels the empty Bin placeholder so screen readers can announce it", () => {
+    renderWithProviders(<EntryForm />);
+    const bin = getNamedSelect("rotationType");
+    const placeholder = bin.options[0];
+    expect(placeholder.value).toBe("");
+    // Visible text on the placeholder option — not zero-width — so VO/JAWS
+    // can announce something meaningful for the unselected state.
+    expect(placeholder.textContent?.trim().length).toBeGreaterThan(0);
+  });
+});
+
+describe("Classic EntryForm — Rotation submission payload", () => {
+  it("submits a rotation entry with album_id, rotation_id, and rotation_bin", async () => {
+    rotationDataMock = [
+      createTestRotationAlbum(Rotation.H, {
+        id: 5101,
+        rotation_id: 5102,
+        title: "Aluminum Tunes",
+        label: "Duophonic",
+        artist: createTestArtist({
+          name: "Stereolab",
+          lettercode: "RO",
+          numbercode: 87,
+        }),
+      }),
+    ];
+    const { user } = renderWithProviders(<EntryForm />);
+    // Default state is Track + Rotation. Pick Heavy, then the release.
+    await user.selectOptions(getNamedSelect("rotationType"), "heavy");
+    await user.selectOptions(getNamedSelect("heavyRelease"), "5101");
+    await user.type(getNamedInput("songTitle"), "Tone Burst");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+    });
+    const payload = addToFlowsheetMock.mock.calls[0][0];
+    expect(payload.album_id).toBe(5101);
+    expect(payload.rotation_id).toBe(5102);
+    expect(payload.rotation_bin).toBe(Rotation.H);
+    expect(payload.track_title).toBe("Tone Burst");
+    expect(payload.record_label).toBe("Duophonic");
+    // Pin the absence of the legacy field name so a future rename doesn't
+    // silently regress to `play_freq`.
+    expect("play_freq" in payload).toBe(false);
+  });
+});
+
+describe("Classic EntryForm — Breakpoint message format", () => {
+  it("formats the breakpoint message as 'H:MM AM/PM Breakpoint'", async () => {
+    // mockCurrentTime() can't be used here because it installs fake timers,
+    // which hangs userEvent's internal setTimeout-based delays. Instead we
+    // pin only the *shape* of the message — that catches regressions to a
+    // 24-hour clock, missing AM/PM, dropped minutes, or wrong word.
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("addEntryType"), "breakpoint");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+    });
+    const message: string = addToFlowsheetMock.mock.calls[0][0].message;
+    expect(message).toMatch(/^\d{1,2}:\d{2} (AM|PM) Breakpoint$/);
+  });
+});
+
+describe("Classic EntryForm — post-submit reset behavior", () => {
+  it("resets Add a back to Track after submitting a Talkset", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("addEntryType"), "talkset");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+    });
+    expect(getNamedSelect("addEntryType").value).toBe("track");
+  });
+});
+
+describe("Classic EntryForm — Enter-key submission guard", () => {
+  it("does NOT submit when pressing Enter in the song field with no artist", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("releaseType"), "otherRelease");
+    const songInput = getNamedInput("songTitle");
+    await user.type(songInput, "untitled{Enter}");
+    // Brief settle so any errant submit could complete.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(addToFlowsheetMock).not.toHaveBeenCalled();
+  });
+
+  it("DOES submit when pressing Enter in the song field after Artist+Song are filled", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("releaseType"), "otherRelease");
+    await user.type(getNamedInput("artistName"), "Cat Power");
+    await user.type(getNamedInput("songTitle"), "Cross Bones Style{Enter}");
+
+    await waitFor(() => {
+      expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+    });
+    expect(addToFlowsheetMock.mock.calls[0][0].track_title).toBe(
+      "Cross Bones Style"
+    );
+    expect(addToFlowsheetMock.mock.calls[0][0].artist_name).toBe("Cat Power");
   });
 });

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryForm.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryForm.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { renderWithProviders } from "@/lib/test-utils/render";
+import { FlowsheetEntryType } from "@wxyc/shared/dtos";
 import EntryForm from "../EntryForm";
 
 // The form calls useAddToFlowsheetMutation() directly; mock that hook so we can
@@ -19,8 +20,8 @@ vi.mock("@/lib/features/flowsheet/api", async (importOriginal) => {
   };
 });
 
-// Rotation data is irrelevant for these tests; return an empty list so the
-// rotation dropdown rows do not need a fixture.
+// Rotation data is irrelevant for most tests; return an empty list by default.
+// Individual tests can override via vi.mocked() when they need fixtures.
 vi.mock("@/lib/features/rotation/api", async (importOriginal) => {
   const actual = await importOriginal<
     typeof import("@/lib/features/rotation/api")
@@ -40,12 +41,10 @@ beforeEach(() => {
 
 /**
  * The Classic form is a port of the tubafrenzy JSP layout: every form control
- * has a `name=` but most inputs (artist textbox, release-type radios) sit next
- * to plain-text labels in adjacent `<td>` cells rather than associated `<label
- * htmlFor>` elements, so RTL's accessible-name lookups (`getByRole("textbox",
- * { name })`, `getByRole("radio", { name })`) cannot find them. We use the
- * named-control helper below for those inputs. The Segue checkbox itself is
- * wrapped in a `<label>` and is queried via `getByRole("checkbox", { name })`.
+ * has a `name=` but several inputs sit next to plain-text labels in adjacent
+ * `<td>` cells rather than associated `<label htmlFor>` elements, so RTL's
+ * accessible-name lookups (`getByRole("textbox", { name })`) cannot find them.
+ * We use the named-control helper below for those inputs.
  */
 function getNamedInput(name: string): HTMLInputElement {
   const el = document.querySelector(
@@ -55,7 +54,134 @@ function getNamedInput(name: string): HTMLInputElement {
   return el;
 }
 
-describe("Classic EntryForm segue checkbox", () => {
+function getNamedSelect(name: string): HTMLSelectElement {
+  const el = document.querySelector(
+    `select[name="${name}"]`
+  ) as HTMLSelectElement | null;
+  if (!el) throw new Error(`Select name="${name}" not found`);
+  return el;
+}
+
+describe("Classic EntryForm — Add a dropdown", () => {
+  it("renders an 'Add a' select with Track / Talkset / Breakpoint options", () => {
+    renderWithProviders(<EntryForm />);
+    const select = getNamedSelect("addEntryType");
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toEqual(["track", "talkset", "breakpoint"]);
+    expect(select.value).toBe("track");
+  });
+
+  it("hides the track-entry UI when Add a = Talkset", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("addEntryType"), "talkset");
+    // The track-entry UI is identified by the From dropdown.
+    expect(document.querySelector('select[name="releaseType"]')).toBeNull();
+  });
+
+  it("hides the track-entry UI when Add a = Breakpoint", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("addEntryType"), "breakpoint");
+    expect(document.querySelector('select[name="releaseType"]')).toBeNull();
+  });
+
+  it("submits a talkset payload immediately when Add a = Talkset + Add clicked", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("addEntryType"), "talkset");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+    });
+    const payload = addToFlowsheetMock.mock.calls[0][0];
+    expect(payload.entry_type).toBe(FlowsheetEntryType.talkset);
+    expect(payload.message).toBe("Talkset");
+  });
+
+  it("submits a breakpoint payload immediately when Add a = Breakpoint + Add clicked", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("addEntryType"), "breakpoint");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+    });
+    const payload = addToFlowsheetMock.mock.calls[0][0];
+    expect(payload.entry_type).toBe(FlowsheetEntryType.breakpoint);
+    expect(typeof payload.message).toBe("string");
+    expect(payload.message.toLowerCase()).toContain("breakpoint");
+  });
+});
+
+describe("Classic EntryForm — From dropdown", () => {
+  it("renders a 'From' select with Rotation / Library / Other when Add a = Track", () => {
+    renderWithProviders(<EntryForm />);
+    const select = getNamedSelect("releaseType");
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toEqual([
+      "rotationRelease",
+      "libraryRelease",
+      "otherRelease",
+    ]);
+  });
+
+  it("shows the Bin dropdown when From = Rotation", () => {
+    renderWithProviders(<EntryForm />);
+    // Default is rotationRelease, so Bin should be visible immediately.
+    const bin = document.querySelector('select[name="rotationType"]');
+    expect(bin).not.toBeNull();
+  });
+
+  it("hides the Bin dropdown when From = Library", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("releaseType"), "libraryRelease");
+    expect(document.querySelector('select[name="rotationType"]')).toBeNull();
+  });
+
+  it("hides the Bin dropdown when From = Other", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("releaseType"), "otherRelease");
+    expect(document.querySelector('select[name="rotationType"]')).toBeNull();
+  });
+
+  it("shows the Artist textbox when From = Library or Other", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("releaseType"), "libraryRelease");
+    expect(document.querySelector('input[name="artistName"]')).not.toBeNull();
+    await user.selectOptions(getNamedSelect("releaseType"), "otherRelease");
+    expect(document.querySelector('input[name="artistName"]')).not.toBeNull();
+  });
+});
+
+describe("Classic EntryForm — Request checkbox (not radios)", () => {
+  it("renders Request as a single checkbox, not a yes/no radio pair", () => {
+    renderWithProviders(<EntryForm />);
+    const requestCheckbox = screen.getByRole("checkbox", {
+      name: /^request$/i,
+    }) as HTMLInputElement;
+    expect(requestCheckbox.type).toBe("checkbox");
+    expect(requestCheckbox.checked).toBe(false);
+    // No leftover request-answer radios.
+    expect(
+      document.querySelector('input[type="radio"][name="requestAnswer"]')
+    ).toBeNull();
+  });
+
+  it("submits request_flag=true when the Request checkbox is checked", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("releaseType"), "otherRelease");
+    await user.type(getNamedInput("artistName"), "Juana Molina");
+    await user.type(getNamedInput("songTitle"), "la paradoja");
+    await user.click(screen.getByRole("checkbox", { name: /^request$/i }));
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+    });
+    expect(addToFlowsheetMock.mock.calls[0][0].request_flag).toBe(true);
+  });
+});
+
+describe("Classic EntryForm — Segue checkbox", () => {
   it("renders a Segue checkbox, unchecked by default", () => {
     renderWithProviders(<EntryForm />);
     const segueCheckbox = screen.getByRole("checkbox", {
@@ -64,62 +190,80 @@ describe("Classic EntryForm segue checkbox", () => {
     expect(segueCheckbox.checked).toBe(false);
   });
 
-  it("toggles segue state when the checkbox is clicked", async () => {
+  it("submits segue=true when the Segue checkbox is checked", async () => {
     const { user } = renderWithProviders(<EntryForm />);
-    const segueCheckbox = screen.getByRole("checkbox", {
-      name: /segue/i,
-    }) as HTMLInputElement;
-    await user.click(segueCheckbox);
-    expect(segueCheckbox.checked).toBe(true);
-    await user.click(segueCheckbox);
-    expect(segueCheckbox.checked).toBe(false);
-  });
-
-  it("submits segue=true in the addToFlowsheet payload when the checkbox is checked", async () => {
-    const { user } = renderWithProviders(<EntryForm />);
-
-    // Switch to the "Other" release type so the artist textbox renders.
-    const otherRadio = document.querySelector(
-      'input[name="releaseType"][value="otherRelease"]'
-    ) as HTMLInputElement;
-    await user.click(otherRadio);
-
-    await user.type(getNamedInput("artistName"), "Juana Molina");
-    await user.type(getNamedInput("songTitle"), "la paradoja");
-    await user.click(screen.getByRole("checkbox", { name: /segue/i }));
-
-    await user.click(
-      screen.getByRole("button", { name: /add this song to the flowsheet/i })
-    );
-
-    await waitFor(() => {
-      expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
-    });
-    const payload = addToFlowsheetMock.mock.calls[0][0];
-    expect(payload.segue).toBe(true);
-    expect(payload.track_title).toBe("la paradoja");
-    expect(payload.artist_name).toBe("Juana Molina");
-  });
-
-  it("submits segue=false when the checkbox is unchecked", async () => {
-    const { user } = renderWithProviders(<EntryForm />);
-
-    const otherRadio = document.querySelector(
-      'input[name="releaseType"][value="otherRelease"]'
-    ) as HTMLInputElement;
-    await user.click(otherRadio);
-
+    await user.selectOptions(getNamedSelect("releaseType"), "otherRelease");
     await user.type(getNamedInput("artistName"), "Jessica Pratt");
     await user.type(getNamedInput("songTitle"), "Back, Baby");
-
-    await user.click(
-      screen.getByRole("button", { name: /add this song to the flowsheet/i })
-    );
+    await user.click(screen.getByRole("checkbox", { name: /segue/i }));
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
 
     await waitFor(() => {
       expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
     });
-    const payload = addToFlowsheetMock.mock.calls[0][0];
-    expect(payload.segue).toBe(false);
+    expect(addToFlowsheetMock.mock.calls[0][0].segue).toBe(true);
+  });
+});
+
+describe("Classic EntryForm — Submit disabled until track chosen", () => {
+  it("disables Submit when From = Library and the song title is empty", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("releaseType"), "libraryRelease");
+    const submit = screen.getByRole("button", {
+      name: /^add$/i,
+    }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+  });
+
+  it("disables Submit when From = Other and the song title is empty", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("releaseType"), "otherRelease");
+    const submit = screen.getByRole("button", {
+      name: /^add$/i,
+    }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+  });
+
+  it("enables Submit once Artist + Song are filled in (From = Other)", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("releaseType"), "otherRelease");
+    await user.type(getNamedInput("artistName"), "Chuquimamani-Condori");
+    await user.type(getNamedInput("songTitle"), "Call Your Name");
+    const submit = screen.getByRole("button", {
+      name: /^add$/i,
+    }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+  });
+
+  it("enables Submit immediately when Add a = Talkset (no track required)", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("addEntryType"), "talkset");
+    const submit = screen.getByRole("button", {
+      name: /^add$/i,
+    }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+  });
+
+  it("enables Submit immediately when Add a = Breakpoint (no track required)", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("addEntryType"), "breakpoint");
+    const submit = screen.getByRole("button", {
+      name: /^add$/i,
+    }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+  });
+});
+
+describe("Classic EntryForm — Bin dropdown (replaces H/M/L/S radios)", () => {
+  it("renders Bin as a select with Heavy/Medium/Light/Singles + empty option", () => {
+    renderWithProviders(<EntryForm />);
+    const bin = getNamedSelect("rotationType");
+    const optionValues = Array.from(bin.options).map((o) => o.value);
+    expect(optionValues).toEqual(["", "heavy", "medium", "light", "singles"]);
+    expect(bin.value).toBe("");
+    // No leftover rotationType radios.
+    expect(
+      document.querySelector('input[type="radio"][name="rotationType"]')
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Replace the three radio groups in `src/components/experiences/classic/flowsheet/EntryForm.tsx` (release type, rotation bin, request yes/no) with native `<select>` elements that mirror tubafrenzy's current shape.
- Consolidate talkset/breakpoint creation into the form via an `Add a` dropdown (Track / Talkset / Breakpoint). Non-track modes hide the rest of the form and submit immediately on Add.
- Make the Add button responsive to entry state: in Track mode it's disabled until a song title plus either an artist (Library/Other) or a selected rotation release (Rotation) is present; in Talkset/Breakpoint mode it's always enabled.

Ports tubafrenzy commit [`0036fe97`](https://github.com/WXYC/tubafrenzy/commit/0036fe977a26b2d4b0322530000a168cea7851dc). Part of the Classic-mode parity port tracked in #511.

Closes #534

## Notes

- The talkset/breakpoint links in `ActionsBar` are now redundant but stay for this PR — they're retired together with the `End Show` move in PR 10.
- Request and Segue both render as checkboxes inline with the Add button.
- 20 EntryForm tests cover Add a × From combinations, the Bin dropdown, the disabled-until-track guard, and request/segue payload round-trips.

## Test plan

- [ ] `tsc --noEmit` clean
- [ ] `npx vitest run` — 195 files / 2805 tests pass
- [ ] `npm run build` clean (Next.js production build)
- [ ] Manually verify in a local dev session: Add a = Talkset → form collapses + Add submits a talkset; switching From hides/shows the Bin dropdown; Submit stays disabled until song + (artist or rotation release) are present.