### PR TITLE
fix(catalog): propagate rotation_id and rotation_bin for library-unlinked rotation rows

### DIFF
--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -316,6 +316,130 @@ describe("convertToAlbumEntry", () => {
         expect(fallback.id).toBeLessThanOrEqual(0);
       });
     });
+
+    // dj-site#691 — BS `getRotationFromDB` LEFT JOINs library, so rotation
+    // rows whose album_id is not in the library catalog return with
+    // `library.id AS id` NULL while `rotation.id AS rotation_id` is
+    // independently populated. When the row arrives at the client with no
+    // `id` key (Express / JSON omits, or the value is `undefined`), the
+    // `isSearchResult` discriminator returns false and the
+    // `rotation_id: isSearchResult(response) ? response.rotation_id :
+    // undefined` ternary at conversions.ts:65 drops `rotation_id`.
+    // Downstream the picker (`RotationEntryFields.tsx`) dispatches
+    // `setRotationMetadata({ rotation_id: undefined })` and iOS/dj-site
+    // lose the rotation linkage needed for artwork/streaming. The fix:
+    // `rotation_id` is populated by the BS query independently of the
+    // library join, so read it ungated by `isSearchResult`.
+    describe("rotation_id propagation for library-unlinked rotation rows (dj-site#691)", () => {
+      it("preserves rotation_id when the response has no id field (unlinked rotation row)", () => {
+        // Reproduces the BS rotation-row shape: `rotation_id` populated,
+        // `id` absent (library LEFT JOIN missed). Cast through `unknown`
+        // because the openapi-derived `AlbumSearchResultJSON` types `id`
+        // as required, but the wire shape from BS includes null/missing
+        // here per `getRotationFromDB`.
+        const unlinkedRotationRow = {
+          rotation_id: 42,
+          rotation_bin: "S",
+          album_title: "Yenbett",
+          artist_name: "Noura Mint Seymali",
+          code_letters: "NM",
+          code_artist_number: 0,
+          code_number: 0,
+          format_name: "CD",
+          genre_name: "Unknown",
+          label: "",
+          add_date: "2026-01-01T00:00:00.000Z",
+        } as unknown as Parameters<typeof convertToAlbumEntry>[0];
+        const result = convertToAlbumEntry(unlinkedRotationRow);
+        expect(result.rotation_id).toBe(42);
+        expect(result.rotation_bin).toBe(Rotation.S);
+      });
+
+      it("preserves rotation_id when id is explicitly null on a search-result-shaped row", () => {
+        const result = convertToAlbumEntry(
+          createTestAlbumSearchResult({
+            id: null as unknown as number,
+            rotation_id: 7,
+          })
+        );
+        expect(result.rotation_id).toBe(7);
+      });
+
+      it("leaves rotation_id undefined when the response itself omits it", () => {
+        const result = convertToAlbumEntry(
+          createTestAlbumSearchResult({
+            id: null as unknown as number,
+            rotation_id: undefined,
+          })
+        );
+        expect(result.rotation_id).toBeUndefined();
+      });
+
+      // End-to-end through the picker chain: BS rotation response →
+      // convertToAlbumEntry → setRotationMetadata reducer →
+      // convertQueryToSubmission. Asserts the rotation_id survives every step
+      // for a library-unlinked rotation row, matching dj-site#691's AC.
+      it("propagates rotation_id end-to-end (conversion → slice → submission)", async () => {
+        const { flowsheetSlice, defaultFlowsheetFrontendState } = await import(
+          "@/lib/features/flowsheet/frontend"
+        );
+        const { convertQueryToSubmission } = await import(
+          "@/lib/features/flowsheet/conversions"
+        );
+
+        const unlinkedRotationRow = {
+          rotation_id: 99,
+          rotation_bin: "H",
+          album_title: "Yenbett",
+          artist_name: "Noura Mint Seymali",
+          label: "Glitterbeat",
+          code_letters: "NM",
+          code_artist_number: 0,
+          code_number: 0,
+          format_name: "CD",
+          genre_name: "Unknown",
+        } as unknown as Parameters<typeof convertToAlbumEntry>[0];
+
+        const albumEntry = convertToAlbumEntry(unlinkedRotationRow);
+
+        let state = defaultFlowsheetFrontendState;
+        state = flowsheetSlice.reducer(
+          state,
+          flowsheetSlice.actions.setRotationMetadata({
+            album_id: albumEntry.id,
+            rotation_id: albumEntry.rotation_id,
+            rotation_bin: albumEntry.rotation_bin,
+          })
+        );
+        // The selected release also seeds artist / album / label via
+        // setSearchProperty in the real picker; replicate the bits that the
+        // submission reads.
+        state = flowsheetSlice.reducer(
+          state,
+          flowsheetSlice.actions.setSearchProperty({
+            name: "artist",
+            value: albumEntry.artist.name,
+          })
+        );
+        state = flowsheetSlice.reducer(
+          state,
+          flowsheetSlice.actions.setSearchProperty({
+            name: "album",
+            value: albumEntry.title,
+          })
+        );
+
+        // Cast to access the runtime fields not exposed on
+        // FlowsheetSubmissionParams' type (mirrors the pattern in
+        // flowsheet/conversions.test.ts).
+        const submission = convertQueryToSubmission(state.search.query) as {
+          rotation_id?: number;
+          rotation_bin?: string;
+        };
+        expect(submission.rotation_id).toBe(99);
+        expect(submission.rotation_bin).toBe(Rotation.H);
+      });
+    });
   });
 
   it.each([

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -56,13 +56,25 @@ export function convertToAlbumEntry(
     format: (response.format_name as Format) ?? "Unknown",
     alternate_artist: "",
     album_artist: isSearchResult(response) ? response.album_artist : undefined,
-    rotation_bin: isSearchResult(response)
-      ? (response.rotation_bin as Rotation)
-      : undefined,
+    // `rotation_bin` and `rotation_id` are populated by BS's `getRotationFromDB`
+    // query independently of the `library` LEFT JOIN (see
+    // Backend-Service/apps/backend/services/library.service.ts: `rotation.id AS
+    // rotation_id`, `rotation.rotation_bin AS rotation_bin`), so they survive
+    // for rotation rows whose `album_id` doesn't link to a library row. Reading
+    // them through `isSearchResult` (which gates on `id`, i.e. `library.id`)
+    // dropped them for library-unlinked rotation rows — dj-site#691. Other
+    // library-bound fields below (`add_date`, `plays`, `on_streaming`,
+    // `date_lost`, `date_found`, `artwork_url`, `matched_via`, `album_artist`)
+    // legitimately stay gated: they ARE null on unlinked rotation rows.
+    rotation_bin: ((response as Record<string, unknown>).rotation_bin as
+      | Rotation
+      | undefined),
     add_date: isSearchResult(response) ? response.add_date : undefined,
     plays: isSearchResult(response) ? response.plays : undefined,
     label: response.label ?? "",
-    rotation_id: isSearchResult(response) ? response.rotation_id : undefined,
+    rotation_id: (response as Record<string, unknown>).rotation_id as
+      | number
+      | undefined,
     on_streaming: isSearchResult(response) ? (response as Record<string, unknown>).on_streaming as boolean | undefined : undefined,
     date_lost: isSearchResult(response) ? (response as Record<string, unknown>).date_lost as string | undefined : undefined,
     date_found: isSearchResult(response) ? (response as Record<string, unknown>).date_found as string | undefined : undefined,


### PR DESCRIPTION
## Summary

`convertToAlbumEntry` previously gated `rotation_id` and `rotation_bin` on `isSearchResult`, which keys on the presence/definedness of `id` (BS alias of `library.id`). For rotation rows whose `album_id` doesn't link to a library catalog row, BS's `getRotationFromDB` returns `id` null/absent via the LEFT JOIN, but `rotation.id AS rotation_id` and `rotation.rotation_bin AS rotation_bin` are independently populated on every row. The old gate dropped both, and downstream the picker dispatched `setRotationMetadata({ rotation_id: undefined })` so the flowsheet entry lost the rotation linkage iOS / dj-site need for artwork. Reading the rotation fields directly fixes the propagation.

## Field audit (per AC)

Lines 58–70 of `convertToAlbumEntry` were audited for the same defect class:

- `rotation_bin`, `rotation_id` — **fixed**: independent of the library LEFT JOIN, populated on every rotation row.
- `add_date`, `plays`, `on_streaming`, `date_lost`, `date_found`, `artwork_url`, `matched_via`, `album_artist` — **legitimately gated**: all sourced from `library` (or library-derived joins) and ARE null on unlinked rotation rows, so the `isSearchResult` gate is correct.

## Test plan

- [x] Unit: `convertToAlbumEntry` returns `rotation_id: 42` and `rotation_bin: S` for a response with no `id` field but `rotation_id: 42, rotation_bin: "S"` (failing red before the fix; green after).
- [x] Unit: still returns `rotation_id: 7` for explicit `id: null`.
- [x] Unit: still returns `rotation_id: undefined` when the response omits the field entirely.
- [x] End-to-end (slice integration): `convertToAlbumEntry` → `flowsheetSlice.setRotationMetadata` → `convertQueryToSubmission` carries `rotation_id: 99, rotation_bin: H` through for a library-unlinked row.
- [x] Existing 3,148 tests pass.
- [x] `npx tsc --noEmit` clean.

## Related

- WXYC/Backend-Service#1268 — sibling: BS legacy/webhook write path.
- WXYC/Backend-Service#1270 — sibling: BS controller allowlist regression on the dj-site direct-POST write path.
- WXYC/library-metadata-lookup#487 — sibling: LML external streaming probe for non-rotation albums.

Closes #691