### PR TITLE
fix(e2e): eliminate entry-caching flake via CI workers=1 + timeout bump

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -26,8 +26,12 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry once on CI to absorb timing flakiness from shared runners */
   retries: process.env.CI ? 1 : 0,
-  /* Limit parallel workers to avoid overwhelming auth service */
-  workers: process.env.CI ? 2 : 3,
+  /* In CI, run with a single worker to eliminate inter-spec contention on
+   * the shared backend. With workers=2, two specs pummeling /flowsheet
+   * simultaneously made individual POSTs exceed 30s (#572 hypothesis 1).
+   * The shard matrix in e2e-tests.yml (#574) still gives 4x parallelism at
+   * the job level, so total CI wall clock stays under 3 min. */
+  workers: process.env.CI ? 1 : 3,
   /* Reporter to use */
   reporter: process.env.CI
     ? [

--- a/e2e/tests/flowsheet/entry-caching.spec.ts
+++ b/e2e/tests/flowsheet/entry-caching.spec.ts
@@ -154,12 +154,17 @@ test.describe("Flowsheet Entry Caching", () => {
       await flowsheet.expectEntryWithText(trackName, 3500);
 
       // Wait for the delayed response to complete and verify the entry is
-      // still there (temp ID replaced with server ID, no flicker)
+      // still there (temp ID replaced with server ID, no flicker). The route
+      // handler holds the POST for 5s before continuing, so only ~5s of this
+      // budget covers the actual backend leg. Under parallel-worker contention
+      // (#572 hypothesis 1) that leg has been observed taking >5s, which blew
+      // the original 10s budget. 20s gives the backend leg the same headroom
+      // addTrack uses (#571).
       await page.waitForResponse(
         (resp) =>
           resp.url().includes("/flowsheet") &&
           resp.request().method() === "POST",
-        { timeout: 10000 }
+        { timeout: 20000 }
       );
       await flowsheet.expectEntryWithText(trackName);
 


### PR DESCRIPTION
## Summary

Two changes targeting #572:

1. **Drop CI workers from 2 to 1** in `playwright.config.ts`. The hypothesis-1 root cause: two workers pummeling /flowsheet simultaneously made individual POSTs exceed 30s. Confirmed by:
   - Trace from #574 shard 3 retry1 showing `Wait for event \"response\"` blowing the 10s budget on the throttled-network test (with a 5s artificial delay, so only ~5s real backend headroom).
   - First iteration of this PR (timeout bump alone) revealing the 12-entries test then hit the same 30s wall in `addTrack`.

2. **Bump the throttled-network `waitForResponse` from 10s to 20s** in `entry-caching.spec.ts`. Defense-in-depth for the route-injected 5s delay: 20s matches the headroom `addTrack` uses (#571).

## Wall-clock cost

Un-sharded: workers=1 means total CI is ~7–8 min (was ~6:30). One PR cycle of slower CI before #574 (sharding) lands and compensates with 4x job-level parallelism → final target ~3 min/shard.

## Test plan

- [ ] `entry-caching.spec.ts` passes without using the `retries: 2` interim from #571
- [ ] Once #574 (sharding) rebases on top of this, all 4 shards green
- [ ] Follow-up: remove the `retries: 2` interim once we have ~5 consecutive green runs

Refs #572