### PR TITLE
fix(flowsheet): gate album_id leak at convertQueryToSubmission for unlinked rotation rows

### DIFF
--- a/lib/__tests__/features/catalog/conversions.test.ts
+++ b/lib/__tests__/features/catalog/conversions.test.ts
@@ -311,7 +311,7 @@ describe("catalog conversions", () => {
         expect(submission.rotation_bin).toBe(Rotation.H);
       });
 
-      it("carries rotation metadata from a library-UNLINKED (id:undefined) row through to the wire payload", () => {
+      it("drops album_id + rotation linkage on the wire for a library-UNLINKED (id:undefined) row", () => {
         const albumEntry = convertToAlbumEntry(unlinkedRowUndefinedId);
         expect(albumEntry.rotation_id).toBe(5042);
         expect(albumEntry.rotation_bin).toBe(Rotation.S);
@@ -324,12 +324,12 @@ describe("catalog conversions", () => {
             rotation_bin: albumEntry.rotation_bin,
           })
         );
-        // Pin chain identity at every stage — a regression that substituted
-        // a different value (e.g. a sentinel -1, a hash from query fields
-        // rather than the album entry) would still satisfy the looser
-        // sign-only `album_id < 0` check below but would be a different
-        // leak than #608 documents.
+        // The synthesized id and the rotation metadata both still live in
+        // Redux state — they're load-bearing for the picker UI (React keys,
+        // displaying the bin badge on the selected row). Only the wire
+        // payload is gated.
         expect(state.search.query.album_id).toBe(albumEntry.id);
+        expect(state.search.query.album_id).toBeLessThan(0);
         expect(state.search.query.rotation_id).toBe(5042);
         expect(state.search.query.rotation_bin).toBe(Rotation.S);
 
@@ -338,24 +338,21 @@ describe("catalog conversions", () => {
           rotation_id?: number;
           rotation_bin?: Rotation;
         };
-        expect(submission.album_id).toBe(albumEntry.id);
-        expect(submission.rotation_id).toBe(5042);
-        expect(submission.rotation_bin).toBe(Rotation.S);
-
-        // Tracked in dj-site#608: synthetic negative album_id from
-        // `synthesizeAlbumId` (used as a stable React key for unlinked rows)
-        // leaks through `setRotationMetadata` and `convertQueryToSubmission`
-        // to the wire. BS `flowsheet.controller.ts` takes the
-        // `body.album_id != null` branch for negative numbers, calls
-        // `getAlbumFromDB(-X)` → undefined → throws TypeError on
-        // `albumInfo.record_label = ...`. This PR restores the conversion-
-        // layer propagation only; the wire leak is the separate follow-up.
-        // Pinned here so any fix in either layer (strip in submission;
-        // coerce to null when synthetic) updates the assertion deliberately.
-        expect(submission.album_id).toBeLessThan(0);
+        // dj-site#701 fix: `convertQueryToSubmission` gates the catalog
+        // variant on `album_id > 0`. Synthesized negative ids fall through
+        // to the freeform variant — BS used to take `albumId != null` on
+        // negative numbers and TypeError; now the unlinked-row submit just
+        // loses rotation linkage on the wire (recoverable when BS-side
+        // schema work lets `rotation_id` ride without `album_id`).
+        // Freeform `artist_name` / `album_title` come from sibling
+        // `setSearchProperty` dispatches in the live picker, not from
+        // `setRotationMetadata`; out of scope for this e2e.
+        expect(submission.album_id).toBeUndefined();
+        expect(submission.rotation_id).toBeUndefined();
+        expect(submission.rotation_bin).toBeUndefined();
       });
 
-      it("carries rotation metadata from a library-UNLINKED (id omitted) row through to the wire payload", () => {
+      it("drops album_id + rotation linkage on the wire for a library-UNLINKED (id omitted) row", () => {
         // Sibling coverage for the omitted-key wire shape — JSON omission
         // is the most common upstream coercion mode. Both id-absence shapes
         // (id:undefined and id-omitted) take the FALSE branch of
@@ -378,6 +375,7 @@ describe("catalog conversions", () => {
           })
         );
         expect(state.search.query.album_id).toBe(albumEntry.id);
+        expect(state.search.query.album_id).toBeLessThan(0);
         expect(state.search.query.rotation_id).toBe(5042);
         expect(state.search.query.rotation_bin).toBe(Rotation.S);
 
@@ -386,12 +384,10 @@ describe("catalog conversions", () => {
           rotation_id?: number;
           rotation_bin?: Rotation;
         };
-        expect(submission.album_id).toBe(albumEntry.id);
-        expect(submission.rotation_id).toBe(5042);
-        expect(submission.rotation_bin).toBe(Rotation.S);
-        // Canary for dj-site#608 wire leak; see explanatory comment on the
-        // sibling id:undefined e2e test above.
-        expect(submission.album_id).toBeLessThan(0);
+        // See sibling id:undefined e2e for the dj-site#701 gate rationale.
+        expect(submission.album_id).toBeUndefined();
+        expect(submission.rotation_id).toBeUndefined();
+        expect(submission.rotation_bin).toBeUndefined();
       });
     });
   });

