### PR TITLE
fix(auth): change password before flipping hasCompletedOnboarding

### DIFF
--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -337,5 +337,82 @@ describe("authenticationHooks", () => {
         hasCompletedOnboarding: true,
       });
     });
+
+    it("calls changePassword before updateUser so a failed password change leaves hasCompletedOnboarding untouched", async () => {
+      mockGetSession.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+      });
+
+      const callOrder: string[] = [];
+      mockChangePassword.mockImplementation(async () => {
+        callOrder.push("changePassword");
+        return { data: {} };
+      });
+      mockUpdateUser.mockImplementation(async () => {
+        callOrder.push("updateUser");
+        return { data: {} };
+      });
+
+      const { useNewUser } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useNewUser(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "testdj" },
+          password: { value: "NewPassword1" },
+          realName: { value: "Real Name" },
+          djName: { value: "DJ Name" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleNewUser(form);
+      });
+
+      expect(callOrder).toEqual(["changePassword", "updateUser"]);
+      expect(mockChangePassword).toHaveBeenCalledWith({
+        currentPassword: "temp123",
+        newPassword: "NewPassword1",
+      });
+    });
+
+    it("does not call updateUser when changePassword rejects, so hasCompletedOnboarding stays false", async () => {
+      mockGetSession.mockResolvedValue({
+        data: { user: { id: "user-1" } },
+      });
+      mockChangePassword.mockResolvedValue({
+        data: null,
+        error: { message: "Current password is incorrect" },
+      });
+
+      const { throwIfBetterAuthError } = await import("@/src/utilities/throwIfBetterAuthError");
+      (throwIfBetterAuthError as any).mockImplementation((res: any, msg: string) => {
+        if (res?.error) {
+          throw new Error(msg);
+        }
+      });
+
+      const { useNewUser } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useNewUser(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "testdj" },
+          password: { value: "NewPassword1" },
+          realName: { value: "Real Name" },
+          djName: { value: "DJ Name" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleNewUser(form);
+      });
+
+      expect(mockChangePassword).toHaveBeenCalled();
+      expect(mockUpdateUser).not.toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -277,6 +277,21 @@ export const useNewUser = () => {
         throw new Error("You must be authenticated to update your profile");
       }
 
+      // Change the password BEFORE flipping hasCompletedOnboarding. If we
+      // flip the flag first and then changePassword fails, the account ends
+      // up flagged complete but still protected only by the publicly-known
+      // NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD — and requireAuth() will no
+      // longer redirect the user back through onboarding to recover. See
+      // WXYC/dj-site#598.
+      if (params.password) {
+        const passwordResult = await authClient.changePassword({
+          currentPassword,
+          newPassword: params.password,
+        });
+
+        throwIfBetterAuthError(passwordResult, "Failed to update password");
+      }
+
       const updateRequest: any = { hasCompletedOnboarding: true };
       if (params.realName) {
         updateRequest.realName = params.realName;
@@ -287,15 +302,6 @@ export const useNewUser = () => {
       const result = await authClient.updateUser(updateRequest);
 
       throwIfBetterAuthError(result, "Failed to update user profile");
-
-      if (params.password) {
-        const passwordResult = await authClient.changePassword({
-          currentPassword,
-          newPassword: params.password,
-        });
-
-        throwIfBetterAuthError(passwordResult, "Failed to update password");
-      }
 
       const dashboardHome = String(process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/catalog");
       toast.success("Profile updated successfully");


### PR DESCRIPTION
## Summary
- Reverses the order in `useNewUser.handleNewUser`: `authClient.changePassword(...)` now runs before `authClient.updateUser({ hasCompletedOnboarding: true, ... })`. If the password change fails, the user record is left with `hasCompletedOnboarding: false` so `requireAuth()` keeps routing them back through onboarding instead of stranding the account on the publicly-known `NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD`.
- Adds two regression tests to `src/hooks/authenticationHooks.test.ts`: one pins the call order (changePassword then updateUser); one pins the failure mode (when changePassword rejects, updateUser is never called and no navigation happens).

Closes #598