### PR TITLE
Show read-only artist/album/label in rotation entry (#710)

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -301,4 +301,55 @@ describe("RotationEntryFields", () => {
       expect(artistValues(dispatchSpy)).toEqual(["OOIOO"]);
     });
   });
+
+  describe("read-only artist/album/label display after release pick (WXYC/dj-site#710)", () => {
+    // Rotation mode does not mount the artist/album/label `<input>` fields the
+    // non-rotation surface uses; the DJ used to see no UI surface for those
+    // values even though `handleSelectRelease` had populated them in Redux.
+    // The display elements below give the DJ visibility (and confirm the
+    // label autopop from sibling #709 is actually landing). Editability is a
+    // separate follow-up.
+
+    it("does not render the read-only displays before a release is picked", () => {
+      renderWithProviders(<RotationEntryFields disabled={false} />);
+
+      expect(
+        screen.queryByTestId("rotation-entry-display-artist")
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("rotation-entry-display-album")
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("rotation-entry-display-label")
+      ).not.toBeInTheDocument();
+    });
+
+    it("surfaces the picked release's artist, album, and label as read-only", () => {
+      renderWithProviders(<RotationEntryFields disabled={false} />);
+
+      selectBinAndRelease();
+
+      const artist = screen.getByTestId("rotation-entry-display-artist");
+      const album = screen.getByTestId("rotation-entry-display-album");
+      const label = screen.getByTestId("rotation-entry-display-label");
+
+      expect(artist).toHaveTextContent("OOIOO");
+      expect(album).toHaveTextContent("OOIOO / Lightning Bolt Split");
+      expect(label).toHaveTextContent("Load Records");
+    });
+
+    it("keeps the track picker mounted after a release is picked", () => {
+      // Regression guard: the displays sit between release-dropdown and the
+      // track picker/song input. Verify the track surface still renders so a
+      // refactor of the layout doesn't accidentally hide it.
+      mockTracksData = [
+        { position: "A1", title: "la paradoja", duration: null, artists: [] },
+      ];
+
+      renderWithProviders(<RotationEntryFields disabled={false} />);
+      selectBinAndRelease();
+
+      expect(screen.getByTestId("track-picker-trigger")).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -351,5 +351,30 @@ describe("RotationEntryFields", () => {
 
       expect(screen.getByTestId("track-picker-trigger")).toBeInTheDocument();
     });
+
+    it("dims the displays when the parent goes disabled mid-flow", () => {
+      // Real flow: DJ picks a release while live, then the show ends and the
+      // searchbar flips `disabled={!live}`. Each display field reads its own
+      // `disabled` prop and fades to opacity 0.5; assert all three so a future
+      // refactor of the dim path can't silently drop one.
+      const { rerender } = renderWithProviders(
+        <RotationEntryFields disabled={false} />
+      );
+      selectBinAndRelease();
+
+      for (const name of ["artist", "album", "label"] as const) {
+        expect(
+          screen.getByTestId(`rotation-entry-display-${name}`)
+        ).toHaveStyle({ opacity: "1" });
+      }
+
+      rerender(<RotationEntryFields disabled={true} />);
+
+      for (const name of ["artist", "album", "label"] as const) {
+        expect(
+          screen.getByTestId(`rotation-entry-display-${name}`)
+        ).toHaveStyle({ opacity: "0.5" });
+      }
+    });
   });
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -11,12 +11,56 @@ import {
 } from "@/lib/features/rotation/api";
 import { useAppDispatch } from "@/lib/hooks";
 import { useFlowsheetSearch } from "@/src/hooks/flowsheetHooks";
-import { Divider } from "@mui/joy";
+import { Box, Divider, Typography } from "@mui/joy";
 import { useCallback, useMemo, useState } from "react";
 import FlowsheetSearchInput from "./FlowsheetSearchInput";
 import RotationBinSelector from "./RotationBinSelector";
 import RotationReleaseDropdown from "./RotationReleaseDropdown";
 import TrackPickerDropdown from "./TrackPickerDropdown";
+
+// Read-only display field used to surface the artist / album / label values
+// that `handleSelectRelease` writes into Redux. Rotation mode never mounts the
+// `<FlowsheetSearchInput>` fields the non-rotation surface uses, so without
+// these the populated values had no UI surface and DJs reported "can't edit
+// anything" after picking a release (WXYC/dj-site#710). Editability is a
+// separate follow-up.
+function RotationEntryDisplayField({
+  name,
+  value,
+  disabled,
+}: {
+  name: "artist" | "album" | "label";
+  value: string;
+  disabled: boolean;
+}) {
+  const label = name === "artist" ? "Artist" : name === "album" ? "Album" : "Label";
+  return (
+    <Box
+      data-testid={`rotation-entry-display-${name}`}
+      sx={{
+        display: "flex",
+        flex: 1,
+        minWidth: 0,
+        alignItems: "center",
+        px: 1,
+        minHeight: "2rem",
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      <Typography
+        level="body-sm"
+        sx={{
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          opacity: value ? 1 : 0.5,
+        }}
+      >
+        {value || label}
+      </Typography>
+    </Box>
+  );
+}
 
 export default function RotationEntryFields({ disabled }: { disabled: boolean }) {
   const dispatch = useAppDispatch();
@@ -139,6 +183,28 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
         onSelectRelease={handleSelectRelease}
         disabled={disabled || !selectedBin}
       />
+      {selectedRelease && (
+        <>
+          <Divider orientation="vertical" />
+          <RotationEntryDisplayField
+            name="artist"
+            value={selectedRelease.artist.name}
+            disabled={disabled}
+          />
+          <Divider orientation="vertical" />
+          <RotationEntryDisplayField
+            name="album"
+            value={selectedRelease.title}
+            disabled={disabled}
+          />
+          <Divider orientation="vertical" />
+          <RotationEntryDisplayField
+            name="label"
+            value={selectedRelease.label}
+            disabled={disabled}
+          />
+        </>
+      )}
       <Divider orientation="vertical" />
       {showTrackDropdown ? (
         <TrackPickerDropdown


### PR DESCRIPTION
## Summary

Rotation entry mode in the flowsheet searchbar only renders `RotationEntryFields`, which historically exposed bin / release / song surfaces but no UI for the artist / album / label values that `handleSelectRelease` writes into Redux. Per the investigation in #710 the DJ complaint "can't edit anything" was actually "can't *see* anything" — the artist / album / label values were populated but invisible. This PR ships the minimum-viable half of the issue's "fix shape": render the three values as read-only Typography displays after a release is picked, so the populated values have a UI surface.

Editability (the #509-style thaw machinery, "fix shape 2" in the issue body) is explicitly out of scope here and stays as the follow-up the issue calls out. Redux dispatches and the surrounding searchbar layout are unchanged.

## Test plan

- [x] `npx vitest run src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx` (8 existing + 3 new pass)
- [x] `npx vitest run src/components/experiences/modern/flowsheet` (29 files, 401 tests pass)
- [x] `npx vitest run` (full suite — 221 files, 3216 tests pass)
- [x] `npx tsc --noEmit` clean
- [ ] Manual smoke: in rotation entry mode, pick a bin, pick a release, confirm artist / album / label appear inline and the track picker still mounts below them

Closes #710.