### PR TITLE
fix(e2e): silence tubafrenzy mirror cert + SSE retry noise

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -121,7 +121,23 @@ jobs:
           E2E_BACKEND_PORT=8085
           COOKIE_SAME_SITE=lax
           NODE_ENV=test
+          # Mirror target: localhost mock that returns 200 to every POST,
+          # short-circuiting the 15.5s exponential-backoff retry storm that
+          # the default (https://www.wxyc.info, currently cert-expired) would
+          # produce. Mock is started in the next workflow step. See #567.
+          TUBAFRENZY_URL=http://localhost:9091
+          MIRROR_API_KEY=e2e-mirror-noop-key
           EOF
+
+      - name: Start mock tubafrenzy mirror
+        working-directory: dj-site
+        run: |
+          node e2e/scripts/mock-tubafrenzy.mjs > /tmp/mock-tubafrenzy.log 2>&1 &
+          echo $! > /tmp/mock-tubafrenzy.pid
+          # Wait for the mock to bind before any later step expects it to
+          # answer. ~50ms in practice; cap at 5s as a safety net.
+          timeout 5 bash -c 'until curl -sf -X POST -H "Content-Type: application/json" --data "{}" http://localhost:9091/ >/dev/null; do sleep 0.1; done'
+          echo "Mock tubafrenzy ready"
 
       - name: Cache Playwright browsers
         id: playwright-cache
@@ -238,6 +254,9 @@ jobs:
           echo ""
           echo "=== Frontend Logs ==="
           cat /tmp/frontend.log 2>/dev/null || echo "No frontend log"
+          echo ""
+          echo "=== Mock Tubafrenzy Logs ==="
+          cat /tmp/mock-tubafrenzy.log 2>/dev/null || echo "No mock-tubafrenzy log"
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
@@ -261,3 +280,4 @@ jobs:
           kill $(cat /tmp/frontend.pid 2>/dev/null) 2>/dev/null || true
           kill $(cat /tmp/auth.pid 2>/dev/null) 2>/dev/null || true
           kill $(cat /tmp/backend.pid 2>/dev/null) 2>/dev/null || true
+          kill $(cat /tmp/mock-tubafrenzy.pid 2>/dev/null) 2>/dev/null || true

--- a/e2e/scripts/mock-tubafrenzy.mjs
+++ b/e2e/scripts/mock-tubafrenzy.mjs
@@ -1,47 +1,84 @@
 #!/usr/bin/env node
 /**
- * Mock tubafrenzy mirror endpoint for E2E.
+ * Mock tubafrenzy endpoint for E2E.
  *
- * The Backend-Service legacy mirror (apps/backend/middleware/legacy/http.mirror.ts)
- * POSTs every show/entry write to TUBAFRENZY_URL, defaulting to
- * https://www.wxyc.info — whose cert is currently expired. In E2E the
- * resulting per-attempt failure cascades through a 5-attempt exponential
- * backoff loop (500ms + 1s + 2s + 4s + 8s = 15.5s of awaited delay) inside
- * the request handler, which routinely starves the test's
- * `expect(songInput).toHaveValue("", { timeout: 10000 })` window and trips
- * the entry-caching.spec.ts flake (see WXYC/dj-site#567).
+ * Backend-Service talks to tubafrenzy from two places (both read
+ * TUBAFRENZY_URL, defaulting to https://www.wxyc.info, whose cert is
+ * currently expired):
  *
- * This mock returns 200 + a synthetic id to all mirror writes so the loop
- * never retries. ~10 lines, no dependencies, starts in <100ms.
+ *   1. The legacy mirror (apps/backend/middleware/legacy/http.mirror.ts)
+ *      POSTs every show/entry write. On per-attempt failure it loops 5x
+ *      with exponential backoff (500ms + 1s + 2s + 4s + 8s = 15.5s of
+ *      awaited delay) inside the request handler, starving the test's
+ *      `expect(songInput).toHaveValue("", { timeout: 10000 })` window.
  *
- * Bound to localhost only. Port from $MOCK_TUBAFRENZY_PORT or 9091.
+ *   2. The playlist proxy (apps/backend/services/playlist-proxy.service.ts)
+ *      opens an EventSource to /playlists/recentStream at backend startup.
+ *      On error it reconnects with exponential backoff capped at 30s; if
+ *      the server returns the wrong content-type the EventSource fires an
+ *      error event immediately and the reconnect storm runs forever in the
+ *      background — noisy in logs, an event-loop tax everywhere.
+ *
+ * This mock handles both shapes:
+ *   - GET /playlists/recentStream → 200 + `text/event-stream` open stream
+ *     (immediately sends an empty `init` event so processInitEvent gets a
+ *     valid empty array; then heartbeat comments every 30s to keep the
+ *     connection alive). EventSource stays connected, no reconnect storm.
+ *   - Any other request → 200 + JSON `{id}` (the mirror's createShow and
+ *     createEntry read `.id`; updateEntry and signoff don't read the body).
+ *
+ * See WXYC/dj-site#567. Bound to 127.0.0.1 only. Port via
+ * $MOCK_TUBAFRENZY_PORT or 9091.
  */
 import { createServer } from 'node:http';
 
 const PORT = Number(process.env.MOCK_TUBAFRENZY_PORT ?? 9091);
 let nextId = 1;
