### PR TITLE
test(sse): pin commit 7b56287 ordering invariant via __getHasEverConnectedForTests

### DIFF
--- a/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
+++ b/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from "msw";
 
 import { flowsheetApi } from "@/lib/features/flowsheet/api";
 import {
+  __getHasEverConnectedForTests,
   __getLiveUpdatesEventSourceForTests,
   __resetLiveUpdatesEventSourceForTests,
 } from "@/lib/features/flowsheet/live-updates-listener";
@@ -432,6 +433,40 @@ describe("liveUpdatesListenerMiddleware", () => {
       } finally {
         invalidateSpy.mockRestore();
         vi.useRealTimers();
+      }
+    });
+
+    it("__getHasEverConnectedForTests follows the request → open → release lifecycle", () => {
+      const store = makeStore();
+      expect(__getHasEverConnectedForTests()).toBe(false);
+      store.dispatch(liveUpdatesConnectionRequested());
+      expect(__getHasEverConnectedForTests()).toBe(false);
+      getLastMock()._fireOpen();
+      expect(__getHasEverConnectedForTests()).toBe(true);
+      store.dispatch(liveUpdatesConnectionReleased());
+      expect(__getHasEverConnectedForTests()).toBe(false);
+    });
+
+    it("does not set hasEverConnected when the onopen handler's status read throws (pins commit 7b56287 ordering invariant)", () => {
+      const store = makeStore();
+      store.dispatch(liveUpdatesConnectionRequested());
+      // Spy AFTER the requested-effect's initial "connecting" status set, so
+      // the next call into the selector is the one inside onopen.
+      const selectorSpy = vi
+        .spyOn(liveUpdatesSlice.selectors, "selectLiveUpdatesConnectionStatus")
+        .mockImplementationOnce(() => {
+          throw new Error("simulated status dispatch failure");
+        });
+      try {
+        expect(() => getLastMock()._fireOpen()).toThrow(
+          "simulated status dispatch failure"
+        );
+        // If a future refactor moves `hasEverConnected = true` back above the
+        // status dispatch, this assertion flips to true and the test fails —
+        // which is the regression we want.
+        expect(__getHasEverConnectedForTests()).toBe(false);
+      } finally {
+        selectorSpy.mockRestore();
       }
     });
   });

--- a/lib/features/flowsheet/live-updates-listener.ts
+++ b/lib/features/flowsheet/live-updates-listener.ts
@@ -315,3 +315,11 @@ export function __resetLiveUpdatesEventSourceForTests(): void {
 export function __getLiveUpdatesEventSourceForTests(): EventSource | null {
   return eventSource;
 }
+
+/** Test-only accessor for the reconnect-detect flag. Lets tests pin the
+ * ordering invariant that `hasEverConnected` is assigned only after the
+ * status-dispatch path in `onopen` completes, so a throwing dispatch can't
+ * leave the flag sticky-true. See #682, #685. */
+export function __getHasEverConnectedForTests(): boolean {
+  return hasEverConnected;
+}


### PR DESCRIPTION
Closes #685.

## Summary

- Export \`__getHasEverConnectedForTests\` alongside the existing \`__getLiveUpdatesEventSourceForTests\` accessor.
- New test \"__getHasEverConnectedForTests follows the request → open → release lifecycle\" pins the basic transitions (false → request → false → open → true → release → false).
- New test \"does not set hasEverConnected when the onopen handler's status read throws\" pins the defensive ordering from commit \`7b56287\` (#683): a throw bubbling out of \`setConnectionStatusIfChanged\` must leave the flag at false so the next observable connect is treated as initial, not reconnect.

## Regression detection

Locally verified that moving \`hasEverConnected = true\` back above \`setConnectionStatusIfChanged\` (the pre-7b56287 ordering) flips the new test to red.

## Test plan

- [x] \`npx vitest run lib/__tests__/features/flowsheet/live-updates-listener.test.ts\` — 22 pass (was 20)
- [x] \`npx tsc --noEmit\` — clean
- [x] Manual regression check: temporary move flag-set to top → new test fails as expected → restore