### PR TITLE
feat(catalog): gate matched_via chips behind CATALOG_TRACK_SEARCH_UI_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# dj-site environment variables. Copy to `.env.local` for development.
+# All NEXT_PUBLIC_* vars are inlined at build time and visible in the browser.
+
+# Backend-Service base URLs
+NEXT_PUBLIC_BACKEND_URL=http://localhost:8080
+NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:8082/auth
+
+# Routing / experience system
+NEXT_PUBLIC_DASHBOARD_HOME_PAGE=/dashboard/flowsheet
+NEXT_PUBLIC_DEFAULT_EXPERIENCE=modern
+NEXT_PUBLIC_ENABLED_EXPERIENCES=modern,classic
+NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING=true
+
+# Catalog Track Search v2: render `matched_via` track-match chips in catalog
+# search results. Defaults to OFF; set to `true` (or `1`) after Backend-Service
+# is serving matched_via in prod. See WXYC/dj-site#498.
+NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,8 @@ The backend must be running locally. See README.md for full setup options.
 
 ### Environment Variables
 
-Create `.env.local`:
+Copy `.env.example` to `.env.local`. Defaults:
+
 ```bash
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8080
 NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:8082/auth
@@ -99,7 +100,12 @@ NEXT_PUBLIC_DASHBOARD_HOME_PAGE=/dashboard/flowsheet
 NEXT_PUBLIC_DEFAULT_EXPERIENCE=modern
 NEXT_PUBLIC_ENABLED_EXPERIENCES=modern,classic
 NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING=true
+NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED=false
 ```
+
+**Feature flags**:
+
+- `NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED` — gates the `matched_via` track-match chip rendering in catalog search results (both classic and modern experiences). Defaults to OFF; set to `"true"` or `"1"` to enable. Helper: `isCatalogTrackSearchUiEnabled()` in `lib/features/catalog/flags.ts`. Flip on after Backend-Service is serving `matched_via` in prod. See WXYC/dj-site#498.
 
 ### Test Credentials (local dev)
 

--- a/lib/__tests__/features/catalog/flags.test.ts
+++ b/lib/__tests__/features/catalog/flags.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { isCatalogTrackSearchUiEnabled } from "@/lib/features/catalog/flags";
+
+const ENV_KEY = "NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED";
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+});
+
+describe("isCatalogTrackSearchUiEnabled", () => {
+  it("returns false when the env var is undefined (default off)", () => {
+    delete process.env[ENV_KEY];
+    expect(isCatalogTrackSearchUiEnabled()).toBe(false);
+  });
+
+  it.each(["true", "1"])(
+    "returns true when env var is %s",
+    (value) => {
+      process.env[ENV_KEY] = value;
+      expect(isCatalogTrackSearchUiEnabled()).toBe(true);
+    }
+  );
+
+  it.each(["false", "0", "", "yes", "TRUE", "  true  "])(
+    "returns false when env var is %s (only exact 'true'/'1' opt in)",
+    (value) => {
+      process.env[ENV_KEY] = value;
+      expect(isCatalogTrackSearchUiEnabled()).toBe(false);
+    }
+  );
+});

--- a/lib/features/catalog/flags.ts
+++ b/lib/features/catalog/flags.ts
@@ -1,0 +1,17 @@
+/**
+ * Catalog feature flags read from public Next.js env vars.
+ *
+ * Values are inlined at build time, so callers must invoke these helpers at
+ * render time rather than at module init.
+ */
+
+/**
+ * Gates the matched_via track-match chip rendering in catalog search results.
+ *
+ * Defaults to OFF; flip on by setting NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED
+ * to "true" (or "1") after Backend-Service is serving matched_via in prod.
+ */
+export function isCatalogTrackSearchUiEnabled(): boolean {
+  const envValue = process.env.NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED;
+  return envValue === "true" || envValue === "1";
+}

--- a/src/components/experiences/classic/catalog/MatchedTrackChips.tsx
+++ b/src/components/experiences/classic/catalog/MatchedTrackChips.tsx
@@ -1,3 +1,4 @@
+import { isCatalogTrackSearchUiEnabled } from "@/lib/features/catalog/flags";
 import type { TrackMatchHint } from "@/lib/features/catalog/types";
 import "@/src/styles/classic/capsules.css";
 
