### PR TITLE
classic flowsheet: action menu + inline edit (port from tubafrenzy)

### DIFF
--- a/src/components/experiences/classic/flowsheet/EntryActionMenu.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryActionMenu.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import "@/src/styles/classic/actions.css";
+
+type Props = {
+  entryId: number;
+  onEdit: (entryId: number) => void;
+  onDelete: (entryId: number) => void;
+};
+
+export default function EntryActionMenu({ entryId, onEdit, onDelete }: Props) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  const handleEdit = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setOpen(false);
+    onEdit(entryId);
+  };
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setOpen(false);
+    onDelete(entryId);
+  };
+
+  return (
+    <div className={`action-menu${open ? " open" : ""}`} ref={menuRef}>
+      <button
+        type="button"
+        className="action-trigger"
+        aria-label="Actions"
+        onClick={() => setOpen((v) => !v)}
+      >
+        {"⋯"}
+      </button>
+      <div className="action-dropdown" role="menu">
+        <a href="#" className="action-item" onClick={handleEdit} role="menuitem">
+          Edit
+        </a>
+        <a
+          href="#"
+          className="action-item action-delete"
+          onClick={handleDelete}
+          role="menuitem"
+        >
+          Delete
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/components/experiences/classic/flowsheet/EntryActionMenu.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryActionMenu.tsx
@@ -15,23 +15,28 @@ export default function EntryActionMenu({ entryId, onEdit, onDelete }: Props) {
 
   useEffect(() => {
     if (!open) return;
-    const handleClickOutside = (e: MouseEvent) => {
+    const handlePointerDown = (e: PointerEvent) => {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         setOpen(false);
       }
     };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
   }, [open]);
 
-  const handleEdit = (e: React.MouseEvent) => {
-    e.preventDefault();
+  const handleEdit = () => {
     setOpen(false);
     onEdit(entryId);
   };
 
-  const handleDelete = (e: React.MouseEvent) => {
-    e.preventDefault();
+  const handleDelete = () => {
     setOpen(false);
     onDelete(entryId);
   };
@@ -42,23 +47,32 @@ export default function EntryActionMenu({ entryId, onEdit, onDelete }: Props) {
         type="button"
         className="action-trigger"
         aria-label="Actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
       >
         {"⋯"}
       </button>
-      <div className="action-dropdown" role="menu">
-        <a href="#" className="action-item" onClick={handleEdit} role="menuitem">
-          Edit
-        </a>
-        <a
-          href="#"
-          className="action-item action-delete"
-          onClick={handleDelete}
-          role="menuitem"
-        >
-          Delete
-        </a>
-      </div>
+      {open && (
+        <div className="action-dropdown" role="menu">
+          <button
+            type="button"
+            className="action-item"
+            onClick={handleEdit}
+            role="menuitem"
+          >
+            Edit
+          </button>
+          <button
+            type="button"
+            className="action-item action-delete"
+            onClick={handleDelete}
+            role="menuitem"
+          >
+            Delete
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/experiences/classic/flowsheet/EntryRow.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryRow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { DragEvent as ReactDragEvent } from "react";
+import { useState, type DragEvent as ReactDragEvent } from "react";
 import {
   FlowsheetEntry,
   isFlowsheetSongEntry,
@@ -8,16 +8,19 @@ import {
   isFlowsheetBreakpointEntry,
   isFlowsheetStartShowEntry,
   isFlowsheetEndShowEntry,
+  UpdateRequestBody,
 } from "@/lib/features/flowsheet/types";
 import { Capsule, capsulesForSongEntry } from "./Capsule";
+import EntryActionMenu from "./EntryActionMenu";
 import { formatShortDate, formatShortTime } from "./marker-format";
 import "@/src/styles/classic/segue.css";
 import "@/src/styles/classic/markers.css";
 import "@/src/styles/classic/drag.css";
+import "@/src/styles/classic/actions.css";
 
 type Props = {
   entry: FlowsheetEntry;
-  onEdit: (entryId: number) => void;
+  onUpdate: (entryId: number, data: UpdateRequestBody) => void;
   onDelete: (entryId: number) => void;
   fontSize: number;
   /** True if the next row in the table is also a song row.
@@ -49,9 +52,17 @@ function EmptyGripCell() {
   return <td className="grip-cell">&nbsp;</td>;
 }
 
+type EditDraft = {
+  artist_name: string;
+  track_title: string;
+  album_title: string;
+  record_label: string;
+  request_flag: boolean;
+};
+
 export default function EntryRow({
   entry,
-  onEdit,
+  onUpdate,
   onDelete,
   fontSize,
   nextIsSong,
@@ -63,6 +74,34 @@ export default function EntryRow({
   onDragEnd,
 }: Props) {
   const fontSizeClass = `fontSize${fontSize}`;
+  const [draft, setDraft] = useState<EditDraft | null>(null);
+  const isEditing = draft !== null;
+
+  const beginEdit = () => {
+    if (!isFlowsheetSongEntry(entry)) return;
+    setDraft({
+      artist_name: entry.artist_name ?? "",
+      track_title: entry.track_title ?? "",
+      album_title: entry.album_title ?? "",
+      record_label: entry.record_label ?? "",
+      request_flag: entry.request_flag ?? false,
+    });
+  };
+
+  const cancelEdit = () => setDraft(null);
+
+  const saveEdit = () => {
+    if (!draft) return;
+    if (!draft.track_title.trim()) return;
+    onUpdate(entry.id, {
+      artist_name: draft.artist_name,
+      track_title: draft.track_title,
+      album_title: draft.album_title,
+      record_label: draft.record_label,
+      request_flag: draft.request_flag,
+    });
+    setDraft(null);
+  };
 
   // Marker rows (talkset / breakpoint / start / end of show) span 5 of the 7
   // post-PR8 columns: grip + indicators + artist + song + release + label + edit.
@@ -72,15 +111,16 @@ export default function EntryRow({
   const dragClass = [
     isDragging ? "dragging" : "",
     isDragOver ? "drag-over" : "",
+    isEditing ? "editing" : "",
   ]
     .filter(Boolean)
     .join(" ");
 
-  // A row is only draggable when the parent wires up reorder handlers. The
-  // previous-show <tbody> in EntryTable renders rows without these, so they
-  // render with an empty grip cell and no drag affordance — the visual matches
-  // the read-only intent.
-  const isDraggable = Boolean(onDragStart);
+  // A row is only draggable when the parent wires up reorder handlers AND we're
+  // not in edit mode. The previous-show <tbody> in EntryTable renders rows
+  // without these, so they render with an empty grip cell and no drag
+  // affordance — the visual matches the read-only intent.
+  const isDraggable = Boolean(onDragStart) && !isEditing;
   const dragHandlers = isDraggable
     ? {
         onDragStart: () => onDragStart?.(entry.id),
@@ -164,7 +204,6 @@ export default function EntryRow({
   }
 
   if (isFlowsheetSongEntry(entry)) {
-    const hasComposer = false; // BMI composer info not in current type
     const capsules = capsulesForSongEntry(entry);
     // Segue indicator: render only when the row's `segue` flag is true AND the
     // next row in the table is also a song row. Tubafrenzy expresses the same
@@ -192,43 +231,110 @@ export default function EntryRow({
       >
         {isDraggable ? <GripCell /> : <EmptyGripCell />}
         <td align="center">
-          {capsules.map((c) => (
-            <Capsule key={c.variant} variant={c.variant} label={c.label} />
-          ))}
-        </td>
-        <td align="left">{entry.artist_name}</td>
-        <td align="left">
-          {entry.track_title}
-          {hasComposer && (
-            <img
-              src="/img/classic/musicnote.gif"
-              height={25}
-              alt="Composer"
+          {isEditing ? (
+            <input
+              type="checkbox"
+              name="request_flag"
+              checked={draft!.request_flag}
+              onChange={(e) =>
+                setDraft({ ...draft!, request_flag: e.target.checked })
+              }
             />
+          ) : (
+            capsules.map((c) => (
+              <Capsule key={c.variant} variant={c.variant} label={c.label} />
+            ))
           )}
         </td>
-        <td align="left">{entry.album_title || ""}</td>
-        <td align="left">{entry.record_label || ""}</td>
-        <td align="center" className="text">
-          <a
-            href="#"
-            onClick={(e) => {
-              e.preventDefault();
-              onEdit(entry.id);
-            }}
-          >
-            Edit
-          </a>
-          &nbsp;&nbsp;
-          <a
-            href="#"
-            onClick={(e) => {
-              e.preventDefault();
-              onDelete(entry.id);
-            }}
-          >
-            Delete
-          </a>
+        <td align="left">
+          {isEditing ? (
+            <input
+              type="text"
+              name="artist_name"
+              className="inline-edit"
+              value={draft!.artist_name}
+              onChange={(e) =>
+                setDraft({ ...draft!, artist_name: e.target.value })
+              }
+            />
+          ) : (
+            entry.artist_name
+          )}
+        </td>
+        <td align="left">
+          {isEditing ? (
+            <input
+              type="text"
+              name="track_title"
+              className="inline-edit"
+              value={draft!.track_title}
+              onChange={(e) =>
+                setDraft({ ...draft!, track_title: e.target.value })
+              }
+            />
+          ) : (
+            entry.track_title
+          )}
+        </td>
+        <td align="left">
+          {isEditing ? (
+            <input
+              type="text"
+              name="album_title"
+              className="inline-edit"
+              value={draft!.album_title}
+              onChange={(e) =>
+                setDraft({ ...draft!, album_title: e.target.value })
+              }
+            />
+          ) : (
+            entry.album_title || ""
+          )}
+        </td>
+        <td align="left">
+          {isEditing ? (
+            <input
+              type="text"
+              name="record_label"
+              className="inline-edit"
+              value={draft!.record_label}
+              onChange={(e) =>
+                setDraft({ ...draft!, record_label: e.target.value })
+              }
+            />
+          ) : (
+            entry.record_label || ""
+          )}
+        </td>
+        <td align="center" className="action-cell">
+          {isEditing ? (
+            <>
+              <button
+                type="button"
+                className="action-save"
+                aria-label="Save"
+                title="Save"
+                onClick={saveEdit}
+              >
+                {"✅"}
+              </button>{" "}
+              <button
+                type="button"
+                className="action-cancel"
+                aria-label="Cancel"
+                title="Cancel"
+                onClick={cancelEdit}
+              >
+                {"🚫"}
+              </button>
+            </>
+          ) : (
+            <EntryActionMenu
+              entryId={entry.id}
+              onEdit={beginEdit}
+              onDelete={onDelete}
+            />
+          )}
         </td>
       </tr>
     );

--- a/src/components/experiences/classic/flowsheet/EntryRow.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryRow.tsx
@@ -92,15 +92,30 @@ export default function EntryRow({
 
   const saveEdit = () => {
     if (!draft) return;
-    if (!draft.track_title.trim()) return;
+    const trimmed = {
+      artist_name: draft.artist_name.trim(),
+      track_title: draft.track_title.trim(),
+      album_title: draft.album_title.trim(),
+      record_label: draft.record_label.trim(),
+    };
+    if (!trimmed.track_title) return;
     onUpdate(entry.id, {
-      artist_name: draft.artist_name,
-      track_title: draft.track_title,
-      album_title: draft.album_title,
-      record_label: draft.record_label,
+      ...trimmed,
       request_flag: draft.request_flag,
     });
     setDraft(null);
+  };
+
+  // Enter saves, Escape cancels — standard inline-edit keyboard ergonomics.
+  // Without this, the inputs are mouse-only once Tab leaves them.
+  const handleEditKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      saveEdit();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      cancelEdit();
+    }
   };
 
   // Marker rows (talkset / breakpoint / start / end of show) span 5 of the 7
@@ -231,13 +246,14 @@ export default function EntryRow({
       >
         {isDraggable ? <GripCell /> : <EmptyGripCell />}
         <td align="center">
-          {isEditing ? (
+          {draft ? (
             <input
               type="checkbox"
               name="request_flag"
-              checked={draft!.request_flag}
+              aria-label="Listener request"
+              checked={draft.request_flag}
               onChange={(e) =>
-                setDraft({ ...draft!, request_flag: e.target.checked })
+                setDraft({ ...draft, request_flag: e.target.checked })
               }
             />
           ) : (
@@ -247,67 +263,71 @@ export default function EntryRow({
           )}
         </td>
         <td align="left">
-          {isEditing ? (
+          {draft ? (
             <input
               type="text"
               name="artist_name"
               className="inline-edit"
-              value={draft!.artist_name}
+              value={draft.artist_name}
               onChange={(e) =>
-                setDraft({ ...draft!, artist_name: e.target.value })
+                setDraft({ ...draft, artist_name: e.target.value })
               }
+              onKeyDown={handleEditKeyDown}
             />
           ) : (
             entry.artist_name
           )}
         </td>
         <td align="left">
-          {isEditing ? (
+          {draft ? (
             <input
               type="text"
               name="track_title"
               className="inline-edit"
-              value={draft!.track_title}
+              value={draft.track_title}
               onChange={(e) =>
-                setDraft({ ...draft!, track_title: e.target.value })
+                setDraft({ ...draft, track_title: e.target.value })
               }
+              onKeyDown={handleEditKeyDown}
             />
           ) : (
             entry.track_title
           )}
         </td>
         <td align="left">
-          {isEditing ? (
+          {draft ? (
             <input
               type="text"
               name="album_title"
               className="inline-edit"
-              value={draft!.album_title}
+              value={draft.album_title}
               onChange={(e) =>
-                setDraft({ ...draft!, album_title: e.target.value })
+                setDraft({ ...draft, album_title: e.target.value })
               }
+              onKeyDown={handleEditKeyDown}
             />
           ) : (
             entry.album_title || ""
           )}
         </td>
         <td align="left">
-          {isEditing ? (
+          {draft ? (
             <input
               type="text"
               name="record_label"
               className="inline-edit"
-              value={draft!.record_label}
+              value={draft.record_label}
               onChange={(e) =>
-                setDraft({ ...draft!, record_label: e.target.value })
+                setDraft({ ...draft, record_label: e.target.value })
               }
+              onKeyDown={handleEditKeyDown}
             />
           ) : (
             entry.record_label || ""
           )}
         </td>
         <td align="center" className="action-cell">
-          {isEditing ? (
+          {draft ? (
             <>
               <button
                 type="button"

--- a/src/components/experiences/classic/flowsheet/EntryTable.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryTable.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import {
   FlowsheetEntry,
   isFlowsheetSongEntry,
+  UpdateRequestBody,
 } from "@/lib/features/flowsheet/types";
 import EntryRow from "./EntryRow";
 
@@ -11,14 +12,14 @@ export default function EntryTable({
   entries,
   previousEntries,
   fontSize,
-  onEdit,
+  onUpdate,
   onDelete,
   onReorder,
 }: {
   entries: FlowsheetEntry[];
   previousEntries: FlowsheetEntry[];
   fontSize: number;
-  onEdit: (entryId: number) => void;
+  onUpdate: (entryId: number, data: UpdateRequestBody) => void;
   onDelete: (entryId: number) => void;
   /** Fired when a row is dropped onto another row. The implementation should
    *  swap the two entries' play_order values (or otherwise reorder). */
@@ -60,7 +61,7 @@ export default function EntryTable({
             <th>Song</th>
             <th>Release</th>
             <th>Label</th>
-            <th>Edit/Delete</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -74,7 +75,7 @@ export default function EntryTable({
                   key={entry.id}
                   entry={entry}
                   fontSize={fontSize}
-                  onEdit={onEdit}
+                  onUpdate={onUpdate}
                   onDelete={onDelete}
                   nextIsSong={nextIsSong}
                   isDragging={draggingId === entry.id}
@@ -128,7 +129,7 @@ export default function EntryTable({
                   key={entry.id}
                   entry={entry}
                   fontSize={fontSize}
-                  onEdit={onEdit}
+                  onUpdate={onUpdate}
                   onDelete={onDelete}
                   nextIsSong={nextIsSong}
                 />

--- a/src/components/experiences/classic/flowsheet/Layout/Main.tsx
+++ b/src/components/experiences/classic/flowsheet/Layout/Main.tsx
@@ -13,6 +13,7 @@ import StartShow from "../StartShow";
 import {
   isFlowsheetStartShowEntry,
   FlowsheetEntry,
+  UpdateRequestBody,
 } from "@/lib/features/flowsheet/types";
 import { useAddToFlowsheetMutation, useSwitchEntriesMutation } from "@/lib/features/flowsheet/api";
 import { FlowsheetEntryType } from "@wxyc/shared/dtos";
@@ -79,9 +80,8 @@ export default function Main() {
     }
   };
 
-  const handleEdit = (entryId: number) => {
-    // Navigate to edit page or open modal
-    window.location.href = `/dashboard/flowsheet/${entryId}`;
+  const handleUpdate = (entryId: number, data: UpdateRequestBody) => {
+    updateFlowsheet({ entry_id: entryId, data });
   };
 
   const handleDelete = (entryId: number) => {
@@ -171,7 +171,7 @@ export default function Main() {
           entries={currentShowEntries}
           previousEntries={previousEntries}
           fontSize={fontSize}
-          onEdit={handleEdit}
+          onUpdate={handleUpdate}
           onDelete={handleDelete}
           onReorder={handleReorder}
         />

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryActionMenu.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryActionMenu.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import EntryActionMenu from "../EntryActionMenu";
+
+function setUp(overrides: Partial<React.ComponentProps<typeof EntryActionMenu>> = {}) {
+  const props = {
+    entryId: 42,
+    onEdit: vi.fn(),
+    onDelete: vi.fn(),
+    ...overrides,
+  };
+  const result = renderWithProviders(<EntryActionMenu {...props} />);
+  return { ...result, props };
+}
+
+describe("Classic EntryActionMenu", () => {
+  it("renders an ellipsis trigger button with an aria-label", () => {
+    setUp();
+    const trigger = screen.getByRole("button", { name: /actions/i });
+    expect(trigger).toBeDefined();
+    expect(trigger.textContent).toBe("⋯");
+  });
+
+  it("renders the dropdown hidden by default", () => {
+    const { container } = setUp();
+    const menu = container.querySelector(".action-menu");
+    expect(menu).not.toBeNull();
+    expect(menu!.classList.contains("open")).toBe(false);
+  });
+
+  it("opens the dropdown on trigger click", () => {
+    const { container } = setUp();
+    const trigger = screen.getByRole("button", { name: /actions/i });
+    fireEvent.click(trigger);
+    const menu = container.querySelector(".action-menu");
+    expect(menu!.classList.contains("open")).toBe(true);
+  });
+
+  it("closes the dropdown on second trigger click", () => {
+    const { container } = setUp();
+    const trigger = screen.getByRole("button", { name: /actions/i });
+    fireEvent.click(trigger);
+    fireEvent.click(trigger);
+    const menu = container.querySelector(".action-menu");
+    expect(menu!.classList.contains("open")).toBe(false);
+  });
+
+  it("fires onEdit and closes the menu when Edit is clicked", () => {
+    const { container, props } = setUp();
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByText("Edit"));
+    expect(props.onEdit).toHaveBeenCalledWith(42);
+    expect(container.querySelector(".action-menu")!.classList.contains("open")).toBe(false);
+  });
+
+  it("fires onDelete and closes the menu when Delete is clicked", () => {
+    const { container, props } = setUp();
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByText("Delete"));
+    expect(props.onDelete).toHaveBeenCalledWith(42);
+    expect(container.querySelector(".action-menu")!.classList.contains("open")).toBe(false);
+  });
+
+  it("marks the Delete item with the action-delete class for red styling", () => {
+    setUp();
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    const del = screen.getByText("Delete");
+    expect(del.classList.contains("action-delete")).toBe(true);
+  });
+
+  it("closes the dropdown when clicking outside the menu", () => {
+    const { container } = setUp();
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    expect(container.querySelector(".action-menu")!.classList.contains("open")).toBe(true);
+    fireEvent.mouseDown(document.body);
+    expect(container.querySelector(".action-menu")!.classList.contains("open")).toBe(false);
+  });
+});

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryActionMenu.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryActionMenu.test.tsx
@@ -22,19 +22,27 @@ describe("Classic EntryActionMenu", () => {
     expect(trigger.textContent).toBe("⋯");
   });
 
-  it("renders the dropdown hidden by default", () => {
-    const { container } = setUp();
-    const menu = container.querySelector(".action-menu");
-    expect(menu).not.toBeNull();
-    expect(menu!.classList.contains("open")).toBe(false);
+  it("exposes menu disclosure semantics on the trigger button", () => {
+    setUp();
+    const trigger = screen.getByRole("button", { name: /actions/i });
+    expect(trigger.getAttribute("aria-haspopup")).toBe("menu");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
   });
 
-  it("opens the dropdown on trigger click", () => {
+  it("does not render the dropdown items in the DOM by default", () => {
+    const { container } = setUp();
+    expect(container.querySelector(".action-dropdown")).toBeNull();
+    expect(screen.queryByText("Edit")).toBeNull();
+    expect(screen.queryByText("Delete")).toBeNull();
+  });
+
+  it("opens the dropdown on trigger click and flips aria-expanded", () => {
     const { container } = setUp();
     const trigger = screen.getByRole("button", { name: /actions/i });
     fireEvent.click(trigger);
-    const menu = container.querySelector(".action-menu");
-    expect(menu!.classList.contains("open")).toBe(true);
+    expect(container.querySelector(".action-menu")!.classList.contains("open")).toBe(true);
+    expect(container.querySelector(".action-dropdown")).not.toBeNull();
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
   });
 
   it("closes the dropdown on second trigger click", () => {
@@ -42,14 +50,14 @@ describe("Classic EntryActionMenu", () => {
     const trigger = screen.getByRole("button", { name: /actions/i });
     fireEvent.click(trigger);
     fireEvent.click(trigger);
-    const menu = container.querySelector(".action-menu");
-    expect(menu!.classList.contains("open")).toBe(false);
+    expect(container.querySelector(".action-menu")!.classList.contains("open")).toBe(false);
+    expect(container.querySelector(".action-dropdown")).toBeNull();
   });
 
   it("fires onEdit and closes the menu when Edit is clicked", () => {
     const { container, props } = setUp();
     fireEvent.click(screen.getByRole("button", { name: /actions/i }));
-    fireEvent.click(screen.getByText("Edit"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
     expect(props.onEdit).toHaveBeenCalledWith(42);
     expect(container.querySelector(".action-menu")!.classList.contains("open")).toBe(false);
   });
@@ -57,23 +65,38 @@ describe("Classic EntryActionMenu", () => {
   it("fires onDelete and closes the menu when Delete is clicked", () => {
     const { container, props } = setUp();
     fireEvent.click(screen.getByRole("button", { name: /actions/i }));
-    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
     expect(props.onDelete).toHaveBeenCalledWith(42);
     expect(container.querySelector(".action-menu")!.classList.contains("open")).toBe(false);
+  });
+
+  it("renders the dropdown items as <button> elements (not anchors)", () => {
+    setUp();
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    expect(screen.getByRole("menuitem", { name: "Edit" }).tagName).toBe("BUTTON");
+    expect(screen.getByRole("menuitem", { name: "Delete" }).tagName).toBe("BUTTON");
   });
 
   it("marks the Delete item with the action-delete class for red styling", () => {
     setUp();
     fireEvent.click(screen.getByRole("button", { name: /actions/i }));
-    const del = screen.getByText("Delete");
+    const del = screen.getByRole("menuitem", { name: "Delete" });
     expect(del.classList.contains("action-delete")).toBe(true);
   });
 
-  it("closes the dropdown when clicking outside the menu", () => {
+  it("closes the dropdown on outside pointerdown", () => {
     const { container } = setUp();
     fireEvent.click(screen.getByRole("button", { name: /actions/i }));
     expect(container.querySelector(".action-menu")!.classList.contains("open")).toBe(true);
-    fireEvent.mouseDown(document.body);
+    fireEvent.pointerDown(document.body);
+    expect(container.querySelector(".action-menu")!.classList.contains("open")).toBe(false);
+  });
+
+  it("closes the dropdown when Escape is pressed", () => {
+    const { container } = setUp();
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    expect(container.querySelector(".action-menu")!.classList.contains("open")).toBe(true);
+    fireEvent.keyDown(document, { key: "Escape" });
     expect(container.querySelector(".action-menu")!.classList.contains("open")).toBe(false);
   });
 });

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
@@ -615,6 +615,97 @@ describe("Classic EntryRow action menu + inline edit (song rows)", () => {
     expect(onDelete).toHaveBeenCalledWith(99);
   });
 
+  it("closes the dropdown when Edit is clicked AND enters edit mode", () => {
+    const { container } = renderRow({ entry: baseEntry() });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    expect(container.querySelector(".action-dropdown")).not.toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
+    // Menu closed
+    expect(container.querySelector(".action-dropdown")).toBeNull();
+    // Row in edit mode
+    expect(container.querySelector('input[name="track_title"]')).not.toBeNull();
+  });
+
+  it("saves on Enter pressed in any edit input", () => {
+    const onUpdate = vi.fn();
+    const { container } = renderRow({ entry: baseEntry(), onUpdate });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
+    const track = container.querySelector(
+      'input[name="track_title"]'
+    ) as HTMLInputElement;
+    fireEvent.change(track, { target: { value: "Edited via Enter" } });
+    fireEvent.keyDown(track, { key: "Enter" });
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledWith(
+      99,
+      expect.objectContaining({ track_title: "Edited via Enter" })
+    );
+    expect(container.querySelector('input[name="track_title"]')).toBeNull();
+  });
+
+  it("cancels on Escape pressed in any edit input", () => {
+    const onUpdate = vi.fn();
+    const { container } = renderRow({ entry: baseEntry(), onUpdate });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
+    const artist = container.querySelector(
+      'input[name="artist_name"]'
+    ) as HTMLInputElement;
+    fireEvent.change(artist, { target: { value: "MANGLED" } });
+    fireEvent.keyDown(artist, { key: "Escape" });
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(container.querySelector('input[name="artist_name"]')).toBeNull();
+    expect(screen.getByText("Juana Molina")).toBeDefined();
+  });
+
+  it("trims whitespace from edited string fields before calling onUpdate", () => {
+    const onUpdate = vi.fn();
+    const { container } = renderRow({ entry: baseEntry(), onUpdate });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
+    fireEvent.change(
+      container.querySelector('input[name="artist_name"]') as HTMLInputElement,
+      { target: { value: "  Juana M.  " } }
+    );
+    fireEvent.change(
+      container.querySelector('input[name="track_title"]') as HTMLInputElement,
+      { target: { value: "\tla paradoja\n" } }
+    );
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(onUpdate).toHaveBeenCalledWith(99, {
+      artist_name: "Juana M.",
+      track_title: "la paradoja",
+      album_title: "DOGA",
+      record_label: "Sonamos",
+      request_flag: false,
+    });
+  });
+
+  it("does NOT fire onUpdate when track_title is only whitespace", () => {
+    const onUpdate = vi.fn();
+    const { container } = renderRow({ entry: baseEntry(), onUpdate });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
+    fireEvent.change(
+      container.querySelector('input[name="track_title"]') as HTMLInputElement,
+      { target: { value: "   \t  " } }
+    );
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("labels the request checkbox so screen readers can announce it", () => {
+    const { container } = renderRow({ entry: baseEntry() });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
+    const checkbox = container.querySelector(
+      'input[type="checkbox"][name="request_flag"]'
+    ) as HTMLInputElement | null;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox!.getAttribute("aria-label")).toBe("Listener request");
+  });
+
   it("does NOT render the action menu on talkset rows", () => {
     const entry: FlowsheetEntry = {
       id: 30,

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryRow.test.tsx
@@ -1,9 +1,12 @@
-import { describe, it, expect } from "vitest";
-import { screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
 import { renderWithProviders } from "@/lib/test-utils/render";
 import { createTestFlowsheetEntry } from "@/lib/test-utils";
 import { Rotation } from "@/lib/features/rotation/types";
-import type { FlowsheetEntry } from "@/lib/features/flowsheet/types";
+import type {
+  FlowsheetEntry,
+  UpdateRequestBody,
+} from "@/lib/features/flowsheet/types";
 import EntryRow from "../EntryRow";
 
 // renderInTable wraps EntryRow in a <table><tbody> so the row's <td> elements
@@ -17,6 +20,8 @@ function renderRow(props: {
   isDragging?: boolean;
   isDragOver?: boolean;
   dragHandlers?: boolean;
+  onUpdate?: (entryId: number, data: UpdateRequestBody) => void;
+  onDelete?: (entryId: number) => void;
   onDragStart?: (entryId: number) => void;
   onDragOver?: (entryId: number) => void;
   onDrop?: (entryId: number) => void;
@@ -29,8 +34,8 @@ function renderRow(props: {
         <EntryRow
           entry={props.entry}
           fontSize={3}
-          onEdit={() => {}}
-          onDelete={() => {}}
+          onUpdate={props.onUpdate ?? (() => {})}
+          onDelete={props.onDelete ?? (() => {})}
           nextIsSong={props.nextIsSong}
           isDragging={props.isDragging}
           isDragOver={props.isDragOver}
@@ -427,5 +432,214 @@ describe("Classic EntryRow markers", () => {
     expect(cell!.textContent).toBe(
       "Start of show — DJ Test @ Unknown Unknown"
     );
+  });
+});
+
+describe("Classic EntryRow action menu + inline edit (song rows)", () => {
+  const baseEntry = () =>
+    createTestFlowsheetEntry({
+      id: 99,
+      artist_name: "Juana Molina",
+      track_title: "la paradoja",
+      album_title: "DOGA",
+      record_label: "Sonamos",
+      request_flag: false,
+    });
+
+  it("renders an action-menu trigger (⋯) on a song row instead of legacy Edit/Delete links", () => {
+    const { container } = renderRow({ entry: baseEntry() });
+    const trigger = screen.getByRole("button", { name: /actions/i });
+    expect(trigger.textContent).toBe("⋯");
+    // No standalone <a>Edit</a> or <a>Delete</a> on the row — those are gone.
+    // Edit and Delete now live inside the dropdown menu (.action-dropdown).
+    const standaloneEditLink = Array.from(container.querySelectorAll("a")).find(
+      (a) => a.textContent === "Edit" && !a.classList.contains("action-item")
+    );
+    const standaloneDeleteLink = Array.from(
+      container.querySelectorAll("a")
+    ).find(
+      (a) => a.textContent === "Delete" && !a.classList.contains("action-item")
+    );
+    expect(standaloneEditLink).toBeUndefined();
+    expect(standaloneDeleteLink).toBeUndefined();
+    // The menu starts closed.
+    expect(container.querySelector(".action-menu.open")).toBeNull();
+  });
+
+  it("opens the dropdown on trigger click and shows Edit + Delete items", () => {
+    renderRow({ entry: baseEntry() });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    expect(screen.getByText("Edit")).toBeDefined();
+    expect(screen.getByText("Delete")).toBeDefined();
+  });
+
+  it("transitions cells to inputs when Edit is clicked", () => {
+    const { container } = renderRow({ entry: baseEntry() });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByText("Edit"));
+
+    const artist = container.querySelector(
+      'input[name="artist_name"]'
+    ) as HTMLInputElement | null;
+    const track = container.querySelector(
+      'input[name="track_title"]'
+    ) as HTMLInputElement | null;
+    const album = container.querySelector(
+      'input[name="album_title"]'
+    ) as HTMLInputElement | null;
+    const label = container.querySelector(
+      'input[name="record_label"]'
+    ) as HTMLInputElement | null;
+    expect(artist?.value).toBe("Juana Molina");
+    expect(track?.value).toBe("la paradoja");
+    expect(album?.value).toBe("DOGA");
+    expect(label?.value).toBe("Sonamos");
+  });
+
+  it("shows a request checkbox in edit mode, pre-checked when request_flag is true", () => {
+    const { container } = renderRow({
+      entry: createTestFlowsheetEntry({ request_flag: true }),
+    });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByText("Edit"));
+    const checkbox = container.querySelector(
+      'input[type="checkbox"][name="request_flag"]'
+    ) as HTMLInputElement | null;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox!.checked).toBe(true);
+  });
+
+  it("shows an unchecked request checkbox when request_flag is false", () => {
+    const { container } = renderRow({ entry: baseEntry() });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByText("Edit"));
+    const checkbox = container.querySelector(
+      'input[type="checkbox"][name="request_flag"]'
+    ) as HTMLInputElement | null;
+    expect(checkbox!.checked).toBe(false);
+  });
+
+  it("disables drag on the row while editing", () => {
+    const { container } = renderRow({ entry: baseEntry() });
+    expect(
+      container.querySelector("tr.flowsheetEntryData")!.getAttribute("draggable")
+    ).toBe("true");
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByText("Edit"));
+    expect(
+      container.querySelector("tr.flowsheetEntryData")!.getAttribute("draggable")
+    ).toBe("false");
+  });
+
+  it("fires onUpdate with the edited values on Save", () => {
+    const onUpdate = vi.fn();
+    const { container } = renderRow({ entry: baseEntry(), onUpdate });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByText("Edit"));
+
+    const artist = container.querySelector(
+      'input[name="artist_name"]'
+    ) as HTMLInputElement;
+    const track = container.querySelector(
+      'input[name="track_title"]'
+    ) as HTMLInputElement;
+    const requestCheckbox = container.querySelector(
+      'input[type="checkbox"][name="request_flag"]'
+    ) as HTMLInputElement;
+
+    fireEvent.change(artist, { target: { value: "Juana M." } });
+    fireEvent.change(track, { target: { value: "la paradoja (live)" } });
+    fireEvent.click(requestCheckbox);
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledWith(99, {
+      artist_name: "Juana M.",
+      track_title: "la paradoja (live)",
+      album_title: "DOGA",
+      record_label: "Sonamos",
+      request_flag: true,
+    });
+  });
+
+  it("exits edit mode after Save", () => {
+    const { container } = renderRow({ entry: baseEntry() });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByText("Edit"));
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(container.querySelector('input[name="artist_name"]')).toBeNull();
+    expect(screen.getByRole("button", { name: /actions/i })).toBeDefined();
+  });
+
+  it("does NOT fire onUpdate when Save is clicked with an empty track_title", () => {
+    const onUpdate = vi.fn();
+    const { container } = renderRow({ entry: baseEntry(), onUpdate });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByText("Edit"));
+
+    const track = container.querySelector(
+      'input[name="track_title"]'
+    ) as HTMLInputElement;
+    fireEvent.change(track, { target: { value: "   " } });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    expect(onUpdate).not.toHaveBeenCalled();
+    // Row remains in edit mode so the user can fix it.
+    expect(container.querySelector('input[name="track_title"]')).not.toBeNull();
+  });
+
+  it("restores original values and exits edit mode on Cancel", () => {
+    const onUpdate = vi.fn();
+    const { container } = renderRow({ entry: baseEntry(), onUpdate });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByText("Edit"));
+
+    const artist = container.querySelector(
+      'input[name="artist_name"]'
+    ) as HTMLInputElement;
+    fireEvent.change(artist, { target: { value: "Mangled" } });
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(container.querySelector('input[name="artist_name"]')).toBeNull();
+    // Original text is visible again.
+    expect(screen.getByText("Juana Molina")).toBeDefined();
+  });
+
+  it("fires onDelete when Delete is clicked in the menu", () => {
+    const onDelete = vi.fn();
+    renderRow({ entry: baseEntry(), onDelete });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByText("Delete"));
+    expect(onDelete).toHaveBeenCalledWith(99);
+  });
+
+  it("does NOT render the action menu on talkset rows", () => {
+    const entry: FlowsheetEntry = {
+      id: 30,
+      show_id: 1,
+      play_order: 1,
+      message: "Talkset - station ID",
+    };
+    renderRow({ entry });
+    expect(
+      screen.queryByRole("button", { name: /actions/i })
+    ).toBeNull();
+  });
+
+  it("does NOT render the action menu on breakpoint rows", () => {
+    const entry: FlowsheetEntry = {
+      id: 31,
+      show_id: 1,
+      play_order: 2,
+      message: "Breakpoint - 5:00 PM",
+      day: "11/14/2023",
+      time: "5:00:00 PM",
+    };
+    renderRow({ entry });
+    expect(
+      screen.queryByRole("button", { name: /actions/i })
+    ).toBeNull();
   });
 });

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryTable.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryTable.test.tsx
@@ -34,7 +34,7 @@ function setup(opts?: { entries?: FlowsheetEntry[]; onReorder?: (sourceId: numbe
       entries={entries}
       previousEntries={[]}
       fontSize={3}
-      onEdit={() => {}}
+      onUpdate={() => {}}
       onDelete={() => {}}
       onReorder={onReorder}
     />
@@ -65,6 +65,13 @@ describe("Classic EntryTable header", () => {
     const { container } = setup();
     const firstTh = container.querySelector("thead th:first-child");
     expect(firstTh!.textContent).toBe("");
+  });
+
+  it("renders an empty trailing column header (no 'Edit/Delete' label)", () => {
+    const { container } = setup();
+    const headers = Array.from(container.querySelectorAll("thead th"));
+    const lastTh = headers[headers.length - 1];
+    expect(lastTh.textContent).toBe("");
   });
 });
 

--- a/src/styles/classic/actions.css
+++ b/src/styles/classic/actions.css
@@ -49,6 +49,14 @@
   text-decoration: none;
   white-space: nowrap;
   font-size: 13px;
+  /* Reset <button> defaults so the items render as the same plain rows the
+     tubafrenzy <a>-styled items did. */
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+  cursor: pointer;
 }
 .action-item:hover {
   background: #f0f0f0;

--- a/src/styles/classic/actions.css
+++ b/src/styles/classic/actions.css
@@ -1,0 +1,94 @@
+/* Per-row action menu (ellipsis dropdown) + inline edit, ported from
+   tubafrenzy webapps/playlists/src/main/webapp/css/flowsheet.css. */
+
+.action-cell {
+  width: 32px;
+  text-align: center;
+  padding: 0;
+}
+.action-menu {
+  position: relative;
+  display: inline-block;
+}
+.action-trigger {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  font-size: 16px;
+  cursor: pointer;
+  color: #666;
+  line-height: 28px;
+  padding: 0;
+}
+.action-trigger:hover {
+  background: #e8e8e8;
+  border-color: #ccc;
+}
+.action-dropdown {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 100;
+  min-width: 90px;
+  padding: 4px 0;
+}
+.action-menu.open .action-dropdown {
+  display: block;
+}
+.action-item {
+  display: block;
+  padding: 6px 14px;
+  color: #333;
+  text-decoration: none;
+  white-space: nowrap;
+  font-size: 13px;
+}
+.action-item:hover {
+  background: #f0f0f0;
+}
+.action-delete {
+  color: #cc0000;
+}
+.action-delete:hover {
+  background: #fce8e8;
+}
+
+/* Inline editing */
+
+.flowsheetEntryData.editing {
+  background-color: #fffff0 !important;
+}
+.inline-edit {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 2px 4px;
+  font-size: inherit;
+  font-family: inherit;
+}
+.action-save,
+.action-cancel {
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 2px 4px;
+}
+.action-save {
+  color: #2a7a2a;
+}
+.action-save:hover {
+  color: #1a5a1a;
+}
+.action-cancel {
+  color: #999;
+}
+.action-cancel:hover {
+  color: #666;
+}


### PR DESCRIPTION
PR 9 of 12 in the Classic ↔ tubafrenzy sync series ([WXYC/dj-site#511](https://github.com/WXYC/dj-site/issues/511)).

## What

Replaces per-row Edit/Delete links with a `⋯` EntryActionMenu and inline-edit mode, matching tubafrenzy commits [`7ef98923`](https://github.com/WXYC/tubafrenzy/commit/7ef98923) and [`fbea79bc`](https://github.com/WXYC/tubafrenzy/commit/fbea79bc).

- New component `EntryActionMenu.tsx`: `⋯` trigger button + dropdown with Edit and Delete (Delete in red). Click-outside closes the menu.
- `EntryRow.tsx` gains a local `draft` state. Clicking Edit converts artist/song/release/label cells to text inputs, request indicator to a checkbox (pre-checked when `request_flag` is true), and the action cell to Save (✅) / Cancel (🚫) buttons. Drag is disabled while editing.
- `EntryTable.tsx` accepts `onUpdate(entryId, data)` in place of `onEdit`. The trailing header cell is now empty (tubafrenzy matches).
- `Main.tsx` wires `onUpdate` to the existing `updateFlowsheet` RTK Query mutation. (Previously, `onEdit` did a full page nav to a non-existent route.)
- Ports tubafrenzy's actions/inline-edit CSS verbatim to `src/styles/classic/actions.css`.

## Behaviour notes

- **Save with empty track_title is a no-op** so the row stays in edit mode and the user can correct. Matches the tubafrenzy intent (server would 400 on empty title) and avoids accidental clears.
- **Cancel discards the draft** without firing any mutation; the original text reappears.
- **Drag during edit is suppressed** by gating `isDraggable` on `!isEditing`.

## Tests

- `EntryActionMenu.test.tsx` (new): trigger renders, dropdown opens/closes on click + click-outside, Edit/Delete callbacks fire with `entryId`, Delete carries `action-delete` class.
- `EntryRow.test.tsx`: action-menu trigger renders instead of legacy links; Edit transitions cells to inputs; request checkbox reflects + toggles `request_flag`; drag is disabled during edit; Save fires `onUpdate` with the full body; Save with empty track is a no-op; Cancel reverts; Delete fires `onDelete`; talkset/breakpoint rows have no menu.
- `EntryTable.test.tsx`: trailing header cell is empty.
- All 2867 unit tests pass; production build (Turbopack) green.

## QA

Verified end-to-end against the local staging stack: PATCH `/flowsheet/` fires with the correct body, returns 200, and the refreshed flowsheet shows the new value. Cancel fires zero PATCH requests.

## Risk

Medium — touches the mutation pathway. Optimistic update + tag invalidation are preserved via the existing `updateFlowsheet` mutation.

## Depends on

[PR 8 — drag-to-reorder grip handle](https://github.com/WXYC/dj-site/pull/538) (merged).