### PR TITLE
ci: add pre-merge preview-URL smoke check

### DIFF
--- a/.github/workflows/pr-preview-smoke.yml
+++ b/.github/workflows/pr-preview-smoke.yml
@@ -1,0 +1,177 @@
+name: PR Preview Smoke Check
+
+# Hard-blocks merge if the Cloudflare Pages preview deployment for a PR's head
+# commit returns 5xx on `/`. Backstop for the 2026-06-03 outage where a
+# Dependabot prod-deps bump (next + @opennextjs/cloudflare) compiled and
+# uploaded cleanly but the worker failed at boot — the preview URL was already
+# returning 500 before merge, and nothing in CI was checking it.
+#
+# See https://github.com/WXYC/dj-site/issues/719 for the design discussion and
+# https://github.com/WXYC/dj-site/issues/715 for the original outage.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: pr-preview-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+# We need pull-requests:write to post the failure comment via `gh pr comment`.
+# contents:read is the safe floor; the job does not push code or modify the
+# repo state otherwise.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  smoke:
+    name: Preview URL smoke check
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    steps:
+      - name: Check required configuration
+        id: config
+        run: |
+          if [ -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ] || [ -z "${{ vars.CLOUDFLARE_ACCOUNT_ID }}" ]; then
+            echo "::warning::Skipping preview smoke — CLOUDFLARE_API_TOKEN secret and/or CLOUDFLARE_ACCOUNT_ID variable not configured (expected for forks)."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for Cloudflare Pages preview deployment
+        id: wait
+        if: steps.config.outputs.configured == 'true'
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # Poll the Pages deployments endpoint for a preview whose
+          # deployment_trigger.metadata.commit_hash matches HEAD_SHA. Cap total
+          # wait at ~10 minutes (40 attempts * 15s sleep). Terminal failure
+          # states (failure, canceled) short-circuit; "success" wins; anything
+          # else (initializing, queued, building, deploying) keeps polling.
+          MAX_ATTEMPTS=40
+          SLEEP_SECONDS=15
+          attempt=0
+          deploy_id=""
+          deploy_url=""
+          status=""
+
+          while [ "$attempt" -lt "$MAX_ATTEMPTS" ]; do
+            attempt=$((attempt + 1))
+            echo "Attempt ${attempt}/${MAX_ATTEMPTS} — searching for preview deployment for ${HEAD_SHA}"
+
+            RESPONSE=$(curl -sf \
+              -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pages/projects/wxyc-dj/deployments?env=preview&per_page=25") || {
+                echo "::warning::Cloudflare API request failed on attempt ${attempt}; retrying"
+                sleep "$SLEEP_SECONDS"
+                continue
+              }
+
+            MATCH=$(echo "$RESPONSE" | jq -r --arg sha "$HEAD_SHA" '
+              .result
+              | map(select(.deployment_trigger.metadata.commit_hash == $sha))
+              | sort_by(.created_on) | reverse | .[0] // empty
+            ')
+
+            if [ -z "$MATCH" ]; then
+              echo "No preview deployment yet for ${HEAD_SHA}; sleeping ${SLEEP_SECONDS}s"
+              sleep "$SLEEP_SECONDS"
+              continue
+            fi
+
+            deploy_id=$(echo "$MATCH" | jq -r '.id')
+            deploy_url=$(echo "$MATCH" | jq -r '.url')
+            status=$(echo "$MATCH" | jq -r '.latest_stage.status')
+            stage=$(echo "$MATCH" | jq -r '.latest_stage.name')
+
+            echo "Found deployment ${deploy_id} — stage=${stage} status=${status} url=${deploy_url}"
+
+            case "$status" in
+              success)
+                echo "deploy_id=${deploy_id}" >> "$GITHUB_OUTPUT"
+                echo "deploy_url=${deploy_url}" >> "$GITHUB_OUTPUT"
+                echo "outcome=ready" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+              failure|failed|canceled|cancelled)
+                echo "deploy_id=${deploy_id}" >> "$GITHUB_OUTPUT"
+                echo "deploy_url=${deploy_url}" >> "$GITHUB_OUTPUT"
+                echo "outcome=build_failed" >> "$GITHUB_OUTPUT"
+                echo "build_stage=${stage}" >> "$GITHUB_OUTPUT"
+                echo "build_status=${status}" >> "$GITHUB_OUTPUT"
+                echo "::error::Cloudflare Pages preview build reached terminal state ${stage}/${status} for deployment ${deploy_id}"
+                exit 1
+                ;;
+              *)
+                echo "Deployment ${deploy_id} not ready yet (stage=${stage} status=${status}); sleeping ${SLEEP_SECONDS}s"
+                sleep "$SLEEP_SECONDS"
+                ;;
+            esac
+          done
+
+          echo "outcome=timeout" >> "$GITHUB_OUTPUT"
+          echo "::error::Timed out after ${MAX_ATTEMPTS} attempts waiting for a Cloudflare Pages preview deployment for commit ${HEAD_SHA}"
+          exit 1
+
+      - name: Smoke-test preview URL
+        id: smoke
+        if: steps.config.outputs.configured == 'true' && steps.wait.outputs.outcome == 'ready'
+        env:
+          DEPLOY_URL: ${{ steps.wait.outputs.deploy_url }}
+        run: |
+          PROBE_URL="${DEPLOY_URL%/}/"
+          echo "Probing ${PROBE_URL}"
+
+          HTTP_CODE=$(curl -sS -o /dev/null -w '%{http_code}\n' --max-time 30 "$PROBE_URL" || echo "000")
+          echo "Preview ${PROBE_URL} returned HTTP ${HTTP_CODE}"
+          echo "http_code=${HTTP_CODE}" >> "$GITHUB_OUTPUT"
+
+          # 2xx and 3xx are success. 401/403 are expected for auth-gated routes
+          # — `/` may redirect through middleware; treat them as success too.
+          # Any 5xx is the failure mode we are guarding against. Any other 4xx
+          # or a network failure (000) is unexpected enough to flag.
+          case "$HTTP_CODE" in
+            2*|3*|401|403)
+              echo "Preview URL is healthy."
+              ;;
+            5*)
+              echo "::error::Preview URL returned ${HTTP_CODE} — likely worker boot failure. Blocking merge."
+              exit 1
+              ;;
+            *)
+              echo "::error::Preview URL returned unexpected status ${HTTP_CODE}. Blocking merge."
+              exit 1
+              ;;
+          esac
+
+      - name: Comment on PR with failure detail
+        if: failure() && steps.config.outputs.configured == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DEPLOY_ID: ${{ steps.wait.outputs.deploy_id }}
+          DEPLOY_URL: ${{ steps.wait.outputs.deploy_url }}
+          WAIT_OUTCOME: ${{ steps.wait.outputs.outcome }}
+          BUILD_STAGE: ${{ steps.wait.outputs.build_stage }}
+          BUILD_STATUS: ${{ steps.wait.outputs.build_status }}
+          HTTP_CODE: ${{ steps.smoke.outputs.http_code }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ "$WAIT_OUTCOME" = "timeout" ]; then
+            BODY="Preview smoke check failed: timed out waiting for a Cloudflare Pages preview deployment for commit ${HEAD_SHA} after ~10 minutes. The Pages build either did not start or did not surface to the API. See the workflow run for details: ${RUN_URL}"
+          elif [ "$WAIT_OUTCOME" = "build_failed" ]; then
+            BODY="Preview smoke check failed: Cloudflare Pages preview build reached terminal state \`${BUILD_STAGE}/${BUILD_STATUS}\` for deployment \`${DEPLOY_ID}\` (${DEPLOY_URL}). Dashboard: https://dash.cloudflare.com/${ACCOUNT_ID}/pages/view/wxyc-dj/${DEPLOY_ID} — workflow run: ${RUN_URL}"
+          else
+            BODY="Preview smoke check failed: ${DEPLOY_URL}/ returned HTTP \`${HTTP_CODE}\` for deployment \`${DEPLOY_ID}\`. A 5xx response usually means the Cloudflare worker failed at boot — see the Cloudflare deployment logs (Dashboard: https://dash.cloudflare.com/${ACCOUNT_ID}/pages/view/wxyc-dj/${DEPLOY_ID}) and the workflow run: ${RUN_URL}. Merging is blocked until the preview URL returns a non-5xx response."
+          fi
+
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$BODY"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pr-preview-smoke.yml`, a PR-only workflow that polls the Cloudflare Pages API for the preview deployment matching the PR head SHA, waits for the build to reach `success`, and then `curl`s the preview URL `/`. Any 5xx (and any unexpected 4xx other than 401/403) fails the check and posts a PR comment with the deployment ID and failing status code. Forks lacking the Cloudflare API token skip cleanly with a warning.

