### PR TITLE
fix(flowsheet): truncate rotation dropdown text instead of pushing submit off-screen

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
@@ -182,6 +182,7 @@ export default function FlowsheetSearchbar() {
               justifyContent: "space-between",
               flexDirection: "row",
               flexGrow: 1,
+              minWidth: 0,
               zIndex: 8001,
               background: "transparent",
               outline: "1px solid",

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
@@ -78,7 +78,7 @@ export default function RotationReleaseDropdown({
   return (
     <ClickAwayListener onClickAway={() => setOpen(false)}>
       <Box
-        sx={{ position: "relative", flex: 1, display: "flex", alignItems: "center" }}
+        sx={{ position: "relative", flex: 1, minWidth: 0, display: "flex", alignItems: "center" }}
         onKeyDown={handleKeyDown}
       >
         <Box

--- a/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
@@ -102,7 +102,7 @@ export default function TrackPickerDropdown<T extends TrackPickerEntry>({
   return (
     <ClickAwayListener onClickAway={() => setOpen(false)}>
       <Box
-        sx={{ position: "relative", flex: 1, display: "flex", alignItems: "center" }}
+        sx={{ position: "relative", flex: 1, minWidth: 0, display: "flex", alignItems: "center" }}
         onKeyDown={handleKeyDown}
       >
         <Box


### PR DESCRIPTION
Closes #742.

## Summary

- When a long release or track title is selected in the flowsheet's rotation-entry mode, the row expands past the form container and pushes the submit (add-to-flowsheet) button off the right edge of the viewport.
- Root cause: the release/track dropdown wrappers and the form Box all use `flex: 1` / `flexGrow: 1` but inherit `min-width: auto`, so the existing `whiteSpace: nowrap` + `textOverflow: ellipsis` on the inner `Typography` never gets to truncate.
- Fix: add `minWidth: 0` at three points in the flex chain — the form Box (`FlowsheetSearchbar`), the outer wrapper of `RotationReleaseDropdown`, and the outer wrapper of `TrackPickerDropdown`. No behavior change beyond the long-text rows now truncating instead of overflowing.

## Test plan

- [x] `vitest run src/components/experiences/modern/flowsheet/Search/` — 162 tests pass
- [x] `tsc --noEmit` clean
- [x] Manual: ran the local dev environment, switched to rotation mode, selected the V/A "Junkshop Synth Pop 1978-1985" release and an "A1 Dreams (Shiva's Clubcut)" track — submit button stays on-screen, dropdown text truncates with ellipsis