### PR TITLE
feat(catalog): render matched_via chips in modern Results (E3-3)

### DIFF
--- a/src/components/experiences/modern/catalog/Results/MatchedTrackChips.tsx
+++ b/src/components/experiences/modern/catalog/Results/MatchedTrackChips.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Chip from "@mui/joy/Chip";
+import Stack from "@mui/joy/Stack";
+import Tooltip from "@mui/joy/Tooltip";
+
+import type { TrackMatchHint } from "@/lib/features/catalog/types";
+
+const VISIBLE_LIMIT = 3;
+
+function describeHint(hint: TrackMatchHint): string {
+  const parts = [hint.title];
+  if (hint.artist_credit) parts.push(`by ${hint.artist_credit}`);
+  if (hint.position) parts.push(`(${hint.position})`);
+  return parts.join(" ");
+}
+
+export function MatchedTrackChips({
+  matched_via,
+}: {
+  matched_via: TrackMatchHint[] | undefined;
+}) {
+  if (!matched_via || matched_via.length === 0) {
+    return null;
+  }
+
+  const visible = matched_via.slice(0, VISIBLE_LIMIT);
+  const overflow = matched_via.slice(VISIBLE_LIMIT);
+
+  return (
+    <Stack
+      direction="row"
+      gap={0.5}
+      flexWrap="wrap"
+      sx={{ marginTop: 0.5 }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {visible.map((hint, idx) => {
+        const label = `matched on track: ${hint.title}`;
+        const ariaLabel = `matched on track: ${describeHint(hint)}`;
+        return (
+          <Tooltip
+            key={`${hint.source}:${hint.title}:${idx}`}
+            title={describeHint(hint)}
+            variant="outlined"
+            size="sm"
+          >
+            <Chip
+              size="sm"
+              variant="soft"
+              color="primary"
+              tabIndex={0}
+              aria-label={ariaLabel}
+            >
+              {label}
+            </Chip>
+          </Tooltip>
+        );
+      })}
+      {overflow.length > 0 && (
+        <Tooltip
+          title={overflow.map((hint) => hint.title).join(", ")}
+          variant="outlined"
+          size="sm"
+        >
+          <Chip
+            size="sm"
+            variant="soft"
+            color="neutral"
+            tabIndex={0}
+            aria-label={`${overflow.length} more matched tracks: ${overflow
+              .map((hint) => hint.title)
+              .join(", ")}`}
+          >
+            +{overflow.length} more
+          </Chip>
+        </Tooltip>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -19,6 +19,7 @@ import { useQueue, useShowControl } from "@/src/hooks/flowsheetHooks";
 import { useAppDispatch } from "@/lib/hooks";
 import { GENRE_COLORS, GENRE_VARIANTS } from "../ArtistAvatar";
 import AddRemoveBin from "./AddRemoveBin";
+import { MatchedTrackChips } from "./MatchedTrackChips";
 import { convertBinToQueue } from "@/lib/features/bin/conversions";
 import { toast } from "sonner";
 
@@ -107,6 +108,7 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
         >
           {album.title}
         </Typography>
+        <MatchedTrackChips matched_via={album.matched_via} />
       </td>
       <td>
         <Stack direction="row" gap={0.75} alignItems="center" flexWrap="nowrap">

--- a/src/components/experiences/modern/catalog/Results/__tests__/MatchedTrackChips.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/MatchedTrackChips.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import type { TrackMatchHint } from "@/lib/features/catalog/types";
+import { MatchedTrackChips } from "../MatchedTrackChips";
+
+function renderChips(matched_via: TrackMatchHint[] | undefined) {
+  renderWithProviders(<MatchedTrackChips matched_via={matched_via} />);
+}
+
+describe("Modern MatchedTrackChips", () => {
+  it("renders nothing when matched_via is undefined", () => {
+    const { container } = renderWithProviders(
+      <MatchedTrackChips matched_via={undefined} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when matched_via is an empty array", () => {
+    const { container } = renderWithProviders(
+      <MatchedTrackChips matched_via={[]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a single chip with 'matched on track: <title>' when one hint is present", () => {
+    renderChips([
+      {
+        source: "cta",
+        title: "In a Sentimental Mood",
+        artist_credit: "Duke Ellington & John Coltrane",
+        confidence: 1.0,
+      },
+    ]);
+    expect(
+      screen.getByText("matched on track: In a Sentimental Mood")
+    ).toBeDefined();
+  });
+
+  it("exposes artist_credit and position in the chip aria-label", () => {
+    renderChips([
+      {
+        source: "discogs_master",
+        title: "In a Sentimental Mood",
+        artist_credit: "Duke Ellington & John Coltrane",
+        position: "A1",
+        confidence: 0.92,
+      },
+    ]);
+    const labelled = screen.getByLabelText(
+      /matched on track: In a Sentimental Mood by Duke Ellington & John Coltrane \(A1\)/
+    );
+    expect(labelled).toBeDefined();
+  });
+
+  it("renders up to 3 matched-track chips inline", () => {
+    renderChips([
+      { source: "cta", title: "Track One", confidence: 1.0 },
+      { source: "discogs_master", title: "Track Two", confidence: 0.9 },
+      { source: "discogs_release", title: "Track Three", confidence: 0.8 },
+    ]);
+    expect(screen.getByText("matched on track: Track One")).toBeDefined();
+    expect(screen.getByText("matched on track: Track Two")).toBeDefined();
+    expect(screen.getByText("matched on track: Track Three")).toBeDefined();
+    expect(screen.queryByText(/\+\d+ more/)).toBeNull();
+  });
+
+  it("collapses overflow past 3 hints into a '+N more' chip", () => {
+    renderChips([
+      { source: "cta", title: "Track One", confidence: 1.0 },
+      { source: "discogs_master", title: "Track Two", confidence: 0.9 },
+      { source: "discogs_release", title: "Track Three", confidence: 0.8 },
+      { source: "discogs_release", title: "Track Four", confidence: 0.7 },
+      { source: "library_identity", title: "Track Five", confidence: 0.6 },
+    ]);
+    expect(screen.getByText("matched on track: Track One")).toBeDefined();
+    expect(screen.getByText("matched on track: Track Two")).toBeDefined();
+    expect(screen.getByText("matched on track: Track Three")).toBeDefined();
+    expect(screen.queryByText("matched on track: Track Four")).toBeNull();
+    expect(screen.queryByText("matched on track: Track Five")).toBeNull();
+    expect(screen.getByText("+2 more")).toBeDefined();
+  });
+
+  it("renders chips as keyboard-focusable elements", () => {
+    renderChips([
+      { source: "cta", title: "In a Sentimental Mood", confidence: 1.0 },
+    ]);
+    const chip = screen
+      .getByText("matched on track: In a Sentimental Mood")
+      .closest("[tabindex]");
+    expect(chip).not.toBeNull();
+    expect(chip?.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("renders the +N more chip as keyboard-focusable with overflow titles in its aria-label", () => {
+    renderChips([
+      { source: "cta", title: "Track One", confidence: 1.0 },
+      { source: "discogs_master", title: "Track Two", confidence: 0.9 },
+      { source: "discogs_release", title: "Track Three", confidence: 0.8 },
+      { source: "discogs_release", title: "Track Four", confidence: 0.7 },
+    ]);
+    const more = screen.getByText("+1 more").closest("[tabindex]");
+    expect(more).not.toBeNull();
+    expect(more?.getAttribute("tabindex")).toBe("0");
+    expect(more?.getAttribute("aria-label")).toContain("Track Four");
+  });
+});


### PR DESCRIPTION
## Summary

Adds matched_via chip rendering to the **modern** catalog Results row, mirroring the classic E3-2 implementation. When a search result was matched on a track title (rather than the artist or album), small chips appear under the album title showing which tracks matched.

- New component `src/components/experiences/modern/catalog/Results/MatchedTrackChips.tsx` (Joy UI `Chip` + `Tooltip`)
- Wired into `Result.tsx` Title `<td>` beneath the album title
- 3 inline chips cap, with `+N more` overflow chip listing the remainder in its tooltip / aria-label
- Each chip is keyboard-focusable (`tabIndex={0}`) and exposes a composite `aria-label` that includes `artist_credit` and `position` when present
- 8 unit tests covering empty / undefined / single / overflow / focusability / aria-label paths

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Full Vitest suite passes (2861 tests, +8 new)
- [x] `npm run build` succeeds
- [ ] Manual: hover a chip in dev to confirm Joy Tooltip renders with title + artist + position

Closes #496