### PR TITLE
fix(search): skip catalog/LML/suggest searches for V/A artist names (#653)

### DIFF
--- a/lib/__tests__/features/catalog/is-compilation-artist.test.ts
+++ b/lib/__tests__/features/catalog/is-compilation-artist.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+
+import { isCompilationArtistName } from "@/lib/features/catalog/is-compilation-artist";
+
+describe("isCompilationArtistName", () => {
+  it.each([
+    "Various Artists",
+    "various artists",
+    "VARIOUS ARTISTS",
+    "Various",
+    "V/A",
+    "v/a",
+    "V.A.",
+    "v.a.",
+    "Soundtrack",
+    "Original Soundtrack",
+    "Compilation",
+    "Best Of Compilation 2025",
+  ])("returns true for %s", (input) => {
+    expect(isCompilationArtistName(input)).toBe(true);
+  });
+
+  it.each([
+    "Juana Molina",
+    "Stereolab",
+    "Cat Power",
+    "Chuquimamani-Condori",
+    "Duke Ellington & John Coltrane",
+    "Variant Configuration", // contains "var" but not "various"
+    "Vamping In Vegas", // starts with "va" but not "v/a" or "various"
+    "VA", // bare "VA" without separators
+  ])("returns false for %s", (input) => {
+    expect(isCompilationArtistName(input)).toBe(false);
+  });
+
+  it.each([null, undefined, ""])("returns false for empty input %s", (input) => {
+    expect(isCompilationArtistName(input)).toBe(false);
+  });
+});

--- a/lib/features/catalog/is-compilation-artist.ts
+++ b/lib/features/catalog/is-compilation-artist.ts
@@ -1,0 +1,19 @@
+// Keep in sync with apps/backend/services/requestLine/matching/compilation.ts.
+const COMPILATION_KEYWORDS = [
+  "various",
+  "soundtrack",
+  "compilation",
+  "v/a",
+  "v.a.",
+];
+
+export function isCompilationArtistName(
+  artist: string | null | undefined
+): boolean {
+  if (!artist) return false;
+  const lower = artist.toLowerCase();
+  for (const keyword of COMPILATION_KEYWORDS) {
+    if (lower.includes(keyword)) return true;
+  }
+  return false;
+}

--- a/src/hooks/__tests__/useCatalogFlowsheetSearch.test.tsx
+++ b/src/hooks/__tests__/useCatalogFlowsheetSearch.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import React, { type PropsWithChildren } from "react";
+import { Provider } from "react-redux";
+import { CssVarsProvider } from "@mui/joy/styles";
+import { makeStore } from "@/lib/store";
+import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import type { SearchCatalogQueryParams } from "@/lib/features/catalog/types";
+
+type QueryResult = {
+  data: unknown;
+  isFetching: boolean;
+  isLoading: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+};
+
+const searchCatalogCalls: Array<{
+  args: SearchCatalogQueryParams;
+  options: { skip?: boolean };
+}> = [];
+
+let nextQueryResult: QueryResult = {
+  data: undefined,
+  isFetching: false,
+  isLoading: false,
+  isSuccess: false,
+  isError: false,
+};
+
+vi.mock("@/lib/features/catalog/api", () => ({
+  catalogApi: {
+    reducerPath: "catalogApi",
+    reducer: (state = {}) => state,
+    middleware:
+      () =>
+      (next: (action: unknown) => unknown) =>
+      (action: unknown) =>
+        next(action),
+    endpoints: {},
+    util: { resetApiState: () => ({ type: "noop" }) },
+  },
+  useLazySearchLibraryQueryQuery: () => [() => {}, nextQueryResult],
+  useSearchCatalogQuery: (
+    args: SearchCatalogQueryParams,
+    options: { skip?: boolean }
+  ) => {
+    searchCatalogCalls.push({ args, options });
+    return nextQueryResult;
+  },
+}));
+
+vi.mock("../authenticationHooks", () => ({
+  useAuthentication: () => ({ authenticating: false, authenticated: true }),
+}));
+
+import { useCatalogFlowsheetSearch } from "../catalogHooks";
+
+function Wrapper({
+  store,
+}: {
+  store: ReturnType<typeof makeStore>;
+}): (props: PropsWithChildren) => React.ReactElement {
+  return function WrapperInner({ children }) {
+    return (
+      <Provider store={store}>
+        <CssVarsProvider>{children}</CssVarsProvider>
+      </Provider>
+    );
+  };
+}
+
+function renderWithQuery(query: { artist: string; album: string }) {
+  const store = makeStore();
+  store.dispatch(
+    flowsheetSlice.actions.setSearchProperty({ name: "artist", value: query.artist })
+  );
+  store.dispatch(
+    flowsheetSlice.actions.setSearchProperty({ name: "album", value: query.album })
+  );
+  return renderHook(() => useCatalogFlowsheetSearch(), {
+    wrapper: Wrapper({ store }),
+  });
+}
+
+describe("useCatalogFlowsheetSearch", () => {
+  beforeEach(() => {
+    searchCatalogCalls.length = 0;
+    nextQueryResult = {
+      data: undefined,
+      isFetching: false,
+      isLoading: false,
+      isSuccess: false,
+      isError: false,
+    };
+  });
+
+  describe("compilation-indicator short-circuit", () => {
+    it.each([
+      ["Various Artists", "In-Correcto 15-25"],
+      ["various artists", "Some Album"],
+      ["V/A", "Some Album"],
+      ["v.a.", "Some Album"],
+      ["Soundtrack", "Movie Title"],
+      ["Compilation", "Best Of"],
+    ])(
+      "passes skip=true and returns [] for artist=%s album=%s",
+      (artist, album) => {
+        const { result } = renderWithQuery({ artist, album });
+
+        const lastCall = searchCatalogCalls.at(-1);
+        expect(lastCall?.options.skip).toBe(true);
+        expect(result.current.searchResults).toEqual([]);
+      }
+    );
+
+    it("does not short-circuit when artist is a legitimate name", () => {
+      const { result } = renderWithQuery({
+        artist: "Juana Molina",
+        album: "DOGA",
+      });
+
+      const lastCall = searchCatalogCalls.at(-1);
+      expect(lastCall?.options.skip).toBe(false);
+      // No data was returned by the mock; expect empty results but the
+      // network call should have been allowed through (skip=false).
+      expect(result.current.searchResults).toEqual([]);
+    });
+
+    it("does not short-circuit on album-only field 'Various Artists Comp'", () => {
+      const { result } = renderWithQuery({
+        artist: "Some Artist",
+        album: "Various Artists Compilation Vol 5",
+      });
+
+      const lastCall = searchCatalogCalls.at(-1);
+      expect(lastCall?.options.skip).toBe(false);
+      expect(result.current.searchResults).toEqual([]);
+    });
+  });
+});

--- a/src/hooks/catalogHooks.ts
+++ b/src/hooks/catalogHooks.ts
@@ -5,6 +5,7 @@ import {
   useSearchCatalogQuery,
 } from "@/lib/features/catalog/api";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
+import { isCompilationArtistName } from "@/lib/features/catalog/is-compilation-artist";
 import {
   AlbumEntry,
   CatalogFilters,
@@ -303,6 +304,8 @@ export const useCatalogFlowsheetSearch = () => {
     flowsheetSlice.selectors.getSearchQuery,
   );
 
+  const isCompilationQuery = isCompilationArtistName(flowsheetQuery.artist);
+
   const { data } = useSearchCatalogQuery(
     {
       artist_name: flowsheetQuery.artist,
@@ -313,6 +316,7 @@ export const useCatalogFlowsheetSearch = () => {
       skip:
         authenticating ||
         !authenticated ||
+        isCompilationQuery ||
         flowsheetQuery.artist.length + flowsheetQuery.album.length <=
           FLOWSHEET_MIN_SEARCH_LENGTH,
     },
@@ -336,10 +340,12 @@ export const useRotationFlowsheetSearch = () => {
     skip: authenticating || !authenticated,
   });
 
+  const isCompilationQuery = isCompilationArtistName(rotationQuery.artist);
+
   const searchResults = useMemo(() => {
-    if (!data || isLoading || !isSuccess) return [];
+    if (!data || isLoading || !isSuccess || isCompilationQuery) return [];
     return filterBySearchTerms(data, rotationQuery);
-  }, [data, isLoading, isSuccess, rotationQuery]);
+  }, [data, isLoading, isSuccess, rotationQuery, isCompilationQuery]);
 
   return {
     searchResults:

--- a/src/hooks/lml/useLmlLibrarySearch.test.ts
+++ b/src/hooks/lml/useLmlLibrarySearch.test.ts
@@ -247,6 +247,64 @@ describe("useLmlLibrarySearch", () => {
     expect(callCount).toBe(1);
   });
 
+  describe("compilation-indicator short-circuit", () => {
+    it.each([
+      ["Various Artists", "In-Correcto 15-25"],
+      ["various artists", "Some Album"],
+      ["V/A", "Some Album"],
+      ["v.a.", "Some Album"],
+      ["Soundtrack", "Movie Title"],
+    ])(
+      "fires zero network calls for artist=%s album=%s",
+      async (artist, album) => {
+        let callCount = 0;
+        server.use(
+          http.get(PROXY_SEARCH_URL, () => {
+            callCount++;
+            return HttpResponse.json({
+              results: [],
+              total: 0,
+              query: null,
+            } satisfies LmlLibrarySearchResponse);
+          })
+        );
+
+        const { result } = renderHook(
+          () => useLmlLibrarySearch({ artist, album }),
+          { wrapper: withStore() }
+        );
+
+        await vi.advanceTimersByTimeAsync(400);
+
+        expect(callCount).toBe(0);
+        expect(result.current.results).toEqual([]);
+        expect(result.current.isLoading).toBe(false);
+      }
+    );
+
+    it("non-compilation artist still fires the network call", async () => {
+      let callCount = 0;
+      server.use(
+        http.get(PROXY_SEARCH_URL, () => {
+          callCount++;
+          return HttpResponse.json({
+            results: [],
+            total: 0,
+            query: null,
+          } satisfies LmlLibrarySearchResponse);
+        })
+      );
+
+      renderHook(
+        () => useLmlLibrarySearch({ artist: "Juana Molina", album: "DOGA" }),
+        { wrapper: withStore() }
+      );
+
+      await vi.advanceTimersByTimeAsync(400);
+      await waitFor(() => expect(callCount).toBe(1));
+    });
+  });
+
   it("isLoading is true while debounce is pending for a valid query", async () => {
     server.use(
       http.get(PROXY_SEARCH_URL, () =>

--- a/src/hooks/lml/useLmlLibrarySearch.ts
+++ b/src/hooks/lml/useLmlLibrarySearch.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import type { AlbumEntry } from "@/lib/features/catalog/types";
+import { isCompilationArtistName } from "@/lib/features/catalog/is-compilation-artist";
 import { useSearchLibraryQuery } from "@/lib/features/lml/api";
 
 const DEBOUNCE_MS = 350;
@@ -48,12 +49,15 @@ export function useLmlLibrarySearch({
     return () => clearTimeout(timer);
   }, [artist, album]);
 
+  const isCompilationQuery = isCompilationArtistName(artist);
+  const debouncedIsCompilation = isCompilationArtistName(debounced?.artist);
   const currentLength = artist.length + album.length;
-  const hasValidQuery = currentLength >= MIN_QUERY_LENGTH;
+  const hasValidQuery = currentLength >= MIN_QUERY_LENGTH && !isCompilationQuery;
   const debouncedLength = debounced
     ? debounced.artist.length + debounced.album.length
     : 0;
-  const skip = !debounced || debouncedLength < MIN_QUERY_LENGTH;
+  const skip =
+    !debounced || debouncedLength < MIN_QUERY_LENGTH || debouncedIsCompilation;
   const pendingDebounce =
     hasValidQuery &&
     (debounced === null ||

--- a/src/hooks/useGhostText.test.ts
+++ b/src/hooks/useGhostText.test.ts
@@ -13,9 +13,16 @@ const mockTrackQuery = {
     | undefined,
 };
 
+const { useSuggestArtistsQueryMock, useSuggestTracksQueryMock } = vi.hoisted(
+  () => ({
+    useSuggestArtistsQueryMock: vi.fn(),
+    useSuggestTracksQueryMock: vi.fn(),
+  })
+);
+
 vi.mock("@/lib/features/flowsheet/api", () => ({
-  useSuggestArtistsQuery: vi.fn(() => mockArtistQuery),
-  useSuggestTracksQuery: vi.fn(() => mockTrackQuery),
+  useSuggestArtistsQuery: useSuggestArtistsQueryMock,
+  useSuggestTracksQuery: useSuggestTracksQueryMock,
 }));
 
 // Mock debounce to return value immediately in tests
@@ -29,6 +36,10 @@ describe("useGhostText", () => {
   beforeEach(() => {
     mockArtistQuery.data = undefined;
     mockTrackQuery.data = undefined;
+    useSuggestArtistsQueryMock.mockReset();
+    useSuggestTracksQueryMock.mockReset();
+    useSuggestArtistsQueryMock.mockImplementation(() => mockArtistQuery);
+    useSuggestTracksQueryMock.mockImplementation(() => mockTrackQuery);
   });
 
   describe("artist field", () => {
@@ -100,6 +111,38 @@ describe("useGhostText", () => {
 
       expect(result.current.ghostSuffix).toBe("techre");
       expect(result.current.acceptGhostText()).toBe("Autechre");
+    });
+  });
+
+  describe("compilation-indicator short-circuit", () => {
+    it.each([
+      "Various Artists",
+      "various artists",
+      "V/A",
+      "v.a.",
+      "Soundtrack",
+      "Compilation",
+    ])("passes skip=true for artist field with %s", (value) => {
+      renderHook(() => useGhostText("artist", value));
+
+      const lastCall = useSuggestArtistsQueryMock.mock.calls.at(-1);
+      expect(lastCall?.[1]).toMatchObject({ skip: true });
+    });
+
+    it("does not skip for the song field even when the value contains 'various'", () => {
+      renderHook(() => useGhostText("song", "Various Versions", "Autechre"));
+
+      // The song-field gate already skips the artist-suggest hook (field !==
+      // "artist"), so we verify the track-suggest hook didn't get skipped.
+      const lastCall = useSuggestTracksQueryMock.mock.calls.at(-1);
+      expect(lastCall?.[1]).toMatchObject({ skip: false });
+    });
+
+    it("passes skip=false for legitimate artist names", () => {
+      renderHook(() => useGhostText("artist", "Stereolab"));
+
+      const lastCall = useSuggestArtistsQueryMock.mock.calls.at(-1);
+      expect(lastCall?.[1]).toMatchObject({ skip: false });
     });
   });
 

--- a/src/hooks/useGhostText.ts
+++ b/src/hooks/useGhostText.ts
@@ -4,6 +4,7 @@ import {
   useSuggestArtistsQuery,
   useSuggestTracksQuery,
 } from "@/lib/features/flowsheet/api";
+import { isCompilationArtistName } from "@/lib/features/catalog/is-compilation-artist";
 import { SuggestTrackResult } from "@/lib/features/flowsheet/types";
 import { useMemo } from "react";
 import { useDebouncedValue } from "./useDebouncedValue";
@@ -33,10 +34,12 @@ export function useGhostText(
 ): GhostTextResult {
   const debouncedValue = useDebouncedValue(currentValue, DEBOUNCE_MS);
   const shouldQuery = debouncedValue.length >= MIN_PREFIX_LENGTH;
+  const skipForCompilation =
+    field === "artist" && isCompilationArtistName(debouncedValue);
 
   const artistQuery = useSuggestArtistsQuery(
     { q: debouncedValue, limit: 1 },
-    { skip: field !== "artist" || !shouldQuery }
+    { skip: field !== "artist" || !shouldQuery || skipForCompilation }
   );
 
   const trackQuery = useSuggestTracksQuery(


### PR DESCRIPTION
## Summary

Picks a Various Artists release in the rotation entry picker → dj-site fires four backend searches that all return useless results for V/A queries, and one (the trigram-OR on `library`) hangs past `statement_timeout`, contributing to a renderer freeze. This stops the wasted fan-out at the source.

## Changes

Three RTK Query hooks now skip when the artist field is a compilation indicator (\`Various Artists\`, \`V/A\`, \`V.A.\`, \`Soundtrack\`, \`Compilation\` — case-insensitive substring match):

| Hook | Previously fired | After |
|---|---|---|
| \`useCatalogFlowsheetSearch\` | \`GET /library/?artist_name=Various+Artists&album_title=...\` | skipped, returns \`[]\` |
| \`useLmlLibrarySearch\` | \`GET /proxy/library/search?artist=Various+Artists&title=...\` | skipped, \`isLoading=false\` |
| \`useGhostText\` (artist field) | \`GET /flowsheet/suggest/artists?q=Various+Artists\` | skipped |

\`useRotationFlowsheetSearch\` already filters in-memory (no network call), but now also short-circuits the filter computation when the search query is V/A.

## Predicate placement

Lives at \`lib/features/catalog/is-compilation-artist.ts\` — small dupe of the BS-side \`isCompilationArtist\` at \`apps/backend/services/requestLine/matching/compilation.ts\`. Five-word constant array, two callers in two repos: not yet worth a \`@wxyc/shared\` round-trip. Will lift if a third caller appears or the predicates diverge.

## Test plan

- [x] \`is-compilation-artist.test.ts\` — 23 new unit tests (positive cases including diacritic/case variants, negative cases including \"Variant\" / bare \"VA\" / \"Vamping\", null/undefined/empty)
- [x] \`useCatalogFlowsheetSearch.test.tsx\` — 8 new tests via renderHook, asserts \`skip=true\` passed to \`useSearchCatalogQuery\` for all keyword × case variants
- [x] \`useLmlLibrarySearch.test.ts\` — 6 new tests via MSW handler call-counting, asserts zero network calls fire for V/A queries
- [x] \`useGhostText.test.ts\` — 8 new tests via \`vi.hoisted\` mock spy on \`useSuggestArtistsQuery\`, asserts \`skip=true\` for V/A artist values
- [x] \`npx vitest run\` — full suite: **3050/3050 passing** (211 files)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Post-merge: manual repro against the original V/A release (In-Correcto 15-25, rotation_id=21417) — picking it should no longer fire the four extra requests in the network panel

## Carve-outs

- Predicate only checks the \`artist\` field, never the \`album\` field. \`Various Artists Compilation Vol 5\` as an album title still gets searched normally.
- \`useGhostText\` song-field path is unaffected — gated on \`field === \"artist\"\`.

## Related

- Sibling: WXYC/Backend-Service#1158 (server-side trigram-OR short-circuit) — PR WXYC/Backend-Service#1160
- Investigation blocked-by both: WXYC/dj-site#654 (renderer-crash root-cause)
- Same predicate used in: WXYC/library-metadata-lookup writeback guard \`46c0c5f\`
- Original report (dedupe fix, landed earlier today): #650

Closes #653