### PR TITLE
fix(auth): clear cached JWT on logout and at sign-in entry points

### DIFF
--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -32,6 +32,8 @@ const mockSignInEmail = vi.fn();
 const mockSignInEmailOtp = vi.fn();
 const mockSendVerificationOtp = vi.fn();
 const mockLookupEmailByIdentifier = vi.fn();
+const mockSignOut = vi.fn();
+const mockClearTokenCache = vi.fn();
 vi.mock("@/lib/features/authentication/client", () => ({
   authClient: {
     updateUser: (...args: any[]) => mockUpdateUser(...args),
@@ -45,8 +47,9 @@ vi.mock("@/lib/features/authentication/client", () => ({
     emailOtp: {
       sendVerificationOtp: (...args: any[]) => mockSendVerificationOtp(...args),
     },
-    signOut: vi.fn(),
+    signOut: (...args: any[]) => mockSignOut(...args),
   },
+  clearTokenCache: (...args: any[]) => mockClearTokenCache(...args),
   lookupEmailByIdentifier: (...args: any[]) => mockLookupEmailByIdentifier(...args),
 }));
 
@@ -413,6 +416,104 @@ describe("authenticationHooks", () => {
       expect(mockChangePassword).toHaveBeenCalled();
       expect(mockUpdateUser).not.toHaveBeenCalled();
       expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("useLogout (WXYC/dj-site#596)", () => {
+    it("clears the JWT token cache before calling signOut", async () => {
+      mockSignOut.mockResolvedValue(undefined);
+
+      const callOrder: string[] = [];
+      mockClearTokenCache.mockImplementation(() => {
+        callOrder.push("clearTokenCache");
+      });
+      mockSignOut.mockImplementation(async () => {
+        callOrder.push("signOut");
+      });
+
+      const { useLogout } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogout(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.handleLogout();
+      });
+
+      expect(mockClearTokenCache).toHaveBeenCalledTimes(1);
+      expect(mockSignOut).toHaveBeenCalledTimes(1);
+      // Cache must be cleared synchronously *before* signOut is awaited so any
+      // racing call to getJWTToken() can't pull the departing user's bearer.
+      expect(callOrder).toEqual(["clearTokenCache", "signOut"]);
+    });
+
+    it("clears the JWT token cache even when no form event is supplied", async () => {
+      mockSignOut.mockResolvedValue(undefined);
+
+      const { useLogout } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogout(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.handleLogout();
+      });
+
+      expect(mockClearTokenCache).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("useLogin (WXYC/dj-site#596 defensive)", () => {
+    it("clears the JWT token cache before signing in", async () => {
+      mockSignInUsername.mockResolvedValue({
+        data: { user: { id: "user-1", hasCompletedOnboarding: true } },
+      });
+
+      const callOrder: string[] = [];
+      mockClearTokenCache.mockImplementation(() => {
+        callOrder.push("clearTokenCache");
+      });
+      mockSignInUsername.mockImplementation(async () => {
+        callOrder.push("signInUsername");
+        return { data: { user: { id: "user-1", hasCompletedOnboarding: true } } };
+      });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "jbromberg" },
+          password: { value: "password123" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleLogin(form);
+      });
+
+      expect(mockClearTokenCache).toHaveBeenCalledTimes(1);
+      expect(callOrder).toEqual(["clearTokenCache", "signInUsername"]);
+    });
+  });
+
+  describe("useOTPVerify (WXYC/dj-site#596 defensive)", () => {
+    it("clears the JWT token cache before verifying the OTP", async () => {
+      const callOrder: string[] = [];
+      mockClearTokenCache.mockImplementation(() => {
+        callOrder.push("clearTokenCache");
+      });
+      mockSignInEmailOtp.mockImplementation(async () => {
+        callOrder.push("signInEmailOtp");
+        return { data: { user: { id: "user-1", hasCompletedOnboarding: true } } };
+      });
+
+      const { useOTPVerify } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useOTPVerify(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.handleVerifyOTP("dj@wxyc.org", "123456");
+      });
+
+      expect(mockClearTokenCache).toHaveBeenCalledTimes(1);
+      expect(callOrder).toEqual(["clearTokenCache", "signInEmailOtp"]);
     });
   });
 });

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -421,8 +421,6 @@ describe("authenticationHooks", () => {
 
   describe("useLogout (WXYC/dj-site#596)", () => {
     it("clears the JWT token cache before calling signOut", async () => {
-      mockSignOut.mockResolvedValue(undefined);
-
       const callOrder: string[] = [];
       mockClearTokenCache.mockImplementation(() => {
         callOrder.push("clearTokenCache");
@@ -446,8 +444,6 @@ describe("authenticationHooks", () => {
     });
 
     it("clears the JWT token cache even when no form event is supplied", async () => {
-      mockSignOut.mockResolvedValue(undefined);
-
       const { useLogout } = await import("./authenticationHooks");
       const { result } = renderHook(() => useLogout(), { wrapper: createWrapper() });
 
@@ -461,10 +457,6 @@ describe("authenticationHooks", () => {
 
   describe("useLogin (WXYC/dj-site#596 defensive)", () => {
     it("clears the JWT token cache before signing in", async () => {
-      mockSignInUsername.mockResolvedValue({
-        data: { user: { id: "user-1", hasCompletedOnboarding: true } },
-      });
-
       const callOrder: string[] = [];
       mockClearTokenCache.mockImplementation(() => {
         callOrder.push("clearTokenCache");

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -36,8 +36,7 @@ export const useLogin = () => {
       const identifier = e.currentTarget.username.value;
       const password = e.currentTarget.password.value;
 
-      // Defensive: drop any cached bearer from a previous session before this
-      // user's authority is established (WXYC/dj-site#596).
+      // Drop any prior session's cached bearer before establishing this one (WXYC/dj-site#596).
       clearTokenCache();
 
       const result = isValidEmail(identifier)
@@ -115,8 +114,7 @@ export const useOTPVerify = () => {
 
   const handleVerifyOTP = (email: string, otp: string) =>
     execute(async () => {
-      // Defensive: drop any cached bearer from a previous session before this
-      // user's authority is established (WXYC/dj-site#596).
+      // Drop any prior session's cached bearer before establishing this one (WXYC/dj-site#596).
       clearTokenCache();
 
       const result = await authClient.signIn.emailOtp({

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { authenticationSlice } from "@/lib/features/authentication/frontend";
-import { authClient, lookupEmailByIdentifier } from "@/lib/features/authentication/client";
+import { authClient, clearTokenCache, lookupEmailByIdentifier } from "@/lib/features/authentication/client";
 import { isValidEmail } from "@wxyc/shared/validation";
 import {
   AuthenticatedUser,
@@ -35,6 +35,10 @@ export const useLogin = () => {
     return execute(async () => {
       const identifier = e.currentTarget.username.value;
       const password = e.currentTarget.password.value;
+
+      // Defensive: drop any cached bearer from a previous session before this
+      // user's authority is established (WXYC/dj-site#596).
+      clearTokenCache();
 
       const result = isValidEmail(identifier)
         ? ((await authClient.signIn.email({ email: identifier, password })) as { error?: unknown })
@@ -111,6 +115,10 @@ export const useOTPVerify = () => {
 
   const handleVerifyOTP = (email: string, otp: string) =>
     execute(async () => {
+      // Defensive: drop any cached bearer from a previous session before this
+      // user's authority is established (WXYC/dj-site#596).
+      clearTokenCache();
+
       const result = await authClient.signIn.emailOtp({
         email,
         otp,
@@ -165,6 +173,10 @@ export const useLogout = () => {
   const handleLogout = (event?: React.FormEvent<HTMLFormElement>) => {
     event?.preventDefault();
     return execute(async () => {
+      // Invalidate the cached bearer synchronously so the next caller — including
+      // any in-flight code paths that race ahead of signOut — cannot reuse the
+      // departing user's JWT (cache TTL is 4 minutes; see WXYC/dj-site#596).
+      clearTokenCache();
       await authClient.signOut();
       router.refresh();
       resetApplication(dispatch);


### PR DESCRIPTION
## Summary
- `useLogout` now calls `clearTokenCache()` synchronously before `authClient.signOut()`, so the 4-minute JWT bearer cache cannot leak the departing user's authority to the next person on the device (the bug surfaces on shared station-room DJ workstations).
- `useLogin` and `useOTPVerify` also drop any stale cache before establishing a new session — defensive belt-and-braces so a follow-up login on a stale cache can never inherit a previous bearer.
- Pinning tests in `src/hooks/authenticationHooks.test.ts` assert the call order (`clearTokenCache` runs *before* `signOut` / `signIn.*`) on all three paths, including the no-event branch of `handleLogout`.

## Test plan
- [x] `npx vitest run src/hooks/authenticationHooks.test.ts` — 14 / 14 pass (4 new).
- [x] `npx vitest run lib/__tests__/features/authentication/` — 217 / 217 pass (JWT cache regression coverage intact).
- [x] `npx vitest run` (full suite) — 3132 / 3132 pass.
- [x] `npx tsc --noEmit` clean.

Closes #596