### PR TITLE
feat(catalog): update classic SearchForm help text for track search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,9 @@ NEXT_PUBLIC_DEFAULT_EXPERIENCE=modern
 NEXT_PUBLIC_ENABLED_EXPERIENCES=modern,classic
 NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING=true
 
-# Catalog Track Search v2: render `matched_via` track-match chips in catalog
-# search results. Defaults to OFF; set to `true` (or `1`) after Backend-Service
-# is serving matched_via in prod. See WXYC/dj-site#498.
+# Catalog Track Search v2: gates two UI surfaces — `matched_via` track-match
+# chips in result rows (classic + modern) and the classic SearchForm help-text
+# refresh with the worked track-lookup example. Defaults to OFF; set to `true`
+# (or `1`) after Backend-Service is serving matched_via in prod. See
+# WXYC/dj-site#497 and WXYC/dj-site#498.
 NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED=false
 
 **Feature flags**:
 
-- `NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED` — gates the `matched_via` track-match chip rendering in catalog search results (both classic and modern experiences). Defaults to OFF; set to `"true"` or `"1"` to enable. Helper: `isCatalogTrackSearchUiEnabled()` in `lib/features/catalog/flags.ts`. Flip on after Backend-Service is serving `matched_via` in prod. See WXYC/dj-site#498.
+- `NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED` — gates the track-search UI surfaces in catalog search: the `matched_via` track-match chip rendering in result rows (both classic and modern experiences) and the classic `SearchForm` help-text refresh (worked track-lookup example replacing the legacy "Coming later" line). Defaults to OFF; set to `"true"` or `"1"` to enable. Helper: `isCatalogTrackSearchUiEnabled()` in `lib/features/catalog/flags.ts`. Flip on after Backend-Service is serving `matched_via` in prod. See WXYC/dj-site#497 and WXYC/dj-site#498.
 
 ### Test Credentials (local dev)
 

--- a/src/components/experiences/classic/catalog/SearchForm.tsx
+++ b/src/components/experiences/classic/catalog/SearchForm.tsx
@@ -3,11 +3,14 @@
 import { useRouter, useSearchParams } from "next/navigation";
 import { FormEvent, useEffect, useRef } from "react";
 
+import { isCatalogTrackSearchUiEnabled } from "@/lib/features/catalog/flags";
+
 export default function SearchForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const searchQuery = searchParams.get("searchString") || "";
   const exclusive = searchParams.get("exclusive") === "true";
+  const trackSearchUiEnabled = isCatalogTrackSearchUiEnabled();
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -152,10 +155,22 @@ export default function SearchForm() {
           characters. <b>Example:</b>{" "}
           <a href="/dashboard/catalog?searchString=elect*">elect*</a>.
         </p>
-        <p>
-          Coming later: searchable song/track names, tags, DJ-generated tags
-          comments.
-        </p>
+        {trackSearchUiEnabled ? (
+          <p>
+            Track lookups: search a track title to find the album that contains
+            it — including compilation and various-artists releases.{" "}
+            <b>Example:</b>{" "}
+            <a href="/dashboard/catalog?searchString=vi+scose+poise">
+              vi scose poise
+            </a>{" "}
+            → Confield by Autechre.
+          </p>
+        ) : (
+          <p>
+            Coming later: searchable song/track names, tags, DJ-generated tags
+            comments.
+          </p>
+        )}
         <p>
           Please email any feedback or suggestions to Tim Ross [tubacity AT
           gmail DOT com].

--- a/src/components/experiences/classic/catalog/__tests__/SearchForm.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchForm.test.tsx
@@ -74,6 +74,10 @@ describe("Classic catalog SearchForm — track-search help text", () => {
   });
 
   describe("when CATALOG_TRACK_SEARCH_UI_ENABLED is on", () => {
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED = "true";
+    });
+
     it("omits the 'Coming later' line", () => {
       renderWithProviders(<SearchForm />);
       expect(screen.queryByText(/Coming later/i)).toBeNull();

--- a/src/components/experiences/classic/catalog/__tests__/SearchForm.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchForm.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/lib/test-utils/render";
 
@@ -66,4 +66,59 @@ describe("Classic catalog SearchForm — Browse Exclusive Albums", () => {
     const input = screen.getByRole("textbox") as HTMLInputElement;
     expect(input.defaultValue).toBe("polvo");
   });
+});
+
+describe("Classic catalog SearchForm — track-search help text", () => {
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED = "true";
+  });
+
+  describe("when CATALOG_TRACK_SEARCH_UI_ENABLED is on", () => {
+    it("omits the 'Coming later' line", () => {
+      renderWithProviders(<SearchForm />);
+      expect(screen.queryByText(/Coming later/i)).toBeNull();
+    });
+
+    it("renders a track-search worked example with a clickable hyperlink", () => {
+      renderWithProviders(<SearchForm />);
+      const link = screen.getByRole("link", { name: /vi scose poise/i });
+      expect(link.getAttribute("href")).toBe(
+        "/dashboard/catalog?searchString=vi+scose+poise"
+      );
+      expect(link.textContent).toMatch(/vi scose poise/i);
+    });
+
+    it("mentions both compilation and general track lookup", () => {
+      renderWithProviders(<SearchForm />);
+      const notes = screen.getByText(/Confield by Autechre/i);
+      const text = notes.textContent ?? "";
+      expect(text).toMatch(/track/i);
+      expect(text).toMatch(/compilation|various[- ]artists/i);
+    });
+  });
+
+  describe.each(["false", "0", undefined] as const)(
+    "when CATALOG_TRACK_SEARCH_UI_ENABLED is %s",
+    (value) => {
+      beforeEach(() => {
+        if (value === undefined) {
+          delete process.env.NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED;
+        } else {
+          process.env.NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED = value;
+        }
+      });
+
+      it("retains the legacy 'Coming later' line", () => {
+        renderWithProviders(<SearchForm />);
+        expect(screen.getByText(/Coming later/i)).toBeDefined();
+      });
+
+      it("does not render the new track-search example", () => {
+        renderWithProviders(<SearchForm />);
+        expect(
+          screen.queryByRole("link", { name: /vi scose poise/i })
+        ).toBeNull();
+      });
+    }
+  );
 });


### PR DESCRIPTION
## Summary

- Removes the "Coming later: searchable song/track names, tags, DJ-generated tags comments" line from the classic catalog SearchForm help text when the new track-search UI is enabled.
- Adds a worked track-lookup example: `vi scose poise` → Confield by Autechre, with the search term hyperlinked to `/dashboard/catalog?searchString=vi+scose+poise`.
- Mentions both general track lookup ("search a track title to find the album that contains it") and compilation track lookup ("including compilation and various-artists releases").
- Gates the new copy on `NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED` so the legacy "Coming later" wording remains accurate while the flag is off in prod.

## Acceptance criteria

- [x] "Coming later" line removed (flag on)
- [x] New worked example present with clickable hyperlink
- [x] Help text mentions both compilation track lookup and general track lookup

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 2924/2924 pass, including 6 new SearchForm specs covering flag-on and flag-off branches
- [x] `npm run build` clean
- [ ] Manual smoke once deployed: visit `/dashboard/catalog` with the flag on, verify new paragraph + clickable example; flip flag off, verify legacy "Coming later" line returns

Closes #497.