### PR TITLE
feat(flowsheet): track picker + instantaneous rotation tracklists (E6-6)

### DIFF
--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -105,6 +105,25 @@ describe("flowsheet conversions", () => {
         expect(result.segue).toBe(expected);
       }
     );
+
+    it("should forward track_position when picked from a tracklist", () => {
+      const query = createTestFlowsheetQuery({
+        album_id: 4242,
+        track_position: "A1",
+      });
+      const result = convertQueryToSubmission(query) as QuerySubmission & {
+        track_position?: string | null;
+      };
+      expect(result.track_position).toBe("A1");
+    });
+
+    it("should omit track_position when none was picked", () => {
+      const query = createTestFlowsheetQuery({ album_id: 4242 });
+      const result = convertQueryToSubmission(query) as QuerySubmission & {
+        track_position?: string | null;
+      };
+      expect(result.track_position).toBeUndefined();
+    });
   });
 
   describe("convertDJsOnAir", () => {

--- a/lib/__tests__/features/metadata/api.test.ts
+++ b/lib/__tests__/features/metadata/api.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { metadataApi } from "@/lib/features/metadata/api";
+import {
+  createTestStore,
+  describeApi,
+  server,
+  TEST_BACKEND_URL,
+} from "@/lib/test-utils";
+
+describe("metadataApi", () => {
+  describeApi(metadataApi, {
+    queries: ["getAlbumMetadata", "getArtistMetadata", "getLibraryTracks"],
+    mutations: [],
+    reducerPath: "metadataApi",
+  });
+
+  describe("getLibraryTracks", () => {
+    it("hits /proxy/library/:libraryId/tracks and returns the wrapper", async () => {
+      const libraryId = 4242;
+      server.use(
+        http.get(
+          `${TEST_BACKEND_URL}/proxy/library/${libraryId}/tracks`,
+          () =>
+            HttpResponse.json({
+              library_id: libraryId,
+              discogs_release_id: 901234,
+              source: "discogs",
+              tracks: [
+                {
+                  position: "A1",
+                  title: "la paradoja",
+                  artist_credit: "Juana Molina",
+                  duration_ms: 218000,
+                },
+                {
+                  position: "A2",
+                  title: "otro track",
+                  artist_credit: "Juana Molina",
+                  duration_ms: null,
+                },
+              ],
+            })
+        )
+      );
+
+      const store = createTestStore();
+      const result = await store
+        .dispatch(metadataApi.endpoints.getLibraryTracks.initiate(libraryId))
+        .unwrap();
+
+      expect(result).toEqual({
+        library_id: libraryId,
+        discogs_release_id: 901234,
+        source: "discogs",
+        tracks: [
+          {
+            position: "A1",
+            title: "la paradoja",
+            artist_credit: "Juana Molina",
+            duration_ms: 218000,
+          },
+          {
+            position: "A2",
+            title: "otro track",
+            artist_credit: "Juana Molina",
+            duration_ms: null,
+          },
+        ],
+      });
+    });
+
+    it("returns the empty-tracklist wrapper when the release is not Discogs-resolvable", async () => {
+      const libraryId = 99;
+      server.use(
+        http.get(
+          `${TEST_BACKEND_URL}/proxy/library/${libraryId}/tracks`,
+          () =>
+            HttpResponse.json({
+              library_id: libraryId,
+              discogs_release_id: null,
+              source: null,
+              tracks: [],
+            })
+        )
+      );
+
+      const store = createTestStore();
+      const result = await store
+        .dispatch(metadataApi.endpoints.getLibraryTracks.initiate(libraryId))
+        .unwrap();
+
+      expect(result.source).toBeNull();
+      expect(result.tracks).toEqual([]);
+    });
+  });
+});

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -29,6 +29,9 @@ export function convertQueryToSubmission(
     album_id: query.album_id,
     rotation_id: query.rotation_id,
     rotation_bin: query.rotation_bin,
+    ...(query.track_position !== undefined && {
+      track_position: query.track_position,
+    }),
   };
 }
 

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -37,6 +37,7 @@ export const flowsheetSlice = createAppSlice({
         state.search.query.album_id = undefined;
         state.search.query.rotation_id = undefined;
         state.search.query.rotation_bin = undefined;
+        state.search.query.track_position = undefined;
       }
     },
     setRotationMetadata: (
@@ -66,6 +67,14 @@ export const flowsheetSlice = createAppSlice({
       state.search.query[action.payload.name] = action.payload.value;
     },
     /**
+     * Set the picked track's Discogs `release_track.position` (e.g. "A1"). Pass
+     * `undefined` to clear — used when the DJ falls back to free-text entry or
+     * picks a different release.
+     */
+    setTrackPosition: (state, action: PayloadAction<string | undefined>) => {
+      state.search.query.track_position = action.payload;
+    },
+    /**
      * Copy a selected search result's fields into the live search query and
      * deselect it, so the user can edit one field without losing the others.
      */
@@ -86,6 +95,7 @@ export const flowsheetSlice = createAppSlice({
       state.search.query.album_id = action.payload.album_id;
       state.search.query.rotation_id = action.payload.rotation_id;
       state.search.query.rotation_bin = action.payload.rotation_bin;
+      state.search.query.track_position = undefined;
       state.search.selectedResult = 0;
     },
     toggleRequest: (state) => {

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -35,6 +35,13 @@ export type FlowsheetQuery = {
   album_id?: number;
   rotation_bin?: Rotation;
   rotation_id?: number;
+  /**
+   * Discogs `release_track.position` for the picked track (e.g. "A1", "B3",
+   * "1-12"). Free-form vinyl side / multi-disc string — TEXT not INT. Stays
+   * undefined when the DJ types track title as free text instead of picking
+   * from the tracklist dropdown.
+   */
+  track_position?: string;
 };
 
 export type FlowsheetSearchProperty = keyof Omit<
@@ -84,6 +91,7 @@ export type FlowsheetSubmissionParams =
   | {
       album_id: number;
       track_title: string;
+      track_position?: string;
       rotation_id?: number;
       request_flag: boolean;
       segue?: boolean;
@@ -94,6 +102,7 @@ export type FlowsheetSubmissionParams =
       artist_name: string;
       album_title: string;
       track_title: string;
+      track_position?: string;
       request_flag: boolean;
       segue?: boolean;
       record_label?: string;

--- a/lib/features/metadata/api.ts
+++ b/lib/features/metadata/api.ts
@@ -1,6 +1,11 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import { backendBaseQuery } from "../backend";
-import { AlbumMetadata, AlbumMetadataQueryParams, ArtistMetadata } from "./types";
+import {
+  AlbumMetadata,
+  AlbumMetadataQueryParams,
+  ArtistMetadata,
+  LibraryTracksResponse,
+} from "./types";
 
 export const metadataApi = createApi({
   reducerPath: "metadataApi",
@@ -18,7 +23,18 @@ export const metadataApi = createApi({
         params: { artistId },
       }),
     }),
+    getLibraryTracks: builder.query<LibraryTracksResponse, number>({
+      query: (libraryId) => ({
+        url: `/library/${libraryId}/tracks`,
+      }),
+    }),
   }),
 });
 
-export const { useGetAlbumMetadataQuery, useGetArtistMetadataQuery } = metadataApi;
+export const {
+  useGetAlbumMetadataQuery,
+  useGetArtistMetadataQuery,
+  useGetLibraryTracksQuery,
+  useLazyGetLibraryTracksQuery,
+  usePrefetch: useMetadataPrefetch,
+} = metadataApi;

--- a/lib/features/metadata/types.ts
+++ b/lib/features/metadata/types.ts
@@ -42,3 +42,17 @@ export interface AlbumMetadataQueryParams {
   releaseTitle: string;
   trackTitle?: string;
 }
+
+export interface LibraryTrack {
+  position: string;
+  title: string;
+  artist_credit: string;
+  duration_ms: number | null;
+}
+
+export interface LibraryTracksResponse {
+  library_id: number;
+  discogs_release_id: number | null;
+  source: "discogs" | null;
+  tracks: LibraryTrack[];
+}

--- a/lib/features/rotation/api.ts
+++ b/lib/features/rotation/api.ts
@@ -53,4 +53,5 @@ export const {
   useAddRotationEntryMutation,
   useKillRotationEntryMutation,
   useGetRotationTracksQuery,
+  usePrefetch: useRotationPrefetch,
 } = rotationApi;

--- a/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import {
+  renderWithProviders,
+  server,
+  TEST_BACKEND_URL,
+  createTestStore,
+} from "@/lib/test-utils";
+import LibraryTrackPicker, {
+  useLibraryTrackPicker,
+} from "./LibraryTrackPicker";
+import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+
+function mockLibraryTracksResponse(
+  libraryId: number,
+  tracks: Array<{ position: string; title: string; artist_credit: string }>,
+  source: "discogs" | null = "discogs"
+) {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/proxy/library/${libraryId}/tracks`, () =>
+      HttpResponse.json({
+        library_id: libraryId,
+        discogs_release_id: source === "discogs" ? 42 : null,
+        source,
+        tracks: tracks.map((t) => ({ ...t, duration_ms: null })),
+      })
+    )
+  );
+}
+
+describe("useLibraryTrackPicker", () => {
+  it("returns show=false when albumId is null", () => {
+    const { result } = renderHook(() => useLibraryTrackPicker(null), {
+      wrapper: ({ children }) => (
+        <Provider store={createTestStore()}>{children}</Provider>
+      ),
+    });
+    expect(result.current.show).toBe(false);
+    expect(result.current.tracks).toEqual([]);
+  });
+
+  it("returns show=true with adapted tracks when the release has a tracklist", async () => {
+    mockLibraryTracksResponse(1001, [
+      { position: "A1", title: "la paradoja", artist_credit: "Juana Molina" },
+      { position: "A2", title: "doga", artist_credit: "Juana Molina" },
+    ]);
+
+    const { result } = renderHook(() => useLibraryTrackPicker(1001), {
+      wrapper: ({ children }) => (
+        <Provider store={createTestStore()}>{children}</Provider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.show).toBe(true));
+    expect(result.current.tracks).toHaveLength(2);
+    expect(result.current.tracks[0]).toMatchObject({
+      position: "A1",
+      title: "la paradoja",
+      artists: ["Juana Molina"],
+    });
+  });
+
+  it("returns show=false when source is null (no Discogs identity)", async () => {
+    mockLibraryTracksResponse(99, [], null);
+    const { result } = renderHook(() => useLibraryTrackPicker(99), {
+      wrapper: ({ children }) => (
+        <Provider store={createTestStore()}>{children}</Provider>
+      ),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.show).toBe(false);
+  });
+
+  it("returns show=false when the tracklist is empty", async () => {
+    mockLibraryTracksResponse(2002, []);
+    const { result } = renderHook(() => useLibraryTrackPicker(2002), {
+      wrapper: ({ children }) => (
+        <Provider store={createTestStore()}>{children}</Provider>
+      ),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.show).toBe(false);
+  });
+});
+
+describe("LibraryTrackPicker", () => {
+  it("writes track_title (via song) and track_position when a track is picked", async () => {
+    const tracks = [
+      {
+        position: "A1",
+        title: "la paradoja",
+        artist_credit: "Juana Molina",
+        duration_ms: null,
+        artists: ["Juana Molina"],
+      },
+    ];
+
+    const { store, user } = renderWithProviders(
+      <LibraryTrackPicker
+        tracks={tracks}
+        isLoading={false}
+        disabled={false}
+        onManualEntry={() => {}}
+      />
+    );
+
+    // Open dropdown via trigger
+    await user.click(screen.getByTestId("track-picker-trigger"));
+    await user.click(screen.getByTestId("track-picker-option-0"));
+
+    const state = store.getState();
+    expect(state.flowsheet.search.query.song).toBe("la paradoja");
+    expect(state.flowsheet.search.query.track_position).toBe("A1");
+  });
+
+  it("clears track_position and calls onManualEntry on the manual fallback", async () => {
+    const tracks = [
+      {
+        position: "A1",
+        title: "la paradoja",
+        artist_credit: "Juana Molina",
+        duration_ms: null,
+        artists: ["Juana Molina"],
+      },
+    ];
+
+    let manualFired = false;
+    const { store, user } = renderWithProviders(
+      <LibraryTrackPicker
+        tracks={tracks}
+        isLoading={false}
+        disabled={false}
+        onManualEntry={() => {
+          manualFired = true;
+        }}
+      />,
+      {
+        preloadedState: {
+          flowsheet: {
+            ...flowsheetSlice.getInitialState(),
+            search: {
+              ...flowsheetSlice.getInitialState().search,
+              query: {
+                ...flowsheetSlice.getInitialState().search.query,
+                track_position: "A1",
+              },
+            },
+          },
+        },
+      }
+    );
+
+    await user.click(screen.getByTestId("track-picker-trigger"));
+    fireEvent.click(screen.getByTestId("track-picker-manual"));
+
+    expect(manualFired).toBe(true);
+    expect(store.getState().flowsheet.search.query.track_position).toBeUndefined();
+  });
+});

--- a/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useGetLibraryTracksQuery } from "@/lib/features/metadata/api";
+import { LibraryTrack } from "@/lib/features/metadata/types";
+import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import { useMemo } from "react";
+import TrackPickerDropdown, { TrackPickerEntry } from "./TrackPickerDropdown";
+
+type PickerTrack = LibraryTrack & TrackPickerEntry;
+
+/**
+ * Hook that resolves the picker state for a given library release.
+ *
+ * `picker.show` is the parent's render gate: true means render
+ * `<LibraryTrackPicker>` in place of the free-text song input, false means
+ * leave the free-text input alone. The picker collapses back to free-text on
+ * three signals — no release selected, query still in flight, and a release
+ * with no Discogs-resolvable tracklist (`source: null` or `tracks: []`).
+ */
+export function useLibraryTrackPicker(albumId: number | null) {
+  const { data, isLoading } = useGetLibraryTracksQuery(albumId ?? 0, {
+    skip: albumId === null,
+  });
+
+  return useMemo(() => {
+    if (albumId === null) {
+      return { show: false, isLoading: false, tracks: [] as PickerTrack[] };
+    }
+    if (isLoading) {
+      return { show: false, isLoading: true, tracks: [] as PickerTrack[] };
+    }
+    const tracks: PickerTrack[] = (data?.tracks ?? []).map((t) => ({
+      ...t,
+      artists: t.artist_credit ? [t.artist_credit] : [],
+    }));
+    return { show: tracks.length > 0, isLoading: false, tracks };
+  }, [albumId, isLoading, data?.tracks]);
+}
+
+/**
+ * Track picker that surfaces the Discogs tracklist for the release the DJ
+ * picked from the search results. On pick: writes both `track_title` (legacy
+ * compat) and `track_position` (Discogs `release_track.position`) into Redux
+ * so the existing submission path picks them up via
+ * `convertQueryToSubmission`.
+ *
+ * Caller is responsible for the "should we render this at all?" decision via
+ * `useLibraryTrackPicker(albumId).show` — when that's false, render the
+ * free-text song input instead.
+ */
+export default function LibraryTrackPicker({
+  tracks,
+  isLoading,
+  disabled,
+  onManualEntry,
+}: {
+  tracks: PickerTrack[];
+  isLoading: boolean;
+  disabled: boolean;
+  onManualEntry: () => void;
+}) {
+  const dispatch = useAppDispatch();
+  const currentPosition = useAppSelector(
+    (s) => s.flowsheet.search.query.track_position
+  );
+
+  const selectedTrack = useMemo(
+    () =>
+      currentPosition
+        ? tracks.find((t) => t.position === currentPosition) ?? null
+        : null,
+    [tracks, currentPosition]
+  );
+
+  const handleSelect = (track: PickerTrack) => {
+    dispatch(
+      flowsheetSlice.actions.setSearchProperty({
+        name: "song",
+        value: track.title,
+      })
+    );
+    dispatch(flowsheetSlice.actions.setTrackPosition(track.position));
+  };
+
+  const handleManual = () => {
+    dispatch(flowsheetSlice.actions.setTrackPosition(undefined));
+    onManualEntry();
+  };
+
+  return (
+    <TrackPickerDropdown
+      tracks={tracks}
+      isLoading={isLoading}
+      selectedTrack={selectedTrack}
+      onSelectTrack={handleSelect}
+      onManualEntry={handleManual}
+      disabled={disabled}
+    />
+  );
+}

--- a/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
@@ -34,6 +34,11 @@ vi.mock("@/src/hooks/flowsheetHooks", () => ({
   }),
 }));
 
+const mockPrefetchTracks = vi.fn();
+vi.mock("@/lib/features/metadata/api", () => ({
+  useMetadataPrefetch: () => mockPrefetchTracks,
+}));
+
 // ArtistAvatar was removed — CODE column displays catalog info directly
 
 describe("FlowsheetBackendResult", () => {

--- a/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
@@ -1,5 +1,6 @@
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { useMetadataPrefetch } from "@/lib/features/metadata/api";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useFlowsheetSubmit } from "@/src/hooks/flowsheetHooks";
 import { Chip, ColorPaletteProp, Stack, Typography } from "@mui/joy";
@@ -20,6 +21,12 @@ export default function FlowsheetBackendResult({
   const { ctrlKeyPressed: submittingToQueue, handleSubmit } =
     useFlowsheetSubmit();
 
+  // Warm the tracklist cache so the picker is instantaneous once the result is
+  // highlighted (LML's 3-tier cache + BS's 10-minute LRU absorb the actual
+  // request). Same pattern as rotation prefetch, but per-row instead of
+  // per-bin since search results are heterogeneous.
+  const prefetchTracks = useMetadataPrefetch("getLibraryTracks");
+
   return (
     <Stack
       key={`bin-${index}`}
@@ -36,7 +43,10 @@ export default function FlowsheetBackendResult({
             : "transparent",
         cursor: "pointer",
       }}
-      onMouseOver={() => setSelected(index)}
+      onMouseOver={() => {
+        setSelected(index);
+        if (entry.id) prefetchTracks(entry.id);
+      }}
       onClick={handleSubmit}
     >
       <Stack direction="column" sx={{ flex: 1, minWidth: 0, px: 1 }}>

--- a/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
@@ -19,6 +19,14 @@ vi.mock("./NewEntry/NewEntryPreview", () => ({
   default: () => <div data-testid="new-entry-preview">New Entry</div>,
 }));
 
+// LibraryTrackPicker hits the proxy `/library/:id/tracks` endpoint via
+// metadataApi; we don't want this test to wire that into the store.
+vi.mock("../LibraryTrackPicker", () => ({
+  __esModule: true,
+  default: () => <div data-testid="library-track-picker" />,
+  useLibraryTrackPicker: () => ({ show: false, isLoading: false, tracks: [] }),
+}));
+
 function createTestStore(searchOpen = false) {
   return configureStore({
     reducer: {

--- a/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
@@ -2,10 +2,14 @@
 
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
-import { useAppSelector } from "@/lib/hooks";
+import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { Box, Chip, Divider, Sheet, Stack, Typography } from "@mui/joy";
+import { useEffect, useMemo, useState } from "react";
 import FlowsheetBackendResults from "./BackendResults/FlowsheetBackendResults";
 import NewEntryPreview from "./NewEntry/NewEntryPreview";
+import LibraryTrackPicker, {
+  useLibraryTrackPicker,
+} from "../LibraryTrackPicker";
 
 export default function FlowsheetSearchResults({
   binResults,
@@ -18,8 +22,43 @@ export default function FlowsheetSearchResults({
   rotationResults: AlbumEntry[];
   lmlResults: AlbumEntry[];
 }) {
+  const dispatch = useAppDispatch();
   const open = useAppSelector(flowsheetSlice.selectors.getSearchOpen);
   const rotationMode = useAppSelector(flowsheetSlice.selectors.getRotationMode);
+  const selectedResult = useAppSelector(
+    flowsheetSlice.selectors.getSelectedResult
+  );
+
+  // Resolve the highlighted result to a release id so the picker knows what to
+  // fetch. Index 0 is the "new entry" preview (free-text only — no release to
+  // pick tracks from). Indices 1+ map into the concatenated result lists in
+  // the same order they're rendered above (bin → rotation → catalog → lml).
+  const allResults = useMemo(
+    () => [...binResults, ...rotationResults, ...catalogResults, ...lmlResults],
+    [binResults, rotationResults, catalogResults, lmlResults]
+  );
+  const highlightedResult: AlbumEntry | null =
+    selectedResult > 0 ? allResults[selectedResult - 1] ?? null : null;
+
+  const [manualOverride, setManualOverride] = useState<number | null>(null);
+  // Reset the "Not listed — enter manually" opt-out when the DJ navigates to a
+  // different result.
+  useEffect(() => {
+    if (
+      manualOverride !== null &&
+      highlightedResult?.id !== manualOverride
+    ) {
+      setManualOverride(null);
+    }
+  }, [highlightedResult?.id, manualOverride]);
+
+  const picker = useLibraryTrackPicker(
+    highlightedResult && highlightedResult.id !== manualOverride
+      ? highlightedResult.id
+      : null
+  );
+
+  const showPickerRow = !!highlightedResult && !rotationMode;
 
   return (
     <Sheet
@@ -96,6 +135,55 @@ export default function FlowsheetSearchResults({
             label="From Library Search"
           />
         </Box>
+        {showPickerRow && (
+          <>
+            <Divider />
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={1}
+              data-testid="flowsheet-search-track-picker-row"
+              sx={{ flexShrink: 0, minHeight: "40px", p: 1 }}
+            >
+              <Typography
+                level="body-xs"
+                sx={{
+                  color: "text.tertiary",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.05em",
+                  minWidth: "fit-content",
+                }}
+              >
+                Track
+              </Typography>
+              {picker.show ? (
+                <LibraryTrackPicker
+                  tracks={picker.tracks}
+                  isLoading={picker.isLoading}
+                  disabled={false}
+                  onManualEntry={() => {
+                    if (highlightedResult)
+                      setManualOverride(highlightedResult.id);
+                    dispatch(
+                      flowsheetSlice.actions.setSearchProperty({
+                        name: "song",
+                        value: "",
+                      })
+                    );
+                  }}
+                />
+              ) : picker.isLoading ? (
+                <Typography level="body-xs" sx={{ opacity: 0.5 }}>
+                  Loading tracks…
+                </Typography>
+              ) : (
+                <Typography level="body-xs" sx={{ opacity: 0.5 }}>
+                  No tracklist on file — type the song title above.
+                </Typography>
+              )}
+            </Stack>
+          </>
+        )}
         <Stack
           direction="row"
           justifyContent="flex-end"

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -3,15 +3,20 @@
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { Rotation } from "@/lib/features/rotation/types";
-import { RotationTrack, useGetRotationQuery, useGetRotationTracksQuery } from "@/lib/features/rotation/api";
+import {
+  RotationTrack,
+  useGetRotationQuery,
+  useGetRotationTracksQuery,
+  useRotationPrefetch,
+} from "@/lib/features/rotation/api";
 import { useAppDispatch } from "@/lib/hooks";
 import { useFlowsheetSearch } from "@/src/hooks/flowsheetHooks";
 import { Divider } from "@mui/joy";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import FlowsheetSearchInput from "./FlowsheetSearchInput";
 import RotationBinSelector from "./RotationBinSelector";
 import RotationReleaseDropdown from "./RotationReleaseDropdown";
-import RotationTrackDropdown from "./RotationTrackDropdown";
+import TrackPickerDropdown from "./TrackPickerDropdown";
 
 export default function RotationEntryFields({ disabled }: { disabled: boolean }) {
   const dispatch = useAppDispatch();
@@ -34,6 +39,19 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
     if (!rotationData || !selectedBin) return [];
     return rotationData.filter((r) => r.rotation_bin === selectedBin);
   }, [rotationData, selectedBin]);
+
+  // Warm the tracklist cache for every release in the picked bin so the picker
+  // is instantaneous — tubafrenzy renders rotation track titles inline and DJs
+  // are used to seeing them with no perceptible delay. One bin is bounded
+  // (~30 releases) and LML's 3-tier cache absorbs the per-release LML fetches.
+  const prefetchRotationTracks = useRotationPrefetch("getRotationTracks");
+  useEffect(() => {
+    for (const release of filteredReleases) {
+      if (release.rotation_id) {
+        prefetchRotationTracks(release.rotation_id);
+      }
+    }
+  }, [filteredReleases, prefetchRotationTracks]);
 
   const handleSelectBin = useCallback(
     (bin: Rotation) => {
@@ -126,7 +144,7 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
       />
       <Divider orientation="vertical" />
       {showTrackDropdown ? (
-        <RotationTrackDropdown
+        <TrackPickerDropdown
           tracks={tracks ?? []}
           isLoading={tracksLoading}
           selectedTrack={selectedTrack}

--- a/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
@@ -1,12 +1,24 @@
 "use client";
 
-import { RotationTrack } from "@/lib/features/rotation/api";
 import { KeyboardArrowDown } from "@mui/icons-material";
 import { Box, CircularProgress, Sheet, Typography } from "@mui/joy";
 import { ClickAwayListener } from "@mui/material";
 import { useCallback, useRef, useState } from "react";
 
-export default function RotationTrackDropdown({
+/**
+ * Minimal shape a track must expose to be rendered by this dropdown. Both the
+ * rotation picker (`RotationTrack`, `library/rotation/:id/tracks`) and the
+ * library picker (`LibraryTrack`, `proxy/library/:id/tracks`) project to this
+ * via thin adapters at the call site — the two BS wire contracts are
+ * intentionally distinct, so the unification happens here at the UI layer.
+ */
+export interface TrackPickerEntry {
+  position: string;
+  title: string;
+  artists: string[];
+}
+
+export default function TrackPickerDropdown<T extends TrackPickerEntry>({
   tracks,
   isLoading,
   selectedTrack,
@@ -14,10 +26,10 @@ export default function RotationTrackDropdown({
   onManualEntry,
   disabled,
 }: {
-  tracks: RotationTrack[];
+  tracks: T[];
   isLoading: boolean;
-  selectedTrack: RotationTrack | null;
-  onSelectTrack: (track: RotationTrack) => void;
+  selectedTrack: T | null;
+  onSelectTrack: (track: T) => void;
   onManualEntry: () => void;
   disabled: boolean;
 }) {
@@ -33,7 +45,7 @@ export default function RotationTrackDropdown({
   }, [disabled, isLoading]);
 
   const handleSelect = useCallback(
-    (track: RotationTrack) => {
+    (track: T) => {
       onSelectTrack(track);
       setOpen(false);
     },
@@ -95,7 +107,7 @@ export default function RotationTrackDropdown({
         <Box
           ref={triggerRef}
           tabIndex={disabled ? -1 : 0}
-          data-testid="rotation-track-trigger"
+          data-testid="track-picker-trigger"
           onClick={handleToggle}
           sx={{
             display: "flex",
@@ -158,7 +170,7 @@ export default function RotationTrackDropdown({
         {open && (
           <Sheet
             variant="outlined"
-            data-testid="rotation-track-panel"
+            data-testid="track-picker-panel"
             sx={{
               position: "absolute",
               top: "calc(100% + 4px)",
@@ -181,7 +193,7 @@ export default function RotationTrackDropdown({
               return (
                 <Box
                   key={`${track.position}-${index}`}
-                  data-testid={`rotation-track-option-${index}`}
+                  data-testid={`track-picker-option-${index}`}
                   onClick={() => handleSelect(track)}
                   sx={{
                     display: "flex",
@@ -233,7 +245,7 @@ export default function RotationTrackDropdown({
               );
             })}
             <Box
-              data-testid="rotation-track-manual"
+              data-testid="track-picker-manual"
               onClick={() => { onManualEntry(); setOpen(false); }}
               sx={{
                 display: "flex",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -11,6 +11,11 @@ afterAll(() => server.close());
 // Specs that exercise the disabled state override per-test.
 process.env.NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED = "true";
 
+// Pin backend URL for RTK Query base queries that read process.env directly
+// (matches TEST_BACKEND_URL default in test-utils/constants.ts).
+process.env.NEXT_PUBLIC_BACKEND_URL =
+  process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:3001";
+
 // Mock localStorage
 const localStorageMock = {
   getItem: vi.fn(() => null),


### PR DESCRIPTION
## Summary

- Modern flowsheet search panel now surfaces a **track picker row** when a release is highlighted. Picking a track writes both `track_title` (legacy) and `track_position` (Discogs `release_track.position`) into the submission — BS#943 (PR #945) persists it onto `flowsheet.track_position`.
- Free-text song input stays the default; the picker collapses back to the manual entry hint when the release has no Discogs identity or an empty tracklist (`source: null`).
- **Rotation tracklists are instantaneous**: when the DJ picks a bin, RotationEntryFields prefetches `getRotationTracks` for every release in that bin via `useRotationPrefetch`. One bin is bounded (~30 releases) and LML's 3-tier cache absorbs the actual fetches, so the picker opens with zero perceptible delay — matching tubafrenzy's UX. Same warming on the library-search side via `onMouseOver` per result row.
- `RotationTrackDropdown` → `TrackPickerDropdown` rename, generalized to a `TrackPickerEntry` shape so the new library picker reuses it via a thin adapter (LML exposes `artist_credit`, rotation exposes `artists: string[]`).

## Where

- `lib/features/metadata/{api,types}.ts` — `getLibraryTracks` endpoint hitting `/proxy/library/:id/tracks` (BS#836 / PR #922); `LibraryTrack` / `LibraryTracksResponse` types.
- `lib/features/flowsheet/{types,conversions,frontend}.ts` — `track_position` in `FlowsheetQuery` + both branches of `FlowsheetSubmissionParams`; `convertQueryToSubmission` passthrough; `setTrackPosition` slice action; clear on `setRotationMode`/`freezeSelectionToQuery`.
- `lib/features/rotation/api.ts` — re-export `usePrefetch` as `useRotationPrefetch`.
- `src/components/experiences/modern/flowsheet/Search/`
  - `TrackPickerDropdown.tsx` (renamed from `RotationTrackDropdown.tsx`, generic shape)
  - `LibraryTrackPicker.tsx` (new) — `useLibraryTrackPicker` hook owns the "should we render?" decision; `LibraryTrackPicker` component handles selection writes.
  - `RotationEntryFields.tsx` — `useEffect` over `filteredReleases` fires `useRotationPrefetch("getRotationTracks")` for each rotation_id.
  - `Results/FlowsheetSearchResults.tsx` — track picker row between result list and keyboard-hints row; `manualOverride` local state for the "Not listed — type manually" fallback (resets when the highlighted result changes).
  - `Results/BackendResults/FlowsheetBackendResult.tsx` — `useMetadataPrefetch("getLibraryTracks")` on `onMouseOver`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 205 files, 2962 tests passing (+6 new picker tests)
- [x] `npm run build` — clean Next.js 16 production build
- [ ] Manual: smoke test in dev (`npm run dev`) against local backend — verify picker appears for a CD release in catalog search, free-text fallback for releases with no tracklist, and rotation picker opens with no spinner on first release after bin selection.

## Related

- Parent epic: WXYC/library-metadata-lookup#294 (E6)
- Schema: WXYC/Backend-Service#835 (PR #932)
- Tracks endpoint: WXYC/Backend-Service#836 (PR #922)
- V1 write path: WXYC/Backend-Service#943 (PR #945)
- DTOs: WXYC/wxyc-shared#111 v1.6.0
- Follow-up: WXYC/dj-site#502 (Playwright e2e — happy path + free-text fallback)

Closes #501