### PR TITLE
fix(posthog): set person_profiles=always so anonymous captures land

### DIFF
--- a/lib/__tests__/posthog.test.ts
+++ b/lib/__tests__/posthog.test.ts
@@ -37,6 +37,7 @@ describe("initPostHog", () => {
       capture_pageview: false,
       capture_pageleave: true,
       capture_exceptions: true,
+      person_profiles: "always",
     });
   });
 

--- a/lib/posthog.ts
+++ b/lib/posthog.ts
@@ -15,6 +15,10 @@ export function initPostHog() {
     capture_pageview: false,
     capture_pageleave: true,
     capture_exceptions: true,
+    // Capture events from anonymous visitors too (logged-out landing, /login,
+    // /live). Without this, the project-level "Identified only" default
+    // silently drops every capture call until posthog.identify() runs.
+    person_profiles: "always",
   });
 }
 


### PR DESCRIPTION
## Summary

Adds `person_profiles: "always"` to `posthog.init()`. Without it, the new dj-site PostHog project's default "Identified only" mode silently drops every `capture()` call until `posthog.identify()` runs — which means $pageview, sse_* events, and unhandled-exception captures from logged-out users on `/`, `/login`, or `/live` never make it to ingest.

## Why it matters

Verified empirically while wiring up #669: posthog-js initializes cleanly on `dj.wxyc.org` — `config.js` loads, distinct_id is assigned, persistence is set up — but zero `/e/` or `/i/v0/e/` POSTs leave the browser. The remote config returned `defaultIdentifiedOnly: true`, and persisted user state stays at `anonymous`, so the SDK no-ops every capture. A manual `POST /i/v0/e/` with the same project key landed without issue, confirming the project ingestion path is fine and the gate is purely SDK-side.

## Why code rather than UI flip

The PostHog UI toggle works, but the value of doing it in code:

- Survives the project being recreated (would re-default to "Identified only")
- Lets dev/preview environments pointing at fresh PostHog projects Just Work
- Makes the intent visible in the diff history — anonymous events are a real audience for dj-site (public landing, login, future `/live`), not an accidental capture

## Refs

Refs #669

## Test plan

- [x] `lib/__tests__/posthog.test.ts` updated to assert `person_profiles: "always"` in the init payload
- [x] `npx vitest run lib/__tests__/posthog.test.ts` → 5/5 pass
- [x] `npx tsc --noEmit` → clean
- [ ] After deploy, verify `$pageview` and `sse_connected` land in dj-site PostHog project (id 444958) within 5 min of a real `dj.wxyc.org` page load