### PR TITLE
chore: bump @wxyc/shared to 1.11.0 and drop JoinShowParams shim

### DIFF
--- a/lib/features/authentication/types.ts
+++ b/lib/features/authentication/types.ts
@@ -148,20 +148,6 @@ export type DJRequestParams = {
   dj_id: string; // User ID from better-auth (string)
 };
 
-// Local field shim: BS#1320 (closes BS#1295) added `dj_name_override` to
-// POST /flowsheet/join. The shared OpenAPI contract in @wxyc/shared/api.yaml
-// has not been updated yet — remove this type and switch the joinShow
-// mutation back to DJRequestParams once @wxyc/shared publishes the field.
-export type JoinShowParams = DJRequestParams & {
-  /**
-   * Optional per-show override for the DJ's public handle. When present and
-   * non-empty, the backend uses this value (instead of `auth_user.dj_name`)
-   * for the show_start marker text + `flowsheet.dj_name` column +
-   * `shows.legacy_dj_name` column. Co-host /join ignores it.
-   */
-  dj_name_override?: string;
-};
-
 export type DJInfoResponse = {
   id: number;
   add_date: string;

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -1,5 +1,5 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
-import { DJRequestParams, JoinShowParams } from "../authentication/types";
+import { DJRequestParams } from "../authentication/types";
 import { backendBaseQuery } from "../backend";
 import {
   FLOWSHEET_OPTIMISTIC_DJ_PLACEHOLDER,
@@ -101,7 +101,10 @@ export const flowsheetApi = createApi({
         }
       },
     }),
-    joinShow: builder.mutation<void, JoinShowParams>({
+    joinShow: builder.mutation<
+      void,
+      DJRequestParams & { dj_name_override?: string }
+    >({
       query: (params) => ({
         url: "/join",
         method: "POST",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@opennextjs/cloudflare": "^1.10.1",
         "@reduxjs/toolkit": "^2.2.0",
         "@uidotdev/usehooks": "^2.4.1",
-        "@wxyc/shared": "^1.4.0",
+        "@wxyc/shared": "^1.11.0",
         "better-auth": "^1.6.13",
         "cookie": "^1.0.2",
         "jose": "^6.2.3",
@@ -13929,7 +13929,6 @@
       "version": "19.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
       "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -13953,12 +13952,6 @@
       "peerDependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
-      "license": "MIT"
     },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.10",
@@ -14198,9 +14191,9 @@
       "license": "MIT"
     },
     "node_modules/@wxyc/shared": {
-      "version": "1.4.1",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.4.1/2f1084d423fa6b9e0487034bd09d6a5e0ede1cbb",
-      "integrity": "sha512-ojzbSVtjSy1HQykHGP/3OhaBG5KxAYKMh043W4YJkd/NNQKQQLT1bvkTP6sqzzURhLk02L5kwfYg5PDg8DPCJA==",
+      "version": "1.11.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.11.0/62bf03b80ede011aef90772eeb328bd954cbe83b",
+      "integrity": "sha512-vcr9ZG1KiZAFYEtjfT18mp5TdxVsPFczhuTQiNF1DRnRlEeCKiJUlRykTknfO22nyYsOr8QzT8AWTFmQk3uu4w==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@opennextjs/cloudflare": "^1.10.1",
     "@reduxjs/toolkit": "^2.2.0",
     "@uidotdev/usehooks": "^2.4.1",
-    "@wxyc/shared": "^1.4.0",
+    "@wxyc/shared": "^1.11.0",
     "better-auth": "^1.6.13",
     "cookie": "^1.0.2",
     "jose": "^6.2.3",


### PR DESCRIPTION
Closes #736.

## Summary

- Bump `@wxyc/shared` from `^1.4.0` (resolved 1.4.1) to `^1.11.0`.
- Delete the `JoinShowParams` shim + TODO in `lib/features/authentication/types.ts`. The shim was introduced in #705 (commit 146b7809, closes #694) to widen the `POST /flowsheet/join` request body with `dj_name_override?: string` while waiting for the shared OpenAPI contract to publish the field. `@wxyc/shared` 1.11.0 (release PR WXYC/wxyc-shared#163) ships the contract update from BS#1320 (closes BS#1295), so the shim is now type debt.
- Switch the `joinShow` mutation in `lib/features/flowsheet/api.ts` to `DJRequestParams & { dj_name_override?: string }` inline. The shared package does not export a named DTO for this body — the schema is inline on the path in `api.yaml` and is not lifted into `components.schemas` — so the type stays inline rather than imported.

Parent epic: BS#1288.

## What did not change

The wire shape and runtime behavior. The shim was already letting `dj_name_override` flow through correctly: `goLive(djNameOverride?: string)` in `src/hooks/flowsheetHooks.ts` builds the payload inline and only includes `dj_name_override` when the caller passed a value.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` clean (3217/3217).
- [x] `git grep JoinShowParams` — no hits.
- [ ] CI green.