### PR TITLE
fix(next.config): honor AUTH_REWRITE_URL for server-side /auth proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,12 @@
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8080
 NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:8082/auth
 
+# Optional server-side override for the /auth/:path* rewrite destination. Set
+# this in containerized deployments where NEXT_PUBLIC_BETTER_AUTH_URL is
+# reachable from the browser but not from inside the dj-site server process
+# (e.g. docker compose). Falls back to NEXT_PUBLIC_BETTER_AUTH_URL when unset.
+# AUTH_REWRITE_URL=http://auth:8082/auth
+
 # Routing / experience system
 NEXT_PUBLIC_DASHBOARD_HOME_PAGE=/dashboard/flowsheet
 NEXT_PUBLIC_DEFAULT_EXPERIENCE=modern

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,11 @@ NEXT_PUBLIC_DEFAULT_EXPERIENCE=modern
 NEXT_PUBLIC_ENABLED_EXPERIENCES=modern,classic
 NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING=true
 NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED=false
+
+# Optional, server-only — override target for the /auth/:path* rewrite in
+# containerized deployments where NEXT_PUBLIC_BETTER_AUTH_URL is reachable
+# from the browser but not from inside the dj-site server.
+# AUTH_REWRITE_URL=http://auth:8082/auth
 ```
 
 **Feature flags**:

--- a/README.md
+++ b/README.md
@@ -55,8 +55,16 @@ Create a `.env.local` file in the project root with the following variables:
 # Backend API URL (required)
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8080
 
-# Better Auth service URL (required for authentication)
+# Better Auth service URL (required for authentication) — browser-facing
 NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:8082/auth
+
+# Optional: server-side override for the /auth/:path* rewrite destination. Set
+# this when the auth service is reachable from the host at NEXT_PUBLIC_BETTER_AUTH_URL
+# but not from inside the dj-site server process (e.g. docker compose, where
+# localhost inside the container is the container itself). Falls back to
+# NEXT_PUBLIC_BETTER_AUTH_URL when unset, so production (Cloudflare Pages) needs
+# no change.
+# AUTH_REWRITE_URL=http://auth:8082/auth
 
 # Default page after login
 NEXT_PUBLIC_DASHBOARD_HOME_PAGE=/dashboard/flowsheet
@@ -72,7 +80,8 @@ NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING=true
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `NEXT_PUBLIC_BACKEND_URL` | Yes | Backend API base URL |
-| `NEXT_PUBLIC_BETTER_AUTH_URL` | Yes | Auth service URL (must end with `/auth`) |
+| `NEXT_PUBLIC_BETTER_AUTH_URL` | Yes | Auth service URL (must end with `/auth`); used by the browser and as the fallback rewrite target |
+| `AUTH_REWRITE_URL` | No | Server-only override for the `/auth/:path*` rewrite destination; defaults to `NEXT_PUBLIC_BETTER_AUTH_URL`. Set in containerized deploys where the browser URL isn't reachable from the dj-site server |
 | `NEXT_PUBLIC_DASHBOARD_HOME_PAGE` | No | Redirect path after login |
 | `NEXT_PUBLIC_DEFAULT_EXPERIENCE` | No | Default UI theme (`modern` or `classic`) |
 | `NEXT_PUBLIC_ENABLED_EXPERIENCES` | No | Comma-separated list of available themes |

--- a/lib/__tests__/next.config.test.ts
+++ b/lib/__tests__/next.config.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  initOpenNextCloudflareForDev: vi.fn(),
+}));
+
+async function loadConfig() {
+  vi.resetModules();
+  const mod = await import("../../next.config.mjs");
+  return mod.default;
+}
+
+describe("next.config rewrites", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.AUTH_REWRITE_URL;
+    delete process.env.NEXT_PUBLIC_BETTER_AUTH_URL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("targets AUTH_REWRITE_URL when set, overriding NEXT_PUBLIC_BETTER_AUTH_URL", async () => {
+    process.env.AUTH_REWRITE_URL = "http://auth:8082/auth";
+    process.env.NEXT_PUBLIC_BETTER_AUTH_URL = "http://localhost:8082/auth";
+
+    const config = await loadConfig();
+    const rewrites = await config.rewrites();
+
+    expect(rewrites).toContainEqual({
+      source: "/auth/:path*",
+      destination: "http://auth:8082/auth/:path*",
+    });
+  });
+
+  it("falls back to NEXT_PUBLIC_BETTER_AUTH_URL when AUTH_REWRITE_URL is unset", async () => {
+    process.env.NEXT_PUBLIC_BETTER_AUTH_URL = "http://localhost:8082/auth";
+
+    const config = await loadConfig();
+    const rewrites = await config.rewrites();
+
+    expect(rewrites).toContainEqual({
+      source: "/auth/:path*",
+      destination: "http://localhost:8082/auth/:path*",
+    });
+  });
+
+  it("falls back to the production default when neither env var is set", async () => {
+    const config = await loadConfig();
+    const rewrites = await config.rewrites();
+
+    expect(rewrites).toContainEqual({
+      source: "/auth/:path*",
+      destination: "https://api.wxyc.org/auth/:path*",
+    });
+  });
+});

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,13 @@
 /** @type {import('next').NextConfig} */
-const authBaseURL = process.env.NEXT_PUBLIC_BETTER_AUTH_URL || "https://api.wxyc.org/auth";
+// AUTH_REWRITE_URL is the server-only override the `/auth/:path*` rewrite proxies to.
+// Set it when the auth service is reachable from the host but not at the public URL from
+// inside the dj-site server (e.g. docker compose, where the host's localhost is the
+// container itself). NEXT_PUBLIC_BETTER_AUTH_URL stays the browser-facing URL and is
+// the fallback for environments without a split (e.g. Cloudflare Pages production).
+const authRewriteURL =
+  process.env.AUTH_REWRITE_URL ||
+  process.env.NEXT_PUBLIC_BETTER_AUTH_URL ||
+  "https://api.wxyc.org/auth";
 
 const nextConfig = {
   reactStrictMode: false,
@@ -25,7 +33,7 @@ const nextConfig = {
     return [
       {
         source: "/auth/:path*",
-        destination: `${authBaseURL}/:path*`,
+        destination: `${authRewriteURL}/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## Summary

- `next.config.mjs` now reads `AUTH_REWRITE_URL` (server-only) as the primary source for the `/auth/:path*` rewrite destination, falling back to `NEXT_PUBLIC_BETTER_AUTH_URL`, then the production default. Browser-side better-auth client continues to use `NEXT_PUBLIC_BETTER_AUTH_URL` unchanged.
- The split unblocks containerized deploys (e.g. staging docker compose) where the browser URL (`http://localhost:8082/auth`) isn't reachable from inside the dj-site server. Production Cloudflare Pages is unaffected — `AUTH_REWRITE_URL` is unset there, so behavior collapses to today's path.
- Adds three rewrites tests (`lib/__tests__/next.config.test.ts`) covering precedence, fallback, and default. Documents the dual-env convention in `next.config.mjs`, `.env.example`, `README.md`, and `CLAUDE.md`.

## Test plan

- [x] `npx vitest run lib/__tests__/next.config.test.ts` — 3 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` with CI env — succeeds
- [ ] In a staging-style Docker Compose with `AUTH_REWRITE_URL=http://auth:8082/auth`, `POST /auth/sign-in/username` returns 200 (covered by acceptance criteria; needs the staging stack to land its companion seed fixes from #541 to QA end-to-end)

Closes #541