### PR TITLE
feat(classic): remove "Add HH:MM Breakpoint" button (closes dup with tubafrenzy auto-breakpoint)

### DIFF
--- a/src/components/experiences/classic/flowsheet/ActionsBar.tsx
+++ b/src/components/experiences/classic/flowsheet/ActionsBar.tsx
@@ -6,25 +6,11 @@ import { OpenHelp } from "@/src/utils/helpScreen";
 
 export default function ActionsBar({
   onAddTalkset,
-  onAddBreakpoint,
-  workingHour,
 }: {
   onAddTalkset: () => void;
-  onAddBreakpoint: () => void;
-  workingHour?: number;
 }) {
   const router = useRouter();
   const { live, leave } = useShowControl();
-
-  const formatHour = (hour?: number) => {
-    if (!hour) return "";
-    const date = new Date(hour);
-    const hours = date.getHours();
-    const minutes = date.getMinutes();
-    const ampm = hours >= 12 ? "PM" : "AM";
-    const displayHours = hours % 12 || 12;
-    return `${displayHours}:${minutes.toString().padStart(2, "0")} ${ampm}`;
-  };
 
   // Atomic show-end + session-end. Ports tubafrenzy's EndShowServlet flow:
   // signoff the radio show and invalidate the session in one click, replacing
@@ -41,16 +27,6 @@ export default function ActionsBar({
           <td className="label" align="center">
             <a href="#" onClick={(e) => { e.preventDefault(); onAddTalkset(); }}>
               Add a Talkset!
-            </a>
-            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-            <a
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                onAddBreakpoint();
-              }}
-            >
-              Add a {formatHour(workingHour)} Breakpoint
             </a>
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
             <a href="/live" target="_blank">

--- a/src/components/experiences/classic/flowsheet/Layout/Main.tsx
+++ b/src/components/experiences/classic/flowsheet/Layout/Main.tsx
@@ -50,33 +50,11 @@ export default function Main() {
     };
   }, [currentShowEntries, userData]);
 
-  const workingHour = useMemo(() => {
-    // Calculate working hour from current time
-    return Date.now();
-  }, []);
-
   const handleAddTalkset = async () => {
     try {
       await addToFlowsheet({ message: "Talkset", entry_type: FlowsheetEntryType.talkset }).unwrap();
     } catch (error) {
       console.error("Failed to add talkset:", error);
-    }
-  };
-
-  const handleAddBreakpoint = async () => {
-    const now = new Date();
-    const hour = now.getHours();
-    const minutes = now.getMinutes();
-    const ampm = hour >= 12 ? "PM" : "AM";
-    const displayHour = hour % 12 || 12;
-    const timeString = `${displayHour}:${minutes.toString().padStart(2, "0")} ${ampm}`;
-    try {
-      await addToFlowsheet({
-        message: `${timeString} Breakpoint`,
-        entry_type: FlowsheetEntryType.breakpoint,
-      }).unwrap();
-    } catch (error) {
-      console.error("Failed to add breakpoint:", error);
     }
   };
 