@@ -8,6 +9,9 @@ export function MatchedTrackChips({
 }: {
   matched_via: TrackMatchHint[] | undefined;
 }) {
+  if (!isCatalogTrackSearchUiEnabled()) {
+    return null;
+  }
   if (!matched_via || matched_via.length === 0) {
     return null;
   }

--- a/src/components/experiences/classic/catalog/__tests__/SearchResults.matchedVia.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchResults.matchedVia.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { screen } from "@testing-library/react";
 import { createTestAlbum, createTestArtist } from "@/lib/test-utils";
 import { renderWithProviders } from "@/lib/test-utils/render";
@@ -124,5 +124,33 @@ describe("Classic SearchResults matched_via chip", () => {
     const more = screen.getByText("+1 more");
     expect(more.getAttribute("tabindex")).toBe("0");
     expect(more.getAttribute("title")).toContain("Track Four");
+  });
+
+  describe("CATALOG_TRACK_SEARCH_UI_ENABLED flag", () => {
+    const FLAG_KEY = "NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED";
+
+    afterEach(() => {
+      process.env[FLAG_KEY] = "true";
+    });
+
+    it.each(["false", "0", undefined])(
+      "renders no matched-track chips when the flag is %s, even with hints present",
+      (value) => {
+        if (value === undefined) {
+          delete process.env[FLAG_KEY];
+        } else {
+          process.env[FLAG_KEY] = value;
+        }
+        renderWithMatchedVia([
+          {
+            source: "cta",
+            title: "In a Sentimental Mood",
+            artist_credit: "Duke Ellington & John Coltrane",
+            confidence: 1.0,
+          },
+        ]);
+        expect(screen.queryByText(/matched on track/i)).toBeNull();
+      }
+    );
   });
 });

--- a/src/components/experiences/modern/catalog/Results/MatchedTrackChips.tsx
+++ b/src/components/experiences/modern/catalog/Results/MatchedTrackChips.tsx
@@ -4,6 +4,7 @@ import Chip from "@mui/joy/Chip";
 import Stack from "@mui/joy/Stack";
 import Tooltip from "@mui/joy/Tooltip";
 
+import { isCatalogTrackSearchUiEnabled } from "@/lib/features/catalog/flags";
 import type { TrackMatchHint } from "@/lib/features/catalog/types";
 
 const VISIBLE_LIMIT = 3;
@@ -20,6 +21,9 @@ export function MatchedTrackChips({
 }: {
   matched_via: TrackMatchHint[] | undefined;
 }) {
+  if (!isCatalogTrackSearchUiEnabled()) {
+    return null;
+  }
   if (!matched_via || matched_via.length === 0) {
     return null;
   }

--- a/src/components/experiences/modern/catalog/Results/__tests__/MatchedTrackChips.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/MatchedTrackChips.test.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/lib/test-utils/render";
 import type { TrackMatchHint } from "@/lib/features/catalog/types";
 import { MatchedTrackChips } from "../MatchedTrackChips";
+
+const FLAG_KEY = "NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED";
 
 function renderChips(matched_via: TrackMatchHint[] | undefined) {
   renderWithProviders(<MatchedTrackChips matched_via={matched_via} />);
@@ -103,5 +105,34 @@ describe("Modern MatchedTrackChips", () => {
     expect(more).not.toBeNull();
     expect(more?.getAttribute("tabindex")).toBe("0");
     expect(more?.getAttribute("aria-label")).toContain("Track Four");
+  });
+
+  describe("CATALOG_TRACK_SEARCH_UI_ENABLED flag", () => {
+    afterEach(() => {
+      process.env[FLAG_KEY] = "true";
+    });
+
+    it.each(["false", "0", undefined])(
+      "renders nothing when the flag is %s, even with hints present",
+      (value) => {
+        if (value === undefined) {
+          delete process.env[FLAG_KEY];
+        } else {
+          process.env[FLAG_KEY] = value;
+        }
+        const { container } = renderWithProviders(
+          <MatchedTrackChips
+            matched_via={[
+              {
+                source: "cta",
+                title: "In a Sentimental Mood",
+                confidence: 1.0,
+              },
+            ]}
+          />
+        );
+        expect(container.firstChild).toBeNull();
+      }
+    );
   });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -7,6 +7,10 @@ beforeAll(() => server.listen({ onUnhandledRequest: "bypass" }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
+// Default catalog-track-search UI flag on in tests so chip-rendering specs pass.
+// Specs that exercise the disabled state override per-test.
+process.env.NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED = "true";
+
 // Mock localStorage
 const localStorageMock = {
   getItem: vi.fn(() => null),


### PR DESCRIPTION
## Summary

- Add `isCatalogTrackSearchUiEnabled()` helper in `lib/features/catalog/flags.ts`, reading `NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED` at call time (defaults OFF; only `"true"`/`"1"` opt in).
- Gate both classic and modern `MatchedTrackChips` so they early-return `null` when the flag is off, regardless of whether `matched_via` is populated.
- Document the new flag in `.env.example` (new file) and `CLAUDE.md`'s Environment Variables section.
- Default the flag to `"true"` in `vitest.setup.ts` so the existing chip-rendering specs continue to pass; the new flag-off specs override per-test.

Defaults to OFF so the production rollout can ship dark and flip on once Backend-Service is serving `matched_via` in prod.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 199/199 files, 2876/2876 tests pass
- [x] `npm run build` — clean Next.js build
- [x] New `flags.test.ts` covers undefined / `"true"` / `"1"` / `"false"` / `"0"` / garbage values
- [x] New flag-off specs in both `MatchedTrackChips.test.tsx` (modern) and `SearchResults.matchedVia.test.tsx` (classic) verify chips don't render when the flag is `"false"`, `"0"`, or unset

Closes #498