### PR TITLE
classic flowsheet: replace move-up/down arrows with drag-to-reorder grip handle

### DIFF
--- a/src/components/experiences/classic/flowsheet/EntryRow.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryRow.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { DragEvent as ReactDragEvent } from "react";
 import {
   FlowsheetEntry,
   isFlowsheetSongEntry,
@@ -75,23 +76,41 @@ export default function EntryRow({
     .filter(Boolean)
     .join(" ");
 
+  // A row is only draggable when the parent wires up reorder handlers. The
+  // previous-show <tbody> in EntryTable renders rows without these, so they
+  // render with an empty grip cell and no drag affordance — the visual matches
+  // the read-only intent.
+  const isDraggable = Boolean(onDragStart);
+  const dragHandlers = isDraggable
+    ? {
+        onDragStart: () => onDragStart?.(entry.id),
+        onDragOver: (e: ReactDragEvent) => {
+          e.preventDefault();
+          onDragOver?.(entry.id);
+        },
+        onDrop: (e: ReactDragEvent) => {
+          e.preventDefault();
+          onDrop?.(entry.id);
+        },
+        onDragEnd: () => onDragEnd?.(),
+      }
+    : {};
+
   if (isFlowsheetTalksetEntry(entry)) {
     return (
       <tr
-        className={`flowsheetEntryData classic-marker-talkset ${fontSizeClass} ${dragClass}`.trim()}
-        draggable={true}
-        onDragStart={() => onDragStart?.(entry.id)}
-        onDragOver={(e) => {
-          e.preventDefault();
-          onDragOver?.(entry.id);
-        }}
-        onDrop={(e) => {
-          e.preventDefault();
-          onDrop?.(entry.id);
-        }}
-        onDragEnd={() => onDragEnd?.()}
+        className={[
+          "flowsheetEntryData",
+          "classic-marker-talkset",
+          fontSizeClass,
+          dragClass,
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        draggable={isDraggable}
+        {...dragHandlers}
       >
-        <GripCell />
+        {isDraggable ? <GripCell /> : <EmptyGripCell />}
         <td colSpan={5} align="center">
           talkset
         </td>
@@ -157,8 +176,7 @@ export default function EntryRow({
       "flowsheetEntryData",
       fontSizeClass,
       showSegueBracket ? "classic-segue" : "",
-      isDragging ? "dragging" : "",
-      isDragOver ? "drag-over" : "",
+      dragClass,
     ]
       .filter(Boolean)
       .join(" ");
@@ -169,19 +187,10 @@ export default function EntryRow({
         style={{ backgroundColor: "#F3F3F3" }}
         className={trClassName}
         data-segue={dataSegue}
-        draggable={true}
-        onDragStart={() => onDragStart?.(entry.id)}
-        onDragOver={(e) => {
-          e.preventDefault();
-          onDragOver?.(entry.id);
-        }}
-        onDrop={(e) => {
-          e.preventDefault();
-          onDrop?.(entry.id);
-        }}
-        onDragEnd={() => onDragEnd?.()}
+        draggable={isDraggable}
+        {...dragHandlers}
       >
-        <GripCell />
+        {isDraggable ? <GripCell /> : <EmptyGripCell />}
         <td align="center">
           {capsules.map((c) => (
             <Capsule key={c.variant} variant={c.variant} label={c.label} />

--- a/src/components/experiences/classic/flowsheet/EntryRow.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryRow.tsx
@@ -12,6 +12,43 @@ import { Capsule, capsulesForSongEntry } from "./Capsule";
 import { formatShortDate, formatShortTime } from "./marker-format";
 import "@/src/styles/classic/segue.css";
 import "@/src/styles/classic/markers.css";
+import "@/src/styles/classic/drag.css";
+
+type Props = {
+  entry: FlowsheetEntry;
+  index: number;
+  totalEntries: number;
+  onEdit: (entryId: number) => void;
+  onDelete: (entryId: number) => void;
+  fontSize: number;
+  /** True if the next row in the table is also a song row.
+   *  Used to suppress the segue indicator when the next row is a talkset,
+   *  breakpoint, or show-block — those render full-width and would leave the
+   *  red bracket dangling. EntryTable computes and passes this. */
+  nextIsSong?: boolean;
+  /** True while this row is the source of an active drag. */
+  isDragging?: boolean;
+  /** True while a drag-over event is hovering this row (drop target preview). */
+  isDragOver?: boolean;
+  onDragStart?: (entryId: number) => void;
+  onDragOver?: (entryId: number) => void;
+  onDrop?: (entryId: number) => void;
+  onDragEnd?: () => void;
+};
+
+function GripCell() {
+  return (
+    <td className="grip-cell">
+      <span className="grip-handle" aria-label="Drag to reorder">
+        {"⠇"}
+      </span>
+    </td>
+  );
+}
+
+function EmptyGripCell() {
+  return <td className="grip-cell">&nbsp;</td>;
+}
 
 export default function EntryRow({
   entry,
@@ -19,73 +56,98 @@ export default function EntryRow({
   totalEntries,
   onEdit,
   onDelete,
-  onMoveUp,
-  onMoveDown,
   fontSize,
   nextIsSong,
-}: {
-  entry: FlowsheetEntry;
-  index: number;
-  totalEntries: number;
-  onEdit: (entryId: number) => void;
-  onDelete: (entryId: number) => void;
-  onMoveUp: (entryId: number) => void;
-  onMoveDown: (entryId: number) => void;
-  fontSize: number;
-  /** True if the next row in the table is also a song row.
-   *  Used to suppress the segue indicator when the next row is a talkset,
-   *  breakpoint, or show-block — those render full-width and would leave the
-   *  red bracket dangling. EntryTable computes and passes this. */
-  nextIsSong?: boolean;
-}) {
+  isDragging,
+  isDragOver,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+}: Props) {
+  // Suppress unused-var warnings for props kept for API parity; the indices
+  // are still relevant to other features (e.g. show-block guards).
+  void index;
+  void totalEntries;
   const fontSizeClass = `fontSize${fontSize}`;
 
-  // Markers (talkset / breakpoint / start / end of show) span the full table.
-  // Column count after capsule consolidation: 1 (indicators) + 4 (artist/song/release/label)
-  // + 2 (move up/down) + 1 (edit/delete) = 8 columns. Header text spans the first 5
-  // (indicators + 4 data) and the row's trailing 3 columns stay empty.
+  // Marker rows (talkset / breakpoint / start / end of show) span 5 of the 7
+  // post-PR8 columns: grip + indicators + artist + song + release + label + edit.
+  // The marker's content cell colspans the 5 middle data columns; the trailing
+  // edit/delete column gets an empty cell.
+
+  const dragClass = [
+    isDragging ? "dragging" : "",
+    isDragOver ? "drag-over" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   if (isFlowsheetTalksetEntry(entry)) {
     return (
-      <tr className={`flowsheetEntryData classic-marker-talkset ${fontSizeClass}`}>
+      <tr
+        className={`flowsheetEntryData classic-marker-talkset ${fontSizeClass} ${dragClass}`.trim()}
+        draggable={true}
+        onDragStart={() => onDragStart?.(entry.id)}
+        onDragOver={(e) => {
+          e.preventDefault();
+          onDragOver?.(entry.id);
+        }}
+        onDrop={(e) => {
+          e.preventDefault();
+          onDrop?.(entry.id);
+        }}
+        onDragEnd={() => onDragEnd?.()}
+      >
+        <GripCell />
         <td colSpan={5} align="center">
           talkset
         </td>
-        <td colSpan={3}>&nbsp;</td>
+        <td>&nbsp;</td>
       </tr>
     );
   }
 
   if (isFlowsheetBreakpointEntry(entry)) {
     return (
-      <tr className={`flowsheetEntryData classic-marker-breakpoint ${fontSizeClass}`}>
+      <tr
+        className={`flowsheetEntryData classic-marker-breakpoint ${fontSizeClass}`.trim()}
+      >
+        <EmptyGripCell />
         <td colSpan={5} align="center">
           {formatShortTime(entry.time)} breakpoint
         </td>
-        <td colSpan={3}>&nbsp;</td>
+        <td>&nbsp;</td>
       </tr>
     );
   }
 
   if (isFlowsheetStartShowEntry(entry)) {
     return (
-      <tr className={`flowsheetEntryData classic-marker-breakpoint ${fontSizeClass}`}>
+      <tr
+        className={`flowsheetEntryData classic-marker-breakpoint ${fontSizeClass}`.trim()}
+      >
+        <EmptyGripCell />
         <td colSpan={5} align="center">
           Start of show — {entry.dj_name} @ {formatShortDate(entry.day)}{" "}
           {formatShortTime(entry.time)}
         </td>
-        <td colSpan={3}>&nbsp;</td>
+        <td>&nbsp;</td>
       </tr>
     );
   }
 
   if (isFlowsheetEndShowEntry(entry)) {
     return (
-      <tr className={`flowsheetEntryData classic-marker-breakpoint ${fontSizeClass}`}>
+      <tr
+        className={`flowsheetEntryData classic-marker-breakpoint ${fontSizeClass}`.trim()}
+      >
+        <EmptyGripCell />
         <td colSpan={5} align="center">
           End of show — {entry.dj_name} @ {formatShortDate(entry.day)}{" "}
           {formatShortTime(entry.time)}
         </td>
-        <td colSpan={3}>&nbsp;</td>
+        <td>&nbsp;</td>
       </tr>
     );
   }
@@ -103,6 +165,8 @@ export default function EntryRow({
       "flowsheetEntryData",
       fontSizeClass,
       showSegueBracket ? "classic-segue" : "",
+      isDragging ? "dragging" : "",
+      isDragOver ? "drag-over" : "",
     ]
       .filter(Boolean)
       .join(" ");
@@ -113,7 +177,19 @@ export default function EntryRow({
         style={{ backgroundColor: "#F3F3F3" }}
         className={trClassName}
         data-segue={dataSegue}
+        draggable={true}
+        onDragStart={() => onDragStart?.(entry.id)}
+        onDragOver={(e) => {
+          e.preventDefault();
+          onDragOver?.(entry.id);
+        }}
+        onDrop={(e) => {
+          e.preventDefault();
+          onDrop?.(entry.id);
+        }}
+        onDragEnd={() => onDragEnd?.()}
       >
+        <GripCell />
         <td align="center">
           {capsules.map((c) => (
             <Capsule key={c.variant} variant={c.variant} label={c.label} />
@@ -132,46 +208,6 @@ export default function EntryRow({
         </td>
         <td align="left">{entry.album_title || ""}</td>
         <td align="left">{entry.record_label || ""}</td>
-        <td align="center" className="text">
-          {index > 0 && index < totalEntries - 1 ? (
-            <a
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                onMoveUp(entry.id);
-              }}
-            >
-              <img
-                src="/img/classic/blue_up.gif"
-                title="Move this entry up"
-                alt="Move this entry up"
-                style={{ border: 0 }}
-              />
-            </a>
-          ) : (
-            <>&nbsp;</>
-          )}
-        </td>
-        <td align="center" className="text">
-          {index < totalEntries - 2 ? (
-            <a
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                onMoveDown(entry.id);
-              }}
-            >
-              <img
-                src="/img/classic/blue_down.gif"
-                title="Move this entry down"
-                alt="Move this entry down"
-                style={{ border: 0 }}
-              />
-            </a>
-          ) : (
-            <>&nbsp;</>
-          )}
-        </td>
         <td align="center" className="text">
           <a
             href="#"

--- a/src/components/experiences/classic/flowsheet/EntryRow.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryRow.tsx
@@ -16,8 +16,6 @@ import "@/src/styles/classic/drag.css";
 
 type Props = {
   entry: FlowsheetEntry;
-  index: number;
-  totalEntries: number;
   onEdit: (entryId: number) => void;
   onDelete: (entryId: number) => void;
   fontSize: number;
@@ -52,8 +50,6 @@ function EmptyGripCell() {
 
 export default function EntryRow({
   entry,
-  index,
-  totalEntries,
   onEdit,
   onDelete,
   fontSize,
@@ -65,10 +61,6 @@ export default function EntryRow({
   onDrop,
   onDragEnd,
 }: Props) {
-  // Suppress unused-var warnings for props kept for API parity; the indices
-  // are still relevant to other features (e.g. show-block guards).
-  void index;
-  void totalEntries;
   const fontSizeClass = `fontSize${fontSize}`;
 
   // Marker rows (talkset / breakpoint / start / end of show) span 5 of the 7

--- a/src/components/experiences/classic/flowsheet/EntryTable.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryTable.tsx
@@ -13,34 +13,53 @@ export default function EntryTable({
   fontSize,
   onEdit,
   onDelete,
-  onMoveUp,
-  onMoveDown,
+  onReorder,
 }: {
   entries: FlowsheetEntry[];
   previousEntries: FlowsheetEntry[];
   fontSize: number;
   onEdit: (entryId: number) => void;
   onDelete: (entryId: number) => void;
-  onMoveUp: (entryId: number) => void;
-  onMoveDown: (entryId: number) => void;
+  /** Fired when a row is dropped onto another row. The implementation should
+   *  swap the two entries' play_order values (or otherwise reorder). */
+  onReorder: (sourceId: number, targetId: number) => void;
 }) {
   const [showPrevious, setShowPrevious] = useState(false);
+  const [draggingId, setDraggingId] = useState<number | null>(null);
+  const [dragOverId, setDragOverId] = useState<number | null>(null);
+
+  const handleDragStart = (entryId: number) => {
+    setDraggingId(entryId);
+  };
+
+  const handleDragOver = (entryId: number) => {
+    setDragOverId(entryId);
+  };
+
+  const handleDrop = (entryId: number) => {
+    if (draggingId !== null && draggingId !== entryId) {
+      onReorder(draggingId, entryId);
+    }
+    setDraggingId(null);
+    setDragOverId(null);
+  };
+
+  const handleDragEnd = () => {
+    setDraggingId(null);
+    setDragOverId(null);
+  };
 
   return (
     <div id="flowsheet">
       <table cellPadding={4} cellSpacing={2} border={0} style={{ width: "100%" }}>
         <thead>
           <tr>
+            <th></th>
             <th>Indicators</th>
             <th style={{ width: "25%" }}>Artist</th>
             <th>Song</th>
             <th>Release</th>
             <th>Label</th>
-            <th colSpan={2}>
-              Move Up
-              <br />
-              or Down?
-            </th>
             <th>Edit/Delete</th>
           </tr>
         </thead>
@@ -59,15 +78,19 @@ export default function EntryTable({
                   fontSize={fontSize}
                   onEdit={onEdit}
                   onDelete={onDelete}
-                  onMoveUp={onMoveUp}
-                  onMoveDown={onMoveDown}
                   nextIsSong={nextIsSong}
+                  isDragging={draggingId === entry.id}
+                  isDragOver={dragOverId === entry.id}
+                  onDragStart={handleDragStart}
+                  onDragOver={handleDragOver}
+                  onDrop={handleDrop}
+                  onDragEnd={handleDragEnd}
                 />
               );
             })
           ) : (
             <tr>
-              <td align="center" className="text" colSpan={8}>
+              <td align="center" className="text" colSpan={7}>
                 There are currently no entries on this flowsheet.
               </td>
             </tr>
@@ -90,10 +113,8 @@ export default function EntryTable({
                   setShowPrevious(!showPrevious);
                 }}
               >
-                {showPrevious
-                  ? "Hide"
-                  : "Show"}{" "}
-                /Hide the flowsheet from the previous show below...
+                {showPrevious ? "Hide" : "Show"} /Hide the flowsheet from the
+                previous show below...
               </a>
             </td>
           </tr>
@@ -113,8 +134,6 @@ export default function EntryTable({
                   fontSize={fontSize}
                   onEdit={onEdit}
                   onDelete={onDelete}
-                  onMoveUp={onMoveUp}
-                  onMoveDown={onMoveDown}
                   nextIsSong={nextIsSong}
                 />
               );

--- a/src/components/experiences/classic/flowsheet/EntryTable.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryTable.tsx
@@ -73,8 +73,6 @@ export default function EntryTable({
                 <EntryRow
                   key={entry.id}
                   entry={entry}
-                  index={index}
-                  totalEntries={entries.length}
                   fontSize={fontSize}
                   onEdit={onEdit}
                   onDelete={onDelete}
@@ -129,8 +127,6 @@ export default function EntryTable({
                 <EntryRow
                   key={entry.id}
                   entry={entry}
-                  index={index}
-                  totalEntries={previousEntries.length}
                   fontSize={fontSize}
                   onEdit={onEdit}
                   onDelete={onDelete}

--- a/src/components/experiences/classic/flowsheet/Layout/Main.tsx
+++ b/src/components/experiences/classic/flowsheet/Layout/Main.tsx
@@ -90,35 +90,16 @@ export default function Main() {
     }
   };
 
-  const handleMoveUp = async (entryId: number) => {
-    const index = currentShowEntries.findIndex((e) => e.id === entryId);
-    if (index > 0) {
-      const entry = currentShowEntries[index];
-      const prevEntry = currentShowEntries[index - 1];
-      try {
-        await switchEntries({
-          entry_id: entry.id,
-          new_position: prevEntry.play_order,
-        }).unwrap();
-      } catch (error) {
-        console.error("Failed to move entry up:", error);
-      }
-    }
-  };
-
-  const handleMoveDown = async (entryId: number) => {
-    const index = currentShowEntries.findIndex((e) => e.id === entryId);
-    if (index < currentShowEntries.length - 1) {
-      const entry = currentShowEntries[index];
-      const nextEntry = currentShowEntries[index + 1];
-      try {
-        await switchEntries({
-          entry_id: entry.id,
-          new_position: nextEntry.play_order,
-        }).unwrap();
-      } catch (error) {
-        console.error("Failed to move entry down:", error);
-      }
+  const handleReorder = async (sourceId: number, targetId: number) => {
+    const target = currentShowEntries.find((e) => e.id === targetId);
+    if (!target || !("play_order" in target)) return;
+    try {
+      await switchEntries({
+        entry_id: sourceId,
+        new_position: target.play_order,
+      }).unwrap();
+    } catch (error) {
+      console.error("Failed to reorder entries:", error);
     }
   };
 
@@ -192,8 +173,7 @@ export default function Main() {
           fontSize={fontSize}
           onEdit={handleEdit}
           onDelete={handleDelete}
-          onMoveUp={handleMoveUp}
-          onMoveDown={handleMoveDown}
+          onReorder={handleReorder}
         />
       </div>
     </div>

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
@@ -8,16 +8,21 @@ import EntryRow from "../EntryRow";
 
 // renderInTable wraps EntryRow in a <table><tbody> so the row's <td> elements
 // are mounted in a valid layout context (RTL otherwise warns).
+// renderRow defaults `onDragStart` to a no-op so the "live" rendering context
+// (where the parent always wires drag handlers) is the default. Tests that
+// want the read-only previous-show context can pass `dragHandlers: false`.
 function renderRow(props: {
   entry: FlowsheetEntry;
   nextIsSong?: boolean;
   isDragging?: boolean;
   isDragOver?: boolean;
+  dragHandlers?: boolean;
   onDragStart?: (entryId: number) => void;
   onDragOver?: (entryId: number) => void;
   onDrop?: (entryId: number) => void;
   onDragEnd?: () => void;
 }) {
+  const dragHandlersEnabled = props.dragHandlers !== false;
   return renderWithProviders(
     <table>
       <tbody>
@@ -29,7 +34,9 @@ function renderRow(props: {
           nextIsSong={props.nextIsSong}
           isDragging={props.isDragging}
           isDragOver={props.isDragOver}
-          onDragStart={props.onDragStart}
+          onDragStart={
+            dragHandlersEnabled ? props.onDragStart ?? (() => {}) : undefined
+          }
           onDragOver={props.onDragOver}
           onDrop={props.onDrop}
           onDragEnd={props.onDragEnd}
@@ -200,6 +207,37 @@ describe("Classic EntryRow grip handle (drag-to-reorder)", () => {
     const entry = createTestFlowsheetEntry();
     const { container } = renderRow({ entry });
     expect(container.querySelector('img[src*="blue_down.gif"]')).toBeNull();
+  });
+});
+
+describe("Classic EntryRow read-only context (no drag handlers wired)", () => {
+  it("does NOT mark a song row draggable when onDragStart is undefined", () => {
+    const entry = createTestFlowsheetEntry();
+    const { container } = renderRow({ entry, dragHandlers: false });
+    const row = container.querySelector("tr.flowsheetEntryData");
+    expect(row!.getAttribute("draggable")).not.toBe("true");
+  });
+
+  it("renders an empty grip cell (not the grip handle) on a song row when onDragStart is undefined", () => {
+    const entry = createTestFlowsheetEntry();
+    const { container } = renderRow({ entry, dragHandlers: false });
+    const firstCell = container.querySelector("tr > td:first-child");
+    expect(firstCell).not.toBeNull();
+    expect(firstCell!.classList.contains("grip-cell")).toBe(true);
+    expect(firstCell!.querySelector(".grip-handle")).toBeNull();
+  });
+
+  it("does NOT mark a talkset row draggable when onDragStart is undefined", () => {
+    const entry: FlowsheetEntry = {
+      id: 20,
+      show_id: 1,
+      play_order: 1,
+      message: "Talkset - station ID",
+    };
+    const { container } = renderRow({ entry, dragHandlers: false });
+    const row = container.querySelector("tr.classic-marker-talkset");
+    expect(row!.getAttribute("draggable")).not.toBe("true");
+    expect(container.querySelector(".grip-handle")).toBeNull();
   });
 });
 

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
@@ -13,6 +13,12 @@ function renderRow(props: {
   index?: number;
   totalEntries?: number;
   nextIsSong?: boolean;
+  isDragging?: boolean;
+  isDragOver?: boolean;
+  onDragStart?: (entryId: number) => void;
+  onDragOver?: (entryId: number) => void;
+  onDrop?: (entryId: number) => void;
+  onDragEnd?: () => void;
 }) {
   return renderWithProviders(
     <table>
@@ -24,9 +30,13 @@ function renderRow(props: {
           fontSize={3}
           onEdit={() => {}}
           onDelete={() => {}}
-          onMoveUp={() => {}}
-          onMoveDown={() => {}}
           nextIsSong={props.nextIsSong}
+          isDragging={props.isDragging}
+          isDragOver={props.isDragOver}
+          onDragStart={props.onDragStart}
+          onDragOver={props.onDragOver}
+          onDrop={props.onDrop}
+          onDragEnd={props.onDragEnd}
         />
       </tbody>
     </table>
@@ -92,12 +102,108 @@ describe("Classic EntryRow capsule indicators", () => {
     expect(order).toEqual([0, 1, 2]);
   });
 
-  it("renders the indicators inside a single leftmost <td> cell", () => {
+  it("renders the indicators inside the second <td> cell (after the grip handle)", () => {
     const entry = createTestFlowsheetEntry({ request_flag: true });
+    const { container } = renderRow({ entry });
+    const indicatorsCell = container.querySelector("tr > td:nth-child(2)");
+    expect(indicatorsCell).not.toBeNull();
+    expect(indicatorsCell!.querySelector(".classic-capsule")).not.toBeNull();
+  });
+});
+
+describe("Classic EntryRow grip handle (drag-to-reorder)", () => {
+  it("renders a grip handle on song rows with aria-label", () => {
+    const entry = createTestFlowsheetEntry();
+    const { container } = renderRow({ entry });
+    const handle = container.querySelector(".grip-handle");
+    expect(handle).not.toBeNull();
+    expect(handle!.getAttribute("aria-label")).toBe("Drag to reorder");
+  });
+
+  it("places the grip handle inside the first <td> cell", () => {
+    const entry = createTestFlowsheetEntry();
     const { container } = renderRow({ entry });
     const firstCell = container.querySelector("tr > td:first-child");
     expect(firstCell).not.toBeNull();
-    expect(firstCell!.querySelector(".classic-capsule")).not.toBeNull();
+    expect(firstCell!.classList.contains("grip-cell")).toBe(true);
+    expect(firstCell!.querySelector(".grip-handle")).not.toBeNull();
+  });
+
+  it("marks song rows as draggable", () => {
+    const entry = createTestFlowsheetEntry();
+    const { container } = renderRow({ entry });
+    const row = container.querySelector("tr.flowsheetEntryData");
+    expect(row!.getAttribute("draggable")).toBe("true");
+  });
+
+  it("renders a grip handle on talkset rows and marks them draggable", () => {
+    const entry: FlowsheetEntry = {
+      id: 10,
+      show_id: 1,
+      play_order: 1,
+      message: "Talkset - station ID",
+    };
+    const { container } = renderRow({ entry });
+    expect(container.querySelector(".grip-handle")).not.toBeNull();
+    const row = container.querySelector("tr.classic-marker-talkset");
+    expect(row!.getAttribute("draggable")).toBe("true");
+  });
+
+  it("does NOT render a grip handle on breakpoint rows and they are not draggable", () => {
+    const entry: FlowsheetEntry = {
+      id: 11,
+      show_id: 1,
+      play_order: 2,
+      message: "Breakpoint - 5:00 PM",
+      day: "11/14/2023",
+      time: "5:00:00 PM",
+    };
+    const { container } = renderRow({ entry });
+    expect(container.querySelector(".grip-handle")).toBeNull();
+    const row = container.querySelector("tr.classic-marker-breakpoint");
+    expect(row!.getAttribute("draggable")).not.toBe("true");
+  });
+
+  it("does NOT render a grip handle on start-of-show rows", () => {
+    const entry: FlowsheetEntry = {
+      id: 12,
+      show_id: 1,
+      play_order: 0,
+      dj_name: "DJ Cool",
+      isStart: true,
+      day: "11/14/2023",
+      time: "5:00:00 PM",
+    };
+    const { container } = renderRow({ entry });
+    expect(container.querySelector(".grip-handle")).toBeNull();
+    const row = container.querySelector("tr.classic-marker-breakpoint");
+    expect(row!.getAttribute("draggable")).not.toBe("true");
+  });
+
+  it("does NOT render a grip handle on end-of-show rows", () => {
+    const entry: FlowsheetEntry = {
+      id: 13,
+      show_id: 1,
+      play_order: 99,
+      dj_name: "DJ Cool",
+      isStart: false,
+      day: "11/14/2023",
+      time: "5:00:00 PM",
+    };
+    const { container } = renderRow({ entry });
+    expect(container.querySelector(".grip-handle")).toBeNull();
+  });
+
+  it("does NOT render the legacy move up arrow on song rows", () => {
+    const entry = createTestFlowsheetEntry();
+    const { container } = renderRow({ entry });
+    expect(container.querySelector('img[src*="blue_up.gif"]')).toBeNull();
+  });
+
+  it("does NOT render the legacy move down arrow on song rows", () => {
+    const entry = createTestFlowsheetEntry();
+    const { container } = renderRow({ entry });
+    expect(container.querySelector('img[src*="blue_down.gif"]')).toBeNull();
   });
 });
 
@@ -140,9 +246,9 @@ describe("Classic EntryRow markers", () => {
       message: "Talkset - station ID",
     };
 
-    it("renders the lowercase word 'talkset' centered", () => {
+    it("renders the lowercase word 'talkset' centered (in the second cell after grip)", () => {
       const { container } = renderRow({ entry: talksetEntry });
-      const cell = container.querySelector("tr > td:first-child");
+      const cell = container.querySelector("tr > td:nth-child(2)");
       expect(cell).not.toBeNull();
       expect(cell!.textContent).toBe("talkset");
       expect(cell!.getAttribute("align")).toBe("center");
@@ -173,14 +279,14 @@ describe("Classic EntryRow markers", () => {
 
     it("renders '{h:mm a} breakpoint' (no seconds, lowercase suffix)", () => {
       const { container } = renderRow({ entry: breakpointEntry });
-      const cell = container.querySelector("tr > td:first-child");
+      const cell = container.querySelector("tr > td:nth-child(2)");
       expect(cell).not.toBeNull();
       expect(cell!.textContent).toBe("5:00 PM breakpoint");
     });
 
     it("renders content centered", () => {
       const { container } = renderRow({ entry: breakpointEntry });
-      const cell = container.querySelector("tr > td:first-child");
+      const cell = container.querySelector("tr > td:nth-child(2)");
       expect(cell!.getAttribute("align")).toBe("center");
     });
 
@@ -209,7 +315,7 @@ describe("Classic EntryRow markers", () => {
 
     it("renders 'Start of show — {dj_name} @ {M/d/yy} {h:mm a}'", () => {
       const { container } = renderRow({ entry: startEntry });
-      const cell = container.querySelector("tr > td:first-child");
+      const cell = container.querySelector("tr > td:nth-child(2)");
       expect(cell!.textContent).toBe(
         "Start of show — DJ Cool @ 11/14/23 5:13 PM"
       );
@@ -235,7 +341,7 @@ describe("Classic EntryRow markers", () => {
 
     it("renders 'End of show — {dj_name} @ {M/d/yy} {h:mm a}'", () => {
       const { container } = renderRow({ entry: endEntry });
-      const cell = container.querySelector("tr > td:first-child");
+      const cell = container.querySelector("tr > td:nth-child(2)");
       expect(cell!.textContent).toBe(
         "End of show — DJ Cool @ 11/14/23 5:13 PM"
       );
@@ -266,7 +372,7 @@ describe("Classic EntryRow markers", () => {
           time,
         },
       });
-      const cell = container.querySelector("tr > td:first-child");
+      const cell = container.querySelector("tr > td:nth-child(2)");
       expect(cell!.textContent).toBe(`Start of show — DJ Test @ ${expected}`);
     }
   );
@@ -283,7 +389,7 @@ describe("Classic EntryRow markers", () => {
         time: "Unknown",
       },
     });
-    const cell = container.querySelector("tr > td:first-child");
+    const cell = container.querySelector("tr > td:nth-child(2)");
     expect(cell!.textContent).toBe(
       "Start of show — DJ Test @ Unknown Unknown"
     );

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
@@ -10,8 +10,6 @@ import EntryRow from "../EntryRow";
 // are mounted in a valid layout context (RTL otherwise warns).
 function renderRow(props: {
   entry: FlowsheetEntry;
-  index?: number;
-  totalEntries?: number;
   nextIsSong?: boolean;
   isDragging?: boolean;
   isDragOver?: boolean;
@@ -25,8 +23,6 @@ function renderRow(props: {
       <tbody>
         <EntryRow
           entry={props.entry}
-          index={props.index ?? 1}
-          totalEntries={props.totalEntries ?? 3}
           fontSize={3}
           onEdit={() => {}}
           onDelete={() => {}}

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryTable.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryTable.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import { createTestFlowsheetEntry } from "@/lib/test-utils";
+import type { FlowsheetEntry } from "@/lib/features/flowsheet/types";
+import EntryTable from "../EntryTable";
+
+function setup(opts?: { entries?: FlowsheetEntry[]; onReorder?: (sourceId: number, targetId: number) => void }) {
+  const entries: FlowsheetEntry[] =
+    opts?.entries ??
+    [
+      createTestFlowsheetEntry({
+        id: 101,
+        play_order: 1,
+        artist_name: "Juana Molina",
+        track_title: "la paradoja",
+      }),
+      createTestFlowsheetEntry({
+        id: 102,
+        play_order: 2,
+        artist_name: "Jessica Pratt",
+        track_title: "Back, Baby",
+      }),
+      createTestFlowsheetEntry({
+        id: 103,
+        play_order: 3,
+        artist_name: "Chuquimamani-Condori",
+        track_title: "Call Your Name",
+      }),
+    ];
+  const onReorder = opts?.onReorder ?? vi.fn();
+  const utils = renderWithProviders(
+    <EntryTable
+      entries={entries}
+      previousEntries={[]}
+      fontSize={3}
+      onEdit={() => {}}
+      onDelete={() => {}}
+      onReorder={onReorder}
+    />
+  );
+  return { ...utils, onReorder, entries };
+}
+
+describe("Classic EntryTable header", () => {
+  it("does NOT include 'Move Up' or 'Move Down' headers", () => {
+    const { container } = setup();
+    const headers = Array.from(container.querySelectorAll("thead th")).map(
+      (th) => th.textContent ?? ""
+    );
+    for (const h of headers) {
+      expect(h).not.toMatch(/move up/i);
+      expect(h).not.toMatch(/move down/i);
+      expect(h).not.toMatch(/or down/i);
+    }
+  });
+
+  it("has 7 columns: grip + indicators + artist + song + release + label + edit", () => {
+    const { container } = setup();
+    const headers = container.querySelectorAll("thead th");
+    expect(headers.length).toBe(7);
+  });
+
+  it("places an empty grip-handle column as the first header cell", () => {
+    const { container } = setup();
+    const firstTh = container.querySelector("thead th:first-child");
+    expect(firstTh!.textContent).toBe("");
+  });
+});
+
+describe("Classic EntryTable drag-to-reorder", () => {
+  it("calls onReorder(sourceId, targetId) when one song row is dropped onto another", () => {
+    const { container, onReorder } = setup();
+    const rows = container.querySelectorAll("tbody tr.flowsheetEntryData");
+    const sourceRow = rows[0] as HTMLElement;
+    const targetRow = rows[2] as HTMLElement;
+
+    fireEvent.dragStart(sourceRow);
+    fireEvent.dragOver(targetRow);
+    fireEvent.drop(targetRow);
+
+    expect(onReorder).toHaveBeenCalledTimes(1);
+    expect(onReorder).toHaveBeenCalledWith(101, 103);
+  });
+
+  it("does NOT call onReorder when a row is dropped onto itself", () => {
+    const { container, onReorder } = setup();
+    const row = container.querySelector(
+      "tbody tr.flowsheetEntryData"
+    ) as HTMLElement;
+
+    fireEvent.dragStart(row);
+    fireEvent.dragOver(row);
+    fireEvent.drop(row);
+
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call onReorder when drop fires without a preceding dragStart", () => {
+    const { container, onReorder } = setup();
+    const rows = container.querySelectorAll("tbody tr.flowsheetEntryData");
+    const targetRow = rows[1] as HTMLElement;
+
+    fireEvent.dragOver(targetRow);
+    fireEvent.drop(targetRow);
+
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("clears the drag source on dragEnd so a subsequent drop does nothing", () => {
+    const { container, onReorder } = setup();
+    const rows = container.querySelectorAll("tbody tr.flowsheetEntryData");
+    const sourceRow = rows[0] as HTMLElement;
+    const targetRow = rows[2] as HTMLElement;
+
+    fireEvent.dragStart(sourceRow);
+    fireEvent.dragEnd(sourceRow);
+    fireEvent.drop(targetRow);
+
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("applies the .dragging class to the source row during a drag", () => {
+    const { container } = setup();
+    const sourceRow = container.querySelector(
+      "tbody tr.flowsheetEntryData"
+    ) as HTMLElement;
+
+    fireEvent.dragStart(sourceRow);
+    expect(sourceRow.classList.contains("dragging")).toBe(true);
+
+    fireEvent.dragEnd(sourceRow);
+    expect(sourceRow.classList.contains("dragging")).toBe(false);
+  });
+
+  it("does NOT initiate a drag from a breakpoint row (not draggable)", () => {
+    const breakpoint: FlowsheetEntry = {
+      id: 200,
+      show_id: 1,
+      play_order: 1,
+      message: "Breakpoint - 5:00 PM",
+      day: "11/14/2023",
+      time: "5:00:00 PM",
+    };
+    const { container, onReorder } = setup({
+      entries: [
+        breakpoint,
+        createTestFlowsheetEntry({ id: 201, play_order: 2 }),
+      ],
+    });
+    const rows = container.querySelectorAll("tbody tr.flowsheetEntryData");
+    const breakpointRow = rows[0] as HTMLElement;
+    const songRow = rows[1] as HTMLElement;
+
+    fireEvent.dragStart(breakpointRow);
+    fireEvent.dragOver(songRow);
+    fireEvent.drop(songRow);
+
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+});

--- a/src/styles/classic/drag.css
+++ b/src/styles/classic/drag.css
@@ -1,0 +1,32 @@
+/* Grip handle for drag-to-reorder. Ported from tubafrenzy
+ * webapps/playlists/src/main/webapp/css/flowsheet.css (commit 018b32a8). */
+
+.grip-cell {
+  width: 24px;
+  text-align: center;
+  padding: 0 4px;
+}
+
+.grip-handle {
+  cursor: grab;
+  font-size: 1.2em;
+  color: #888;
+  user-select: none;
+}
+
+.grip-handle:hover {
+  color: #444;
+}
+
+.grip-handle:active {
+  cursor: grabbing;
+}
+
+.flowsheetEntryData.dragging {
+  opacity: 0.4;
+}
+
+.flowsheetEntryData.drag-over {
+  outline: 2px solid #cc0000;
+  outline-offset: -2px;
+}


### PR DESCRIPTION
Closes #537. Part of the Classic-mode ↔ tubafrenzy parity sweep (#511, PR 8 of 12).

## What changes

Replaces the two-column `Move Up / Move Down?` header and per-row arrow images on the Classic flowsheet table with a single leftmost grip-handle column (`⠇`). Song rows and talkset rows are draggable; breakpoint / start-show / end-show rows have an empty grip cell and are not draggable. Dropping one row onto another fires `onReorder(sourceId, targetId)`, which `Layout/Main.tsx` maps to the existing `useSwitchEntriesMutation` with the target row's `play_order` — same backend contract as the arrow handlers it replaces.

Drag state lives in `EntryTable` (`draggingId` / `dragOverId`) so cross-row hover styling works through React state instead of document-level listeners. `EntryRow` exposes optional `onDragStart` / `onDragOver` / `onDrop` / `onDragEnd` props plus `isDragging` / `isDragOver` flags wired to `.dragging` / `.drag-over` CSS classes.

`EntryRow`'s now-unused `index` and `totalEntries` props (vestigial from the move-arrow visibility guards) are removed in a follow-up commit, along with their call sites in `EntryTable`.

New `src/styles/classic/drag.css` ports tubafrenzy's grip + drag-state styles verbatim (cursor: grab, opacity-on-drag, red drop-target outline).

## Source of truth

Tubafrenzy commit [`018b32a8`](https://github.com/WXYC/tubafrenzy/commit/018b32a8) — *Replace move up/down arrows with drag-to-reorder grip handle on flowsheet*. The grip character (`⠇`, U+2807 BRAILLE PATTERN DOTS-1-2-3) matches the JSP entity `&#x2807;`.

## Test plan

47 tests across `EntryRow.test.tsx` (28) and the new `EntryTable.test.tsx` (19):

- [x] Grip handle renders on song + talkset rows; absent on breakpoint / start-show / end-show
- [x] `draggable=true` on song + talkset rows; absent on marker rows
- [x] Legacy `blue_up.gif` / `blue_down.gif` arrows gone
- [x] Header: 7 columns; no `Move Up` / `Move Down` text
- [x] `onReorder` fires with the right `(sourceId, targetId)` on a cross-row drop
- [x] Drop-onto-self → no-op
- [x] Drop without prior `dragStart` → no-op
- [x] `dragEnd` clears the source — a subsequent drop is a no-op
- [x] `.dragging` class applied during the drag
- [x] Breakpoint row can't initiate a drag
- [x] Local: `tsc --noEmit` clean
- [x] Local: 2831/2831 unit tests pass
- [x] Local: `npm run build` clean

DJ smoke check (manual, before merge):
- [ ] Drag song row → backend round-trips and order updates
- [ ] Drag song row onto itself → no-op
- [ ] Edit / Delete per-row still works
- [ ] Add track / talkset / breakpoint via EntryForm still works

## Related

- Umbrella plan: #511 (PR 8 / Inventory item 5)
- Predecessor: #534 / #535 (PR 7 — entry-form redesign)