### PR TITLE
test(e2e): Tier 3 SSE refetch event

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -149,6 +149,9 @@ jobs:
           # registers on the same LISTEN — so without this, pg_notify is
           # silently dropped. Tracked as a Backend-Service follow-up.
           CDC_SECRET=e2e-cdc-secret-not-used-by-tests
+          # Tier 3 refetch test triggers liveFs:refetch by posting to
+          # POST /internal/flowsheet-sync-notify with X-Internal-Key.
+          ETL_NOTIFY_KEY=e2e-etl-notify-key
           EOF
 
       - name: Start mock tubafrenzy mirror
@@ -299,6 +302,9 @@ jobs:
         working-directory: dj-site
         env:
           SECOND_FRONTEND_PORT: "3001"
+          # Tier 3 refetch test posts directly to BS's internal route.
+          E2E_BACKEND_URL: "http://localhost:8085"
+          ETL_NOTIFY_KEY: "e2e-etl-notify-key"
         # --max-failures kept at 10 per shard: with sharding, a stuck shard
         # hits its cap on its own, so dropping to 1 tanks otherwise-green
         # shards (see prior commit on #574).

--- a/docs/plans/sse-tier3-e2e.md
+++ b/docs/plans/sse-tier3-e2e.md
@@ -1,0 +1,188 @@
+# Plan: Tier 3 SSE refetch-event E2E
+
+## Issue
+
+[WXYC/dj-site#662](https://github.com/WXYC/dj-site/issues/662) — Tier 3 covers the `liveFs:refetch` event and the `WXYC/BackendService/SSE/ClientCount` metric. This plan is the **dj-site half** only: a single new Playwright spec that exercises Backend-Service's refetch broadcast → dj-site listener middleware's debounced cache invalidation. The Backend-Service `sse-metrics.spec.js` half lands in that repo as a separate PR and is **out of scope here** (the issue text confirms this: "the BS test lands there").
+
+## Goal
+
+Pin the dj-site refetch path so a regression in either (a) Backend-Service's `liveFs:refetch` envelope or (b) dj-site's `scheduleDebouncedInvalidate` wiring is caught before flag flip.
+
+## Wire contract recap
+
+The flow is:
+
+```
+ETL/tubafrenzy bulk-sync
+  → POST /internal/flowsheet-sync-notify (X-Internal-Key: $ETL_NOTIFY_KEY)
+    → serverEventsMgr.broadcast(Topics.liveFs, { type: 'refetch', payload: { source: 'etl' }, timestamp })
+      → SSE frame to every liveFs subscriber
+        → dj-site listener middleware: scheduleDebouncedInvalidate(['Flowsheet', 'NowPlaying']) after REFETCH_DEBOUNCE_MS (500ms)
+          → RTK Query re-fires GET /flowsheet/* for any active subscriber (the dashboard's getInfiniteEntries)
+```
+
+The receiver side lives at `lib/features/flowsheet/live-updates-listener.ts:243`:
+
+```ts
+if (parsed.type === "refetch") {
+  scheduleDebouncedInvalidate(listenerApi.dispatch, ["Flowsheet", "NowPlaying"]);
+  return;
+}
+```
+
+The Tier 3 issue body suggests `pg_notify('cdc', '<refetch payload>')` as the trigger, but that is mistaken: there is no production code path mapping a CDC event to a `liveFs:refetch` broadcast — the refetch broadcast lives behind the four `internal.route.ts` handlers (`flowsheet-sync-notify`, `flowsheet-webhook`, etc.). The test will therefore POST to `/internal/flowsheet-sync-notify` (the cleanest, side-effect-free of the four) with the shared secret.
+
+## New file
+
+`e2e/tests/sse/refetch-event.spec.ts` — single test, file-scoped serial mode, dj2.json storage (matches Tier 1 + Tier 2 SSE specs since dj.json is invalidated by auth/logout.spec.ts).
+
+```ts
+import { test, expect } from "@playwright/test";
+import path from "path";
+import { FlowsheetPage } from "../../pages/flowsheet.page";
+import { waitForSSEConnected } from "../../helpers/sse-wait";
+import { triggerFlowsheetSyncNotify } from "../../helpers/internal-refetch";
+import { ensureOffAirInFreshContext } from "../../helpers/flowsheet-cleanup";
+
+const authDir = path.join(__dirname, "..", "..", ".auth");
+const DJ_STORAGE = path.join(authDir, "dj2.json");
+
+test.describe("SSE Tier 3 — refetch event", () => {
+  test.use({ storageState: DJ_STORAGE });
+  test.describe.configure({ mode: "serial" });
+  test.setTimeout(60_000);
+
+  test.afterAll(async ({ browser }) => {
+    await ensureOffAirInFreshContext(browser, DJ_STORAGE);
+  });
+
+  test("liveFs:refetch triggers a debounced GET /flowsheet/* within 5s", async ({ page }) => {
+    const fs = new FlowsheetPage(page);
+    await fs.goto();
+    await fs.waitForEntriesLoaded();
+    await fs.ensureLive();
+    await waitForSSEConnected(page);
+
+    // Capture the very next GET against the infinite-entries endpoint
+    // *after* we fire the refetch trigger. Polling is in slow mode (60s)
+    // while SSE is connected, so anything that arrives within 5s is
+    // attributable to our trigger.
+    const refetchResp = page.waitForResponse(
+      (resp) =>
+        /\/flowsheet\/?(\?|$)/.test(resp.url()) &&
+        resp.request().method() === "GET" &&
+        resp.status() === 200,
+      { timeout: 5_000 }
+    );
+
+    await triggerFlowsheetSyncNotify();
+
+    const resp = await refetchResp;
+    expect(resp.ok()).toBe(true);
+  });
+});
+```
+
+## New helper
+
+`e2e/helpers/internal-refetch.ts` — minimal POST helper, env-var-validated like `pg-notify.ts`:
+
+```ts
+/**
+ * Fire BS's POST /internal/flowsheet-sync-notify so it broadcasts a
+ * `liveFs:refetch` to every subscribed SSE client. Used by the Tier 3
+ * refetch test as the trigger for dj-site's debounced invalidate path.
+ *
+ * Env from scripts/e2e-local.sh / the E2E workflow:
+ *   E2E_BACKEND_URL — the BS origin (e.g. http://localhost:8085)
+ *   ETL_NOTIFY_KEY  — shared secret BS uses to authenticate internal callers
+ */
+export async function triggerFlowsheetSyncNotify(): Promise<void> {
+  const backend = process.env.E2E_BACKEND_URL;
+  const key = process.env.ETL_NOTIFY_KEY;
+  const missing: string[] = [];
+  if (!backend) missing.push("E2E_BACKEND_URL");
+  if (!key) missing.push("ETL_NOTIFY_KEY");
+  if (missing.length > 0) {
+    throw new Error(
+      `triggerFlowsheetSyncNotify: missing env: ${missing.join(", ")}. ` +
+        `Ensure scripts/e2e-local.sh (or the CI workflow) exports them before running Playwright.`
+    );
+  }
+
+  const resp = await fetch(`${backend}/internal/flowsheet-sync-notify`, {
+    method: "POST",
+    headers: { "X-Internal-Key": key! },
+  });
+  if (!resp.ok) {
+    throw new Error(
+      `POST /internal/flowsheet-sync-notify returned ${resp.status}: ${await resp.text()}`
+    );
+  }
+}
+```
+
+## Test-env wiring
+
+Two infra files need new exports:
+
+**`scripts/e2e-local.sh`** — add an `ETL_NOTIFY_KEY` for both Backend-Service (server) and the Playwright env (client). Place it near the existing `CDC_SECRET` block since both serve the "test-secret for an in-prod auth gate" pattern:
+
+```bash
+# Backend-Service's internal-route refetch endpoint (POST
+# /internal/flowsheet-sync-notify) is gated on ETL_NOTIFY_KEY. The Tier 3
+# refetch test posts with this same value to trigger a liveFs:refetch
+# broadcast without going through the real ETL.
+export ETL_NOTIFY_KEY=e2e-etl-notify-key
+export E2E_BACKEND_URL=http://localhost:$BACKEND_PORT
+```
+
+**`.github/workflows/e2e-tests.yml`** — same two exports added to the test step's env block (alongside the existing `CDC_SECRET` carry-through).
+
+`E2E_BACKEND_URL` is a new var; pg-notify.ts already infers its config from `DB_*` vars and doesn't need the backend URL. The new internal-refetch helper does because it's hitting BS over HTTP, not Postgres.
+
+## Why not assert on a unique source label
+
+The Tier 3 issue body suggests `source: e2e-${Date.now()}` for log debuggability. The current `internal.route.ts:34` hardcodes `payload: { source: 'etl' }` and does not accept a body-passed override. Plumbing a per-request source through would be a BS-side change (out of scope here) and would not strengthen the dj-site assertion — the receiver code (`live-updates-listener.ts:243`) treats every refetch identically (it never inspects `source`). The test instead observes the only causal signal that matters to the consumer: a GET /flowsheet/* request fired within the 500ms debounce window + reasonable margin.
+
+If BS later grows a body-passed `source`, the test could be tightened to assert PostHog telemetry includes that label, but that's a follow-up.
+
+## Why not `waitForLoadState("networkidle")`
+
+Same reason as Tier 2's polling-rate spec (per `docs/plans/sse-tier2-e2e.md`): the SSE EventSource holds the `GET /events/stream` connection open indefinitely, so networkidle never resolves. The test uses targeted `waitForResponse` / `waitForEntriesLoaded` instead.
+
+## Why serial mode
+
+All SSE specs are serial-within-file because dj2.json is the only authed storage state available (dj.json is invalidated by `auth/logout.spec.ts`) and parallel workers would race the `afterAll` `ensureOffAir`. Single test in this file means serial mode has no current effect, but encoding it now prevents a future second test in this file from silently parallelising.
+
+## Constraints honored
+
+| Issue constraint | How it's met |
+|---|---|
+| "Refetch test uses a unique `source` label per run" | Not honored as stated — see rationale above. Test observes the network-level effect, which is the strongest assertion the dj-site receiver path can make. |
+| "Metric test needs to wait ≥ `SSE_METRICS_INTERVAL_MS` (60s default) for the gauge to publish — gate behind a slow-CI bucket" | N/A — Backend-Service half, out of scope. |
+| "Tagged appropriately so CI doesn't time out" | 60s test timeout (vs. 30s default for normal e2e specs); the actual wait budget is 5s, so the timeout is just a safety net. |
+
+## Out of scope
+
+- The Backend-Service `tests/integration/sse-metrics.spec.js` half (separate PR in WXYC/Backend-Service).
+- Hardening source-label plumbing in `internal.route.ts`.
+- Asserting PostHog telemetry shape on refetch — already covered at the unit layer in `lib/__tests__/features/flowsheet/live-updates-listener.test.ts`.
+
+## Acceptance
+
+- New spec passes against `scripts/e2e-local.sh` locally.
+- Same spec passes in CI's E2E workflow with the new `ETL_NOTIFY_KEY` / `E2E_BACKEND_URL` exports wired through.
+- `tsc --noEmit`, `vitest run`, and `next build` stay clean (no app-code changes; new file is e2e-only).
+- No new dependencies (`fetch` is built into Node 22+ which the workflow already uses).
+- PR body cites issue #662 and the listener-middleware line that this test exercises.
+
+## File summary
+
+| File | Action | Notes |
+|---|---|---|
+| `e2e/tests/sse/refetch-event.spec.ts` | new | The only test |
+| `e2e/helpers/internal-refetch.ts` | new | HTTP POST helper, env-validated |
+| `scripts/e2e-local.sh` | modify | Add `ETL_NOTIFY_KEY` + `E2E_BACKEND_URL` exports |
+| `.github/workflows/e2e-tests.yml` | modify | Same exports in test step env block |
+| `docs/plans/sse-tier3-e2e.md` | new | This file |

--- a/e2e/helpers/env.ts
+++ b/e2e/helpers/env.ts
@@ -1,0 +1,20 @@
+/**
+ * Validate that required env vars are present, throwing with a guidance
+ * message naming the caller and the missing keys. Used by e2e helpers
+ * that consume `scripts/e2e-local.sh` / CI workflow exports.
+ */
+export function requireEnv(
+  caller: string,
+  names: readonly string[]
+): Record<string, string> {
+  const missing = names.filter((k) => !process.env[k]);
+  if (missing.length > 0) {
+    throw new Error(
+      `${caller}: missing required env vars: ${missing.join(", ")}. ` +
+        `Ensure scripts/e2e-local.sh (or the CI workflow) exports them before running Playwright.`
+    );
+  }
+  const out: Record<string, string> = {};
+  for (const k of names) out[k] = process.env[k]!;
+  return out;
+}

--- a/e2e/helpers/internal-refetch.ts
+++ b/e2e/helpers/internal-refetch.ts
@@ -1,0 +1,33 @@
+/**
+ * Fire BS's POST /internal/flowsheet-sync-notify so it broadcasts a
+ * `liveFs:refetch` to every subscribed SSE client. Used by the Tier 3
+ * refetch test as the trigger for dj-site's debounced invalidate path
+ * (see lib/features/flowsheet/live-updates-listener.ts:243).
+ *
+ * Env from scripts/e2e-local.sh / the E2E workflow:
+ *   E2E_BACKEND_URL — the BS origin (e.g. http://localhost:8085)
+ *   ETL_NOTIFY_KEY  — shared secret BS uses to authenticate internal callers
+ */
+export async function triggerFlowsheetSyncNotify(): Promise<void> {
+  const backend = process.env.E2E_BACKEND_URL;
+  const key = process.env.ETL_NOTIFY_KEY;
+  const missing: string[] = [];
+  if (!backend) missing.push("E2E_BACKEND_URL");
+  if (!key) missing.push("ETL_NOTIFY_KEY");
+  if (missing.length > 0) {
+    throw new Error(
+      `triggerFlowsheetSyncNotify: missing env: ${missing.join(", ")}. ` +
+        `Ensure scripts/e2e-local.sh (or the CI workflow) exports them before running Playwright.`
+    );
+  }
+
+  const resp = await fetch(`${backend}/internal/flowsheet-sync-notify`, {
+    method: "POST",
+    headers: { "X-Internal-Key": key! },
+  });
+  if (!resp.ok) {
+    throw new Error(
+      `POST /internal/flowsheet-sync-notify returned ${resp.status}: ${await resp.text()}`
+    );
+  }
+}

--- a/e2e/helpers/internal-refetch.ts
+++ b/e2e/helpers/internal-refetch.ts
@@ -1,29 +1,20 @@
+import { requireEnv } from "./env";
+
 /**
  * Fire BS's POST /internal/flowsheet-sync-notify so it broadcasts a
  * `liveFs:refetch` to every subscribed SSE client. Used by the Tier 3
  * refetch test as the trigger for dj-site's debounced invalidate path
  * (see lib/features/flowsheet/live-updates-listener.ts:243).
- *
- * Env from scripts/e2e-local.sh / the E2E workflow:
- *   E2E_BACKEND_URL — the BS origin (e.g. http://localhost:8085)
- *   ETL_NOTIFY_KEY  — shared secret BS uses to authenticate internal callers
  */
 export async function triggerFlowsheetSyncNotify(): Promise<void> {
-  const backend = process.env.E2E_BACKEND_URL;
-  const key = process.env.ETL_NOTIFY_KEY;
-  const missing: string[] = [];
-  if (!backend) missing.push("E2E_BACKEND_URL");
-  if (!key) missing.push("ETL_NOTIFY_KEY");
-  if (missing.length > 0) {
-    throw new Error(
-      `triggerFlowsheetSyncNotify: missing env: ${missing.join(", ")}. ` +
-        `Ensure scripts/e2e-local.sh (or the CI workflow) exports them before running Playwright.`
-    );
-  }
+  const env = requireEnv("triggerFlowsheetSyncNotify", [
+    "E2E_BACKEND_URL",
+    "ETL_NOTIFY_KEY",
+  ]);
 
-  const resp = await fetch(`${backend}/internal/flowsheet-sync-notify`, {
+  const resp = await fetch(`${env.E2E_BACKEND_URL}/internal/flowsheet-sync-notify`, {
     method: "POST",
-    headers: { "X-Internal-Key": key! },
+    headers: { "X-Internal-Key": env.ETL_NOTIFY_KEY },
   });
   if (!resp.ok) {
     throw new Error(

--- a/e2e/helpers/pg-notify.ts
+++ b/e2e/helpers/pg-notify.ts
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { requireEnv } from "./env";
 
 /**
  * Fire a Postgres NOTIFY from a Playwright test, so tests can bypass the
@@ -8,20 +9,19 @@ import { Client } from "pg";
  * loudly rather than silently connecting to the wrong place.
  */
 function getDbConfig() {
-  const required = ["DB_HOST", "DB_PORT", "DB_NAME", "DB_USERNAME", "DB_PASSWORD"] as const;
-  const missing = required.filter((k) => !process.env[k]);
-  if (missing.length > 0) {
-    throw new Error(
-      `pg-notify: missing required env vars: ${missing.join(", ")}. ` +
-        `Ensure scripts/e2e-local.sh (or the CI workflow) exports DB_* before running Playwright.`
-    );
-  }
+  const env = requireEnv("pg-notify", [
+    "DB_HOST",
+    "DB_PORT",
+    "DB_NAME",
+    "DB_USERNAME",
+    "DB_PASSWORD",
+  ]);
   return {
-    host: process.env.DB_HOST,
-    port: Number(process.env.DB_PORT),
-    database: process.env.DB_NAME,
-    user: process.env.DB_USERNAME,
-    password: process.env.DB_PASSWORD,
+    host: env.DB_HOST,
+    port: Number(env.DB_PORT),
+    database: env.DB_NAME,
+    user: env.DB_USERNAME,
+    password: env.DB_PASSWORD,
   };
 }
 

--- a/e2e/tests/sse/refetch-event.spec.ts
+++ b/e2e/tests/sse/refetch-event.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+import path from "path";
+import { FlowsheetPage } from "../../pages/flowsheet.page";
+import { waitForSSEConnected } from "../../helpers/sse-wait";
+import { triggerFlowsheetSyncNotify } from "../../helpers/internal-refetch";
+import { ensureOffAirInFreshContext } from "../../helpers/flowsheet-cleanup";
+
+const authDir = path.join(__dirname, "..", "..", ".auth");
+const DJ_STORAGE = path.join(authDir, "dj2.json");
+
+/**
+ * Tier 3 SSE refetch event — pins the cross-repo refetch path.
+ *
+ * Flow:
+ *   POST /internal/flowsheet-sync-notify (X-Internal-Key)
+ *     -> BS serverEventsMgr.broadcast(liveFs, { type: 'refetch', ... })
+ *       -> dj-site listener middleware: scheduleDebouncedInvalidate(
+ *            ['Flowsheet', 'NowPlaying']) after 500ms
+ *         -> RTK Query re-fires GET /flowsheet/* for active subscribers.
+ *
+ * Polling is in slow mode (60s) while SSE is connected, so any GET
+ * /flowsheet/* arriving within 5s of the trigger is attributable to the
+ * refetch broadcast — there's no other plausible cause.
+ *
+ * Serial mode: encodes the same dj2.json constraint that the Tier 1 and
+ * Tier 2 specs document (dj.json is invalidated by auth/logout.spec.ts).
+ * Single test today, but a future second test in this file would race
+ * `ensureOffAir` across parallel workers without this.
+ */
+test.describe("SSE Tier 3 — refetch event", () => {
+  test.use({ storageState: DJ_STORAGE });
+  test.describe.configure({ mode: "serial" });
+  test.setTimeout(60_000);
+
+  test.afterAll(async ({ browser }) => {
+    await ensureOffAirInFreshContext(browser, DJ_STORAGE);
+  });
+
+  test("liveFs:refetch triggers a debounced GET /flowsheet/* within 5s", async ({ page }) => {
+    const fs = new FlowsheetPage(page);
+    await fs.goto();
+    await fs.waitForEntriesLoaded();
+    await fs.ensureLive();
+    await waitForSSEConnected(page);
+
+    const refetchResp = page.waitForResponse(
+      (resp) =>
+        /\/flowsheet\/?(\?|$)/.test(resp.url()) &&
+        resp.request().method() === "GET" &&
+        resp.status() === 200,
+      { timeout: 5_000 }
+    );
+
+    await triggerFlowsheetSyncNotify();
+
+    const resp = await refetchResp;
+    expect(resp.ok()).toBe(true);
+  });
+});

--- a/e2e/tests/sse/refetch-event.spec.ts
+++ b/e2e/tests/sse/refetch-event.spec.ts
@@ -8,24 +8,14 @@ import { ensureOffAirInFreshContext } from "../../helpers/flowsheet-cleanup";
 const authDir = path.join(__dirname, "..", "..", ".auth");
 const DJ_STORAGE = path.join(authDir, "dj2.json");
 
+// Matches both invalidate targets the receiver fires (Flowsheet -> /?page=,
+// NowPlaying -> /latest). Mirrors the regex in polling-rate.spec.ts.
+const FLOWSHEET_REFETCH_RE = /\/flowsheet\/(latest\b|\?page=)/;
+
 /**
- * Tier 3 SSE refetch event — pins the cross-repo refetch path.
- *
- * Flow:
- *   POST /internal/flowsheet-sync-notify (X-Internal-Key)
- *     -> BS serverEventsMgr.broadcast(liveFs, { type: 'refetch', ... })
- *       -> dj-site listener middleware: scheduleDebouncedInvalidate(
- *            ['Flowsheet', 'NowPlaying']) after 500ms
- *         -> RTK Query re-fires GET /flowsheet/* for active subscribers.
- *
- * Polling is in slow mode (60s) while SSE is connected, so any GET
- * /flowsheet/* arriving within 5s of the trigger is attributable to the
- * refetch broadcast — there's no other plausible cause.
- *
- * Serial mode: encodes the same dj2.json constraint that the Tier 1 and
- * Tier 2 specs document (dj.json is invalidated by auth/logout.spec.ts).
- * Single test today, but a future second test in this file would race
- * `ensureOffAir` across parallel workers without this.
+ * Serial mode: dj2.json is the only authed storage state available
+ * (dj.json is invalidated by auth/logout.spec.ts), so a parallel sibling
+ * test in this file would race the afterAll ensureOffAir.
  */
 test.describe("SSE Tier 3 — refetch event", () => {
   test.use({ storageState: DJ_STORAGE });
@@ -45,7 +35,7 @@ test.describe("SSE Tier 3 — refetch event", () => {
 
     const refetchResp = page.waitForResponse(
       (resp) =>
-        /\/flowsheet\/?(\?|$)/.test(resp.url()) &&
+        FLOWSHEET_REFETCH_RE.test(resp.url()) &&
         resp.request().method() === "GET" &&
         resp.status() === 200,
       { timeout: 5_000 }

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -61,6 +61,12 @@ export NODE_ENV=test
 # Without this, the SSE Tier 1 tests' NOTIFYs are silently dropped. Tracked
 # as a Backend-Service follow-up to split LISTEN startup from CDC_SECRET.
 export CDC_SECRET=e2e-cdc-secret-not-used-by-tests
+# Backend-Service's POST /internal/flowsheet-sync-notify is gated on
+# ETL_NOTIFY_KEY. The Tier 3 refetch test posts with this same value to
+# trigger a liveFs:refetch broadcast without going through the real ETL.
+# E2E_BACKEND_URL tells the helper where BS listens.
+export ETL_NOTIFY_KEY=e2e-etl-notify-key
+export E2E_BACKEND_URL=http://localhost:$BACKEND_PORT
 
 echo "==> Building Backend-Service..."
 cd "$BACKEND_DIR"


### PR DESCRIPTION
## Summary

- Adds `e2e/tests/sse/refetch-event.spec.ts` pinning the cross-repo refetch path: `POST /internal/flowsheet-sync-notify` → BS `liveFs:refetch` broadcast → dj-site listener middleware's debounced Flowsheet/NowPlaying invalidate at `lib/features/flowsheet/live-updates-listener.ts:243` → RTK Query refetch of `GET /flowsheet/*`.
- Adds a small HTTP helper at `e2e/helpers/internal-refetch.ts` plus the `ETL_NOTIFY_KEY` / `E2E_BACKEND_URL` env wiring in `scripts/e2e-local.sh` and `.github/workflows/e2e-tests.yml`.
- Plan + rationale at `docs/plans/sse-tier3-e2e.md`.

The Tier 3 issue body suggests `pg_notify('cdc', ...)` as the trigger, but the production refetch path is `internal.route.ts`, not CDC — the spec posts to `/internal/flowsheet-sync-notify` with the shared secret instead. The plan documents the deviation.

Backend-Service half of #662 (`tests/integration/sse-metrics.spec.js`) lands separately in that repo, per the issue body.

## Test plan

- [ ] CI's E2E workflow runs the new spec against the standard Docker stack
- [ ] `scripts/e2e-local.sh` exports the new env vars and the spec passes locally
- [ ] No app-code changes — Next.js build / vitest / unit-test suite unaffected

Closes #662