### PR TITLE
fix(rotation-picker): dedupe per-track artists + strip Discogs (N) disambig

### DIFF
--- a/lib/__tests__/features/rotation/normalize-track-artists.test.ts
+++ b/lib/__tests__/features/rotation/normalize-track-artists.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTrackArtists } from "@/lib/features/rotation/normalize-track-artists";
+
+describe("normalizeTrackArtists", () => {
+  it.each<[unknown[] | null | undefined, string[]]>([
+    // Same artist returned twice — the on-disk dupe pattern (LML release_track_artist
+    // has 6,973 such rows across 144 prod releases as of 2026-05-25) plus the
+    // Discogs same-name multi-role pattern ("Producer" + "Co-writer" on one track).
+    [["Warrior", "Warrior"], ["Warrior"]],
+    [["Miss Shiva", "Miss Shiva"], ["Miss Shiva"]],
+    [["Warrior", "Warrior", "Warrior"], ["Warrior"]],
+
+    // Discogs `(N)` disambig suffix is stripped before dedupe so "M.I.A. (2)" and
+    // "M.I.A. (2)" collapse, and so the suffix doesn't leak into the artist field.
+    [["M.I.A. (2)"], ["M.I.A."]],
+    [["M.I.A. (2)", "M.I.A. (2)"], ["M.I.A."]],
+    [["Dry Cleaning (2)", "Dry Cleaning"], ["Dry Cleaning"]],
+
+    // Whitespace differences collapse after trim.
+    [["Miss Shiva ", " Miss Shiva", "Miss Shiva"], ["Miss Shiva"]],
+
+    // Genuine multi-credit cases preserve order and both names.
+    [["Florence Shaw", "Tom Dowse"], ["Florence Shaw", "Tom Dowse"]],
+    [["Stereolab", "Nurse With Wound"], ["Stereolab", "Nurse With Wound"]],
+
+    // Empty / missing inputs degrade to empty array without throwing.
+    [[], []],
+    [null, []],
+    [undefined, []],
+    [["", "  ", "\t"], []],
+    [["", "Real Artist", ""], ["Real Artist"]],
+
+    // Defensive against malformed shapes from a partial-write LML row.
+    [[null as unknown as string, "Real"], ["Real"]],
+    [[undefined as unknown as string, "Real"], ["Real"]],
+    [[42 as unknown as string, "Real"], ["Real"]],
+    [[{} as unknown as string, "Real"], ["Real"]],
+  ])("normalizes %j → %j", (input, expected) => {
+    expect(normalizeTrackArtists(input)).toEqual(expected);
+  });
+
+  it("preserves first-occurrence order when duplicates are interleaved", () => {
+    expect(normalizeTrackArtists(["A", "B", "A", "C", "B"])).toEqual(["A", "B", "C"]);
+  });
+
+  it("returns a fresh array on every call (no shared mutable state)", () => {
+    const first = normalizeTrackArtists(["X"]);
+    const second = normalizeTrackArtists(["X"]);
+    expect(first).not.toBe(second);
+    expect(first).toEqual(second);
+  });
+});

--- a/lib/features/rotation/normalize-track-artists.ts
+++ b/lib/features/rotation/normalize-track-artists.ts
@@ -1,0 +1,42 @@
+// Discogs disambiguates two artists sharing a name with a parenthesized
+// numeric suffix (e.g. "M.I.A. (2)" for the rapper vs. the older artist).
+// LML's release_track_artist read path forwards the raw name, so the suffix
+// surfaces to dj-site verbatim. We strip it before display and before writing
+// to the Redux artist field — DJs don't want to see "(2)" in the flowsheet.
+const DISCOGS_DISAMBIG_SUFFIX = /\s*\(\d+\)\s*$/;
+
+/**
+ * Clean and dedupe a track's per-artist credits.
+ *
+ * Discogs returns artists per-track-credit (Producer, Co-writer, Member, etc.)
+ * with no role column on `release_track_artist`, so the same artist can appear
+ * multiple times — "Warrior, Warrior" reaches the dj-site for any track where
+ * the same person holds two roles. Compounding that, the LML cache table has
+ * no unique constraint (6,973 duplicate rows / 144 releases in prod as of
+ * 2026-05-25), so even a single-role artist can show up multiple times.
+ *
+ * This helper folds three normalizations the picker needs:
+ *  - strip Discogs `" (N)"` disambig suffix
+ *  - trim and drop empty entries
+ *  - dedupe by the cleaned name, preserving first-occurrence order
+ *
+ * Defensive against null/undefined/non-string entries so a malformed LML
+ * response can't crash the picker (V/A pre-`46c0c5f` partial-write rows
+ * occasionally surface unexpected shapes).
+ */
+export function normalizeTrackArtists(
+  raw: readonly unknown[] | null | undefined
+): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const name of raw) {
+    if (typeof name !== "string") continue;
+    const cleaned = name.replace(DISCOGS_DISAMBIG_SUFFIX, "").trim();
+    if (!cleaned) continue;
+    if (seen.has(cleaned)) continue;
+    seen.add(cleaned);
+    out.push(cleaned);
+  }
+  return out;
+}

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -228,5 +228,77 @@ describe("RotationEntryFields", () => {
         })
       );
     });
