### PR TITLE
fix(flowsheet): sanitize album_id at queue boundary; covers SongEntry 'Play Now' bypass

### DIFF
--- a/lib/__tests__/features/flowsheet/flowsheet.test.ts
+++ b/lib/__tests__/features/flowsheet/flowsheet.test.ts
@@ -207,6 +207,84 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(mockedSaveQueue).toHaveBeenCalled();
     });
 
+    describe("addToQueue album-linkage sanitization (dj-site#703)", () => {
+      // The Modern rotation picker + bin/catalog deposit paths can feed
+      // addToQueue with a synthesized negative album_id (from
+      // synthesizeAlbumId, for library-unlinked rows). SongEntry's "Play Now"
+      // bypasses convertQueryToSubmission and would forward the negative id to
+      // BS — same 500 PR #702 fixed for the form-submit path. Sanitize at the
+      // reducer so the queue never holds a synthesized id, mirroring the
+      // chokepoint logic in convertQueryToSubmission.
+      it("strips album_id, rotation_id, and rotation when album_id is a synthesized negative hash", () => {
+        const query = createTestFlowsheetQuery({
+          album_id: -123456,
+          rotation_id: 7,
+          rotation_bin: "H",
+        });
+        const result = harness().reduce(actions.addToQueue(query));
+        expect(result.queue[0].album_id).toBeUndefined();
+        expect(result.queue[0].rotation_id).toBeUndefined();
+        expect(result.queue[0].rotation).toBeUndefined();
+      });
+
+      it("strips the catalog-anchored trio when album_id is zero", () => {
+        const query = createTestFlowsheetQuery({
+          album_id: 0,
+          rotation_id: 7,
+          rotation_bin: "H",
+        });
+        const result = harness().reduce(actions.addToQueue(query));
+        expect(result.queue[0].album_id).toBeUndefined();
+        expect(result.queue[0].rotation_id).toBeUndefined();
+        expect(result.queue[0].rotation).toBeUndefined();
+      });
+
+      it("strips orphaned rotation linkage when album_id is undefined", () => {
+        const query = createTestFlowsheetQuery({
+          album_id: undefined,
+          rotation_id: 7,
+          rotation_bin: "H",
+        });
+        const result = harness().reduce(actions.addToQueue(query));
+        expect(result.queue[0].album_id).toBeUndefined();
+        expect(result.queue[0].rotation_id).toBeUndefined();
+        expect(result.queue[0].rotation).toBeUndefined();
+      });
+
+      it("preserves the catalog-anchored trio when album_id is a positive library.id", () => {
+        const query = createTestFlowsheetQuery({
+          album_id: 1001,
+          rotation_id: 7,
+          rotation_bin: "H",
+        });
+        const result = harness().reduce(actions.addToQueue(query));
+        expect(result.queue[0].album_id).toBe(1001);
+        expect(result.queue[0].rotation_id).toBe(7);
+        expect(result.queue[0].rotation).toBe("H");
+      });
+
+      it("preserves freeform fields (song/artist/album/label/segue/request) regardless of album_id", () => {
+        const query = createTestFlowsheetQuery({
+          song: "Track Title",
+          artist: "Artist Name",
+          album: "Album Title",
+          label: "Record Label",
+          segue: true,
+          request: true,
+          album_id: -1,
+          rotation_id: 7,
+          rotation_bin: "H",
+        });
+        const result = harness().reduce(actions.addToQueue(query));
+        expect(result.queue[0].track_title).toBe("Track Title");
+        expect(result.queue[0].artist_name).toBe("Artist Name");
+        expect(result.queue[0].album_title).toBe("Album Title");
+        expect(result.queue[0].record_label).toBe("Record Label");
+        expect(result.queue[0].segue).toBe(true);
+        expect(result.queue[0].request_flag).toBe(true);
+      });
+    });
+
     it("should remove item from queue", () => {
       const query = createTestFlowsheetQuery();
       const withItem = harness().reduce(actions.addToQueue(query));
@@ -262,6 +340,42 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       const result = harness().reduce(actions.loadQueue());
       expect(result.queue).toEqual([]);
       expect(result.queueIdCounter).toBe(0);
+    });
+
+    describe("loadQueue album-linkage sanitization (dj-site#703)", () => {
+      // Queues persisted to localStorage before #703 shipped may contain rows
+      // with synthesized negative album_id. Sanitize on load so a stale
+      // poisoned queue can't leak a negative album_id via SongEntry "Play Now"
+      // after the user reloads the page.
+      it("sanitizes poisoned localStorage entries with negative album_id", () => {
+        const poisoned = createTestFlowsheetEntry({
+          id: 1,
+          album_id: -42,
+          rotation_id: 7,
+          rotation: "H",
+        });
+        mockedLoadQueue.mockReturnValueOnce([poisoned]);
+
+        const result = harness().reduce(actions.loadQueue());
+        expect(result.queue[0].album_id).toBeUndefined();
+        expect(result.queue[0].rotation_id).toBeUndefined();
+        expect(result.queue[0].rotation).toBeUndefined();
+      });
+
+      it("preserves linkage for library-linked entries on load", () => {
+        const linked = createTestFlowsheetEntry({
+          id: 1,
+          album_id: 1001,
+          rotation_id: 7,
+          rotation: "H",
+        });
+        mockedLoadQueue.mockReturnValueOnce([linked]);
+
+        const result = harness().reduce(actions.loadQueue());
+        expect(result.queue[0].album_id).toBe(1001);
+        expect(result.queue[0].rotation_id).toBe(7);
+        expect(result.queue[0].rotation).toBe("H");
+      });
     });
 
     it("should update queue entry field", () => {

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -4,6 +4,32 @@ import { FlowsheetEntry, FlowsheetFrontendState, FlowsheetQuery, FlowsheetSearch
 import { Rotation } from "../rotation/types";
 import { clearQueueFromStorage, loadQueueFromStorage, saveQueueToStorage } from "./queue-storage";
 
+// Drop the catalog-anchored trio (album_id, rotation_id, rotation) from a
+// would-be queue entry when album_id isn't a real positive library.id.
+// SongEntry's "Play Now" handler (src/components/experiences/modern/flowsheet/
+// Entries/SongEntry/SongEntry.tsx) reads entry.album_id directly and bypasses
+// convertQueryToSubmission, so without sanitization here a synthesized
+// negative id from synthesizeAlbumId (library-unlinked rotation/catalog rows)
+// rides the wire and trips BS's `album_id != null` branch → TypeError 500 —
+// same shape PR #702 gated for the form-submit path. (dj-site#703)
+function withSanitizedAlbumLinkage<
+  T extends {
+    album_id?: number;
+    rotation_id?: number;
+    rotation?: Rotation;
+  }
+>(entry: T): T {
+  if (typeof entry.album_id === "number" && entry.album_id > 0) {
+    return entry;
+  }
+  return {
+    ...entry,
+    album_id: undefined,
+    rotation_id: undefined,
+    rotation: undefined,
+  };
+}
+
 export const defaultFlowsheetFrontendState: FlowsheetFrontendState = {
   autoplay: false,
   rotationMode: false,
@@ -103,20 +129,22 @@ export const flowsheetSlice = createAppSlice({
     },
     addToQueue: (state, action: PayloadAction<FlowsheetQuery>) => {
       const newId = state.queueIdCounter;
-      state.queue.push({
-        id: newId,
-        play_order: state.queue.length,
-        show_id: -1,
-        track_title: action.payload.song,
-        artist_name: action.payload.artist,
-        album_title: action.payload.album,
-        record_label: action.payload.label,
-        request_flag: action.payload.request,
-        segue: action.payload.segue,
-        rotation: action.payload.rotation_bin,
-        rotation_id: action.payload.rotation_id,
-        album_id: action.payload.album_id,
-      });
+      state.queue.push(
+        withSanitizedAlbumLinkage({
+          id: newId,
+          play_order: state.queue.length,
+          show_id: -1,
+          track_title: action.payload.song,
+          artist_name: action.payload.artist,
+          album_title: action.payload.album,
+          record_label: action.payload.label,
+          request_flag: action.payload.request,
+          segue: action.payload.segue,
+          rotation: action.payload.rotation_bin,
+          rotation_id: action.payload.rotation_id,
+          album_id: action.payload.album_id,
+        })
+      );
       state.queueIdCounter += 1;
       saveQueueToStorage(state.queue);
     },
@@ -130,7 +158,7 @@ export const flowsheetSlice = createAppSlice({
       clearQueueFromStorage();
     },
     loadQueue: (state) => {
-      state.queue = loadQueueFromStorage();
+      state.queue = loadQueueFromStorage().map(withSanitizedAlbumLinkage);
       // Set counter to max ID + 1 to avoid duplicates
       const maxId = state.queue.reduce((max, entry) => Math.max(max, entry.id), -1);
       state.queueIdCounter = maxId + 1;


### PR DESCRIPTION
## Summary

- Sanitize the catalog-anchored trio (`album_id`, `rotation_id`, `rotation`) at the `addToQueue` reducer when `album_id` is non-positive (a synthesized hash from `synthesizeAlbumId`, used for library-unlinked rotation/catalog rows).
- Apply the same sanitizer at `loadQueue` so a `localStorage`-persisted queue that already contains a poisoned entry can't leak after page reload.
- Mirrors the chokepoint logic landed in PR #702 / dj-site#701 (`convertQueryToSubmission`); covers the third bypass path: `SongEntry.tsx:140` "Play Now" reads `entry.album_id` straight from the queue and skips `convertQueryToSubmission` entirely.

## Why

PR #702 gated the form-submit path. The Modern queue → SongEntry "Play Now" path doesn't route through `convertQueryToSubmission`; it builds the submission inline from queue-entry fields. Three deposit paths feed the queue with a synthesized negative `album_id`:

1. **Ctrl+Enter** on a search result — `flowsheetHooks.ts` builds `selectedResultData` with `album_id: selectedEntry.id ?? undefined` (which is the synthesized id for unlinked rows).
2. **Add to Queue from Bin** — `convertBinToQueue` sets `album_id: binEntry.id`.
3. **Add to Queue from Catalog Result** — same shape as the bin path.

Once persisted to `localStorage` via `queue-storage.ts`, the poisoned entry survives reloads. Clicking "Play Now" then sends `album_id: -<hash>` to BS, which takes the `body.album_id != null` branch, calls `getAlbumFromDB(-X)` → `undefined`, and throws `TypeError` on `albumInfo.record_label = …` — the same 500 #701 / #702 closed for the rotation-picker path.

Sanitizing at the reducer covers all three deposit paths in one place and keeps the queue entry shape internally coherent: the library-anchored fields are kept together or dropped together. The narrow UX cost is that library-unlinked rotation rows lose their rotation-bin badge in the queue — which matches what BS would actually persist (no rotation info without a real `library.id`) and aligns with the chokepoint shape from #702.

## Acceptance criteria (from #703)

- [x] A queued library-unlinked row's "Play Now" produces no negative `album_id` on the wire.
- [x] A queued library-linked row's "Play Now" still submits with `album_id + rotation_id + rotation_bin` intact.
- [x] Unit tests pin the fix at the chosen surface (`addToQueue` reducer + `loadQueue` reducer).
- [x] Existing `localStorage`-persisted poisoned queues are cleaned at load time (`loadQueue` sanitizes the result of `loadQueueFromStorage`).

## Test plan

- [x] `npx vitest run lib/__tests__/features/flowsheet/flowsheet.test.ts` — 57 passed, including 6 new tests (4 for `addToQueue`, 2 for `loadQueue`).
- [x] `npx vitest run` — 3184 tests pass across 220 files.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: queue an unlinked rotation row → reload → "Play Now" → no 500.
- [ ] Manual: queue a library-linked row → "Play Now" → entry persists with rotation linkage intact.

## Related

- #701 / PR #702 — sibling P1; rotation-picker path. Closed.
- #608 — sibling P1; bin direct-submit path (`convertBinToFlowsheet` via `PlayFromBin`). Different code path; still open.
- WXYC/Backend-Service#1271 — root-cause investigation of the 2026-06-02 `POST /flowsheet` error burst.

Closes #703.