### PR TITLE
fix(bin): gate album_id leak in convertBinToFlowsheet for library-unlinked rows

### DIFF
--- a/lib/__tests__/features/bin/conversions.test.ts
+++ b/lib/__tests__/features/bin/conversions.test.ts
@@ -174,13 +174,14 @@ describe("bin conversions", () => {
       expect(result.track_title).toBe("Cool Album");
     });
 
-    it("should include artist_name", () => {
-      const binEntry = createBinEntry({
-        artist: { id: undefined, name: "Awesome Artist", lettercode: "AA", numbercode: 1, genre: "Rock" },
-      });
-      const result = convertBinToFlowsheet(binEntry) as BinFlowsheetResult;
-      expect(result.artist_name).toBe("Awesome Artist");
-    });
+    // Catalog variant intentionally omits artist_name — the wire schema's
+    // FlowsheetCreateSongFromCatalog (@wxyc/shared) has no such field, and
+    // BS backfills artist info from the library row keyed by album_id
+    // (apps/backend/controllers/flowsheet.controller.ts addEntry, lookup
+    // branch). Sending it would be a no-op at best and a type-violation
+    // against the wire union. Freeform branch coverage for artist_name
+    // preservation lives in the `synthesized negative album_id` describe
+    // block below.
 
     it("should include record_label", () => {
       const binEntry = createBinEntry({ label: "Big Label" });
@@ -200,6 +201,73 @@ describe("bin conversions", () => {
       const binEntry = createBinEntry();
       const result = convertBinToFlowsheet(binEntry) as BinFlowsheetResult;
       expect(result.request_flag).toBe(false);
+    });
+
+    // #608 — "Play Now from bin" on a library-unlinked bin row was sending
+    // the synthesized negative `album_id` (from synthesizeAlbumId) straight
+    // through to POST /flowsheet/, bypassing the convertQueryToSubmission
+    // gate Jake added in 04f027a. BS branches on `album_id != null` and
+    // takes the library-lookup path on negative numbers → TypeError 500.
+    // Gate at source: drop album_id when synthesized, route via freeform
+    // with the snapshot fields BS's else branch requires. As of
+    // @wxyc/shared 1.9.0 (BS#1308) the freeform variant carries rotation_id,
+    // so the rotation linkage stays on the wire too.
+    describe("synthesized negative album_id", () => {
+      type FreeformResult = {
+        album_id?: undefined;
+        track_title: string;
+        artist_name: string;
+        album_title: string;
+        record_label?: string;
+        rotation_id?: number;
+        request_flag: boolean;
+      };
+
+      it("omits album_id when binEntry.id is negative (synthesized)", () => {
+        const binEntry = createBinEntry({ id: -987654321 });
+        const result = convertBinToFlowsheet(binEntry) as FreeformResult;
+        expect(result.album_id).toBeUndefined();
+      });
+
+      it("carries the album_title snapshot field BS's freeform branch requires", () => {
+        const binEntry = createBinEntry({ id: -1, title: "Tzenni" });
+        const result = convertBinToFlowsheet(binEntry) as FreeformResult;
+        expect(result.album_title).toBe("Tzenni");
+      });
+
+      it("preserves rotation_id on the freeform shape (BS#1308 / @wxyc/shared 1.9.0)", () => {
+        const binEntry = createBinEntry({
+          id: -1,
+          rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
+        });
+        const result = convertBinToFlowsheet(binEntry) as FreeformResult;
+        expect(result.rotation_id).toBe(TEST_ENTITY_IDS.ROTATION.HEAVY);
+      });
+
+      it("still carries artist_name + track_title + record_label snapshot", () => {
+        const binEntry = createBinEntry({
+          id: -1,
+          title: "Tzenni",
+          label: "Glitterbeat",
+          artist: {
+            id: undefined,
+            name: "Noura Mint Seymali",
+            lettercode: "S",
+            numbercode: 1,
+            genre: "Unknown",
+          },
+        });
+        const result = convertBinToFlowsheet(binEntry) as FreeformResult;
+        expect(result.artist_name).toBe("Noura Mint Seymali");
+        expect(result.track_title).toBe("Tzenni");
+        expect(result.record_label).toBe("Glitterbeat");
+      });
+
+      it("leaves positive ids unchanged (catalog variant still emits album_id)", () => {
+        const binEntry = createBinEntry({ id: 42 });
+        const result = convertBinToFlowsheet(binEntry) as BinFlowsheetResult;
+        expect(result.album_id).toBe(42);
+      });
     });
   });
 

