### PR TITLE
test(e2e): cut entry-caching backend load + re-enable on PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -246,28 +246,15 @@ jobs:
 
       - name: Run E2E tests
         working-directory: dj-site
-        # PRs skip the known-flaky entry-caching describe block (tracked in
-        # #572). Pushes to main still run the full suite, so coverage is
-        # preserved at merge time. --max-failures kept at 10 per shard: with
-        # sharding, a stuck shard hits its cap on its own, so dropping to 1
-        # just tanked otherwise-green shards (see prior commit on this PR).
-        #
-        # Note: --grep-invert's value contains a space ("Flowsheet Entry
-        # Caching"), so it has to be appended as a single array element —
-        # ${VAR:+"$VAR"} does NOT preserve the quoting through expansion and
-        # word-splits the value into three positional args, which Playwright
-        # then misreads as test-path filters (silently skipping nothing).
+        # --max-failures kept at 10 per shard: with sharding, a stuck shard
+        # hits its cap on its own, so dropping to 1 tanks otherwise-green
+        # shards (see prior commit on #574).
         run: |
-          args=(
-            "--shard=${{ matrix.shard }}/${{ strategy.job-total }}"
-            "--max-failures=10"
-            "--reporter=html"
+          npm run test:e2e -- \
+            "--shard=${{ matrix.shard }}/${{ strategy.job-total }}" \
+            "--max-failures=10" \
+            "--reporter=html" \
             "--reporter=github"
-          )
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            args+=("--grep-invert=Flowsheet Entry Caching")
-          fi
-          npm run test:e2e -- "${args[@]}"
 
       - name: Show service logs on failure
         if: failure()

--- a/e2e/tests/flowsheet/entry-caching.spec.ts
+++ b/e2e/tests/flowsheet/entry-caching.spec.ts
@@ -94,11 +94,13 @@ test.describe("Flowsheet Entry Caching", () => {
   // 2. Consistency across multiple attempts
   // ---------------------------------------------------------------
   test.describe("2. Consistency", () => {
-    test("all tracks appear after adding 12 entries", async ({ page }) => {
-      test.slow(); // This test adds many entries
-
-      const trackCount = 12;
-      const initialCount = await flowsheet.getAllEntries().count();
+    test("all tracks appear after adding multiple entries", async ({ page }) => {
+      // 4 entries exercises the same code path (button + enter, multiple
+      // adds, every track visible) at a fraction of the cumulative backend
+      // load that the previous 12-entry version generated. By test 6 of this
+      // serial-mode suite the dockerized BS used to wedge under the 20+ row
+      // accumulation; trimming this test was the cheapest mitigation. See #577.
+      const trackCount = 4;
       const trackNames: string[] = [];
 
       for (let i = 0; i < trackCount; i++) {
@@ -111,7 +113,6 @@ test.describe("Flowsheet Entry Caching", () => {
         );
       }
 
-      // All tracks should be present
       for (const name of trackNames) {
         await flowsheet.expectEntryWithText(name, 20000);
       }


### PR DESCRIPTION
## Summary

Apply mitigation #1 from #577 (cheapest) and re-enable the `Flowsheet Entry Caching` describe on PR runs:

- **`e2e/tests/flowsheet/entry-caching.spec.ts`** — drop the `Consistency` test from 12 entries to 4. The test asserts "all tracks appear after adding multiple entries", not that 12 is significant. PR #576's `retain-on-failure` traces showed test 6 wedging the BS container under 20+ rows of cumulative state; ~12 of those rows came from this test alone. Cutting to 4 keeps the code path (button + enter, multiple adds, all-tracks-visible) intact at ~1/3 the POST load.
- **`.github/workflows/e2e-tests.yml`** — remove the `--grep-invert=Flowsheet Entry Caching` PR-skip introduced by #574, plus the array-arg workaround comment that explained it. PR runs now exercise the full suite again. (`--max-failures=10` retained — the comment notes why dropping to 1 tanks otherwise-green shards.)

If CI still flakes on entry-caching after this, the followup is mitigation #2 from #577: `test.afterEach` cleanup via `DELETE /flowsheet/:id` to bound cumulative state per sub-describe.

## Test plan

- [ ] E2E shards 1–4 green (full suite running on PR for the first time since #574)
- [ ] `Flowsheet Entry Caching` describe passes without retries on the failing tests
- [ ] Median wall clock per shard ≤ 3 min (#573 acceptance bar held)

Closes #577.