### PR TITLE
test(catalog): post-merge follow-ups for #691 — ticket links + e2e coverage + hash-input gap

### DIFF
--- a/lib/__tests__/features/catalog/conversions.test.ts
+++ b/lib/__tests__/features/catalog/conversions.test.ts
@@ -168,21 +168,46 @@ describe("catalog conversions", () => {
         expect(yenbett.id).not.toBe(differentArtistAlbumLabel.id);
       });
 
-      it("synthesizes DIFFERENT ids when only code_letters / code_number differ", () => {
-        // Hash inputs include `code_letters`, `code_artist_number`, and
-        // `code_number` — same album/artist/label across two unlinked rows
-        // with different catalog codes must still hash distinctly. Real WXYC
-        // case: a multi-format reissue (CD vs LP) of the same release where
-        // the rotation snapshot carries different code_number values.
-        const yenbett = convertToAlbumEntry(unlinkedRowNullId);
-        const yenbettDifferentCodes = convertToAlbumEntry({
+      // Per-field collision pins for synthesizeAlbumId. The hash inputs
+      // are 6 fields (artist|album|label|letters|artist_num|num). A single
+      // combined "all code_* differ at once" assertion would still pass if
+      // a regression dropped any one of those fields from the hash key —
+      // the remaining 5 inputs would still produce distinct hashes. Pin
+      // each input individually by holding all others equal to
+      // `unlinkedRowBase` (which has empty strings / zeros for code_*),
+      // varying exactly one.
+      it("synthesizes DIFFERENT ids when only code_letters differ", () => {
+        const a = convertToAlbumEntry(unlinkedRowNullId);
+        const b = convertToAlbumEntry({
           ...unlinkedRowBase,
-          code_letters: "B",
+          code_letters: "Z",
+          id: null as unknown as number,
+        } as AlbumSearchResultJSON);
+        expect(a.id).not.toBe(b.id);
+      });
+
+      it("synthesizes DIFFERENT ids when only code_artist_number differs", () => {
+        const a = convertToAlbumEntry(unlinkedRowNullId);
+        const b = convertToAlbumEntry({
+          ...unlinkedRowBase,
           code_artist_number: 7,
+          id: null as unknown as number,
+        } as AlbumSearchResultJSON);
+        expect(a.id).not.toBe(b.id);
+      });
+
+      it("synthesizes DIFFERENT ids when only code_number differs", () => {
+        // Real WXYC case: a multi-format reissue (CD vs LP) of the same
+        // release where the rotation snapshot carries different
+        // code_number values but identical artist / album / label / letters
+        // / code_artist_number.
+        const a = convertToAlbumEntry(unlinkedRowNullId);
+        const b = convertToAlbumEntry({
+          ...unlinkedRowBase,
           code_number: 99,
           id: null as unknown as number,
         } as AlbumSearchResultJSON);
-        expect(yenbett.id).not.toBe(yenbettDifferentCodes.id);
+        expect(a.id).not.toBe(b.id);
       });
     });
 

--- a/lib/__tests__/features/catalog/conversions.test.ts
+++ b/lib/__tests__/features/catalog/conversions.test.ts
@@ -64,7 +64,13 @@ const unlinkedRowUndefinedId = {
   ...unlinkedRowBase,
   id: undefined as unknown as number,
 } as AlbumSearchResultJSON;
-const unlinkedRowOmittedId = unlinkedRowBase as unknown as AlbumSearchResultJSON;
+// Cloned (not aliased) so a later test mutating this fixture wouldn't
+// silently corrupt `unlinkedRowBase` and the two spread-derived fixtures
+// above. The `expect("id" in unlinkedRowOmittedId).toBe(false)` assertion in
+// the omitted-key tests is load-bearing — keeping the clone isolates it.
+const unlinkedRowOmittedId = {
+  ...unlinkedRowBase,
+} as unknown as AlbumSearchResultJSON;
 
 // Real `BinLibraryDetails` shape per `@wxyc/shared/api.yaml:1505-1525` — 9
 // fields, no `id`, no rotation fields, no `add_date`, no `plays`. This is the
@@ -148,23 +154,34 @@ describe("catalog conversions", () => {
         expect(first.id).toBe(second.id);
       });
 
-      it("synthesizes DIFFERENT ids for different snapshots", () => {
-        // Partial collision-freedom pin: two rows with different snapshot
-        // fields must hash to different negative ids. (True collision-freedom
-        // over arbitrary inputs is not testable; this guards the common case
-        // and would catch a regression that, say, hashed only `artist_name`.)
-        // Known collision risk: two unlinked rotation rows with IDENTICAL
-        // snapshot fields but different rotation_ids would still collide —
-        // tracked as a follow-up; see comment on `synthesizeAlbumId`.
+      it("synthesizes DIFFERENT ids when artist/album/label differ", () => {
+        // Catches a regression that drops any of those three from the hash.
         const yenbett = convertToAlbumEntry(unlinkedRowNullId);
-        const otherUnlinked = convertToAlbumEntry({
+        const differentArtistAlbumLabel = convertToAlbumEntry({
           ...unlinkedRowBase,
           album_title: "DOGA",
           artist_name: "Juana Molina",
           label: "Sonamos",
           id: null as unknown as number,
         } as AlbumSearchResultJSON);
-        expect(yenbett.id).not.toBe(otherUnlinked.id);
+        expect(yenbett.id).not.toBe(differentArtistAlbumLabel.id);
+      });
+
+      it("synthesizes DIFFERENT ids when only code_letters / code_number differ", () => {
+        // Hash inputs include `code_letters`, `code_artist_number`, and
+        // `code_number` — same album/artist/label across two unlinked rows
+        // with different catalog codes must still hash distinctly. Real WXYC
+        // case: a multi-format reissue (CD vs LP) of the same release where
+        // the rotation snapshot carries different code_number values.
+        const yenbett = convertToAlbumEntry(unlinkedRowNullId);
+        const yenbettDifferentCodes = convertToAlbumEntry({
+          ...unlinkedRowBase,
+          code_letters: "B",
+          code_artist_number: 7,
+          code_number: 99,
+          id: null as unknown as number,
+        } as AlbumSearchResultJSON);
+        expect(yenbett.id).not.toBe(yenbettDifferentCodes.id);
       });
     });
 
@@ -268,9 +285,10 @@ describe("catalog conversions", () => {
         expect(submission.rotation_bin).toBe(Rotation.H);
       });
 
-      it("carries rotation_id from a library-UNLINKED row through to the wire payload", () => {
+      it("carries rotation metadata from a library-UNLINKED (id:undefined) row through to the wire payload", () => {
         const albumEntry = convertToAlbumEntry(unlinkedRowUndefinedId);
         expect(albumEntry.rotation_id).toBe(5042);
+        expect(albumEntry.rotation_bin).toBe(Rotation.S);
 
         const state = flowsheetSlice.reducer(
           defaultFlowsheetFrontendState,
@@ -280,28 +298,65 @@ describe("catalog conversions", () => {
             rotation_bin: albumEntry.rotation_bin,
           })
         );
+        // Pin chain identity at every stage — a regression that substituted
+        // a different value (e.g. a sentinel -1, a hash from query fields
+        // rather than the album entry) would still satisfy the looser
+        // sign-only `album_id < 0` check below but would be a different
+        // leak than #608 documents.
+        expect(state.search.query.album_id).toBe(albumEntry.id);
         expect(state.search.query.rotation_id).toBe(5042);
+        expect(state.search.query.rotation_bin).toBe(Rotation.S);
 
         const submission = convertQueryToSubmission(state.search.query) as {
           album_id?: number;
           rotation_id?: number;
+          rotation_bin?: Rotation;
         };
+        expect(submission.album_id).toBe(albumEntry.id);
         expect(submission.rotation_id).toBe(5042);
+        expect(submission.rotation_bin).toBe(Rotation.S);
 
-        // KNOWN ISSUE (not introduced by #691; tracked separately): the
-        // submission also carries the negative synthetic album_id from
-        // `synthesizeAlbumId`. Backend-Service `flowsheet.controller.ts`
-        // takes the `body.album_id != null` branch for any negative number,
-        // calls `getAlbumFromDB(-X)` (returns undefined), then throws
-        // TypeError on `albumInfo.record_label = ...`. The fix in this PR
-        // restores rotation_id propagation through the conversion layer; the
-        // end-to-end picker flow for library-unlinked rotation rows requires
-        // a follow-up to either (a) strip negative ids in
-        // `convertQueryToSubmission`, or (b) coerce to null when the id is
-        // synthetic. Asserted here as the current observed behavior so the
-        // test fails loudly if either layer changes without a coordinated
-        // update.
+        // Tracked in dj-site#608: synthetic negative album_id from
+        // `synthesizeAlbumId` (used as a stable React key for unlinked rows)
+        // leaks through `setRotationMetadata` and `convertQueryToSubmission`
+        // to the wire. BS `flowsheet.controller.ts` takes the
+        // `body.album_id != null` branch for negative numbers, calls
+        // `getAlbumFromDB(-X)` → undefined → throws TypeError on
+        // `albumInfo.record_label = ...`. This PR restores the conversion-
+        // layer propagation only; the wire leak is the separate follow-up.
+        // Pinned here so any fix in either layer (strip in submission;
+        // coerce to null when synthetic) updates the assertion deliberately.
         expect(submission.album_id).toBeLessThan(0);
+      });
+
+      it("carries rotation metadata from a library-UNLINKED (id omitted) row through to the wire payload", () => {
+        // Sibling coverage for the omitted-key wire shape — the JSON-
+        // omission upstream coercion mode. Same chain as the id:undefined
+        // variant; the two id-absence shapes flow through different
+        // `isSearchResult` branches in `convertToAlbumEntry`, so both need
+        // wire-chain coverage.
+        const albumEntry = convertToAlbumEntry(unlinkedRowOmittedId);
+        expect(albumEntry.rotation_id).toBe(5042);
+        expect(albumEntry.rotation_bin).toBe(Rotation.S);
+
+        const state = flowsheetSlice.reducer(
+          defaultFlowsheetFrontendState,
+          flowsheetSlice.actions.setRotationMetadata({
+            album_id: albumEntry.id,
+            rotation_id: albumEntry.rotation_id,
+            rotation_bin: albumEntry.rotation_bin,
+          })
+        );
+
+        const submission = convertQueryToSubmission(state.search.query) as {
+          album_id?: number;
+          rotation_id?: number;
+          rotation_bin?: Rotation;
+        };
+        expect(submission.album_id).toBe(albumEntry.id);
+        expect(submission.rotation_id).toBe(5042);
+        expect(submission.rotation_bin).toBe(Rotation.S);
+        expect(submission.album_id).toBeLessThan(0); // see dj-site#608
       });
     });
   });

--- a/lib/__tests__/features/catalog/conversions.test.ts
+++ b/lib/__tests__/features/catalog/conversions.test.ts
@@ -67,7 +67,8 @@ const unlinkedRowUndefinedId = {
 // Cloned (not aliased) so a later test mutating this fixture wouldn't
 // silently corrupt `unlinkedRowBase` and the two spread-derived fixtures
 // above. The `expect("id" in unlinkedRowOmittedId).toBe(false)` assertion in
-// the omitted-key tests is load-bearing — keeping the clone isolates it.
+// the omitted-key rotation_id test is load-bearing — keeping the clone
+// isolates it.
 const unlinkedRowOmittedId = {
   ...unlinkedRowBase,
 } as unknown as AlbumSearchResultJSON;
@@ -330,11 +331,15 @@ describe("catalog conversions", () => {
       });
 
       it("carries rotation metadata from a library-UNLINKED (id omitted) row through to the wire payload", () => {
-        // Sibling coverage for the omitted-key wire shape — the JSON-
-        // omission upstream coercion mode. Same chain as the id:undefined
-        // variant; the two id-absence shapes flow through different
-        // `isSearchResult` branches in `convertToAlbumEntry`, so both need
-        // wire-chain coverage.
+        // Sibling coverage for the omitted-key wire shape — JSON omission
+        // is the most common upstream coercion mode. Both id-absence shapes
+        // (id:undefined and id-omitted) take the FALSE branch of
+        // `isSearchResult` and the same `synthesizeAlbumId` path; the only
+        // observable difference is whether `"id" in response` short-circuits
+        // inside the discriminator. Structurally symmetric to the
+        // id:undefined sibling above so a regression that diverged only one
+        // path (e.g., a future reducer that special-cased absent keys)
+        // would surface here, not pass silently.
         const albumEntry = convertToAlbumEntry(unlinkedRowOmittedId);
         expect(albumEntry.rotation_id).toBe(5042);
         expect(albumEntry.rotation_bin).toBe(Rotation.S);
@@ -347,6 +352,9 @@ describe("catalog conversions", () => {
             rotation_bin: albumEntry.rotation_bin,
           })
         );
+        expect(state.search.query.album_id).toBe(albumEntry.id);
+        expect(state.search.query.rotation_id).toBe(5042);
+        expect(state.search.query.rotation_bin).toBe(Rotation.S);
 
         const submission = convertQueryToSubmission(state.search.query) as {
           album_id?: number;
@@ -356,7 +364,9 @@ describe("catalog conversions", () => {
         expect(submission.album_id).toBe(albumEntry.id);
         expect(submission.rotation_id).toBe(5042);
         expect(submission.rotation_bin).toBe(Rotation.S);
-        expect(submission.album_id).toBeLessThan(0); // see dj-site#608
+        // Canary for dj-site#608 wire leak; see explanatory comment on the
+        // sibling id:undefined e2e test above.
+        expect(submission.album_id).toBeLessThan(0);
       });
     });
   });

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -14,17 +14,27 @@ function isSearchResult(
 // the same list collapse to a single React key. The hash is deterministic
 // across renders and negated so it can't collide with real positive album ids.
 //
-// Known follow-ups (out of scope for #691):
-//   1. dj-site#626 — hash inputs are (artist|album|label|letters|artist_num|
-//      num); two unlinked rotation rows with identical denormalized snapshots
-//      but different rotation_ids collide on the same React key.
-//   2. dj-site#608 — the synthetic id is intended for client-side rendering
-//      only, but currently propagates through `setRotationMetadata` →
-//      `convertQueryToSubmission` to the wire. BS takes the `album_id != null`
-//      branch on negative numbers and throws TypeError. The unlinked-row e2e
-//      test in `__tests__/features/catalog/conversions.test.ts` pins the
-//      current observed behavior so a future fix in either layer must update
-//      the assertion deliberately.
+// Known follow-ups (out of scope for #691). Hash inputs are
+// (artist|album|label|letters|artist_num|num):
+//
+//   1. dj-site#626 — same hash for all-null fields (joined to "|||||"). The
+//      related-but-not-identical case of two rows with IDENTICAL populated
+//      snapshots but different rotation_ids producing the same React key is
+//      a sibling defect with the same root cause; see scope-expansion
+//      comment on #626 for the rotation-picker variant.
+//   2. dj-site#608 — synthetic id leaks to the wire from bin operations
+//      (`lib/features/bin/conversions.ts:8,19`, `flowsheet/connections.ts:10`
+//      per the issue's Evidence section). The rotation-picker path through
+//      `setRotationMetadata` → `convertQueryToSubmission` is a sibling
+//      surface with the same root cause and same fix shape; see scope-
+//      expansion comment on #608. Backend-Service treats negative album_id
+//      as a present FK (`flowsheet.controller.ts:255` `if (body.album_id !=
+//      null)`), then `getAlbumFromDB(-X)` returns undefined and the next
+//      line `albumInfo.record_label = ...` throws TypeError (controller line
+//      ~260) before BS's FK-validation layer can return 4xx. The unlinked-
+//      row e2e test in `__tests__/features/catalog/conversions.test.ts` pins
+//      the current observed wire shape so any fix in either layer must
+//      update the assertion deliberately.
 function synthesizeAlbumId(
   response: AlbumSearchResultJSON | BinLibraryDetails
 ): number {

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -15,11 +15,11 @@ function isSearchResult(
 // across renders and negated so it can't collide with real positive album ids.
 //
 // Known follow-ups (out of scope for #691):
-//   1. Hash inputs are (artist|album|label|letters|artist_num|num) — two
-//      unlinked rotation rows with identical denormalized snapshots but
-//      different rotation_ids collide on the same React key.
-//   2. The synthetic id is intended for client-side rendering only, but
-//      currently propagates through `setRotationMetadata` →
+//   1. dj-site#626 — hash inputs are (artist|album|label|letters|artist_num|
+//      num); two unlinked rotation rows with identical denormalized snapshots
+//      but different rotation_ids collide on the same React key.
+//   2. dj-site#608 — the synthetic id is intended for client-side rendering
+//      only, but currently propagates through `setRotationMetadata` →
 //      `convertQueryToSubmission` to the wire. BS takes the `album_id != null`
 //      branch on negative numbers and throws TypeError. The unlinked-row e2e
 //      test in `__tests__/features/catalog/conversions.test.ts` pins the


### PR DESCRIPTION
## Summary

Test-only follow-up to PR #695 (merged earlier today, closing dj-site#691). Surfaces the synthetic-id follow-ups in the comment graph and closes coverage gaps that a deep code review of #695 surfaced after merge.

- Wire the two synthesizeAlbumId follow-ups from the #695 comment to their tracked tickets — **dj-site#608** (negative synthetic album_id leaks through `setRotationMetadata` → `convertQueryToSubmission` to the wire; BS throws TypeError) and **dj-site#626** (hash collides for unlinked rotation rows with identical denormalized snapshots but different rotation_ids). These were orphan comments before; now they show up in the graph.
- Strengthen the unlinked-row e2e: add `rotation_bin` assertions to match the linked-row coverage, pin chain identity (`album_id === albumEntry.id`) at every stage so a regression that substituted a different negative value would still trip the test, and split into `id:undefined` and id-omitted variants since the two coercion modes flow through different `isSearchResult` branches in `convertToAlbumEntry`.
- Split the `synthesizeAlbumId` DIFFERENT-ids test into two: one for artist/album/label divergence, one for `code_letters` / `code_artist_number` / `code_number` divergence. The previous single assertion exercised only 3 of the 6 hash inputs — a regression dropping any of the code_* fields from the hash key would have slipped past.
- Clone `unlinkedRowOmittedId` from `unlinkedRowBase` rather than aliasing the reference. The `\`"id" in unlinkedRowOmittedId\`` assertion in the regression block is load-bearing; isolating the fixture removes a latent mutation hazard.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run lib/__tests__/features/catalog/conversions.test.ts` — 21/21 pass (was 19)
- [x] `npx vitest run` — 3165/3165 (was 3163)
- [ ] CI green

## Related

- https://github.com/WXYC/dj-site/pull/695 (merged; original #691 fix)
- https://github.com/WXYC/dj-site/issues/691 (closed by #695)
- https://github.com/WXYC/dj-site/issues/608 (referenced from new comment)
- https://github.com/WXYC/dj-site/issues/626 (referenced from new comment)

No behavior change to `conversions.ts` (comment-only edits to expand ticket references).