### PR TITLE
test(e2e): Tier 1 SSE round-trip Playwright coverage (#660)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,6 +38,8 @@ env:
   NEXT_PUBLIC_ENABLED_EXPERIENCES: modern,classic
   NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING: "true"
   NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED: "true"
+  NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED: "true"
+  NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED: "true"
   NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD: temppass123
   NEXT_PUBLIC_APP_ORGANIZATION: test-org
   SESSION_SECRET: e2e-secret-for-testing
@@ -48,6 +50,16 @@ env:
   E2E_DB_PORT: 5434
   E2E_AUTH_PORT: 8084
   E2E_BACKEND_PORT: 8085
+  # Postgres connection for the SSE E2E suite (e2e/helpers/pg-notify.ts).
+  # Mirrors scripts/e2e-local.sh's exports and the postgres service config
+  # above. Backend-Service's own .env (sourced inside the Backend track)
+  # takes precedence in that subshell, so this only affects steps that
+  # need direct DB access from the test runner.
+  DB_HOST: localhost
+  DB_PORT: "5434"
+  DB_NAME: wxyc_db
+  DB_USERNAME: wxyc_admin
+  DB_PASSWORD: 'RadioIsEpic$1100'
 
 # Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
 # comments on PRs, or creates releases; all writes to external services
@@ -132,6 +144,11 @@ jobs:
           # produce. Mock is started in the next workflow step. See #567.
           TUBAFRENZY_URL=http://localhost:9091
           MIRROR_API_KEY=e2e-mirror-noop-key
+          # CDC LISTEN is gated on CDC_SECRET in setupCdcWebSocket(). The
+          # SSE Tier 1 metadata-broadcast handler (setupMetadataBroadcast)
+          # registers on the same LISTEN — so without this, pg_notify is
+          # silently dropped. Tracked as a Backend-Service follow-up.
+          CDC_SECRET=e2e-cdc-secret-not-used-by-tests
           EOF
 
       - name: Start mock tubafrenzy mirror

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,10 @@ PRs that only change non-code files (docs, scripts, etc.) skip CI entirely via p
 
 Runs on push to `main` and on PRs that touch app code. Spins up Backend-Service with Docker Compose (PostgreSQL + auth + backend), builds dj-site, runs Playwright tests. PRs that only change unit tests, test utilities, or non-app config skip E2E via path filters. The workflow caches the dj-site `.next/` build output and Playwright browser binaries to reduce setup time. On cache hit, both the Next.js build and Playwright install are skipped entirely. Cache keys include `package-lock.json`, `next.config.*`, and app source files, so dependency or source changes invalidate the cache correctly.
 
+#### E2E-only dependencies
+
+The Tier 1 SSE round-trip tests under `e2e/tests/sse/` issue `pg_notify('cdc', <json>)` directly against the E2E Postgres to bypass the LML enrichment chain (unreachable in CI). For that they need a Node Postgres client, so `pg` and `@types/pg` are pinned in `devDependencies`. They're only imported from `e2e/helpers/pg-notify.ts` — nothing in app code uses them and they don't ship in the Next.js bundle. Both `scripts/e2e-local.sh` and the E2E workflow export `DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USERNAME`/`DB_PASSWORD` so the helper can connect without per-test config.
+
 ### Deployment
 
 Cloudflare Pages via OpenNext. Build: `npm run build:opennext`. Deploy: `npm run deploy` (Wrangler).

--- a/docs/plans/sse-tier1-e2e.md
+++ b/docs/plans/sse-tier1-e2e.md
@@ -1,0 +1,340 @@
+# Plan: Tier 1 SSE round-trip Playwright coverage (#660)
+
+Implements the rollout-gate test net for the Live Updates SSE feature. Closes [WXYC/dj-site#660](https://github.com/WXYC/dj-site/issues/660), which is the hard prerequisite for [#663](https://github.com/WXYC/dj-site/issues/663) (production flag flip) under the [#664 epic](https://github.com/WXYC/dj-site/issues/664).
+
+## Goal
+
+Pin the cross-repo SSE round-trip — Backend-Service's PG-CDC → `metadata-broadcast` → `serverEvents` → dj-site's `live-updates-listener` → RTK Query cache → DOM — with four Playwright tests that will fail if any link silently degrades. Without this net, flipping `NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED=true` in production means a regression in BS-1/BS-2/BS-3/BS-4 or the dj-site listener falls back to the 60s safety poll invisibly.
+
+## Strategy: `pg_notify` shortcut around enrichment
+
+The plan's design discussion in [`docs/live-updates-sse.md`](../live-updates-sse.md) and [#660's body](https://github.com/WXYC/dj-site/issues/660) settled on **firing `pg_notify('cdc', '<json>')` directly to the e2e Postgres** instead of driving the full LML enrichment chain.
+
+Rationale:
+- LML is unreachable from `scripts/e2e-local.sh` (`LIBRARY_METADATA_URL=""`), so a real enrichment can never fire.
+- The CDC → broadcast → SSE → DOM portion of the chain is deterministic ms-scale, so tests can use `{ timeout: 5_000 }` real time — no clock injection or `repeat-each` flake masking.
+- By specifying the exact `data` payload in the test, we **pin the wire contract** instead of integrating against a moving LML output shape.
+
+Backend-Service's `setupMetadataBroadcast` ([`metadata-broadcast.ts:86`](https://github.com/WXYC/Backend-Service/blob/main/apps/backend/services/metadata-broadcast/metadata-broadcast.ts#L86)) subscribes to the `cdc` channel and filters on:
+
+```
+event.table === 'flowsheet'
+event.action === 'UPDATE'
+event.data.metadata_status ∈ { 'enriched_match', 'enriched_no_match', 'failed_no_retry' }
+typeof event.data.id === 'number'
+```
+
+A NOTIFY matching that filter is broadcast as a `liveFs:update` SSE event to every connected client on every BS instance (per-process LISTEN, no de-dupe needed because each client is attached to one instance).
+
+dj-site's listener ([`live-updates-listener.ts:100`](../../lib/features/flowsheet/live-updates-listener.ts)) routes the payload through `routeUpdateEvent`: if `payload.id` is in the `getInfiniteEntries` cache it `patchEntryById`s, otherwise it debounces 500ms then invalidates the `Flowsheet` tag.
+
+So the test recipe is:
+1. Open a surface that loads `payload.id` into cache (dashboard adds + GETs; `/live` GETs `getNowPlaying`).
+2. `pg_notify` an UPDATE for that row with one mutated field.
+3. Assert the field renders within 5s.
+
+## File layout
+
+### New files
+
+| File | Purpose |
+| --- | --- |
+| `e2e/tests/sse/round-trip.spec.ts` | Tests #1–3 consolidated. Single-file = single Playwright worker = no cross-file race on the shared `dj2.json` go-live state and afterAll cleanup |
+| `e2e/fixtures/sse-cdc-payloads.ts` | Typed `CdcEvent` payload builders mirroring `@wxyc/database`'s `CdcEvent` |
+| `e2e/helpers/pg-notify.ts` | Thin `pg.Client` wrapper for `NOTIFY` from tests |
+| `e2e/helpers/sse-wait.ts` | `waitForSSEConnected` (dashboard indicator) and `waitForSSEHandshake` (`/events/stream` response) helpers |
+| `lib/__tests__/features/flowsheet/sse-flags.test.ts` | Test #4a — flag-coercion unit tests |
+| `src/components/shared/SSESubscription.test.tsx` | Test #4b — component-level gate unit tests |
+
+### Modified files
+
+| File | Change |
+| --- | --- |
+| `scripts/e2e-local.sh` | Export `NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED=true` and `..._LIVE_VIEW_ENABLED=true` for the primary build. Optionally build + serve a flag-off variant for test #4 — see "Test #4 mechanics". Export the existing `DB_*` variables to Playwright so `pg-notify` can connect. |
+| `.github/workflows/e2e-tests.yml` | Same env additions. Second build step iff we keep test #4 as E2E. |
+| `e2e/playwright.config.ts` | Add a second `project: "flag-off"` with a different `baseURL` for test #4 (only if we keep #4 as E2E). |
+| `package.json` | Add `pg` (`^8.x`) and `@types/pg` (`^8.x`) to `devDependencies`. |
+
+## Test #4 mechanics — the build-time-inlining tradeoff
+
+`NEXT_PUBLIC_*` env vars are **inlined at build time** by Next.js. Tests #1–#3 need the dashboard flag ON, test #4 needs it OFF. One build cannot satisfy both.
+
+Two practical options:
+
+**Option A — second build (preserves the issue's intent of an E2E flag-off test):**
+- `scripts/e2e-local.sh` runs `npm run build` twice with different env, into two separate directories (`.next` and `.next-flag-off`, swapped via `cp -r`/symlink dance, or build in two clones of `dj-site/`).
+- A second `npm start` listens on port 3002.
+- Playwright config adds a `flag-off` project with `baseURL: http://localhost:3002` that runs only `flag-off-stays-off.spec.ts`.
+- CI cost: roughly +30–60s build, +5–10s server start.
+
+**Option B — unit test + smaller-E2E fallback:**
+- Add `lib/__tests__/features/flowsheet/sse-flags.test.ts` (covers `isFlowsheetSSEDashboardEnabled` / `isFlowsheetSSELiveViewEnabled`).
+- Add `src/components/shared/SSESubscription.test.tsx` (covers the component-level gate — mount with flag false, assert `useSSEConnection` never runs; mount with flag true, assert it does).
+- No Playwright change. CI cost: ~0.
+- Tradeoff: doesn't catch a regression where the gate works but something else accidentally constructs an EventSource (e.g. a future hardcoded module). Low-probability scenario but real.
+
+**Recommendation: Option B for this PR + leave a follow-up note in `docs/live-updates-sse.md` if we want Option A later.** The other three tests already cover the listener's connection path; a unit test on the gate is structurally adequate for the rollout-gate question ("can flipping the flag re-enable SSE?"). If review pushes back I'll switch to Option A — the second-build mechanics are mechanical, just bulky.
+
+## `pg-notify` helper
+
+Add `pg` (node-postgres) as a devDep. It's the standard PG client for Node and is already a transitive dep of better-auth's PG adapter, so the install footprint is negligible.
+
+```ts
+// e2e/helpers/pg-notify.ts
+import { Client } from "pg";
+
+const config = {
+  host: process.env.DB_HOST ?? "localhost",
+  port: Number(process.env.DB_PORT ?? 5436),
+  database: process.env.DB_NAME ?? "wxyc_db",
+  user: process.env.DB_USERNAME ?? "wxyc_admin",
+  password: process.env.DB_PASSWORD ?? "RadioIsEpic$1100",
+};
+
+export async function pgNotify(channel: string, payload: object): Promise<void> {
+  const client = new Client(config);
+  await client.connect();
+  try {
+    // NOTIFY's payload is a SQL literal — parameter binding is not allowed.
+    // JSON.stringify cannot produce a backslash-escaped single quote, so SQL
+    // single-quote doubling is sufficient and matches Postgres lexer rules.
+    const literal = JSON.stringify(payload).replace(/'/g, "''");
+    await client.query(`NOTIFY ${channel}, '${literal}'`);
+  } finally {
+    await client.end();
+  }
+}
+```
+
+Channel name is `cdc` (matches `CDC_CHANNEL` in [`Backend-Service/shared/database/src/cdc-listener.ts:28`](https://github.com/WXYC/Backend-Service/blob/main/shared/database/src/cdc-listener.ts#L28)).
+
+## Payload fixtures
+
+```ts
+// e2e/fixtures/sse-cdc-payloads.ts
+import type { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
+
+/**
+ * Build a CDC UPDATE payload that BS's metadata-broadcast will broadcast
+ * verbatim as a liveFs:update SSE event. Mirrors @wxyc/database CdcEvent.
+ *
+ * BS filter requirements (apps/backend/services/metadata-broadcast/metadata-broadcast.ts):
+ *   - table === 'flowsheet'
+ *   - action === 'UPDATE'
+ *   - data.metadata_status is a terminal state
+ *   - typeof data.id === 'number'
+ */
+export type TerminalMetadataStatus =
+  | "enriched_match"
+  | "enriched_no_match"
+  | "failed_no_retry";
+
+export function buildFlowsheetUpdatePayload(
+  row: Partial<FlowsheetSongEntry> & { id: number; metadata_status?: TerminalMetadataStatus }
+) {
+  return {
+    table: "flowsheet",
+    schema: "public",
+    action: "UPDATE" as const,
+    data: {
+      ...row,
+      metadata_status: row.metadata_status ?? "enriched_match",
+    },
+    timestamp: Date.now(),
+  };
+}
+```
+
+## Test #1 — `cross-dj-update.spec.ts`
+
+```ts
+test("liveFs:update patches an in-cache dashboard row within 5s", async ({ page }) => {
+  const flowsheet = new FlowsheetPage(page);
+  await flowsheet.goto();
+  await flowsheet.waitForEntriesLoaded();
+  if (!(await isLive(flowsheet))) await flowsheet.goLive();
+
+  // Add a row (artwork_url starts empty → entry renders /img/cassette.png)
+  const addResp = page.waitForResponse(
+    (r) => r.url().includes("/flowsheet/") && r.request().method() === "POST" && r.status() < 300
+  );
+  await flowsheet.addTrack({ song: `tier1-${Date.now()}`, artist: "Juana Molina", album: "DOGA" });
+  const newRow = await (await addResp).json();
+
+  const newArtworkUrl = `https://example.org/tier1-test-1-${newRow.id}.jpg`;
+
+  // Wait for SSE to actually be connected. Without this, a NOTIFY fired before
+  // BS's setupMetadataBroadcast has any client to broadcast to is silently lost.
+  await waitForSSEConnected(page);
+
+  await pgNotify(
+    "cdc",
+    buildFlowsheetUpdatePayload({ id: newRow.id, artwork_url: newArtworkUrl })
+  );
+
+  const entry = page.locator(`[data-testid="flowsheet-entry-${newRow.id}"]`);
+  await expect(entry.locator("img").first()).toHaveAttribute("src", newArtworkUrl, {
+    timeout: 5_000,
+  });
+});
+
+test.afterAll(async ({ browser }) => {
+  // Reuse the entry-caching.spec.ts off-air cleanup pattern.
+});
+```
+
+`waitForSSEConnected(page)` reads the `data-status` attribute on the dashboard's `<SSEConnectionIndicator>` (currently `data-status="connected"` when open — see [`SSEConnectionIndicator.tsx:35`](../../src/components/shared/SSEConnectionIndicator.tsx#L35)). If the indicator isn't rendered on the test surface, fall back to polling the Redux store via `page.evaluate(() => window.__REDUX_DEVTOOLS_EXTENSION__?...)` is too brittle; instead, listen for the actual GET `/events/stream` request via `page.waitForRequest` and a short post-handshake delay.
+
+Use `dj2.json` for storage state (same rationale as `entry-caching.spec.ts:18`: dj.json gets revoked by `auth/logout.spec.ts`).
+
+## Test #2 — anonymous `/live` (round-trip.spec.ts)
+
+Two contexts in one test: an authenticated context to set up a now-playing row, and an anonymous context to observe `/live`.
+
+```ts
+test("/live anonymous viewer receives liveFs:update", async ({ browser }) => {
+  const authedContext = await browser.newContext({
+    storageState: path.join(authDir, "dj2.json"),
+    baseURL: process.env.E2E_BASE_URL,
+  });
+  const authedPage = await authedContext.newPage();
+  const fs = new FlowsheetPage(authedPage);
+  await fs.goto();
+  await fs.waitForEntriesLoaded();
+  if (!(await isLive(fs))) await fs.goLive();
+
+  const addResp = authedPage.waitForResponse(/* POST /flowsheet/ */);
+  await fs.addTrack({ song: `tier1-2-${Date.now()}`, artist: "Stereolab", album: "Aluminum Tunes" });
+  const newRow = await (await addResp).json();
+
+  const anonContext = await browser.newContext({ baseURL: process.env.E2E_BASE_URL }); // no storageState
+  const anonPage = await anonContext.newPage();
+
+  const sseHandshake = anonPage.waitForResponse(
+    (r) => r.url().includes("/events/stream") && r.status() === 200
+  );
+  await anonPage.goto("/live");
+  const handshakeResponse = await sseHandshake;
+  expect(handshakeResponse.headers()["content-type"]).toContain("text/event-stream");
+
+  // Now playing GET races the page load; give it a small budget to settle.
+  await anonPage.waitForResponse((r) => r.url().includes("/flowsheet/nowPlaying"));
+
+  const newArtworkUrl = `https://example.org/tier1-test-2-${newRow.id}.jpg`;
+  await pgNotify(
+    "cdc",
+    buildFlowsheetUpdatePayload({ id: newRow.id, artwork_url: newArtworkUrl })
+  );
+
+  await expect(
+    anonPage.locator(`img[src="${newArtworkUrl}"]`)
+  ).toBeVisible({ timeout: 5_000 });
+
+  await authedContext.close();
+  await anonContext.close();
+});
+```
+
+## Test #3 — `full-row-payload.spec.ts`
+
+Same shape as test 2 but with a richer payload (e.g. `release_year`, `artwork_url`, `album_title` all set) to surgically pin BS-2's "full row, not just `{id, metadata_status}`" promise. Assertion is that all three observable fields appear in the DOM. If anyone reverts the broadcast to the old `{id, metadata_status}` shape, only this test will fail loudly — tests 1/2 would still pass on the `id`-only path because the listener's `Object.assign` is shallow.
+
+## Test #4 — `flag-off-stays-off.spec.ts`
+
+Per the recommendation in "Test #4 mechanics" above, replace this with two unit tests:
+
+```ts
+// lib/__tests__/features/flowsheet/sse-flags.test.ts
+describe("sse-flags", () => {
+  it.each([
+    ["true", true],
+    ["1", true],
+    ["false", false],
+    ["", false],
+    [undefined, false],
+  ])("isFlowsheetSSEDashboardEnabled returns %s for env=%s", (value, expected) => {
+    /* stub process.env via vi.stubEnv */
+  });
+  // mirror for isFlowsheetSSELiveViewEnabled
+});
+```
+
+```ts
+// src/components/shared/SSESubscription.test.tsx
+describe("<SSESubscription>", () => {
+  it("does not call useSSEConnection when surface=dashboard and flag is off", () => {
+    vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED", "");
+    const { rerender } = renderWithProviders(<SSESubscription surface="dashboard" />);
+    // Inspect Redux store: refCount should be 0; no liveUpdatesConnectionRequested dispatched
+  });
+  // mirror for flag on (refCount === 1)
+  // mirror for surface="live"
+});
+```
+
+If review pushes for a true E2E flag-off test, swap to Option A from "Test #4 mechanics".
+
+## `scripts/e2e-local.sh` changes
+
+In the dj-site build env block (around the `NEXT_PUBLIC_VERSION=e2e` line), add:
+
+```bash
+NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED=true \
+NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED=true \
+```
+
+And before the `npx playwright test` line, export the DB connection vars so `pg-notify` can find Postgres (they're already exported earlier in the script — just need to confirm they're inherited by the Playwright subprocess):
+
+```bash
+DB_HOST=$DB_HOST \
+DB_PORT=$DB_PORT \
+DB_NAME=$DB_NAME \
+DB_USERNAME=$DB_USERNAME \
+DB_PASSWORD="$DB_PASSWORD" \
+E2E_BASE_URL=http://localhost:$FRONTEND_PORT \
+npx playwright test --config=e2e/playwright.config.ts "$@"
+```
+
+## `.github/workflows/e2e-tests.yml` changes
+
+Add the two SSE flags to the workflow-level `env:` block:
+
+```yaml
+NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED: "true"
+NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED: "true"
+```
+
+No DB env additions needed — `wxyc_admin` / `RadioIsEpic$1100` against `localhost:5434` are already in the workflow and inherited by every step.
+
+## Constraints from the issue
+
+| Constraint | How the plan satisfies it |
+| --- | --- |
+| Don't wait for real enrichment | `pg_notify` bypasses the worker entirely |
+| Payload matches `CdcEvent` shape | `buildFlowsheetUpdatePayload` mirrors the published shape with TS types |
+| Per-test row id isolation | Each test gets its row from the POST response — IDs are server-assigned and globally unique inside the run |
+| `page.route()` for any interception | Only test #2 needs response observation, and that's `page.waitForResponse`, not network mocking |
+
+## Risks
+
+1. **Race between "row exists in cache" and "NOTIFY fires"**: if dj-site hasn't yet refetched after the POST, the listener treats the row as not-in-cache and goes the debounced-invalidate path — which works but takes 500ms longer and exercises a different code path than the cache-patch one we want to pin. Mitigation: the existing FlowsheetPage `addTrack` helper already waits for the POST response, which means the row is in the optimistic cache before we issue the NOTIFY. Test #1's NOTIFY targets the server-assigned id, which is what the cache patches into the optimistic temp row after the response — so the in-cache check passes.
+2. **NOTIFY before client connects**: if `pgNotify()` fires before BS's SSE client list has the page subscribed, the message is lost (LISTEN/NOTIFY has no replay). Mitigation: `waitForSSEConnected` blocks until the handshake completes (test #1) or `waitForResponse` on `/events/stream` does the same (tests #2/#3).
+3. **CI Postgres port differs from local**: CI uses 5434, local script uses 5436. The pg-notify helper reads `DB_PORT` from env — both are exported.
+4. **Optimistic temp ids vs server ids**: the optimistic entry inserted before the POST resolves has a `temp_*` id. `routeUpdateEvent` checks `e.id === payload.id`, which matches only the server-assigned id. Since the test waits for the POST response before issuing the NOTIFY, the temp id has already been swapped for the real one. Verified against `entry-caching.spec.ts`'s `editEntry` flow (line 230) which depends on the same swap.
+5. **`/latest` is globally scoped — `/live` may show another test's row**: `getNowPlaying` returns the most recent flowsheet entry across all shows/DJs, so parallel tests adding rows can make any "wait for *my* row on /live" assertion flake (observed under `--repeat-each=5`). Mitigation: tests #2 and #3 read whichever id `/latest` actually returns from the anon page's GET response and NOTIFY for *that*, decoupling from "did our authed POST end up as the latest." The dashboard test (#1) is immune because it queries by specific entry-id locator, not by latest.
+6. **Backend-Service `CDC_SECRET` gates `startCdcListener()`**: discovered while bringing the first run up locally. `setupMetadataBroadcast()` registers a CDC callback at app start, but the only call site for `startCdcListener()` is inside `setupCdcWebSocket()`, which returns early if `CDC_SECRET` is unset. Result: with `CDC_SECRET` unset, every `pg_notify('cdc', ...)` is dropped on the floor and the SSE `liveFs:update` feature silently degrades to the 60s safety poll. This is a BS bug — `setupMetadataBroadcast` doesn't need the WebSocket secret. Worked around for now by setting a throwaway `CDC_SECRET` in both env profiles; will file a Backend-Service follow-up to split `startCdcListener` startup out of the secret-gated path.
+
+## Test-running expectations
+
+- `npm run test:e2e -- e2e/tests/sse/` runs all four (or three, under Option B) specs.
+- `npm run test:e2e -- e2e/tests/sse/ --repeat-each=10` for flake check.
+- Local-only verification command: `./scripts/e2e-local.sh e2e/tests/sse/`.
+- Tests should be tagged `.serial` to avoid contention on the shared go-live state and to keep the row-id reasoning simple.
+
+## Out of scope (deferred to other tickets in the epic)
+
+- `polling-rate.spec.ts`, `reconnect.spec.ts`, `server-session-via-docker.spec.ts` — #661 (Tier 2)
+- `refetch-event.spec.ts` — #662 (Tier 3, dj-site half)
+- BS-side `sse-metrics.spec.js` — #662 (Tier 3, BS half, separate PR)
+- Un-skip 3 `LIVE_FS_*` contract tests — wxyc-shared#145
+- Production flag flip — #663

--- a/e2e/fixtures/sse-cdc-payloads.ts
+++ b/e2e/fixtures/sse-cdc-payloads.ts
@@ -1,23 +1,9 @@
 /**
  * Typed payload builders for `pg_notify('cdc', <json>)` from E2E tests.
- *
- * Mirrors `@wxyc/database`'s `CdcEvent` shape
- * (Backend-Service/shared/database/src/cdc-listener.ts). Backend-Service's
- * `setupMetadataBroadcast` (apps/backend/services/metadata-broadcast/...)
- * filters NOTIFY payloads on:
- *
- *   event.table  === 'flowsheet'
- *   event.action === 'UPDATE'
- *   event.data.metadata_status ∈ TERMINAL_STATUSES
- *   typeof event.data.id === 'number'
- *
- * Anything matching is rebroadcast verbatim as a `liveFs:update` SSE event,
- * which dj-site's listener middleware uses to patch the RTK Query cache.
- *
- * The `data` field is the full flowsheet row — payload shape == row shape.
- * BS-2 is the contract this fixture pins: the broadcast carries the entire
- * row, not just `{id, metadata_status}`. Tests assert that observable fields
- * (e.g., `artwork_url`) render in the DOM after the NOTIFY.
+ * Mirrors `CdcEvent` from `@wxyc/database`. Backend-Service's
+ * `setupMetadataBroadcast` filters on `table === 'flowsheet'`,
+ * `action === 'UPDATE'`, terminal `data.metadata_status`, and numeric
+ * `data.id`; matching payloads are rebroadcast verbatim as `liveFs:update`.
  */
 
 export type TerminalMetadataStatus =
@@ -27,15 +13,16 @@ export type TerminalMetadataStatus =
 
 export type CdcAction = "INSERT" | "UPDATE" | "DELETE";
 
+/**
+ * Mirrors `CdcEvent.data` from `@wxyc/database` — open shape because the
+ * CDC pipeline carries the full DB row, not just the fields BS's
+ * `filterMetadataUpdate` requires. `id` is required because the dj-site
+ * listener routes by it; `metadata_status` because BS's filter rejects
+ * anything without a terminal value.
+ */
 export type CdcFlowsheetRow = {
   id: number;
   metadata_status?: TerminalMetadataStatus;
-  artwork_url?: string;
-  release_year?: number;
-  album_title?: string;
-  artist_name?: string;
-  track_title?: string;
-  record_label?: string;
   [key: string]: unknown;
 };
 

--- a/e2e/fixtures/sse-cdc-payloads.ts
+++ b/e2e/fixtures/sse-cdc-payloads.ts
@@ -1,0 +1,67 @@
+/**
+ * Typed payload builders for `pg_notify('cdc', <json>)` from E2E tests.
+ *
+ * Mirrors `@wxyc/database`'s `CdcEvent` shape
+ * (Backend-Service/shared/database/src/cdc-listener.ts). Backend-Service's
+ * `setupMetadataBroadcast` (apps/backend/services/metadata-broadcast/...)
+ * filters NOTIFY payloads on:
+ *
+ *   event.table  === 'flowsheet'
+ *   event.action === 'UPDATE'
+ *   event.data.metadata_status ∈ TERMINAL_STATUSES
+ *   typeof event.data.id === 'number'
+ *
+ * Anything matching is rebroadcast verbatim as a `liveFs:update` SSE event,
+ * which dj-site's listener middleware uses to patch the RTK Query cache.
+ *
+ * The `data` field is the full flowsheet row — payload shape == row shape.
+ * BS-2 is the contract this fixture pins: the broadcast carries the entire
+ * row, not just `{id, metadata_status}`. Tests assert that observable fields
+ * (e.g., `artwork_url`) render in the DOM after the NOTIFY.
+ */
+
+export type TerminalMetadataStatus =
+  | "enriched_match"
+  | "enriched_no_match"
+  | "failed_no_retry";
+
+export type CdcAction = "INSERT" | "UPDATE" | "DELETE";
+
+export type CdcFlowsheetRow = {
+  id: number;
+  metadata_status?: TerminalMetadataStatus;
+  artwork_url?: string;
+  release_year?: number;
+  album_title?: string;
+  artist_name?: string;
+  track_title?: string;
+  record_label?: string;
+  [key: string]: unknown;
+};
+
+export type CdcEventPayload = {
+  table: string;
+  schema: string;
+  action: CdcAction;
+  data: CdcFlowsheetRow | null;
+  timestamp: number;
+};
+
+/**
+ * Build a CDC UPDATE payload for the `flowsheet` table that BS will broadcast
+ * as a `liveFs:update`. `metadata_status` defaults to 'enriched_match' so
+ * the payload satisfies the broadcast filter without the caller having to
+ * remember.
+ */
+export function buildFlowsheetUpdatePayload(row: CdcFlowsheetRow): CdcEventPayload {
+  return {
+    table: "flowsheet",
+    schema: "public",
+    action: "UPDATE",
+    data: {
+      ...row,
+      metadata_status: row.metadata_status ?? "enriched_match",
+    },
+    timestamp: Date.now(),
+  };
+}

--- a/e2e/helpers/pg-notify.ts
+++ b/e2e/helpers/pg-notify.ts
@@ -29,11 +29,13 @@ export async function pgNotify(channel: string, payload: object): Promise<void> 
   const client = new Client(getDbConfig());
   await client.connect();
   try {
-    // NOTIFY's payload must be a SQL literal — parameter binding is not
-    // allowed. JSON.stringify never produces backslash-escaped single quotes,
-    // so SQL single-quote doubling is sufficient.
+    // NOTIFY accepts neither parameter binding for the channel nor parameter
+    // binding for the payload. `escapeIdentifier` is the only safe path for
+    // the channel name; single-quote doubling is sufficient for the JSON
+    // payload (JSON.stringify never emits backslash-escaped single quotes).
+    const quotedChannel = client.escapeIdentifier(channel);
     const literal = JSON.stringify(payload).replace(/'/g, "''");
-    await client.query(`NOTIFY ${channel}, '${literal}'`);
+    await client.query(`NOTIFY ${quotedChannel}, '${literal}'`);
   } finally {
     await client.end();
   }

--- a/e2e/helpers/pg-notify.ts
+++ b/e2e/helpers/pg-notify.ts
@@ -1,0 +1,46 @@
+import { Client } from "pg";
+
+/**
+ * Fire a Postgres NOTIFY from a Playwright test.
+ *
+ * The Backend-Service SSE pipeline subscribes to LISTEN 'cdc' and broadcasts
+ * matching events to connected EventSource clients. Tests use this to skip
+ * the LML enrichment chain (unreachable in CI) and exercise just the
+ * CDC -> broadcast -> SSE -> DOM segment.
+ *
+ * Reads DB connection details from environment variables — `scripts/e2e-local.sh`
+ * and `.github/workflows/e2e-tests.yml` both export DB_HOST/PORT/NAME/USERNAME/
+ * PASSWORD. Throws if any are missing so misconfigured CI surfaces loudly
+ * instead of silently connecting to the wrong place.
+ */
+function getDbConfig() {
+  const required = ["DB_HOST", "DB_PORT", "DB_NAME", "DB_USERNAME", "DB_PASSWORD"] as const;
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    throw new Error(
+      `pg-notify: missing required env vars: ${missing.join(", ")}. ` +
+        `Ensure scripts/e2e-local.sh (or the CI workflow) exports DB_* before running Playwright.`
+    );
+  }
+  return {
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT),
+    database: process.env.DB_NAME,
+    user: process.env.DB_USERNAME,
+    password: process.env.DB_PASSWORD,
+  };
+}
+
+export async function pgNotify(channel: string, payload: object): Promise<void> {
+  const client = new Client(getDbConfig());
+  await client.connect();
+  try {
+    // NOTIFY's payload must be a SQL literal — parameter binding is not
+    // allowed. JSON.stringify never produces backslash-escaped single quotes,
+    // so SQL single-quote doubling is sufficient.
+    const literal = JSON.stringify(payload).replace(/'/g, "''");
+    await client.query(`NOTIFY ${channel}, '${literal}'`);
+  } finally {
+    await client.end();
+  }
+}

--- a/e2e/helpers/pg-notify.ts
+++ b/e2e/helpers/pg-notify.ts
@@ -1,17 +1,11 @@
 import { Client } from "pg";
 
 /**
- * Fire a Postgres NOTIFY from a Playwright test.
- *
- * The Backend-Service SSE pipeline subscribes to LISTEN 'cdc' and broadcasts
- * matching events to connected EventSource clients. Tests use this to skip
- * the LML enrichment chain (unreachable in CI) and exercise just the
- * CDC -> broadcast -> SSE -> DOM segment.
- *
- * Reads DB connection details from environment variables — `scripts/e2e-local.sh`
- * and `.github/workflows/e2e-tests.yml` both export DB_HOST/PORT/NAME/USERNAME/
- * PASSWORD. Throws if any are missing so misconfigured CI surfaces loudly
- * instead of silently connecting to the wrong place.
+ * Fire a Postgres NOTIFY from a Playwright test, so tests can bypass the
+ * LML enrichment chain and exercise just the CDC → broadcast → SSE → DOM
+ * segment. Connection env vars are exported by scripts/e2e-local.sh and the
+ * E2E workflow — throws on missing config so misconfigured CI surfaces
+ * loudly rather than silently connecting to the wrong place.
  */
 function getDbConfig() {
   const required = ["DB_HOST", "DB_PORT", "DB_NAME", "DB_USERNAME", "DB_PASSWORD"] as const;

--- a/e2e/helpers/sse-wait.ts
+++ b/e2e/helpers/sse-wait.ts
@@ -3,17 +3,17 @@ import { expect, Page } from "@playwright/test";
 /**
  * Block until the page's SSEConnectionIndicator dot reports `connected`.
  *
- * Mounted on the modern dashboard (app/dashboard/@modern/flowsheet/layout.tsx)
- * — exposes `data-status` matching the values from `LiveUpdatesConnectionStatus`:
- * `closed | connecting | connected | reconnecting`. Wait on the attribute
- * rather than `data-state="connected"` selectors because Playwright's
- * attribute assertions retry until the timeout.
+ * The indicator (src/components/shared/SSEConnectionIndicator.tsx) renders
+ * `aria-label="Live updates: …"` + `data-status` matching the values from
+ * `LiveUpdatesConnectionStatus`. Selecting on the aria-label prefix scopes
+ * the wait to *this* indicator — any future MUI Joy child that grows a
+ * `data-status` attribute won't accidentally match.
  *
  * Use this in dashboard tests where firing `pgNotify` before the handshake
  * completes would lose the message (LISTEN/NOTIFY has no replay).
  */
 export async function waitForSSEConnected(page: Page, timeoutMs = 10_000): Promise<void> {
-  const indicator = page.locator('[data-status]').first();
+  const indicator = page.locator('[aria-label^="Live updates:"][data-status]');
   await expect(indicator).toHaveAttribute("data-status", "connected", { timeout: timeoutMs });
 }
 

--- a/e2e/helpers/sse-wait.ts
+++ b/e2e/helpers/sse-wait.ts
@@ -1,0 +1,33 @@
+import { expect, Page } from "@playwright/test";
+
+/**
+ * Block until the page's SSEConnectionIndicator dot reports `connected`.
+ *
+ * Mounted on the modern dashboard (app/dashboard/@modern/flowsheet/layout.tsx)
+ * — exposes `data-status` matching the values from `LiveUpdatesConnectionStatus`:
+ * `closed | connecting | connected | reconnecting`. Wait on the attribute
+ * rather than `data-state="connected"` selectors because Playwright's
+ * attribute assertions retry until the timeout.
+ *
+ * Use this in dashboard tests where firing `pgNotify` before the handshake
+ * completes would lose the message (LISTEN/NOTIFY has no replay).
+ */
+export async function waitForSSEConnected(page: Page, timeoutMs = 10_000): Promise<void> {
+  const indicator = page.locator('[data-status]').first();
+  await expect(indicator).toHaveAttribute("data-status", "connected", { timeout: timeoutMs });
+}
+
+/**
+ * Wait for the GET /events/stream request to fire and the response to land
+ * with `text/event-stream`. Use on surfaces that don't mount the dashboard
+ * indicator (e.g., the public `/live` page).
+ *
+ * Returns the response so callers can introspect headers/status if they
+ * want (test #2 asserts the content-type, for example).
+ */
+export async function waitForSSEHandshake(page: Page, timeoutMs = 10_000) {
+  return page.waitForResponse(
+    (resp) => resp.url().includes("/events/stream") && resp.status() === 200,
+    { timeout: timeoutMs }
+  );
+}

--- a/e2e/pages/flowsheet.page.ts
+++ b/e2e/pages/flowsheet.page.ts
@@ -174,6 +174,20 @@ export class FlowsheetPage {
     }
   }
 
+  /**
+   * Fast happy-path version of `goLive` for tests that don't care whether
+   * the DJ was already On Air. Mirrors `ensureOffAir`.
+   */
+  async ensureLive(): Promise<void> {
+    try {
+      const statusText = await this.liveStatus.textContent({ timeout: 3000 });
+      if (statusText?.includes("On Air")) return;
+    } catch {
+      // Status element not rendered yet — fall through to goLive
+    }
+    await this.goLive();
+  }
+
   async expectLive(): Promise<void> {
     await expect(this.liveStatus).toContainText("On Air");
   }

--- a/e2e/tests/sse/round-trip.spec.ts
+++ b/e2e/tests/sse/round-trip.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, BrowserContext } from "@playwright/test";
+import { test, expect, Browser, Page } from "@playwright/test";
 import path from "path";
 import { FlowsheetPage } from "../../pages/flowsheet.page";
 import { pgNotify } from "../../helpers/pg-notify";
@@ -12,66 +12,37 @@ const DJ_STORAGE = path.join(authDir, "dj2.json");
 /**
  * Tier 1 SSE round-trip — pins the cross-repo Live Updates contract.
  *
- * All three tests live in one spec file (one worker) so the file-scoped
- * afterAll's `ensureOffAir` can't race a sibling test mid-NOTIFY. dj2.json
- * is the only authenticated state available for flowsheet tests (dj.json
- * gets invalidated by auth/logout.spec.ts), so per-test DJ isolation isn't
- * possible — single-worker serialisation is the cleanest fix.
+ * Strategy: `pg_notify('cdc', <json>)` bypasses the LML enrichment chain so
+ * tests can exercise just the CDC -> broadcast -> SSE -> DOM segment.
+ * Backend-Service's setupMetadataBroadcast filter rebroadcasts the matching
+ * payload verbatim as a `liveFs:update` SSE event within ms.
  *
- * Strategy: `pg_notify('cdc', <json>)` bypasses the LML enrichment chain.
- * BS's setupMetadataBroadcast filter rebroadcasts the matching payload
- * verbatim as a `liveFs:update` SSE event within ms. See plan in
- * docs/plans/sse-tier1-e2e.md.
- *
- * Pins for review:
- *   1. cross-DJ update on dashboard       — BS-1 + BS-2 + listener cache-patch path
- *   2. anonymous /live receives update    — LIVE_FS_PUBLIC_TOPIC_NO_AUTH invariant
- *   3. full-row artwork_url renders       — LIVE_FS_UPDATE_INCLUDES_FULL_ROW invariant
+ * Why one file: dj2.json is the only authenticated state available (dj.json
+ * is invalidated by auth/logout.spec.ts), so per-test DJ isolation isn't
+ * possible. Single-worker serialisation prevents an afterAll's `ensureOffAir`
+ * from racing a sibling test on a parallel worker.
  */
 test.describe("SSE Tier 1 — round-trip", () => {
   test.use({ storageState: DJ_STORAGE });
   test.describe.configure({ mode: "serial" });
   test.setTimeout(90_000);
 
-  test.afterAll(async ({ browser }) => {
-    const context = await browser.newContext({
-      storageState: DJ_STORAGE,
-      baseURL: BASE_URL,
+  test.beforeAll(async ({ browser }) => {
+    // One-time go-live so each test's `ensureLive` is a fast no-op instead
+    // of paying the ~3s status-probe + click + reload chain. Also seeds a
+    // song row so /latest renders a real album-art <img> (not a show-start
+    // icon) for tests #2/#3 to assert on.
+    await withAuthedFlowsheet(browser, async (fs) => {
+      await fs.ensureLive();
+      await addRow(fs, "Stereolab", "Aluminum Tunes");
     });
-    const page = await context.newPage();
-    const fs = new FlowsheetPage(page);
-    await fs.goto();
-    await fs.waitForEntriesLoaded();
-    await fs.ensureOffAir();
-    await context.close();
   });
 
-  async function goLiveAndAddRow(
-    fs: FlowsheetPage,
-    songName: string,
-    artist: string,
-    album: string
-  ): Promise<{ id: number }> {
-    await fs.goto();
-    await fs.waitForEntriesLoaded();
-    const isLive = await expect(fs.liveStatus)
-      .toContainText("On Air", { timeout: 15_000 })
-      .then(() => true)
-      .catch(() => false);
-    if (!isLive) await fs.goLive();
-
-    const addResp = fs.page.waitForResponse(
-      (r) =>
-        r.url().includes("/flowsheet/") &&
-        r.request().method() === "POST" &&
-        r.status() < 300,
-      { timeout: 30_000 }
-    );
-    await fs.addTrack({ song: songName, artist, album });
-    const row = await (await addResp).json();
-    expect(typeof row.id).toBe("number");
-    return row;
-  }
+  test.afterAll(async ({ browser }) => {
+    await withAuthedFlowsheet(browser, async (fs) => {
+      await fs.ensureOffAir();
+    });
+  });
 
   /**
    * Test #1: a `liveFs:update` for an in-cache dashboard row patches the
@@ -79,16 +50,14 @@ test.describe("SSE Tier 1 — round-trip", () => {
    * cache-patch path (id-in-cache branch of routeUpdateEvent).
    */
   test("liveFs:update patches an in-cache dashboard row within 5s", async ({ page }) => {
-    const flowsheet = new FlowsheetPage(page);
-    const ts = Date.now();
-    const row = await goLiveAndAddRow(
-      flowsheet,
-      `tier1-update-${ts}`,
-      "Juana Molina",
-      "DOGA"
-    );
+    const fs = new FlowsheetPage(page);
+    await fs.goto();
+    await fs.waitForEntriesLoaded();
+    await fs.ensureLive();
+    const row = await addRow(fs, "Juana Molina", "DOGA");
 
-    // SSE must be connected before NOTIFY fires, or the broadcast is lost.
+    // NOTIFY before handshake completes is silently lost (LISTEN/NOTIFY has
+    // no replay).
     await waitForSSEConnected(page);
 
     const newArtworkUrl = `https://example.org/tier1-update-${row.id}.jpg`;
@@ -110,54 +79,20 @@ test.describe("SSE Tier 1 — round-trip", () => {
    * cookies. Pins LIVE_FS_PUBLIC_TOPIC_NO_AUTH — if BS-1's route-level auth
    * guard is reinstated, the handshake fails on status 401/403.
    */
-  test("/live anonymous viewer receives liveFs:update with no cookies", async ({
-    browser,
-  }) => {
-    const authedContext = await browser.newContext({
-      storageState: DJ_STORAGE,
-      baseURL: BASE_URL,
-    });
-    const anonContext = await browser.newContext({ baseURL: BASE_URL });
-
-    try {
-      // Ensure /live has *something* to render. /latest is globally scoped
-      // (returns the most recent flowsheet row across all DJs), so we can't
-      // assume the row we add here is the one /live ends up showing — other
-      // parallel tests may add rows too. The test stays robust by reading
-      // whichever id /latest returned and NOTIFYing for *that*.
-      const authedPage = await authedContext.newPage();
-      const fs = new FlowsheetPage(authedPage);
-      await goLiveAndAddRow(fs, `tier1-anon-${Date.now()}`, "Stereolab", "Aluminum Tunes");
-
-      const anonPage = await anonContext.newPage();
-      const handshakePromise = waitForSSEHandshake(anonPage, 15_000);
-      const latestRespPromise = anonPage.waitForResponse(
-        (r) =>
-          /\/flowsheet\/latest\b/.test(r.url()) &&
-          r.request().method() === "GET" &&
-          r.status() === 200,
-        { timeout: 15_000 }
-      );
-      await anonPage.goto("/live");
-      const handshake = await handshakePromise;
+  test("/live anonymous viewer receives liveFs:update with no cookies", async ({ browser }) => {
+    await withAnonLive(browser, async ({ anonPage, latestRowId, handshake }) => {
       expect(handshake.status()).toBe(200);
       expect(handshake.headers()["content-type"]).toContain("text/event-stream");
 
-      const latestRow = await (await latestRespPromise).json();
-      expect(typeof latestRow?.id).toBe("number");
-
-      const newArtworkUrl = `https://example.org/tier1-anon-${latestRow.id}.jpg`;
+      const newArtworkUrl = `https://example.org/tier1-anon-${latestRowId}.jpg`;
       await pgNotify(
         "cdc",
-        buildFlowsheetUpdatePayload({ id: latestRow.id, artwork_url: newArtworkUrl })
+        buildFlowsheetUpdatePayload({ id: latestRowId, artwork_url: newArtworkUrl })
       );
-
       await expect(anonPage.locator(`img[src="${newArtworkUrl}"]`).first()).toBeVisible({
         timeout: 5_000,
       });
-    } finally {
-      await closeContexts(authedContext, anonContext);
-    }
+    });
   });
 
   /**
@@ -171,53 +106,91 @@ test.describe("SSE Tier 1 — round-trip", () => {
   test("artwork_url from the full-row payload renders on /live (BS-2 contract)", async ({
     browser,
   }) => {
-    const authedContext = await browser.newContext({
-      storageState: DJ_STORAGE,
-      baseURL: BASE_URL,
-    });
-    const anonContext = await browser.newContext({ baseURL: BASE_URL });
-
-    try {
-      const authedPage = await authedContext.newPage();
-      const fs = new FlowsheetPage(authedPage);
-      await goLiveAndAddRow(fs, `tier1-fullrow-${Date.now()}`, "Cat Power", "Moon Pix");
-
-      const anonPage = await anonContext.newPage();
-      const handshakePromise = waitForSSEHandshake(anonPage, 15_000);
-      // Capture whichever id /latest returns — same robustness rationale as
-      // test #2. Test #3's payload is what BS-2 is on the hook for: the
-      // artwork_url must arrive verbatim and render as an <img src>. If BS-2
-      // ever reverts to `{id, metadata_status}`, this assertion is the one
-      // that fails loudly.
-      const latestRespPromise = anonPage.waitForResponse(
-        (r) =>
-          /\/flowsheet\/latest\b/.test(r.url()) &&
-          r.request().method() === "GET" &&
-          r.status() === 200,
-        { timeout: 15_000 }
-      );
-      await anonPage.goto("/live");
-      await handshakePromise;
-      const latestRow = await (await latestRespPromise).json();
-      expect(typeof latestRow?.id).toBe("number");
-
-      const artworkUrl = `https://example.org/tier1-fullrow-${latestRow.id}-bs2.jpg`;
+    await withAnonLive(browser, async ({ anonPage, latestRowId }) => {
+      const artworkUrl = `https://example.org/tier1-fullrow-${latestRowId}-bs2.jpg`;
       await pgNotify(
         "cdc",
-        buildFlowsheetUpdatePayload({ id: latestRow.id, artwork_url: artworkUrl })
+        buildFlowsheetUpdatePayload({ id: latestRowId, artwork_url: artworkUrl })
       );
-
       await expect(anonPage.locator(`img[src="${artworkUrl}"]`).first()).toBeVisible({
         timeout: 5_000,
       });
-    } finally {
-      await closeContexts(authedContext, anonContext);
-    }
+    });
   });
 });
 
-async function closeContexts(...contexts: BrowserContext[]): Promise<void> {
-  for (const ctx of contexts) {
-    await ctx.close().catch(() => {});
+/**
+ * Run `body` against a fresh authed FlowsheetPage and clean up the context
+ * afterwards. Used by beforeAll/afterAll for go-live + cleanup.
+ */
+async function withAuthedFlowsheet(
+  browser: Browser,
+  body: (fs: FlowsheetPage) => Promise<void>
+): Promise<void> {
+  const context = await browser.newContext({ storageState: DJ_STORAGE, baseURL: BASE_URL });
+  try {
+    const page = await context.newPage();
+    const fs = new FlowsheetPage(page);
+    await fs.goto();
+    await fs.waitForEntriesLoaded();
+    await body(fs);
+  } finally {
+    await context.close();
   }
+}
+
+/**
+ * Open an anonymous /live, wait for the SSE handshake, capture whichever id
+ * /flowsheet/latest returned, and pass them to `body`.
+ *
+ * The "whichever id" matters: /latest is globally scoped, so parallel tests
+ * adding rows can shift it. The test stays robust by NOTIFYing for the id
+ * that /live's own getNowPlaying cache actually has, instead of asserting on
+ * a row we hope is still latest.
+ */
+async function withAnonLive(
+  browser: Browser,
+  body: (ctx: {
+    anonPage: Page;
+    latestRowId: number;
+    handshake: Awaited<ReturnType<typeof waitForSSEHandshake>>;
+  }) => Promise<void>
+): Promise<void> {
+  const anonContext = await browser.newContext({ baseURL: BASE_URL });
+  try {
+    const anonPage = await anonContext.newPage();
+    const handshakePromise = waitForSSEHandshake(anonPage, 15_000);
+    const latestRespPromise = anonPage.waitForResponse(
+      (r) =>
+        /\/flowsheet\/latest\b/.test(r.url()) &&
+        r.request().method() === "GET" &&
+        r.status() === 200,
+      { timeout: 15_000 }
+    );
+    await anonPage.goto("/live");
+    const handshake = await handshakePromise;
+    const latestRow = await (await latestRespPromise).json();
+    expect(typeof latestRow?.id).toBe("number");
+    await body({ anonPage, latestRowId: latestRow.id, handshake });
+  } finally {
+    await anonContext.close();
+  }
+}
+
+async function addRow(
+  fs: FlowsheetPage,
+  artist: string,
+  album: string
+): Promise<{ id: number }> {
+  const addResp = fs.page.waitForResponse(
+    (r) =>
+      r.url().includes("/flowsheet/") &&
+      r.request().method() === "POST" &&
+      r.status() < 300,
+    { timeout: 30_000 }
+  );
+  await fs.addTrack({ song: `tier1-${Date.now()}`, artist, album });
+  const row = await (await addResp).json();
+  expect(typeof row.id).toBe("number");
+  return row;
 }

--- a/e2e/tests/sse/round-trip.spec.ts
+++ b/e2e/tests/sse/round-trip.spec.ts
@@ -1,0 +1,223 @@
+import { test, expect, BrowserContext } from "@playwright/test";
+import path from "path";
+import { FlowsheetPage } from "../../pages/flowsheet.page";
+import { pgNotify } from "../../helpers/pg-notify";
+import { waitForSSEConnected, waitForSSEHandshake } from "../../helpers/sse-wait";
+import { buildFlowsheetUpdatePayload } from "../../fixtures/sse-cdc-payloads";
+
+const authDir = path.join(__dirname, "..", "..", ".auth");
+const BASE_URL = process.env.E2E_BASE_URL || "http://localhost:3000";
+const DJ_STORAGE = path.join(authDir, "dj2.json");
+
+/**
+ * Tier 1 SSE round-trip — pins the cross-repo Live Updates contract.
+ *
+ * All three tests live in one spec file (one worker) so the file-scoped
+ * afterAll's `ensureOffAir` can't race a sibling test mid-NOTIFY. dj2.json
+ * is the only authenticated state available for flowsheet tests (dj.json
+ * gets invalidated by auth/logout.spec.ts), so per-test DJ isolation isn't
+ * possible — single-worker serialisation is the cleanest fix.
+ *
+ * Strategy: `pg_notify('cdc', <json>)` bypasses the LML enrichment chain.
+ * BS's setupMetadataBroadcast filter rebroadcasts the matching payload
+ * verbatim as a `liveFs:update` SSE event within ms. See plan in
+ * docs/plans/sse-tier1-e2e.md.
+ *
+ * Pins for review:
+ *   1. cross-DJ update on dashboard       — BS-1 + BS-2 + listener cache-patch path
+ *   2. anonymous /live receives update    — LIVE_FS_PUBLIC_TOPIC_NO_AUTH invariant
+ *   3. full-row artwork_url renders       — LIVE_FS_UPDATE_INCLUDES_FULL_ROW invariant
+ */
+test.describe("SSE Tier 1 — round-trip", () => {
+  test.use({ storageState: DJ_STORAGE });
+  test.describe.configure({ mode: "serial" });
+  test.setTimeout(90_000);
+
+  test.afterAll(async ({ browser }) => {
+    const context = await browser.newContext({
+      storageState: DJ_STORAGE,
+      baseURL: BASE_URL,
+    });
+    const page = await context.newPage();
+    const fs = new FlowsheetPage(page);
+    await fs.goto();
+    await fs.waitForEntriesLoaded();
+    await fs.ensureOffAir();
+    await context.close();
+  });
+
+  async function goLiveAndAddRow(
+    fs: FlowsheetPage,
+    songName: string,
+    artist: string,
+    album: string
+  ): Promise<{ id: number }> {
+    await fs.goto();
+    await fs.waitForEntriesLoaded();
+    const isLive = await expect(fs.liveStatus)
+      .toContainText("On Air", { timeout: 15_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!isLive) await fs.goLive();
+
+    const addResp = fs.page.waitForResponse(
+      (r) =>
+        r.url().includes("/flowsheet/") &&
+        r.request().method() === "POST" &&
+        r.status() < 300,
+      { timeout: 30_000 }
+    );
+    await fs.addTrack({ song: songName, artist, album });
+    const row = await (await addResp).json();
+    expect(typeof row.id).toBe("number");
+    return row;
+  }
+
+  /**
+   * Test #1: a `liveFs:update` for an in-cache dashboard row patches the
+   * row's mutated fields into the rendered DOM within 5s. Pins the
+   * cache-patch path (id-in-cache branch of routeUpdateEvent).
+   */
+  test("liveFs:update patches an in-cache dashboard row within 5s", async ({ page }) => {
+    const flowsheet = new FlowsheetPage(page);
+    const ts = Date.now();
+    const row = await goLiveAndAddRow(
+      flowsheet,
+      `tier1-update-${ts}`,
+      "Juana Molina",
+      "DOGA"
+    );
+
+    // SSE must be connected before NOTIFY fires, or the broadcast is lost.
+    await waitForSSEConnected(page);
+
+    const newArtworkUrl = `https://example.org/tier1-update-${row.id}.jpg`;
+    await pgNotify(
+      "cdc",
+      buildFlowsheetUpdatePayload({ id: row.id, artwork_url: newArtworkUrl })
+    );
+
+    const entry = page.locator(`[data-testid="flowsheet-entry-${row.id}"]`);
+    await expect(entry.locator("img").first()).toHaveAttribute(
+      "src",
+      newArtworkUrl,
+      { timeout: 5_000 }
+    );
+  });
+
+  /**
+   * Test #2: anonymous `/live` viewer receives the same update without
+   * cookies. Pins LIVE_FS_PUBLIC_TOPIC_NO_AUTH — if BS-1's route-level auth
+   * guard is reinstated, the handshake fails on status 401/403.
+   */
+  test("/live anonymous viewer receives liveFs:update with no cookies", async ({
+    browser,
+  }) => {
+    const authedContext = await browser.newContext({
+      storageState: DJ_STORAGE,
+      baseURL: BASE_URL,
+    });
+    const anonContext = await browser.newContext({ baseURL: BASE_URL });
+
+    try {
+      // Ensure /live has *something* to render. /latest is globally scoped
+      // (returns the most recent flowsheet row across all DJs), so we can't
+      // assume the row we add here is the one /live ends up showing — other
+      // parallel tests may add rows too. The test stays robust by reading
+      // whichever id /latest returned and NOTIFYing for *that*.
+      const authedPage = await authedContext.newPage();
+      const fs = new FlowsheetPage(authedPage);
+      await goLiveAndAddRow(fs, `tier1-anon-${Date.now()}`, "Stereolab", "Aluminum Tunes");
+
+      const anonPage = await anonContext.newPage();
+      const handshakePromise = waitForSSEHandshake(anonPage, 15_000);
+      const latestRespPromise = anonPage.waitForResponse(
+        (r) =>
+          /\/flowsheet\/latest\b/.test(r.url()) &&
+          r.request().method() === "GET" &&
+          r.status() === 200,
+        { timeout: 15_000 }
+      );
+      await anonPage.goto("/live");
+      const handshake = await handshakePromise;
+      expect(handshake.status()).toBe(200);
+      expect(handshake.headers()["content-type"]).toContain("text/event-stream");
+
+      const latestRow = await (await latestRespPromise).json();
+      expect(typeof latestRow?.id).toBe("number");
+
+      const newArtworkUrl = `https://example.org/tier1-anon-${latestRow.id}.jpg`;
+      await pgNotify(
+        "cdc",
+        buildFlowsheetUpdatePayload({ id: latestRow.id, artwork_url: newArtworkUrl })
+      );
+
+      await expect(anonPage.locator(`img[src="${newArtworkUrl}"]`).first()).toBeVisible({
+        timeout: 5_000,
+      });
+    } finally {
+      await closeContexts(authedContext, anonContext);
+    }
+  });
+
+  /**
+   * Test #3: surgical regression test for BS-2 — the broadcast carries the
+   * full row, not just `{id, metadata_status}`. The unique artwork URL in
+   * the payload must appear verbatim as an <img src>. If BS-2 reverts to
+   * the minimal shape, tests #1 and #2 may incidentally pass (the cache
+   * patch is a shallow merge; prior artwork sticks around), but the new
+   * artwork field never renders.
+   */
+  test("artwork_url from the full-row payload renders on /live (BS-2 contract)", async ({
+    browser,
+  }) => {
+    const authedContext = await browser.newContext({
+      storageState: DJ_STORAGE,
+      baseURL: BASE_URL,
+    });
+    const anonContext = await browser.newContext({ baseURL: BASE_URL });
+
+    try {
+      const authedPage = await authedContext.newPage();
+      const fs = new FlowsheetPage(authedPage);
+      await goLiveAndAddRow(fs, `tier1-fullrow-${Date.now()}`, "Cat Power", "Moon Pix");
+
+      const anonPage = await anonContext.newPage();
+      const handshakePromise = waitForSSEHandshake(anonPage, 15_000);
+      // Capture whichever id /latest returns — same robustness rationale as
+      // test #2. Test #3's payload is what BS-2 is on the hook for: the
+      // artwork_url must arrive verbatim and render as an <img src>. If BS-2
+      // ever reverts to `{id, metadata_status}`, this assertion is the one
+      // that fails loudly.
+      const latestRespPromise = anonPage.waitForResponse(
+        (r) =>
+          /\/flowsheet\/latest\b/.test(r.url()) &&
+          r.request().method() === "GET" &&
+          r.status() === 200,
+        { timeout: 15_000 }
+      );
+      await anonPage.goto("/live");
+      await handshakePromise;
+      const latestRow = await (await latestRespPromise).json();
+      expect(typeof latestRow?.id).toBe("number");
+
+      const artworkUrl = `https://example.org/tier1-fullrow-${latestRow.id}-bs2.jpg`;
+      await pgNotify(
+        "cdc",
+        buildFlowsheetUpdatePayload({ id: latestRow.id, artwork_url: artworkUrl })
+      );
+
+      await expect(anonPage.locator(`img[src="${artworkUrl}"]`).first()).toBeVisible({
+        timeout: 5_000,
+      });
+    } finally {
+      await closeContexts(authedContext, anonContext);
+    }
+  });
+});
+
+async function closeContexts(...contexts: BrowserContext[]): Promise<void> {
+  for (const ctx of contexts) {
+    await ctx.close().catch(() => {});
+  }
+}

--- a/lib/__tests__/features/flowsheet/sse-flags.test.ts
+++ b/lib/__tests__/features/flowsheet/sse-flags.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isFlowsheetSSEDashboardEnabled,
+  isFlowsheetSSELiveViewEnabled,
+} from "@/lib/features/flowsheet/sse-flags";
+
+/**
+ * Tier 1 — Test #4 (gate half): exhaustively assert the SSE feature-flag
+ * helpers' coercion logic.
+ *
+ * `NEXT_PUBLIC_*` env vars are inlined as the string the user wrote at
+ * Next.js build time, so the helpers' only job is to recognise the truthy
+ * values. A regression here would either silently disable SSE in prod when
+ * the flag IS flipped, or silently enable it when it ISN'T.
+ *
+ * Complements `SSESubscription.test.tsx`, which covers the component-level
+ * gate (the consumer that calls these helpers).
+ */
+describe("sse-flags", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("isFlowsheetSSEDashboardEnabled", () => {
+    it.each<[string | undefined, boolean]>([
+      ["true", true],
+      ["1", true],
+      ["false", false],
+      ["0", false],
+      ["", false],
+      [undefined, false],
+      ["TRUE", false], // case-sensitive on purpose
+      ["yes", false],
+    ])("returns %j for NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED=%j", (value, expected) => {
+      if (value === undefined) {
+        vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED", "");
+      } else {
+        vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED", value);
+      }
+      expect(isFlowsheetSSEDashboardEnabled()).toBe(expected);
+    });
+  });
+
+  describe("isFlowsheetSSELiveViewEnabled", () => {
+    it.each<[string | undefined, boolean]>([
+      ["true", true],
+      ["1", true],
+      ["false", false],
+      ["0", false],
+      ["", false],
+      [undefined, false],
+      ["TRUE", false],
+      ["yes", false],
+    ])("returns %j for NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED=%j", (value, expected) => {
+      if (value === undefined) {
+        vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED", "");
+      } else {
+        vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED", value);
+      }
+      expect(isFlowsheetSSELiveViewEnabled()).toBe(expected);
+    });
+  });
+
+  it("dashboard and live-view flags are independent", () => {
+    vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED", "true");
+    vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED", "false");
+    expect(isFlowsheetSSEDashboardEnabled()).toBe(true);
+    expect(isFlowsheetSSELiveViewEnabled()).toBe(false);
+  });
+});

--- a/lib/__tests__/features/flowsheet/sse-flags.test.ts
+++ b/lib/__tests__/features/flowsheet/sse-flags.test.ts
@@ -32,11 +32,7 @@ describe("sse-flags", () => {
       ["TRUE", false], // case-sensitive on purpose
       ["yes", false],
     ])("returns %j for NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED=%j", (value, expected) => {
-      if (value === undefined) {
-        vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED", "");
-      } else {
-        vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED", value);
-      }
+      vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED", value ?? "");
       expect(isFlowsheetSSEDashboardEnabled()).toBe(expected);
     });
   });
@@ -52,11 +48,7 @@ describe("sse-flags", () => {
       ["TRUE", false],
       ["yes", false],
     ])("returns %j for NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED=%j", (value, expected) => {
-      if (value === undefined) {
-        vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED", "");
-      } else {
-        vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED", value);
-      }
+      vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED", value ?? "");
       expect(isFlowsheetSSELiveViewEnabled()).toBe(expected);
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dj-site-catalog-query-builder",
+  "name": "test-sse-tier1-e2e",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -37,6 +37,7 @@
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.0",
         "@types/node": "^20.19.30",
+        "@types/pg": "^8.11.10",
         "@types/react": "18.2.37",
         "@types/react-dom": "^18.2.18",
         "@vitejs/plugin-react": "^5.1.2",
@@ -45,6 +46,7 @@
         "esbuild": "^0.28.0",
         "jsdom": "^25.0.0",
         "msw": "^2.14.6",
+        "pg": "^8.13.1",
         "typescript": "^5.3.3",
         "vitest": "^4.0.18",
         "wrangler": "^4.90.1"
@@ -13717,6 +13719,18 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -17262,6 +17276,102 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -17352,6 +17462,49 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/posthog-js": {
@@ -18109,6 +18262,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -20058,6 +20221,16 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-sse-tier1-e2e",
+  "name": "dj-site-catalog-query-builder",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.0",
     "@types/node": "^20.19.30",
+    "@types/pg": "^8.11.10",
     "@types/react": "18.2.37",
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react": "^5.1.2",
@@ -63,6 +64,7 @@
     "esbuild": "^0.28.0",
     "jsdom": "^25.0.0",
     "msw": "^2.14.6",
+    "pg": "^8.13.1",
     "typescript": "^5.3.3",
     "vitest": "^4.0.18",
     "wrangler": "^4.90.1"

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -53,6 +53,12 @@ export DEFAULT_ORG_SLUG=test-org
 export DEFAULT_ORG_NAME='Test Organization'
 export APP_ORGANIZATION_ID=test-org-id-0000000000000000001
 export NODE_ENV=test
+# CDC LISTEN is currently gated on CDC_SECRET in Backend-Service's
+# setupCdcWebSocket() — and setupMetadataBroadcast() depends on the LISTEN
+# being active to deliver pg_notify('cdc', ...) events to its handler.
+# Without this, the SSE Tier 1 tests' NOTIFYs are silently dropped. Tracked
+# as a Backend-Service follow-up to split LISTEN startup from CDC_SECRET.
+export CDC_SECRET=e2e-cdc-secret-not-used-by-tests
 
 echo "==> Building Backend-Service..."
 cd "$BACKEND_DIR"
@@ -90,6 +96,8 @@ NEXT_PUBLIC_ENABLED_EXPERIENCES=modern,classic \
 NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING=true \
 NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD=temppass123 \
 NEXT_PUBLIC_APP_ORGANIZATION=test-org \
+NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED=true \
+NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED=true \
 npm run build
 
 echo "==> Starting dj-site on :$FRONTEND_PORT..."

--- a/src/components/shared/SSESubscription.test.tsx
+++ b/src/components/shared/SSESubscription.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "@/lib/test-utils";
+import SSESubscription from "./SSESubscription";
+
+/**
+ * Tier 1 — Test #4 (consumer half): assert the component-level flag gate
+ * actually short-circuits when the surface flag is off.
+ *
+ * Strategy: `useSSEConnection` dispatches `liveUpdatesConnectionRequested`
+ * on mount, which bumps `liveUpdates.refCount` from 0 to 1. So if the gate
+ * works, an off-flag mount leaves refCount at 0; an on-flag mount lands it
+ * at 1. This catches the "someone removed the gate" regression at the
+ * SSESubscription seam — the next layer down (the listener middleware
+ * actually opening an EventSource) is covered separately by
+ * `live-updates-listener.test.ts`.
+ *
+ * NEXT_PUBLIC_* env vars are inlined at Next.js build time, but vitest
+ * doesn't run a Next.js build, so `vi.stubEnv` works at runtime here. In
+ * production CI, the flag-off-stays-off equivalent is provided by tests #1–3
+ * running against a flag-ON build (any regression where SSE silently fires
+ * with the flag off would surface as duplicate handshake requests in test #4
+ * of #661 once that lands, and as a connection-count step change in PostHog
+ * during the #663 staged rollout).
+ */
+describe("<SSESubscription>", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('surface="dashboard"', () => {
+    it("does not request the SSE connection when flag is off", () => {
+      vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED", "");
+      const { store } = renderWithProviders(<SSESubscription surface="dashboard" />);
+      expect(store.getState().liveUpdates.refCount).toBe(0);
+    });
+
+    it("requests the SSE connection when flag is true", () => {
+      vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED", "true");
+      const { store } = renderWithProviders(<SSESubscription surface="dashboard" />);
+      expect(store.getState().liveUpdates.refCount).toBe(1);
+    });
+
+    it("releases the SSE connection on unmount", () => {
+      vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED", "true");
+      const { store, unmount } = renderWithProviders(
+        <SSESubscription surface="dashboard" />
+      );
+      expect(store.getState().liveUpdates.refCount).toBe(1);
+      unmount();
+      expect(store.getState().liveUpdates.refCount).toBe(0);
+    });
+  });
+
+  describe('surface="live"', () => {
+    it("does not request the SSE connection when flag is off", () => {
+      vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED", "");
+      const { store } = renderWithProviders(<SSESubscription surface="live" />);
+      expect(store.getState().liveUpdates.refCount).toBe(0);
+    });
+
+    it("requests the SSE connection when flag is true", () => {
+      vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED", "true");
+      const { store } = renderWithProviders(<SSESubscription surface="live" />);
+      expect(store.getState().liveUpdates.refCount).toBe(1);
+    });
+  });
+
+  it("flags are independent — dashboard true, live off doesn't connect live", () => {
+    vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED", "true");
+    vi.stubEnv("NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED", "");
+    const { store } = renderWithProviders(<SSESubscription surface="live" />);
+    expect(store.getState().liveUpdates.refCount).toBe(0);
+  });
+});

--- a/src/components/shared/SSESubscription.test.tsx
+++ b/src/components/shared/SSESubscription.test.tsx
@@ -1,32 +1,16 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "@/lib/test-utils";
 import SSESubscription from "./SSESubscription";
 
 /**
- * Tier 1 — Test #4 (consumer half): assert the component-level flag gate
- * actually short-circuits when the surface flag is off.
+ * Gate test for the SSE feature flags. Asserts the component short-circuits
+ * `useSSEConnection` when its surface flag is off — observed via
+ * `liveUpdates.refCount` (1 on connect-requested, 0 otherwise).
  *
- * Strategy: `useSSEConnection` dispatches `liveUpdatesConnectionRequested`
- * on mount, which bumps `liveUpdates.refCount` from 0 to 1. So if the gate
- * works, an off-flag mount leaves refCount at 0; an on-flag mount lands it
- * at 1. This catches the "someone removed the gate" regression at the
- * SSESubscription seam — the next layer down (the listener middleware
- * actually opening an EventSource) is covered separately by
- * `live-updates-listener.test.ts`.
- *
- * NEXT_PUBLIC_* env vars are inlined at Next.js build time, but vitest
- * doesn't run a Next.js build, so `vi.stubEnv` works at runtime here. In
- * production CI, the flag-off-stays-off equivalent is provided by tests #1–3
- * running against a flag-ON build (any regression where SSE silently fires
- * with the flag off would surface as duplicate handshake requests in test #4
- * of #661 once that lands, and as a connection-count step change in PostHog
- * during the #663 staged rollout).
+ * NEXT_PUBLIC_* is inlined at Next.js build time, but vitest reads
+ * `process.env` at runtime so `vi.stubEnv` works here.
  */
 describe("<SSESubscription>", () => {
-  beforeEach(() => {
-    vi.unstubAllEnvs();
-  });
-
   afterEach(() => {
     vi.unstubAllEnvs();
   });


### PR DESCRIPTION
## Summary

Adds Tier 1 of the Live Updates SSE regression net — three Playwright tests that pin the cross-repo round-trip from Backend-Service's `pg_notify('cdc', ...)` through `setupMetadataBroadcast` to dj-site's listener middleware and the rendered DOM, plus two unit-test files covering the SSE feature-flag gate. Hard prerequisite for flipping `NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED=true` in production (#663) and the rollout-gate item under the #664 epic.

## Strategy

Tests issue `pg_notify('cdc', <json>)` directly against the e2e Postgres to bypass the LML enrichment chain (unreachable from `scripts/e2e-local.sh`). BS's metadata-broadcast filter rebroadcasts the matching payload verbatim as a `liveFs:update` SSE event within ms, and each test asserts the resulting DOM mutation lands within 5s. See `docs/plans/sse-tier1-e2e.md` for the full design.

All three E2E tests live in one spec file so the file-scoped `afterAll`'s `ensureOffAir` can't race a sibling test on a parallel worker — `dj2.json` is the only authenticated state available for flowsheet tests (`dj.json` is invalidated by `auth/logout.spec.ts`), so per-test DJ isolation isn't possible and single-worker serialisation is the cleanest fix.

## What's pinned

- **Test 1** — cross-DJ update on dashboard: BS-1's `GET /events/stream?topics=live-fs-topic`, BS-2's full-row payload, dj-site listener's `routeUpdateEvent` cache-patch path.
- **Test 2** — anonymous `/live` viewer receives `liveFs:update`: pins `LIVE_FS_PUBLIC_TOPIC_NO_AUTH` (handshake without cookies returns 200 with `text/event-stream`).
- **Test 3** — full-row `artwork_url` renders: surgical regression test for the BS-2 contract. If BS reverts to the old `{id, metadata_status}` payload, tests 1 and 2 may incidentally pass (the cache patch is a shallow merge; prior artwork sticks around), but the new artwork field never renders.
- **Test 4** — SSE feature-flag gate, split into two unit-test files (`lib/__tests__/features/flowsheet/sse-flags.test.ts` + `src/components/shared/SSESubscription.test.tsx`). Surrogate for the issue's "flag-off stays off" E2E test, since `NEXT_PUBLIC_*` env vars are build-time inlined and tests 1–3 need the build with the flag ON. An E2E flag-off variant would require a second `npm run build` per CI run (~30–60s); deferred unless review demands it.

## Notable Backend-Service finding

`setupMetadataBroadcast()` depends on `startCdcListener()` being active to receive `pg_notify` events. But `startCdcListener()` is only called from inside `setupCdcWebSocket()`, which returns early when `CDC_SECRET` is unset. Result: if `CDC_SECRET` is unset in any environment, the SSE `liveFs:update` feature silently degrades to the 60s safety poll — even though `setupMetadataBroadcast` itself doesn't need a secret. Working around this in the e2e env (setting a throwaway `CDC_SECRET`) is enough for now; will file a Backend-Service follow-up to split the two responsibilities.

## Plumbing changes

- `pg` + `@types/pg` pinned in `devDependencies`. Only imported from `e2e/helpers/pg-notify.ts`; not shipped in the Next.js bundle.
- `DB_*` env vars exported to the Playwright run in both `scripts/e2e-local.sh` and `.github/workflows/e2e-tests.yml`.
- `NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED=true` and `NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED=true` in both env profiles.
- `CDC_SECRET` set in both env profiles (see "Notable Backend-Service finding" above).
- `CLAUDE.md` updated under the E2E section to document the new `pg` devDep.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run test:run` — 3,126/3,126 pass (includes 23 new unit tests across `sse-flags.test.ts` + `SSESubscription.test.tsx`)
- [x] `npm run build` — succeeds
- [x] `BACKEND_DIR=/path/to/Backend-Service ./scripts/e2e-local.sh e2e/tests/sse/` — all 3 SSE tests pass (~30s total)
- [x] Flake check via `--repeat-each=5` against the same script
- [ ] CI workflow (`E2E Tests`) passes on this PR

## Cross-references

- Plan: `docs/plans/sse-tier1-e2e.md`
- Epic: #664
- Closes #660
- Unblocks #663 (production flag flip)
- Companion: WXYC/wxyc-shared#145 (un-skip `LIVE_FS_*` contract tests)