### PR TITLE
feat(catalog): render matched_via chips in classic SearchResults

### DIFF
--- a/src/components/experiences/classic/catalog/MatchedTrackChips.tsx
+++ b/src/components/experiences/classic/catalog/MatchedTrackChips.tsx
@@ -1,0 +1,52 @@
+import type { TrackMatchHint } from "@/lib/features/catalog/types";
+import "@/src/styles/classic/capsules.css";
+
+const VISIBLE_LIMIT = 3;
+
+export function MatchedTrackChips({
+  matched_via,
+}: {
+  matched_via: TrackMatchHint[] | undefined;
+}) {
+  if (!matched_via || matched_via.length === 0) {
+    return null;
+  }
+
+  const visible = matched_via.slice(0, VISIBLE_LIMIT);
+  const overflow = matched_via.slice(VISIBLE_LIMIT);
+
+  return (
+    <div className="classic-matched-chip-row">
+      {visible.map((hint, idx) => {
+        const label = `matched on track: ${hint.title}`;
+        const tooltipParts = [hint.title];
+        if (hint.artist_credit) tooltipParts.push(`by ${hint.artist_credit}`);
+        if (hint.position) tooltipParts.push(`(${hint.position})`);
+        const tooltip = tooltipParts.join(" ");
+        return (
+          <span
+            key={`${hint.source}:${hint.title}:${idx}`}
+            className="classic-matched-chip"
+            tabIndex={0}
+            title={tooltip}
+            aria-label={label}
+          >
+            {label}
+          </span>
+        );
+      })}
+      {overflow.length > 0 && (
+        <span
+          className="classic-matched-chip classic-matched-chip--more"
+          tabIndex={0}
+          title={overflow.map((hint) => hint.title).join(", ")}
+          aria-label={`${overflow.length} more matched tracks: ${overflow
+            .map((hint) => hint.title)
+            .join(", ")}`}
+        >
+          +{overflow.length} more
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/experiences/classic/catalog/SearchResults.tsx
+++ b/src/components/experiences/classic/catalog/SearchResults.tsx
@@ -3,6 +3,7 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSearchCatalogQuery } from "@/lib/features/catalog/api";
 import { Capsule } from "@/src/components/experiences/classic/flowsheet/Capsule";
+import { MatchedTrackChips } from "./MatchedTrackChips";
 
 export default function SearchResults() {
   const router = useRouter();
@@ -115,6 +116,7 @@ export default function SearchResults() {
                     <Capsule variant="exclusive" label="EXCLUSIVE" />
                   </>
                 )}
+                <MatchedTrackChips matched_via={result.matched_via} />
               </td>
               <td align="left">{result.format}</td>
               <td align="left">

--- a/src/components/experiences/classic/catalog/__tests__/SearchResults.matchedVia.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchResults.matchedVia.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { createTestAlbum, createTestArtist } from "@/lib/test-utils";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import type { TrackMatchHint } from "@/lib/features/catalog/types";
+
+const mockSearchCatalogQuery = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams("searchString=sentimental"),
+}));
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return {
+    ...actual,
+    useSearchCatalogQuery: (...args: unknown[]) => mockSearchCatalogQuery(...args),
+  };
+});
+
+import SearchResults from "../SearchResults";
+
+function renderWithMatchedVia(matched_via: TrackMatchHint[] | undefined) {
+  const album = createTestAlbum({
+    artist: createTestArtist({
+      name: "Duke Ellington & John Coltrane",
+      lettercode: "JA",
+      numbercode: 7,
+    }),
+    title: "Duke Ellington & John Coltrane",
+    matched_via,
+  });
+  mockSearchCatalogQuery.mockReturnValue({
+    data: [album],
+    isLoading: false,
+    error: undefined,
+  });
+  renderWithProviders(<SearchResults />);
+}
+
+describe("Classic SearchResults matched_via chip", () => {
+  it("does not render any matched-track chip when matched_via is undefined", () => {
+    renderWithMatchedVia(undefined);
+    expect(screen.queryByText(/matched on track/i)).toBeNull();
+  });
+
+  it("does not render any matched-track chip when matched_via is an empty array", () => {
+    renderWithMatchedVia([]);
+    expect(screen.queryByText(/matched on track/i)).toBeNull();
+  });
+
+  it("renders a single chip with 'matched on track: <title>' when matched_via has one hint", () => {
+    renderWithMatchedVia([
+      {
+        source: "cta",
+        title: "In a Sentimental Mood",
+        artist_credit: "Duke Ellington & John Coltrane",
+        confidence: 1.0,
+      },
+    ]);
+    expect(
+      screen.getByText("matched on track: In a Sentimental Mood")
+    ).toBeDefined();
+  });
+
+  it("exposes artist_credit via the title attribute (native tooltip) when present", () => {
+    renderWithMatchedVia([
+      {
+        source: "discogs_master",
+        title: "In a Sentimental Mood",
+        artist_credit: "Duke Ellington & John Coltrane",
+        position: "A1",
+        confidence: 0.92,
+      },
+    ]);
+    const chip = screen.getByText("matched on track: In a Sentimental Mood");
+    expect(chip.getAttribute("title")).toContain("Duke Ellington & John Coltrane");
+  });
+
+  it("renders up to 3 matched-track chips inline", () => {
+    renderWithMatchedVia([
+      { source: "cta", title: "Track One", confidence: 1.0 },
+      { source: "discogs_master", title: "Track Two", confidence: 0.9 },
+      { source: "discogs_release", title: "Track Three", confidence: 0.8 },
+    ]);
+    expect(screen.getByText("matched on track: Track One")).toBeDefined();
+    expect(screen.getByText("matched on track: Track Two")).toBeDefined();
+    expect(screen.getByText("matched on track: Track Three")).toBeDefined();
+    expect(screen.queryByText(/\+\d+ more/)).toBeNull();
+  });
+
+  it("collapses overflow past 3 hints into a '+N more' chip", () => {
+    renderWithMatchedVia([
+      { source: "cta", title: "Track One", confidence: 1.0 },
+      { source: "discogs_master", title: "Track Two", confidence: 0.9 },
+      { source: "discogs_release", title: "Track Three", confidence: 0.8 },
+      { source: "discogs_release", title: "Track Four", confidence: 0.7 },
+      { source: "discogs_release", title: "Track Five", confidence: 0.6 },
+    ]);
+    expect(screen.getByText("matched on track: Track One")).toBeDefined();
+    expect(screen.getByText("matched on track: Track Two")).toBeDefined();
+    expect(screen.getByText("matched on track: Track Three")).toBeDefined();
+    expect(screen.queryByText("matched on track: Track Four")).toBeNull();
+    expect(screen.queryByText("matched on track: Track Five")).toBeNull();
+    expect(screen.getByText("+2 more")).toBeDefined();
+  });
+
+  it("renders chips as keyboard-focusable elements", () => {
+    renderWithMatchedVia([
+      { source: "cta", title: "In a Sentimental Mood", confidence: 1.0 },
+    ]);
+    const chip = screen.getByText("matched on track: In a Sentimental Mood");
+    expect(chip.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("renders the +N more chip as keyboard-focusable with overflow titles in its tooltip", () => {
+    renderWithMatchedVia([
+      { source: "cta", title: "Track One", confidence: 1.0 },
+      { source: "discogs_master", title: "Track Two", confidence: 0.9 },
+      { source: "discogs_release", title: "Track Three", confidence: 0.8 },
+      { source: "discogs_release", title: "Track Four", confidence: 0.7 },
+    ]);
+    const more = screen.getByText("+1 more");
+    expect(more.getAttribute("tabindex")).toBe("0");
+    expect(more.getAttribute("title")).toContain("Track Four");
+  });
+});

--- a/src/styles/classic/capsules.css
+++ b/src/styles/classic/capsules.css
@@ -31,3 +31,33 @@
 
 /* Capsule backgrounds are saturated enough to stay legible in Classic's
    dark color scheme; no dark-mode overrides needed today. */
+
+.classic-matched-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.classic-matched-chip {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-family: Verdana, Geneva, Arial, Helvetica, sans-serif;
+  font-size: 0.7em;
+  font-weight: bold;
+  color: #FFFFFF;
+  background-color: #2E5E8B;
+  white-space: nowrap;
+  line-height: 1.4;
+  cursor: default;
+}
+
+.classic-matched-chip:focus {
+  outline: 2px solid #FFCC00;
+  outline-offset: 1px;
+}
+
+.classic-matched-chip--more {
+  background-color: #4A4A4A;
+}


### PR DESCRIPTION
## Summary

- When a classic catalog search result carries non-empty `matched_via` hints, render up to 3 "matched on track: <title>" chips in the Album cell beneath the title.
- Overflow past 3 collapses into a `+N more` chip whose `title` tooltip lists the remaining track titles.
- Chips are keyboard-focusable (`tabIndex={0}`), expose `artist_credit` + `position` through the native `title` tooltip, and announce themselves to screen readers via `aria-label`.

## Where

- `src/components/experiences/classic/catalog/SearchResults.tsx` — renders `<MatchedTrackChips matched_via={result.matched_via} />` in the Album `<td>`.
- `src/components/experiences/classic/catalog/MatchedTrackChips.tsx` — new component (3-chip cap + overflow logic).
- `src/styles/classic/capsules.css` — new `.classic-matched-chip` + `.classic-matched-chip--more` rules; focus outline for keyboard users.
- `src/components/experiences/classic/catalog/__tests__/SearchResults.matchedVia.test.tsx` — 8 new tests covering: absence (undefined / empty), single chip, tooltip exposes `artist_credit`, 3 inline chips with no overflow, `+N more` collapse, focusability of both regular and overflow chips.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 197 files, 2853 tests pass
- [x] `npm run build` — production build succeeds
- [ ] CI: lint/typecheck/build/unit/e2e green
- [ ] Manual sanity check in dev: run a search whose results carry `matched_via` (gated on prod backfill — E3-5 flag will land separately)

Closes #495.

## Related

- Parent epic: #493 (E3)
- Predecessor: #494 (E3-1, merged) — added `matched_via` to `AlbumEntry`
- Sibling: #496 (E3-3, modern Results chips)
- Blocks: #498 (E3-5, `CATALOG_TRACK_SEARCH_UI_ENABLED` flag)