### PR TITLE
ci(smoke): hard-fail same-repo PRs missing secrets; soft-skip only real forks

### DIFF
--- a/.github/workflows/pr-preview-smoke.yml
+++ b/.github/workflows/pr-preview-smoke.yml
@@ -34,13 +34,31 @@ jobs:
     steps:
       - name: Check required configuration
         id: config
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          HAS_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
+          HAS_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID != '' }}
         run: |
-          if [ -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ] || [ -z "${{ vars.CLOUDFLARE_ACCOUNT_ID }}" ]; then
-            echo "::warning::Skipping preview smoke — CLOUDFLARE_API_TOKEN secret and/or CLOUDFLARE_ACCOUNT_ID variable not configured (expected for forks)."
+          # Real forks can never access repo secrets — soft-skip those so we
+          # don't block external contributors on infra they don't own. For
+          # same-repo PRs (including Dependabot, which runs from a same-repo
+          # branch but in its own secret context), missing secrets must hard
+          # fail so the silent-pass path that masked the 2026-06-04 outage
+          # (issue #740) can't recur. Dependabot secrets live separately under
+          # Settings → Secrets and variables → Dependabot.
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::warning::Skipping preview smoke — PR head is in fork ${HEAD_REPO}, which cannot access repo secrets."
             echo "configured=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "configured=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          if [ "$HAS_TOKEN" != "true" ] || [ "$HAS_ACCOUNT_ID" != "true" ]; then
+            echo "::error::Same-repo PR but CLOUDFLARE_API_TOKEN secret and/or CLOUDFLARE_ACCOUNT_ID variable is missing in this workflow's secret context. For Dependabot PRs, add CLOUDFLARE_API_TOKEN under Settings → Secrets and variables → Dependabot (separate from Actions). See issue #740."
+            exit 1
+          fi
+
+          echo "configured=true" >> "$GITHUB_OUTPUT"
 
       - name: Wait for Cloudflare Pages preview deployment
         id: wait


### PR DESCRIPTION
## Summary

- Replace the `[ -z \"$TOKEN\" ]` soft-skip in `pr-preview-smoke.yml` with an explicit fork detection (`github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name`).
- On real forks, keep the soft-skip behaviour (forks can't access secrets, no point blocking them).
- On same-repo PRs (including Dependabot, whose branches live in the same repo but run in a separate secret context), hard-fail with an error message that points at **Settings → Secrets and variables → Dependabot** as the remediation.

This is fix (B) from #740. Fix (A) — adding `CLOUDFLARE_API_TOKEN` to the Dependabot secret context — is a repo-settings change that must be done separately; without it, this PR will hard-fail Dependabot PRs (which is the correct signal, since the silent-pass alternative is what caused the 2026-06-04 outage).

## Test plan

- [x] `actionlint .github/workflows/pr-preview-smoke.yml` passes locally
- [ ] CI green on this PR (a same-repo non-Dependabot PR — should run the full smoke check against the preview URL and pass)
- [ ] Once (A) is in place, the next Dependabot PR exercises the full smoke path (`Secret source: Dependabot` + non-empty token + actual probe). Until (A) is in place, Dependabot PRs will be blocked by this check with a clear actionable error — which is the intended behaviour.

Closes #740.