+const sseClients = new Set();
 
 const server = createServer((req, res) => {
-  // Consume the body to satisfy Node's parser; we don't inspect it.
+  // SSE endpoint — keep the connection open so playlist-proxy's EventSource
+  // doesn't error-and-reconnect every loop iteration.
+  if (req.method === 'GET' && req.url === '/playlists/recentStream') {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    // Send an empty init so processInitEvent reaches `entries = []` and the
+    // proxy reports `connected = true` instead of staying in error state.
+    res.write('event: init\ndata: []\n\n');
+    sseClients.add(res);
+    req.on('close', () => sseClients.delete(res));
+    return;
+  }
+
+  // Everything else (mirror writes) — JSON {id} works for createShow,
+  // createEntry, updateEntry, signoff.
   req.on('data', () => {});
   req.on('end', () => {
     res.statusCode = 200;
     res.setHeader('Content-Type', 'application/json');
-    // mirrorCreateShow and mirrorCreateEntry both read `.id` from the JSON
-    // response. mirrorUpdateEntry and the signoff endpoint don't read the
-    // body. Returning `{id}` for everything keeps all paths happy.
     res.end(JSON.stringify({ id: nextId++ }));
   });
 });
+
+// Heartbeat keeps the SSE connection open across proxies/timeouts.
+const heartbeat = setInterval(() => {
+  for (const res of sseClients) res.write(': heartbeat\n\n');
+}, 30_000);
+heartbeat.unref();
 
 server.listen(PORT, '127.0.0.1', () => {
   // eslint-disable-next-line no-console
   console.log(`[mock-tubafrenzy] listening on http://127.0.0.1:${PORT}`);
 });
 
-// Be a good background process: exit cleanly on SIGTERM so CI cleanup is fast.
+// Be a good background process: close SSE connections + exit cleanly on
+// SIGTERM so CI cleanup is fast.
 for (const signal of ['SIGTERM', 'SIGINT']) {
   process.on(signal, () => {
+    clearInterval(heartbeat);
+    for (const res of sseClients) res.end();
     server.close(() => process.exit(0));
   });
 }

