### PR TITLE
fix(rotation-entry): refetch on release pick + drop prefetch wave

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.refetch.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.refetch.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import {
+  renderWithProviders,
+  server,
+  TEST_BACKEND_URL,
+  createTestAlbumSearchResult,
+} from "@/lib/test-utils";
+import { rotationApi } from "@/lib/features/rotation/api";
+import RotationEntryFields from "./RotationEntryFields";
+
+// useFlowsheetSearch fans out into many RTK Query hooks (live show, bin,
+// catalog, rotation, LML). Mocking it here matches the sibling
+// RotationEntryFields.test.tsx pattern so this file only owns the rotation
+// surface. Refetch behavior is what's under test; the search-side effects of
+// release selection (the dispatch calls in handleSelectRelease) are not.
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useFlowsheetSearch: () => ({
+    setSearchOpen: vi.fn(),
+    getDisplayValue: () => "",
+    setSearchProperty: vi.fn(),
+    selectedIndex: 0,
+    selectedEntry: null,
+  }),
+}));
+
+const ROTATION_ID_OOIOO = 42;
+const ROTATION_ID_JESSICA_PRATT = 43;
+
+const ooioo = createTestAlbumSearchResult({
+  id: 7,
+  album_title: "OOIOO / Lightning Bolt Split",
+  artist_name: "OOIOO",
+  label: "Load Records",
+  rotation_id: ROTATION_ID_OOIOO,
+  rotation_bin: "H",
+});
+
+const jessicaPratt = createTestAlbumSearchResult({
+  id: 8,
+  album_title: "On Your Own Love Again",
+  artist_name: "Jessica Pratt",
+  label: "Drag City",
+  rotation_id: ROTATION_ID_JESSICA_PRATT,
+  rotation_bin: "H",
+});
+
+const trackForOoioo = {
+  position: "A1",
+  title: "OO I Oh",
+  duration: null,
+  artists: ["OOIOO"],
+};
+
+type TracksHandler = (rotationId: number) => unknown[];
+
+function mockRotationListAndTracks(handler: TracksHandler): {
+  trackRequestsFor: (rotationId: number) => number;
+} {
+  const callCounts = new Map<number, number>();
+  server.use(
+    // backendBaseQuery("library/rotation") + url="" resolves to
+    // `${TEST_BACKEND_URL}/library/rotation`. Match the trailing-slashed and
+    // unslashed forms both to be robust to fetchBaseQuery's URL joining.
+    http.get(`${TEST_BACKEND_URL}/library/rotation`, () =>
+      HttpResponse.json([ooioo, jessicaPratt])
+    ),
+    http.get(
+      `${TEST_BACKEND_URL}/library/rotation/:rotation_id/tracks`,
+      ({ params }) => {
+        const rotationId = Number(params.rotation_id);
+        callCounts.set(rotationId, (callCounts.get(rotationId) ?? 0) + 1);
+        return HttpResponse.json(handler(rotationId));
+      }
+    )
+  );
+  return {
+    trackRequestsFor: (rotationId) => callCounts.get(rotationId) ?? 0,
+  };
+}
+
+const selectBin = () => fireEvent.click(screen.getByRole("radio", { name: "H" }));
+
+const selectRelease = async (releaseId: number) => {
+  const trigger = await screen.findByTestId("rotation-release-trigger");
+  fireEvent.click(trigger);
+  fireEvent.click(
+    await screen.findByTestId(`rotation-release-option-${releaseId}`)
+  );
+};
+
+describe("RotationEntryFields — refetch on release pick (#589)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("re-queries when a release is picked, even if the cache already holds an empty tracklist from a prefetch", async () => {
+    // A prior prefetch wave under LML pressure cached `[]` for OOIOO's
+    // rotation_id (BS swallowed the LML timeout → `200 + []`). The picker
+    // must not trust that cached empty; it should re-issue the request when
+    // the DJ actually picks the release.
+    const { trackRequestsFor } = mockRotationListAndTracks(() => [trackForOoioo]);
+
+    const { store } = renderWithProviders(<RotationEntryFields disabled={false} />);
+    store.dispatch(
+      rotationApi.util.upsertQueryData("getRotationTracks", ROTATION_ID_OOIOO, [])
+    );
+
+    selectBin();
+    await selectRelease(ooioo.id);
+
+    await waitFor(() =>
+      expect(trackRequestsFor(ROTATION_ID_OOIOO)).toBeGreaterThanOrEqual(1)
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("track-picker-trigger")).toBeInTheDocument()
+    );
+  });
+
+  it("issues a separate fetch when the DJ switches to a different release in the same bin", async () => {
+    const tracksByRotation: Record<number, unknown[]> = {
+      [ROTATION_ID_OOIOO]: [trackForOoioo],
+      [ROTATION_ID_JESSICA_PRATT]: [
+        { position: "A1", title: "Wrong Hand", duration: null, artists: [] },
+      ],
+    };
+    const { trackRequestsFor } = mockRotationListAndTracks(
+      (rotationId) => tracksByRotation[rotationId] ?? []
+    );
+
+    renderWithProviders(<RotationEntryFields disabled={false} />);
+
+    selectBin();
+    await selectRelease(ooioo.id);
+    await waitFor(() => expect(trackRequestsFor(ROTATION_ID_OOIOO)).toBe(1));
+
+    await selectRelease(jessicaPratt.id);
+    await waitFor(() =>
+      expect(trackRequestsFor(ROTATION_ID_JESSICA_PRATT)).toBe(1)
+    );
+  });
+
+  it("recovers without a page reload when LML returns tracks on a subsequent pick", async () => {
+    // First call to OOIOO's rotation_id returns empty (LML still saturated);
+    // second call returns the real tracklist. Going back to OOIOO must
+    // re-fetch and render the dropdown, not serve the cached empty.
+    const responsesByRotation = new Map<number, unknown[][]>([
+      [ROTATION_ID_OOIOO, [[], [trackForOoioo]]],
+      [ROTATION_ID_JESSICA_PRATT, [[]]],
+    ]);
+    mockRotationListAndTracks((rotationId) => {
+      const queue = responsesByRotation.get(rotationId) ?? [];
+      return queue.shift() ?? [];
+    });
+
+    renderWithProviders(<RotationEntryFields disabled={false} />);
+
+    selectBin();
+    await selectRelease(ooioo.id);
+    // First pick: empty response, dropdown should not render.
+    await waitFor(() =>
+      expect(screen.queryByTestId("track-picker-trigger")).not.toBeInTheDocument()
+    );
+
+    // Switch away and back. Each arg change triggers a refetch.
+    await selectRelease(jessicaPratt.id);
+    await selectRelease(ooioo.id);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("track-picker-trigger")).toBeInTheDocument()
+    );
+  });
+});

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.refetch.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.refetch.test.tsx
@@ -60,9 +60,6 @@ function mockRotationListAndTracks(handler: TracksHandler): {
 } {
   const callCounts = new Map<number, number>();
   server.use(
-    // backendBaseQuery("library/rotation") + url="" resolves to
-    // `${TEST_BACKEND_URL}/library/rotation`. Match the trailing-slashed and
-    // unslashed forms both to be robust to fetchBaseQuery's URL joining.
     http.get(`${TEST_BACKEND_URL}/library/rotation`, () =>
       HttpResponse.json([ooioo, jessicaPratt])
     ),
@@ -158,12 +155,10 @@ describe("RotationEntryFields — refetch on release pick (#589)", () => {
 
     selectBin();
     await selectRelease(ooioo.id);
-    // First pick: empty response, dropdown should not render.
     await waitFor(() =>
       expect(screen.queryByTestId("track-picker-trigger")).not.toBeInTheDocument()
     );
 
-    // Switch away and back. Each arg change triggers a refetch.
     await selectRelease(jessicaPratt.id);
     await selectRelease(ooioo.id);
 

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -50,9 +50,15 @@ let mockTracksLoading = false;
 vi.mock("@/lib/features/rotation/api", async () => {
   // Keep rotationApi intact — lib/store.ts consumes it for the real store
   // that renderWithProviders wires up. Override only the two query hooks
-  // the component reads. Returning a minimal {data, isLoading} subset (vs.
-  // the full UseQueryHookResult) is fine because the component never reads
-  // refetch / fulfilledTimeStamp / etc.
+  // the component reads. Returning a minimal {data, isLoading, isFetching}
+  // subset is fine because the component never reads refetch /
+  // fulfilledTimeStamp / etc.
+  //
+  // Surface `isFetching` from the same source as `isLoading` — the component
+  // reads `isFetching` to keep the picker visible across refetches (BS#589),
+  // but at this tier we only have one "loading" knob to drive. Refetch-on-
+  // arg-change behavior is exercised in RotationEntryFields.refetch.test.tsx
+  // with MSW + real RTK Query.
   const actual = await vi.importActual<typeof import("@/lib/features/rotation/api")>(
     "@/lib/features/rotation/api"
   );
@@ -62,6 +68,7 @@ vi.mock("@/lib/features/rotation/api", async () => {
     useGetRotationTracksQuery: () => ({
       data: mockTracksData,
       isLoading: mockTracksLoading,
+      isFetching: mockTracksLoading,
     }),
   };
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -28,17 +28,13 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
 
   const { data: rotationData } = useGetRotationQuery();
 
-  // Fetch tracks when a release is selected (uses its rotation_id). Aliased
-  // `isFetching` to `tracksLoading` so the gate below reads as intent ("is a
-  // request in flight that should keep the picker visible") regardless of
-  // whether it's the first call or a refetch over stale cache.
-  //
-  // `refetchOnMountOrArgChange: true` forces a re-query on every release
-  // pick rather than trusting the RTK Query cache. The cache may hold
-  // `200 + []` from a swallowed LML timeout (BS `resolveRotationDiscogsReleaseViaLml`
-  // returns null on AbortError → controller emits `[]`); without forcing
-  // refetch the picker silently falls through to the free-text input
-  // (WXYC/dj-site#589).
+  // `refetchOnMountOrArgChange` forces a re-query on every release pick
+  // rather than trusting the RTK Query cache: the cache may hold `200 + []`
+  // from a swallowed LML timeout (BS `resolveRotationDiscogsReleaseViaLml`
+  // returns null on AbortError → controller emits `[]`), and without the
+  // forced refetch the picker silently falls through to the free-text input
+  // (WXYC/dj-site#589). Reading `isFetching` rather than `isLoading` keeps
+  // the dropdown visible during refetches over that stale-empty cache.
   const { data: tracks, isFetching: tracksLoading } = useGetRotationTracksQuery(
     selectedRelease?.rotation_id ?? 0,
     { skip: !selectedRelease?.rotation_id, refetchOnMountOrArgChange: true }

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -7,12 +7,11 @@ import {
   RotationTrack,
   useGetRotationQuery,
   useGetRotationTracksQuery,
-  useRotationPrefetch,
 } from "@/lib/features/rotation/api";
 import { useAppDispatch } from "@/lib/hooks";
 import { useFlowsheetSearch } from "@/src/hooks/flowsheetHooks";
 import { Divider } from "@mui/joy";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import FlowsheetSearchInput from "./FlowsheetSearchInput";
 import RotationBinSelector from "./RotationBinSelector";
 import RotationReleaseDropdown from "./RotationReleaseDropdown";
@@ -29,29 +28,26 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
 
   const { data: rotationData } = useGetRotationQuery();
 
-  // Fetch tracks when a release is selected (uses its rotation_id)
-  const { data: tracks, isLoading: tracksLoading } = useGetRotationTracksQuery(
+  // Fetch tracks when a release is selected (uses its rotation_id). Aliased
+  // `isFetching` to `tracksLoading` so the gate below reads as intent ("is a
+  // request in flight that should keep the picker visible") regardless of
+  // whether it's the first call or a refetch over stale cache.
+  //
+  // `refetchOnMountOrArgChange: true` forces a re-query on every release
+  // pick rather than trusting the RTK Query cache. The cache may hold
+  // `200 + []` from a swallowed LML timeout (BS `resolveRotationDiscogsReleaseViaLml`
+  // returns null on AbortError → controller emits `[]`); without forcing
+  // refetch the picker silently falls through to the free-text input
+  // (WXYC/dj-site#589).
+  const { data: tracks, isFetching: tracksLoading } = useGetRotationTracksQuery(
     selectedRelease?.rotation_id ?? 0,
-    { skip: !selectedRelease?.rotation_id }
+    { skip: !selectedRelease?.rotation_id, refetchOnMountOrArgChange: true }
   );
 
   const filteredReleases = useMemo(() => {
     if (!rotationData || !selectedBin) return [];
     return rotationData.filter((r) => r.rotation_bin === selectedBin);
   }, [rotationData, selectedBin]);
-
-  // Warm the tracklist cache for every release in the picked bin so the picker
-  // is instantaneous — tubafrenzy renders rotation track titles inline and DJs
-  // are used to seeing them with no perceptible delay. One bin is bounded
-  // (~30 releases) and LML's 3-tier cache absorbs the per-release LML fetches.
-  const prefetchRotationTracks = useRotationPrefetch("getRotationTracks");
-  useEffect(() => {
-    for (const release of filteredReleases) {
-      if (release.rotation_id) {
-        prefetchRotationTracks(release.rotation_id);
-      }
-    }
-  }, [filteredReleases, prefetchRotationTracks]);
 
   const handleSelectBin = useCallback(
     (bin: Rotation) => {


### PR DESCRIPTION
## Summary

Under LML cold-cache pressure, the rotation entry picker silently degraded to the free-text fallback across an entire bin once selected. Backend swallows LML timeouts as `200 + []` (by design — fast-fail UI flow per WXYC/Backend-Service#992), RTK Query cached that empty under each release's `rotation_id`, and the on-demand `useGetRotationTracksQuery` served the cached empty without any retry path. Switching to a different release served *that* release's cached-empty too, since the prefetch wave had warmed all ~30 releases in the bin.

- Add `refetchOnMountOrArgChange: true` to the on-demand hook so every release pick re-queries Backend, never trusting prefetched empties.
- Switch the local `tracksLoading` source from `isLoading` to `isFetching` so the dropdown stays visible (with the existing "Loading tracks…" spinner) during refetches over stale cache — that's the user-visible signal the issue's first acceptance criterion asks for.
- Remove the prefetch wave entirely. With the refetch in place, its cache value is ignored on every pick, leaving it as pure LML pressure — exactly the contributor to the failure mode it was meant to absorb. Backend additionally does not negative-cache the swallowed-timeout path, so prefetch waves under load hit the LML chokepoint afresh each time. Re-add behind a concurrency cap once LML cold-cache fan-out is healthy (WXYC/library-metadata-lookup#338).

## Behavior

| Cache state | Before | After |
|---|---|---|
| Prefetched empty (LML timed out) | Silent free-text, no retry | "Loading tracks…" spinner, then either dropdown or free-text |
| Prefetched populated | Instantaneous dropdown | Brief spinner, then dropdown (one extra round-trip) |
| Switch between two releases in same bin | Each release's cached empty served | Each release re-queries on pick |
| LML recovers between pick #1 and pick #2 | Page reload required | Picker recovers automatically on the next pick |

## Tests

- Existing `RotationEntryFields.test.tsx` (artist auto-fill, V/A credits) keeps its flat hook mock, with the mock now surfacing `isFetching` alongside `isLoading` so the gate semantics still match the component.
- New `RotationEntryFields.refetch.test.tsx` exercises the refetch behavior end-to-end with MSW + real RTK Query:
  - re-queries when a release is picked over a prefetched-empty cache entry
  - issues a separate fetch when the DJ switches to a different release in the same bin
  - recovers without a page reload when LML returns tracks on a subsequent pick

## Test plan

- [x] `npm run test:run -- src/components/experiences/modern/flowsheet/Search/` — all 156 tests pass (14 files)
- [x] `npx tsc --noEmit` — clean
- [ ] Local manual: open rotation picker against a backend with a stubbed slow LML; confirm spinner appears, refetch fires, and switching releases re-queries
- [ ] CI green

## Out of scope (deliberately)

- Backend-side wire-level distinction between "confirmed empty" and "swallowed timeout" (issue option 4). Defer; if this PR plus LML perf work don't close out the UX gap, file a Backend-Service ticket.
- Backend negative-cache for the swallowed-timeout path. Worth a follow-up Backend-Service ticket — independent of this fix, would reduce LML pressure for all consumers.
- Prefetch concurrency cap. Only relevant when prefetch is re-added post-LML#338.

Closes #589

## Related

- WXYC/Backend-Service#992 — 5s picker tier-3 timeout (closed). Makes the `200 + []` arrive faster, surfacing this bug.
- WXYC/Backend-Service#994 — 2026-05-21 LML monopolization incident. Original surfacing of the class of UX failure.
- WXYC/library-metadata-lookup#338 — LML cold-cache perf epic. Durable upstream fix that reduces how often the picker hits this surface.
- WXYC/dj-site#519 — prior precedent for hook-level defensive handling (`useGetRotationTracksQuery` 404 path).
- WXYC/dj-site#584 — sibling pattern on the flowsheet add path.