### PR TITLE
test(e2e): retain trace + video on failure for #572 investigation

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -42,12 +42,15 @@ export default defineConfig({
   /* Shared settings for all projects */
   use: {
     baseURL: process.env.E2E_BASE_URL || "http://localhost:3000",
-    /* Collect trace when retrying the failed test */
-    trace: "on-first-retry",
+    /* Retain trace + video for every failed attempt, not just the retry.
+     * When the original attempt fails differently than the retry (timeout
+     * on first run, hang on second), we need both traces to discriminate
+     * between hypotheses. Cost is bounded because retries=1 and only
+     * failures retain. See #572. */
+    trace: "retain-on-failure",
     /* Capture screenshot on failure */
     screenshot: "only-on-failure",
-    /* Record video on first retry */
-    video: "on-first-retry",
+    video: "retain-on-failure",
     /* Maximum time each action such as click() can take */
     actionTimeout: 10000,
   },

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -45,8 +45,9 @@ export default defineConfig({
     /* Retain trace + video for every failed attempt, not just the retry.
      * When the original attempt fails differently than the retry (timeout
      * on first run, hang on second), we need both traces to discriminate
-     * between hypotheses. Cost is bounded because retries=1 and only
-     * failures retain. See #572. */
+     * between hypotheses. Only failed attempts retain artifacts, so cost
+     * scales with failure count (and per-spec retry overrides like
+     * entry-caching's retries=2). See #572. */
     trace: "retain-on-failure",
     /* Capture screenshot on failure */
     screenshot: "only-on-failure",


### PR DESCRIPTION
## Summary

Bumps Playwright's trace and video policy from `on-first-retry` to `retain-on-failure` so every failed attempt produces diagnostic data, not just the retry.

## Value confirmed on the first CI run

This PR was branched from `main` (not from #574), so #574's PR-grep-skip didn't apply and the entry-caching describe ran. Three tests failed — and with `retain-on-failure` the traces revealed the **actual root cause**: ten `503 Service Unavailable` console errors in a 145ms window before the failing PATCH listener was set up. See WXYC/dj-site#572 comment for the full breakdown.

`on-first-retry` would have captured only the retry traces, not the original attempt's 503 cluster. The bump paid for itself before merging.

## Test plan

- [x] CI ran and the new trace policy retained data for every failed attempt
- [x] Failure artifacts include `trace.zip` + `video.webm` per attempt (verified: 3 failed-test folders, each with multi-attempt traces)
- [ ] Land alongside #574 so future main-branch flakes always leave diagnostic data

Refs #572.