### PR TITLE
fix(flowsheet): Ctrl+Enter reliably adds to queue (read modifier from ref)

### DIFF
--- a/src/hooks/flowsheetHooks.test.tsx
+++ b/src/hooks/flowsheetHooks.test.tsx
@@ -1055,9 +1055,10 @@ describe("flowsheetHooks", () => {
       expect(result.current.ctrlKeyPressed).toBe(false);
     });
 
+    // Dispatching keydown without an act() wrap leaves the React state
+    // uncommitted before handleSubmit fires — the same race the production
+    // form's implicit submit exposes when Ctrl+Enter is pressed quickly.
     it("routes submission to queue even when the keydown state hasn't been observed yet", () => {
-      // Preload a song title so the song-title guard doesn't short-circuit
-      // before the queue branch is reached.
       const wrapper = createHookWrapper(
         { flowsheet: flowsheetSlice },
         {
@@ -1078,10 +1079,6 @@ describe("flowsheetHooks", () => {
 
       const { result } = renderHook(() => useFlowsheetSubmit(), { wrapper });
 
-      // Dispatch keydown synchronously (no act wrap), then immediately submit.
-      // This simulates the real-world race where the user presses Ctrl+Enter
-      // fast enough that React hasn't committed the setCtrlKeyPressed update
-      // before the form's implicit submit fires.
       document.dispatchEvent(new KeyboardEvent("keydown", { key: "Control" }));
 
       act(() => {
@@ -1090,9 +1087,6 @@ describe("flowsheetHooks", () => {
         } as unknown as React.FormEvent);
       });
 
-      // If the modifier were read from React state, the stale closure would
-      // see ctrlKeyPressed === false and call addToFlowsheet. Reading from
-      // the ref avoids that race.
       expect(mockAddToFlowsheet).not.toHaveBeenCalled();
     });
 

--- a/src/hooks/flowsheetHooks.test.tsx
+++ b/src/hooks/flowsheetHooks.test.tsx
@@ -1039,6 +1039,63 @@ describe("flowsheetHooks", () => {
       // The dispatch should have been called with the queue action
     });
 
+    it("treats Meta (Cmd) keydown the same as Control", () => {
+      const { result } = renderHook(() => useFlowsheetSubmit(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "Meta" }));
+      });
+      expect(result.current.ctrlKeyPressed).toBe(true);
+
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent("keyup", { key: "Meta" }));
+      });
+      expect(result.current.ctrlKeyPressed).toBe(false);
+    });
+
+    it("routes submission to queue even when the keydown state hasn't been observed yet", () => {
+      // Preload a song title so the song-title guard doesn't short-circuit
+      // before the queue branch is reached.
+      const wrapper = createHookWrapper(
+        { flowsheet: flowsheetSlice },
+        {
+          flowsheet: {
+            ...flowsheetSlice.getInitialState(),
+            search: {
+              ...flowsheetSlice.getInitialState().search,
+              query: {
+                ...flowsheetSlice.getInitialState().search.query,
+                song: "la paradoja",
+                artist: "Juana Molina",
+                album: "DOGA",
+              },
+            },
+          },
+        }
+      );
+
+      const { result } = renderHook(() => useFlowsheetSubmit(), { wrapper });
+
+      // Dispatch keydown synchronously (no act wrap), then immediately submit.
+      // This simulates the real-world race where the user presses Ctrl+Enter
+      // fast enough that React hasn't committed the setCtrlKeyPressed update
+      // before the form's implicit submit fires.
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Control" }));
+
+      act(() => {
+        result.current.handleSubmit({
+          preventDefault: vi.fn(),
+        } as unknown as React.FormEvent);
+      });
+
+      // If the modifier were read from React state, the stale closure would
+      // see ctrlKeyPressed === false and call addToFlowsheet. Reading from
+      // the ref avoids that race.
+      expect(mockAddToFlowsheet).not.toHaveBeenCalled();
+    });
+
     it("should include selectedEntry values in selectedResultData when selectedResult > 0", () => {
       // Mock search results with an album entry
       const mockAlbum = createTestAlbum({

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -25,7 +25,7 @@ import {
 import type { RootState } from "@/lib/store";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import type { FormEvent } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useRegistry } from "./authenticationHooks";
 import { useBinResults } from "./binHooks";
@@ -402,6 +402,13 @@ export const useQueue = () => {
 };
 
 export const useFlowsheetSubmit = () => {
+  // Track modifier state with a ref so handleSubmit reads the current value
+  // synchronously. useState alone races with the form's implicit submit:
+  // pressing Ctrl then Enter quickly fires the submit before React commits
+  // the setState, so the closure reads stale `false` and the entry lands in
+  // the flowsheet instead of the queue. The state mirror is kept for UI
+  // (button color / icon) feedback.
+  const queueModifierRef = useRef(false);
   const [ctrlKeyPressed, setCtrlKeyPressed] = useState(false);
 
   const { addToQueue } = useQueue();
@@ -409,14 +416,15 @@ export const useFlowsheetSubmit = () => {
   const dispatch = useAppDispatch();
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    if (e.key === "Control") {
-      e.preventDefault();
+    if (e.key === "Control" || e.key === "Meta") {
+      queueModifierRef.current = true;
       setCtrlKeyPressed(true);
     }
   }, []);
 
   const handleKeyUp = useCallback((e: KeyboardEvent) => {
-    if (e.key === "Control") {
+    if (e.key === "Control" || e.key === "Meta") {
+      queueModifierRef.current = false;
       setCtrlKeyPressed(false);
     }
   }, []);
@@ -503,7 +511,7 @@ export const useFlowsheetSubmit = () => {
         toast.error("Song title is required");
         return;
       }
-      if (ctrlKeyPressed) {
+      if (queueModifierRef.current) {
         addToQueue(selectedResultData);
         dispatch(flowsheetSlice.actions.resetSearch());
         return;
@@ -528,7 +536,6 @@ export const useFlowsheetSubmit = () => {
       }
     },
     [
-      ctrlKeyPressed,
       addToFlowsheet,
       addToQueue,
       selectedResultData,

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -402,12 +402,10 @@ export const useQueue = () => {
 };
 
 export const useFlowsheetSubmit = () => {
-  // Track modifier state with a ref so handleSubmit reads the current value
-  // synchronously. useState alone races with the form's implicit submit:
-  // pressing Ctrl then Enter quickly fires the submit before React commits
-  // the setState, so the closure reads stale `false` and the entry lands in
-  // the flowsheet instead of the queue. The state mirror is kept for UI
-  // (button color / icon) feedback.
+  // Ref drives the submit-path decision (synchronous read); the state mirror
+  // drives the button color/icon. Without the ref, a fast Ctrl+Enter races
+  // the form's implicit submit and lands the entry in the flowsheet because
+  // React hasn't committed setCtrlKeyPressed by the time handleSubmit fires.
   const queueModifierRef = useRef(false);
   const [ctrlKeyPressed, setCtrlKeyPressed] = useState(false);
 


### PR DESCRIPTION
Closes #590.

## Summary

- \`useFlowsheetSubmit\` tracked the Ctrl modifier through \`useState\` on a separate document keydown listener. Pressing Ctrl+Enter quickly fired the form's implicit submit before React committed \`setCtrlKeyPressed(true)\`, so \`handleSubmit\`'s closure read stale \`false\` and the entry landed in the flowsheet instead of the queue.
- Mirror the modifier into a \`useRef\` updated synchronously alongside the state. \`handleSubmit\` reads from the ref; \`ctrlKeyPressed\` state stays for the button color/icon.
- Accept \`Meta\` in addition to \`Control\` so Cmd+Enter works on macOS, where the hook is used daily.

## Test plan

- [x] \`npx vitest run src/hooks/flowsheetHooks.test.tsx\` — 76 pass (added 2 regression tests: Meta key parity, race-condition path that dispatches keydown without an \`act()\` wrap before submit)
- [x] \`npx vitest run src/components/experiences/modern/flowsheet/\` — 389 pass
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [ ] Manual: while live, type an entry in the flowsheet search bar, hold Ctrl (or Cmd), press Enter — entry should appear in the queue, not the flowsheet. Submit button icon/color should remain the green queue icon while the modifier is held.