### PR TITLE
fix(flowsheet): clear track_position when album_id changes; hide picker for unlinked rows

### DIFF
--- a/lib/__tests__/features/flowsheet/flowsheet.test.ts
+++ b/lib/__tests__/features/flowsheet/flowsheet.test.ts
@@ -83,6 +83,31 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.search.selectedResult).toBe(3);
     });
 
+    // Arrow-key navigation between search results moves to a different
+    // album_id (each result is a distinct release). track_position picked on
+    // the previous result would orphan onto the new release if not cleared.
+    // Re-selecting the SAME index (e.g. on mouseover) must preserve a freshly
+    // picked position. (dj-site#704)
+    describe("setSelectedResult track_position hygiene", () => {
+      it("clears track_position when the selected result index changes", () => {
+        const result = harness().chain(
+          actions.setSelectedResult(2),
+          actions.setTrackPosition("A1"),
+          actions.setSelectedResult(3)
+        );
+        expect(result.search.query.track_position).toBeUndefined();
+      });
+
+      it("preserves track_position when the selected result index is unchanged", () => {
+        const result = harness().chain(
+          actions.setSelectedResult(2),
+          actions.setTrackPosition("A1"),
+          actions.setSelectedResult(2)
+        );
+        expect(result.search.query.track_position).toBe("A1");
+      });
+    });
+
     describe("freezeSelectionToQuery", () => {
       it("should copy the selected entry's fields into the query and deselect", () => {
         const result = harness().chain(
@@ -507,6 +532,22 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.search.query.album_id).toBe(TEST_ENTITY_IDS.ALBUM.ROTATION_ALBUM);
       expect(result.search.query.rotation_id).toBe(TEST_ENTITY_IDS.ROTATION.HEAVY);
       expect(result.search.query.rotation_bin).toBe("H");
+    });
+
+    // track_position is anchored to a specific album_id (it's a Discogs
+    // release_track.position reference). Any reducer that overwrites album_id
+    // must clear track_position or it orphans onto the wrong release.
+    // (dj-site#704)
+    it("setRotationMetadata clears track_position when album_id changes", () => {
+      const result = harness().chain(
+        actions.setTrackPosition("A1"),
+        actions.setRotationMetadata({
+          album_id: TEST_ENTITY_IDS.ALBUM.ROTATION_ALBUM,
+          rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
+          rotation_bin: "H" as const,
+        })
+      );
+      expect(result.search.query.track_position).toBeUndefined();
     });
 
     it("should preserve rotation mode across resetSearch", () => {

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -73,6 +73,10 @@ export const flowsheetSlice = createAppSlice({
       state.search.query.album_id = action.payload.album_id;
       state.search.query.rotation_id = action.payload.rotation_id;
       state.search.query.rotation_bin = action.payload.rotation_bin;
+      // track_position references a release_track row on the previous
+      // album_id; orphan it on the new album and it points at the wrong
+      // release. Symmetric to setRotationMode(false). (dj-site#704)
+      state.search.query.track_position = undefined;
     },
     setSearchOpen: (state, action) => {
       state.search.open = action.payload;
@@ -174,7 +178,15 @@ export const flowsheetSlice = createAppSlice({
       state.queue = action.payload;
       saveQueueToStorage(state.queue);
     },
-    setSelectedResult: (state, action) => {
+    setSelectedResult: (state, action: PayloadAction<number>) => {
+      // Each search result is a distinct release; navigating between results
+      // moves the album_id anchor, so any previously picked track_position
+      // (e.g. "A1") would orphan onto the new release. Idempotent re-selection
+      // (e.g. mouseover on the already-highlighted row) preserves a freshly
+      // picked position. (dj-site#704)
+      if (state.search.selectedResult !== action.payload) {
+        state.search.query.track_position = undefined;
+      }
       state.search.selectedResult = action.payload;
     },
     setCurrentShowEntries: (state, action: PayloadAction<FlowsheetEntry[]>) => {

--- a/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import FlowsheetSearchResults from "./FlowsheetSearchResults";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
@@ -20,22 +20,45 @@ vi.mock("./NewEntry/NewEntryPreview", () => ({
 }));
 
 // LibraryTrackPicker hits the proxy `/library/:id/tracks` endpoint via
-// metadataApi; we don't want this test to wire that into the store.
+// metadataApi; we don't want this test to wire that into the store. The
+// default stub returns `show: true` so the picker row is rendered when its
+// other guards pass — individual tests override useLibraryTrackPicker as
+// needed.
+const libraryTrackPickerSpy = vi.fn();
 vi.mock("../LibraryTrackPicker", () => ({
   __esModule: true,
-  default: () => <div data-testid="library-track-picker" />,
-  useLibraryTrackPicker: () => ({ show: false, isLoading: false, tracks: [] }),
+  default: (props: any) => {
+    libraryTrackPickerSpy(props);
+    return (
+      <button
+        data-testid="library-track-picker-manual"
+        onClick={() => props.onManualEntry?.()}
+      >
+        Not listed
+      </button>
+    );
+  },
+  useLibraryTrackPicker: () => ({ show: true, isLoading: false, tracks: [] }),
 }));
 
-function createTestStore(searchOpen = false) {
+function createTestStore(
+  searchOpen = false,
+  overrides: Partial<ReturnType<typeof flowsheetSlice.getInitialState>> = {}
+) {
+  const initial = flowsheetSlice.getInitialState();
   return configureStore({
     reducer: {
       flowsheet: flowsheetSlice.reducer,
     },
     preloadedState: {
       flowsheet: {
-        ...flowsheetSlice.getInitialState(),
-        searchOpen,
+        ...initial,
+        ...overrides,
+        search: {
+          ...initial.search,
+          ...(overrides.search ?? {}),
+          open: searchOpen,
+        },
       },
     },
   });
@@ -168,6 +191,107 @@ describe("FlowsheetSearchResults", () => {
     expect(screen.getByText("next entry")).toBeInTheDocument();
     expect(screen.getByText("play")).toBeInTheDocument();
     expect(screen.getByText("queue")).toBeInTheDocument();
+  });
+
+  // dj-site#704: a library-unlinked rotation row carries a synthesized
+  // negative AlbumEntry.id (from synthesizeAlbumId). The picker over such a
+  // row would let the DJ pick "A1" via setTrackPosition, which #702's
+  // chokepoint then silently drops on submit (no positive album_id to anchor
+  // it). Hide the picker entirely instead — the freeform variant has no
+  // track_position field anyway.
+  describe("LibraryTrackPicker visibility over unlinked rotation rows", () => {
+    it("hides the picker row when the highlighted result has a synthesized negative id", () => {
+      const store = createTestStore(true, {
+        search: {
+          open: true,
+          query: flowsheetSlice.getInitialState().search.query,
+          selectedResult: 1,
+          confirmedArtist: "",
+        },
+      });
+      const unlinkedRotationResult: AlbumEntry[] = [
+        { id: -987654, title: "Unlinked Rotation Row" } as AlbumEntry,
+      ];
+
+      render(
+        <Provider store={store}>
+          <FlowsheetSearchResults
+            binResults={unlinkedRotationResult}
+            catalogResults={[]}
+            rotationResults={[]}
+            lmlResults={[]}
+          />
+        </Provider>
+      );
+
+      expect(
+        screen.queryByTestId("flowsheet-search-track-picker-row")
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the picker row when the highlighted result has a positive library.id", () => {
+      const store = createTestStore(true, {
+        search: {
+          open: true,
+          query: flowsheetSlice.getInitialState().search.query,
+          selectedResult: 1,
+          confirmedArtist: "",
+        },
+      });
+      const linkedResult: AlbumEntry[] = [
+        { id: 1234, title: "Linked Library Row" } as AlbumEntry,
+      ];
+
+      render(
+        <Provider store={store}>
+          <FlowsheetSearchResults
+            binResults={linkedResult}
+            catalogResults={[]}
+            rotationResults={[]}
+            lmlResults={[]}
+          />
+        </Provider>
+      );
+
+      expect(
+        screen.getByTestId("flowsheet-search-track-picker-row")
+      ).toBeInTheDocument();
+    });
+  });
+
+  // dj-site#704: clicking "Not listed" must clear any track_position the DJ
+  // previously picked, otherwise a stale "A1" rides through on submit
+  // pointing at an album the DJ no longer intends.
+  it("clears track_position in Redux when the manual-entry button is clicked", () => {
+    const store = createTestStore(true, {
+      search: {
+        open: true,
+        query: {
+          ...flowsheetSlice.getInitialState().search.query,
+          track_position: "A1",
+        },
+        selectedResult: 1,
+        confirmedArtist: "",
+      },
+    });
+    const linkedResult: AlbumEntry[] = [
+      { id: 1234, title: "Linked Library Row" } as AlbumEntry,
+    ];
+
+    render(
+      <Provider store={store}>
+        <FlowsheetSearchResults
+          binResults={linkedResult}
+          catalogResults={[]}
+          rotationResults={[]}
+          lmlResults={[]}
+        />
+      </Provider>
+    );
+
+    fireEvent.click(screen.getByTestId("library-track-picker-manual"));
+
+    expect(store.getState().flowsheet.search.query.track_position).toBeUndefined();
   });
 
   it("should calculate correct offsets for results", () => {

--- a/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
@@ -52,13 +52,21 @@ export default function FlowsheetSearchResults({
     }
   }, [highlightedResult?.id, manualOverride]);
 
-  const picker = useLibraryTrackPicker(
-    highlightedResult && highlightedResult.id !== manualOverride
+  // A library-unlinked rotation/catalog row carries a synthesized negative
+  // id from synthesizeAlbumId — there's no real release to pick tracks from,
+  // and #702's chokepoint drops track_position anyway. Skip the picker entirely
+  // for those rows instead of letting the DJ pick something we'll silently
+  // discard. (dj-site#704)
+  const pickerAlbumId =
+    highlightedResult &&
+    highlightedResult.id > 0 &&
+    highlightedResult.id !== manualOverride
       ? highlightedResult.id
-      : null
-  );
+      : null;
+  const picker = useLibraryTrackPicker(pickerAlbumId);
 
-  const showPickerRow = !!highlightedResult && !rotationMode;
+  const showPickerRow =
+    !!highlightedResult && highlightedResult.id > 0 && !rotationMode;
 
   return (
     <Sheet
@@ -170,6 +178,10 @@ export default function FlowsheetSearchResults({
                         value: "",
                       })
                     );
+                    // The DJ is opting out of the tracklist — any previously
+                    // picked position would otherwise ride through paired with
+                    // the highlighted album_id. (dj-site#704)
+                    dispatch(flowsheetSlice.actions.setTrackPosition(undefined));
                   }}
                 />
               ) : picker.isLoading ? (


### PR DESCRIPTION
> **Note**: stacked on top of #706. Set base back to `main` after that PR merges.

## Summary

Three coordinated changes keep `query.track_position` from orphaning onto the wrong release.

1. **`setRotationMetadata` clears `track_position`** — symmetric to `setRotationMode(false)`, which already does. Picking a rotation row moves the `album_id` anchor; the previously-picked `track_position` belongs to the previous album.
2. **`setSelectedResult` clears `track_position` when the selected-result index actually changes** — arrow-key nav and mouseover both dispatch this; the equality guard means idempotent re-selection on the already-highlighted row preserves a freshly picked position.
3. **`FlowsheetSearchResults` hides `LibraryTrackPicker` over library-unlinked results** (synthesized negative `AlbumEntry.id` from `synthesizeAlbumId`). #702's chokepoint drops `track_position` on those rows anyway; rendering the picker there lets the DJ pick something we silently discard. Also clears `track_position` when the DJ clicks "Not listed" so any prior pick can't ride through on submit.

## Why

`query.track_position` is a Discogs `release_track.position` reference (e.g. `"A1"`) anchored to a specific `album_id`. The picker writes it via `setTrackPosition`, but the reducers that change `album_id` don't keep it in sync. Two distinct leaks before this PR:

**Leak 1 — silent drop on unlinked rotation rows (loud → quiet regression after #702).** A library-unlinked rotation row carries a synthesized negative `album_id`. The picker rendered over it, the DJ could pick "A1", and #702's chokepoint correctly omitted both `album_id` and `track_position` from the wire — but the DJ's pick was silently discarded with no UI cue. Hiding the picker on those rows surfaces the constraint instead of swallowing the input.

**Leak 2 — stale `track_position` across positive-`album_id` boundaries.** Both album_ids are positive, so #702's chokepoint can't catch it:

1. DJ on result A picks track "A1" → `query.track_position = "A1"`, `query.album_id = A.id`.
2. DJ arrows to result B (different positive `album_id`).
3. `selectedResultData` rebuilds with `album_id: B.id` and `track_position: "A1"` (still in Redux from step 1).
4. DJ clicks "Not listed" on B → before this PR, `track_position` survived.
5. Submit: chokepoint sees positive `album_id = B.id` AND `track_position = "A1"` → both ride the wire.

BS would record the entry against release B with a position string referencing release A's tracklist. Reducer-level hygiene catches the navigation case; the manual-entry handler catches the "Not listed" case.

## Acceptance criteria (from #704)

- [x] DJ navigates from a library-linked result (with picked tracklist position) to a different result → `query.track_position` is cleared automatically.
- [x] DJ over a library-unlinked rotation row — the picker doesn't render.
- [x] A submission with a stale `track_position` from a prior pick on a different `album_id` is no longer possible from the picker UI.
- [x] Unit tests pin: (a) `setRotationMetadata` clears `track_position`; (b) arrow-key navigation (via `setSelectedResult` index change) clears it; (c) "Not listed" clears it via `setTrackPosition(undefined)`.

## Test plan

- [x] `npx vitest run` — 3190 tests pass across 220 files; 6 new tests added (3 slice, 3 component).
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: pick "A1" on result A, arrow to result B, "Not listed", submit — entry is freeform, no `track_position` on the wire.
- [ ] Manual: highlight an unlinked rotation row — no picker row renders.
- [ ] Manual: mouseover already-highlighted row preserves freshly picked position.

## Related

- #701 / PR #702 — wire-side chokepoint; covers stale-position case where the new `album_id` is negative. This PR covers the parallel positive-`album_id` cases.
- #703 / PR #706 — sibling: queue → SongEntry "Play Now" bypass. **This PR is stacked on it; set base back to `main` after #706 merges.**
- #608 — sibling: `convertBinToFlowsheet` direct-submit path.

Closes #704.