--- a/lib/features/bin/conversions.ts
+++ b/lib/features/bin/conversions.ts
@@ -4,13 +4,36 @@ import { FlowsheetQuery, FlowsheetSubmissionParams } from "../flowsheet/types";
 export function convertBinToFlowsheet(
   binEntry: AlbumEntry
 ): FlowsheetSubmissionParams {
+  // #608: gate album_id on `> 0` to drop the synthesized negative id that
+  // `synthesizeAlbumId` produces for library-unlinked bin rows. Bypassed
+  // `convertQueryToSubmission`'s chokepoint gate (04f027a) because
+  // PlayFromBin pipes directly into `addToFlowsheet`. Without this gate
+  // BS branches on `album_id != null`, takes the library-lookup path on a
+  // negative id, and throws TypeError 500. Mirrors the chokepoint shape.
+  //
+  // rotation_id stays on the wire (BS#1308 / @wxyc/shared 1.9.0 added it to
+  // FlowsheetCreateSongFreeform), so the iOS rotation-artwork resolver can
+  // still find unlinked-rotation bin plays by rotation_id alone.
+  const hasLinkedAlbum =
+    typeof binEntry.id === "number" && binEntry.id > 0;
+
+  if (hasLinkedAlbum) {
+    return {
+      album_id: binEntry.id,
+      track_title: binEntry.title,
+      rotation_id: binEntry.rotation_id,
+      request_flag: false,
+      record_label: binEntry.label,
+    };
+  }
+
   return {
-    album_id: binEntry.id,
-    track_title: binEntry.title,
     artist_name: binEntry.artist.name,
-    record_label: binEntry.label,
+    album_title: binEntry.title,
+    track_title: binEntry.title,
     rotation_id: binEntry.rotation_id,
     request_flag: false,
+    record_label: binEntry.label,
   };
 }
 

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -107,6 +107,13 @@ export type FlowsheetSubmissionParams =
       request_flag: boolean;
       segue?: boolean;
       record_label?: string;
+      // BS#1308 / @wxyc/shared 1.9.0 added rotation_id to
+      // FlowsheetCreateSongFreeform so library-unlinked rotation rows
+      // preserve rotation linkage on the wire (and the iOS V2 reader's
+      // rotation-artwork path can resolve them). Mirrors the canonical
+      // type; consumers in bin/conversions.ts forward it when album_id
+      // can't be sent.
+      rotation_id?: number;
     }
   | {
       message: string;


### PR DESCRIPTION
## Summary

`PlayFromBin.tsx` pipes `convertBinToFlowsheet` straight into `addToFlowsheet`, bypassing `convertQueryToSubmission`'s chokepoint gate from `04f027a`. Library-unlinked bin rows carry `synthesizeAlbumId`'s negative `album_id` to BS, which branches on `album_id != null`, takes the library-lookup path on a negative id, and throws TypeError 500. This is the residual surface of the `synthesizeAlbumId` defect class after #698/#701/#703.

- Gate `album_id` on `> 0` in `lib/features/bin/conversions.ts:convertBinToFlowsheet` at source.
- Route library-unlinked bin rows through the freeform variant with `album_title + artist_name + track_title + rotation_id + record_label`. `album_title` was previously missing — BS's else branch validates against it (`addEntry` 'Missing Flowsheet Parameters' guard).
- `rotation_id` stays on the wire post-BS#1308 / `@wxyc/shared@1.9.0`, so the iOS V2 reader's rotation-artwork resolver still finds unlinked-rotation bin plays.
- Update hand-rolled `FlowsheetSubmissionParams.Freeform` to mirror the new `@wxyc/shared` shape with `rotation_id?`.

Closes #608.

## Test plan

- [x] TDD-added regressions in `lib/__tests__/features/bin/conversions.test.ts`:
  - `omits album_id when binEntry.id is negative (synthesized)`
  - `carries the album_title snapshot field BS's freeform branch requires`
  - `preserves rotation_id on the freeform shape (BS#1308 / @wxyc/shared 1.9.0)`
  - `still carries artist_name + track_title + record_label snapshot`
  - `leaves positive ids unchanged (catalog variant still emits album_id)`
- [x] Replaced pre-existing `should include artist_name` test — wire schema's `FlowsheetCreateSongFromCatalog` has no `artist_name`, and BS backfills from the library row keyed by `album_id`. Comment block explains the omission.
- [x] Full vitest suite — 220 files, 3188 tests pass.
- [x] `tsc --noEmit` clean.
- [ ] Manual verify: "Play Now from bin" on a library-unlinked rotation row (e.g. the "Setting" album that surfaced this defect class).

## Related

- WXYC/dj-site#699 — Classic EntryForm fix (#698 closed).
- `04f027a` — chokepoint gate at `convertQueryToSubmission` (#701 closed).
- `fe4dedc` — queue-boundary `album_id` sanitize (#703 closed).
- WXYC/Backend-Service#1308 — wire schema relaxation that lets `rotation_id` ride without `album_id`.
- WXYC/wxyc-shared#158 — schema addition.