### PR TITLE
ci(staging-gate): CF Pages preview-deploy gate between main and prod

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# actionlint config for dj-site workflows.
+#
+# self-hosted-runner.labels lists custom labels we register on org-level
+# self-hosted runners. Without this, actionlint flags `runs-on:
+# [self-hosted, e2e-runner]` as an unknown label (used by
+# .github/workflows/staging-gate.yml).
+self-hosted-runner:
+  labels:
+    - e2e-runner

--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -1,0 +1,281 @@
+name: staging-gate
+
+# Staging gate for dj-site CF Pages promotion. Runs on every merge to
+# `main`: waits for the CF Pages preview build, probes the preview URL
+# for runtime health, and on pass fast-forwards `prod` to the merged
+# SHA. CF Pages's existing prod deploy (configured to watch `prod`)
+# fires from `push: prod`.
+#
+# Helpers live alongside this workflow at scripts/staging-gate/ (not
+# scripts/) so the gate's blast radius is obvious from one directory
+# listing. Each helper has bats tests in scripts/__tests__/staging-gate/.
+#
+# Design notes:
+#   - CF Pages does NOT emit `repository_dispatch` on preview deploy
+#     success, so we poll the CF API in wait-for-cf-preview.sh rather
+#     than wait for a dispatch (the bs-lml-gate pattern).
+#   - concurrency.cancel-in-progress is false because a cancelled
+#     mid-push would leave the prod ref in an indeterminate state.
+#   - The prod push uses a repo-scoped fine-grained PAT (PROD_PUSH_PAT),
+#     not GITHUB_TOKEN, so the audit log shows the promoter bot and so
+#     the workflow's own GITHUB_TOKEN can stay at contents:read.
+#   - No canary suite here — BS+LML health is already gated by
+#     bs-lml-gate (per BS/LML staging deploy) and the wxyc-canary Lambda
+#     (every 5 min). Adding a third probe on every dj-site main push
+#     would be redundant. The preview-URL probe IS the runtime smoke.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      skip_gate:
+        description: 'Bypass CF preview wait + URL probe (still posts audit comment).'
+        type: boolean
+        default: false
+      justification:
+        # `required: true` would force a justification on every
+        # workflow_dispatch (including normal re-runs where it's
+        # ignored), so we keep this as `required: false` and let
+        # log-bypass.sh enforce non-emptiness when skip_gate=true.
+        description: 'Required when skip_gate=true; ignored otherwise. Audited (markdown is escaped).'
+        type: string
+        required: false
+      target_sha:
+        description: 'Override SHA to promote (defaults to the workflow ref HEAD). Must already be on main.'
+        type: string
+        required: false
+
+permissions:
+  contents: read
+  issues: write   # for the bypass audit comment
+
+concurrency:
+  group: dj-site-gate
+  cancel-in-progress: false
+
+env:
+  BYPASS_TRACKER_REPO: ${{ github.repository }}
+  # Set in the repo as a *variable* (not secret). Created once by the
+  # operator setup checklist in README — points at the long-lived pinned
+  # "gate bypasses" tracker issue.
+  BYPASS_TRACKER_ISSUE: ${{ vars.GATE_BYPASS_ISSUE_NUMBER }}
+
+jobs:
+  gate:
+    runs-on: [self-hosted, e2e-runner]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout dj-site (for helper scripts)
+        uses: actions/checkout@v6
+        with:
+          # Only need the helpers; fetch-depth: 1 keeps the runner clean.
+          fetch-depth: 1
+
+      - name: Resolve target_sha + current prod SHA
+        id: shas
+        # Both values pass through env to avoid shell-quoting hazards if
+        # github.event.after or inputs.target_sha ever contains exotic
+        # bytes (push:main can never inject — GitHub validates SHAs —
+        # but inputs.target_sha is operator-controlled).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TARGET_SHA: ${{ inputs.target_sha }}
+          EVENT_AFTER: ${{ github.event.after }}
+          DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          target="${INPUT_TARGET_SHA:-${EVENT_AFTER:-$DEFAULT_SHA}}"
+          if ! [[ "$target" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::target_sha is not a 40-char hex SHA: '$target'"
+            exit 1
+          fi
+          echo "target_sha=$target" >>"$GITHUB_OUTPUT"
+
+          # Current prod ref; 404 means seed (no `prod` branch yet).
+          # `gh api` exits non-zero on 404, so route through `|| rc=$?`
+          # and grep stderr for the explicit 404 marker.
+          err_file=$(mktemp)
+          if body=$(gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/prod" 2>"$err_file"); then
+            prod=$(echo "$body" | jq -r '.object.sha')
+          elif grep -q 'HTTP 404' "$err_file"; then
+            prod=""
+          else
+            echo "::error::gh api failed unexpectedly:"
+            cat "$err_file" >&2
+            rm -f "$err_file"
+            exit 1
+          fi
+          rm -f "$err_file"
+          echo "prod_sha=$prod" >>"$GITHUB_OUTPUT"
+          echo "Target: $target"
+          echo "Prod:   ${prod:-<seed>}"
+
+      - name: Early-exit if prod already matches target (nothing to promote)
+        id: noop
+        env:
+          TARGET: ${{ steps.shas.outputs.target_sha }}
+          PROD: ${{ steps.shas.outputs.prod_sha }}
+        run: |
+          if [[ "$TARGET" == "$PROD" ]]; then
+            echo "noop=true" >>"$GITHUB_OUTPUT"
+            echo "prod already at $TARGET; nothing to do."
+          else
+            echo "noop=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for CF Pages preview deployment
+        id: cf
+        if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
+        env:
+          CF_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_PROJECT: wxyc-dj
+          TARGET_SHA: ${{ steps.shas.outputs.target_sha }}
+          # 10 min default already; explicit here so a future operator
+          # tuning the poll budget knows where to look.
+          POLL_TIMEOUT_SECS: '600'
+          POLL_INTERVAL_SECS: '10'
+        run: ./scripts/staging-gate/wait-for-cf-preview.sh
+
+      - name: Probe preview URL for runtime health
+        if: steps.noop.outputs.noop != 'true' && inputs.skip_gate != true
+        env:
+          # The URL came from wait-for-cf-preview's output; hoist through
+          # env even though CF-issued URLs are trustworthy, to keep the
+          # injection-defense pattern consistent across the workflow.
+          PREVIEW_URL: ${{ steps.cf.outputs.preview_url }}
+        run: |
+          set -uo pipefail
+          # The 2026-06-03 outage shipped a build that CF reported as
+          # `success` but whose worker 500'd on every request. Re-probe
+          # the live URL before promoting. 3 attempts × 5s = 15s budget
+          # absorbs the small window between CF's success-report and
+          # worker readiness without burning a full minute.
+          last=""
+          for attempt in 1 2 3; do
+            last="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "$PREVIEW_URL/" || echo 000)"
+            case "$last" in
+              # 401/403 are healthy for an unauthenticated curl against
+              # a route the worker auth-gates — matches the convention
+              # in cloudflare-deploy-status.yml.
+              2*|3*|401|403)
+                echo "Preview URL $PREVIEW_URL healthy ($last) on attempt $attempt"
+                exit 0
+                ;;
+              *)
+                echo "Attempt $attempt: $last (retrying in 5s)"
+                ;;
+            esac
+            sleep 5
+          done
+          echo "::error::Preview URL $PREVIEW_URL unhealthy after 3 attempts (last: $last)"
+          exit 1
+
+      # Bypass audit MUST run before any prod push. The push step below
+      # gates on `success() &&` (load-bearing — see below): if log-bypass
+      # exits non-zero, success() goes false and the push skips. The noop
+      # guard prevents misleading "promoted" audit entries when prod is
+      # already at target.
+      - name: Audit bypass to tracker issue (before any prod push)
+        id: audit
+        if: inputs.skip_gate == true && steps.noop.outputs.noop != 'true'
+        env:
+          BYPASS_REPO: ${{ env.BYPASS_TRACKER_REPO }}
+          BYPASS_ISSUE_NUMBER: ${{ env.BYPASS_TRACKER_ISSUE }}
+          BYPASS_ACTOR: ${{ github.actor }}
+          BYPASS_JUSTIFICATION: ${{ inputs.justification }}
+          BYPASS_DJ_SITE_SHA: ${{ steps.shas.outputs.target_sha }}
+          BYPASS_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/staging-gate/log-bypass.sh
+
+      # `success() &&` is explicit here (and load-bearing): it ensures
+      # that if ANY prior step failed — CF wait, URL probe, audit — the
+      # prod push is skipped. Do not remove without first replacing it
+      # with an equivalent guard, or the gate will silently bypass.
+      - name: Push dj-site prod
+        id: push
+        if: success() && steps.noop.outputs.noop != 'true'
+        env:
+          PUSH_REPO: ${{ github.repository }}
+          PUSH_TARGET_SHA: ${{ steps.shas.outputs.target_sha }}
+          PUSH_CURRENT_SHA: ${{ steps.shas.outputs.prod_sha }}
+          PUSH_PAT: ${{ secrets.PROD_PUSH_PAT }}
+        run: ./scripts/staging-gate/push-prod.sh
+
+      - name: Job summary
+        if: always()
+        env:
+          PUSH_OUTCOME: ${{ steps.push.outcome }}
+          # did_push is "true" when push-prod actually called the
+          # refs API, "false" when it short-circuited at
+          # target==current, and empty when the step didn't run.
+          DID_PUSH: ${{ steps.push.outputs.did_push }}
+          # Audit outcome distinguishes "audit ran and succeeded"
+          # (footer reference is valid) from "audit was skipped"
+          # (no comment posted — footer would lie).
+          AUDIT_OUTCOME: ${{ steps.audit.outcome }}
+          NOOP: ${{ steps.noop.outputs.noop }}
+          SKIP_GATE: ${{ inputs.skip_gate }}
+          TARGET: ${{ steps.shas.outputs.target_sha }}
+          PROD: ${{ steps.shas.outputs.prod_sha }}
+          PREVIEW_URL: ${{ steps.cf.outputs.preview_url }}
+        run: |
+          render_outcome() {
+            # $1 = step outcome (success|failure|skipped|cancelled|"")
+            # $2 = did_push output (true|false|"")
+            # $3 = "true" iff noop early-exit fired
+            case "$1" in
+              success)
+                if [[ "$2" == "false" ]]; then
+                  echo "unchanged (already at target)"
+                else
+                  echo "advanced"
+                fi
+                ;;
+              failure)   echo ":warning: **push failed**" ;;
+              skipped)
+                if [[ "$3" == "true" ]]; then
+                  echo "unchanged (prod already at target)"
+                else
+                  echo "skipped (prior step failed)"
+                fi
+                ;;
+              cancelled) echo ":octagonal_sign: cancelled mid-push" ;;
+              "")        echo "not reached" ;;
+              *)         echo "$1" ;;
+            esac
+          }
+          {
+            echo "## dj-site staging-gate run"
+            echo ""
+            echo "| Old prod | New prod | Preview | Outcome |"
+            echo "| --- | --- | --- | --- |"
+            preview_cell="${PREVIEW_URL:-n/a}"
+            echo "| \`${PROD:0:12}${PROD:+ }${PROD:-<seed>}\` | \`${TARGET:0:12}\` | ${preview_cell} | $(render_outcome "$PUSH_OUTCOME" "$DID_PUSH" "$NOOP") |"
+            echo ""
+            # Possible-split detection: emit_output is fail-loud in
+            # push-prod.sh, so a successful gh PATCH followed by a
+            # failed $GITHUB_OUTPUT write produces step
+            # outcome=failure with did_push="" — the ref may or may
+            # not have moved. We can't tell from the step output, so
+            # we flag and point at the runbook. Most push failures
+            # will be before the API call (so no split), but the
+            # runbook check is cheap.
+            if [[ ( "$PUSH_OUTCOME" == "failure" || "$PUSH_OUTCOME" == "cancelled" ) && "$DID_PUSH" != "true" ]]; then
+              echo ":warning: **Possible ambiguous push outcome**: push step ended in \`$PUSH_OUTCOME\`; the API PATCH may have landed before the bad-state outcome. Check \`prod\` HEAD against \`${TARGET:0:12}\` directly via the GitHub API. If advanced, treat as a successful promotion and check CF Pages deploy status."
+              echo ""
+            fi
+            # Only print the bypass footer if the audit step actually
+            # ran and succeeded — otherwise it would point at a tracker
+            # comment that doesn't exist (e.g., noop + skip_gate=true
+            # skips the audit step, so no comment was posted).
+            if [[ "$SKIP_GATE" == "true" && "$AUDIT_OUTCOME" == "success" ]]; then
+              echo "**Bypass:** gate skipped per workflow_dispatch input. Justification logged at ${BYPASS_TRACKER_REPO}#${BYPASS_TRACKER_ISSUE}."
+            elif [[ "$SKIP_GATE" == "true" && "$NOOP" == "true" ]]; then
+              echo "**Bypass requested but suppressed:** prod already at target; nothing to promote. No audit comment posted."
+            elif [[ "$SKIP_GATE" == "true" ]]; then
+              echo "**Bypass requested but blocked:** audit step did not succeed (\`$AUDIT_OUTCOME\`); prod was not advanced."
+            fi
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,52 @@ The WXYC Card Catalog, Revised is a React-based revision of the original WXYC ca
 - Mail Bin: a digital mail bin is available on every account, so DJs can add to the flowsheet directly from their bin without having to type during their sets.
 
 ## Deployment
-Is handled by github actions.
+Production is on Cloudflare Pages (`wxyc-dj` project). The CF Pages project is configured to deploy from the `prod` branch; merges to `main` build a preview deploy first and are then promoted to `prod` by the staging-gate workflow (see below).
+
+## Staging gate (dj-site)
+The staging gate inserts a CF Pages preview-deploy + runtime-probe step between merge-to-`main` and the Cloudflare Pages production deploy. Lives at `.github/workflows/staging-gate.yml`, with helpers in `scripts/staging-gate/` and bats tests in `scripts/__tests__/staging-gate/`. Part of [WXYC/wiki#80](https://github.com/WXYC/wiki/issues/80); mirrors the BS+LML coordinator workflow at [WXYC/wxyc-shared/.github/workflows/bs-lml-gate.yml](https://github.com/WXYC/wxyc-shared/blob/main/.github/workflows/bs-lml-gate.yml).
+
+Flow per merge to `main`:
+
+```
+PR merged to main
+  -> CF Pages preview build for the main branch (existing, unchanged)
+  -> staging-gate polls Cloudflare API for the preview deploy
+  -> probes the preview URL for runtime health
+  -> on pass, fast-forwards the `prod` branch to <main-sha>
+  -> existing CF Pages prod deploy (configured to watch `prod`) fires
+```
+
+### Operator setup (one-shot)
+The workflow + scripts + tests ship in this repo, but the gate cannot promote until an operator completes these six steps. Failure to complete them is detected at runtime (missing repo vars / secrets cause the gate to surface a clear failure rather than silently bypass).
+
+1. **Seed the `prod` branch** at the current `main` HEAD: `gh api -X POST repos/WXYC/dj-site/git/refs -f ref=refs/heads/prod -f sha=<main-sha>` (or `git push origin <main-sha>:prod` from a clean local clone).
+2. **Flip CF Pages production branch** from `main` to `prod`. Path: Cloudflare dashboard → Workers & Pages → `wxyc-dj` → Settings → Builds & deployments → Production branch → change from `main` to `prod`. Leave the preview branch list set to include `main` (or `*` if it already is) so the gate has a preview to wait on.
+3. **Create the bypass tracker issue.** Open a long-lived "Gate bypasses" issue in this repo, label it appropriately, and pin it. Note the issue number.
+4. **Set repo variables.**
+   - `CLOUDFLARE_ACCOUNT_ID` — already set for the existing `cloudflare-deploy-status.yml` monitor; verify.
+   - `GATE_BYPASS_ISSUE_NUMBER` — integer from step 3.
+5. **Set repo secrets.**
+   - `CLOUDFLARE_API_TOKEN` — already set for the existing monitor; verify (needs `Account: Cloudflare Pages: Read` minimum).
+   - `PROD_PUSH_PAT` — new. Fine-grained PAT with `Contents: write` permission scoped to `refs/heads/prod` of `WXYC/dj-site` only (a per-ref PAT minimizes blast radius if it leaks).
+6. **Branch-protect `prod`.** Repository settings → Branches → add ruleset for `prod`: linear history, restrict push access to the `PROD_PUSH_PAT` identity (or whatever bot account holds the PAT). Operator pushes for rollback are still allowed because they use the same PAT (or a manual `gh api PATCH` from an authorized account).
+
+The in-flight bypass and rollback procedures live in [WXYC/wiki#81](https://github.com/WXYC/wiki/issues/81) (Phase 6 runbook).
+
+### Bypass
+Manual `workflow_dispatch` with `skip_gate=true` and a non-empty `justification` skips the CF wait + URL probe but still posts an audit comment to the tracker issue before advancing `prod`. If the audit POST fails, the workflow exits before pushing `prod` (no silent bypasses). The bypass path is intended for cases where the gate itself is broken (e.g., CF API outage) and an out-of-band verified SHA needs to ship.
+
+### Rollback
+Roll `prod` back to a prior SHA via the GitHub refs API; CF Pages picks up the change and rebuilds the prior version in ~2 min.
+
+```
+gh api -X PATCH repos/WXYC/dj-site/git/refs/heads/prod -f sha=<prior-sha> -F force=true
+```
+
+The `force=true` flag is required because the rollback target is an ancestor of the current `prod` HEAD; the API otherwise refuses non-fast-forward updates.
+
+### Tests
+Run `npm run test:staging-gate` to execute the bats suite for the helper scripts. The workflow YAML is checked by `actionlint` (see `.github/actionlint.yaml` for the custom `e2e-runner` self-hosted runner label).
 
 ## API Integration
 The revised catalog leverages services defined in `api-service.js`, which utilizes the popular Axios library to communicate with an AWS API Gateway. This integration allows seamless communication between the front-end application and the API endpoints, enabling data retrieval and manipulation.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ gh api -X PATCH repos/WXYC/dj-site/git/refs/heads/prod -f sha=<prior-sha> -F for
 The `force=true` flag is required because the rollback target is an ancestor of the current `prod` HEAD; the API otherwise refuses non-fast-forward updates.
 
 ### Tests
-Run `npm run test:staging-gate` to execute the bats suite for the helper scripts. The workflow YAML is checked by `actionlint` (see `.github/actionlint.yaml` for the custom `e2e-runner` self-hosted runner label).
+Run `npm run test:staging-gate` to execute the bats suite for the helper scripts. The workflow YAML is `actionlint`-clean against the config in `.github/actionlint.yaml` (which declares the custom `e2e-runner` self-hosted runner label so `runs-on: [self-hosted, e2e-runner]` doesn't trip the linter); run `actionlint .github/workflows/staging-gate.yml` locally before pushing changes to the workflow. Not currently wired into CI.
 
 ## API Integration
 The revised catalog leverages services defined in `api-service.js`, which utilizes the popular Axios library to communicate with an AWS API Gateway. This integration allows seamless communication between the front-end application and the API endpoints, enabling data retrieval and manipulation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dj-site-catalog-query-builder",
+  "name": "staging-gate",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -43,6 +43,7 @@
         "@vitejs/plugin-react": "^5.1.2",
         "@vitest/coverage-v8": "^4.1.7",
         "@vitest/ui": "^4.0.18",
+        "bats": "^1.11.0",
         "esbuild": "^0.28.0",
         "jsdom": "^29.1.1",
         "msw": "^2.14.6",
@@ -13929,7 +13930,6 @@
       "version": "19.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
       "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -13953,12 +13953,6 @@
       "peerDependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
-      "license": "MIT"
     },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.10",
@@ -14371,6 +14365,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bats": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.13.0.tgz",
+      "integrity": "sha512-giSYKGTOcPZyJDbfbTtzAedLcNWdjCLbXYU3/MwPnjyvDXzu6Dgw8d2M+8jHhZXSmsCMSQqCp+YBsJ603UO4vQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "bats": "bin/bats"
       }
     },
     "node_modules/better-auth": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "staging-gate",
+  "name": "dj-site-catalog-query-builder",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13930,6 +13930,7 @@
       "version": "19.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
       "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -13953,6 +13954,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
+      "license": "MIT"
     },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.10",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:e2e": "playwright test --config=e2e/playwright.config.ts",
     "test:e2e:ui": "playwright test --config=e2e/playwright.config.ts --ui",
     "test:e2e:headed": "playwright test --config=e2e/playwright.config.ts --headed",
