### PR TITLE
feat(classic-flowsheet): enable Public DJ Handle field and wire dj_name_override

### DIFF
--- a/lib/features/authentication/types.ts
+++ b/lib/features/authentication/types.ts
@@ -148,6 +148,20 @@ export type DJRequestParams = {
   dj_id: string; // User ID from better-auth (string)
 };
 
+// Local field shim: BS#1320 (closes BS#1295) added `dj_name_override` to
+// POST /flowsheet/join. The shared OpenAPI contract in @wxyc/shared/api.yaml
+// has not been updated yet — remove this type and switch the joinShow
+// mutation back to DJRequestParams once @wxyc/shared publishes the field.
+export type JoinShowParams = DJRequestParams & {
+  /**
+   * Optional per-show override for the DJ's public handle. When present and
+   * non-empty, the backend uses this value (instead of `auth_user.dj_name`)
+   * for the show_start marker text + `flowsheet.dj_name` column +
+   * `shows.legacy_dj_name` column. Co-host /join ignores it.
+   */
+  dj_name_override?: string;
+};
+
 export type DJInfoResponse = {
   id: number;
   add_date: string;

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -1,5 +1,5 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
-import { DJRequestParams } from "../authentication/types";
+import { DJRequestParams, JoinShowParams } from "../authentication/types";
 import { backendBaseQuery } from "../backend";
 import {
   FLOWSHEET_OPTIMISTIC_DJ_PLACEHOLDER,
@@ -101,7 +101,7 @@ export const flowsheetApi = createApi({
         }
       },
     }),
