### PR TITLE
classic flowsheet ActionsBar: consolidate Sign Out + Log Out into End Show

### DIFF
--- a/src/components/experiences/classic/flowsheet/ActionsBar.tsx
+++ b/src/components/experiences/classic/flowsheet/ActionsBar.tsx
@@ -2,7 +2,6 @@
 
 import { useRouter } from "next/navigation";
 import { useShowControl } from "@/src/hooks/flowsheetHooks";
-import { useRegistry } from "@/src/hooks/authenticationHooks";
 import { OpenHelp } from "@/src/utils/helpScreen";
 
 export default function ActionsBar({
@@ -16,7 +15,6 @@ export default function ActionsBar({
 }) {
   const router = useRouter();
   const { live, leave } = useShowControl();
-  const { info: userData } = useRegistry();
 
   const formatHour = (hour?: number) => {
     if (!hour) return "";
@@ -28,7 +26,11 @@ export default function ActionsBar({
     return `${displayHours}:${minutes.toString().padStart(2, "0")} ${ampm}`;
   };
 
-  const handleLogout = () => {
+  // Atomic show-end + session-end. Ports tubafrenzy's EndShowServlet flow:
+  // signoff the radio show and invalidate the session in one click, replacing
+  // the prior two-step "Sign Out When Finished!" + "Log Out" pair.
+  const endShow = () => {
+    leave();
     router.push("/login?loginAction=endSession");
   };
 
@@ -56,8 +58,8 @@ export default function ActionsBar({
             </a>
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             {live ? (
-              <a href="#" onClick={(e) => { e.preventDefault(); leave(); }}>
-                Sign Out When Finished!
+              <a href="#" onClick={(e) => { e.preventDefault(); endShow(); }}>
+                End Show
               </a>
             ) : (
               <span>Not currently live</span>
@@ -71,10 +73,6 @@ export default function ActionsBar({
               }}
             >
               Help
-            </a>
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-            <a href="#" onClick={(e) => { e.preventDefault(); handleLogout(); }}>
-              Log Out
             </a>
           </td>
         </tr>

--- a/src/components/experiences/classic/flowsheet/__tests__/ActionsBar.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/ActionsBar.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+
+const leaveMock = vi.fn();
+const pushMock = vi.fn();
+let liveMock = true;
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useShowControl: () => ({ live: liveMock, leave: leaveMock }),
+}));
+
+vi.mock("@/src/hooks/authenticationHooks", () => ({
+  useRegistry: () => ({ info: { real_name: "Test DJ" } }),
+}));
+
+vi.mock("@/src/utils/helpScreen", () => ({
+  OpenHelp: vi.fn(),
+}));
+
+import ActionsBar from "../ActionsBar";
+
+beforeEach(() => {
+  leaveMock.mockReset();
+  pushMock.mockReset();
+  liveMock = true;
+});
+
+describe("Classic ActionsBar — End-Show consolidation", () => {
+  it("renders a single 'End Show' link when the DJ is live", () => {
+    renderWithProviders(
+      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+    );
+    expect(screen.getByRole("link", { name: /^end show$/i })).toBeDefined();
+  });
+
+  it("does NOT render 'Sign Out When Finished!' when live", () => {
+    renderWithProviders(
+      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+    );
+    expect(screen.queryByText(/sign out when finished/i)).toBeNull();
+  });
+
+  it("does NOT render a 'Log Out' link when live", () => {
+    renderWithProviders(
+      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+    );
+    expect(screen.queryByRole("link", { name: /^log out$/i })).toBeNull();
+  });
+
+  it("calls leave() exactly once when 'End Show' is clicked", () => {
+    renderWithProviders(
+      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+    );
+    fireEvent.click(screen.getByRole("link", { name: /^end show$/i }));
+    expect(leaveMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("redirects to /login?loginAction=endSession after ending the show", () => {
+    renderWithProviders(
+      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+    );
+    fireEvent.click(screen.getByRole("link", { name: /^end show$/i }));
+    expect(pushMock).toHaveBeenCalledWith("/login?loginAction=endSession");
+  });
+
+  it("shows 'Not currently live' instead of End Show when not live", () => {
+    liveMock = false;
+    renderWithProviders(
+      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+    );
+    expect(screen.queryByRole("link", { name: /^end show$/i })).toBeNull();
+    expect(screen.getByText(/not currently live/i)).toBeDefined();
+  });
+
+  it("still renders the Help link", () => {
+    renderWithProviders(
+      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+    );
+    expect(screen.getByRole("link", { name: /^help$/i })).toBeDefined();
+  });
+
+  it("still renders the Add Talkset / Breakpoint / Last 24 Hours links", () => {
+    renderWithProviders(
+      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+    );
+    expect(screen.getByText(/add a talkset/i)).toBeDefined();
+    expect(screen.getByText(/breakpoint/i)).toBeDefined();
+    expect(screen.getByRole("link", { name: /last 24 hours/i })).toBeDefined();
+  });
+});


### PR DESCRIPTION
PR 10 of 12 in the Classic ↔ tubafrenzy sync series ([WXYC/dj-site#511](https://github.com/WXYC/dj-site/issues/511)).

## What

Replaces the two-step `Sign Out When Finished!` + `Log Out` flow in the Classic flowsheet's ActionsBar with a single `End Show` action, matching tubafrenzy commit [`b88da186`](https://github.com/WXYC/tubafrenzy/commit/b88da186).

- `End Show` calls `useShowControl().leave()` (the existing end-show RTK mutation that writes the END marker and signoff time) **and** routes to `/login?loginAction=endSession` to invalidate the better-auth session, in one click.
- ActionsBar's own `Log Out` link is removed. The global Classic `Navigation` retains its own `Log Out` (still needed on non-flowsheet pages — Card Catalog, Settings, etc.); that one is untouched.
- The unused `useRegistry` import drops out of `ActionsBar.tsx`.
- Inventory item 7 (`Undo removal`, tubafrenzy [`a9a6480a`](https://github.com/WXYC/tubafrenzy/commit/a9a6480a)) is verify-only: Classic never had an Undo affordance.

New `ActionsBar.test.tsx` covers all eight behavioral assertions (live vs. not-live, link presence/absence, click handler firing, navigation push target, surrounding link integrity).

## Smoke checklist (DJ flow)

- [ ] Go live as a DJ → ActionsBar shows `End Show`, no `Sign Out When Finished!`, no `Log Out`.
- [ ] Click `End Show` → flowsheet ends, browser lands on `/login` with the session invalidated.
- [ ] Reach `/dashboard/catalog` while not live → Navigation's `Log Out` still works.
- [ ] When not live (transitional state), ActionsBar shows `Not currently live` placeholder.

## Verification

- `npx tsc --noEmit` — clean.
- `npx vitest run` — 2900 passed (was 2892 before; +8 new ActionsBar tests).
- `npm run build` — green.

Closes #546
