### PR TITLE
fix(sse): silently drop server handshake frames to clean up unknown-type noise

### DIFF
--- a/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
+++ b/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
@@ -204,10 +204,8 @@ describe("liveUpdatesListenerMiddleware", () => {
       const store = makeStore();
       store.dispatch(liveUpdatesConnectionRequested());
       getLastMock()._fireMessage(frame({ type: handshakeType }));
-      expect(captureSpy).not.toHaveBeenCalledWith(
-        "sse_unknown_event_type",
-        expect.anything()
-      );
+      expect(captureSpy).not.toHaveBeenCalled();
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
     }
   );
 

--- a/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
+++ b/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
@@ -198,6 +198,19 @@ describe("liveUpdatesListenerMiddleware", () => {
     );
   });
 
+  it.each(["connection-established", "subscription"])(
+    "silently drops the %s handshake frame",
+    (handshakeType) => {
+      const store = makeStore();
+      store.dispatch(liveUpdatesConnectionRequested());
+      getLastMock()._fireMessage(frame({ type: handshakeType }));
+      expect(captureSpy).not.toHaveBeenCalledWith(
+        "sse_unknown_event_type",
+        expect.anything()
+      );
+    }
+  );
+
   it("rejects an update event whose payload is null", () => {
     const store = makeStore();
     const updateSpy = vi.spyOn(flowsheetApi.util, "updateQueryData");

--- a/lib/features/flowsheet/live-updates-listener.ts
+++ b/lib/features/flowsheet/live-updates-listener.ts
@@ -16,6 +16,15 @@ import type { FlowsheetEntry } from "./types";
 const LIVE_FS_TOPIC = "live-fs-topic";
 const REFETCH_DEBOUNCE_MS = 500;
 
+// Backend emits these as the first two `data:` lines on every new SSE
+// subscription. They don't carry payload any client needs to act on, so
+// silently drop them to keep `sse_unknown_event_type` as a real
+// contract-drift signal rather than per-connection noise. See WXYC/dj-site#673.
+const BENIGN_HANDSHAKE_TYPES = new Set<string>([
+  "connection-established",
+  "subscription",
+]);
+
 type FlowsheetTag = "Flowsheet" | "NowPlaying";
 
 const SSE_EVENTS = {
@@ -229,13 +238,17 @@ startListening({
         });
         return;
       }
+      const rawType =
+        typeof parsed === "object" && parsed !== null
+          ? (parsed as { type?: unknown }).type
+          : null;
+      if (typeof rawType === "string" && BENIGN_HANDSHAKE_TYPES.has(rawType)) {
+        return;
+      }
       if (!isLiveFsEvent(parsed)) {
         safeCapture(SSE_EVENTS.UNKNOWN_EVENT_TYPE, {
           topic: LIVE_FS_TOPIC,
-          raw_type:
-            typeof parsed === "object" && parsed !== null
-              ? (parsed as { type?: unknown }).type
-              : null,
+          raw_type: rawType,
         });
         return;
       }

--- a/lib/features/flowsheet/live-updates-listener.ts
+++ b/lib/features/flowsheet/live-updates-listener.ts
@@ -16,10 +16,8 @@ import type { FlowsheetEntry } from "./types";
 const LIVE_FS_TOPIC = "live-fs-topic";
 const REFETCH_DEBOUNCE_MS = 500;
 
-// Backend emits these as the first two `data:` lines on every new SSE
-// subscription. They don't carry payload any client needs to act on, so
-// silently drop them to keep `sse_unknown_event_type` as a real
-// contract-drift signal rather than per-connection noise. See WXYC/dj-site#673.
+// Drop benign SSE handshake frames so `sse_unknown_event_type` stays a
+// contract-drift signal, not per-connection noise. See WXYC/dj-site#673.
 const BENIGN_HANDSHAKE_TYPES = new Set<string>([
   "connection-established",
   "subscription",


### PR DESCRIPTION
## Summary

- Filter the backend's `connection-established` and `subscription` handshake frames at the listener so they stop firing `sse_unknown_event_type` on every new SSE connection.
- `sse_unknown_event_type` was producing 2 noise events per connection in prod (verified 2026-05-29 against PostHog project `dj-site` id 444958), which scales to 70-140 noise events/week vs. (hopefully) zero real envelope-drift events — the contract-drift signal the metric was created to surface was becoming undetectable.
- No backend or `@wxyc/shared` change: the handshake frames already didn't drive any client behavior (they failed `isLiveFsEvent`), so the only thing that changes is PostHog noise. A genuinely unknown type still captures with `raw_type` populated.

Closes #673.

## Test plan

- [x] `npx vitest run lib/__tests__/features/flowsheet/live-updates-listener.test.ts` — 16 pass (14 pre-existing + 2 new `it.each` cases for `connection-established` and `subscription`)
- [x] `npx vitest run --changed origin/main` — 1277 pass / 88 files
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] After deploy: confirm `sse_unknown_event_type` count stays at ~0 under normal traffic on the `dj-site` PostHog project