-    joinShow: builder.mutation<void, DJRequestParams>({
+    joinShow: builder.mutation<void, JoinShowParams>({
       query: (params) => ({
         url: "/join",
         method: "POST",

--- a/src/components/experiences/classic/flowsheet/StartShow.tsx
+++ b/src/components/experiences/classic/flowsheet/StartShow.tsx
@@ -3,7 +3,7 @@
 import "@/src/styles/classic/wxyc.css";
 import { useShowControl } from "@/src/hooks/flowsheetHooks";
 import { useRegistry } from "@/src/hooks/authenticationHooks";
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { OpenHelp } from "@/src/utils/helpScreen";
 
 export default function StartShow() {
@@ -12,17 +12,36 @@ export default function StartShow() {
   // Editable per-show override for the DJ's public handle. Initialized to
   // the registry's `dj_name` so the user sees their current value and can
   // type over it. See #694 + BS#1295.
-  const initialDjHandle = userData?.dj_name ?? "";
-  const [djHandle, setDjHandle] = useState(initialDjHandle);
+  //
+  // `useRegistry()` is async: the first render is typically `info: null`
+  // and `userData?.dj_name` lands on a later render. `useState`'s
+  // initializer only runs once, so we sync the editable state to the
+  // registry value via `useEffect` until the user types into the field.
+  // After the user edits, their in-progress value wins even if the
+  // registry refetches.
+  const registryDjHandle = userData?.dj_name ?? "";
+  const [djHandle, setDjHandle] = useState(registryDjHandle);
+  const [userEditedDjHandle, setUserEditedDjHandle] = useState(false);
+
+  useEffect(() => {
+    if (!userEditedDjHandle) {
+      setDjHandle(registryDjHandle);
+    }
+  }, [registryDjHandle, userEditedDjHandle]);
 
   const handleStartShow = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     // Pass the override only when the user-typed value is non-empty after
-    // trimming AND differs from the initial registry value. Otherwise let
-    // the backend fall back to `auth_user.dj_name` as it always has.
+    // trimming AND differs from the *current* registry value (read at
+    // submit time, not captured at mount). This keeps the comparison
+    // stable against a mid-form registry refetch: if the registry value
+    // matches what the user typed at submit time, no override fires.
+    const currentRegistryValue = (userData?.dj_name ?? "").trim();
     const trimmed = djHandle.trim();
     const override =
-      trimmed.length > 0 && trimmed !== initialDjHandle ? trimmed : undefined;
+      trimmed.length > 0 && trimmed !== currentRegistryValue
+        ? trimmed
+        : undefined;
     goLive(override);
   };
 
@@ -150,7 +169,10 @@ export default function StartShow() {
                     type="text"
                     name="djHandle"
                     value={djHandle}
-                    onChange={(e) => setDjHandle(e.target.value)}
+                    onChange={(e) => {
+                      setUserEditedDjHandle(true);
+                      setDjHandle(e.target.value);
+                    }}
                     placeholder="(optional)"
                   />
                   &nbsp;(optional)

--- a/src/components/experiences/classic/flowsheet/StartShow.tsx
+++ b/src/components/experiences/classic/flowsheet/StartShow.tsx
@@ -3,16 +3,27 @@
 import "@/src/styles/classic/wxyc.css";
 import { useShowControl } from "@/src/hooks/flowsheetHooks";
 import { useRegistry } from "@/src/hooks/authenticationHooks";
-import { FormEvent } from "react";
+import { FormEvent, useState } from "react";
 import { OpenHelp } from "@/src/utils/helpScreen";
 
 export default function StartShow() {
   const { goLive } = useShowControl();
   const { info: userData } = useRegistry();
+  // Editable per-show override for the DJ's public handle. Initialized to
+  // the registry's `dj_name` so the user sees their current value and can
+  // type over it. See #694 + BS#1295.
+  const initialDjHandle = userData?.dj_name ?? "";
+  const [djHandle, setDjHandle] = useState(initialDjHandle);
 
   const handleStartShow = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    goLive();
+    // Pass the override only when the user-typed value is non-empty after
+    // trimming AND differs from the initial registry value. Otherwise let
+    // the backend fall back to `auth_user.dj_name` as it always has.
+    const trimmed = djHandle.trim();
+    const override =
+      trimmed.length > 0 && trimmed !== initialDjHandle ? trimmed : undefined;
+    goLive(override);
   };
 
   // Format current time for display in disabled dropdown
@@ -138,14 +149,9 @@ export default function StartShow() {
                   <input
                     type="text"
                     name="djHandle"
-                    value={userData?.dj_name || ""}
+                    value={djHandle}
+                    onChange={(e) => setDjHandle(e.target.value)}
                     placeholder="(optional)"
-                    disabled
-                    style={{
-                      backgroundColor: "#f0f0f0",
-                      color: "#666",
-                      cursor: "not-allowed",
-                    }}
                   />
                   &nbsp;(optional)
                 </td>

--- a/src/components/experiences/classic/flowsheet/__tests__/StartShow.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/StartShow.test.tsx
@@ -119,6 +119,67 @@ describe("Classic StartShow — Public DJ Handle override (#694)", () => {
     submitForm();
     expect(goLiveMock).toHaveBeenCalledWith(undefined);
   });
+
+  it("reflects userData.dj_name when the registry resolves after mount", () => {
+    // First render: registry still loading, dj_name unknown.
+    userInfoMock = null;
+    const { rerender } = renderWithProviders(<StartShow />);
+    expect(getNamedInput("djHandle").value).toBe("");
+
+    // Registry resolves with the user's dj_name. Re-render with the same
+    // component instance — the input value should now reflect the resolved
+    // dj_name, not the empty string captured at initial mount.
+    userInfoMock = {
+      id: "test-user-1",
+      real_name: "Maura Partrick",
+      dj_name: "Anonymous",
+    };
+    rerender(<StartShow />);
+    expect(getNamedInput("djHandle").value).toBe("Anonymous");
+  });
+
+  it("stops syncing from the registry once the user types into the field", () => {
+    const { rerender } = renderWithProviders(<StartShow />);
+    const input = getNamedInput("djHandle");
+    // User types over the prefilled value.
+    fireEvent.change(input, { target: { value: "Aubrey Hearst" } });
+
+    // Registry refetches and lands a different dj_name. The user's typed
+    // value should win — we do not clobber their in-progress edit.
+    userInfoMock = {
+      id: "test-user-1",
+      real_name: "Maura Partrick",
+      dj_name: "SomethingElse",
+    };
+    rerender(<StartShow />);
+    expect(getNamedInput("djHandle").value).toBe("Aubrey Hearst");
+  });
+
+  it("submits no override when the registry refetches to match the user-typed value", () => {
+    // Mount with one dj_name…
+    userInfoMock = {
+      id: "test-user-1",
+      real_name: "Maura Partrick",
+      dj_name: "OldName",
+    };
+    const { rerender } = renderWithProviders(<StartShow />);
+    const input = getNamedInput("djHandle");
+    // User types a different value.
+    fireEvent.change(input, { target: { value: "NewName" } });
+
+    // Registry refetches to the same value the user typed (e.g. a parallel
+    // tab updated it). At submit time the comparison should see equality
+    // and omit the override — not send a redundant override that captures
+    // the initial-mount value.
+    userInfoMock = {
+      id: "test-user-1",
+      real_name: "Maura Partrick",
+      dj_name: "NewName",
+    };
+    rerender(<StartShow />);
+    submitForm();
+    expect(goLiveMock).toHaveBeenCalledWith(undefined);
+  });
 });
 
 describe("Classic StartShow — out-of-scope fields stay disabled (#694)", () => {

--- a/src/components/experiences/classic/flowsheet/__tests__/StartShow.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/StartShow.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+
+// Mock useShowControl().goLive — we only care that StartShow forwards the
+// trimmed Public DJ Handle as the second arg (the override) when the user
+// edits it, and omits it when unchanged.
+const goLiveMock = vi.fn();
+let userInfoMock: { id: string; real_name?: string; dj_name?: string } | null = {
+  id: "test-user-1",
+  real_name: "Maura Partrick",
+  dj_name: "Anonymous",
+};
+
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useShowControl: () => ({ goLive: goLiveMock }),
+}));
+
+vi.mock("@/src/hooks/authenticationHooks", () => ({
+  useRegistry: () => ({ info: userInfoMock, loading: false }),
+}));
+
+vi.mock("@/src/utils/helpScreen", () => ({
+  OpenHelp: vi.fn(),
+}));
+
+import StartShow from "../StartShow";
+
+function getNamedInput(name: string): HTMLInputElement {
+  const el = document.querySelector(
+    `input[name="${name}"]`
+  ) as HTMLInputElement | null;
+  if (!el) throw new Error(`Input name="${name}" not found`);
+  return el;
+}
+
+function submitForm() {
+  const form = document.querySelector(
+    'form[name="userpw"]'
+  ) as HTMLFormElement | null;
+  if (!form) throw new Error("Form not found");
+  fireEvent.submit(form);
+}
+
+beforeEach(() => {
+  goLiveMock.mockReset();
+  userInfoMock = {
+    id: "test-user-1",
+    real_name: "Maura Partrick",
+    dj_name: "Anonymous",
+  };
+});
+
+describe("Classic StartShow — Public DJ Handle override (#694)", () => {
+  it("renders the Public DJ Handle input as editable (not disabled)", () => {
+    renderWithProviders(<StartShow />);
+    const input = getNamedInput("djHandle");
+    expect(input.disabled).toBe(false);
+  });
+
+  it("initializes the Public DJ Handle with the registry's dj_name", () => {
+    renderWithProviders(<StartShow />);
+    const input = getNamedInput("djHandle");
+    expect(input.value).toBe("Anonymous");
+  });
+
+  it("initializes the Public DJ Handle to empty string when dj_name is missing", () => {
+    userInfoMock = { id: "test-user-1", real_name: "Some DJ" };
+    renderWithProviders(<StartShow />);
+    const input = getNamedInput("djHandle");
+    expect(input.value).toBe("");
+  });
+
+  it("submitting after typing a new handle calls goLive with the override", () => {
+    renderWithProviders(<StartShow />);
+    const input = getNamedInput("djHandle");
+    fireEvent.change(input, { target: { value: "Aubrey Hearst" } });
+    submitForm();
+    expect(goLiveMock).toHaveBeenCalledTimes(1);
+    expect(goLiveMock).toHaveBeenCalledWith("Aubrey Hearst");
+  });
+
+  it("trims whitespace before forwarding the override", () => {
+    renderWithProviders(<StartShow />);
+    const input = getNamedInput("djHandle");
+    fireEvent.change(input, { target: { value: "  Aubrey Hearst  " } });
+    submitForm();
+    expect(goLiveMock).toHaveBeenCalledWith("Aubrey Hearst");
+  });
+
+  it("submitting with the field untouched calls goLive without an override", () => {
+    renderWithProviders(<StartShow />);
+    submitForm();
+    expect(goLiveMock).toHaveBeenCalledTimes(1);
+    expect(goLiveMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("submitting with whitespace-only input calls goLive without an override", () => {
+    renderWithProviders(<StartShow />);
+    const input = getNamedInput("djHandle");
+    fireEvent.change(input, { target: { value: "   " } });
+    submitForm();
+    expect(goLiveMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("submitting after clearing a populated handle calls goLive without an override", () => {
+    renderWithProviders(<StartShow />);
+    const input = getNamedInput("djHandle");
+    fireEvent.change(input, { target: { value: "" } });
+    submitForm();
+    expect(goLiveMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("submitting when the typed handle matches the initial dj_name calls goLive without an override", () => {
+    renderWithProviders(<StartShow />);
+    const input = getNamedInput("djHandle");
+    // Simulate a focus/blur with no real change
+    fireEvent.change(input, { target: { value: "Anonymous" } });
+    submitForm();
+    expect(goLiveMock).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe("Classic StartShow — out-of-scope fields stay disabled (#694)", () => {
+  // Locked decision in #694: only the Public DJ Handle field is enabled.
+  // The other hardcoded-disabled fields remain disabled until separate tickets
+  // re-enable them.
+
+  it("Real Name input remains disabled", () => {
+    renderWithProviders(<StartShow />);
+    expect(getNamedInput("djName").disabled).toBe(true);
+  });
+
+  it("Show Name input remains disabled", () => {
+    renderWithProviders(<StartShow />);
+    expect(getNamedInput("showName").disabled).toBe(true);
+  });
+
+  it("Starting Time select remains disabled", () => {
+    renderWithProviders(<StartShow />);
+    const select = document.querySelector(
+      'select[name="startingHour"]'
+    ) as HTMLSelectElement | null;
+    expect(select?.disabled).toBe(true);
+  });
+
+  it("Reset button remains disabled", () => {
+    renderWithProviders(<StartShow />);
+    const reset = document.querySelector(
+      'input[type="reset"]'
+    ) as HTMLInputElement | null;
+    expect(reset?.disabled).toBe(true);
+  });
+});

--- a/src/hooks/flowsheetHooks.test.tsx
+++ b/src/hooks/flowsheetHooks.test.tsx
@@ -269,6 +269,47 @@ describe("flowsheetHooks", () => {
       });
     });
 
+    it("should pass dj_name_override when goLive is called with an override", () => {
+      const { result } = renderHook(() => useShowControl(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.goLive("Aubrey Hearst");
+      });
+
+      expect(mockGoLiveFunction).toHaveBeenCalledWith({
+        dj_id: "test-user-1",
+        dj_name_override: "Aubrey Hearst",
+      });
+    });
+
+    it("should omit dj_name_override when goLive is called without one", () => {
+      const { result } = renderHook(() => useShowControl(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.goLive();
+      });
+
+      const args = mockGoLiveFunction.mock.calls[0][0];
+      expect(args).not.toHaveProperty("dj_name_override");
+    });
+
+    it("should omit dj_name_override when goLive is called with undefined", () => {
+      const { result } = renderHook(() => useShowControl(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.goLive(undefined);
+      });
+
+      const args = mockGoLiveFunction.mock.calls[0][0];
+      expect(args).not.toHaveProperty("dj_name_override");
+    });
+
     it("should call leaveFunction when leave is called", () => {
       const { result } = renderHook(() => useShowControl(), {
         wrapper: createWrapper(),

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -111,12 +111,21 @@ export const useShowControl = () => {
     dispatch(flowsheetSlice.actions.setAutoplay(autoplay));
   };
 
-  const goLive = () => {
+  const goLive = (djNameOverride?: string) => {
     if (!userData || userData.id === undefined || userloading) {
       return;
     }
-    // Tag invalidation from the mutation handles refetching
-    goLiveFunction({ dj_id: userData.id });
+    // Tag invalidation from the mutation handles refetching.
+    // Only include `dj_name_override` when the caller actually wants to
+    // override; the backend treats empty/whitespace as absent, but the
+    // hook keeps the wire-shape clean either way.
+    const payload: { dj_id: string; dj_name_override?: string } = {
+      dj_id: userData.id,
+    };
+    if (djNameOverride !== undefined) {
+      payload.dj_name_override = djNameOverride;
+    }
+    goLiveFunction(payload);
   };
 
   const leave = () => {


### PR DESCRIPTION
Closes #694

## Summary

Enables the Public DJ Handle input in Classic StartShow (was hardcoded `disabled`) and plumbs the per-show value through `useShowControl().goLive` to `POST /flowsheet/join` as `dj_name_override`.

Initial value comes from `useRegistry().info.dj_name`. The override is forwarded to the backend only when the trimmed user-typed value is non-empty AND differs from the registry value; otherwise no override is sent and the backend falls back to `auth_user.dj_name` as it always has.

## Background

Backend support landed in WXYC/Backend-Service#1320 (closes WXYC/Backend-Service#1295). The epic for the broader incident is WXYC/Backend-Service#1288 — DJ Maura Partrick had `auth_user.dj_name = "Anonymous"` on 2026-06-02, tried to override to "Aubrey Hearst" via classic mode, and discovered the Public DJ Handle field was hardcoded disabled.

## Out of scope

The four other hardcoded-disabled fields in the same form remain disabled — each needs its own plumbing decision and backend support, and is out of scope for #694:

- Real Name of DJ (`name="djName"`, line 82)
- Starting Time (`name="startingHour"`, line 101)
- Show Name (`name="showName"`, line 119)
- Reset button (line 164)

Regression tests pin those four as still-disabled so a future PR can flip them deliberately.

## Shared-types shim

`@wxyc/shared` does not yet declare `dj_name_override` on the join request body. The join params are widened locally via a new `JoinShowParams` type in `lib/features/authentication/types.ts` (with a TODO comment pointing at the shared package). Once `@wxyc/shared` publishes the field, `JoinShowParams` should be deleted and `joinShow` switched back to `DJRequestParams`.

No open PR in WXYC/wxyc-shared introduces this field yet — search `gh pr list --repo WXYC/wxyc-shared --search "dj_name_override"` came up empty as of opening this PR.

## Test plan

- [x] Component test: Public DJ Handle input is editable (not disabled).
- [x] Component test: input initializes to `userData?.dj_name`, or `""` when missing.
- [x] Component test: typing a new handle + submitting calls `goLive("<typed>")`.
- [x] Component test: leading/trailing whitespace is trimmed before forwarding.
- [x] Component test: leaving the field untouched calls `goLive(undefined)`.
- [x] Component test: whitespace-only + cleared + unchanged inputs all call `goLive(undefined)`.
- [x] Component test: the four out-of-scope disabled fields stay disabled.
- [x] Hook test: `goLive("X")` sends `dj_name_override: "X"` in the request body; `goLive()` and `goLive(undefined)` omit the key.
- [x] `npx tsc --noEmit` clean.
- [x] Full vitest suite: 3193 / 3193 passing.
- [x] `npm run build` clean.

## Cross-refs

- Epic: WXYC/Backend-Service#1288
- Backend ticket: WXYC/Backend-Service#1295
- Backend PR: WXYC/Backend-Service#1320 (merged, commit `d8140231`)