### PR TITLE
ci: replace workflow paths: filters with per-job if: guards

### DIFF
--- a/.github/workflows/charset-corpus-drift.yml
+++ b/.github/workflows/charset-corpus-drift.yml
@@ -4,9 +4,6 @@ name: Charset Corpus Drift
 
 on:
   pull_request:
-    paths:
-      - "tests/fixtures/charset-torture.json.sha256"
-      - ".github/workflows/charset-corpus-drift.yml"
   push:
     branches: [main]
   schedule:
@@ -20,7 +17,30 @@ permissions:
   packages: read
 
 jobs:
+  # See ci.yml for the rationale on the changes-job pattern (issue #731).
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      corpus: ${{ steps.filter.outputs.corpus }}
+    steps:
+      - name: Checkout
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+
+      - name: Filter
+        if: github.event_name == 'pull_request'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            corpus:
+              - 'tests/fixtures/charset-torture.json.sha256'
+              - '.github/workflows/charset-corpus-drift.yml'
+
   drift:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.corpus == 'true'
     uses: WXYC/wxyc-shared/.github/workflows/check-charset-corpus-drift.yml@gha/v1
     with:
       pinned-sha256: 75a3395bb10894480dba95bf5b7f379f5056645098d6a1bf9e94416709e5214a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - 'app/**'
-      - 'src/**'
-      - 'lib/**'
-      - 'tests/**'
-      - 'public/**'
-      - '*.ts'
-      - '*.tsx'
-      - '*.mts'
-      - '*.json'
-      - '*.config.*'
-      - '.github/workflows/ci.yml'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -38,8 +26,44 @@ permissions:
   contents: read
 
 jobs:
+  # Compute which path categories changed in this PR. Downstream jobs read
+  # outputs from here so their `if:` guard can short-circuit before doing
+  # any setup work, while still posting a (skipped) check status. This is
+  # what lets branch protection require Type Check / Build / Unit Tests
+  # without locking out workflow-only or docs-only PRs (see #731).
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      app_source: ${{ steps.filter.outputs.app_source }}
+    steps:
+      - name: Checkout
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+
+      - name: Filter
+        if: github.event_name == 'pull_request'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            app_source:
+              - 'app/**'
+              - 'src/**'
+              - 'lib/**'
+              - 'tests/**'
+              - 'public/**'
+              - '*.ts'
+              - '*.tsx'
+              - '*.mts'
+              - '*.json'
+              - '*.config.*'
+              - '.github/workflows/ci.yml'
+
   typecheck:
     name: Type Check
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.app_source == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -61,6 +85,8 @@ jobs:
 
   test:
     name: Unit Tests (${{ matrix.shard }})
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.app_source == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -94,6 +120,8 @@ jobs:
 
   build:
     name: Build
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.app_source == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,18 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - 'app/**'
-      - 'src/**'
-      - 'lib/features/**'
-      - 'lib/store.ts'
-      - 'lib/hooks.ts'
-      - 'e2e/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'next.config.*'
-      - 'playwright.config.*'
-      - '.github/workflows/e2e-tests.yml'
   workflow_dispatch:
     inputs:
       backend_ref:
@@ -68,8 +56,40 @@ permissions:
   contents: read
 
 jobs:
+  # See ci.yml for the rationale on the changes-job pattern (issue #731).
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      app_source: ${{ steps.filter.outputs.app_source }}
+    steps:
+      - name: Checkout
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+
+      - name: Filter
+        if: github.event_name == 'pull_request'
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            app_source:
+              - 'app/**'
+              - 'src/**'
+              - 'lib/features/**'
+              - 'lib/store.ts'
+              - 'lib/hooks.ts'
+              - 'e2e/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'next.config.*'
+              - 'playwright.config.*'
+              - '.github/workflows/e2e-tests.yml'
+
   e2e:
     name: E2E Tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.app_source == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -362,6 +382,11 @@ jobs:
   # shard jobs are named "E2E Tests (shard N/M)" — that name shifts if we ever
   # change the shard count. This aggregator stays "E2E Tests" so the required-
   # status-check rule doesn't need touching.
+  #
+  # `skipped` is treated as success because the e2e matrix is gated by the
+  # `changes` job's path filter (issue #731). On a PR that doesn't touch app
+  # source, the matrix skips and we should pass — not fail — so workflow-only
+  # PRs can satisfy the required check.
   e2e-all:
     name: E2E Tests
     needs: e2e
@@ -370,8 +395,12 @@ jobs:
     steps:
       - name: Verify all shards passed
         run: |
