### PR TITLE
fix(flowsheet): pin SSR to skeleton to fix hydration mismatch

### DIFF
--- a/app/dashboard/@modern/flowsheet/@entries/page.tsx
+++ b/app/dashboard/@modern/flowsheet/@entries/page.tsx
@@ -5,6 +5,7 @@ import FlowsheetSkeletonLoader from "@/src/components/experiences/modern/flowshe
 import { useFlowsheet } from "@/src/hooks/flowsheetHooks";
 import { Table, useColorScheme } from "@mui/joy";
 import { Reorder } from "motion/react";
+import { useEffect, useState } from "react";
 
 export default function FlowsheetEntries() {
   const { mode } = useColorScheme();
@@ -14,7 +15,18 @@ export default function FlowsheetEntries() {
     entries: { current, setCurrentShowEntries, previous },
   } = useFlowsheet();
 
-  if (loading) {
+  // Pin SSR to the skeleton: `loading` derives from RTK Query + persisted
+  // auth state that diverges between the server's first render (no session,
+  // no query has fired) and the client's hydration (persisted Redux session
+  // already populated). Without this guard the SSR returns <Stack> (skeleton)
+  // while the client hydrates <Table>, tripping React's hydration check.
+  // See WXYC/dj-site#562.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted || loading) {
     return <FlowsheetSkeletonLoader count={10} />;
   }
 


### PR DESCRIPTION
## Summary

`/dashboard/flowsheet` was logging a React hydration warning on every visit: SSR rendered `<Stack>` (the skeleton) while the client hydrated `<Table>` (the entries). React then regenerated the subtree on the client, masking the visual impact but leaving the warning in the console and burning a render cycle on every visit.

Root cause: [`app/dashboard/@modern/flowsheet/@entries/page.tsx:17-22`](https://github.com/WXYC/dj-site/blob/main/app/dashboard/@modern/flowsheet/@entries/page.tsx#L17-L22) branches on `loading` from `useFlowsheet()`, which derives from `useShowControl()` → `useRegistry()`. The user-registry RTK Query is in initial / pending state on the server (no session, no fetch fired) and `loading` evaluates true there; on the client, the persisted Redux session is already hydrated and the query is in a different state by first render, so `loading` evaluates false. Two structurally different roots → hydration mismatch.

## Fix

Add a `useHasMounted`-style guard so the page renders the skeleton during SSR and the first client render, then cuts over after `useEffect` fires. Same pattern that closed #441 (WelcomeQuotes) and #323 (password-reset race).

```diff
+ const [mounted, setMounted] = useState(false);
+ useEffect(() => { setMounted(true); }, []);

- if (loading) {
+ if (!mounted || loading) {
    return <FlowsheetSkeletonLoader count={10} />;
  }
```

The visible UX is unchanged — the skeleton already shows for the loading window, and "first paint" on the client is now exactly one React tick later (the immediate `useEffect` callback). Real perceived latency is unchanged.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run --changed origin/main` — no affected test files (page-level component, no unit tests in this repo for `app/**` routes); existing flowsheet hook tests untouched
- [ ] Manual smoke: open `/dashboard/flowsheet` in dev as a logged-in user with persisted session → console shows no hydration warning; skeleton flashes briefly; entries render
- [ ] Manual smoke: same page in a fresh incognito (no persisted session) → no warning; redirected to login or whatever the unauthenticated path is, depending on route guard

## Out of scope

- The `suppressHydrationWarning` flags scattered in [`FlowsheetSearchbar.tsx:220-278`](https://github.com/WXYC/dj-site/blob/main/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx#L220-L278) and [`RotationEntryFields.tsx:142`](https://github.com/WXYC/dj-site/blob/main/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx#L142) are paper-overs for similar mismatches in adjacent surfaces. They're left in place by this PR — revisiting them would benefit from a shared `useHasMounted` hook, and that's a refactor with broader scope than #562 warranted. Worth a follow-up if the pattern recurs.
- `app/dashboard/@modern/flowsheet/@queue/page.tsx` has a similar shape and may or may not need the same treatment. Spot-checking it isn't worth gating this fix.

## Related

- Closes #562
- Previously closed hydration fixes following the same pattern: WXYC/dj-site#441, WXYC/dj-site#323
- Surfaced during the WXYC/Backend-Service#944 / WXYC/dj-site#560 preview session 2026-05-18