### PR TITLE
fix(auth): wire @reset slot into classic login layout (#680)

### DIFF
--- a/app/login/@classic/@reset/page.tsx
+++ b/app/login/@classic/@reset/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { PasswordResetUser } from "@/lib/features/authentication/types";
+import RequestPasswordResetForm from "@/src/components/experiences/modern/login/Forms/RequestPasswordResetForm";
+import ResetPasswordForm from "@/src/components/experiences/modern/login/Forms/ResetPasswordForm";
+import { Alert } from "@mui/joy";
+import { useSearchParams } from "next/navigation";
+
+export default function ClassicPasswordResetPage() {
+  const searchParams = useSearchParams();
+  const token = searchParams?.get("token") || undefined;
+  const error = searchParams?.get("error") || undefined;
+
+  const confirmationMessage = error
+    ? "This reset link is invalid or expired. Please request a new one."
+    : token
+      ? "Enter your new password below."
+      : "Enter your email to receive a reset link.";
+
+  const resetData: PasswordResetUser = {
+    token,
+    error,
+    confirmationMessage,
+  };
+
+  return (
+    <>
+      <Alert color={error ? "danger" : "neutral"}>{confirmationMessage}</Alert>
+      {token ? (
+        <ResetPasswordForm {...resetData} />
+      ) : (
+        <RequestPasswordResetForm />
+      )}
+    </>
+  );
+}

--- a/app/login/@classic/ClassicLoginSlotSwitcher.test.tsx
+++ b/app/login/@classic/ClassicLoginSlotSwitcher.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ClassicLoginSlotSwitcher from "./ClassicLoginSlotSwitcher";
+
+const searchParamsMock = vi.fn<() => URLSearchParams>();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsMock(),
+}));
+
+const normal = <div data-testid="normal-slot">normal</div>;
+const reset = <div data-testid="reset-slot">reset</div>;
+
+describe("ClassicLoginSlotSwitcher", () => {
+  it("renders the normal slot when no token or error param is present", () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams(""));
+    render(<ClassicLoginSlotSwitcher normal={normal} reset={reset} />);
+    expect(screen.getByTestId("normal-slot")).toBeInTheDocument();
+    expect(screen.queryByTestId("reset-slot")).not.toBeInTheDocument();
+  });
+
+  it("renders the reset slot when a token param is present", () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams("token=abc123"));
+    render(<ClassicLoginSlotSwitcher normal={normal} reset={reset} />);
+    expect(screen.getByTestId("reset-slot")).toBeInTheDocument();
+    expect(screen.queryByTestId("normal-slot")).not.toBeInTheDocument();
+  });
+
+  it("renders the reset slot when an error param is present", () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams("error=invalid-token"));
+    render(<ClassicLoginSlotSwitcher normal={normal} reset={reset} />);
+    expect(screen.getByTestId("reset-slot")).toBeInTheDocument();
+    expect(screen.queryByTestId("normal-slot")).not.toBeInTheDocument();
+  });
+});

--- a/app/login/@classic/ClassicLoginSlotSwitcher.tsx
+++ b/app/login/@classic/ClassicLoginSlotSwitcher.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { ReactNode } from "react";
+import { useSearchParams } from "next/navigation";
+
+export default function ClassicLoginSlotSwitcher({
+  normal,
+  reset,
+}: {
+  normal: ReactNode;
+  reset: ReactNode;
+}) {
+  const searchParams = useSearchParams();
+  const hasResetParams =
+    !!searchParams?.get("token") || !!searchParams?.get("error");
+
+  return <>{hasResetParams ? reset : normal}</>;
+}

--- a/app/login/@classic/layout.tsx
+++ b/app/login/@classic/layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 import Header from "@/src/components/experiences/classic/login/Layout/Header";
 import { Metadata } from "next";
 import { getPageTitle } from "@/lib/utils/page-title";
+import ClassicLoginSlotSwitcher from "./ClassicLoginSlotSwitcher";
 
 export const metadata: Metadata = {
   title: getPageTitle("Login"),
@@ -10,9 +11,10 @@ export const metadata: Metadata = {
 interface LoginProps {
   readonly normal: ReactNode;
   readonly newuser: ReactNode;
+  readonly reset: ReactNode;
 }
 
-export default async function Layout({ normal, newuser }: LoginProps) {
+export default async function Layout({ normal, newuser, reset }: LoginProps) {
   return (
     <div
       style={{
@@ -25,7 +27,7 @@ export default async function Layout({ normal, newuser }: LoginProps) {
       }}
     >
       <Header />
-      {normal}
+      <ClassicLoginSlotSwitcher normal={normal} reset={reset} />
       <footer>
         <p>Copyright &copy; {new Date().getFullYear()} WXYC Chapel Hill</p>
       </footer>


### PR DESCRIPTION
## Summary

- Add `app/login/@classic/@reset/page.tsx` mirroring the modern reset page's behavior: render `RequestPasswordResetForm` when no `token`, `ResetPasswordForm` when `?token=…`, and an invalid/expired alert when `?error=…`.
- Add `ClassicLoginSlotSwitcher` (small client component) that reads `useSearchParams()` and renders the new `reset` slot when `token` or `error` is present, otherwise the `normal` slot.
- Update `app/login/@classic/layout.tsx` to accept the `reset` parallel-slot prop and delegate slot selection to the switcher.

Before this change, the classic login layout rendered only the `normal` slot, so a password-reset link with `?token=…` silently dropped the token and dumped the user on the username/password form (see issue body for the screenshot). Default-experience users were unaffected because `NEXT_PUBLIC_DEFAULT_EXPERIENCE=modern` and the modern layout already routes correctly.

Reusing the modern `RequestPasswordResetForm` / `ResetPasswordForm` components keeps the diff minimal. They render acceptably under the classic theme (both experiences use MUI Joy); a classic-styled variant can be a follow-up if the team wants it.

The pre-existing bug that classic's layout also ignores its `@newuser` slot is intentionally not touched here — see the "Constraints" section in #680.

Closes #680

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `npx vitest run app/login/@classic/ClassicLoginSlotSwitcher.test.tsx` — 3 passed (renders `normal` with no params, `reset` with `?token=`, `reset` with `?error=`)
- [x] `npx vitest run --changed origin/main` — clean
- [ ] Manual: switch user preference to classic experience, log out, paste a real reset URL → expect new-password form, not the login form
- [ ] Manual: classic experience with `/login` (no params) still shows the regular login form