### PR TITLE
fix(sse): include WhoIsLive tag in SSE-driven cache invalidations so on-air indicator recovers without 60s polling lag

### DIFF
--- a/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
+++ b/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
@@ -363,7 +363,7 @@ describe("liveUpdatesListenerMiddleware", () => {
       }
     });
 
-    it("schedules a Flowsheet + NowPlaying invalidate on the second onopen (browser reconnect after transient drop)", () => {
+    it("schedules a Flowsheet + NowPlaying + WhoIsLive invalidate on the second onopen (browser reconnect after transient drop)", () => {
       vi.useFakeTimers();
       const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
       try {
@@ -379,7 +379,26 @@ describe("liveUpdatesListenerMiddleware", () => {
         vi.advanceTimersByTime(600);
         expect(invalidateSpy).toHaveBeenCalledTimes(1);
         expect(invalidateSpy).toHaveBeenCalledWith(
-          expect.arrayContaining(["Flowsheet", "NowPlaying"])
+          expect.arrayContaining(["Flowsheet", "NowPlaying", "WhoIsLive"])
+        );
+      } finally {
+        invalidateSpy.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+
+    it("the refetch envelope also invalidates Flowsheet + NowPlaying + WhoIsLive so DJ join/leave during the ETL window doesn't lag the on-air indicator", () => {
+      vi.useFakeTimers();
+      const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
+      try {
+        const store = makeStore();
+        store.dispatch(liveUpdatesConnectionRequested());
+        getLastMock()._fireMessage(
+          frame({ type: "refetch", payload: { source: "etl" }, timestamp: 1 })
+        );
+        vi.advanceTimersByTime(600);
+        expect(invalidateSpy).toHaveBeenCalledWith(
+          expect.arrayContaining(["Flowsheet", "NowPlaying", "WhoIsLive"])
         );
       } finally {
         invalidateSpy.mockRestore();

--- a/lib/features/flowsheet/live-updates-listener.ts
+++ b/lib/features/flowsheet/live-updates-listener.ts
@@ -23,7 +23,7 @@ const BENIGN_HANDSHAKE_TYPES = new Set<string>([
   "subscription",
 ]);
 
-type FlowsheetTag = "Flowsheet" | "NowPlaying";
+type FlowsheetTag = "Flowsheet" | "NowPlaying" | "WhoIsLive";
 
 const SSE_EVENTS = {
   CONNECTED: "sse_connected",
@@ -214,6 +214,7 @@ startListening({
         scheduleDebouncedInvalidate(listenerApi.dispatch, [
           "Flowsheet",
           "NowPlaying",
+          "WhoIsLive",
         ]);
       }
       // Set last so a throwing dispatch above leaves the flag false and the
@@ -273,6 +274,7 @@ startListening({
         scheduleDebouncedInvalidate(listenerApi.dispatch, [
           "Flowsheet",
           "NowPlaying",
+          "WhoIsLive",
         ]);
         return;
       }


### PR DESCRIPTION
Closes #684.

## Summary

- \`FlowsheetTag\` widened to \`\"Flowsheet\" | \"NowPlaying\" | \"WhoIsLive\"\`.
- Both SSE invalidate sites updated to include \`\"WhoIsLive\"\`:
  - The \`refetch\` envelope handler (line ~270).
  - The reconnect-driven dispatch added in #682 (line ~215).
- Existing reconnect test updated to assert the tag is in the dispatched set.
- New test: \"the refetch envelope also invalidates Flowsheet + NowPlaying + WhoIsLive…\" pins the same invariant for the envelope path.

## Motivation

Before this change, if a DJ joined or left during an SSE blackout or during an ETL \`refetch\` window, the on-air-DJ list stayed stale until the next \`useShowControl\` \`whoIsLive\` polling tick — up to 60 seconds. The blackout-recovery argument that motivated #682 applies equally to DJ join/leave events; both are state changes the client missed and needs to refetch.

## Test plan

- [x] \`npx vitest run lib/__tests__/features/flowsheet/live-updates-listener.test.ts\` — 21 pass (was 20)
- [x] \`npx tsc --noEmit\` — clean
- [ ] Post-merge: confirm DJ join/leave round-trip through the live page within the debounce window after a reconnect (manual verification on next on-air shift)