### PR TITLE
fix(classic): key rotation picker on rotation_id, gate album_id leak

### DIFF
--- a/src/components/experiences/classic/flowsheet/EntryForm.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryForm.tsx
@@ -34,6 +34,11 @@ export default function EntryForm({
   const [entryType, setEntryType] = useState<EntryType>("track");
   const [releaseType, setReleaseType] = useState<ReleaseType>("rotationRelease");
   const [rotationType, setRotationType] = useState<RotationType | "">("");
+  // Holds the picked release's `rotation_id` (rotation row PK), NOT its album
+  // id. `release.id` can be a synthesized negative for library-unlinked
+  // rotation rows (see `synthesizeAlbumId` in catalog/conversions.ts); keying
+  // on `rotation_id` keeps the picker working regardless of library-link
+  // state (dj-site#698). 0 means nothing selected.
   const [selectedRotationId, setSelectedRotationId] = useState<number>(0);
   const [artistName, setArtistName] = useState("");
   const [songTitle, setSongTitle] = useState("");
@@ -57,10 +62,10 @@ export default function EntryForm({
     }
   }, [useArtistForComposer, artistName]);
 
-  const handleRotationSelect = (type: RotationType, releaseId: number) => {
+  const handleRotationSelect = (type: RotationType, rotationId: number) => {
     setRotationType(type);
-    setSelectedRotationId(releaseId);
-    const release = rotationData?.find((r) => r.id === releaseId);
+    setSelectedRotationId(rotationId);
+    const release = rotationData?.find((r) => r.rotation_id === rotationId);
     if (release) {
       setArtistName(release.artist.name);
       setReleaseTitle(release.title);
@@ -109,17 +114,39 @@ export default function EntryForm({
         entry_type: FlowsheetEntryType.breakpoint,
       };
     } else if (releaseType === "rotationRelease" && selectedRotationId > 0) {
-      const release = rotationData?.find((r) => r.id === selectedRotationId);
+      const release = rotationData?.find(
+        (r) => r.rotation_id === selectedRotationId
+      );
       if (!release) return;
-      submissionData = {
-        album_id: release.id,
-        track_title: songTitle,
-        rotation_id: release.rotation_id,
-        request_flag: requestFlag,
-        segue,
-        record_label: labelName || release.label,
-        rotation_bin: release.rotation_bin,
-      };
+      // Library-unlinked rotation rows have a synthesized negative
+      // `release.id` (see `synthesizeAlbumId` in catalog/conversions.ts).
+      // BS's POST /flowsheet rotation variant
+      // (`FlowsheetCreateSongFromCatalog`) requires a real positive
+      // `album_id`, so we fall back to the freeform variant for unlinked
+      // rows. This trades the rotation linkage (sibling: dj-site#691) for
+      // a non-error submit; recovering the linkage requires BS to accept
+      // `rotation_id` without `album_id` (Option C, BS-side schema work).
+      // Aligned with sibling dj-site#608's fix shape.
+      if (typeof release.id === "number" && release.id > 0) {
+        submissionData = {
+          album_id: release.id,
+          track_title: songTitle,
+          rotation_id: release.rotation_id,
+          request_flag: requestFlag,
+          segue,
+          record_label: labelName || release.label,
+          rotation_bin: release.rotation_bin,
+        };
+      } else {
+        submissionData = {
+          artist_name: release.artist.name,
+          album_title: release.title,
+          track_title: songTitle,
+          request_flag: requestFlag,
+          segue,
+          record_label: labelName || release.label,
+        };
+      }
     } else {
       // libraryRelease + otherRelease both fall through to the free-text
       // submission path. Plumbing a real `library_album_id` for the Library
@@ -227,7 +254,10 @@ export default function EntryForm({
                         Rotation ------------------
                       </option>
                       {heavyReleases.map((release) => (
-                        <option key={release.id} value={release.id}>
+                        <option
+                          key={release.rotation_id}
+                          value={release.rotation_id}
+                        >
                           {release.artist.name} - {release.title}
                         </option>
                       ))}
@@ -247,7 +277,10 @@ export default function EntryForm({
                         Rotation -----------------
                       </option>
                       {mediumReleases.map((release) => (
-                        <option key={release.id} value={release.id}>
+                        <option
+                          key={release.rotation_id}
+                          value={release.rotation_id}
+                        >
                           {release.artist.name} - {release.title}
                         </option>
                       ))}
@@ -267,7 +300,10 @@ export default function EntryForm({
                         Rotation ------------------
                       </option>
                       {lightReleases.map((release) => (
-                        <option key={release.id} value={release.id}>
+                        <option
+                          key={release.rotation_id}
+                          value={release.rotation_id}
+                        >
                           {release.artist.name} - {release.title}
                         </option>
                       ))}
@@ -290,7 +326,10 @@ export default function EntryForm({
                         Rotation ----------------
                       </option>
                       {singlesReleases.map((release) => (
-                        <option key={release.id} value={release.id}>
+                        <option
+                          key={release.rotation_id}
+                          value={release.rotation_id}
+                        >
                           {release.artist.name} - {release.title}
                         </option>
                       ))}

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryForm.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryForm.test.tsx
@@ -287,6 +287,21 @@ describe("Classic EntryForm — Bin dropdown (replaces H/M/L/S radios)", () => {
 });
 
 describe("Classic EntryForm — Rotation submission payload", () => {
+  // Select a release by its visible text rather than its `value=` attribute
+  // so the test stays decoupled from whether the picker keys on `id` or
+  // `rotation_id` (see #698: pre-fix used `id`, post-fix uses `rotation_id`).
+  async function selectByText(
+    user: ReturnType<typeof renderWithProviders>["user"],
+    select: HTMLSelectElement,
+    textContains: string
+  ): Promise<void> {
+    const option = Array.from(select.options).find((o) =>
+      o.text.includes(textContains)
+    );
+    if (!option) throw new Error(`No option text contains: ${textContains}`);
+    await user.selectOptions(select, option);
+  }
+
   it("submits a rotation entry with album_id, rotation_id, and rotation_bin", async () => {
     rotationDataMock = [
       createTestRotationAlbum(Rotation.H, {
@@ -304,7 +319,7 @@ describe("Classic EntryForm — Rotation submission payload", () => {
     const { user } = renderWithProviders(<EntryForm />);
     // Default state is Track + Rotation. Pick Heavy, then the release.
     await user.selectOptions(getNamedSelect("rotationType"), "heavy");
-    await user.selectOptions(getNamedSelect("heavyRelease"), "5101");
+    await selectByText(user, getNamedSelect("heavyRelease"), "Aluminum Tunes");
     await user.type(getNamedInput("songTitle"), "Tone Burst");
     await user.click(screen.getByRole("button", { name: /^add$/i }));
 
@@ -320,6 +335,81 @@ describe("Classic EntryForm — Rotation submission payload", () => {
     // Pin the absence of the legacy field name so a future rename doesn't
     // silently regress to `play_freq`.
     expect("play_freq" in payload).toBe(false);
+  });
+
+  // Regression: #698 — library-unlinked rotation rows are returned by BS with
+  // `id: null` and round-tripped through `convertToAlbumEntry` as a synthesized
+  // *negative* `id` (deterministic hash, see `synthesizeAlbumId` in
+  // `lib/features/catalog/conversions.ts`). The Classic picker's submit-enable
+  // gate used to require `selectedRotationId > 0`, so picking such a row left
+  // the ADD button greyed out forever (reported by bill burton 2026-06-02 on
+  // the rotation album "Setting"). The wire payload also must not carry a
+  // negative `album_id` (sibling: dj-site#608).
+  it("enables ADD for a library-unlinked rotation row (synthesized negative id)", async () => {
+    rotationDataMock = [
+      createTestRotationAlbum(Rotation.H, {
+        id: -987654321, // synthesized — what convertToAlbumEntry produces for id:null
+        rotation_id: 7331,
+        title: "Setting",
+        label: "Paradise of Bachelors",
+        artist: createTestArtist({
+          name: "Setting",
+          lettercode: "SE",
+          numbercode: 1,
+        }),
+      }),
+    ];
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("rotationType"), "heavy");
+    await selectByText(user, getNamedSelect("heavyRelease"), "Setting");
+    await user.type(getNamedInput("songTitle"), "Charcoal Bow");
+
+    const submit = screen.getByRole("button", {
+      name: /^add$/i,
+    }) as HTMLButtonElement;
+    // Pre-fix this stayed `true` forever; the button never went grey → black.
+    expect(submit.disabled).toBe(false);
+  });
+
+  it("submits a library-unlinked rotation row as freeform (no negative album_id, no rotation linkage on the wire)", async () => {
+    // BS's POST /flowsheet rotation variant requires a real positive
+    // `album_id`, so unlinked rows fall back to the freeform variant.
+    // Losing the rotation linkage on the wire is a known cost — recovering
+    // it requires BS-side schema work (Option C). The non-goal here is
+    // sending a negative `album_id` (sibling: dj-site#608).
+    rotationDataMock = [
+      createTestRotationAlbum(Rotation.H, {
+        id: -987654321,
+        rotation_id: 7331,
+        title: "Setting",
+        label: "Paradise of Bachelors",
+        artist: createTestArtist({
+          name: "Setting",
+          lettercode: "SE",
+          numbercode: 1,
+        }),
+      }),
+    ];
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("rotationType"), "heavy");
+    await selectByText(user, getNamedSelect("heavyRelease"), "Setting");
+    await user.type(getNamedInput("songTitle"), "Charcoal Bow");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+    });
+    const payload = addToFlowsheetMock.mock.calls[0][0];
+    expect(payload.track_title).toBe("Charcoal Bow");
+    // Freeform variant carries the denormalized artist/album/label
+    // snapshot from the rotation row so BS can persist the entry.
+    expect(payload.artist_name).toBe("Setting");
+    expect(payload.album_title).toBe("Setting");
+    expect(payload.record_label).toBe("Paradise of Bachelors");
+    // No negative album_id on the wire — never the synthesized id.
+    if ("album_id" in payload && payload.album_id !== undefined) {
+      expect(payload.album_id).toBeGreaterThan(0);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Bill Burton reported via email (2026-06-02 ~9:52 PM ET) that the ADD button in the Classic flowsheet wouldn't enable for a rotation album called "Setting" — the "add block" never went from grey to black. Other tracks the same session worked fine.
- Root cause: BS's `/library/rotation` returns `id: null` for library-unlinked rotation rows; `convertToAlbumEntry` synthesizes a deterministic *negative* `id` for them (React-key uniqueness); the Classic picker stored that as `selectedRotationId`; the submit-enable gate required `> 0`, so the button stayed disabled.
- Fix (Option B per the issue): key the rotation picker on `rotation_id` (always positive, independent of the library join) instead of `release.id`. Gate `album_id` on `> 0` so a synthesized negative never reaches the wire; fall back to the freeform variant for unlinked rows (matching the fix shape sibling dj-site#608 calls for).

## Test plan

- [x] Regression test: ADD button enables for a rotation row with synthesized-negative `id` but real positive `rotation_id` (the "Setting" case).
- [x] Regression test: submission for that row uses the freeform variant, never carries a negative `album_id`, and carries the rotation row's denormalized artist/album/label snapshot.
- [x] Existing test: library-linked rotation row still submits with `album_id + rotation_id + rotation_bin` intact.
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` — 3165/3165 pass.
- [ ] Manual verify against the "Setting" album in prod rotation once deployed.

## Out of scope (durable follow-ups)

- Rotation linkage for unlinked rows is lost on the wire until BS accepts `rotation_id` without `album_id` (Option C / BS-side schema work). Sibling: dj-site#691.
- The Modern theme's `RotationEntryFields` has the analogous negative-id leak but no `> 0` gate — it submits, and BS errors. That path is sibling dj-site#608's territory.

Closes #698.