-    "test:e2e:debug": "playwright test --config=e2e/playwright.config.ts --debug"
+    "test:e2e:debug": "playwright test --config=e2e/playwright.config.ts --debug",
+    "test:staging-gate": "bats scripts/__tests__/staging-gate/*.test.sh"
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.7.2",
@@ -61,6 +62,7 @@
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^4.1.7",
     "@vitest/ui": "^4.0.18",
+    "bats": "^1.11.0",
     "esbuild": "^0.28.0",
     "jsdom": "^29.1.1",
     "msw": "^2.14.6",

--- a/scripts/__tests__/staging-gate/log-bypass.test.sh
+++ b/scripts/__tests__/staging-gate/log-bypass.test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bats
+#
+# BATS tests for scripts/staging-gate/log-bypass.sh.
+#
+# Mirror of WXYC/wxyc-shared scripts/__tests__/bs-lml-gate/log-bypass.test.sh,
+# adapted for dj-site's single-SHA promotion (BYPASS_DJ_SITE_SHA in place
+# of BYPASS_BS_SHA + BYPASS_LML_SHA). Keep the shared invariants in sync.
+#
+# log-bypass.sh appends a comment to a long-lived "gate-bypasses"
+# tracker issue with who/when/justification/SHA. Called by the
+# workflow on the bypass path before any prod push. If the append
+# fails, log-bypass exits non-zero so the workflow bails out before
+# advancing prod — bypass-with-no-audit is forbidden.
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../staging-gate" && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/log-bypass.sh"
+
+setup() {
+    TEST_TEMP_DIR="$(mktemp -d)"
+    export FAKE_BIN="$TEST_TEMP_DIR/bin"
+    mkdir -p "$FAKE_BIN"
+    export PATH="$FAKE_BIN:$PATH"
+    export GH_CALL_LOG="$TEST_TEMP_DIR/gh-calls.log"
+    export GH_BODY_LOG="$TEST_TEMP_DIR/gh-body.log"
+    : >"$GH_CALL_LOG"
+    : >"$GH_BODY_LOG"
+
+    export BYPASS_REPO='WXYC/dj-site'
+    export BYPASS_ISSUE_NUMBER='42'
+    export BYPASS_ACTOR='jakebromberg'
+    export BYPASS_JUSTIFICATION='CF preview flake; verified preview URL serves 200 manually'
+    export BYPASS_DJ_SITE_SHA='a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9'
+    export BYPASS_RUN_URL='https://github.com/WXYC/dj-site/actions/runs/123456'
+    export BYPASS_WHEN='2026-06-05T22:00:00Z'
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+install_fake_gh_success() {
+    cat >"$FAKE_BIN/gh" <<GH_EOF
+#!/usr/bin/env bash
+# Mirror real \`gh api\` flag semantics: only -F (--field) treats
+# @<path> as a file reference; -f (--raw-field) sends it as a literal
+# string. Capturing both behaviors lets the test distinguish them so
+# a swap of -F → -f doesn't silently pass.
+printf '%s\n' "\$*" >>"$GH_CALL_LOG"
+prev=""
+for arg in "\$@"; do
+    if [[ "\$arg" == "body="* ]]; then
+        value="\${arg#body=}"
+        if [[ "\$value" == "@"* && ( "\$prev" == "-F" || "\$prev" == "--field" ) ]]; then
+            cat "\${value#@}" >>"\$GH_BODY_LOG"
+        else
+            printf '%s\n' "\$value" >>"\$GH_BODY_LOG"
+        fi
+    fi
+    prev="\$arg"
+done
+exit 0
+GH_EOF
+    chmod +x "$FAKE_BIN/gh"
+}
+
+install_fake_gh_failure() {
+    cat >"$FAKE_BIN/gh" <<GH_EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$GH_CALL_LOG"
+echo "fake gh: simulated failure" >&2
+exit 1
+GH_EOF
+    chmod +x "$FAKE_BIN/gh"
+}
+
+@test "posts a comment containing actor, justification, dj-site SHA, when, and run URL" {
+    install_fake_gh_success
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+
+    grep -q "POST" "$GH_CALL_LOG"
+    grep -q "repos/WXYC/dj-site/issues/42/comments" "$GH_CALL_LOG"
+
+    grep -q 'jakebromberg' "$GH_BODY_LOG"
+    grep -q 'CF preview flake' "$GH_BODY_LOG"
+    grep -q 'a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9' "$GH_BODY_LOG"
+    grep -q '2026-06-05T22:00:00Z' "$GH_BODY_LOG"
+    grep -q 'actions/runs/123456' "$GH_BODY_LOG"
+}
+
+@test "comment header says 'dj-site gate bypass' (not the bs-lml-gate template)" {
+    install_fake_gh_success
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -q 'dj-site gate bypass' "$GH_BODY_LOG"
+    # Regression guard: must NOT inherit the bs-lml-gate-flavored heading
+    # from a botched copy-paste.
+    ! grep -q 'Gate bypass —' "$GH_BODY_LOG" || \
+        grep -q 'dj-site gate bypass' "$GH_BODY_LOG"
+}
+
+@test "comment lists a single dj-site SHA bullet (not the dual BS+LML bullets)" {
+    install_fake_gh_success
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -q 'dj-site SHA promoted' "$GH_BODY_LOG"
+    # Regression guard: must NOT carry over bs-lml-gate's two bullets.
+    ! grep -q 'Backend-Service SHA promoted' "$GH_BODY_LOG"
+    ! grep -q 'library-metadata-lookup SHA promoted' "$GH_BODY_LOG"
+}
+
+@test "exits 1 when gh fails — workflow must abort before pushing prod" {
+    install_fake_gh_failure
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+}
+
+@test "exits 2 when justification is empty (defends invariant: no silent bypass)" {
+    install_fake_gh_success
+    export BYPASS_JUSTIFICATION=''
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [ ! -s "$GH_CALL_LOG" ]
+}
+
+@test "exits 2 when justification is whitespace-only (no silent bypass via blank)" {
+    install_fake_gh_success
+    export BYPASS_JUSTIFICATION=$'   \n\t  \n'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [ ! -s "$GH_CALL_LOG" ]
+}
+
+@test "handles justification line equal to 'EOF' (heredoc-injection defense)" {
+    install_fake_gh_success
+    # If the body were built with an unquoted heredoc <<EOF, this line
+    # would terminate the heredoc early. The script must build the
+    # body via a delimiter-free mechanism so this is just text.
+    export BYPASS_JUSTIFICATION=$'before\nEOF\nafter'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -q '^before$' "$GH_BODY_LOG"
+    grep -q '^EOF$' "$GH_BODY_LOG"
+    grep -q '^after$' "$GH_BODY_LOG"
+    tail -1 "$GH_BODY_LOG" | grep -qE '^(```|~~~)$'
+}
+
+@test "exits 2 when any required field is missing" {
+    install_fake_gh_success
+    unset BYPASS_ACTOR
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+}
+
+@test "exits 2 when BYPASS_DJ_SITE_SHA is missing (catches blank-SHA bypass)" {
+    install_fake_gh_success
+    unset BYPASS_DJ_SITE_SHA
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"BYPASS_DJ_SITE_SHA"* ]]
+}
+
+@test "error message names the exact env-var the operator must set" {
+    install_fake_gh_success
+    unset BYPASS_ISSUE_NUMBER
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"BYPASS_ISSUE_NUMBER"* ]]
+    [[ "$output" != *"BYPASS_ISSUE is"* ]]
+}
+
+@test "defaults BYPASS_WHEN to current UTC time when unset" {
+    install_fake_gh_success
+    unset BYPASS_WHEN
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -qE '20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z' "$GH_BODY_LOG"
+}
+
+@test "wraps justification in a fenced code block so markdown is neutralized" {
+    install_fake_gh_success
+    export BYPASS_JUSTIFICATION='Approved by @wxyc/oncall — see https://evil.example/spoof'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -qE '^```$' "$GH_BODY_LOG" || grep -qE '^~~~$' "$GH_BODY_LOG"
+    grep -q 'Approved by @wxyc/oncall' "$GH_BODY_LOG"
+}
+
+@test "falls back to ~~~ fence if justification contains backtick fence" {
+    install_fake_gh_success
+    export BYPASS_JUSTIFICATION=$'try this:\n```rm -rf /```'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -qE '^~~~$' "$GH_BODY_LOG"
+}
+
+@test "disarms input fence that matches the chosen outer fence" {
+    install_fake_gh_success
+    export BYPASS_JUSTIFICATION=$'has ``` and\n~~~\nstandalone'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    count=$(grep -cE '^~~~$' "$GH_BODY_LOG")
+    [ "$count" -eq 2 ]
+}
+
+@test "posts the rendered body via -F (not -f), so audit content reaches the issue" {
+    install_fake_gh_success
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -qE '(^| )-F( |$)' "$GH_CALL_LOG"
+    [ -s "$GH_BODY_LOG" ]
+    ! grep -qE '^@/' "$GH_BODY_LOG"
+}

