### PR TITLE
Split runtime-adapter out of prod-deps Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       wxyc-shared:
         patterns:
           - "@wxyc/shared"
+      runtime-adapter:
+        patterns:
+          - "next"
+          - "@opennextjs/cloudflare"
+          - "wrangler"
       dev-dependencies:
         dependency-type: "development"
         update-types:
@@ -22,6 +27,9 @@ updates:
           - "better-auth"
           - "@better-auth/*"
           - "@wxyc/shared"
+          - "next"
+          - "@opennextjs/cloudflare"
+          - "wrangler"
       production-dependencies:
         dependency-type: "production"
         update-types:
@@ -31,6 +39,9 @@ updates:
           - "better-auth"
           - "@better-auth/*"
           - "@wxyc/shared"
+          - "next"
+          - "@opennextjs/cloudflare"
+          - "wrangler"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Edits `.github/dependabot.yml` to add a dedicated `runtime-adapter` group covering `next`, `@opennextjs/cloudflare`, and `wrangler`, and excludes those three packages from the existing `production-dependencies` and `dev-dependencies` groups so they never fold back into the broader bumps.

The 2026-06-03 outage (https://github.com/WXYC/dj-site/issues/715, reverted in https://github.com/WXYC/dj-site/pull/716) came from a single Dependabot PR that bumped 13 production dependencies at once, including a five-minor jump on `@opennextjs/cloudflare` paired with a `next` bump. The worker booted in compile but failed at boot in the production runtime — no Sentry events, no app code reached. With 13 suspects in one PR, bisecting required reverting the whole group. After this lands, the runtime-adapter pair (plus the tightly-correlated `wrangler` CLI) ships in its own small group, so a regression has at most one PR to revert.

`wrangler` is the Cloudflare deploy CLI and is upgrade-correlated with the OpenNext adapter, so it lives in the same group. The rest of the prod-deps grouping (React, Redux, motion, posthog-js, etc.) is untouched.

## Test plan

- [x] `python -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'` parses cleanly.
- [ ] Next Dependabot run (Monday) opens a separate `runtime-adapter` PR for any pending `next` / `@opennextjs/cloudflare` / `wrangler` bumps, and the `production-dependencies` / `dev-dependencies` PRs omit those three.

Closes #720