### PR TITLE
fix(catalog): synthesize stable id for null-id rows to stop React key collisions

### DIFF
--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -187,7 +187,10 @@ describe("convertToAlbumEntry", () => {
         name: "should default optional bin fields",
         input: {} as any,
         assertions: (result) => {
-          expect(result.id).toBe(0);
+          // id is derived from content when album_id is missing; an empty input
+          // still gets a stable non-positive synthesized id (see dj-site#564).
+          expect(typeof result.id).toBe("number");
+          expect(result.id).toBeLessThanOrEqual(0);
           expect(result.title).toBe("");
           expect(result.artist.name).toBe("");
           expect(result.artist.lettercode).toBe("");
@@ -240,6 +243,78 @@ describe("convertToAlbumEntry", () => {
       });
       const result = convertToAlbumEntry(searchResult);
       expect(result.artist.id).toBeUndefined();
+    });
+
+    // dj-site#564 — BS proxy returns id: null for unlinked rotation/LML rows.
+    // Two such rows used to map to AlbumEntry.id = null and collide on React keys
+    // (RotationReleaseDropdown.tsx:166 etc.). Conversion must produce distinct,
+    // stable, non-null ids so consumers can keep using `key={entry.id}`.
+    describe("null id fallback (dj-site#564)", () => {
+      it("substitutes a non-null id when search result id is null", () => {
+        const result = convertToAlbumEntry(
+          createTestAlbumSearchResult({ id: null as unknown as number })
+        );
+        expect(result.id).not.toBeNull();
+        expect(typeof result.id).toBe("number");
+      });
+
+      it("substitutes a non-null id when bin response album_id is null", () => {
+        const result = convertToAlbumEntry(
+          createTestBinResponse({ album_id: null as unknown as number })
+        );
+        expect(result.id).not.toBeNull();
+        expect(typeof result.id).toBe("number");
+      });
+
+      it("produces distinct ids for two null-id rows with different content", () => {
+        const a = convertToAlbumEntry(
+          createTestAlbumSearchResult({
+            id: null as unknown as number,
+            artist_name: "Juana Molina",
+            album_title: "DOGA",
+            label: "Sonamos",
+          })
+        );
+        const b = convertToAlbumEntry(
+          createTestAlbumSearchResult({
+            id: null as unknown as number,
+            artist_name: "Cat Power",
+            album_title: "Moon Pix",
+            label: "Matador Records",
+          })
+        );
+        expect(a.id).not.toBe(b.id);
+      });
+
+      it("produces a stable id across re-conversions of the same input", () => {
+        const input = createTestAlbumSearchResult({
+          id: null as unknown as number,
+          artist_name: "Jessica Pratt",
+          album_title: "On Your Own Love Again",
+          label: "Drag City",
+        });
+        const a = convertToAlbumEntry(input);
+        const b = convertToAlbumEntry(input);
+        expect(a.id).toBe(b.id);
+      });
+
+      it("preserves real positive ids untouched", () => {
+        const result = convertToAlbumEntry(
+          createTestAlbumSearchResult({ id: 12345 })
+        );
+        expect(result.id).toBe(12345);
+      });
+
+      it("does not let the fallback collide with real positive album ids", () => {
+        const fallback = convertToAlbumEntry(
+          createTestAlbumSearchResult({
+            id: null as unknown as number,
+            artist_name: "Stereolab",
+            album_title: "Aluminum Tunes",
+          })
+        );
+        expect(fallback.id).toBeLessThanOrEqual(0);
+      });
     });
   });
 

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -8,10 +8,39 @@ function isSearchResult(
   return "id" in response && response.id !== undefined;
 }
 