--- a/scripts/__tests__/staging-gate/push-prod.test.sh
+++ b/scripts/__tests__/staging-gate/push-prod.test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+#
+# BATS tests for scripts/staging-gate/push-prod.sh.
+#
+# Mirror of WXYC/wxyc-shared scripts/__tests__/bs-lml-gate/push-prod.test.sh.
+# Both copies share the same fake-gh fixture + assertion set; keep them
+# in sync when fixing bugs. The dj-site copy uses WXYC/dj-site instead
+# of WXYC/Backend-Service as the example repo.
+#
+# push-prod.sh advances a single repo's `prod` branch to a target SHA
+# via the GitHub API (no local clone — the gate runs on a self-hosted
+# runner that we don't want to pollute with per-repo clones).
+#
+# Env:
+#   PUSH_REPO       — required, e.g. WXYC/Backend-Service
+#   PUSH_TARGET_SHA — required, 40-char hex
+#   PUSH_CURRENT_SHA— required, "" means seed (create branch)
+#   PUSH_PAT        — required, fine-grained PAT for the target repo's `prod` ref
+#   PUSH_DRY_RUN    — optional, "1" prints the gh call(s) instead of running them
+#
+# Exit:
+#   0 — push succeeded OR no-op (target == current)
+#   1 — push failed
+#   2 — usage error
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../staging-gate" && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/push-prod.sh"
+
+EXPECTED='a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9'
+
+setup() {
+    TEST_TEMP_DIR="$(mktemp -d)"
+    export FAKE_BIN="$TEST_TEMP_DIR/bin"
+    mkdir -p "$FAKE_BIN"
+    export PATH="$FAKE_BIN:$PATH"
+    export GH_CALL_LOG="$TEST_TEMP_DIR/gh-calls.log"
+    : >"$GH_CALL_LOG"
+    export GITHUB_OUTPUT="$TEST_TEMP_DIR/github_output"
+    : >"$GITHUB_OUTPUT"
+    # Common required env
+    export PUSH_REPO='WXYC/dj-site'
+    export PUSH_TARGET_SHA="$EXPECTED"
+    export PUSH_CURRENT_SHA=""
+    export PUSH_PAT='ghp_fake'
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+install_fake_gh_success() {
+    cat >"$FAKE_BIN/gh" <<GH_EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$GH_CALL_LOG"
+exit 0
+GH_EOF
+    chmod +x "$FAKE_BIN/gh"
+}
+
+install_fake_gh_failure() {
+    cat >"$FAKE_BIN/gh" <<GH_EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$GH_CALL_LOG"
+echo "fake gh: simulated failure" >&2
+exit 1
+GH_EOF
+    chmod +x "$FAKE_BIN/gh"
+}
+
+@test "no-op when PUSH_TARGET_SHA == PUSH_CURRENT_SHA (skips gh entirely, did_push=false)" {
+    install_fake_gh_failure   # would fail if it were called
+    export PUSH_CURRENT_SHA="$EXPECTED"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"no-op"* || "$output" == *"already"* ]]
+    [ ! -s "$GH_CALL_LOG" ]
+    grep -q '^did_push=false$' "$GITHUB_OUTPUT"
+}
+
+@test "fast-forward updates an existing prod ref via PATCH (did_push=true)" {
+    install_fake_gh_success
+    export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -q 'PATCH' "$GH_CALL_LOG"
+    grep -q "refs/heads/prod" "$GH_CALL_LOG"
+    grep -q "$EXPECTED" "$GH_CALL_LOG"
+    grep -q '^did_push=true$' "$GITHUB_OUTPUT"
+}
+
+@test "seed (PUSH_CURRENT_SHA empty) POSTs a new ref (did_push=true)" {
+    install_fake_gh_success
+    export PUSH_CURRENT_SHA=""
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -q 'POST' "$GH_CALL_LOG"
+    grep -q "refs/heads/prod" "$GH_CALL_LOG"
+    grep -q "$EXPECTED" "$GH_CALL_LOG"
+    grep -q '^did_push=true$' "$GITHUB_OUTPUT"
+}
+
+@test "exits 1 if gh fails (and does NOT claim did_push=true)" {
+    install_fake_gh_failure
+    export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+    # On gh failure, we don't know if the ref moved; the summary
+    # logic depends on did_push staying unset rather than 'true'.
+    ! grep -q '^did_push=true$' "$GITHUB_OUTPUT"
+}
+
+@test "dry-run does not invoke gh" {
+    install_fake_gh_failure   # would fail if invoked
+    export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'
+    export PUSH_DRY_RUN='1'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    [ ! -s "$GH_CALL_LOG" ]
+    [[ "$output" == *"$EXPECTED"* ]]
+    [[ "$output" == *"$PUSH_REPO"* ]]
+}
+
+@test "exits 2 if required env is missing" {
+    unset PUSH_TARGET_SHA
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+}
+
+@test "rejects PUSH_TARGET_SHA that is not 40-char hex" {
+    install_fake_gh_failure
+    export PUSH_TARGET_SHA='not-a-sha'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [ ! -s "$GH_CALL_LOG" ]
+}
+
+@test "exits non-zero if \$GITHUB_OUTPUT write fails (no silent did_push loss)" {
+    install_fake_gh_success
+    export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'
+    # Point GITHUB_OUTPUT at a directory (not a file) so the append
+    # fails predictably without needing root or fs manipulation.
+    export GITHUB_OUTPUT="$TEST_TEMP_DIR"
+    run "$SCRIPT_PATH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"GITHUB_OUTPUT"* ]]
+}
+
+@test "does not leak PAT to stdout/stderr or the call log" {
+    install_fake_gh_success
+    export PUSH_CURRENT_SHA='1111111111111111111111111111111111111111'
+    export PUSH_PAT='ghp_secretsecretsecretsecretsecret'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"ghp_secret"* ]]
+    ! grep -q 'ghp_secret' "$GH_CALL_LOG"
+}

