### PR TITLE
feat(login): accept username or email in a single field

### DIFF
--- a/e2e/pages/dashboard.page.ts
+++ b/e2e/pages/dashboard.page.ts
@@ -131,7 +131,7 @@ export class DashboardPage {
     // Error pages have various headings but consistent body text
     await Promise.race([
       expect(this.page).toHaveURL(/.*\/login.*/, { timeout: 15000 }),
-      this.page.locator('input[name="email"]').waitFor({ state: "visible", timeout: 15000 }),
+      this.page.locator('input[name="identifier"]').waitFor({ state: "visible", timeout: 15000 }),
       this.page.locator('input[name="username"]').waitFor({ state: "visible", timeout: 15000 }),
       this.page.getByText("We couldn't find the resource you were looking for").waitFor({ state: "visible", timeout: 15000 }),
     ]);

--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -40,7 +40,7 @@ export class LoginPage {
     this.forgotPasswordLink = page.locator('button:has-text("Forgot?"), a:has-text("Forgot?")');
 
     // OTP form
-    this.otpEmailInput = page.locator('input[name="email"]');
+    this.otpEmailInput = page.locator('input[name="identifier"]');
     this.sendCodeButton = page.locator('button:has-text("Send login code")');
     this.switchToPasswordLink = page.getByRole("button", {
       name: "Sign in with password instead",
@@ -167,7 +167,7 @@ export class LoginPage {
 
   async expectLoginFormVisible(): Promise<void> {
     // The login page may show the OTP form or password form depending on state.
-    // Wait for either the username input or the OTP email input to appear.
+    // Wait for either form's identifier input to appear.
     await expect(this.usernameInput.or(this.otpEmailInput)).toBeVisible();
   }
 

--- a/e2e/tests/rbac/role-access.spec.ts
+++ b/e2e/tests/rbac/role-access.spec.ts
@@ -127,7 +127,7 @@ test.describe("Role-Based Access Control", () => {
       // App may redirect to login or show 404/error page for unauthenticated users
       await Promise.race([
         page.waitForURL("**/login**", { timeout: 10000 }),
-        page.locator('input[name="email"]').waitFor({ state: "visible", timeout: 10000 }),
+        page.locator('input[name="identifier"]').waitFor({ state: "visible", timeout: 10000 }),
         page.locator('input[name="username"]').waitFor({ state: "visible", timeout: 10000 }),
         page.getByText("We couldn't find the resource you were looking for").waitFor({ state: "visible", timeout: 10000 }),
       ]);
@@ -154,7 +154,7 @@ test.describe("Role-Based Access Control", () => {
     test("should allow access to login page", async ({ page }) => {
       await page.goto("/login");
       // The default login form is the OTP email form
-      await page.waitForSelector('input[name="email"]');
+      await page.waitForSelector('input[name="identifier"]');
       expect(page.url()).toContain("/login");
     });
   });

--- a/lib/features/authentication/client.ts
+++ b/lib/features/authentication/client.ts
@@ -2,6 +2,7 @@
 
 import { createAuthClient } from "better-auth/react"
 import { adminClient, emailOTPClient, usernameClient, jwtClient, organizationClient } from "better-auth/client/plugins"
+import { isValidEmail } from "@wxyc/shared/validation"
 
 // Client-side only - contains React hooks
 // This file should only be imported in client components
@@ -104,4 +105,29 @@ export function clearTokenCache(): void {
   cachedToken = null;
   cacheExpiry = 0;
   inflight = null;
+}
+
+/**
+ * Resolve a login identifier (username or email) to an email address.
+ * Returns the email when the username matches a user; returns the
+ * identifier unchanged when it already contains '@'; returns null when
+ * a username has no match. Rate-limited by the auth server.
+ */
+export async function lookupEmailByIdentifier(identifier: string): Promise<string | null> {
+  if (isValidEmail(identifier)) {
+    return identifier;
+  }
+
+  const response = await fetch(`${baseURL}/wxyc/lookup-email`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ identifier }),
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data = (await response.json()) as { email?: string | null };
+  return data.email ?? null;
 }

--- a/src/components/experiences/modern/Leftbar/LeftbarLogout.test.tsx
+++ b/src/components/experiences/modern/Leftbar/LeftbarLogout.test.tsx
@@ -5,9 +5,8 @@ import type { User } from "@/lib/features/authentication/types";
 import { Authorization } from "@/lib/features/admin/types";
 
 // Mock the useLogout hook
-const mockHandleLogout = vi.fn(async (e?: React.FormEvent<HTMLFormElement>): Promise<boolean> => {
+const mockHandleLogout = vi.fn(async (e?: React.FormEvent<HTMLFormElement>): Promise<void> => {
   e?.preventDefault();
-  return true;
 });
 vi.mock("@/src/hooks/authenticationHooks", () => ({
   useLogout: vi.fn(() => ({

--- a/src/components/experiences/modern/login/Forms/AuthBackButton.test.tsx
+++ b/src/components/experiences/modern/login/Forms/AuthBackButton.test.tsx
@@ -6,7 +6,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import { applicationSlice } from "@/lib/features/application/frontend";
 
 // Mock hooks
-const mockHandleLogout = vi.fn(() => Promise.resolve(true));
+const mockHandleLogout = vi.fn(() => Promise.resolve(undefined));
 const mockReplace = vi.fn();
 
 vi.mock("@/src/hooks/authenticationHooks", () => ({

--- a/src/components/experiences/modern/login/Forms/EmailOTPForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/EmailOTPForm.test.tsx
@@ -13,11 +13,11 @@ vi.mock("next/navigation", () => ({
 describe("EmailOTPForm", () => {
   const defaultProps = { onCodeSent: vi.fn() };
 
-  it("should render email input", () => {
+  it("should render identifier input", () => {
     renderWithProviders(<EmailOTPForm {...defaultProps} />);
 
-    expect(screen.getByText("Email")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("you@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Username or email")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Username or email")).toBeInTheDocument();
   });
 
   it("should render submit button", () => {
@@ -32,10 +32,10 @@ describe("EmailOTPForm", () => {
     expect(screen.getByRole("button", { name: "Send login code" })).toBeDisabled();
   });
 
-  it("should enable submit button when email is entered", async () => {
+  it("should enable submit button when identifier is entered", async () => {
     const { user } = renderWithProviders(<EmailOTPForm {...defaultProps} />);
 
-    await user.type(screen.getByPlaceholderText("you@example.com"), "dj@wxyc.org");
+    await user.type(screen.getByPlaceholderText("Username or email"), "jbromberg");
 
     expect(screen.getByRole("button", { name: "Send login code" })).not.toBeDisabled();
   });

--- a/src/components/experiences/modern/login/Forms/EmailOTPForm.tsx
+++ b/src/components/experiences/modern/login/Forms/EmailOTPForm.tsx
@@ -10,18 +10,18 @@ import { useState } from "react";
 export default function EmailOTPForm({
   onCodeSent,
 }: {
-  onCodeSent: (email: string) => void;
+  onCodeSent: (state: { identifier: string; email: string }) => void;
 }) {
   const dispatch = useAppDispatch();
   const { handleSendOTP, isLoading } = useOTPRequest();
-  const [email, setEmail] = useState("");
+  const [identifier, setIdentifier] = useState("");
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const trimmedEmail = email.trim();
+    const trimmedIdentifier = identifier.trim();
     try {
-      await handleSendOTP(trimmedEmail);
-      onCodeSent(trimmedEmail);
+      const { email } = await handleSendOTP(trimmedIdentifier);
+      onCodeSent({ identifier: trimmedIdentifier, email });
       dispatch(applicationSlice.actions.setAuthStage("otp-verify"));
     } catch {
       // Error already handled in hook
@@ -37,23 +37,24 @@ export default function EmailOTPForm({
   return (
     <form onSubmit={handleSubmit} method="post">
       <FormControl required>
-        <FormLabel>Email</FormLabel>
+        <FormLabel>Username or email</FormLabel>
         <Input
-          name="email"
-          type="email"
-          placeholder="you@example.com"
-          value={email}
+          name="identifier"
+          type="text"
+          placeholder="Username or email"
+          value={identifier}
           disabled={isLoading}
-          onChange={(event) => setEmail(event.target.value)}
+          onChange={(event) => setIdentifier(event.target.value)}
+          slotProps={{ input: { autoCapitalize: "none", autoCorrect: "off" } }}
         />
       </FormControl>
       <Typography level="body-xs" sx={{ mt: 1 }}>
-        We&apos;ll send a 6-digit code to your email.
+        We&apos;ll send a 6-digit code to your registered email.
       </Typography>
       <Button
         type="submit"
         loading={isLoading}
-        disabled={isLoading || !email.trim()}
+        disabled={isLoading || !identifier.trim()}
         sx={{ mt: 2 }}
         fullWidth
       >

--- a/src/components/experiences/modern/login/Forms/LoginFormSwitcher.test.tsx
+++ b/src/components/experiences/modern/login/Forms/LoginFormSwitcher.test.tsx
@@ -49,7 +49,7 @@ describe("LoginFormSwitcher", () => {
   it("should render password form for password stage", () => {
     renderWithAuthStage("password");
 
-    expect(screen.getByText("Username")).toBeInTheDocument();
+    expect(screen.getByText("Username or email")).toBeInTheDocument();
     expect(screen.getByText("Password")).toBeInTheDocument();
   });
 });

--- a/src/components/experiences/modern/login/Forms/LoginFormSwitcher.tsx
+++ b/src/components/experiences/modern/login/Forms/LoginFormSwitcher.tsx
@@ -4,6 +4,7 @@ import { applicationSlice } from "@/lib/features/application/frontend";
 import { getPreferredLoginMethod } from "@/lib/features/application/login-method-storage";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import WelcomeQuotes from "@/src/components/experiences/modern/login/Quotes/Welcome";
+import { isValidEmail } from "@wxyc/shared/validation";
 import { useLayoutEffect, useRef, useState } from "react";
 import EmailOTPForm from "./EmailOTPForm";
 import OTPCodeForm from "./OTPCodeForm";
@@ -12,7 +13,7 @@ import UserPasswordForm from "./UserPasswordForm";
 export default function LoginFormSwitcher() {
   const dispatch = useAppDispatch();
   const authStage = useAppSelector(applicationSlice.selectors.getAuthStage);
-  const [otpEmail, setOtpEmail] = useState("");
+  const [otpState, setOtpState] = useState<{ identifier: string; email: string }>({ identifier: "", email: "" });
   const hasSyncedRef = useRef(false);
 
   // Sync before paint so the correct form renders without a flash.
@@ -28,10 +29,14 @@ export default function LoginFormSwitcher() {
   }, [authStage, dispatch]);
 
   if (authStage === "otp-verify") {
+    const displayTarget = isValidEmail(otpState.identifier)
+      ? otpState.identifier
+      : "your registered email";
     return (
       <OTPCodeForm
-        email={otpEmail}
-        onChangeEmail={() => dispatch(applicationSlice.actions.setAuthStage("otp-email"))}
+        email={otpState.email}
+        displayTarget={displayTarget}
+        onChangeIdentifier={() => dispatch(applicationSlice.actions.setAuthStage("otp-email"))}
       />
     );
   }
@@ -49,7 +54,7 @@ export default function LoginFormSwitcher() {
   return (
     <>
       <WelcomeQuotes />
-      <EmailOTPForm onCodeSent={setOtpEmail} />
+      <EmailOTPForm onCodeSent={setOtpState} />
     </>
   );
 }

--- a/src/components/experiences/modern/login/Forms/OTPCodeForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/OTPCodeForm.test.tsx
@@ -13,13 +13,27 @@ vi.mock("next/navigation", () => ({
 describe("OTPCodeForm", () => {
   const defaultProps = {
     email: "dj@wxyc.org",
-    onChangeEmail: vi.fn(),
+    displayTarget: "dj@wxyc.org",
+    onChangeIdentifier: vi.fn(),
   };
 
-  it("should display the email address", () => {
+  it("should display the displayTarget verbatim", () => {
     renderWithProviders(<OTPCodeForm {...defaultProps} />);
 
     expect(screen.getByText("dj@wxyc.org")).toBeInTheDocument();
+  });
+
+  it("should not leak the resolved email when displayTarget is a placeholder", () => {
+    renderWithProviders(
+      <OTPCodeForm
+        email="jbromberg@wxyc.org"
+        displayTarget="your registered email"
+        onChangeIdentifier={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("jbromberg@wxyc.org")).not.toBeInTheDocument();
+    expect(screen.getByText("your registered email")).toBeInTheDocument();
   });
 
   it("should render code input", () => {
@@ -57,11 +71,11 @@ describe("OTPCodeForm", () => {
     expect(screen.getByPlaceholderText("000000")).toHaveValue("123");
   });
 
-  it("should render resend and change email links", () => {
+  it("should render resend and change-account links", () => {
     renderWithProviders(<OTPCodeForm {...defaultProps} />);
 
     expect(screen.getByRole("button", { name: "Resend code" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Try a different email" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try a different account" })).toBeInTheDocument();
   });
 
   it("should render as a form with post method", () => {

--- a/src/components/experiences/modern/login/Forms/OTPCodeForm.tsx
+++ b/src/components/experiences/modern/login/Forms/OTPCodeForm.tsx
@@ -6,10 +6,12 @@ import { useState } from "react";
 
 export default function OTPCodeForm({
   email,
-  onChangeEmail,
+  displayTarget,
+  onChangeIdentifier,
 }: {
   email: string;
-  onChangeEmail: () => void;
+  displayTarget: string;
+  onChangeIdentifier: () => void;
 }) {
   const { handleVerifyOTP, handleResendOTP, isLoading } = useOTPVerify();
   const [otp, setOtp] = useState("");
@@ -27,7 +29,7 @@ export default function OTPCodeForm({
   return (
     <form onSubmit={handleSubmit} method="post">
       <Typography level="body-sm" sx={{ mb: 2 }}>
-        Code sent to <strong>{email}</strong>
+        Code sent to <strong>{displayTarget}</strong>
       </Typography>
       <FormControl required>
         <FormLabel>Login code</FormLabel>
@@ -63,10 +65,10 @@ export default function OTPCodeForm({
         <Link
           component="button"
           type="button"
-          onClick={onChangeEmail}
+          onClick={onChangeIdentifier}
           disabled={isLoading}
         >
-          Try a different email
+          Try a different account
         </Link>
       </Typography>
     </form>

--- a/src/components/experiences/modern/login/Forms/UserPasswordForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/UserPasswordForm.test.tsx
@@ -12,10 +12,10 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("UserPasswordForm", () => {
-  it("should render username and password fields", () => {
+  it("should render identifier and password fields", () => {
     renderWithProviders(<UserPasswordForm />);
 
-    expect(screen.getByText("Username")).toBeInTheDocument();
+    expect(screen.getByText("Username or email")).toBeInTheDocument();
     expect(screen.getByText("Password")).toBeInTheDocument();
   });
 
@@ -40,7 +40,7 @@ describe("UserPasswordForm", () => {
   it("should enable submit button when both fields have values", async () => {
     const { user } = renderWithProviders(<UserPasswordForm />);
 
-    const usernameInput = screen.getByPlaceholderText("Username");
+    const usernameInput = screen.getByPlaceholderText("Username or email");
     const passwordInput = screen.getByPlaceholderText("Enter your password");
 
     await user.type(usernameInput, "testuser");
@@ -52,7 +52,7 @@ describe("UserPasswordForm", () => {
   it("should keep submit button disabled with only username", async () => {
     const { user } = renderWithProviders(<UserPasswordForm />);
 
-    const usernameInput = screen.getByPlaceholderText("Username");
+    const usernameInput = screen.getByPlaceholderText("Username or email");
     await user.type(usernameInput, "testuser");
 
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();

--- a/src/components/experiences/modern/login/Forms/UserPasswordForm.tsx
+++ b/src/components/experiences/modern/login/Forms/UserPasswordForm.tsx
@@ -21,8 +21,8 @@ export default function UserPasswordForm() {
     <form onSubmit={handleLogin} method="post">
       <RequiredBox
         name="username"
-        title="Username"
-        placeholder="Username"
+        title="Username or email"
+        placeholder="Username or email"
         type="text"
         disabled={authenticating}
       />

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -28,7 +28,10 @@ const mockUpdateUser = vi.fn();
 const mockChangePassword = vi.fn();
 const mockGetSession = vi.fn();
 const mockSignInUsername = vi.fn();
+const mockSignInEmail = vi.fn();
 const mockSignInEmailOtp = vi.fn();
+const mockSendVerificationOtp = vi.fn();
+const mockLookupEmailByIdentifier = vi.fn();
 vi.mock("@/lib/features/authentication/client", () => ({
   authClient: {
     updateUser: (...args: any[]) => mockUpdateUser(...args),
@@ -36,10 +39,15 @@ vi.mock("@/lib/features/authentication/client", () => ({
     getSession: (...args: any[]) => mockGetSession(...args),
     signIn: {
       username: (...args: any[]) => mockSignInUsername(...args),
+      email: (...args: any[]) => mockSignInEmail(...args),
       emailOtp: (...args: any[]) => mockSignInEmailOtp(...args),
+    },
+    emailOtp: {
+      sendVerificationOtp: (...args: any[]) => mockSendVerificationOtp(...args),
     },
     signOut: vi.fn(),
   },
+  lookupEmailByIdentifier: (...args: any[]) => mockLookupEmailByIdentifier(...args),
 }));
 
 // Mock throwIfBetterAuthError
@@ -163,6 +171,108 @@ describe("authenticationHooks", () => {
       });
 
       expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
+    });
+
+    it("routes to signIn.username when the identifier has no @", async () => {
+      mockSignInUsername.mockResolvedValue({ data: { user: { id: "user-1" } } });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "jbromberg" },
+          password: { value: "password123" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleLogin(form);
+      });
+
+      expect(mockSignInUsername).toHaveBeenCalledWith({
+        username: "jbromberg",
+        password: "password123",
+      });
+      expect(mockSignInEmail).not.toHaveBeenCalled();
+    });
+
+    it("routes to signIn.email when the identifier contains @", async () => {
+      mockSignInEmail.mockResolvedValue({ data: { user: { id: "user-1" } } });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "jbromberg@wxyc.org" },
+          password: { value: "password123" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleLogin(form);
+      });
+
+      expect(mockSignInEmail).toHaveBeenCalledWith({
+        email: "jbromberg@wxyc.org",
+        password: "password123",
+      });
+      expect(mockSignInUsername).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("useOTPRequest", () => {
+    it("resolves a username via lookup before calling sendVerificationOtp", async () => {
+      mockLookupEmailByIdentifier.mockResolvedValue("jbromberg@wxyc.org");
+      mockSendVerificationOtp.mockResolvedValue({ data: {} });
+
+      const { useOTPRequest } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useOTPRequest(), { wrapper: createWrapper() });
+
+      let returned: { email: string } | undefined;
+      await act(async () => {
+        returned = await result.current.handleSendOTP("jbromberg");
+      });
+
+      expect(mockLookupEmailByIdentifier).toHaveBeenCalledWith("jbromberg");
+      expect(mockSendVerificationOtp).toHaveBeenCalledWith({
+        email: "jbromberg@wxyc.org",
+        type: "sign-in",
+      });
+      expect(returned).toEqual({ email: "jbromberg@wxyc.org" });
+    });
+
+    it("passes an email identifier through to sendVerificationOtp unchanged", async () => {
+      mockLookupEmailByIdentifier.mockResolvedValue("dj@wxyc.org");
+      mockSendVerificationOtp.mockResolvedValue({ data: {} });
+
+      const { useOTPRequest } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useOTPRequest(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.handleSendOTP("dj@wxyc.org");
+      });
+
+      expect(mockSendVerificationOtp).toHaveBeenCalledWith({
+        email: "dj@wxyc.org",
+        type: "sign-in",
+      });
+    });
+
+    it("throws when the lookup returns null", async () => {
+      mockLookupEmailByIdentifier.mockResolvedValue(null);
+
+      const { useOTPRequest } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useOTPRequest(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await expect(result.current.handleSendOTP("nobody")).rejects.toThrow();
+      });
+
+      expect(mockSendVerificationOtp).not.toHaveBeenCalled();
     });
   });
 

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -1,7 +1,8 @@
 "use client";
 
 import { authenticationSlice } from "@/lib/features/authentication/frontend";
-import { authClient } from "@/lib/features/authentication/client";
+import { authClient, lookupEmailByIdentifier } from "@/lib/features/authentication/client";
+import { isValidEmail } from "@wxyc/shared/validation";
 import {
   AuthenticatedUser,
   AuthenticationData,
@@ -32,13 +33,12 @@ export const useLogin = () => {
   const handleLogin = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     return execute(async () => {
-      const username = e.currentTarget.username.value;
+      const identifier = e.currentTarget.username.value;
       const password = e.currentTarget.password.value;
 
-      const result = (await authClient.signIn.username({
-        username,
-        password,
-      })) as { error?: unknown };
+      const result = isValidEmail(identifier)
+        ? ((await authClient.signIn.email({ email: identifier, password })) as { error?: unknown })
+        : ((await authClient.signIn.username({ username: identifier, password })) as { error?: unknown });
 
       if (result.error) {
         const errorMessage = result.error instanceof Error
@@ -78,21 +78,28 @@ export const useLogin = () => {
 export const useOTPRequest = () => {
   const { execute, isLoading, error } = useAsyncAction();
 
-  const handleSendOTP = async (email: string) => {
-    const success = await execute(async () => {
-      const result = await authClient.emailOtp.sendVerificationOtp({
+  const handleSendOTP = async (identifier: string): Promise<{ email: string }> => {
+    const result = await execute(async () => {
+      const email = await lookupEmailByIdentifier(identifier);
+      if (!email) {
+        throw new Error("No account matches that username or email.");
+      }
+
+      const sendResult = await authClient.emailOtp.sendVerificationOtp({
         email,
         type: "sign-in",
       });
 
-      throwIfBetterAuthError(result as any, "Failed to send login code");
+      throwIfBetterAuthError(sendResult as any, "Failed to send login code");
 
       toast.success("Login code sent! Check your email.");
+      return { email };
     }, "Failed to send login code. Please try again.");
 
-    if (!success) {
-      throw new Error(error?.message || "Failed to send login code");
+    if (!result) {
+      throw new Error("Failed to send login code");
     }
+    return result;
   };
 
   return { handleSendOTP, isLoading, error };

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -6,22 +6,23 @@ import { toast } from "sonner";
  *
  * The provided async function should throw on failure; useAsyncAction
  * catches the error, extracts a message, sets error state, and shows
- * a toast. Returns `true` on success, `false` on failure.
+ * a toast. Returns the function's resolved value on success, or
+ * `undefined` on failure — letting callers plumb a value through
+ * without closing over mutable state.
  */
 export function useAsyncAction() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
   const execute = useCallback(
-    async (
-      fn: () => Promise<void>,
+    async <T>(
+      fn: () => Promise<T>,
       fallbackMessage = "An unexpected error occurred",
-    ): Promise<boolean> => {
+    ): Promise<T | undefined> => {
       setIsLoading(true);
       setError(null);
       try {
-        await fn();
-        return true;
+        return await fn();
       } catch (err) {
         const message =
           err instanceof Error ? err.message : fallbackMessage;
@@ -31,7 +32,7 @@ export function useAsyncAction() {
         if (message.trim().length > 0) {
           toast.error(message);
         }
-        return false;
+        return undefined;
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
Closes #592

## Summary

Both the password form and the email-OTP form now take a unified "Username or email" input. The password hook sniffs `@` via `isValidEmail` and routes to `signIn.email` vs `signIn.username`; the OTP hook calls the new BS `/auth/wxyc/lookup-email` endpoint to resolve a username to an email before sending the code. When a username is typed, the verify form shows "Code sent to your registered email" rather than the resolved address.

`useAsyncAction.execute` is generalized to `Promise<T | undefined>` so the OTP hook can return the resolved email for the verify step (replaces a closed-over `let` hack and fixes a latent stale-state bug in the error path).

## Test plan

- [x] `npx vitest run` — 2996/2996 green (including new sniff coverage for `useLogin` and `useOTPRequest`)
- [x] `npx tsc --noEmit` clean (two existing logout-test mocks updated to match the new `execute` signature)
- [x] `npm run build` clean
- [x] Curl-verified the same-origin proxy: `POST http://localhost:3000/auth/wxyc/lookup-email` correctly forwards to BS

### Browser smoke checklist (run after merging BS#1039 and deploying auth)

- [ ] Password form: `test_dj1` + password → signs in
- [ ] Password form: `test_dj1@wxyc.org` + password → signs in (different route)
- [ ] Password form: `nobody` + anything → "Login failed" error
- [ ] OTP form: `test_dj1` → "Login code sent!" toast; verify form shows "your registered email"
- [ ] OTP form: `test_dj1@wxyc.org` → "Login code sent!" toast; verify form shows the email verbatim
- [ ] OTP form: `nobody` → "No account matches that username or email." error

## Dependencies

**Blocked by:** WXYC/Backend-Service#1039 — needs `POST /auth/wxyc/lookup-email` deployed before this merges, or the OTP-by-username flow 404s.

## Related

- Backend resolver: WXYC/Backend-Service#1038, WXYC/Backend-Service#1039