+// Stable synthetic id for rows whose canonical id is null/missing. The BS
+// catalog proxy returns `id: null` for LML-only and unlinked-rotation rows
+// (see dj-site#564 + Backend-Service#689); without this, multiple such rows in
+// the same list collapse to a single React key. The hash is deterministic
+// across renders and negated so it can't collide with real positive album ids.
+function synthesizeAlbumId(
+  response: AlbumSearchResultJSON | BinLibraryDetails
+): number {
+  const key = [
+    response.artist_name ?? "",
+    response.album_title ?? "",
+    response.label ?? "",
+    response.code_letters ?? "",
+    response.code_artist_number ?? "",
+    response.code_number ?? "",
+  ].join("|");
+  let hash = 5381;
+  for (let i = 0; i < key.length; i++) {
+    hash = ((hash << 5) + hash + key.charCodeAt(i)) | 0;
+  }
+  return -(Math.abs(hash) || 1);
+}
+
 export function convertToAlbumEntry(
   response: AlbumSearchResultJSON | BinLibraryDetails
 ): AlbumEntry {
-  const id = isSearchResult(response) ? response.id : (response.album_id ?? 0);
+  const rawId = isSearchResult(response)
+    ? response.id
+    : (response as BinLibraryDetails).album_id;
+  const id =
+    typeof rawId === "number" && Number.isFinite(rawId) && rawId > 0
+      ? rawId
+      : synthesizeAlbumId(response);
 
   return {
     id,


### PR DESCRIPTION
Closes #564.

## Problem

`convertToAlbumEntry` mapped a null `response.id` straight to `AlbumEntry.id`. The search-result branch passed `response.id` through unfiltered; only the bin branch had a `?? 0` fallback. The BS catalog proxy returns `id: null` for LML-only / unlinked-rotation rows (per [Backend-Service#689](https://github.com/WXYC/Backend-Service/issues/689)), so two such rows in the same list both became `id: null` and collapsed to a single React key at every `key={entry.id}` call site — most visibly `RotationReleaseDropdown.tsx:166` (live repro on 2026-05-18 with rotation mode + bin H).

The ticket explicitly recommended fixing this at the data layer (one place) rather than papering over it with `?? index` at every consumer.

## Fix

Coerce both branches (search-result and bin) through a content-derived synthetic id when the canonical id is missing or non-positive:

```ts
function synthesizeAlbumId(response): number {
  const key = [
    response.artist_name ?? "",
    response.album_title ?? "",
    response.label ?? "",
    response.code_letters ?? "",
    response.code_artist_number ?? "",
    response.code_number ?? "",
  ].join("|");
  let hash = 5381;
  for (let i = 0; i < key.length; i++) hash = ((hash << 5) + hash + key.charCodeAt(i)) | 0;
  return -(Math.abs(hash) || 1);
}
```

- **Deterministic** djb2 over a 6-field content tuple — same input renders to the same id across re-renders (no memoization breakage).
- **Negative** — can't collide with real positive album ids.
- **Distinct across different content** — two LML-only rows for different releases get distinct ids.

`AlbumEntry.id` stays typed `number`, so consumers keep using `key={entry.id}` unchanged.

The previous `?? 0` bin fallback also went; an empty bin response now gets a synthesized negative id, so two empty bin responses no longer collide either. The existing "default optional bin fields" assertion was updated to pin the new contract (numeric, ≤ 0) instead of the prior `id === 0`.

## Test plan

Six new tests in `lib/__tests__/features/catalog/catalog.test.ts` under `convertToAlbumEntry > bug fixes > null id fallback (dj-site#564)`:

- [x] `substitutes a non-null id when search result id is null`
- [x] `substitutes a non-null id when bin response album_id is null`
- [x] `produces distinct ids for two null-id rows with different content`
- [x] `produces a stable id across re-conversions of the same input`
- [x] `preserves real positive ids untouched`
- [x] `does not let the fallback collide with real positive album ids`

Verified red → green: the search-result null path, the distinct-ids assertion, and the non-positive assertion all failed on `main` (output: \"expected null not to be null\" / \"actual value must be number or bigint, received 'object'\"). All 64 catalog tests pass after the fix.

Repo-wide pre-flight (matches CI):
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run --changed origin/main` — 109 files / 1624 tests pass
- [ ] `npm run build` — skipped locally (Turbopack rejects symlinked node_modules in worktree); covered by CI

## Out of scope

- **`?? index` at consumer sites.** Per #564's preferred approach, the data-layer fix is the safety net; consumer keys keep working unchanged. Not bundling drive-by changes to `RotationReleaseDropdown`, `Result`, `EntryForm`, etc.
- **BS proxy returning `id: null`.** Real data bug upstream — separate issue (likely a missing join in the rotation/library proxy controller). The frontend fallback is the immediate user-visible fix; the upstream is its own ticket.

## Related

- [Backend-Service#689](https://github.com/WXYC/Backend-Service/issues/689) — LEFT JOIN that surfaced the 147 unlinked rotation rows whose downstream effect is this bug.
- [Backend-Service#933](https://github.com/WXYC/Backend-Service/issues/933) — addEntry 500 regression from the same LEFT JOIN change.
- WXYC/dj-site#561 — surfaced this while testing the E6-6 track picker in rotation mode.
- WXYC/dj-site#563 — companion fetch-storm bug, same upstream condition.