### PR TITLE
classic login: centered redesign — port tubafrenzy showLogin.jsp

### DIFF
--- a/src/components/experiences/classic/login/Forms/UserPasswordForm.test.tsx
+++ b/src/components/experiences/classic/login/Forms/UserPasswordForm.test.tsx
@@ -96,8 +96,22 @@ describe("UserPasswordForm", () => {
   it("should render within a table structure", () => {
     renderWithProviders(<UserPasswordForm />);
     const tables = document.querySelectorAll("table");
-    // Main component has nested tables from Main layout and RequiredBox fields
     expect(tables.length).toBeGreaterThan(0);
+  });
+
+  it("should NOT render a Reset button (tubafrenzy parity, commit 83a1ebe7)", () => {
+    renderWithProviders(<UserPasswordForm />);
+    expect(
+      screen.queryByRole("button", { name: /reset/i })
+    ).not.toBeInTheDocument();
+    const resetInput = document.querySelector('input[type="reset"]');
+    expect(resetInput).toBeNull();
+  });
+
+  it("should render inside a signon-card wrapper", () => {
+    renderWithProviders(<UserPasswordForm />);
+    const card = document.querySelector(".signon-card");
+    expect(card).toBeInTheDocument();
   });
 
   it("should wrap content in Main layout component with title", () => {

--- a/src/components/experiences/classic/login/Forms/UserPasswordForm.test.tsx
+++ b/src/components/experiences/classic/login/Forms/UserPasswordForm.test.tsx
@@ -99,7 +99,7 @@ describe("UserPasswordForm", () => {
     expect(tables.length).toBeGreaterThan(0);
   });
 
-  it("should NOT render a Reset button (tubafrenzy parity, commit 83a1ebe7)", () => {
+  it("should NOT render a Reset button", () => {
     renderWithProviders(<UserPasswordForm />);
     expect(
       screen.queryByRole("button", { name: /reset/i })

--- a/src/components/experiences/classic/login/Forms/UserPasswordForm.tsx
+++ b/src/components/experiences/classic/login/Forms/UserPasswordForm.tsx
@@ -12,43 +12,37 @@ export default function UserPasswordForm() {
     <form
       onSubmit={handleLogin}
       style={{
-        height: "90%",
         display: "flex",
         flexDirection: "column",
         justifyContent: "center",
       }}
     >
       <Main title="Please log in to WXYC Library:">
-        <table cellPadding="10">
-          <tbody>
-            <tr>
-              <RequiredBox
-                name="username"
-                title="User Login"
-                placeholder="Username"
-                type="text"
-                disabled={authenticating}
-              />
-            </tr>
-            <tr>
-              <RequiredBox
-                name="password"
-                title="Password"
-                type="password"
-                disabled={authenticating}
-              />
-            </tr>
-            <tr>
-              <td></td>
-              <td>
-                <ValidatedSubmitButton
-                  authenticating={authenticating}
-                  valid={verified}
-                />
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <tr>
+          <RequiredBox
+            name="username"
+            title="User Login"
+            placeholder="Username"
+            type="text"
+            disabled={authenticating}
+          />
+        </tr>
+        <tr>
+          <RequiredBox
+            name="password"
+            title="Password"
+            type="password"
+            disabled={authenticating}
+          />
+        </tr>
+        <tr className="signon-submit-row">
+          <td colSpan={2}>
+            <ValidatedSubmitButton
+              authenticating={authenticating}
+              valid={verified}
+            />
+          </td>
+        </tr>
       </Main>
     </form>
   );

--- a/src/components/experiences/classic/login/Layout/Main.test.tsx
+++ b/src/components/experiences/classic/login/Layout/Main.test.tsx
@@ -2,32 +2,50 @@ import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import Main from "./Main";
 
-describe("Main", () => {
+describe("Main (classic login signon-card)", () => {
   it("should render a table element", () => {
-    render(<Main title="Test Title">Test Content</Main>);
+    render(
+      <Main title="Test Title">
+        <tr>
+          <td>Test Content</td>
+        </tr>
+      </Main>
+    );
     expect(document.querySelector("table")).toBeInTheDocument();
   });
 
   it("should render the title prop", () => {
-    render(<Main title="Test Title">Test Content</Main>);
+    render(
+      <Main title="Test Title">
+        <tr>
+          <td>Test Content</td>
+        </tr>
+      </Main>
+    );
     expect(screen.getByText("Test Title")).toBeInTheDocument();
   });
 
-  it("should render children", () => {
+  it("should render children as table body rows", () => {
     render(
       <Main title="Test Title">
-        <span data-testid="child">Child Content</span>
+        <tr>
+          <td data-testid="child">Child Content</td>
+        </tr>
       </Main>
     );
     expect(screen.getByTestId("child")).toBeInTheDocument();
     expect(screen.getByText("Child Content")).toBeInTheDocument();
   });
 
-  it("should render multiple children", () => {
+  it("should render multiple child rows", () => {
     render(
       <Main title="Test Title">
-        <div data-testid="first">First</div>
-        <div data-testid="second">Second</div>
+        <tr>
+          <td data-testid="first">First</td>
+        </tr>
+        <tr>
+          <td data-testid="second">Second</td>
+        </tr>
       </Main>
     );
     expect(screen.getByTestId("first")).toBeInTheDocument();
@@ -35,44 +53,79 @@ describe("Main", () => {
   });
 
   it("should wrap title in span with title class", () => {
-    render(<Main title="Test Title">Test Content</Main>);
+    render(
+      <Main title="Test Title">
+        <tr>
+          <td>Test Content</td>
+        </tr>
+      </Main>
+    );
     const titleSpan = screen.getByText("Test Title");
     expect(titleSpan.tagName).toBe("SPAN");
     expect(titleSpan).toHaveClass("title");
   });
 
-  it("should have cellPadding on the table", () => {
-    render(<Main title="Test Title">Test Content</Main>);
+  it("should constrain the layout to a centered signon-card wrapper", () => {
+    render(
+      <Main title="Test Title">
+        <tr>
+          <td>Test Content</td>
+        </tr>
+      </Main>
+    );
+    const card = document.querySelector(".signon-card");
+    expect(card).toBeInTheDocument();
+    expect(card).toContainElement(screen.getByText("Test Title"));
+  });
+
+  it("should apply the signon-table class to the wrapper table", () => {
+    render(
+      <Main title="Test Title">
+        <tr>
+          <td>Test Content</td>
+        </tr>
+      </Main>
+    );
     const table = document.querySelector("table");
-    expect(table).toHaveAttribute("cellPadding", "10");
+    expect(table).toHaveClass("signon-table");
   });
 
-  it("should center align the title cell", () => {
-    render(<Main title="Test Title">Test Content</Main>);
-    const titleCell = screen.getByText("Test Title").closest("td");
-    expect(titleCell).toHaveAttribute("align", "center");
-    expect(titleCell).toHaveAttribute("valign", "top");
-  });
-
-  it("should center align the children cell", () => {
+  it("should render the title inside a thead header row", () => {
     render(
       <Main title="Test Title">
-        <span data-testid="child">Content</span>
+        <tr>
+          <td>Test Content</td>
+        </tr>
       </Main>
     );
-    const childCell = screen.getByTestId("child").closest("td");
-    expect(childCell).toHaveAttribute("align", "center");
+    const thead = document.querySelector("thead");
+    expect(thead).toBeInTheDocument();
+    expect(thead).toContainElement(screen.getByText("Test Title"));
   });
 
-  it("should render title and children in separate rows", () => {
+  it("should render the title in a th with the signon-header class", () => {
     render(
       <Main title="Test Title">
-        <span data-testid="child">Content</span>
+        <tr>
+          <td>Test Content</td>
+        </tr>
       </Main>
     );
-    const rows = document.querySelectorAll("tr");
-    expect(rows).toHaveLength(2);
-    expect(rows[0]).toContainElement(screen.getByText("Test Title"));
-    expect(rows[1]).toContainElement(screen.getByTestId("child"));
+    const headerCell = screen.getByText("Test Title").closest("th");
+    expect(headerCell).toBeInTheDocument();
+    const headerRow = headerCell?.closest("tr");
+    expect(headerRow).toHaveClass("signon-header");
+  });
+
+  it("should render children inside the table body", () => {
+    render(
+      <Main title="Test Title">
+        <tr>
+          <td data-testid="child">Body Content</td>
+        </tr>
+      </Main>
+    );
+    const tbody = document.querySelector("tbody");
+    expect(tbody).toContainElement(screen.getByTestId("child"));
   });
 });

--- a/src/components/experiences/classic/login/Layout/Main.tsx
+++ b/src/components/experiences/classic/login/Layout/Main.tsx
@@ -1,3 +1,5 @@
+import "@/src/styles/classic/login.css";
+
 export default function Main({
   title,
   children,
@@ -6,18 +8,17 @@ export default function Main({
   children: React.ReactNode;
 }) {
   return (
-    <table cellPadding={10}>
-      <tbody>
-        <tr>
-          <td align="center" valign="top">
-            <span className="title">{title}</span>
-            <br />
-          </td>
-        </tr>
-        <tr>
-          <td align="center">{children}</td>
-        </tr>
-      </tbody>
-    </table>
+    <div className="signon-card">
+      <table className="signon-table">
+        <thead>
+          <tr className="signon-header">
+            <th colSpan={2}>
+              <span className="title">{title}</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
   );
 }

--- a/src/styles/classic/login.css
+++ b/src/styles/classic/login.css
@@ -1,8 +1,3 @@
-/**
- * Classic login signon card — port of tubafrenzy showLogin.jsp redesign
- * (tubafrenzy commit 83a1ebe7). Centered card with a dark header banner.
- */
-
 .signon-card {
   max-width: 500px;
   margin: 0 auto;

--- a/src/styles/classic/login.css
+++ b/src/styles/classic/login.css
@@ -1,0 +1,59 @@
+/**
+ * Classic login signon card — port of tubafrenzy showLogin.jsp redesign
+ * (tubafrenzy commit 83a1ebe7). Centered card with a dark header banner.
+ */
+
+.signon-card {
+  max-width: 500px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.signon-table {
+  border-collapse: collapse;
+  width: 100%;
+  border: 1px solid #ddd;
+  font-size: 0.9em;
+  line-height: 1.4;
+}
+
+.signon-table .signon-header th {
+  background: #444;
+  color: #fff;
+  padding: 8px;
+  text-align: center;
+}
+
+.signon-table .signon-header .title {
+  color: #fff;
+}
+
+.signon-table tbody td {
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+  vertical-align: middle;
+}
+
+.signon-table tbody tr:nth-child(even) td {
+  background-color: #f9f9f9;
+}
+
+html[data-experience="classic"][data-joy-color-scheme="dark"]
+  .signon-table tbody tr:nth-child(even) td {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+html[data-experience="classic"][data-joy-color-scheme="dark"] .signon-table {
+  border-color: #555;
+}
+
+html[data-experience="classic"][data-joy-color-scheme="dark"]
+  .signon-table tbody td {
+  border-bottom-color: #444;
+}
+
+.signon-submit-row td {
+  text-align: center;
+  padding: 12px;
+  background: none !important;
+}


### PR DESCRIPTION
## Summary

- Port tubafrenzy's [showLogin.jsp redesign (commit `83a1ebe7`)](https://github.com/WXYC/tubafrenzy/commit/83a1ebe7) to the dj-site Classic login page: centered max-width card, dark `#444` header banner, zebra-striped form rows.
- New `src/styles/classic/login.css` carries `.signon-card` / `.signon-table` / `.signon-header` styles; dark-mode aware via `html[data-experience="classic"][data-joy-color-scheme="dark"]`.
- `Main` now wraps children directly as table-body rows (the old inner `<table cellPadding="10">` in `UserPasswordForm` is gone).
- Adds a regression-guard test that no Reset button exists in the form (parity with tubafrenzy's removal).

## Scope note

Tubafrenzy's redesign covers two pages: the *user login* form (member auth) and the *show signon* form (Real Name · DJ Name · Starting Time · Show Name). dj-site separates these — the show-signon flow lives on the flowsheet page, not on `/login`. This PR ports the **visual structure** of the tubafrenzy redesign to dj-site's Classic user-login page.

What ports:

- Centered card layout (`max-width: 500px; margin: 0 auto; text-align: center`).
- WXYC logo above the title (already true via layout ordering; reinforced by the new card constraint).
- Table-header-style banner: dark `#444` background, white text.
- Zebra-striped form rows with `1px solid #ddd` separators.
- No Reset button (regression guard — none existed; the change pins that).

What's intentionally **not** ported here:

- Field reorder (Real Name → DJ Name → Starting Time → Show Name) — N/A: dj-site Classic login is username/password, not show-signon.
- DJ-name validation — N/A for the same reason; that's part of the show-signon workflow on the flowsheet page.
- The tubafrenzy "new-site banner" — explicitly skipped per the umbrella plan; dj-site *is* the new site.

## Files

- `src/components/experiences/classic/login/Layout/Main.tsx` — restructured to render a `signon-card` div wrapping a `signon-table` with a `signon-header` thead row.
- `src/components/experiences/classic/login/Forms/UserPasswordForm.tsx` — children become `<tr>` rows directly under Main's `<tbody>`; dropped the inner `<table cellPadding="10">` wrapper and the obsolete `height: 90%` form style.
- `src/styles/classic/login.css` — new.
- `src/components/experiences/classic/login/Layout/Main.test.tsx` — rewritten for the new structure (10 tests).
- `src/components/experiences/classic/login/Forms/UserPasswordForm.test.tsx` — added two tests: no Reset button, signon-card present.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/components/experiences/classic/login/` — 59/59 passing
- [x] `npx vitest run` — 2918/2918 passing
- [x] `npm run build` — green
- [x] Visual smoke: `npm run dev`, `/login` with `experience=classic` cookie → logo above title, centered card, dark `#444` banner with "Please log in to WXYC Library:", zebra-striped rows, no Reset button.

## Reference

- Tubafrenzy redesign commit: [`83a1ebe7`](https://github.com/WXYC/tubafrenzy/commit/83a1ebe7)
- Umbrella: #511

Closes #550.