--- a/scripts/__tests__/staging-gate/wait-for-cf-preview.test.sh
+++ b/scripts/__tests__/staging-gate/wait-for-cf-preview.test.sh
@@ -178,6 +178,27 @@ JSON_EOF
     ! grep -q '^preview_url=' "$GITHUB_OUTPUT"
 }
 
+@test "exits 1 on 'failed' status alias (CF uses both 'failure' and 'failed')" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" failed "" deploy-3a)"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+    ! grep -q '^preview_url=' "$GITHUB_OUTPUT"
+}
+
+@test "exits 1 on 'canceled' status (CF cancellation, US spelling)" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" canceled "" deploy-3b)"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+    ! grep -q '^preview_url=' "$GITHUB_OUTPUT"
+}
+
+@test "exits 1 on 'cancelled' status (CF cancellation, UK spelling)" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" cancelled "" deploy-3c)"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+    ! grep -q '^preview_url=' "$GITHUB_OUTPUT"
+}
+
 @test "exits 1 on timeout when matching deployment never appears" {
     # Response always contains a deployment for a DIFFERENT SHA — our
     # target is never present, so the script should poll until timeout.
@@ -256,4 +277,41 @@ JSON_EOF
     grep -q "api.cloudflare.com" "$CURL_CALL_LOG"
     grep -q "pages/projects/wxyc-dj/deployments" "$CURL_CALL_LOG"
     grep -q "env=preview" "$CURL_CALL_LOG"
+}
+
+@test "picks the latest deployment (sort_by created_on) when CF returns multiple matches for the SHA" {
+    # CF may return >1 deployment for the same commit (e.g. a re-trigger
+    # via the dashboard). The script must pick the LATEST attempt, not
+    # whichever the API returns first. Construct a response with two
+    # matches: the first listed is an older failure, the second is the
+    # newer success. A naive `head -n 1 after select` would pick the
+    # failure; the sort_by(.created_on)|reverse|.[0] in the script must
+    # pick the success instead.
+    response=$(cat <<JSON_EOF
+{
+  "result": [
+    {
+      "id": "older-failure",
+      "url": "",
+      "created_on": "2026-06-05T00:00:00Z",
+      "latest_stage": { "status": "failure" },
+      "deployment_trigger": { "metadata": { "commit_hash": "$TARGET_SHA_FIXTURE" } }
+    },
+    {
+      "id": "newer-success",
+      "url": "https://newer.wxyc-dj.pages.dev",
+      "created_on": "2026-06-05T01:00:00Z",
+      "latest_stage": { "status": "success" },
+      "deployment_trigger": { "metadata": { "commit_hash": "$TARGET_SHA_FIXTURE" } }
+    }
+  ],
+  "success": true
+}
+JSON_EOF
+)
+    install_fake_curl "$response"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -q '^preview_url=https://newer.wxyc-dj.pages.dev$' "$GITHUB_OUTPUT"
+    grep -q '^deployment_id=newer-success$' "$GITHUB_OUTPUT"
 }

