### PR TITLE
feat(catalog): propagate matched_via from AlbumSearchResult to AlbumEntry

### DIFF
--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -112,6 +112,38 @@ describe("convertToAlbumEntry", () => {
           expect(result.artwork_url).toBeUndefined();
         },
       },
+      {
+        name: "should pass through matched_via hints when present",
+        input: createTestAlbumSearchResult({
+          matched_via: [
+            { source: "cta", title: "In a Sentimental Mood", confidence: 1.0 },
+            {
+              source: "discogs_master",
+              title: "In a Sentimental Mood",
+              position: "A1",
+              confidence: 0.92,
+            },
+          ],
+        }),
+        assertions: (result) => {
+          expect(result.matched_via).toEqual([
+            { source: "cta", title: "In a Sentimental Mood", confidence: 1.0 },
+            {
+              source: "discogs_master",
+              title: "In a Sentimental Mood",
+              position: "A1",
+              confidence: 0.92,
+            },
+          ]);
+        },
+      },
+      {
+        name: "should default matched_via to undefined when absent",
+        input: createTestAlbumSearchResult(),
+        assertions: (result) => {
+          expect(result.matched_via).toBeUndefined();
+        },
+      },
     ]
   );
 

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -38,6 +38,7 @@ export function convertToAlbumEntry(
     date_lost: isSearchResult(response) ? (response as Record<string, unknown>).date_lost as string | undefined : undefined,
     date_found: isSearchResult(response) ? (response as Record<string, unknown>).date_found as string | undefined : undefined,
     artwork_url: isSearchResult(response) ? (response as Record<string, unknown>).artwork_url as string | null | undefined : undefined,
+    matched_via: isSearchResult(response) ? response.matched_via : undefined,
   };
 }
 

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -1,7 +1,9 @@
-import type { AlbumSearchResult } from "@wxyc/shared/dtos";
+import type { AlbumSearchResult, TrackMatchHint } from "@wxyc/shared/dtos";
+import { TrackMatchSource } from "@wxyc/shared/dtos";
 import { Rotation } from "../rotation/types";
 
-export type { AlbumSearchResult };
+export type { AlbumSearchResult, TrackMatchHint };
+export { TrackMatchSource };
 
 /**
  * JSON boundary adapter for AlbumSearchResult.
@@ -56,6 +58,7 @@ export type AlbumEntry = {
   date_lost?: string;
   date_found?: string;
   artwork_url?: string | null;
+  matched_via?: TrackMatchHint[];
 };
 
 export type ArtistEntry = {


### PR DESCRIPTION
## Summary

E3-1 prep for the dj-site UI side of the catalog-track-search feature. `@wxyc/shared@1.3.0` introduced `matched_via?: TrackMatchHint[]` on `AlbumSearchResult` and `LibrarySearchItem` (and `LookupResultItem`), populated by Backend's `/library/` search when a track-title match (CTA or LML's SONG_AS_TRACK fallback) drove a release into the result set.

dj-site already runs against `@wxyc/shared@^1.4.0` (resolved to 1.4.1 in the lockfile), so the openapi-derived `AlbumSearchResultJSON` already carries the field via `Omit<AlbumSearchResult, "add_date">`. This PR plumbs it through to the internal `AlbumEntry` type so E3-2 / E3-3 chip rendering has a path to consume it.

Changes:
- Re-export `TrackMatchHint` and `TrackMatchSource` from `lib/features/catalog/types.ts`.
- Add `matched_via?: TrackMatchHint[]` to `AlbumEntry`.
- Pass `matched_via` through `convertToAlbumEntry` (defaults to `undefined` for `BinLibraryDetails` inputs).
- Two new assertion cases in `catalog.test.ts` covering pass-through and absence.

No runtime behavior change: the field is currently `undefined` on every response because `CATALOG_TRACK_SEARCH_DISCOGS_ENABLED` is off in prod.

Closes #494.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run lib/__tests__/features/catalog` — 104 passed
- [x] Full suite `npx vitest run` — 2845 passed
- [x] `npm run build` succeeds

## Related

- Parent epic: WXYC/dj-site#493 (E3)
- Plan: [catalog-track-search](https://github.com/WXYC/wiki/blob/main/plans/catalog-track-search.md)