### PR TITLE
Revert "fix(posthog): set person_profiles=always so anonymous captures land"

### DIFF
--- a/lib/__tests__/posthog.test.ts
+++ b/lib/__tests__/posthog.test.ts
@@ -37,7 +37,6 @@ describe("initPostHog", () => {
       capture_pageview: false,
       capture_pageleave: true,
       capture_exceptions: true,
-      person_profiles: "always",
     });
   });
 

--- a/lib/posthog.ts
+++ b/lib/posthog.ts
@@ -15,10 +15,6 @@ export function initPostHog() {
     capture_pageview: false,
     capture_pageleave: true,
     capture_exceptions: true,
-    // Capture events from anonymous visitors too (logged-out landing, /login,
-    // /live). Without this, the project-level "Identified only" default
-    // silently drops every capture call until posthog.identify() runs.
-    person_profiles: "always",
   });
 }
 


### PR DESCRIPTION
## Summary

Reverts #671, which was based on a misdiagnosis.

## What happened

While verifying #669 (PostHog ingestion for dj-site), the initial signal was zero events landing in the new project. Diagnosis attributed this to the project's remote-config `defaultIdentifiedOnly: true` silently dropping anonymous captures, and #671 added `person_profiles: "always"` to override it.

Re-reading [the docs](https://posthog.com/docs/data/anonymous-vs-identified-events) and observing real-browser traffic post-deploy: `defaultIdentifiedOnly` only controls *person profile creation* for anonymous users — anonymous events are captured by default in both modes. The original premise was wrong.

The actual reasons for the zero-event signal turned out to be two unrelated client-side filters:

1. **posthog-js bot detection.** The SDK silently no-ops captures when `navigator.webdriver === true` or the UA matches strings like `headlesschrome`. Playwright headless Chromium triggers both, so the headless verification probe could never produce events regardless of any SDK config or project setting.
2. **Ad blocker on the verifying browser session.** Once disabled, anonymous `$pageview` / `$pageleave` / `$autocapture` events landed cleanly under the project's default `identified_only` mode.

## Why revert instead of keep

`person_profiles: "always"` isn't broken — it just creates a persistent profile per anonymous visitor. PostHog [notes](https://posthog.com/docs/product-analytics/identify#best-practices-when-using-identify) anonymous events with `identified_only` can be ~4x cheaper than identified ones. dj-site is mostly authenticated DJs; turning every anonymous landing-page visit into a persistent profile is the wrong cost trade-off. Reverting to PostHog's recommended default.

## Refs

Refs #669

## Test plan

- [x] `npx vitest run lib/__tests__/posthog.test.ts` → 5/5 pass (test assertions revert with the production change)
- [ ] After deploy, real-browser `$pageview` continues to land in the dj-site PostHog project