### PR TITLE
Read flowsheet artwork from entry.artwork_url instead of per-row name search

### DIFF
--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -220,6 +220,22 @@ describe("flowsheet conversions", () => {
         expect(result.on_streaming).toBeUndefined();
       });
 
+      it("should pass artwork_url through on track entries", () => {
+        const entry = createTestV2TrackEntry({
+          artwork_url: "https://example.com/cover.jpg",
+        } as any);
+        const result = convertV2Entry(entry) as FlowsheetSongEntry;
+
+        expect(result.artwork_url).toBe("https://example.com/cover.jpg");
+      });
+
+      it("should default artwork_url to undefined when absent", () => {
+        const entry = createTestV2TrackEntry();
+        const result = convertV2Entry(entry) as FlowsheetSongEntry;
+
+        expect(result.artwork_url).toBeUndefined();
+      });
+
       it.each([
         { wire: true, expected: true },
         { wire: false, expected: false },

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -98,6 +98,7 @@ export function convertV2Entry(entry: FlowsheetV2EntryJSON): FlowsheetEntry {
         rotation_id: entry.rotation_id ?? undefined,
         rotation: entry.rotation_bin as Rotation,
         on_streaming: entry.on_streaming ?? undefined,
+        artwork_url: entry.artwork_url ?? undefined,
       };
 
     case "show_start": {

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -66,7 +66,7 @@ export type FlowsheetSongBase = {
   rotation_id?: number;
   rotation?: Rotation;
   on_streaming?: boolean;
-  artwork_url?: string | null;
+  artwork_url?: string;
 };
 
 export type FlowsheetSongEntry = FlowsheetEntryBase & FlowsheetSongBase;

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -66,6 +66,7 @@ export type FlowsheetSongBase = {
   rotation_id?: number;
   rotation?: Rotation;
   on_streaming?: boolean;
+  artwork_url?: string | null;
 };
 
 export type FlowsheetSongEntry = FlowsheetEntryBase & FlowsheetSongBase;

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
@@ -6,7 +6,6 @@ import { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
 // Mock hooks
 const mockUseShowControl = vi.fn();
 const mockUseFlowsheet = vi.fn();
-const mockUseAlbumArtwork = vi.fn();
 const mockAddToFlowsheet = vi.fn();
 const mockDispatch = vi.fn();
 const mockUpdateFlowsheet = vi.fn();
@@ -14,11 +13,6 @@ const mockUpdateFlowsheet = vi.fn();
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
   useShowControl: () => mockUseShowControl(),
   useFlowsheet: () => mockUseFlowsheet(),
-}));
-
-vi.mock("@/lib/features/metadata/hooks", () => ({
-  useAlbumArtwork: (artistName?: string, releaseTitle?: string) =>
-    mockUseAlbumArtwork(artistName, releaseTitle),
 }));
 
 vi.mock("@/lib/features/flowsheet/api", () => ({
@@ -118,6 +112,7 @@ describe("SongEntry", () => {
     album_id: 42,
     rotation: "H",
     rotation_id: 10,
+    artwork_url: "/test-album-art.jpg",
   };
 
   beforeEach(() => {
@@ -131,12 +126,6 @@ describe("SongEntry", () => {
 
     mockUseFlowsheet.mockReturnValue({
       updateFlowsheet: mockUpdateFlowsheet,
-    });
-
-    mockUseAlbumArtwork.mockReturnValue({
-      artworkUrl: "/test-album-art.jpg",
-      isLoading: false,
-      metadata: null,
     });
 
     mockAddToFlowsheet.mockReturnValue(Promise.resolve());
@@ -161,7 +150,7 @@ describe("SongEntry", () => {
       expect(screen.getByText("Test Label")).toBeInTheDocument();
     });
 
-    it("should render album art image when available and not loading", () => {
+    it("should render album art image from entry.artwork_url", () => {
       render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
 
       const image = screen.getByRole("img");
@@ -169,17 +158,15 @@ describe("SongEntry", () => {
       expect(image).toHaveAttribute("alt", "album art");
     });
 
-    it("should show CircularProgress when image is loading", () => {
-      mockUseAlbumArtwork.mockReturnValue({
-        artworkUrl: "/img/cassette.png",
-        isLoading: true,
-        metadata: null,
-      });
+    it("should fall back to the default cassette image when entry.artwork_url is missing", () => {
+      const entryWithoutArtwork = { ...mockEntry, artwork_url: undefined };
 
-      render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
+      render(
+        <SongEntry entry={entryWithoutArtwork} playing={false} queue={false} />
+      );
 
-      // When loading, should show CircularProgress (MUI component renders with role="progressbar")
-      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+      const image = screen.getByRole("img");
+      expect(image).toHaveAttribute("src", "/img/cassette.png");
     });
 
     it("should render info button for album detail", () => {

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
@@ -8,7 +8,6 @@ import {
   FlowsheetSubmissionParams,
 } from "@/lib/features/flowsheet/types";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
-import { useAlbumArtwork } from "@/lib/features/metadata/hooks";
 import { useFlowsheet, useShowControl } from "@/src/hooks/flowsheetHooks";
 import { getStyleForRotation } from "@/src/utilities/modern/rotationstyles";
 import {
@@ -28,7 +27,6 @@ import {
   Box,
   Checkbox,
   Chip,
-  CircularProgress,
   IconButton,
   Stack,
   Tooltip,
@@ -62,10 +60,7 @@ export default function SongEntry({
 
   const { updateFlowsheet } = useFlowsheet();
 
-  const {
-    artworkUrl: image,
-    isLoading: imageLoading,
-  } = useAlbumArtwork(entry.artist_name, entry.album_title);
+  const image = entry.artwork_url ?? "/img/cassette.png";
 
   const dispatch = useAppDispatch();
 
@@ -116,15 +111,11 @@ export default function SongEntry({
                 minHeight: "48px",
               }}
             >
-              {imageLoading ? (
-                <CircularProgress />
-              ) : (
-                <img
-                  src={image}
-                  alt="album art"
-                  style={{ minWidth: "48px", minHeight: "48px" }}
-                />
-              )}
+              <img
+                src={image}
+                alt="album art"
+                style={{ minWidth: "48px", minHeight: "48px" }}
+              />
             </AspectRatio>
           </Badge>
           {canClose && queue && (

--- a/src/widgets/NowPlaying/AlbumArtAndIcons.test.tsx
+++ b/src/widgets/NowPlaying/AlbumArtAndIcons.test.tsx
@@ -8,20 +8,6 @@ import type {
   FlowsheetMessageEntry,
 } from "@/lib/features/flowsheet/types";
 
-// Mock useAlbumArtwork hook
-const mockUseAlbumArtwork = vi.fn(
-  (_artistName?: string, _releaseTitle?: string) => ({
-    artworkUrl: "https://example.com/album-art.jpg",
-    isLoading: false,
-    metadata: null,
-  }),
-);
-
-vi.mock("@/lib/features/metadata/hooks", () => ({
-  useAlbumArtwork: (artistName?: string, releaseTitle?: string) =>
-    mockUseAlbumArtwork(artistName, releaseTitle),
-}));
-
 // Mock MUI components - render children to allow img testing
 vi.mock("@mui/joy", () => ({
   AspectRatio: ({ children, ...props }: any) => (
@@ -53,11 +39,6 @@ describe("AlbumArtAndIcons", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseAlbumArtwork.mockReturnValue({
-      artworkUrl: "https://example.com/album-art.jpg",
-      isLoading: false,
-      metadata: null,
-    });
   });
 
   describe("when entry is undefined", () => {
@@ -70,38 +51,33 @@ describe("AlbumArtAndIcons", () => {
       expect(screen.getByTestId("aspect-ratio")).toBeInTheDocument();
     });
 
-    it("should call useAlbumArtwork with undefined params", () => {
-      render(<AlbumArtAndIcons entry={undefined} />);
-      expect(mockUseAlbumArtwork).toHaveBeenCalledWith(undefined, undefined);
-    });
-  });
-
-  describe("when loading is true", () => {
-    it("should display aspect-ratio wrapper while loading", () => {
-      mockUseAlbumArtwork.mockReturnValue({
-        artworkUrl: "https://example.com/album-art.jpg",
-        isLoading: true,
-        metadata: null,
-      });
-
-      const songEntry: FlowsheetSongEntry = {
-        ...baseEntry,
-        track_title: "Test Track",
-        artist_name: "Test Artist",
-        album_title: "Test Album",
-        record_label: "Test Label",
-        request_flag: false,
-        segue: false,
-      };
-
-      render(<AlbumArtAndIcons entry={songEntry} />);
-
-      expect(screen.getByTestId("aspect-ratio")).toBeInTheDocument();
+    it("should render the default cassette image", () => {
+      const { container } = render(<AlbumArtAndIcons entry={undefined} />);
+      const img = container.querySelector("img");
+      expect(img).toHaveAttribute("src", "/img/cassette.png");
     });
   });
 
   describe("when entry is a song entry", () => {
-    it("should call useAlbumArtwork with artist and album", () => {
+    it("should render the artwork from entry.artwork_url", () => {
+      const songEntry: FlowsheetSongEntry = {
+        ...baseEntry,
+        track_title: "Test Track",
+        artist_name: "Test Artist",
+        album_title: "Test Album",
+        record_label: "Test Label",
+        request_flag: false,
+        segue: false,
+        artwork_url: "https://example.com/album-art.jpg",
+      };
+
+      const { container } = render(<AlbumArtAndIcons entry={songEntry} />);
+
+      const img = container.querySelector("img");
+      expect(img).toHaveAttribute("src", "https://example.com/album-art.jpg");
+    });
+
+    it("should fall back to the default cassette image when artwork_url is missing", () => {
       const songEntry: FlowsheetSongEntry = {
         ...baseEntry,
         track_title: "Test Track",
@@ -112,9 +88,10 @@ describe("AlbumArtAndIcons", () => {
         segue: false,
       };
 
-      render(<AlbumArtAndIcons entry={songEntry} />);
+      const { container } = render(<AlbumArtAndIcons entry={songEntry} />);
 
-      expect(mockUseAlbumArtwork).toHaveBeenCalledWith("Test Artist", "Test Album");
+      const img = container.querySelector("img");
+      expect(img).toHaveAttribute("src", "/img/cassette.png");
     });
 
     it("should render aspect-ratio wrapper", () => {
@@ -126,6 +103,7 @@ describe("AlbumArtAndIcons", () => {
         record_label: "Test Label",
         request_flag: false,
         segue: false,
+        artwork_url: "https://example.com/album-art.jpg",
       };
 
       render(<AlbumArtAndIcons entry={songEntry} />);
@@ -207,16 +185,4 @@ describe("AlbumArtAndIcons", () => {
     });
   });
 
-  describe("when entry is a non-song entry", () => {
-    it("should call useAlbumArtwork with undefined params", () => {
-      const messageEntry: FlowsheetMessageEntry = {
-        ...baseEntry,
-        message: "PSA: Community announcement",
-      };
-
-      render(<AlbumArtAndIcons entry={messageEntry} />);
-
-      expect(mockUseAlbumArtwork).toHaveBeenCalledWith(undefined, undefined);
-    });
-  });
 });

--- a/src/widgets/NowPlaying/AlbumArtAndIcons.tsx
+++ b/src/widgets/NowPlaying/AlbumArtAndIcons.tsx
@@ -6,24 +6,22 @@ import {
   isFlowsheetStartShowEntry,
   isFlowsheetTalksetEntry,
 } from "@/lib/features/flowsheet/types";
-import { useAlbumArtwork } from "@/lib/features/metadata/hooks";
 import { Headphones, Logout, Mic, Timer } from "@mui/icons-material";
 import { AspectRatio, Box } from "@mui/joy";
+
+const DEFAULT_ARTWORK_URL = "/img/cassette.png";
 
 export default function AlbumArtAndIcons({
   entry,
 }: {
   entry: FlowsheetEntry | undefined;
 }) {
-  const songEntry = entry && isFlowsheetSongEntry(entry) ? entry : undefined;
-  const { artworkUrl, isLoading } = useAlbumArtwork(songEntry?.artist_name, songEntry?.album_title);
-
-  if (!entry || isLoading) {
+  if (!entry) {
     return (
       <ImageWrapper>
         <img
-          src="/img/cassette.png"
-          srcSet="/img/cassette.png"
+          src={DEFAULT_ARTWORK_URL}
+          srcSet={DEFAULT_ARTWORK_URL}
           loading="lazy"
           alt=""
           style={{ width: "100%", objectPosition: "center" }}
@@ -33,6 +31,7 @@ export default function AlbumArtAndIcons({
   }
 
   if (isFlowsheetSongEntry(entry)) {
+    const artworkUrl = entry.artwork_url ?? DEFAULT_ARTWORK_URL;
     return (
       <ImageWrapper>
         <img
@@ -81,8 +80,8 @@ export default function AlbumArtAndIcons({
   return (
     <ImageWrapper>
       <img
-        src="/img/cassette.png"
-        srcSet="/img/cassette.png"
+        src={DEFAULT_ARTWORK_URL}
+        srcSet={DEFAULT_ARTWORK_URL}
         loading="lazy"
         alt=""
       />

--- a/src/widgets/NowPlaying/index.test.tsx
+++ b/src/widgets/NowPlaying/index.test.tsx
@@ -17,15 +17,6 @@ vi.mock("@/lib/features/flowsheet/api", () => ({
   useWhoIsLiveQuery: () => mockUseWhoIsLiveQuery(),
 }));
 
-// Mock the useAlbumArtwork hook
-vi.mock("@/lib/features/metadata/hooks", () => ({
-  useAlbumArtwork: () => ({
-    artworkUrl: "https://example.com/album.jpg",
-    isLoading: false,
-    metadata: null,
-  }),
-}));
-
 // Mock NowPlayingMain component
 vi.mock("./Main", () => ({
   default: ({


### PR DESCRIPTION
## Summary

The flowsheet view was firing `GET /proxy/metadata/album?artistName=...&releaseTitle=...` for every row, which runs LML's fuzzy name-resolution pipeline. When LML didn't have a cache hit and Discogs was slow, the LML client timed out at 30 s — exactly when the Backend-Service Express server timeout also fires — and the socket was torn down. nginx surfaced this as a 502 with no `Access-Control-Allow-Origin` header, which showed up in the browser as:

```
Cross-Origin Request Blocked: ... at https://api.wxyc.org/proxy/metadata/album?...
(Reason: CORS header 'Access-Control-Allow-Origin' missing). Status code: 502.
```

Sentry confirmed the failure mode: every burst contained 1–3 spans on `GET /proxy/metadata/album` at exactly `30001 ms`.

The v2 flowsheet endpoint already returns enriched metadata inline. `FlowsheetV2TrackEntry` carries `artwork_url` (plus streaming URLs and other enrichment), backed by Backend-Service write-time enrichment. Two issues were hiding that data:

1. `lib/features/flowsheet/conversions.ts` `convertV2Entry` dropped `artwork_url` when mapping V2 to `FlowsheetSongEntry`.
2. `SongEntry.tsx` and `NowPlaying/AlbumArtAndIcons.tsx` always called `useAlbumArtwork(artist_name, album_title)`, even though those surfaces receive the already-enriched entry.

Changes:

- Add `artwork_url?: string` to `FlowsheetSongBase`
- Pass it through in `convertV2Entry` for the `"track"` case (`entry.artwork_url ?? undefined`)
- Read `entry.artwork_url ?? "/img/cassette.png"` directly in `SongEntry` and `AlbumArtAndIcons`; drop the `useAlbumArtwork` calls there
- Keep `useAlbumArtwork` in place for `AlbumDetailPanel.tsx`, which legitimately operates without a pre-enriched entry

## Trigger of the current 502 burst

Worth naming explicitly so the PR isn't read as "fixes the 502s by itself." The dominant LML pressure right now is the `flowsheet-metadata-backfill-cron` container that's been running on the EC2 host since 2026-05-21 06:00 UTC. Latest batch logged 439 `lml_error` timeouts on an 8000-row scan; the last 30 min of LML telemetry shows `/api/v1/lookup` at p50 23s / p95 32s / p99 29s, with `http.client GET api.discogs.com/releases/{id}` ranging 100ms–1.4s inside each lookup. All 10 of the slowest LML traces in the last 30 min share the backfill's long-lived root span.

This PR is correct independent of that — removing per-row LML calls from flowsheet rendering eliminates the symptom on this surface and subtracts one source of LML pressure. But the timeout-coupling and Discogs-saturation problems live upstream and are not addressed here.

## Out of scope

- **`AlbumDetailPanel.tsx`** still calls `useAlbumArtwork` — preserved as the legitimate context-less caller. If click-through volume on album detail keeps producing 30s timeouts, a follow-up could feed `artwork_url` into the detail panel from the originating entry.
- **OnAirDJ "loading tracks" Slack report** — that's the rotation-add search path (`/library/query` cascade), not flowsheet rendering. Not addressed by this PR; should not be considered resolved by this merge alone.
- **iOS metadata path** — iOS doesn't go through `convertV2Entry` and is currently sitting through the same 30s catch-arm on cold-cache misses, with only the label coming back populated. This PR doesn't help iOS. The fix on iOS is either the upstream LML perf work ([WXYC/library-metadata-lookup#338](https://github.com/WXYC/library-metadata-lookup/issues/338)) or a parallel migration to entry-inline artwork on the iOS side.

## Follow-up (Backend-Service, separate PR)

The LML client timeout and Express server timeout are both 30 s (`apps/backend/services/lml/lml.client.ts:66` + `apps/backend/app.ts:137`). The two firing in the same tick is what turns a slow LML miss into a 502 with no CORS headers. Setting the server timeout strictly higher than the LML client timeout would let the controller's catch path complete and return 200 with fallback URLs instead. The BS `CLAUDE.md` claim "Server timeout is 5 seconds globally" is also stale. Tightening this won't stop the backfill from monopolizing LML capacity for real-time users — that's an LML-side rate-limit / concurrency-cap question (LML#338 territory) — but it does make this class of failure invisible to clients.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` on touched paths — 9 files / 259 tests pass, including new `convertV2Entry` cases for `artwork_url` pass-through and default, and a new "fall back to cassette when `artwork_url` is missing" test on both `SongEntry` and `AlbumArtAndIcons`
- [x] `npm run build` — clean
- [ ] **Manual (gating):** load `dj.wxyc.org/dashboard/flowsheet` after deploy and verify (a) zero `/proxy/metadata/album` requests in the network tab from flowsheet rows, (b) artwork still renders from `entry.artwork_url` for recent entries that went through BS write-time enrichment, (c) the default cassette image shows for older entries that pre-date enrichment (i.e. rows that #641's backfill hasn't drained yet — those will now show a cassette rather than a name-search 502). This is load-bearing: the unit tests verify that `convertV2Entry` carries `artwork_url` through, not that BS write-time enrichment actually populates it on live rows.