+
+    it("dedupes doubled per-track credits before writing to the artist field", () => {
+      // Reproduces the on-air-DJ report from 2026-05-25: V/A track artists
+      // arrive as ["Warrior", "Warrior"] (Discogs multi-role on a single
+      // person + on-disk LML cache duplicates) and used to land in the Redux
+      // artist field as "Warrior, Warrior". After normalization the field
+      // gets a single "Warrior".
+      mockTracksData = [
+        {
+          position: "A2",
+          title: "Warrior",
+          duration: null,
+          artists: ["Warrior", "Warrior"],
+        },
+      ];
+
+      const { store } = renderWithProviders(
+        <RotationEntryFields disabled={false} />
+      );
+      const dispatchSpy = vi.spyOn(store, "dispatch");
+      selectBinAndRelease();
+      selectTrack(0);
+
+      expect(artistValues(dispatchSpy)).toEqual(["OOIOO", "Warrior"]);
+    });
+
+    it("strips Discogs (N) disambig before writing to the artist field", () => {
+      // Prod LML serves disambig suffixes verbatim — "M.I.A. (2)" appears in
+      // the top-20 dup tuples (4× releases). Stripping in the dropdown display
+      // only (the prior behavior) left the suffix in the form field on submit.
+      mockTracksData = [
+        {
+          position: "A1",
+          title: "Galang",
+          duration: null,
+          artists: ["M.I.A. (2)"],
+        },
+      ];
+
+      const { store } = renderWithProviders(
+        <RotationEntryFields disabled={false} />
+      );
+      const dispatchSpy = vi.spyOn(store, "dispatch");
+      selectBinAndRelease();
+      selectTrack(0);
+
+      expect(artistValues(dispatchSpy)).toEqual(["OOIOO", "M.I.A."]);
+    });
+
+    it("falls back to the release-level artist when every per-track credit is malformed", () => {
+      // A partial-write LML cache row could surface [null, ""] as artists.
+      // normalizeTrackArtists returns [] for that shape; the auto-fill must
+      // be a no-op so the release-level artist (seeded by handleSelectRelease)
+      // stays in the field rather than being clobbered with an empty string.
+      mockTracksData = [
+        {
+          position: "A1",
+          title: "Ghost Track",
+          duration: null,
+          artists: [null as unknown as string, ""],
+        },
+      ];
+
+      const { store } = renderWithProviders(
+        <RotationEntryFields disabled={false} />
+      );
+      const dispatchSpy = vi.spyOn(store, "dispatch");
+      selectBinAndRelease();
+      selectTrack(0);
+
+      expect(artistValues(dispatchSpy)).toEqual(["OOIOO"]);
+    });
   });
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -3,6 +3,7 @@
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { Rotation } from "@/lib/features/rotation/types";
+import { normalizeTrackArtists } from "@/lib/features/rotation/normalize-track-artists";
 import {
   RotationTrack,
   useGetRotationQuery,
@@ -91,19 +92,23 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
     (track: RotationTrack) => {
       setSelectedTrack(track);
       setManualEntry(false);
-      dispatch(flowsheetSlice.actions.setSearchProperty({ name: "song", value: track.title }));
+      dispatch(flowsheetSlice.actions.setSearchProperty({ name: "song", value: track.title ?? "" }));
       // Auto-fill artist from per-track Discogs credits (surfaced by BS#944)
       // for V/A and split releases. For normal releases BS falls back to
       // [release.artist] so this just re-sets the value already seeded by
-      // handleSelectRelease. When credits are empty (Discogs has no per-track
-      // data) leave the release-level artist in place; mis-credited cases fall
-      // through to manual-entry mode (the existing escape hatch).
-      // Join separator mirrors buildArtistCredit in apps/backend/controllers/proxy.controller.ts.
-      if (track.artists.length > 0) {
+      // handleSelectRelease. `normalizeTrackArtists` strips the Discogs `(N)`
+      // disambig and dedupes — see its header for the LML cache duplication
+      // root cause. When credits are empty (Discogs has no per-track data, or
+      // every entry was malformed) leave the release-level artist in place;
+      // mis-credited cases fall through to manual-entry mode (the existing
+      // escape hatch). Join separator mirrors buildArtistCredit in
+      // apps/backend/controllers/proxy.controller.ts.
+      const credits = normalizeTrackArtists(track.artists);
+      if (credits.length > 0) {
         dispatch(
           flowsheetSlice.actions.setSearchProperty({
             name: "artist",
-            value: track.artists.join(", "),
+            value: credits.join(", "),
           })
         );
       }

--- a/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { normalizeTrackArtists } from "@/lib/features/rotation/normalize-track-artists";
 import { KeyboardArrowDown } from "@mui/icons-material";
 import { Box, CircularProgress, Sheet, Typography } from "@mui/joy";
 import { ClickAwayListener } from "@mui/material";
@@ -187,9 +188,7 @@ export default function TrackPickerDropdown<T extends TrackPickerEntry>({
             }}
           >
             {tracks.map((track, index) => {
-              const cleanArtists = track.artists
-                .map((a) => a.replace(/\s*\(\d+\)\s*$/, ""))
-                .filter((a) => a.length > 0);
+              const cleanArtists = normalizeTrackArtists(track.artists);
               return (
                 <Box
                   key={`${track.position}-${index}`}


### PR DESCRIPTION
## Summary

- Adds ``normalizeTrackArtists`` helper that strips Discogs ``(N)`` disambig, trims, dedupes, and tolerates malformed shapes.
- Wires the helper into ``RotationEntryFields.handleSelectTrack`` (Redux write) and ``TrackPickerDropdown`` (per-track display), closing the asymmetry where the dropdown stripped ``(N)`` but the form field didn't.
- Null-guards ``track.title`` against partial-write LML rows.

User-visible: rotation picker stops surfacing ``"Warrior, Warrior"`` and ``"M.I.A. (2)"``. Defensive only — root cause (LML cache duplicates + missing schema constraint) is filed for separate fixes in BS / LML / discogs-etl. See issue body for the four-step fix sequence and the prod-data scope (6,973 dup rows / 144 releases).

Closes #649

## Test plan

- [x] ``npx tsc --noEmit`` — passes
- [x] ``npm run test:run`` — 3,027/3,027 tests passing across 210 files
- [x] ``npm run build`` — succeeds
- [ ] Manual: on a deploy preview, open the modern flowsheet search → rotation tab → pick a V/A release that previously showed doubled artists. Confirm:
  - dropdown lists each artist once
  - selecting a track writes the singular name to the artist field
  - no ``(N)`` disambig suffix in the field on submit
- [ ] Manual: pick a release where ``track.artists`` is genuinely multi-credit (e.g. a split release) — confirm both names render and reach the field joined with ``", "``.
- [ ] Manual: pick a release that previously crashed the page (per Slack 2026-05-25). The crash is not addressed by this PR (BS controller fix is in flight) — confirm whether the symptom changes at all.

## Notes for reviewers

- The helper is intentionally exported separately rather than inlined so the BS-side equivalent (filed separately) can mirror its semantics without duplicating regex.
- Existing ``RotationEntryFields.refetch.test.tsx`` is unaffected — this PR doesn't touch the fetch/cache path #594 introduced.