### PR TITLE
fix(rotation): remove artist override input from rotation entry mode

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -92,25 +92,23 @@ describe("RotationEntryFields", () => {
     mockTracksLoading = false;
   });
 
-  it("does not render the artist input before a release is selected", () => {
+  it("never renders an artist input — rotation mode has no override UI", () => {
     renderWithProviders(<RotationEntryFields disabled={false} />);
+    expect(
+      screen.queryByTestId("flowsheet-search-artist")
+    ).not.toBeInTheDocument();
+
+    selectBinAndRelease();
+
     expect(
       screen.queryByTestId("flowsheet-search-artist")
     ).not.toBeInTheDocument();
   });
 
-  it("renders an editable artist input once a release is selected", () => {
-    renderWithProviders(<RotationEntryFields disabled={false} />);
-    selectBinAndRelease();
-
-    const artistInput = screen.getByTestId("flowsheet-search-artist");
-    expect(artistInput).toBeInTheDocument();
-    expect(artistInput).not.toHaveAttribute("readonly");
-  });
-
-  it("seeds the artist input with the release's primary artist", () => {
-    // Assert against the *real* action creator so the test catches drift if
-    // the slice ever renames the action or reshapes the payload.
+  it("seeds the artist into the search query on release selection", () => {
+    // The artist is no longer rendered as an input, but the value still has
+    // to flow into Redux so form submission carries the release's primary
+    // artist. Assert against the real action creator to catch slice drift.
     const { store } = renderWithProviders(
       <RotationEntryFields disabled={false} />
     );
@@ -124,29 +122,5 @@ describe("RotationEntryFields", () => {
         value: "OOIOO",
       })
     );
-  });
-
-  it("lets the DJ override the seeded artist (split release case)", () => {
-    renderWithProviders(<RotationEntryFields disabled={false} />);
-    selectBinAndRelease();
-
-    const artistInput = screen.getByTestId("flowsheet-search-artist");
-    fireEvent.change(artistInput, { target: { value: "Lightning Bolt" } });
-
-    expect(setSearchPropertyMock).toHaveBeenCalledWith(
-      "artist",
-      "Lightning Bolt"
-    );
-  });
-
-  it("propagates the disabled prop to the artist input", () => {
-    const { rerender } = renderWithProviders(
-      <RotationEntryFields disabled={false} />
-    );
-    selectBinAndRelease();
-    expect(screen.getByTestId("flowsheet-search-artist")).not.toBeDisabled();
-
-    rerender(<RotationEntryFields disabled={true} />);
-    expect(screen.getByTestId("flowsheet-search-artist")).toBeDisabled();
   });
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -127,17 +127,6 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
           suppressHydrationWarning
         />
       )}
-      {selectedRelease && (
-        <>
-          <Divider orientation="vertical" />
-          <FlowsheetSearchInput
-            name="artist"
-            disabled={disabled}
-            required
-            suppressHydrationWarning
-          />
-        </>
-      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary

- Reverts the artist override input added in 6f757c8 (#518). With the release picker showing 'Artist — Album' inline, the standalone artist cell on the right of the row read as redundant: same value displayed twice, second cell visually indistinguishable from a real input.
- Drops the cell + its `<Divider>`. The artist value still flows into Redux via `setSearchProperty` on release selection (`RotationEntryFields.tsx:66`), so form submission carries it unchanged. The change is a pure deletion of UI; no new state, no behavior changes for non-rotation modes.
- Reopens #518: V/A / split-release / mis-credit overrides are unsolved again. DJs needing them fall back to manual-entry mode until a less obtrusive affordance lands (kebab menu, pencil icon, or inline-edit-within-the-release-picker are all candidates).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run --changed origin/main` — 26/26 passing
- [x] `RotationEntryFields.test.tsx` rewritten: broadened existing 'does not render before release' assertion into 'never renders an artist input' (covers both pre- and post-release-select); kept the Redux seed-on-release-select assertion; dropped the override + disabled-propagation tests since they targeted UI that no longer exists
- [ ] Manual: rotation entry mode → pick H bin → pick a release → row shows bins | release picker | song input only, no artist cell on the right
- [ ] Manual: submit after pick — artist still present in the resulting flowsheet entry

## Notes for follow-up (not in this PR)

The missing rotation track dropdown surfaced during this UI iteration is captured in tracker #520. Worth flagging: that tracker points to WXYC/Backend-Service#836 as the proper fix, but **BS#836 is closed and exposes `/proxy/library/{libraryId}/tracks` — not the `/library/rotation/:rotation_id/tracks` URL `useGetRotationTracksQuery` calls in `lib/features/rotation/api.ts:36-40`.** So the rotation entry picker still 404s and silently falls through to the song text input. Resolution is either (a) a thin BS alias route at `/library/rotation/:rotation_id/tracks` that resolves `rotation.album_id` and delegates to the proxy composition, or (b) rewire `useGetRotationTracksQuery` to call `/proxy/library/{album_id}/tracks` directly. Probably worth a follow-up comment on #520 to disambiguate.

## Related

- Reopens #518
- Tracker: #520 (rotation/flowsheet entry — Slack feedback 2026-05-13)
- Original commit being reverted: 6f757c8