--- a/e2e/scripts/mock-tubafrenzy.mjs
+++ b/e2e/scripts/mock-tubafrenzy.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Mock tubafrenzy mirror endpoint for E2E.
+ *
+ * The Backend-Service legacy mirror (apps/backend/middleware/legacy/http.mirror.ts)
+ * POSTs every show/entry write to TUBAFRENZY_URL, defaulting to
+ * https://www.wxyc.info — whose cert is currently expired. In E2E the
+ * resulting per-attempt failure cascades through a 5-attempt exponential
+ * backoff loop (500ms + 1s + 2s + 4s + 8s = 15.5s of awaited delay) inside
+ * the request handler, which routinely starves the test's
+ * `expect(songInput).toHaveValue("", { timeout: 10000 })` window and trips
+ * the entry-caching.spec.ts flake (see WXYC/dj-site#567).
+ *
+ * This mock returns 200 + a synthetic id to all mirror writes so the loop
+ * never retries. ~10 lines, no dependencies, starts in <100ms.
+ *
+ * Bound to localhost only. Port from $MOCK_TUBAFRENZY_PORT or 9091.
+ */
+import { createServer } from 'node:http';
+
+const PORT = Number(process.env.MOCK_TUBAFRENZY_PORT ?? 9091);
+let nextId = 1;
+
+const server = createServer((req, res) => {
+  // Consume the body to satisfy Node's parser; we don't inspect it.
+  req.on('data', () => {});
+  req.on('end', () => {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    // mirrorCreateShow and mirrorCreateEntry both read `.id` from the JSON
+    // response. mirrorUpdateEntry and the signoff endpoint don't read the
+    // body. Returning `{id}` for everything keeps all paths happy.
+    res.end(JSON.stringify({ id: nextId++ }));
+  });
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  // eslint-disable-next-line no-console
+  console.log(`[mock-tubafrenzy] listening on http://127.0.0.1:${PORT}`);
+});
+
+// Be a good background process: exit cleanly on SIGTERM so CI cleanup is fast.
+for (const signal of ['SIGTERM', 'SIGINT']) {
+  process.on(signal, () => {
+    server.close(() => process.exit(0));
+  });
+}


### PR DESCRIPTION
## Summary

Silences two sources of `TUBAFRENZY_URL` noise in the E2E backend log:

1. **Mirror cert errors**: `apps/backend/middleware/legacy/http.mirror.ts` POSTs every show/entry write to `TUBAFRENZY_URL` (default `https://www.wxyc.info`, cert currently expired). 5-attempt exponential-backoff retry loop in `mirrorCreateShow`. Mock returns `{id}` to every POST so the loop never retries.

2. **playlist-proxy SSE reconnect storm**: `apps/backend/services/playlist-proxy.service.ts` opens an EventSource to `/playlists/recentStream` at startup. If the server returns a non-`text/event-stream` content-type the EventSource errors and reconnects with exponential backoff capped at 30s — forever, in the background. Mock now returns a proper SSE stream with an empty `init` event + 30s heartbeats so the connection stays open.

Adds `e2e/scripts/mock-tubafrenzy.mjs` (~50 lines, no dependencies). Workflow wires it in, points the backend at it via `TUBAFRENZY_URL=http://localhost:9091` + `MIRROR_API_KEY=e2e-mirror-noop-key`, kills it in cleanup, and surfaces its log in the failure diagnostics block.

## Scope

This was originally written to fix the `entry-caching.spec.ts` flake (#567). It doesn't. Two CI runs on this branch confirmed:

- **5c183cf** ([run](https://github.com/WXYC/dj-site/actions/runs/26136613929)): mirror cert errors gone. Flake unchanged.
- **dd192aa** ([run](https://github.com/WXYC/dj-site/actions/runs/26138458733)): SSE reconnect chatter also gone. Flake unchanged.

The flake is somewhere else — see the diagnosis comment + #569 (filed as the actual follow-up). This PR's value is now strictly log hygiene: future E2E debugging starts from a clean backend log instead of digging through 90% retry-storm spam. Merge as quality-of-life, not as a #567 fix.

## Test plan

- [x] Mock script smoke-tested locally — POST returns `{id:N}`, GET `/playlists/recentStream` returns `event: init\ndata: []\n\n` and stays open.
- [x] CI run 1 confirmed mirror cert errors eliminated from backend log.
- [x] CI run 2 confirmed SSE reconnect storm eliminated (single `Connecting to SSE` line, no error/reconnect chatter).
- [x] `actionlint` clean (4 pre-existing SC2046 warnings on the existing `kill $(cat ...)` pattern in Cleanup; the new line matches that pattern).

## Notes

- **Local-dev gap**: the local `e2e/scripts/start-e2e-services.sh` uses Docker Compose against Backend-Service's compose file; wiring `TUBAFRENZY_URL` into the e2e backend container is a cross-repo env change. Not blocking #567; tracked as known gap.
- **Doesn't close #567.** The cert+SSE were plausible suspects but ruled out by the two runs. #569 captures the actual next thread.

## Related

- Refined diagnosis on #567
- Actual follow-up: #569 (harden `entry-caching.spec.ts`)
- Unblocks (per Jake's pattern of merging despite known flake): #560