### PR TITLE
fix(sse): refetch on reconnect so mid-blackout entries don't trip unknown_event_id

### DIFF
--- a/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
+++ b/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
@@ -350,24 +350,24 @@ describe("liveUpdatesListenerMiddleware", () => {
   describe("reconnect refetch (issue #682)", () => {
     it("does not schedule an invalidate on the first onopen (initial connect)", () => {
       vi.useFakeTimers();
+      const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
       try {
         const store = makeStore();
-        const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
         store.dispatch(liveUpdatesConnectionRequested());
         getLastMock()._fireOpen();
         vi.advanceTimersByTime(600);
         expect(invalidateSpy).not.toHaveBeenCalled();
-        invalidateSpy.mockRestore();
       } finally {
+        invalidateSpy.mockRestore();
         vi.useRealTimers();
       }
     });
 
     it("schedules a Flowsheet + NowPlaying invalidate on the second onopen (browser reconnect after transient drop)", () => {
       vi.useFakeTimers();
+      const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
       try {
         const store = makeStore();
-        const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
         store.dispatch(liveUpdatesConnectionRequested());
         // First open — initial connect.
         getLastMock()._fireOpen();
@@ -381,17 +381,17 @@ describe("liveUpdatesListenerMiddleware", () => {
         expect(invalidateSpy).toHaveBeenCalledWith(
           expect.arrayContaining(["Flowsheet", "NowPlaying"])
         );
-        invalidateSpy.mockRestore();
       } finally {
+        invalidateSpy.mockRestore();
         vi.useRealTimers();
       }
     });
 
     it("coalesces a reconnect-driven refetch with a coincident refetch envelope into one invalidate", () => {
       vi.useFakeTimers();
+      const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
       try {
         const store = makeStore();
-        const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
         store.dispatch(liveUpdatesConnectionRequested());
         getLastMock()._fireOpen();
         getLastMock()._fireError(MockEventSourceCtor.CONNECTING);
@@ -401,17 +401,17 @@ describe("liveUpdatesListenerMiddleware", () => {
         );
         vi.advanceTimersByTime(600);
         expect(invalidateSpy).toHaveBeenCalledTimes(1);
-        invalidateSpy.mockRestore();
       } finally {
+        invalidateSpy.mockRestore();
         vi.useRealTimers();
       }
     });
 
     it("resets the reconnect-detect flag on connectionReleased so a fresh subscriber's first onopen is not treated as a reconnect", () => {
       vi.useFakeTimers();
+      const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
       try {
         const store = makeStore();
-        const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
 
         // First subscriber: connect, fully release.
         store.dispatch(liveUpdatesConnectionRequested());
@@ -419,13 +419,18 @@ describe("liveUpdatesListenerMiddleware", () => {
         store.dispatch(liveUpdatesConnectionReleased());
 
         // Fresh subscriber after full teardown — first onopen should be
-        // treated as an initial connect, not a reconnect.
+        // treated as an initial connect, not a reconnect. Asserting that a
+        // second EventSource was actually constructed guards against a
+        // regression that would suppress the re-open path (in which case
+        // getLastMock() returns the original ES and _fireOpen() reads a
+        // correctly-reset flag for the wrong reason).
         store.dispatch(liveUpdatesConnectionRequested());
+        expect(MockEventSourceCtor._instances).toHaveLength(2);
         getLastMock()._fireOpen();
         vi.advanceTimersByTime(600);
         expect(invalidateSpy).not.toHaveBeenCalled();
-        invalidateSpy.mockRestore();
       } finally {
+        invalidateSpy.mockRestore();
         vi.useRealTimers();
       }
     });

--- a/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
+++ b/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
@@ -347,4 +347,88 @@ describe("liveUpdatesListenerMiddleware", () => {
     }
   });
 
+  describe("reconnect refetch (issue #682)", () => {
+    it("does not schedule an invalidate on the first onopen (initial connect)", () => {
+      vi.useFakeTimers();
+      try {
+        const store = makeStore();
+        const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
+        store.dispatch(liveUpdatesConnectionRequested());
+        getLastMock()._fireOpen();
+        vi.advanceTimersByTime(600);
+        expect(invalidateSpy).not.toHaveBeenCalled();
+        invalidateSpy.mockRestore();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("schedules a Flowsheet + NowPlaying invalidate on the second onopen (browser reconnect after transient drop)", () => {
+      vi.useFakeTimers();
+      try {
+        const store = makeStore();
+        const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
+        store.dispatch(liveUpdatesConnectionRequested());
+        // First open — initial connect.
+        getLastMock()._fireOpen();
+        // Browser sees a transient drop and is retrying transparently.
+        getLastMock()._fireError(MockEventSourceCtor.CONNECTING);
+        // Browser-initiated retry succeeds — onopen fires again.
+        getLastMock()._fireOpen();
+        expect(invalidateSpy).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(600);
+        expect(invalidateSpy).toHaveBeenCalledTimes(1);
+        expect(invalidateSpy).toHaveBeenCalledWith(
+          expect.arrayContaining(["Flowsheet", "NowPlaying"])
+        );
+        invalidateSpy.mockRestore();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("coalesces a reconnect-driven refetch with a coincident refetch envelope into one invalidate", () => {
+      vi.useFakeTimers();
+      try {
+        const store = makeStore();
+        const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
+        store.dispatch(liveUpdatesConnectionRequested());
+        getLastMock()._fireOpen();
+        getLastMock()._fireError(MockEventSourceCtor.CONNECTING);
+        getLastMock()._fireOpen();
+        getLastMock()._fireMessage(
+          frame({ type: "refetch", payload: { source: "etl" }, timestamp: 1 })
+        );
+        vi.advanceTimersByTime(600);
+        expect(invalidateSpy).toHaveBeenCalledTimes(1);
+        invalidateSpy.mockRestore();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resets the reconnect-detect flag on connectionReleased so a fresh subscriber's first onopen is not treated as a reconnect", () => {
+      vi.useFakeTimers();
+      try {
+        const store = makeStore();
+        const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
+
+        // First subscriber: connect, fully release.
+        store.dispatch(liveUpdatesConnectionRequested());
+        getLastMock()._fireOpen();
+        store.dispatch(liveUpdatesConnectionReleased());
+
+        // Fresh subscriber after full teardown — first onopen should be
+        // treated as an initial connect, not a reconnect.
+        store.dispatch(liveUpdatesConnectionRequested());
+        getLastMock()._fireOpen();
+        vi.advanceTimersByTime(600);
+        expect(invalidateSpy).not.toHaveBeenCalled();
+        invalidateSpy.mockRestore();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
 });

--- a/lib/features/flowsheet/live-updates-listener.ts
+++ b/lib/features/flowsheet/live-updates-listener.ts
@@ -53,6 +53,13 @@ type LiveFsEvent = LiveFsUpdateEvent | LiveFsRefetchEvent;
 let eventSource: EventSource | null = null;
 let debouncedInvalidateTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingInvalidateTags: Set<FlowsheetTag> = new Set();
+// Tracks whether the current EventSource has ever fired onopen. The browser
+// fires onopen again after a transparent reconnect; if hasEverConnected was
+// already true when onopen fires, anything the backend pushed during the
+// blackout window is missing from local cache, so we schedule an explicit
+// refetch to repair it. Reset on connectionReleased so a fresh subscriber's
+// first open is treated as an initial connect, not a reconnect. See #682.
+let hasEverConnected = false;
 
 function isLiveFsEvent(value: unknown): value is LiveFsEvent {
   if (typeof value !== "object" || value === null) return false;
@@ -199,8 +206,16 @@ startListening({
     eventSource = es;
 
     es.onopen = () => {
+      const isReconnect = hasEverConnected;
+      hasEverConnected = true;
       if (setConnectionStatusIfChanged(listenerApi, "connected")) {
         safeCapture(SSE_EVENTS.CONNECTED, { topic: LIVE_FS_TOPIC });
+      }
+      if (isReconnect) {
+        scheduleDebouncedInvalidate(listenerApi.dispatch, [
+          "Flowsheet",
+          "NowPlaying",
+        ]);
       }
     };
 
@@ -273,6 +288,7 @@ startListening({
     if (refCount !== 0 || eventSource === null) return;
     eventSource.close();
     eventSource = null;
+    hasEverConnected = false;
     clearDebouncedInvalidate();
     setConnectionStatusIfChanged(listenerApi, "closed");
   },
@@ -288,6 +304,7 @@ export function __resetLiveUpdatesEventSourceForTests(): void {
     }
   }
   eventSource = null;
+  hasEverConnected = false;
   clearDebouncedInvalidate();
 }
 

--- a/lib/features/flowsheet/live-updates-listener.ts
+++ b/lib/features/flowsheet/live-updates-listener.ts
@@ -207,7 +207,6 @@ startListening({
 
     es.onopen = () => {
       const isReconnect = hasEverConnected;
-      hasEverConnected = true;
       if (setConnectionStatusIfChanged(listenerApi, "connected")) {
         safeCapture(SSE_EVENTS.CONNECTED, { topic: LIVE_FS_TOPIC });
       }
@@ -217,6 +216,10 @@ startListening({
           "NowPlaying",
         ]);
       }
+      // Set last so a throwing dispatch above leaves the flag false and the
+      // next onopen is treated as the first observable connect, not a
+      // reconnect.
+      hasEverConnected = true;
     };
 
     es.onerror = () => {


### PR DESCRIPTION
Closes #682.

## Summary

- Track `hasEverConnected` per EventSource. On the second `onopen` (browser-driven transparent retry), schedule `Flowsheet` + `NowPlaying` invalidate through the existing 500 ms debounce so any rows the backend pushed during the blackout window get pulled in before the next typed `update` arrives and trips the `sse_unknown_event_id` branch.
- Reset the flag in `liveUpdatesConnectionReleased` (refCount=0 close) and in the test-only reset hook, so a fresh subscriber's first open is treated as an initial connect.
- Reuses the existing debounce, so a coincident `refetch` envelope and a reconnect-driven refetch coalesce into a single invalidate (covered by a new test).

## Companion to #674

#674 stopped the SSE handshake frames (`connection-established`, `subscription`) from polluting `sse_unknown_event_type`. #682 closes the other half of the post-reconnect noise: typed `update` payloads whose ids aren't in cache because the row was created during the disconnect window. After this lands, both `sse_unknown_event_*` channels should be near-zero in steady state.

## Test plan

- [x] `npx vitest run lib/__tests__/features/flowsheet/live-updates-listener.test.ts` — 4 new tests added, all 20 pass
- [x] `npx vitest run` — full suite (219 files / 3141 tests) green
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] Post-merge: re-run the watch-list query after the next on-air shift; expect zero `sse_unknown_event_id` events caused by reconnects (background steady-state may still surface ones caused by other envelope drift, but the post-reconnect spike should be gone).

## New tests

1. First `onopen` after initial connect does **not** schedule an invalidate.
2. Second `onopen` after `onerror(CONNECTING)` schedules a `Flowsheet` + `NowPlaying` invalidate.
3. A coincident `refetch` envelope and a reconnect coalesce into a single debounced invalidate (regression guard against accidentally doubling refetches).
4. After `connectionReleased` → `connectionRequested`, the next `onopen` is treated as an initial connect again (regression guard against module-state leak across subscriber lifecycles).