### PR TITLE
fix(rotation): auto-fill artist from track per-track credits (#518)

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -83,6 +83,11 @@ const selectBinAndRelease = () => {
   );
 };
 
+const selectTrack = (index: number) => {
+  fireEvent.click(screen.getByTestId("rotation-track-trigger"));
+  fireEvent.click(screen.getByTestId(`rotation-track-option-${index}`));
+};
+
 describe("RotationEntryFields", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -122,5 +127,99 @@ describe("RotationEntryFields", () => {
         value: "OOIOO",
       })
     );
+  });
+
+  describe("track-selection artist auto-fill", () => {
+    // When a DJ picks a track from the dropdown, we override the artist that
+    // handleSelectRelease seeded iff the per-track Discogs credits (surfaced
+    // by BS#944) carry artist names. This covers V/A and split releases
+    // without any new UI. For normal releases BS falls back to
+    // [release.artist] so the value is identical to what handleSelectRelease
+    // already set; the override is functionally a no-op.
+    //
+    // Test invariant: spy on `store.dispatch` *before* any clicks. react-redux's
+    // useDispatch captures the dispatch reference at mount time, so spying
+    // after a click won't intercept later dispatches from the captured ref.
+    const artistValues = (
+      dispatchSpy: { mock: { calls: unknown[][] } }
+    ): string[] =>
+      dispatchSpy.mock.calls
+        .map(
+          (call) =>
+            call[0] as ReturnType<typeof flowsheetSlice.actions.setSearchProperty>
+        )
+        .filter(
+          (action) =>
+            action?.type === flowsheetSlice.actions.setSearchProperty.type &&
+            action.payload.name === "artist"
+        )
+        .map((action) => action.payload.value);
+
+    it("does not change artist when track has no per-track credits", () => {
+      mockTracksData = [
+        { position: "A1", title: "la paradoja", duration: null, artists: [] },
+      ];
+
+      const { store } = renderWithProviders(
+        <RotationEntryFields disabled={false} />
+      );
+      const dispatchSpy = vi.spyOn(store, "dispatch");
+      selectBinAndRelease();
+      selectTrack(0);
+
+      // Release select dispatches artist=OOIOO; track select with empty
+      // credits must not dispatch any further artist value.
+      expect(artistValues(dispatchSpy)).toEqual(["OOIOO"]);
+    });
+
+    it("sets artist to track's single per-track credit on V/A releases", () => {
+      mockTracksData = [
+        {
+          position: "A1",
+          title: "Smoke Signal",
+          duration: null,
+          artists: ["Skull Mitten"],
+        },
+      ];
+
+      const { store } = renderWithProviders(
+        <RotationEntryFields disabled={false} />
+      );
+      const dispatchSpy = vi.spyOn(store, "dispatch");
+      selectBinAndRelease();
+      selectTrack(0);
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        flowsheetSlice.actions.setSearchProperty({
+          name: "artist",
+          value: "Skull Mitten",
+        })
+      );
+    });
+
+    it("joins multi-credit tracks with ', '", () => {
+      mockTracksData = [
+        {
+          position: "A1",
+          title: "Drum Circle",
+          duration: null,
+          artists: ["Skull Mitten", "Various Drummers"],
+        },
+      ];
+
+      const { store } = renderWithProviders(
+        <RotationEntryFields disabled={false} />
+      );
+      const dispatchSpy = vi.spyOn(store, "dispatch");
+      selectBinAndRelease();
+      selectTrack(0);
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        flowsheetSlice.actions.setSearchProperty({
+          name: "artist",
+          value: "Skull Mitten, Various Drummers",
+        })
+      );
+    });
   });
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -82,6 +82,21 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
       setSelectedTrack(track);
       setManualEntry(false);
       dispatch(flowsheetSlice.actions.setSearchProperty({ name: "song", value: track.title }));
+      // Auto-fill artist from per-track Discogs credits (surfaced by BS#944)
+      // for V/A and split releases. For normal releases BS falls back to
+      // [release.artist] so this just re-sets the value already seeded by
+      // handleSelectRelease. When credits are empty (Discogs has no per-track
+      // data) leave the release-level artist in place; mis-credited cases fall
+      // through to manual-entry mode (the existing escape hatch).
+      // Join separator mirrors buildArtistCredit in apps/backend/controllers/proxy.controller.ts.
+      if (track.artists.length > 0) {
+        dispatch(
+          flowsheetSlice.actions.setSearchProperty({
+            name: "artist",
+            value: track.artists.join(", "),
+          })
+        );
+      }
     },
     [dispatch]
   );


### PR DESCRIPTION
## Summary

Closes #518.

When a DJ picks a track from the rotation track dropdown, set the Redux `artist` value from `track.artists` (per-track Discogs credits surfaced by the BS#944 route). For non-V/A releases Discogs leaves per-track artist credits empty and the BS-side composition falls back to `[release.artist]`, so the field is never empty and the artist value seeded by `handleSelectRelease` stays put.

## Background

The original fix for #518 (commit 6f757c8) added an explicit artist override input next to the song input. That cell was visually busy and confusing — the artist value was already visible in the release picker's "Artist — Album" line, so DJs saw the same value rendered twice and the second cell read as a duplicate input. It was reverted in 88e26bc and #518 was reopened.

This change avoids new UI entirely: the override is implicit and falls out of per-track Discogs credits we already surface to the client.

## Cases handled

- **V/A release** (`Resonance Sessions`): track A1 by Skull Mitten, track A2 by Various Drummers → `track.artists = ["Skull Mitten"]` then `["Various Drummers"]` → artist field updates per pick.
- **Split release** (`OOIOO / Lightning Bolt`): tracks 1-4 by OOIOO, tracks 5-8 by Lightning Bolt → per-track artists carry the right side.
- **Normal release** (`DOGA` by Juana Molina): every track's `artists` falls back to `["Juana Molina"]` → artist field stays unchanged from what `handleSelectRelease` set.
- **Mis-credited / Discogs-is-wrong**: falls through to manual-entry mode (the existing `onManualEntry` escape hatch).

Join separator is `", "`, mirroring `buildArtistCredit` in `apps/backend/controllers/proxy.controller.ts` for the parallel `/proxy/library/:libraryId/tracks` endpoint.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run --changed origin/main` — 29 passed, including 3 new cases under `track-selection artist auto-fill`:
  - does not change artist when track has no per-track credits
  - sets artist to track's single per-track credit on V/A releases
  - joins multi-credit tracks with ", "
- [ ] Manual smoke testing deferred: the rotation track dropdown is currently empty in dev because `library_identity` is empty (depends on WXYC/Backend-Service#802 backfill in prod), so the auto-fill is exercised by unit tests rather than manual smoke testing today.