--- a/scripts/__tests__/staging-gate/wait-for-cf-preview.test.sh
+++ b/scripts/__tests__/staging-gate/wait-for-cf-preview.test.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bats
+#
+# BATS tests for scripts/staging-gate/wait-for-cf-preview.sh.
+#
+# wait-for-cf-preview.sh polls the Cloudflare Pages deployments API for
+# the preview deployment whose commit_hash matches TARGET_SHA. Returns
+# the deployment URL on success; fails on CF-side failure, timeout, or
+# missing URL. Designed to be called by .github/workflows/staging-gate.yml
+# immediately after `push: main` (or workflow_dispatch).
+#
+# Env:
+#   CF_ACCOUNT_ID      — required, Cloudflare account UUID
+#   CF_API_TOKEN       — required, CF API bearer
+#   CF_PROJECT         — required, Pages project name (e.g. wxyc-dj)
+#   TARGET_SHA         — required, 40-char hex SHA to find
+#   POLL_TIMEOUT_SECS  — optional, default 600 (10 minutes)
+#   POLL_INTERVAL_SECS — optional, default 10
+#
+# Outputs (to $GITHUB_OUTPUT if set):
+#   preview_url=<url>
+#   deployment_id=<id>
+#
+# Exit:
+#   0 — found a matching deployment with status=success and non-empty url
+#   1 — matching deployment had status=failure, OR url was empty, OR timeout
+#   2 — usage error
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../staging-gate" && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/wait-for-cf-preview.sh"
+
+TARGET_SHA_FIXTURE='a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9'
+
+setup() {
+    TEST_TEMP_DIR="$(mktemp -d)"
+    export FAKE_BIN="$TEST_TEMP_DIR/bin"
+    mkdir -p "$FAKE_BIN"
+    export PATH="$FAKE_BIN:$PATH"
+    export CURL_CALL_LOG="$TEST_TEMP_DIR/curl-calls.log"
+    export CURL_RESPONSE_FILE="$TEST_TEMP_DIR/curl-response.json"
+    export CURL_STATE_FILE="$TEST_TEMP_DIR/curl-state"
+    : >"$CURL_CALL_LOG"
+    echo 0 >"$CURL_STATE_FILE"
+    export GITHUB_OUTPUT="$TEST_TEMP_DIR/github_output"
+    : >"$GITHUB_OUTPUT"
+
+    export CF_ACCOUNT_ID='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    export CF_API_TOKEN='cf_fake_token'
+    export CF_PROJECT='wxyc-dj'
+    export TARGET_SHA="$TARGET_SHA_FIXTURE"
+    # Fast tests: 5s timeout, 1s interval. Each test that takes the
+    # poll path will block for at most 5s.
+    export POLL_TIMEOUT_SECS='5'
+    export POLL_INTERVAL_SECS='1'
+}
+
+teardown() {
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+# Install a fake curl whose response body is read from CURL_RESPONSE_FILE
+# and whose exit status reflects curl's behavior: connection failures
+# would return non-zero, but for tests we always return 0 (CF returned
+# a payload) and let the script's jq filtering decide success.
+install_fake_curl() {
+    local response_json="$1"
+    printf '%s' "$response_json" >"$CURL_RESPONSE_FILE"
+    cat >"$FAKE_BIN/curl" <<'CURL_EOF'
+#!/usr/bin/env bash
+# Log every invocation for assertion. Real curl with -w '\n%{http_code}'
+# emits body followed by a newline-prefixed status code; mirror that so
+# the script's parser (which strips trailing-line as http_code) works.
+{
+    printf '%s\n' "$*"
+} >>"$CURL_CALL_LOG"
+
+status_code=200
+if [[ -n "${CURL_STATUS_FILE:-}" && -f "$CURL_STATUS_FILE" ]]; then
+    status_code="$(cat "$CURL_STATUS_FILE")"
+fi
+
+has_w=false
+for arg in "$@"; do
+    if [[ "$arg" == "-w" || "$arg" == "--write-out" ]]; then
+        has_w=true
+        break
+    fi
+done
+
+cat "$CURL_RESPONSE_FILE"
+if $has_w; then
+    printf '\n%s' "$status_code"
+fi
+exit 0
+CURL_EOF
+    chmod +x "$FAKE_BIN/curl"
+}
+
+# Install a fake curl that emits different responses on successive calls
+# (simulates a deploy moving from `active` to `success`).
+install_fake_curl_progressive() {
+    local response_active="$1"
+    local response_success="$2"
+    printf '%s' "$response_active" >"$TEST_TEMP_DIR/active.json"
+    printf '%s' "$response_success" >"$TEST_TEMP_DIR/success.json"
+    cat >"$FAKE_BIN/curl" <<CURL_EOF
+#!/usr/bin/env bash
+{
+    printf '%s\n' "\$*"
+} >>"$CURL_CALL_LOG"
+state="\$(cat "$CURL_STATE_FILE")"
+if (( state == 0 )); then
+    cat "$TEST_TEMP_DIR/active.json"
+    echo \$((state + 1)) >"$CURL_STATE_FILE"
+else
+    cat "$TEST_TEMP_DIR/success.json"
+fi
+has_w=false
+for arg in "\$@"; do
+    if [[ "\$arg" == "-w" || "\$arg" == "--write-out" ]]; then
+        has_w=true
+        break
+    fi
+done
+if \$has_w; then
+    printf '\n%s' "200"
+fi
+exit 0
+CURL_EOF
+    chmod +x "$FAKE_BIN/curl"
+}
+
+# Helper to build a CF response with one deployment matching SHA in stage.
+make_response() {
+    local sha="$1"
+    local status="$2"
+    local url="$3"
+    local deploy_id="${4:-deploy-id-xxx}"
+    cat <<JSON_EOF
+{
+  "result": [
+    {
+      "id": "${deploy_id}",
+      "url": "${url}",
+      "latest_stage": { "status": "${status}" },
+      "deployment_trigger": { "metadata": { "commit_hash": "${sha}" } }
+    }
+  ],
+  "success": true
+}
+JSON_EOF
+}
+
+@test "returns URL when deployment is success on first poll" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" success https://abc123.wxyc-dj.pages.dev deploy-1)"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -q '^preview_url=https://abc123.wxyc-dj.pages.dev$' "$GITHUB_OUTPUT"
+    grep -q '^deployment_id=deploy-1$' "$GITHUB_OUTPUT"
+}
+
+@test "polls until success when first response shows active" {
+    install_fake_curl_progressive \
+        "$(make_response "$TARGET_SHA_FIXTURE" active "" deploy-2)" \
+        "$(make_response "$TARGET_SHA_FIXTURE" success https://def456.wxyc-dj.pages.dev deploy-2)"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    grep -q '^preview_url=https://def456.wxyc-dj.pages.dev$' "$GITHUB_OUTPUT"
+    # Must have polled at least twice.
+    [ "$(wc -l <"$CURL_CALL_LOG")" -ge 2 ]
+}
+
+@test "exits 1 when matching deployment status is failure" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" failure "" deploy-3)"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"failure"* ]] || [[ "$output" == *"failed"* ]]
+    # Must not claim a URL.
+    ! grep -q '^preview_url=' "$GITHUB_OUTPUT"
+}
+
+@test "exits 1 on timeout when matching deployment never appears" {
+    # Response always contains a deployment for a DIFFERENT SHA — our
+    # target is never present, so the script should poll until timeout.
+    install_fake_curl "$(make_response 'b000000000000000000000000000000000000001' success https://other.pages.dev deploy-x)"
+    export POLL_TIMEOUT_SECS='2'
+    export POLL_INTERVAL_SECS='1'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"timed out"* ]] || [[ "$output" == *"timeout"* ]]
+    ! grep -q '^preview_url=' "$GITHUB_OUTPUT"
+}
+
+@test "exits 1 when matching deployment has empty url (build-without-serve edge)" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" success '' deploy-empty)"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"empty"* ]] || [[ "$output" == *"url"* ]]
+    ! grep -q '^preview_url=' "$GITHUB_OUTPUT"
+}
+
+@test "exits 2 on missing CF_ACCOUNT_ID" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" success https://x.pages.dev deploy-y)"
+    unset CF_ACCOUNT_ID
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"CF_ACCOUNT_ID"* ]]
+}
+
+@test "exits 2 on missing CF_API_TOKEN" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" success https://x.pages.dev deploy-y)"
+    unset CF_API_TOKEN
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"CF_API_TOKEN"* ]]
+}
+
+@test "exits 2 on missing CF_PROJECT" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" success https://x.pages.dev deploy-y)"
+    unset CF_PROJECT
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"CF_PROJECT"* ]]
+}
+
+@test "exits 2 on missing TARGET_SHA" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" success https://x.pages.dev deploy-y)"
+    unset TARGET_SHA
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"TARGET_SHA"* ]]
+}
+
+@test "exits 2 on TARGET_SHA that is not 40-char hex" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" success https://x.pages.dev deploy-y)"
+    export TARGET_SHA='not-a-sha'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 2 ]
+}
+
+@test "does NOT leak CF_API_TOKEN to stdout/stderr or the call log" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" success https://x.pages.dev deploy-y)"
+    export CF_API_TOKEN='cf_secret_token_xxxxxxxxxxxxxxxxxxxx'
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    # The token will appear in the Authorization header sent via curl,
+    # but it must not appear in the script's own stdout/stderr.
+    [[ "$output" != *"cf_secret_token"* ]]
+}
+
+@test "queries Cloudflare Pages preview deployments endpoint" {
+    install_fake_curl "$(make_response "$TARGET_SHA_FIXTURE" success https://x.pages.dev deploy-y)"
+    run "$SCRIPT_PATH"
+    [ "$status" -eq 0 ]
+    # URL must hit the Pages deployments endpoint with env=preview and the
+    # project name from CF_PROJECT.
+    grep -q "api.cloudflare.com" "$CURL_CALL_LOG"
+    grep -q "pages/projects/wxyc-dj/deployments" "$CURL_CALL_LOG"
+    grep -q "env=preview" "$CURL_CALL_LOG"
+}