-          if [ "${{ needs.e2e.result }}" != "success" ]; then
-            echo "One or more E2E shards failed: ${{ needs.e2e.result }}"
-            exit 1
-          fi
-          echo "All E2E shards passed"
+          case "${{ needs.e2e.result }}" in
+            success|skipped)
+              echo "E2E matrix result: ${{ needs.e2e.result }}"
+              ;;
+            *)
+              echo "One or more E2E shards failed: ${{ needs.e2e.result }}"
+              exit 1
+              ;;
+          esac

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -7,11 +7,11 @@ Runs on push to `main` (full suite) and on PRs (scoped to changed code):
 2. **Unit Tests** -- On PRs, uses `vitest --changed origin/main` to only run tests affected by the diff. On `main` pushes, runs all tests.
 3. **Build** -- `npm run build`
 
-PRs that only change non-code files (docs, scripts, etc.) skip CI entirely via path filters.
+PRs that only change non-code files (docs, scripts, etc.) skip the actual work via per-job `if:` guards but **still post a (skipped) check status**. A leading `changes` job runs `dorny/paths-filter@v3` against the PR diff and exposes an `app_source` boolean output; downstream jobs declare `needs: changes` plus `if: github.event_name != 'pull_request' || needs.changes.outputs.app_source == 'true'`. This lets branch protection require Type Check / Build / Unit Tests on every PR without locking out workflow-only or docs-only PRs — skipped jobs count as success for required status checks. See issue #731 for the migration rationale.
 
 ## E2E (`.github/workflows/e2e-tests.yml`)
 
-Runs on push to `main` and on PRs that touch app code. Spins up Backend-Service with Docker Compose (PostgreSQL + auth + backend), builds dj-site, runs Playwright tests. PRs that only change unit tests, test utilities, or non-app config skip E2E via path filters. The workflow caches the dj-site `.next/` build output and Playwright browser binaries to reduce setup time. On cache hit, both the Next.js build and Playwright install are skipped entirely. Cache keys include `package-lock.json`, `next.config.*`, and app source files, so dependency or source changes invalidate the cache correctly.
+Runs on push to `main` and on PRs that touch app code. Spins up Backend-Service with Docker Compose (PostgreSQL + auth + backend), builds dj-site, runs Playwright tests. Same `changes` + `if:` pattern as CI: PRs that only change unit tests, test utilities, or non-app config skip the matrix but the `E2E Tests` umbrella check still posts (treating `skipped` as success). The workflow caches the dj-site `.next/` build output and Playwright browser binaries to reduce setup time. On cache hit, both the Next.js build and Playwright install are skipped entirely. Cache keys include `package-lock.json`, `next.config.*`, and app source files, so dependency or source changes invalidate the cache correctly.
 
 ### E2E-only dependencies
 


### PR DESCRIPTION
## Summary

- Each workflow (`ci.yml`, `e2e-tests.yml`, `charset-corpus-drift.yml`) gets a leading `changes` job that runs [`dorny/paths-filter@v3`](https://github.com/dorny/paths-filter) against the PR diff and exposes a boolean output. Downstream jobs declare `needs: changes` plus `if: github.event_name != 'pull_request' || needs.changes.outputs.<filter> == 'true'`.
- Every PR — including workflow-only and docs-only PRs — now posts a (skipped) check status for `Type Check`, `Build`, `Unit Tests (1/3 .. 3/3)`, `E2E Tests`, and `E2E Tests (shard 1/4 .. 4/4)`. Skipped status counts as success for required status checks, so branch protection can require all of them without locking workflow-only PRs out.
- The `E2E Tests` umbrella check now treats `skipped` as success (case-statement matching `success|skipped`), since the matrix below it is the thing being gated.
- `docs/ci-cd.md` updated to describe the new pattern.

## How it satisfies the issue acceptance

- [x] Every PR (regardless of touched paths) will produce statuses for `Type Check`, `Build`, `Unit Tests (1/3)`, `Unit Tests (2/3)`, `Unit Tests (3/3)`, `E2E Tests`, `E2E Tests (shard 1/4)` through `(shard 4/4)`. Skipped jobs count as success.
- [x] Workflow-only / docs-only PRs short-circuit: the `changes` job runs `dorny/paths-filter@v3` (~10s), downstream jobs are skipped without doing `npm ci` or Playwright bootstrap.
- [x] Branch-protection update (Type Check / Build / Unit Tests / E2E Tests + shards) will land as a follow-up after this PR merges, since the new check names need to be observed on `main` before they can be required.
- [x] `Charset Corpus Drift` gets the same treatment.

## Test plan

- [ ] CI on this PR posts statuses for `Type Check`, `Build`, `Unit Tests (1/3 .. 3/3)`, `E2E Tests`, `E2E Tests (shard 1/4 .. 4/4)` — all green (this PR touches workflows, which are in the `app_source` filter via `'.github/workflows/ci.yml'` / `'.github/workflows/e2e-tests.yml'`).
- [ ] After merge, open a workflow-only follow-up PR (e.g. adding a comment to `cloudflare-deploy-status.yml`) and confirm the same check names post as `skipped` and are treated as success by branch protection.
- [ ] After both observations, update branch-protection's required-status-checks to include the new entries.

Closes #731.