### PR TITLE
fix(flowsheet): require song title on all submission paths

### DIFF
--- a/src/hooks/flowsheetHooks.test.tsx
+++ b/src/hooks/flowsheetHooks.test.tsx
@@ -141,6 +141,14 @@ vi.mock("@/lib/features/flowsheet/conversions", () => ({
   })),
 }));
 
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
 const createWrapper = () =>
   createHookWrapper({ flowsheet: flowsheetSlice, catalog: catalogSlice });
 
@@ -966,8 +974,27 @@ describe("flowsheetHooks", () => {
     });
 
     it("should call handleSubmit and add to flowsheet when ctrl is not pressed", () => {
+      // Preload a song title — handleSubmit now requires it (covers the
+      // row-click bypass of the form's HTML5 validation; see the
+      // "song-title validation" describe block below).
+      const wrapper = createHookWrapper(
+        { flowsheet: flowsheetSlice },
+        {
+          flowsheet: {
+            ...flowsheetSlice.getInitialState(),
+            search: {
+              ...flowsheetSlice.getInitialState().search,
+              query: {
+                ...flowsheetSlice.getInitialState().search.query,
+                song: "la paradoja",
+              },
+            },
+          },
+        }
+      );
+
       const { result } = renderHook(() => useFlowsheetSubmit(), {
-        wrapper: createWrapper(),
+        wrapper,
       });
 
       act(() => {
@@ -1213,6 +1240,91 @@ describe("flowsheetHooks", () => {
       expect(result.current.selectedResultData.artist).toBe("Fallback Artist");
       expect(result.current.selectedResultData.album).toBe("Fallback Album");
       expect(result.current.selectedResultData.label).toBe("Fallback Label");
+    });
+
+    describe("handleSubmit song-title validation", () => {
+      // Catalog/LML result rows wire `onClick={handleSubmit}` (see
+      // FlowsheetBackendResult.tsx), which sidesteps the form's HTML5
+      // `required` on the song input. handleSubmit must reject empty
+      // song titles on every submission path.
+      const mkPreloaded = (song: string) => ({
+        flowsheet: {
+          ...flowsheetSlice.getInitialState(),
+          search: {
+            ...flowsheetSlice.getInitialState().search,
+            selectedResult: 0,
+            query: {
+              song,
+              artist: "Juana Molina",
+              album: "DOGA",
+              label: "Sonamos",
+              request: false,
+            },
+          },
+        },
+      });
+
+      it("rejects submission when song is empty and does not call addToFlowsheet", async () => {
+        const wrapper = createHookWrapper(
+          { flowsheet: flowsheetSlice },
+          mkPreloaded("")
+        );
+
+        const { result } = renderHook(() => useFlowsheetSubmit(), {
+          wrapper,
+        });
+
+        await act(async () => {
+          await result.current.handleSubmit({
+            preventDefault: vi.fn(),
+          } as unknown as React.FormEvent);
+        });
+
+        expect(mockAddToFlowsheet).not.toHaveBeenCalled();
+        expect(mockToastError).toHaveBeenCalledWith(
+          expect.stringMatching(/song title is required/i)
+        );
+      });
+
+      it("rejects submission when song is whitespace-only", async () => {
+        const wrapper = createHookWrapper(
+          { flowsheet: flowsheetSlice },
+          mkPreloaded("   ")
+        );
+
+        const { result } = renderHook(() => useFlowsheetSubmit(), {
+          wrapper,
+        });
+
+        await act(async () => {
+          await result.current.handleSubmit({
+            preventDefault: vi.fn(),
+          } as unknown as React.FormEvent);
+        });
+
+        expect(mockAddToFlowsheet).not.toHaveBeenCalled();
+        expect(mockToastError).toHaveBeenCalled();
+      });
+
+      it("submits normally when song is present", async () => {
+        const wrapper = createHookWrapper(
+          { flowsheet: flowsheetSlice },
+          mkPreloaded("la paradoja")
+        );
+
+        const { result } = renderHook(() => useFlowsheetSubmit(), {
+          wrapper,
+        });
+
+        await act(async () => {
+          await result.current.handleSubmit({
+            preventDefault: vi.fn(),
+          } as unknown as React.FormEvent);
+        });
+
+        expect(mockAddToFlowsheet).toHaveBeenCalledTimes(1);
+        expect(mockToastError).not.toHaveBeenCalled();
+      });
     });
 
     it("should return selectedEntry when selectedResult > 0 and results exist", () => {

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -496,6 +496,13 @@ export const useFlowsheetSubmit = () => {
   const handleSubmit = useCallback(
     async (e: FormEvent) => {
       e.preventDefault();
+      // Guard required fields here because clicking a search result row
+      // bypasses the form's HTML5 `required` validation (the row's onClick
+      // calls handleSubmit directly instead of submitting the form).
+      if (!(selectedResultData.song ?? "").trim()) {
+        toast.error("Song title is required");
+        return;
+      }
       if (ctrlKeyPressed) {
         addToQueue(selectedResultData);
         dispatch(flowsheetSlice.actions.resetSearch());


### PR DESCRIPTION
## Summary

- A DJ can currently add a flowsheet entry with no song title by typing an artist and clicking a release row in the search dropdown.
- The form's HTML5 `required` on the song input only fires for Enter / submit-button paths; each search-result row in [`FlowsheetBackendResult.tsx:50`](https://github.com/WXYC/dj-site/blob/main/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx#L50) wires `onClick={handleSubmit}` directly, bypassing constraint validation.
- Guards inside `handleSubmit` in `useFlowsheetSubmit` (`src/hooks/flowsheetHooks.ts`): if `selectedResultData.song` is empty/whitespace, surface `toast.error("Song title is required")` and return before either the queue or the add-to-flowsheet path. Catches every submission path (row click, Enter, submit button, Ctrl+Enter queue) in one place.

Closes #587

## Test plan

- [ ] Run `npm run test:run -- src/hooks/flowsheetHooks.test.tsx` — new `handleSubmit song-title validation` describe block + the existing 71 tests pass (74 total).
- [ ] Manually verify in dev: go live, type only an artist (e.g. `Juana Molina`), click a release row from the dropdown — confirm toast appears, no entry is added, song input retains focus expectation.
- [ ] Type a full artist + song + click a release row — confirm entry is added as before.
- [ ] Ctrl+click / Ctrl+Enter on a result with empty song — confirm queue path is also blocked.
- [ ] Rotation mode: pick a bin + release, leave song blank, submit — confirm rejection.