--- a/scripts/staging-gate/log-bypass.sh
+++ b/scripts/staging-gate/log-bypass.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# log-bypass.sh — append an audit comment to the gate-bypasses tracker
+# issue for the dj-site staging gate.
+#
+# Source-of-truth: WXYC/wxyc-shared scripts/bs-lml-gate/log-bypass.sh.
+# Adapted for dj-site's single-SHA promotion (vs the BS+LML dual-SHA
+# coordinator). Keep the shared invariants (whitespace defense,
+# fence-escape defense, -F vs -f, no-heredoc) in sync.
+#
+# Invariant: the workflow MUST NOT advance prod via the bypass path if
+# this script fails. The audit append is the only record of a manual
+# promotion, so failing-open here would be a silent bypass.
+#
+# Env (all required unless noted):
+#   BYPASS_REPO           — e.g. WXYC/dj-site
+#   BYPASS_ISSUE_NUMBER   — integer
+#   BYPASS_ACTOR          — github.actor
+#   BYPASS_JUSTIFICATION  — non-empty
+#   BYPASS_DJ_SITE_SHA    — dj-site main SHA being promoted
+#   BYPASS_RUN_URL        — link to the GHA run
+#   BYPASS_WHEN           — optional ISO timestamp; defaults to now (UTC)
+#
+# Exit:
+#   0 — comment posted
+#   1 — gh api failed
+#   2 — usage error
+
+set -uo pipefail
+
+WHEN="${BYPASS_WHEN:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+# Loop iterates over the ACTUAL env-var names so error messages match
+# what an operator needs to set — not the local script aliases.
+for var in BYPASS_REPO BYPASS_ISSUE_NUMBER BYPASS_ACTOR \
+           BYPASS_JUSTIFICATION BYPASS_DJ_SITE_SHA BYPASS_RUN_URL; do
+    if [[ -z "${!var:-}" ]]; then
+        echo "log-bypass: ${var} is required (no silent bypasses)" >&2
+        exit 2
+    fi
+done
+
+# Whitespace-only justification is a silent-bypass-by-content. `-z`
+# above catches truly empty strings; this catches space/tab/newline-only
+# payloads that would pass the length check but contribute no content.
+if [[ -z "${BYPASS_JUSTIFICATION//[[:space:]]/}" ]]; then
+    echo "log-bypass: BYPASS_JUSTIFICATION is whitespace-only (no silent bypasses)" >&2
+    exit 2
+fi
+
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+
+# Justification is user input; render it inside a fenced code block so
+# markdown (@-mentions, links, headings) is neutralized in the audit
+# comment. The fence label is empty so the block doesn't get a language
+# tag. Anyone reading the source can still see the text verbatim, but
+# they can't be social-engineered by a fake "Approved by" link.
+#
+# Defense against fence-escape: if the justification itself contains
+# ``` we fall back to ~~~ (CommonMark allows either, and code fences
+# must match the opening sequence). Belt-and-suspenders: we also strip
+# any embedded fence sequence that matches the chosen delimiter.
+if [[ "$BYPASS_JUSTIFICATION" == *'```'* ]]; then
+    fence='~~~'
+    sanitized="${BYPASS_JUSTIFICATION//\~\~\~/\~\~ \~}"
+else
+    fence='```'
+    sanitized="${BYPASS_JUSTIFICATION//\`\`\`/\`\` \`}"
+fi
+
+# Build the body via printf (not heredoc) so a justification line of
+# exactly `EOF` can't terminate the heredoc early and corrupt the
+# audit comment. printf doesn't have a delimiter to inject.
+printf '%s\n' \
+    "## dj-site gate bypass — ${WHEN}" \
+    "" \
+    "- **Actor:** @${BYPASS_ACTOR}" \
+    "- **Run:** ${BYPASS_RUN_URL}" \
+    "- **dj-site SHA promoted:** \`${BYPASS_DJ_SITE_SHA}\`" \
+    "" \
+    "**Justification**" \
+    "" \
+    "${fence}" \
+    "${sanitized}" \
+    "${fence}" \
+    >"$body_file"
+
+# NB: `-F` (--field) is required here, NOT `-f` (--raw-field). Per
+# `gh api --help`: only `-F` supports the `@<path>` syntax to read
+# the value from a file. `-f body=@path` posts the literal seven-char
+# string `@<path>` — destroying the audit trail without erroring.
+if ! gh api -X POST "repos/${BYPASS_REPO}/issues/${BYPASS_ISSUE_NUMBER}/comments" \
+    -F "body=@${body_file}" --silent; then
+    echo "log-bypass: failed to append comment to ${BYPASS_REPO}#${BYPASS_ISSUE_NUMBER}" >&2
+    exit 1
+fi
+
+echo "log-bypass: appended bypass audit to ${BYPASS_REPO}#${BYPASS_ISSUE_NUMBER}"
+exit 0