@@ -125,11 +103,7 @@ export default function Main() {
   return (
     <div style={{ width: "100%", margin: "0 auto" }}>
       <Navigation />
-      <ActionsBar
-        onAddTalkset={handleAddTalkset}
-        onAddBreakpoint={handleAddBreakpoint}
-        workingHour={workingHour}
-      />
+      <ActionsBar onAddTalkset={handleAddTalkset} />
       <hr />
       <EntryForm onSuccess={() => {}} isLive={live} />
       <hr />

--- a/src/components/experiences/classic/flowsheet/__tests__/ActionsBar.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/ActionsBar.test.tsx
@@ -33,28 +33,28 @@ beforeEach(() => {
 describe("Classic ActionsBar — End-Show consolidation", () => {
   it("renders a single 'End Show' link when the DJ is live", () => {
     renderWithProviders(
-      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+      <ActionsBar onAddTalkset={vi.fn()} />
     );
     expect(screen.getByRole("link", { name: /^end show$/i })).toBeDefined();
   });
 
   it("does NOT render 'Sign Out When Finished!' when live", () => {
     renderWithProviders(
-      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+      <ActionsBar onAddTalkset={vi.fn()} />
     );
     expect(screen.queryByText(/sign out when finished/i)).toBeNull();
   });
 
   it("does NOT render a 'Log Out' link when live", () => {
     renderWithProviders(
-      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+      <ActionsBar onAddTalkset={vi.fn()} />
     );
     expect(screen.queryByRole("link", { name: /^log out$/i })).toBeNull();
   });
 
   it("calls leave() exactly once when 'End Show' is clicked", () => {
     renderWithProviders(
-      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+      <ActionsBar onAddTalkset={vi.fn()} />
     );
     fireEvent.click(screen.getByRole("link", { name: /^end show$/i }));
     expect(leaveMock).toHaveBeenCalledTimes(1);
@@ -62,7 +62,7 @@ describe("Classic ActionsBar — End-Show consolidation", () => {
 
   it("redirects to /login?loginAction=endSession after ending the show", () => {
     renderWithProviders(
-      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+      <ActionsBar onAddTalkset={vi.fn()} />
     );
     fireEvent.click(screen.getByRole("link", { name: /^end show$/i }));
     expect(pushMock).toHaveBeenCalledWith("/login?loginAction=endSession");
@@ -71,7 +71,7 @@ describe("Classic ActionsBar — End-Show consolidation", () => {
   it("shows 'Not currently live' instead of End Show when not live", () => {
     liveMock = false;
     renderWithProviders(
-      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+      <ActionsBar onAddTalkset={vi.fn()} />
     );
     expect(screen.queryByRole("link", { name: /^end show$/i })).toBeNull();
     expect(screen.getByText(/not currently live/i)).toBeDefined();
@@ -79,17 +79,23 @@ describe("Classic ActionsBar — End-Show consolidation", () => {
 
   it("still renders the Help link", () => {
     renderWithProviders(
-      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+      <ActionsBar onAddTalkset={vi.fn()} />
     );
     expect(screen.getByRole("link", { name: /^help$/i })).toBeDefined();
   });
 
-  it("still renders the Add Talkset / Breakpoint / Last 24 Hours links", () => {
+  it("still renders the Add Talkset and Last 24 Hours links", () => {
     renderWithProviders(
-      <ActionsBar onAddTalkset={vi.fn()} onAddBreakpoint={vi.fn()} />
+      <ActionsBar onAddTalkset={vi.fn()} />
     );
     expect(screen.getByText(/add a talkset/i)).toBeDefined();
-    expect(screen.getByText(/breakpoint/i)).toBeDefined();
     expect(screen.getByRole("link", { name: /last 24 hours/i })).toBeDefined();
+  });
+
+  it("does NOT render the 'Add Breakpoint' link (tubafrenzy is the sole hourly-breakpoint source)", () => {
+    renderWithProviders(
+      <ActionsBar onAddTalkset={vi.fn()} />
+    );
+    expect(screen.queryByText(/breakpoint/i)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- The classic-mode "Add HH:MM Breakpoint" button POSTed a dj-site-format breakpoint to BS, where it sat alongside tubafrenzy's auto-generated `--- HH:MM PM BREAKPOINT ---` at the same hour boundary. DJs saw a visible duplicate; downstream consumers (archive segmentation, on-air automation) saw two boundaries.
- Per the 2026-05-19 product call: tubafrenzy owns hourly breakpoints. The dj-site button is the relic. Remove it.
- Drops `handleAddBreakpoint` from `Main.tsx`, the `onAddBreakpoint` + `workingHour` props from `ActionsBar`, the now-unused `formatHour` helper, and the `workingHour` useMemo. Updates `ActionsBar.test.tsx` to drop the obsolete prop on the existing render calls and adds a regression test asserting no breakpoint link is rendered.
- Net diff: -44 lines across 3 files.
- Closes the paired tickets: `dj-site#479` (this side, button removal) and `Backend-Service#699` (other side, the visible duplicate).

## Future: post-tubafrenzy auto-breakpoint home

When tubafrenzy turns down, the auto-breakpoint mechanism goes with it. The right successor home is **Backend-Service** (server-side cron at top-of-hour), not a client-side dj-site timer — client-side breaks if no DJ session is open, and creates race conditions if multiple sessions are open. Out of scope for this PR; would be a follow-up issue when the tubafrenzy turndown date firms up.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run src/components/experiences/classic/flowsheet` — 116 tests pass (incl. the new "does NOT render breakpoint link" regression).
- [ ] Build verification deferred to CI (worktree path triggered a Turbopack workspace-resolution warning; environmental, not code).
- [ ] Manual smoke against staging classic flowsheet — confirm the talkset link still works and no breakpoint link is rendered.