### PR TITLE
chore: drop default React import, use named imports

### DIFF
--- a/app/dashboard/@modern/layout.tsx
+++ b/app/dashboard/@modern/layout.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@mui/joy";
-import React from "react";
+import type { JSX, ReactNode } from "react";
 import Main from "@/src/components/experiences/modern/Main";
 import Rightbar from "@/src/components/experiences/modern/Rightbar/Rightbar";
 import MobileHeader from "@/src/components/experiences/modern/Header/MobileHeader";
@@ -9,8 +9,8 @@ import Leftbar from "@/src/components/experiences/modern/Leftbar/Leftbar";
 export default function ModernDashboard({
   children,
 }: {
-  children: React.ReactNode;
-}): React.JSX.Element {
+  children: ReactNode;
+}): JSX.Element {
   return (
     <Box sx={{ display: "flex", height: "100dvh", overflow: "hidden" }}>
       <MobileHeader />

--- a/lib/__tests__/features/experiences/hooks.test.ts
+++ b/lib/__tests__/features/experiences/hooks.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
-import React from "react";
+import { createElement, type ReactNode } from "react";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import {
@@ -26,8 +26,8 @@ function createMockStore(applicationState: Record<string, unknown> = {}) {
 
 function createWrapper(applicationState: Record<string, unknown> = {}) {
   const store = createMockStore(applicationState);
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(Provider, { store, children });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(Provider, { store, children });
   };
 }
 

--- a/lib/test-utils/component-harness.ts
+++ b/lib/test-utils/component-harness.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { createElement, type ComponentType, type ReactNode } from "react";
 import { screen } from "@testing-library/react";
 import type { RenderResult } from "@testing-library/react";
 import type userEvent from "@testing-library/user-event";
@@ -39,12 +39,12 @@ export interface ComponentHarnessResult extends RenderResult {
  * });
  */
 export function createComponentHarness<P extends object>(
-  Component: React.ComponentType<P>,
+  Component: ComponentType<P>,
   defaultProps: P
 ) {
   return function setup(propsOverride?: Partial<P>): ComponentHarnessResult {
     const props = { ...defaultProps, ...propsOverride } as P;
-    const result = renderWithProviders(React.createElement(Component, props));
+    const result = renderWithProviders(createElement(Component, props));
 
     return {
       ...result,
@@ -80,13 +80,13 @@ export function createComponentHarnessWithQueries<
   P extends object,
   Q extends Record<string, () => HTMLElement | null>
 >(
-  Component: React.ComponentType<P>,
+  Component: ComponentType<P>,
   defaultProps: P,
   queries: Q
 ): (propsOverride?: Partial<P>) => ComponentHarnessResult & Q {
   return function setup(propsOverride?: Partial<P>) {
     const props = { ...defaultProps, ...propsOverride } as P;
-    const result = renderWithProviders(React.createElement(Component, props));
+    const result = renderWithProviders(createElement(Component, props));
 
     return {
       ...result,
@@ -126,7 +126,7 @@ export const componentQueries = {
  * ]);
  */
 export function testPropVariants<P extends object>(
-  Component: React.ComponentType<P>,
+  Component: ComponentType<P>,
   defaultProps: P,
   variants: Partial<P>[],
   assertion: (result: ComponentHarnessResult) => void = () => {}
@@ -171,8 +171,8 @@ export function createHookWrapper<S extends Record<string, Slice>>(
     preloadedState,
   });
 
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(Provider, { store, children });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(Provider, { store, children });
   };
 }
 

--- a/lib/test-utils/render.tsx
+++ b/lib/test-utils/render.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { RenderOptions, RenderResult } from "@testing-library/react";
 import { render as rtlRender } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/src/components/Theme/ThemeSwitcher.tsx
+++ b/src/components/Theme/ThemeSwitcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { IconButton, Tooltip } from "@mui/joy";
-import React from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
 
 import { useRouter } from "next/navigation";
 
@@ -26,7 +26,7 @@ export default function ThemeSwitcher() {
   const { data: experience, isLoading } = useGetActiveExperienceQuery();
   const [switchExperience, result] = useSwitchExperienceMutation();
 
-  const handleSwitch = async (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleSwitch = async (e: ReactMouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     const newExperience = experience === "classic" ? "modern" : "classic";
     switchExperience(newExperience);

--- a/src/components/experiences/modern/Main.tsx
+++ b/src/components/experiences/modern/Main.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { Box } from "@mui/joy";
-import React from "react";
+import type { ReactNode } from "react";
 
-export default function Main({ children }: { children: React.ReactNode }) {
+export default function Main({ children }: { children: ReactNode }) {
   return (
     <Box
       component="main"

--- a/src/components/experiences/modern/Rightbar/RightbarContainer.tsx
+++ b/src/components/experiences/modern/Rightbar/RightbarContainer.tsx
@@ -1,10 +1,10 @@
 import { Sheet } from "@mui/joy";
-import React from "react";
+import type { ReactNode } from "react";
 
 export default function RightbarContainer({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <Sheet

--- a/src/components/experiences/modern/catalog/Search/Filters.tsx
+++ b/src/components/experiences/modern/catalog/Search/Filters.tsx
@@ -10,7 +10,7 @@ import {
   Option,
   Select,
 } from "@mui/joy";
-import React from "react";
+import { Fragment } from "react";
 
 const GENRE_OPTIONS: (Genre | "All")[] = [
   "All",
@@ -29,7 +29,7 @@ export const Filters = ({ color }: { color: ColorPaletteProp | undefined }) => {
   const { filters, setFilter } = useCatalogQuerySearch();
 
   return (
-    <React.Fragment>
+    <Fragment>
       <FormControl size="sm" sx={{ flex: 1 }}>
         <FormLabel>Genre</FormLabel>
         <Select
@@ -85,6 +85,6 @@ export const Filters = ({ color }: { color: ColorPaletteProp | undefined }) => {
           }}
         />
       </FormControl>
-    </React.Fragment>
+    </Fragment>
   );
 };

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.tsx
@@ -5,7 +5,7 @@ import { useFlowsheet, useShowControl } from "@/src/hooks/flowsheetHooks";
 import { toTitleCase } from "@/src/utilities/stringutilities";
 import { Typography, TypographyProps } from "@mui/joy";
 import { ClickAwayListener } from "@mui/material";
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { useAppDispatch } from "@/lib/hooks";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 
@@ -40,7 +40,7 @@ export default function FlowsheetEntryField({
   const { updateFlowsheet } = useFlowsheet();
 
   const saveAndClose = useCallback(
-    (e: MouseEvent | TouchEvent | React.FormEvent<HTMLFormElement>) => {
+    (e: MouseEvent | TouchEvent | FormEvent<HTMLFormElement>) => {
       e.preventDefault();
       setEditing(false);
 

--- a/src/components/experiences/modern/flowsheet/InfiniteScroller.test.tsx
+++ b/src/components/experiences/modern/flowsheet/InfiniteScroller.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import InfiniteScroller from "./InfiniteScroller";
-import React from "react";
 
 const mockFetchNextPage = vi.fn();
 const mockUseFlowsheet = vi.fn();

--- a/src/components/experiences/modern/login/Forms/OnboardingForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/OnboardingForm.test.tsx
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import OnboardingForm from "./OnboardingForm";
 import { authenticationSlice } from "@/lib/features/authentication/frontend";
-import React from "react";
+import type { ReactNode } from "react";
 
 // Mock authentication hooks
 const mockHandleNewUser = vi.fn((e) => e.preventDefault());
@@ -29,7 +29,7 @@ function createTestStore() {
 
 function createWrapper() {
   const store = createTestStore();
-  return function Wrapper({ children }: { children: React.ReactNode }) {
+  return function Wrapper({ children }: { children: ReactNode }) {
     return <Provider store={store}>{children}</Provider>;
   };
 }

--- a/src/components/experiences/modern/login/Quotes/Forgot.tsx
+++ b/src/components/experiences/modern/login/Quotes/Forgot.tsx
@@ -1,5 +1,4 @@
 "use client";
-import React from "react";
 import { Box, Typography } from "@mui/joy";
 
 export default function ForgotQuotes() {

--- a/src/components/experiences/modern/login/Quotes/Welcome.tsx
+++ b/src/components/experiences/modern/login/Quotes/Welcome.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Typography } from "@mui/joy";
 
 const greetingsAndArtists: [string, string, string][] = [

--- a/src/components/experiences/modern/settings/SettingsInput.test.tsx
+++ b/src/components/experiences/modern/settings/SettingsInput.test.tsx
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import SettingsInput from "./SettingsInput";
 import { authenticationSlice } from "@/lib/features/authentication/frontend";
-import React from "react";
+import type { ReactNode } from "react";
 
 function createTestStore() {
   return configureStore({
@@ -16,7 +16,7 @@ function createTestStore() {
 
 function createWrapper() {
   const store = createTestStore();
-  return { Wrapper: function Wrapper({ children }: { children: React.ReactNode }) {
+  return { Wrapper: function Wrapper({ children }: { children: ReactNode }) {
     return <Provider store={store}>{children}</Provider>;
   }, store };
 }

--- a/src/components/shared/General/LinkButton.test.tsx
+++ b/src/components/shared/General/LinkButton.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { LinkButton, LinkIconButton, MenuLinkItem } from "./LinkButton";
 import { Menu } from "@mui/joy";
-import React from "react";
+import type { ReactNode } from "react";
 
 // Mock next/navigation
 const mockPush = vi.fn();
@@ -97,7 +97,7 @@ describe("LinkButton components", () => {
   });
 
   describe("MenuLinkItem", () => {
-    const MenuWrapper = ({ children }: { children: React.ReactNode }) => (
+    const MenuWrapper = ({ children }: { children: ReactNode }) => (
       <Menu open={true} anchorEl={document.createElement("div")}>
         {children}
       </Menu>

--- a/src/components/shared/Theme/ThemeSwitcher.tsx
+++ b/src/components/shared/Theme/ThemeSwitcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { IconButton, Tooltip } from "@mui/joy";
-import React from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
 
 import { useRouter } from "next/navigation";
 
@@ -30,7 +30,7 @@ export default function ThemeSwitcher() {
   const { mode } = useColorScheme();
   const { persistPreference } = useThemePreferenceActions();
 
-  const handleSwitch = async (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleSwitch = async (e: ReactMouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     const newExperience = experience === "classic" ? "modern" : "classic";
     const nextMode = mode === "light" || mode === "dark" ? mode : "light";

--- a/src/hooks/__tests__/useCatalogFlowsheetSearch.test.tsx
+++ b/src/hooks/__tests__/useCatalogFlowsheetSearch.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
-import React, { type PropsWithChildren } from "react";
+import type { PropsWithChildren, ReactElement } from "react";
 import { Provider } from "react-redux";
 import { CssVarsProvider } from "@mui/joy/styles";
 import { makeStore } from "@/lib/store";
@@ -60,7 +60,7 @@ function Wrapper({
   store,
 }: {
   store: ReturnType<typeof makeStore>;
-}): (props: PropsWithChildren) => React.ReactElement {
+}): (props: PropsWithChildren) => ReactElement {
   return function WrapperInner({ children }) {
     return (
       <Provider store={store}>

--- a/src/hooks/__tests__/useCatalogQueryResults.test.tsx
+++ b/src/hooks/__tests__/useCatalogQueryResults.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import React, { type PropsWithChildren } from "react";
+import type { PropsWithChildren, ReactElement } from "react";
 import { Provider } from "react-redux";
 import { CssVarsProvider } from "@mui/joy/styles";
 import { makeStore } from "@/lib/store";
@@ -58,7 +58,7 @@ function Wrapper({
   store,
 }: {
   store: ReturnType<typeof makeStore>;
-}): (props: PropsWithChildren) => React.ReactElement {
+}): (props: PropsWithChildren) => ReactElement {
   return ({ children }) => (
     <Provider store={store}>
       <CssVarsProvider>{children}</CssVarsProvider>

--- a/src/hooks/adminHooks.test.ts
+++ b/src/hooks/adminHooks.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
-import React from "react";
+import { createElement, type ReactNode } from "react";
 import { Provider } from "react-redux";
 import { makeStore, AppStore } from "@/lib/store";
 import { MOCK_USERS } from "@/lib/test-utils/fixtures";
@@ -79,8 +79,8 @@ function createWrapper(store?: AppStore) {
   const s = store ?? makeStore();
   return {
     store: s,
-    wrapper: ({ children }: { children: React.ReactNode }) =>
-      React.createElement(Provider, { store: s, children }),
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(Provider, { store: s, children }),
   };
 }
 

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import React from "react";
+import { createElement, type ReactNode } from "react";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import { authenticationSlice } from "@/lib/features/authentication/frontend";
@@ -73,8 +73,8 @@ function createTestStore() {
 
 function createWrapper() {
   const store = createTestStore();
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(Provider, { store, children });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(Provider, { store, children });
   };
 }
 

--- a/src/hooks/flowsheetHooks.test.tsx
+++ b/src/hooks/flowsheetHooks.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type { FormEvent } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import {
@@ -1044,7 +1044,7 @@ describe("flowsheetHooks", () => {
       });
 
       act(() => {
-        result.current.handleSubmit({ preventDefault: vi.fn() } as unknown as React.FormEvent);
+        result.current.handleSubmit({ preventDefault: vi.fn() } as unknown as FormEvent);
       });
 
       expect(mockAddToFlowsheet).toHaveBeenCalled();
@@ -1078,7 +1078,7 @@ describe("flowsheetHooks", () => {
 
       // Call handleSubmit while ctrl is pressed
       act(() => {
-        result.current.handleSubmit({ preventDefault: vi.fn() } as unknown as React.FormEvent);
+        result.current.handleSubmit({ preventDefault: vi.fn() } as unknown as FormEvent);
       });
 
       // addToQueue should have been called instead of addToFlowsheet
@@ -1130,7 +1130,7 @@ describe("flowsheetHooks", () => {
       act(() => {
         result.current.handleSubmit({
           preventDefault: vi.fn(),
-        } as unknown as React.FormEvent);
+        } as unknown as FormEvent);
       });
 
       expect(mockAddToFlowsheet).not.toHaveBeenCalled();
@@ -1374,7 +1374,7 @@ describe("flowsheetHooks", () => {
         await act(async () => {
           await result.current.handleSubmit({
             preventDefault: vi.fn(),
-          } as unknown as React.FormEvent);
+          } as unknown as FormEvent);
         });
 
         expect(mockAddToFlowsheet).not.toHaveBeenCalled();
@@ -1396,7 +1396,7 @@ describe("flowsheetHooks", () => {
         await act(async () => {
           await result.current.handleSubmit({
             preventDefault: vi.fn(),
-          } as unknown as React.FormEvent);
+          } as unknown as FormEvent);
         });
 
         expect(mockAddToFlowsheet).not.toHaveBeenCalled();
@@ -1416,7 +1416,7 @@ describe("flowsheetHooks", () => {
         await act(async () => {
           await result.current.handleSubmit({
             preventDefault: vi.fn(),
-          } as unknown as React.FormEvent);
+          } as unknown as FormEvent);
         });
 
         expect(mockAddToFlowsheet).toHaveBeenCalledTimes(1);

--- a/src/hooks/lml/useLmlLibrarySearch.test.ts
+++ b/src/hooks/lml/useLmlLibrarySearch.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { http, HttpResponse } from "msw";
-import React from "react";
+import { createElement, type ReactNode } from "react";
 import {
   server,
   createTestLmlLibraryItem,
@@ -20,8 +20,8 @@ vi.mock("@/lib/features/authentication/client", () => ({
 const PROXY_SEARCH_URL = `${TEST_BACKEND_URL}/proxy/library/search`;
 
 function withStore(store: AppStore = createTestStore()) {
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(Provider, { store, children });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(Provider, { store, children });
   };
 }
 

--- a/src/hooks/playlistSearchHooks.test.ts
+++ b/src/hooks/playlistSearchHooks.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
-import React from "react";
+import { createElement, type ReactNode } from "react";
 import { Provider } from "react-redux";
 import { makeStore, AppStore } from "@/lib/store";
 import { playlistSearchSlice } from "@/lib/features/playlist-search/frontend";
@@ -33,8 +33,8 @@ function createWrapper(store?: AppStore) {
   const s = store ?? makeStore();
   return {
     store: s,
-    wrapper: ({ children }: { children: React.ReactNode }) =>
-      React.createElement(Provider, { store: s, children }),
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(Provider, { store: s, children }),
   };
 }
 

--- a/src/hooks/useSSEConnection.test.tsx
+++ b/src/hooks/useSSEConnection.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
-import React from "react";
+import { createElement, type ReactNode } from "react";
 import { Provider } from "react-redux";
 import {
   liveUpdatesConnectionRequested,
@@ -19,8 +19,8 @@ function makeWrapper() {
     return realDispatch(action);
   }) as typeof store.dispatch;
 
-  function Wrapper({ children }: { children: React.ReactNode }) {
-    return React.createElement(Provider, { store, children });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(Provider, { store, children });
   }
   return { store, dispatched, Wrapper };
 }

--- a/src/styles/ThemeRegistry.tsx
+++ b/src/styles/ThemeRegistry.tsx
@@ -5,7 +5,7 @@ import { GlobalStyles } from "@mui/joy";
 import CssBaseline from "@mui/joy/CssBaseline";
 import { CssVarsProvider } from "@mui/joy/styles";
 import { useServerInsertedHTML } from "next/navigation";
-import React from "react";
+import { useState, type PropsWithChildren } from "react";
 import { useActiveExperience } from "@/lib/features/experiences/hooks";
 import { useThemePreferenceSync } from "@/src/hooks/themePreferenceHooks";
 import modernTheme from "@/lib/features/experiences/modern/theme";
@@ -14,11 +14,11 @@ import classicTheme from "@/lib/features/experiences/classic/theme";
 // This implementation is from emotion-js
 // https://github.com/emotion-js/emotion/issues/2928#issuecomment-1319747902
 export default function ThemeRegistry(
-  props: React.PropsWithChildren<{ options?: any }>
+  props: PropsWithChildren<{ options?: any }>
 ) {
   const { options, children } = props;
 
-  const [{ cache, flush }] = React.useState(() => {
+  const [{ cache, flush }] = useState(() => {
     const cache = createCache(options);
     cache.compat = true;
     const prevInsert = cache.insert;

--- a/src/widgets/NowPlaying/Main.test.tsx
+++ b/src/widgets/NowPlaying/Main.test.tsx
@@ -6,7 +6,7 @@ import type {
   FlowsheetShowBlockEntry,
   FlowsheetMessageEntry,
 } from "@/lib/features/flowsheet/types";
-import React from "react";
+import type { MutableRefObject, RefObject } from "react";
 
 // Mock child components
 vi.mock("./AlbumArtAndIcons", () => ({
@@ -125,12 +125,12 @@ import NowPlayingMain from "./Main";
 function createDefaultProps(overrides: Record<string, any> = {}) {
   return {
     live: false as boolean,
-    audioRef: { current: null } as React.RefObject<HTMLAudioElement | null>,
+    audioRef: { current: null } as RefObject<HTMLAudioElement | null>,
     isPlaying: false,
     onTogglePlay: vi.fn(),
     audioContext: null as AudioContext | null,
     analyserNode: null as AnalyserNode | null,
-    animationFrameRef: { current: null } as React.MutableRefObject<number | null>,
+    animationFrameRef: { current: null } as MutableRefObject<number | null>,
     ...overrides,
   };
 }

--- a/src/widgets/NowPlaying/Mini.test.tsx
+++ b/src/widgets/NowPlaying/Mini.test.tsx
@@ -7,7 +7,7 @@ import type {
   FlowsheetMessageEntry,
   OnAirDJResponse,
 } from "@/lib/features/flowsheet/types";
-import React from "react";
+import type { MutableRefObject, RefObject } from "react";
 
 // Mock child components
 vi.mock("./AlbumArtAndIcons", () => ({
@@ -101,12 +101,12 @@ import NowPlayingMini from "./Mini";
 function createDefaultProps(overrides: Record<string, any> = {}) {
   return {
     live: false as boolean,
-    audioRef: { current: null } as React.RefObject<HTMLAudioElement | null>,
+    audioRef: { current: null } as RefObject<HTMLAudioElement | null>,
     isPlaying: false,
     onTogglePlay: vi.fn(),
     audioContext: null as AudioContext | null,
     analyserNode: null as AnalyserNode | null,
-    animationFrameRef: { current: null } as React.MutableRefObject<number | null>,
+    animationFrameRef: { current: null } as MutableRefObject<number | null>,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Follow-up to #714. React 19 + Next 16's automatic JSX runtime mean `import React from "react"` is no longer needed for JSX. Across 27 files: drops the import where unused, converts type-only references to `import type { ... }`, and converts value references (`createElement` / `useState` / `Fragment`) to named imports.

No behavior changes. `MutableRefObject` left as-is (deprecated but still works in React 19) for a separate PR.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 221 files / 3217 tests pass
- [x] `npm run build` (Next.js 16) compiles
- [ ] CI green

Closes #732