### PR TITLE
chore(env): document NEXT_PUBLIC_POSTHOG_* in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,11 @@ NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED=false
 # being observed. See docs/live-updates-sse.md.
 NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED=false
 NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED=false
+
+# PostHog telemetry. Both vars are optional; if NEXT_PUBLIC_POSTHOG_KEY is
+# unset, initPostHog() short-circuits and every safeCapture / captureException
+# call is a no-op (see lib/posthog.ts). Set in Cloudflare Pages Production env
+# for dj.wxyc.org telemetry — local dev rarely needs it. Host defaults to
+# https://us.i.posthog.com when unset.
+# NEXT_PUBLIC_POSTHOG_KEY=phc_...
+# NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com


### PR DESCRIPTION
## Summary

Adds commented placeholders for `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` to `.env.example` so the existence of PostHog telemetry config is discoverable without reading `lib/posthog.ts`.

The silent no-op in `initPostHog()` when the key is unset is exactly the failure mode that hid the prod telemetry gap until #669 — anyone setting up a fresh `.env.local` had no signal these vars existed. Promoting documentation from "optional follow-up" to in-tree.

## Scope

This is the documentation slice of #669. The Cloudflare Pages env-var setup (project chosen, key minted, vars added, redeploy triggered) is being handled in the same session but lives outside the repo. #669 stays open until `\$pageview` and `sse_connected` events are observed in the new `dj-site` PostHog project (id 444958).

Refs #669

## Test plan

- [x] `.env.example` parses (no syntax change — commented lines only)
- [ ] After deploy, verify `\$pageview` lands in dj-site PostHog project within 5 min of a real `dj.wxyc.org` page load
- [ ] Verify `sse_connected` lands when an authenticated DJ session connects