### PR TITLE
fix(catalog): replace animated spinner with status line

### DIFF
--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -27,6 +27,7 @@ export default function Results({
     results: releaseList,
     total,
     isLoading: loading,
+    isError,
     hasMore,
     loadNextPage,
   } = useCatalogQueryResults();
@@ -42,6 +43,8 @@ export default function Results({
         >
           {loading
             ? "Searching..."
+            : isError
+            ? "Search failed. Please try again."
             : hasResults
             ? `Found ${total.toLocaleString()} result${total === 1 ? "" : "s"}`
             : "No results found"}

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -41,7 +41,7 @@ export default function Results({
           sx={{ px: 2, py: 1.5, color: "text.secondary" }}
         >
           {loading
-            ? "Searching…"
+            ? "Searching..."
             : hasResults
             ? `Found ${total.toLocaleString()} result${total === 1 ? "" : "s"}`
             : "No results found"}

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -2,7 +2,7 @@
 
 import Button from "@mui/joy/Button";
 import Checkbox from "@mui/joy/Checkbox";
-import CircularProgress from "@mui/joy/CircularProgress";
+import Typography from "@mui/joy/Typography";
 import { ChangeEvent } from "react";
 
 import { Table } from "@mui/joy";
@@ -21,123 +21,125 @@ export default function Results({
 }: {
   color: ColorPaletteProp | undefined;
 }) {
-  const { selected, setSelection } = useCatalogQuerySearch();
+  const { selected, setSelection, hasActiveQuery } = useCatalogQuerySearch();
 
   const {
     results: releaseList,
+    total,
     isLoading: loading,
     hasMore,
     loadNextPage,
   } = useCatalogQueryResults();
+
+  const hasResults = releaseList.length > 0;
+
   return (
     <ResultsContainer>
-      <Table
-        aria-labelledby="tableTitle"
-        stickyHeader
-        hoverRow
-        sx={{
-          "--TableCell-headBackground": (theme) =>
-            theme.vars.palette.background.level1,
-          "--Table-headerUnderlineThickness": "1px",
-          "--TableRow-hoverBackground": (theme) =>
-            theme.vars.palette.background.level1,
-          "& thead tr > *:last-child": {
-            position: "sticky",
-            right: 0,
-            bgcolor: "var(--TableCell-headBackground)",
-          },
-          "& tbody tr > *:last-child": {
-            position: "sticky",
-            right: 0,
-            bgcolor: "var(--joy-palette-background-surface)",
-          },
-          "& tbody tr:hover > *:last-child": {
-            bgcolor: "var(--TableRow-hoverBackground)",
-          },
-        }}
-      >
-        <thead>
-          <tr>
-            <th style={{ width: 48, textAlign: "center", padding: 12 }}>
-              <Checkbox
-                indeterminate={
-                  selected.length > 0 && selected.length !== releaseList?.length
-                }
-                checked={
-                  releaseList != null &&
-                  releaseList.length > 0 &&
-                  selected.length === releaseList.length
-                }
-                onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                  setSelection(
-                    event.target.checked
-                      ? releaseList?.map((row) => row.id) ?? []
-                      : []
-                  );
-                }}
-                color={
-                  selected.length > 0 || selected.length === releaseList?.length
-                    ? "primary"
-                    : undefined
-                }
-                sx={{ verticalAlign: "text-bottom" }}
-              />
-            </th>
-            <th style={{ width: 50, padding: 12 }}></th>
-            <th style={{ width: 180, padding: 12 }}>
-              <TableHeader textValue="Artist" />
-            </th>
-            <th style={{ width: 180, padding: 12 }}>
-              <TableHeader textValue="Title" />
-            </th>
-            <th style={{ width: 280, padding: 12 }}>
-              <TableHeader textValue="Code" />
-            </th>
-            <th style={{ width: 80, padding: 12 }}>
-              <TableHeader textValue="Plays" />
-            </th>
-            <th style={{ width: 120, padding: 12 }}></th>
-          </tr>
-        </thead>
-        <tbody>
-          {loading ? (
-            <tr style={{ background: "transparent" }}>
-              <td
-                colSpan={7}
-                style={{
-                  textAlign: "center",
-                  paddingTop: "3rem",
-                  background: "transparent",
-                }}
-              >
-                <CircularProgress color="primary" size="md" />
-              </td>
-            </tr>
-          ) : (
-            releaseList?.map((album) => (
-              <CatalogResult album={album} key={`result-${album.id}`} />
-            ))
-          )}
-
-          {!loading && hasMore && (
+      {hasActiveQuery && (
+        <Typography
+          level="body-sm"
+          sx={{ px: 2, py: 1.5, color: "text.secondary" }}
+        >
+          {loading
+            ? "Searching…"
+            : hasResults
+            ? `Found ${total.toLocaleString()} result${total === 1 ? "" : "s"}`
+            : "No results found"}
+        </Typography>
+      )}
+      {hasResults && (
+        <Table
+          aria-labelledby="tableTitle"
+          stickyHeader
+          hoverRow
+          sx={{
+            "--TableCell-headBackground": (theme) =>
+              theme.vars.palette.background.level1,
+            "--Table-headerUnderlineThickness": "1px",
+            "--TableRow-hoverBackground": (theme) =>
+              theme.vars.palette.background.level1,
+            "& thead tr > *:last-child": {
+              position: "sticky",
+              right: 0,
+              bgcolor: "var(--TableCell-headBackground)",
+            },
+            "& tbody tr > *:last-child": {
+              position: "sticky",
+              right: 0,
+              bgcolor: "var(--joy-palette-background-surface)",
+            },
+            "& tbody tr:hover > *:last-child": {
+              bgcolor: "var(--TableRow-hoverBackground)",
+            },
+          }}
+        >
+          <thead>
             <tr>
-              <td colSpan={7} style={{ textAlign: "center" }}>
-                <Button
-                  variant="solid"
-                  color="primary"
-                  size="lg"
-                  sx={{
-                    marginRight: "1rem",
+              <th style={{ width: 48, textAlign: "center", padding: 12 }}>
+                <Checkbox
+                  indeterminate={
+                    selected.length > 0 && selected.length !== releaseList.length
+                  }
+                  checked={
+                    releaseList.length > 0 &&
+                    selected.length === releaseList.length
+                  }
+                  onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                    setSelection(
+                      event.target.checked
+                        ? releaseList.map((row) => row.id)
+                        : []
+                    );
                   }}
-                  onClick={loadNextPage}
-                >
-                  Load more
-                </Button>
-              </td>
+                  color={
+                    selected.length > 0 || selected.length === releaseList.length
+                      ? "primary"
+                      : undefined
+                  }
+                  sx={{ verticalAlign: "text-bottom" }}
+                />
+              </th>
+              <th style={{ width: 50, padding: 12 }}></th>
+              <th style={{ width: 180, padding: 12 }}>
+                <TableHeader textValue="Artist" />
+              </th>
+              <th style={{ width: 180, padding: 12 }}>
+                <TableHeader textValue="Title" />
+              </th>
+              <th style={{ width: 280, padding: 12 }}>
+                <TableHeader textValue="Code" />
+              </th>
+              <th style={{ width: 80, padding: 12 }}>
+                <TableHeader textValue="Plays" />
+              </th>
+              <th style={{ width: 120, padding: 12 }}></th>
             </tr>
-          )}
-        </tbody>
-      </Table>
+          </thead>
+          <tbody>
+            {releaseList.map((album) => (
+              <CatalogResult album={album} key={`result-${album.id}`} />
+            ))}
+
+            {!loading && hasMore && (
+              <tr>
+                <td colSpan={7} style={{ textAlign: "center" }}>
+                  <Button
+                    variant="solid"
+                    color="primary"
+                    size="lg"
+                    sx={{
+                      marginRight: "1rem",
+                    }}
+                    onClick={loadNextPage}
+                  >
+                    Load more
+                  </Button>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </Table>
+      )}
     </ResultsContainer>
   );
 }

--- a/src/components/experiences/modern/catalog/Results/__tests__/Results.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/Results.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import { createTestAlbum, createTestArtist } from "@/lib/test-utils";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/dashboard/catalog",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useShowControl: () => ({ live: false }),
+  useQueue: () => ({ addToQueue: vi.fn() }),
+}));
+
+vi.mock("@/src/hooks/binHooks", () => ({
+  useAddToBin: () => ({ addToBin: vi.fn(), loading: false }),
+  useRemoveFromBin: () => ({ removeFromBin: vi.fn(), loading: false }),
+  useBin: () => ({ bin: [], loading: false, isSuccess: true, isError: false }),
+}));
+
+const hookState = {
+  search: {
+    selected: [] as number[],
+    setSelection: vi.fn(),
+    hasActiveQuery: false,
+    clearSelection: vi.fn(),
+  },
+  results: {
+    results: [] as ReturnType<typeof createTestAlbum>[],
+    total: 0,
+    isLoading: false,
+    hasMore: false,
+    loadNextPage: vi.fn(),
+  },
+};
+
+vi.mock("@/src/hooks/catalogHooks", () => ({
+  useCatalogQuerySearch: () => hookState.search,
+  useCatalogQueryResults: () => hookState.results,
+}));
+
+import Results from "../Results";
+
+function setHookState(overrides: {
+  hasActiveQuery?: boolean;
+  isLoading?: boolean;
+  results?: ReturnType<typeof createTestAlbum>[];
+  total?: number;
+}) {
+  hookState.search.hasActiveQuery = overrides.hasActiveQuery ?? false;
+  hookState.results.isLoading = overrides.isLoading ?? false;
+  hookState.results.results = overrides.results ?? [];
+  hookState.results.total = overrides.total ?? 0;
+}
+
+describe("Catalog Results status line", () => {
+  beforeEach(() => {
+    setHookState({});
+  });
+
+  it("renders 'Searching...' while a search is in flight", () => {
+    setHookState({ hasActiveQuery: true, isLoading: true });
+    renderWithProviders(<Results color="primary" />);
+    expect(screen.getByText("Searching...")).toBeDefined();
+  });
+
+  it("renders 'Found N results' once results land (plural)", () => {
+    const albums = [
+      createTestAlbum({
+        title: "DOGA",
+        artist: createTestArtist({ name: "Juana Molina", lettercode: "RO", numbercode: 42 }),
+      }),
+      createTestAlbum({
+        title: "Moon Pix",
+        artist: createTestArtist({ name: "Cat Power", lettercode: "RO", numbercode: 23 }),
+      }),
+    ];
+    setHookState({ hasActiveQuery: true, isLoading: false, results: albums, total: 2 });
+    renderWithProviders(<Results color="primary" />);
+    expect(screen.getByText("Found 2 results")).toBeDefined();
+  });
+
+  it("renders 'Found 1 result' (singular) when total is 1", () => {
+    const albums = [
+      createTestAlbum({
+        title: "On Your Own Love Again",
+        artist: createTestArtist({ name: "Jessica Pratt", lettercode: "RO", numbercode: 112 }),
+      }),
+    ];
+    setHookState({ hasActiveQuery: true, isLoading: false, results: albums, total: 1 });
+    renderWithProviders(<Results color="primary" />);
+    expect(screen.getByText("Found 1 result")).toBeDefined();
+  });
+
+  it("renders 'No results found' when the search completes with zero matches", () => {
+    setHookState({ hasActiveQuery: true, isLoading: false, results: [], total: 0 });
+    renderWithProviders(<Results color="primary" />);
+    expect(screen.getByText("No results found")).toBeDefined();
+  });
+
+  it("renders no status line at all when there is no active query", () => {
+    setHookState({ hasActiveQuery: false });
+    renderWithProviders(<Results color="primary" />);
+    expect(screen.queryByText("Searching...")).toBeNull();
+    expect(screen.queryByText("No results found")).toBeNull();
+    expect(screen.queryByText(/^Found /)).toBeNull();
+  });
+});

--- a/src/components/experiences/modern/catalog/Results/__tests__/Results.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/Results.test.tsx
@@ -35,6 +35,7 @@ const hookState = {
     results: [] as ReturnType<typeof createTestAlbum>[],
     total: 0,
     isLoading: false,
+    isError: false,
     hasMore: false,
     loadNextPage: vi.fn(),
   },
@@ -50,17 +51,20 @@ import Results from "../Results";
 function setHookState(overrides: {
   hasActiveQuery?: boolean;
   isLoading?: boolean;
+  isError?: boolean;
   results?: ReturnType<typeof createTestAlbum>[];
   total?: number;
 }) {
   hookState.search.hasActiveQuery = overrides.hasActiveQuery ?? false;
   hookState.results.isLoading = overrides.isLoading ?? false;
+  hookState.results.isError = overrides.isError ?? false;
   hookState.results.results = overrides.results ?? [];
   hookState.results.total = overrides.total ?? 0;
 }
 
 describe("Catalog Results status line", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     setHookState({});
   });
 
@@ -102,6 +106,19 @@ describe("Catalog Results status line", () => {
     setHookState({ hasActiveQuery: true, isLoading: false, results: [], total: 0 });
     renderWithProviders(<Results color="primary" />);
     expect(screen.getByText("No results found")).toBeDefined();
+  });
+
+  it("renders an error message when the query errors", () => {
+    setHookState({
+      hasActiveQuery: true,
+      isLoading: false,
+      isError: true,
+      results: [],
+      total: 0,
+    });
+    renderWithProviders(<Results color="primary" />);
+    expect(screen.getByText("Search failed. Please try again.")).toBeDefined();
+    expect(screen.queryByText("No results found")).toBeNull();
   });
 
   it("renders no status line at all when there is no active query", () => {


### PR DESCRIPTION
## Summary

- The modern Card Catalog `<CircularProgress>` snapped back to frame zero on every keystroke. Root cause: throttled-search drain effect in `useCatalogQueryResults` (`src/hooks/catalogHooks.ts:235-271`) flips `isFetching` false→true across a single render between requests, which unmounts and remounts the spinner each keystroke and restarts its CSS keyframes animation.
- Replace the spinner with a `<Typography level="body-sm">` status line above the table — `"Searching…"` / `"Found N results"` / `"No results found"` — mirroring `PlaylistSearchContainer.tsx:38-43`. String content changes don't reset animations.
- Gate the `<Table>` on `releaseList.length > 0` (mirrors `PlaylistSearchContainer.tsx:51`) instead of `!loading`. The two surfaces now follow the same shape.

Closes #585

## Test plan

- [ ] `npm run dev`, sign in as `test_dj1`, open Card Catalog (modern)
- [ ] Type a 2+ character query and continue adding characters — confirm no snapping/restarting spinner; status text reads "Searching…" between requests
- [ ] Confirm "Found N results" appears once a response lands
- [ ] Confirm "No results found" appears for a query with no matches
- [ ] Confirm Playlist Archive search is unchanged
- [ ] `npm run test:run` — unit tests stay green
- [ ] `npx tsc --noEmit` — typecheck passes
- [ ] `npm run build` — Next.js build succeeds