--- a/scripts/staging-gate/push-prod.sh
+++ b/scripts/staging-gate/push-prod.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# push-prod.sh — advance a repo's `prod` branch to a target SHA.
+#
+# Source-of-truth: WXYC/wxyc-shared scripts/bs-lml-gate/push-prod.sh.
+# Copied verbatim into dj-site so the dj-site gate doesn't depend on
+# wxyc-shared's deploy path. Keep these in sync when fixing bugs.
+#
+# Uses the GitHub API (refs PATCH / POST) rather than a local clone so
+# the self-hosted runner stays clean. Authentication is via a
+# fine-grained PAT scoped to `Contents: write` on the `prod` ref of
+# the target repo only.
+#
+# Env:
+#   PUSH_REPO        — required, e.g. WXYC/Backend-Service
+#   PUSH_TARGET_SHA  — required, 40-char hex
+#   PUSH_CURRENT_SHA — required, "" means seed (no prod branch yet)
+#   PUSH_PAT         — required, fine-grained PAT
+#   PUSH_DRY_RUN     — optional, "1" prints the planned API call
+#
+# Outputs (to $GITHUB_OUTPUT if set):
+#   did_push=true    — a PATCH/POST landed against the GitHub API
+#   did_push=false   — short-circuited at target==current (no API call)
+#
+# Exit:
+#   0 — push succeeded OR no-op (target == current)
+#   1 — push failed
+#   2 — usage error
+#
+# Requires: gh.
+
+set -uo pipefail
+
+REPO="${PUSH_REPO:-}"
+TARGET="${PUSH_TARGET_SHA:-}"
+CURRENT="${PUSH_CURRENT_SHA-__UNSET__}"
+PAT="${PUSH_PAT:-}"
+DRY_RUN="${PUSH_DRY_RUN:-0}"
+
+if [[ -z "$REPO" || -z "$TARGET" || "$CURRENT" == "__UNSET__" || -z "$PAT" ]]; then
+    echo "push-prod: PUSH_REPO, PUSH_TARGET_SHA, PUSH_CURRENT_SHA, PUSH_PAT are required" >&2
+    exit 2
+fi
+
+if ! [[ "$TARGET" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "push-prod: PUSH_TARGET_SHA is not a 40-char hex sha: '$TARGET'" >&2
+    exit 2
+fi
+
+if [[ -n "$CURRENT" ]] && ! [[ "$CURRENT" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "push-prod: PUSH_CURRENT_SHA is not a 40-char hex sha: '$CURRENT'" >&2
+    exit 2
+fi
+
+emit_output() {
+    # Write key=value to $GITHUB_OUTPUT when in GHA; no-op locally.
+    # Fail loud on write error — the workflow's split-promotion detector
+    # tests `did_push == "true"` exactly, so a silent emit-failure after
+    # a real push would mask the actual state and could even trigger a
+    # spurious inverted-split warning.
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        if ! printf '%s=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"; then
+            echo "push-prod: failed to write $1=$2 to \$GITHUB_OUTPUT ($GITHUB_OUTPUT)" >&2
+            exit 1
+        fi
+    fi
+}
+
+if [[ "$TARGET" == "$CURRENT" ]]; then
+    echo "push-prod: $REPO prod already at $TARGET (no-op)"
+    emit_output did_push false
+    exit 0
+fi
+
+# Decide PATCH vs POST. Seed (no prod yet) = POST /git/refs with ref=refs/heads/prod.
+# Fast-forward = PATCH /git/refs/heads/prod with sha=TARGET.
+if [[ -z "$CURRENT" ]]; then
+    method="POST"
+    path="repos/${REPO}/git/refs"
+    fields=( -f "ref=refs/heads/prod" -f "sha=${TARGET}" )
+else
+    method="PATCH"
+    path="repos/${REPO}/git/refs/heads/prod"
+    fields=( -f "sha=${TARGET}" )
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+    echo "push-prod: DRY_RUN $method $path sha=$TARGET (repo=$REPO from=${CURRENT:-<seed>})"
+    emit_output did_push false
+    exit 0
+fi
+
+# Pass the PAT via env to gh so it never appears on argv (would otherwise
+# show in `ps`). `gh` reads $GH_TOKEN before $GITHUB_TOKEN.
+if ! GH_TOKEN="$PAT" gh api -X "$method" "$path" "${fields[@]}" --silent; then
+    echo "push-prod: $method $path failed" >&2
+    # Even on failure, the request reached the API — but we don't
+    # know whether the ref moved. Don't claim did_push=true; leave
+    # the output unset so the workflow falls back to step outcome.
+    exit 1
+fi
+
+echo "push-prod: $REPO prod -> $TARGET (${method})"
+emit_output did_push true
+exit 0

--- a/scripts/staging-gate/wait-for-cf-preview.sh
+++ b/scripts/staging-gate/wait-for-cf-preview.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# wait-for-cf-preview.sh — poll Cloudflare Pages deployments API for the
+# preview deployment matching TARGET_SHA, returning its URL on success.
+#
+# Called by .github/workflows/staging-gate.yml immediately after
+# `push: main` (or `workflow_dispatch`). Treats CF's `latest_stage.status`
+# field as the source of truth — same convention as the existing
+# `cloudflare-deploy-status.yml` hourly monitor. Adds a SHA filter on
+# `deployment_trigger.metadata.commit_hash` so we wait for the *exact*
+# build of the SHA we want to promote (CF returns deployments in
+# reverse-chronological order, so the latest deploy is not necessarily
+# the one we're gating on if pushes arrive close together).
+#
+# Env:
+#   CF_ACCOUNT_ID      — required, Cloudflare account UUID
+#   CF_API_TOKEN       — required, CF API bearer
+#   CF_PROJECT         — required, Pages project name (e.g. wxyc-dj)
+#   TARGET_SHA         — required, 40-char hex SHA to find
+#   POLL_TIMEOUT_SECS  — optional, default 600 (10 minutes)
+#   POLL_INTERVAL_SECS — optional, default 10
+#
+# Outputs (to $GITHUB_OUTPUT if set):
+#   preview_url=<url>
+#   deployment_id=<id>
+#
+# Exit:
+#   0 — found a matching deployment with status=success and non-empty url
+#   1 — matching deployment had status=failure, OR url was empty, OR timeout
+#   2 — usage error
+#
+# Requires: curl, jq, bash 4+.
+
+set -uo pipefail
+
+ACCOUNT_ID="${CF_ACCOUNT_ID:-}"
+API_TOKEN="${CF_API_TOKEN:-}"
+PROJECT="${CF_PROJECT:-}"
+TARGET="${TARGET_SHA:-}"
+TIMEOUT_SECS="${POLL_TIMEOUT_SECS:-600}"
+INTERVAL_SECS="${POLL_INTERVAL_SECS:-10}"
+
+if [[ -z "$ACCOUNT_ID" ]]; then
+    echo "wait-for-cf-preview: CF_ACCOUNT_ID is required" >&2
+    exit 2
+fi
+if [[ -z "$API_TOKEN" ]]; then
+    echo "wait-for-cf-preview: CF_API_TOKEN is required" >&2
+    exit 2
+fi
+if [[ -z "$PROJECT" ]]; then
+    echo "wait-for-cf-preview: CF_PROJECT is required" >&2
+    exit 2
+fi
+if [[ -z "$TARGET" ]]; then
+    echo "wait-for-cf-preview: TARGET_SHA is required" >&2
+    exit 2
+fi
+if ! [[ "$TARGET" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "wait-for-cf-preview: TARGET_SHA is not a 40-char hex sha: '$TARGET'" >&2
+    exit 2
+fi
+
+emit_output() {
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        if ! printf '%s=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"; then
+            echo "wait-for-cf-preview: failed to write $1=$2 to \$GITHUB_OUTPUT ($GITHUB_OUTPUT)" >&2
+            exit 1
+        fi
+    fi
+}
+
+# CF Pages deployments endpoint; per_page=25 covers the recent window.
+# Reverse-chronological order means our target deploy is usually at the
+# top, but we filter by SHA defensively.
+URL="https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/pages/projects/${PROJECT}/deployments?env=preview&per_page=25"
+
+# SECONDS resets per subshell; safe in this single-script context.
+SECONDS=0
+last_status=""
+
+while (( SECONDS < TIMEOUT_SECS )); do
+    # Capture both body and HTTP status. -s silent, -m 30 per-request cap
+    # so a hung connection can't eat the whole budget.
+    response="$(curl -sS -m 30 \
+        -H "Authorization: Bearer ${API_TOKEN}" \
+        -H "Accept: application/json" \
+        -w '\n%{http_code}' \
+        "$URL" 2>/dev/null || echo $'\n000')"
+    http_code="${response##*$'\n'}"
+    body="${response%$'\n'*}"
+
+    if [[ "$http_code" != "200" ]]; then
+        last_status="http=${http_code}"
+        sleep "$INTERVAL_SECS"
+        continue
+    fi
+
+    # Find the deployment for TARGET. jq returns the first match.
+    # If no match, match_status is empty string.
+    match_json="$(jq -c --arg sha "$TARGET" \
+        '.result[] | select(.deployment_trigger.metadata.commit_hash == $sha)' \
+        <<<"$body" 2>/dev/null | head -n 1)"
+
+    if [[ -z "$match_json" ]]; then
+        last_status="no-match-yet"
+        sleep "$INTERVAL_SECS"
+        continue
+    fi
+
+    match_status="$(jq -r '.latest_stage.status // ""' <<<"$match_json")"
+    match_url="$(jq -r '.url // ""' <<<"$match_json")"
+    match_id="$(jq -r '.id // ""' <<<"$match_json")"
+
+    case "$match_status" in
+        success)
+            if [[ -z "$match_url" ]]; then
+                echo "wait-for-cf-preview: deployment ${match_id} reported success but url is empty" >&2
+                exit 1
+            fi
+            echo "wait-for-cf-preview: ${TARGET} ready at ${match_url} (deployment ${match_id}, elapsed ${SECONDS}s)"
+            emit_output preview_url "$match_url"
+            emit_output deployment_id "$match_id"
+            exit 0
+            ;;
+        failure)
+            echo "wait-for-cf-preview: deployment ${match_id} for ${TARGET} reported failure — not promoting" >&2
+            echo "wait-for-cf-preview: CF Pages dashboard: https://dash.cloudflare.com/${ACCOUNT_ID}/pages/view/${PROJECT}/${match_id}" >&2
+            exit 1
+            ;;
+        *)
+            last_status="cf=${match_status}"
+            sleep "$INTERVAL_SECS"
+            ;;
+    esac
+done
+
+echo "wait-for-cf-preview: timed out after ${TIMEOUT_SECS}s waiting for ${TARGET} (last status: ${last_status})" >&2
+exit 1

--- a/scripts/staging-gate/wait-for-cf-preview.sh
+++ b/scripts/staging-gate/wait-for-cf-preview.sh
@@ -96,11 +96,17 @@ while (( SECONDS < TIMEOUT_SECS )); do
         continue
     fi
 
-    # Find the deployment for TARGET. jq returns the first match.
-    # If no match, match_status is empty string.
-    match_json="$(jq -c --arg sha "$TARGET" \
-        '.result[] | select(.deployment_trigger.metadata.commit_hash == $sha)' \
-        <<<"$body" 2>/dev/null | head -n 1)"
+    # Find the latest deployment matching TARGET. Sort by `created_on` so
+    # that if CF reordered the result array (rare but observed in their
+    # API during high-load windows), we still pick the most recent
+    # attempt for the SHA — not whichever one happens to come first.
+    # Pattern lifted from .github/workflows/pr-preview-smoke.yml's wait
+    # step, which has been live since 2026-06-03.
+    match_json="$(jq -c --arg sha "$TARGET" '
+        .result
+        | map(select(.deployment_trigger.metadata.commit_hash == $sha))
+        | sort_by(.created_on) | reverse | .[0] // empty
+    ' <<<"$body" 2>/dev/null)"
 
     if [[ -z "$match_json" ]]; then
         last_status="no-match-yet"
@@ -123,8 +129,12 @@ while (( SECONDS < TIMEOUT_SECS )); do
             emit_output deployment_id "$match_id"
             exit 0
             ;;
-        failure)
-            echo "wait-for-cf-preview: deployment ${match_id} for ${TARGET} reported failure — not promoting" >&2
+        # CF Pages emits all four spellings across endpoints (`failure`
+        # appears in some payloads, `failed` in others; same for the
+        # cancellation pair). Treat all as terminal-fail so a typo in
+        # the CF API doesn't silently unblock the promotion.
+        failure|failed|canceled|cancelled)
+            echo "wait-for-cf-preview: deployment ${match_id} for ${TARGET} reported ${match_status} — not promoting" >&2
             echo "wait-for-cf-preview: CF Pages dashboard: https://dash.cloudflare.com/${ACCOUNT_ID}/pages/view/${PROJECT}/${match_id}" >&2
             exit 1
             ;;


### PR DESCRIPTION
## Summary

- Inserts a staging gate between merge-to-`main` and the Cloudflare Pages production deploy: workflow polls the CF API for the preview deployment matching the merged SHA, probes the preview URL for runtime health, and on pass fast-forwards the `prod` branch. CF Pages's existing prod deploy is configured (by an operator step) to watch `prod`, so the existing deploy machinery is unchanged — only the trigger shifts from `push: main` to `push: prod`.
- Mirrors the BS+LML coordinator workflow at [WXYC/wxyc-shared `bs-lml-gate.yml`](https://github.com/WXYC/wxyc-shared/blob/main/.github/workflows/bs-lml-gate.yml) (Phase 5 of [WXYC/wiki#80](https://github.com/WXYC/wiki/issues/80)). `push-prod.sh` is copied verbatim from bs-lml-gate; `log-bypass.sh` is adapted to a single SHA payload; `wait-for-cf-preview.sh` is new and polls the CF Pages deployments API filtered by `deployment_trigger.metadata.commit_hash` so we wait for the exact build of the SHA we're promoting (not whatever's most recent).
- Canary smoke against BS+LML is intentionally NOT in this workflow — BS+LML are already covered by their own coordinator gate + the wxyc-canary Lambda. The inline preview-URL probe (accepts 2xx/3xx/401/403 per the existing `cloudflare-deploy-status.yml` convention, 3 attempts × 5s) catches the build-success-worker-500 class of bug that the 2026-06-03 outage hit.

Closes #739

## What the workflow does

```
push: main
  -> CF Pages preview build for main (existing, unchanged)
  -> staging-gate.yml waits for that preview to report success in the CF API
  -> probes the preview URL: GET / with retry, accepts 2xx/3xx/401/403
  -> (if skip_gate=true) audits the bypass to a tracker issue
  -> push <sha>:prod via fine-grained PAT (PROD_PUSH_PAT, refs/heads/prod scope)
  -> CF Pages prod deploy fires from push: prod
```

## Files

- `.github/workflows/staging-gate.yml` — coordinator workflow
- `.github/actionlint.yaml` — declares the `e2e-runner` self-hosted runner label
- `scripts/staging-gate/wait-for-cf-preview.sh` — CF Pages deployments API poller (NEW, with bats tests)
- `scripts/staging-gate/push-prod.sh` — verbatim copy from wxyc-shared `bs-lml-gate/push-prod.sh`
- `scripts/staging-gate/log-bypass.sh` — adapted from wxyc-shared `bs-lml-gate/log-bypass.sh` (single SHA payload)
- `scripts/__tests__/staging-gate/*.test.sh` — bats tests, 36 cases total
- `README.md` — new "Staging gate (dj-site)" section with operator setup checklist
- `package.json` + `package-lock.json` — adds `bats@^1.11.0` devDep + `test:staging-gate` script

## Operator setup required after merge (NOT in this PR)

The workflow + scripts + tests ship in this PR but the gate cannot promote until an operator completes the six steps documented in the README's "Staging gate (dj-site)" section: seed `prod`, flip the CF Pages production branch from `main` to `prod`, create the bypass tracker issue, set the `GATE_BYPASS_ISSUE_NUMBER` repo variable, mint the `PROD_PUSH_PAT` fine-grained PAT (scoped to `refs/heads/prod` only), and branch-protect `prod`. Until the CF Pages production branch is flipped, this workflow will simply advance `prod` without triggering a prod deploy — safe but inert.

The Playwright suite against staging is out of scope here; it's deferred to a follow-up that needs the test-user-provisioning decision separately.

## Test plan

- [x] `npm run test:staging-gate` — 36/36 bats tests pass locally
- [x] `actionlint .github/workflows/staging-gate.yml` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 3217/3217 pass
- [ ] After operator setup completes, run `workflow_dispatch` with `skip_gate=true` + a benign justification against a known SHA on `main` to validate the audit + push path end-to-end
- [ ] After operator setup completes, merge a no-op PR to `main` to validate the full preview-poll + URL probe + push path