### PR TITLE
fix: drop hard-coded "DJ " prefix from djName/dj_name renders

### DIFF
--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -140,22 +140,22 @@ describe("flowsheet conversions", () => {
     });
 
     it("should format single DJ on air", () => {
-      const response = [createTestOnAirDJResponse({ dj_name: "Cool DJ" })];
+      const response = [createTestOnAirDJResponse({ dj_name: "Turncoat" })];
       const result = convertDJsOnAir(response);
 
       expect(result.djs).toHaveLength(1);
-      expect(result.onAir).toBe("Cool DJ");
+      expect(result.onAir).toBe("Turncoat");
     });
 
     it("should format multiple DJs on air", () => {
       const response = [
-        createTestOnAirDJResponse({ id: "1", dj_name: "First DJ" }),
-        createTestOnAirDJResponse({ id: "2", dj_name: "Second DJ" }),
+        createTestOnAirDJResponse({ id: "1", dj_name: "Turncoat" }),
+        createTestOnAirDJResponse({ id: "2", dj_name: "desire path" }),
       ];
       const result = convertDJsOnAir(response);
 
       expect(result.djs).toHaveLength(2);
-      expect(result.onAir).toBe("First DJ, Second DJ");
+      expect(result.onAir).toBe("Turncoat, desire path");
     });
 
     it("should preserve original DJ response objects", () => {

--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -144,7 +144,7 @@ describe("flowsheet conversions", () => {
       const result = convertDJsOnAir(response);
 
       expect(result.djs).toHaveLength(1);
-      expect(result.onAir).toBe("DJ Cool DJ");
+      expect(result.onAir).toBe("Cool DJ");
     });
 
     it("should format multiple DJs on air", () => {
@@ -155,7 +155,7 @@ describe("flowsheet conversions", () => {
       const result = convertDJsOnAir(response);
 
       expect(result.djs).toHaveLength(2);
-      expect(result.onAir).toBe("DJ First DJ, DJ Second DJ");
+      expect(result.onAir).toBe("First DJ, Second DJ");
     });
 
     it("should preserve original DJ response objects", () => {

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -10,10 +10,9 @@ import {
   OnAirDJResponse,
 } from "./types";
 
-/** Single place for "DJ A, DJ B" on-air string (WhoIsLive + optimistic patches). */
 export function formatOnAirSummary(djs: OnAirDJResponse[]): string {
   if (!djs.length) return OFF_AIR_LABEL;
-  return djs.map((dj) => `DJ ${dj.dj_name}`).join(", ");
+  return djs.map((dj) => dj.dj_name).join(", ");
 }
 
 export function convertQueryToSubmission(

--- a/src/components/experiences/modern/Leftbar/LeftbarLogout.tsx
+++ b/src/components/experiences/modern/Leftbar/LeftbarLogout.tsx
@@ -46,7 +46,7 @@ export default function LeftbarLogout({ user }: { user: User }): JSX.Element {
                 </Box>
               )}
               {user?.djName && (
-                <Typography level="body-lg">DJ {user.djName}</Typography>
+                <Typography level="body-lg">{user.djName}</Typography>
               )}
             </Stack>
           )}

--- a/src/components/experiences/modern/Rightbar/panels/AccountEditPanel.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/AccountEditPanel.tsx
@@ -18,7 +18,7 @@ export default function AccountEditPanel() {
   return (
     <RightbarPanelContainer
       title={displayName}
-      subtitle={account.djName ? `DJ ${account.djName}` : undefined}
+      subtitle={account.djName || undefined}
       onClose={handleClose}
     >
       <AccountEditForm

--- a/src/components/experiences/modern/admin/roster/AccountEntry.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEntry.tsx
@@ -88,7 +88,7 @@ export const AccountEntry = ({
       </td>
       <td>{account.userName}</td>
       <td>
-        {account.djName && account.djName.length > 0 && "DJ"} {account.djName ?? ""}
+        {account.djName ?? ""}
       </td>
       <td>{account.email}</td>
       <td>

--- a/src/widgets/NowPlaying/Mini.test.tsx
+++ b/src/widgets/NowPlaying/Mini.test.tsx
@@ -258,8 +258,8 @@ describe("NowPlayingMini", () => {
         { id: "2", dj_name: "DJ Hot" },
       ];
       render(<NowPlayingMini {...createDefaultProps({ live: true, onAirDJs: djs })} />);
-      expect(screen.getByText("DJ DJ Cool")).toBeInTheDocument();
-      expect(screen.getByText("DJ DJ Hot")).toBeInTheDocument();
+      expect(screen.getByText("DJ Cool")).toBeInTheDocument();
+      expect(screen.getByText("DJ Hot")).toBeInTheDocument();
     });
 
     it("should render Chip component for each DJ", () => {

--- a/src/widgets/NowPlaying/Mini.test.tsx
+++ b/src/widgets/NowPlaying/Mini.test.tsx
@@ -254,33 +254,33 @@ describe("NowPlayingMini", () => {
   describe("DJs display", () => {
     it("should display DJ chips when onAirDJs is provided", () => {
       const djs: OnAirDJResponse[] = [
-        { id: "1", dj_name: "DJ Cool" },
-        { id: "2", dj_name: "DJ Hot" },
+        { id: "1", dj_name: "Turncoat" },
+        { id: "2", dj_name: "desire path" },
       ];
       render(<NowPlayingMini {...createDefaultProps({ live: true, onAirDJs: djs })} />);
-      expect(screen.getByText("DJ Cool")).toBeInTheDocument();
-      expect(screen.getByText("DJ Hot")).toBeInTheDocument();
+      expect(screen.getByText("Turncoat")).toBeInTheDocument();
+      expect(screen.getByText("desire path")).toBeInTheDocument();
     });
 
     it("should render Chip component for each DJ", () => {
       const djs: OnAirDJResponse[] = [
-        { id: "1", dj_name: "DJ Cool" },
-        { id: "2", dj_name: "DJ Hot" },
+        { id: "1", dj_name: "Turncoat" },
+        { id: "2", dj_name: "desire path" },
       ];
       render(<NowPlayingMini {...createDefaultProps({ live: true, onAirDJs: djs })} />);
       expect(screen.getAllByTestId("chip").length).toBe(2);
     });
 
     it("should render Headset icon in each DJ chip", () => {
-      const djs: OnAirDJResponse[] = [{ id: "1", dj_name: "DJ Cool" }];
+      const djs: OnAirDJResponse[] = [{ id: "1", dj_name: "Turncoat" }];
       render(<NowPlayingMini {...createDefaultProps({ live: true, onAirDJs: djs })} />);
       expect(screen.getByTestId("headset-icon")).toBeInTheDocument();
     });
 
     it("should render multiple Headset icons for multiple DJs", () => {
       const djs: OnAirDJResponse[] = [
-        { id: "1", dj_name: "DJ Cool" },
-        { id: "2", dj_name: "DJ Hot" },
+        { id: "1", dj_name: "Turncoat" },
+        { id: "2", dj_name: "desire path" },
       ];
       render(<NowPlayingMini {...createDefaultProps({ live: true, onAirDJs: djs })} />);
       expect(screen.getAllByTestId("headset-icon").length).toBe(2);
@@ -395,7 +395,7 @@ describe("NowPlayingMini", () => {
     });
 
     it("should render Stack for DJ chips with row direction", () => {
-      const djs: OnAirDJResponse[] = [{ id: "1", dj_name: "DJ Cool" }];
+      const djs: OnAirDJResponse[] = [{ id: "1", dj_name: "Turncoat" }];
       render(<NowPlayingMini {...createDefaultProps({ live: true, onAirDJs: djs })} />);
       const stacks = screen.getAllByTestId("stack");
       const rowStack = stacks.find(

--- a/src/widgets/NowPlaying/Mini.tsx
+++ b/src/widgets/NowPlaying/Mini.tsx
@@ -89,7 +89,7 @@ export default function NowPlayingMini({
         <Stack direction="row" spacing={1} alignItems="center" sx={{ flexWrap: "wrap" }}>
           {onAirDJs?.map((dj) => (
             <Chip key={dj.dj_name} variant="soft" startDecorator={<Headset />}>
-              DJ {dj.dj_name}
+              {dj.dj_name}
             </Chip>
           ))}
         </Stack>


### PR DESCRIPTION
## Summary

- Stop concatenating `"DJ "` in front of every rendered DJ name. If a DJ wants the prefix, they can type it; the site shouldn't decide for them.
- Finishes the work #171 started — that PR handled empty `djName` (no name → render nothing) but left the prefix in place for populated values, producing "DJ Anonymous", "DJ dj meowww", etc. on the roster page.
- Five call-sites updated: `formatOnAirSummary`, `AccountEditPanel` subtitle, `LeftbarLogout` tooltip, `NowPlaying/Mini` on-air chip, admin roster `AccountEntry` row.
- Two tests were asserting the buggy double-prefix (`"DJ DJ Cool"`, `"DJ First DJ, DJ Second DJ"`) — updated to assert the un-prefixed values.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test:run` — 3004/3004 pass
- [ ] Manual: open `/dashboard/admin/roster`, confirm names render verbatim (Anonymous shows as "Anonymous", "Turncoat" shows as "Turncoat", "DJ dvd" shows as "DJ dvd" not "DJ DJ dvd")
- [ ] Manual: open NowPlaying mini widget while a show is live, confirm the on-air chip shows the DJ's handle without a leading "DJ "
- [ ] Manual: hover the leftbar logout icon, confirm the tooltip shows the user's djName verbatim
- [ ] Manual: open the AccountEditPanel rightbar for a DJ, confirm the subtitle is the djName as stored

Closes #651