This is the smallest mechanical backstop for the 2026-06-03 outage: the Dependabot PR that broke production already had a 500-returning preview URL before merge, but nothing in CI was checking it. Reuses the API shape, secret, and `curl`-with-`jq` style of the existing `cloudflare-deploy-status.yml` for consistency.

## Behavior

- Trigger: `pull_request` (opened, synchronize, reopened) targeting `main`.
- Polls `https://api.cloudflare.com/client/v4/accounts/{accountId}/pages/projects/wxyc-dj/deployments?env=preview&per_page=25`, filters by `deployment_trigger.metadata.commit_hash == github.event.pull_request.head.sha`, and waits for `latest_stage.status == "success"`. Cap: ~10 minutes (40 attempts at 15s each).
- Terminal failure states (`failure`/`canceled`) short-circuit the poll.
- Probe is `curl -sS -o /dev/null -w '%{http_code}' "$URL/"` with a 30s max-time. 2xx and 3xx pass; 401/403 pass (auth-gated middleware redirects are a real possibility on `/`); 5xx and other 4xx fail.
- On failure, the workflow posts a PR comment via `gh pr comment` with the failing status, deployment ID, and a link to the Cloudflare dashboard + the workflow run.
- Job timeout: 12 minutes. Permissions: `contents: read` + `pull-requests: write`.

## Verified locally

- `actionlint` passes.
- Workflow is gated on the same `CLOUDFLARE_API_TOKEN` secret + `CLOUDFLARE_ACCOUNT_ID` variable that `cloudflare-deploy-status.yml` uses, so it picks up the existing repo config with no infra changes.

## Limitations

- **Forks.** PRs from external forks won't have the Cloudflare API token; the workflow detects the missing secret and skips with a warning rather than failing. That's intentional — Dependabot (the primary risk vector for the 2026-06-03 outage class) runs on branches inside the repo, not forks.
- **Lookup race.** There's a small window between PR open and Cloudflare receiving the push webhook where the preview deployment doesn't exist yet. The poll handles this by retrying; the 10-minute cap accommodates the typical Pages build time.
- **Single-path probe.** We only probe `/`. The 2026-06-03 outage broke every dynamic route, so `/` was sufficient signal; multi-path smoke can come later if a future regression escapes through that gap.

## Related

- https://github.com/WXYC/dj-site/issues/715 — original outage post-mortem
- https://github.com/WXYC/dj-site/pull/559 — the Dependabot PR that triggered the outage
- https://github.com/WXYC/dj-site/blob/main/.github/workflows/cloudflare-deploy-status.yml — existing post-deploy monitor whose API patterns we reuse

Closes #719