### PR TITLE
fix(e2e): wait for /flowsheet POST response before asserting form clear (#570)

### DIFF
--- a/e2e/pages/flowsheet.page.ts
+++ b/e2e/pages/flowsheet.page.ts
@@ -229,12 +229,18 @@ export class FlowsheetPage {
     } else {
       await this.submitViaEnter();
     }
-    // Wait for the form to clear — handleSubmit dispatches addToFlowsheet()
-    // then immediately resets the search form, so this confirms the mutation
-    // was initiated (though not necessarily that the response has arrived).
-    await expect(this.songInput).toHaveValue("", { timeout: 10000 });
-    // Wait for the POST response to confirm the entry is persisted on the server.
+    // Wait for the server's response FIRST — that's the structural signal that
+    // the mutation completed end-to-end. THEN assert the form cleared with a
+    // short follow-up timeout: handleSubmit awaits addToFlowsheet, dispatches
+    // resetSearch on success ([flowsheetHooks.ts:494-520]), and the input
+    // value re-reads from Redux state — all synchronous after the response.
+    // 2s is plenty for React's commit + DOM update.
+    //
+    // The previous shape raced the form-clear (10s timeout) against the
+    // response itself, which is non-deterministic when the server is slow.
+    // See WXYC/dj-site#570.
     await responsePromise;
+    await expect(this.songInput).toHaveValue("", { timeout: 2000 });
   }
 
   // --- Entry locators ---

--- a/e2e/pages/flowsheet.page.ts
+++ b/e2e/pages/flowsheet.page.ts
@@ -219,10 +219,14 @@ export class FlowsheetPage {
   ): Promise<void> {
     await this.fillSearchForm(data);
     // Register response listener BEFORE submitting so we don't miss the POST
-    // if it completes while we're waiting for the form to clear.
+    // if it completes while we're waiting for the form to clear. Timeout is
+    // generous (30s) because parallel-worker contention on the shared E2E
+    // backend can stretch a single POST end-to-end well past 15s — the
+    // previous 15s value was the masked failure mode that the form-clear
+    // race used to hide (see #570 diagnosis).
     const responsePromise = this.page.waitForResponse(
       (r) => r.url().includes("/flowsheet") && r.request().method() === "POST" && r.status() < 300,
-      { timeout: 15000 }
+      { timeout: 30000 }
     );
     if (method === "button") {
       await this.submitViaButton();

--- a/e2e/tests/flowsheet/entry-caching.spec.ts
+++ b/e2e/tests/flowsheet/entry-caching.spec.ts
@@ -17,6 +17,12 @@ test.describe("Flowsheet Entry Caching", () => {
   // Use dj2 to avoid session invalidation by auth/logout.spec.ts (which uses dj.json)
   test.use({ storageState: path.join(authDir, "dj2.json") });
   test.describe.configure({ mode: "serial" });
+  // Interim retry-2 from #570 fix-list item 3. Even with the response-first
+  // assertion shape (fix #1, this PR), some POSTs take >30s in CI for reasons
+  // not yet root-caused — likely parallel-worker contention or browser
+  // event-loop saturation, no Playwright trace in hand yet. Remove this once
+  // the followup investigation closes (filed separately).
+  test.describe.configure({ retries: 2 });
   // goLive() reloads the page and waits up to 20s for the flowsheet to render;
   // the default 20s test timeout doesn't leave room for beforeEach + test body.
   test.setTimeout(60_000);


### PR DESCRIPTION
## Summary

`addTrack()` in `e2e/pages/flowsheet.page.ts` was the source of every `entry-caching.spec.ts` flake. The old shape raced the form-clear assertion against the POST response itself:

```ts
await submit();
await expect(songInput).toHaveValue("", { timeout: 10000 });  // races slow response
await responsePromise;
```

`handleSubmit` ([flowsheetHooks.ts:494-520](https://github.com/WXYC/dj-site/blob/main/src/hooks/flowsheetHooks.ts#L494-L520)) only dispatches `resetSearch` after `await addToFlowsheet()` resolves, so the input clear is **downstream** of the response. Whenever the round-trip exceeded 10s, the assertion timed out before the response arrived.

## Fix

Wait for the response first, then assert the form clear with a short follow-up:

```ts
await responsePromise;
await expect(songInput).toHaveValue("", { timeout: 2000 });
```

Response timeout bumped 15s → 30s after the first run on this branch surfaced the deeper truth: some POSTs end-to-end take >15s in CI (root cause not yet pinned — see #572).

Plus `test.describe.configure({ retries: 2 })` on the spec as the interim mitigation from #570 fix-list item 3. The 30s timeout still doesn't fully eliminate the flake (the round-trip occasionally exceeds 30s despite the backend log showing fast `200 ok? true` responses), so a retry-2 covers the remaining residual until #572 closes.

## What the runs proved (across this PR's three commits)

1. **bf22c39** (response-first assertion, 15s timeout): assertion shape correct; the failure mode shifted from `toHaveValue("")` 10s race to `waitForResponse` 15s timeout. Diagnostically useful — proved the form-clear was masking a slower problem.
2. **de96b76** (timeout 15s → 30s): still failed at 30s `waitForResponse`. Backend log showed every POST returning fast — the gap is in browser/network observation, not backend processing. Filed as #572.
3. **dc4dc3f** (retry-2 interim): covers the residual. To be removed when #572 lands.

## Why this isn't 100% solving #570

#570 listed three suggested fixes. Status:

- Fix #1 (response-first assertion): ✅ landed here, structurally correct
- Fix #2 (`test_dj1` dup-key race): ✅ ruled out — turned out to be `e2e/tests/admin/user-creation.spec.ts:161` deliberately probing the duplicate-username error path. Benign log noise, not a cause.
- Fix #3 (`retries: 2` interim): ✅ landed here as the interim while #572 investigates the residual.

The residual (POSTs >30s despite fast backend responses) is the actual remaining unknown. Captured fully in #572 with hypotheses + suggested investigation path. Closing #570 once this PR lands; #572 takes the thread.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] **E2E run on this PR — proof.** With retry-2, even residual flakes shouldn't fail the suite. If the spec consistently passes (with or without retries firing internally), we're done with the user-facing flake problem and #572 becomes a quality-of-CI investigation rather than a blocker.

## Related

- Closes #570 (closes the assertion-shape + dup-key + retry-interim subset; #572 takes the remaining residual)
- Filed #572 (deeper investigation: why POST sometimes exceeds 30s despite fast backend)
- Filed #573 (E2E suite wall-clock — adjacent concern raised by user during this session)
- Diagnosis trail: #520 → #567 → #568 (silenced two confounds — cert + SSE — turned out to be noise) → this PR → #572