--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -73,16 +73,24 @@ describe("flowsheet conversions", () => {
       expect(result.album_id).toBe(123);
     });
 
-    it("should include rotation_id when present", () => {
+    // rotation_id and rotation_bin only ride on the wire alongside a positive
+    // `album_id` — they're optional fields on BS's `FlowsheetCreateSongFromCatalog`
+    // variant, which itself requires `album_id`. See the chokepoint guard in
+    // `convertQueryToSubmission` for the dj-site#701 context.
+    it("should include rotation_id when paired with a positive album_id", () => {
       const query = createTestFlowsheetQuery({
+        album_id: 1001,
         rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
       });
       const result = convertQueryToSubmission(query) as QuerySubmission;
       expect(result.rotation_id).toBe(TEST_ENTITY_IDS.ROTATION.HEAVY);
     });
 
-    it("should include rotation_bin when present", () => {
-      const query = createTestFlowsheetQuery({ rotation_bin: Rotation.H });
+    it("should include rotation_bin when paired with a positive album_id", () => {
+      const query = createTestFlowsheetQuery({
+        album_id: 1001,
+        rotation_bin: Rotation.H,
+      });
       const result = convertQueryToSubmission(query) as QuerySubmission;
       expect(result.rotation_bin).toBe("H");
     });
@@ -123,6 +131,69 @@ describe("flowsheet conversions", () => {
         track_position?: string | null;
       };
       expect(result.track_position).toBeUndefined();
+    });
+
+    // The Modern rotation picker can dispatch a synthesized negative album_id
+    // into `state.search.query` when the picked rotation row is library-
+    // unlinked (`synthesizeAlbumId` in catalog/conversions.ts hashes the
+    // denormalized snapshot into a stable negative int for React keys). BS
+    // takes the `album_id != null` branch on negative numbers, calls
+    // `getAlbumFromDB(-X)` → undefined → throws TypeError. Gate the wire
+    // payload at the chokepoint so picker / queue / future-caller leaks all
+    // route through the freeform variant for unlinked rows. (dj-site#701,
+    // sibling shape #608. Classic-side equivalent shipped in PR #699.)
+    describe("synthesized negative album_id", () => {
+      it("omits album_id, rotation_id, rotation_bin when album_id is negative", () => {
+        const query = createTestFlowsheetQuery({
+          album_id: -987654321,
+          rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
+          rotation_bin: Rotation.H,
+        });
+        const result = convertQueryToSubmission(query) as QuerySubmission;
+        expect(result.album_id).toBeUndefined();
+        expect(result.rotation_id).toBeUndefined();
+        expect(result.rotation_bin).toBeUndefined();
+      });
+
+      it("preserves freeform fields when falling back from a negative album_id", () => {
+        const query = createTestFlowsheetQuery({
+          album_id: -987654321,
+          rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
+          rotation_bin: Rotation.H,
+        });
+        const result = convertQueryToSubmission(query) as QuerySubmission;
+        expect(result.artist_name).toBe(TEST_SEARCH_STRINGS.ARTIST_NAME);
+        expect(result.album_title).toBe(TEST_SEARCH_STRINGS.ALBUM_NAME);
+        expect(result.track_title).toBe(TEST_SEARCH_STRINGS.TRACK_TITLE);
+        expect(result.record_label).toBe(TEST_SEARCH_STRINGS.LABEL);
+      });
+
+      it("preserves album_id + rotation_id + rotation_bin when album_id is positive", () => {
+        const query = createTestFlowsheetQuery({
+          album_id: 1001,
+          rotation_id: 5001,
+          rotation_bin: Rotation.H,
+        });
+        const result = convertQueryToSubmission(query) as QuerySubmission;
+        expect(result.album_id).toBe(1001);
+        expect(result.rotation_id).toBe(5001);
+        expect(result.rotation_bin).toBe("H");
+      });
+
+      // Zero is not a legitimate album_id (PG serial starts at 1), but the
+      // sign check below is the load-bearing one; pin zero too so a future
+      // fix can't quietly switch the guard to `!= 0` and drift the boundary.
+      it("omits album_id when album_id is zero", () => {
+        const query = createTestFlowsheetQuery({
+          album_id: 0,
+          rotation_id: 5001,
+          rotation_bin: Rotation.H,
+        });
+        const result = convertQueryToSubmission(query) as QuerySubmission;
+        expect(result.album_id).toBeUndefined();
+        expect(result.rotation_id).toBeUndefined();
+        expect(result.rotation_bin).toBeUndefined();
+      });
     });
   });
 

--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -194,6 +194,64 @@ describe("flowsheet conversions", () => {
         expect(result.rotation_id).toBeUndefined();
         expect(result.rotation_bin).toBeUndefined();
       });
+
+      // Orthogonal: rotation_id / rotation_bin set without album_id. No
+      // dispatcher currently produces this (rotation picker writes the trio
+      // together; setRotationMode clears all three), but pinning the case
+      // catches a future regression that decouples rotation pass-through
+      // from the album_id gate (e.g. moving rotation_id outside the
+      // hasLinkedAlbum spread).
+      it("omits rotation_id and rotation_bin when album_id is undefined", () => {
+        const query = createTestFlowsheetQuery({
+          album_id: undefined,
+          rotation_id: 5001,
+          rotation_bin: Rotation.H,
+        });
+        const result = convertQueryToSubmission(query) as QuerySubmission;
+        expect(result.album_id).toBeUndefined();
+        expect(result.rotation_id).toBeUndefined();
+        expect(result.rotation_bin).toBeUndefined();
+      });
+
+      // `track_position` is a `release_track.position` reference (e.g. "A1")
+      // into a specific Discogs release — it must ride with album_id or it
+      // points at nothing. setRotationMetadata overwrites album_id without
+      // touching track_position, so a stale "A1" from a prior linked-album
+      // pick could orphan onto the freeform variant; gate it together with
+      // the catalog trio at the chokepoint.
+      it("omits track_position when album_id is negative", () => {
+        const query = createTestFlowsheetQuery({
+          album_id: -987654321,
+          track_position: "A1",
+        });
+        const result = convertQueryToSubmission(query) as QuerySubmission & {
+          track_position?: string;
+        };
+        expect(result.track_position).toBeUndefined();
+      });
+
+      it("omits track_position when album_id is undefined", () => {
+        const query = createTestFlowsheetQuery({
+          album_id: undefined,
+          track_position: "A1",
+        });
+        const result = convertQueryToSubmission(query) as QuerySubmission & {
+          track_position?: string;
+        };
+        expect(result.track_position).toBeUndefined();
+      });
+
+      it("preserves track_position when paired with a positive album_id", () => {
+        const query = createTestFlowsheetQuery({
+          album_id: 1001,
+          track_position: "A1",
+        });
+        const result = convertQueryToSubmission(query) as QuerySubmission & {
+          track_position?: string;
+        };
+        expect(result.album_id).toBe(1001);
+        expect(result.track_position).toBe("A1");
+      });
     });
   });
 

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -20,7 +20,13 @@ export function convertQueryToSubmission(
 ): FlowsheetSubmissionParams {
   // BS's `FlowsheetCreateSongFromCatalog` variant requires a positive
   // `album_id` (a real `library.id`); the rotation-linkage fields
-  // (`rotation_id`, `rotation_bin`) only land on the wire when paired with it.
+  // (`rotation_id`, `rotation_bin`) and the Discogs tracklist position
+  // (`track_position`) only land on the wire when paired with it.
+  // `track_position` is a `release_track.position` reference into a specific
+  // Discogs release — orphaning it on the freeform variant produces a
+  // position string ("A1") with no album to position into, so reducers that
+  // overwrite `album_id` but leave a stale `track_position` (e.g.
+  // `setRotationMetadata`) must not leak it to the wire.
   // The Modern rotation picker and the bin → queue path can both write a
   // synthesized negative `album_id` for library-unlinked rotation rows
   // (`synthesizeAlbumId` in `lib/features/catalog/conversions.ts`); on
@@ -42,9 +48,9 @@ export function convertQueryToSubmission(
       album_id: query.album_id,
       rotation_id: query.rotation_id,
       rotation_bin: query.rotation_bin,
-    }),
-    ...(query.track_position !== undefined && {
-      track_position: query.track_position,
+      ...(query.track_position !== undefined && {
+        track_position: query.track_position,
+      }),
     }),
   };
 }

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -18,6 +18,19 @@ export function formatOnAirSummary(djs: OnAirDJResponse[]): string {
 export function convertQueryToSubmission(
   query: FlowsheetQuery
 ): FlowsheetSubmissionParams {
+  // BS's `FlowsheetCreateSongFromCatalog` variant requires a positive
+  // `album_id` (a real `library.id`); the rotation-linkage fields
+  // (`rotation_id`, `rotation_bin`) only land on the wire when paired with it.
+  // The Modern rotation picker and the bin → queue path can both write a
+  // synthesized negative `album_id` for library-unlinked rotation rows
+  // (`synthesizeAlbumId` in `lib/features/catalog/conversions.ts`); on
+  // negative numbers BS takes the `album_id != null` branch, calls
+  // `getAlbumFromDB(-X)` → undefined → throws TypeError. Gate here so any
+  // caller that lands a non-positive `album_id` falls back to the freeform
+  // variant — at the cost of the rotation linkage, until BS-side schema work
+  // lands. Matches the Classic-side shape from PR #699. (dj-site#701)
+  const hasLinkedAlbum =
+    typeof query.album_id === "number" && query.album_id > 0;
   return {
     track_title: query.song,
     artist_name: query.artist,
@@ -25,9 +38,11 @@ export function convertQueryToSubmission(
     record_label: query.label,
     request_flag: query.request,
     segue: query.segue,
-    album_id: query.album_id,
-    rotation_id: query.rotation_id,
-    rotation_bin: query.rotation_bin,
+    ...(hasLinkedAlbum && {
+      album_id: query.album_id,
+      rotation_id: query.rotation_id,
+      rotation_bin: query.rotation_bin,
+    }),
     ...(query.track_position !== undefined && {
       track_position: query.track_position,
     }),


### PR DESCRIPTION
## Summary

- Modern's rotation picker leaks a synthesized negative `album_id` from `convertToAlbumEntry` straight into `state.search.query.album_id` via `setRotationMetadata`; `convertQueryToSubmission` then forwards it unconditionally to `POST /flowsheet`. BS takes the `album_id != null` branch on negative numbers and TypeErrors — the live "internal server error" some DJs hit yesterday (lines up with the burst captured in WXYC/Backend-Service#1271).
- Gate the catalog-variant trio (`album_id` + `rotation_id` + `rotation_bin`) **and `track_position`** on `album_id > 0` at the conversion chokepoint so the picker (and any caller that flows through Redux query state into the form-submit path) falls back to the freeform variant for library-unlinked rows. Accepts the rotation linkage loss on the wire (recoverable when BS-side schema work lets `rotation_id` ride without `album_id`). Mirrors the Classic-side shape from #699.

## Scope of coverage (corrected)

The gate covers every caller that funnels through `convertQueryToSubmission` — concretely, the rotation-picker form-submit path. It does **not** cover:

- **Queue → SongEntry "Play Now"** (`src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx:140`) — sends `album_id`/`rotation_id`/`rotation` to `addToFlowsheet` directly, no chokepoint. Negative ids deposited into `state.flowsheet.queue` via Ctrl+Enter, `AddToQueueFromBin`, or catalog `Result` row → "Add to Queue" reach BS unchanged. Filed as **#703**.
- **`convertBinToFlowsheet`** (PlayFromBin direct-submit) — separate ticket **#608**.

An earlier draft of this PR body claimed the bin → queue path was implicit collateral coverage; that's only true for the bin → queue → form-submit path. The bin → queue → "Play Now" path is #703.

## Test changes

- New conversion tests pin the gate on negative, positive, zero, and undefined `album_id`, plus the orthogonal `{album_id: undefined, rotation_id: 5001}` case (uncovered after two pre-existing tests were re-paired with a positive `album_id`), plus `track_position` negative/undefined/positive cases.
- Two pre-existing canary tests in `lib/__tests__/features/catalog/conversions.test.ts` asserted `submission.album_id < 0` to pin the wire leak; their comments explicitly anticipated this deliberate flip ("Pinned here so any fix in either layer ... updates the assertion deliberately"). Updated to assert the new wire shape (`undefined`).
- Two pre-existing tests asserting `rotation_id` / `rotation_bin` come through without an `album_id` are corrected to pair them with a positive `album_id` — those fields are only optional within the `FlowsheetCreateSongFromCatalog` variant, which itself requires `album_id`.

## Test plan

- [x] `npx vitest run lib/__tests__/features/flowsheet/conversions.test.ts` — passes (62 / 62 after the track_position + orthogonal tests).
- [x] `npx vitest run lib/__tests__/features/catalog/conversions.test.ts` — passes.
- [x] `npx vitest run` — full suite passes (3177 / 3177).
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: pick the rotation album "Setting" (or any library-unlinked rotation row) in Modern's picker → confirm `POST /flowsheet` lands without the 500. Then a linked row → confirm `album_id + rotation_id + rotation_bin` still ride on the wire.

## Related

- WXYC/dj-site#701 — this PR.
- WXYC/dj-site#703 — follow-up: queue → SongEntry "Play Now" bypass (not covered here).
- WXYC/dj-site#699 — Classic-side equivalent (shipped 2026-06-02).
- WXYC/dj-site#608 — sibling P1 covering the direct `convertBinToFlowsheet` paths. Out of scope here.
- WXYC/dj-site#700 — open forensics on the original #691 data flow (independent).
- WXYC/Backend-Service#1271 — investigation of the 2026-06-02 `POST /flowsheet` error burst; this PR is the dj-site-side cause for at least the picker-driven entries.

Closes #701.