### PR TITLE
feat(rotation): A→Z sort + type-ahead search in rotation picker

### DIFF
--- a/e2e/tests/flowsheet/flowsheet-track-picker.spec.ts
+++ b/e2e/tests/flowsheet/flowsheet-track-picker.spec.ts
@@ -194,8 +194,10 @@ test.describe("Flowsheet Track Picker", () => {
       page.locator('[data-testid="flowsheet-search-track-picker-row"]')
     ).toBeVisible({ timeout: 5_000 });
 
-    // Once the tracklist resolves with tracks.length > 0, the trigger renders.
-    const pickerTrigger = page.locator('[data-testid="track-picker-trigger"]');
+    // Once the tracklist resolves with tracks.length > 0, the combobox renders.
+    const pickerTrigger = page.locator(
+      '[data-testid="track-picker-combobox"]'
+    );
     await expect(pickerTrigger).toBeVisible({ timeout: 10_000 });
 
     // Open the dropdown and pick the first track.
@@ -328,13 +330,13 @@ test.describe("Flowsheet Track Picker", () => {
     await expect(resultRow).toBeVisible({ timeout: 10_000 });
     await resultRow.hover();
 
-    // Picker row visible, but the trigger never renders — the fallback
+    // Picker row visible, but the combobox never renders — the fallback
     // message replaces it.
     await expect(
       page.locator('[data-testid="flowsheet-search-track-picker-row"]')
     ).toBeVisible({ timeout: 5_000 });
     await expect(
-      page.locator('[data-testid="track-picker-trigger"]')
+      page.locator('[data-testid="track-picker-combobox"]')
     ).toHaveCount(0);
     await expect(
       page.getByText("No tracklist on file — type the song title above.")

--- a/lib/__tests__/features/rotation/sort.test.ts
+++ b/lib/__tests__/features/rotation/sort.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { sortRotationReleases } from "@/lib/features/rotation/sort";
+import { createTestAlbum, createTestArtist } from "@/lib/test-utils";
+
+describe("sortRotationReleases", () => {
+  it("sorts alphabetically by artist name", () => {
+    const releases = [
+      createTestAlbum({
+        id: 1,
+        title: "Aluminum Tunes",
+        artist: createTestArtist({ name: "Stereolab" }),
+      }),
+      createTestAlbum({
+        id: 2,
+        title: "Confield",
+        artist: createTestArtist({ name: "Autechre" }),
+      }),
+      createTestAlbum({
+        id: 3,
+        title: "Moon Pix",
+        artist: createTestArtist({ name: "Cat Power" }),
+      }),
+    ];
+    const sorted = sortRotationReleases(releases);
+    expect(sorted.map((r) => r.artist.name)).toEqual([
+      "Autechre",
+      "Cat Power",
+      "Stereolab",
+    ]);
+  });
+
+  it("breaks artist-name ties by album title", () => {
+    const releases = [
+      createTestAlbum({
+        id: 1,
+        title: "Mars Audiac Quintet",
+        artist: createTestArtist({ name: "Stereolab" }),
+      }),
+      createTestAlbum({
+        id: 2,
+        title: "Aluminum Tunes",
+        artist: createTestArtist({ name: "Stereolab" }),
+      }),
+    ];
+    const sorted = sortRotationReleases(releases);
+    expect(sorted.map((r) => r.title)).toEqual([
+      "Aluminum Tunes",
+      "Mars Audiac Quintet",
+    ]);
+  });
+
+  it("is case-insensitive on the artist name", () => {
+    const releases = [
+      createTestAlbum({
+        id: 1,
+        title: "Z",
+        artist: createTestArtist({ name: "stereolab" }),
+      }),
+      createTestAlbum({
+        id: 2,
+        title: "A",
+        artist: createTestArtist({ name: "Autechre" }),
+      }),
+    ];
+    const sorted = sortRotationReleases(releases);
+    expect(sorted.map((r) => r.artist.name)).toEqual(["Autechre", "stereolab"]);
+  });
+
+  it("does not mutate the input", () => {
+    const releases = [
+      createTestAlbum({
+        id: 1,
+        title: "Aluminum Tunes",
+        artist: createTestArtist({ name: "Stereolab" }),
+      }),
+      createTestAlbum({
+        id: 2,
+        title: "Confield",
+        artist: createTestArtist({ name: "Autechre" }),
+      }),
+    ];
+    const before = releases.map((r) => r.artist.name);
+    sortRotationReleases(releases);
+    expect(releases.map((r) => r.artist.name)).toEqual(before);
+  });
+
+  it("handles an empty list", () => {
+    expect(sortRotationReleases([])).toEqual([]);
+  });
+
+  it("sorts unicode artist names with diacritics next to their base equivalents", () => {
+    // Real fixture: BS / Discogs surface artists with stripped or accented
+    // names interchangeably (e.g. "Émilie" ↔ "Emilie"). Diacritic-insensitive
+    // sort keeps them adjacent. WXYC/dj-site#745.
+    const releases = [
+      createTestAlbum({
+        id: 1,
+        title: "Z",
+        artist: createTestArtist({ name: "Émilie Simon" }),
+      }),
+      createTestAlbum({
+        id: 2,
+        title: "A",
+        artist: createTestArtist({ name: "Emilie Levienaise-Farrouch" }),
+      }),
+    ];
+    const sorted = sortRotationReleases(releases);
+    expect(sorted[0].artist.name).toBe("Emilie Levienaise-Farrouch");
+  });
+});

--- a/lib/features/rotation/sort.ts
+++ b/lib/features/rotation/sort.ts
@@ -1,0 +1,21 @@
+import type { AlbumEntry } from "../catalog/types";
+
+/**
+ * Sort rotation releases alphabetically by artist (case-insensitive), ties
+ * broken by album title. Used by both Modern and Classic rotation pickers
+ * so a release lands in the same neighborhood regardless of which UI the
+ * DJ is using. WXYC/dj-site#745.
+ *
+ * `localeCompare` handles unicode (e.g. "Á", "ß", "É") more naturally than
+ * naive `<` on strings; `sensitivity: "base"` collapses diacritics so
+ * "Émilie" sorts alongside "Emilie".
+ */
+export function sortRotationReleases(releases: AlbumEntry[]): AlbumEntry[] {
+  return [...releases].sort((a, b) => {
+    const artistCmp = a.artist.name.localeCompare(b.artist.name, undefined, {
+      sensitivity: "base",
+    });
+    if (artistCmp !== 0) return artistCmp;
+    return a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
+  });
+}

--- a/src/components/experiences/classic/flowsheet/EntryForm.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryForm.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch } from "@/lib/hooks";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { useAddToFlowsheetMutation } from "@/lib/features/flowsheet/api";
 import { useGetRotationQuery } from "@/lib/features/rotation/api";
+import { sortRotationReleases } from "@/lib/features/rotation/sort";
 import { Rotation } from "@/lib/features/rotation/types";
 import { FlowsheetEntryType } from "@wxyc/shared/dtos";
 
@@ -51,10 +52,20 @@ export default function EntryForm({
 
   const { data: rotationData } = useGetRotationQuery();
 
-  const heavyReleases = rotationData?.filter((r) => r.rotation_bin === Rotation.H) || [];
-  const mediumReleases = rotationData?.filter((r) => r.rotation_bin === Rotation.M) || [];
-  const lightReleases = rotationData?.filter((r) => r.rotation_bin === Rotation.L) || [];
-  const singlesReleases = rotationData?.filter((r) => r.rotation_bin === Rotation.S) || [];
+  // Sorted A→Z by artist (ties broken by album title) so the native <select>
+  // type-ahead lands the DJ in the right neighborhood. WXYC/dj-site#745.
+  const heavyReleases = sortRotationReleases(
+    rotationData?.filter((r) => r.rotation_bin === Rotation.H) || []
+  );
+  const mediumReleases = sortRotationReleases(
+    rotationData?.filter((r) => r.rotation_bin === Rotation.M) || []
+  );
+  const lightReleases = sortRotationReleases(
+    rotationData?.filter((r) => r.rotation_bin === Rotation.L) || []
+  );
+  const singlesReleases = sortRotationReleases(
+    rotationData?.filter((r) => r.rotation_bin === Rotation.S) || []
+  );
 
   useEffect(() => {
     if (useArtistForComposer) {

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryForm.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryForm.test.tsx
@@ -284,6 +284,43 @@ describe("Classic EntryForm — Bin dropdown (replaces H/M/L/S radios)", () => {
     // can announce something meaningful for the unselected state.
     expect(placeholder.textContent?.trim().length).toBeGreaterThan(0);
   });
+
+  // WXYC/dj-site#745 — DJs need releases sorted A→Z by artist so the native
+  // <select> type-ahead lands them in the right neighborhood.
+  it("sorts heavy-rotation releases alphabetically by artist", async () => {
+    rotationDataMock = [
+      createTestRotationAlbum(Rotation.H, {
+        id: 7001,
+        rotation_id: 7001,
+        title: "Mirror Mirror",
+        artist: createTestArtist({ name: "Stereolab" }),
+      }),
+      createTestRotationAlbum(Rotation.H, {
+        id: 7002,
+        rotation_id: 7002,
+        title: "Confield",
+        artist: createTestArtist({ name: "Autechre" }),
+      }),
+      createTestRotationAlbum(Rotation.H, {
+        id: 7003,
+        rotation_id: 7003,
+        title: "Moon Pix",
+        artist: createTestArtist({ name: "Cat Power" }),
+      }),
+    ];
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("rotationType"), "heavy");
+    const heavy = getNamedSelect("heavyRelease");
+    // First option is the "Choose one..." placeholder; release names follow.
+    const releaseNames = Array.from(heavy.options)
+      .slice(1)
+      .map((o) => o.textContent?.trim() ?? "");
+    expect(releaseNames).toEqual([
+      "Autechre - Confield",
+      "Cat Power - Moon Pix",
+      "Stereolab - Mirror Mirror",
+    ]);
+  });
 });
 
 describe("Classic EntryForm — Rotation submission payload", () => {

--- a/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker.test.tsx
@@ -108,7 +108,7 @@ describe("LibraryTrackPicker", () => {
     );
 
     // Open dropdown via trigger
-    await user.click(screen.getByTestId("track-picker-trigger"));
+    await user.click(screen.getByTestId("track-picker-combobox"));
     await user.click(screen.getByTestId("track-picker-option-0"));
 
     const state = store.getState();
@@ -153,7 +153,7 @@ describe("LibraryTrackPicker", () => {
       }
     );
 
-    await user.click(screen.getByTestId("track-picker-trigger"));
+    await user.click(screen.getByTestId("track-picker-combobox"));
     fireEvent.click(screen.getByTestId("track-picker-manual"));
 
     expect(manualFired).toBe(true);

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.refetch.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.refetch.test.tsx
@@ -80,8 +80,8 @@ function mockRotationListAndTracks(handler: TracksHandler): {
 const selectBin = () => fireEvent.click(screen.getByRole("radio", { name: "H" }));
 
 const selectRelease = async (releaseId: number) => {
-  const trigger = await screen.findByTestId("rotation-release-trigger");
-  fireEvent.click(trigger);
+  const trigger = await screen.findByTestId("rotation-release-combobox");
+  fireEvent.focus(trigger);
   fireEvent.click(
     await screen.findByTestId(`rotation-release-option-${releaseId}`)
   );

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.refetch.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.refetch.test.tsx
@@ -111,7 +111,7 @@ describe("RotationEntryFields — refetch on release pick (#589)", () => {
       expect(trackRequestsFor(ROTATION_ID_OOIOO)).toBeGreaterThanOrEqual(1)
     );
     await waitFor(() =>
-      expect(screen.getByTestId("track-picker-trigger")).toBeInTheDocument()
+      expect(screen.getByTestId("track-picker-combobox")).toBeInTheDocument()
     );
   });
 
@@ -156,14 +156,14 @@ describe("RotationEntryFields — refetch on release pick (#589)", () => {
     selectBin();
     await selectRelease(ooioo.id);
     await waitFor(() =>
-      expect(screen.queryByTestId("track-picker-trigger")).not.toBeInTheDocument()
+      expect(screen.queryByTestId("track-picker-combobox")).not.toBeInTheDocument()
     );
 
     await selectRelease(jessicaPratt.id);
     await selectRelease(ooioo.id);
 
     await waitFor(() =>
-      expect(screen.getByTestId("track-picker-trigger")).toBeInTheDocument()
+      expect(screen.getByTestId("track-picker-combobox")).toBeInTheDocument()
     );
   });
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -84,7 +84,7 @@ const lightningBoltOoioo = createTestAlbum({
 
 const selectBinAndRelease = () => {
   fireEvent.click(screen.getByRole("radio", { name: "H" }));
-  fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+  fireEvent.focus(screen.getByTestId("rotation-release-combobox"));
   fireEvent.click(
     screen.getByTestId(`rotation-release-option-${lightningBoltOoioo.id}`)
   );

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -91,7 +91,7 @@ const selectBinAndRelease = () => {
 };
 
 const selectTrack = (index: number) => {
-  fireEvent.click(screen.getByTestId("track-picker-trigger"));
+  fireEvent.click(screen.getByTestId("track-picker-combobox"));
   fireEvent.click(screen.getByTestId(`track-picker-option-${index}`));
 };
 

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
@@ -138,4 +138,198 @@ describe("RotationReleaseDropdown", () => {
     fireEvent.click(screen.getByTestId("rotation-release-trigger"));
     expect(screen.getByText(/no releases/i)).toBeInTheDocument();
   });
+
+  // WXYC/dj-site#745 — DJ feedback: can't quickly find a release in the picker.
+  describe("search and sort (#745)", () => {
+    it("sorts releases alphabetically by artist name regardless of input order", () => {
+      render(
+        <RotationReleaseDropdown
+          releases={releases}
+          selectedRelease={null}
+          onSelectRelease={mockOnSelectRelease}
+          disabled={false}
+        />
+      );
+      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      const options = screen.getAllByTestId(/^rotation-release-option-/);
+      // Input order in fixture: Autechre, Cat Power, Stereolab (already sorted).
+      // Hand a re-shuffled fixture to make sure sort is enforced.
+      expect(options.map((o) => o.dataset.testid)).toEqual([
+        "rotation-release-option-1", // Autechre
+        "rotation-release-option-2", // Cat Power
+        "rotation-release-option-3", // Stereolab
+      ]);
+    });
+
+    it("breaks artist-name ties by album title", () => {
+      const sameArtist = [
+        createTestAlbum({
+          id: 11,
+          title: "Mars Audiac Quintet",
+          artist: createTestArtist({ name: "Stereolab" }),
+          label: "Elektra",
+        }),
+        createTestAlbum({
+          id: 12,
+          title: "Aluminum Tunes",
+          artist: createTestArtist({ name: "Stereolab" }),
+          label: "Duophonic",
+        }),
+        createTestAlbum({
+          id: 13,
+          title: "Emperor Tomato Ketchup",
+          artist: createTestArtist({ name: "Stereolab" }),
+          label: "Duophonic",
+        }),
+      ];
+      render(
+        <RotationReleaseDropdown
+          releases={sameArtist}
+          selectedRelease={null}
+          onSelectRelease={mockOnSelectRelease}
+          disabled={false}
+        />
+      );
+      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      const options = screen.getAllByTestId(/^rotation-release-option-/);
+      expect(options.map((o) => o.dataset.testid)).toEqual([
+        "rotation-release-option-12", // Aluminum Tunes
+        "rotation-release-option-13", // Emperor Tomato Ketchup
+        "rotation-release-option-11", // Mars Audiac Quintet
+      ]);
+    });
+
+    it("sort is case-insensitive on artist name", () => {
+      const mixedCase = [
+        createTestAlbum({
+          id: 21,
+          title: "Album Z",
+          artist: createTestArtist({ name: "stereolab" }),
+        }),
+        createTestAlbum({
+          id: 22,
+          title: "Album A",
+          artist: createTestArtist({ name: "Autechre" }),
+        }),
+        createTestAlbum({
+          id: 23,
+          title: "Album B",
+          artist: createTestArtist({ name: "cat power" }),
+        }),
+      ];
+      render(
+        <RotationReleaseDropdown
+          releases={mixedCase}
+          selectedRelease={null}
+          onSelectRelease={mockOnSelectRelease}
+          disabled={false}
+        />
+      );
+      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      const options = screen.getAllByTestId(/^rotation-release-option-/);
+      expect(options.map((o) => o.dataset.testid)).toEqual([
+        "rotation-release-option-22", // Autechre
+        "rotation-release-option-23", // cat power
+        "rotation-release-option-21", // stereolab
+      ]);
+    });
+
+    it("renders a search input when the dropdown opens", () => {
+      render(
+        <RotationReleaseDropdown
+          releases={releases}
+          selectedRelease={null}
+          onSelectRelease={mockOnSelectRelease}
+          disabled={false}
+        />
+      );
+      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      expect(
+        screen.getByTestId("rotation-release-search")
+      ).toBeInTheDocument();
+    });
+
+    it("filters the visible releases by artist name as the DJ types (case-insensitive substring)", () => {
+      render(
+        <RotationReleaseDropdown
+          releases={releases}
+          selectedRelease={null}
+          onSelectRelease={mockOnSelectRelease}
+          disabled={false}
+        />
+      );
+      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      const search = screen.getByTestId("rotation-release-search");
+      fireEvent.change(search, { target: { value: "ste" } });
+      expect(
+        screen.queryByTestId("rotation-release-option-3")
+      ).toBeInTheDocument(); // Stereolab
+      expect(
+        screen.queryByTestId("rotation-release-option-1")
+      ).not.toBeInTheDocument(); // Autechre filtered out
+      expect(
+        screen.queryByTestId("rotation-release-option-2")
+      ).not.toBeInTheDocument(); // Cat Power filtered out
+    });
+
+    it("filters by album title too", () => {
+      render(
+        <RotationReleaseDropdown
+          releases={releases}
+          selectedRelease={null}
+          onSelectRelease={mockOnSelectRelease}
+          disabled={false}
+        />
+      );
+      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      const search = screen.getByTestId("rotation-release-search");
+      fireEvent.change(search, { target: { value: "moon" } });
+      expect(
+        screen.queryByTestId("rotation-release-option-2")
+      ).toBeInTheDocument(); // Moon Pix
+      expect(
+        screen.queryByTestId("rotation-release-option-1")
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows a 'no matches' state when the filter eliminates everything", () => {
+      render(
+        <RotationReleaseDropdown
+          releases={releases}
+          selectedRelease={null}
+          onSelectRelease={mockOnSelectRelease}
+          disabled={false}
+        />
+      );
+      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      const search = screen.getByTestId("rotation-release-search");
+      fireEvent.change(search, { target: { value: "zzzz-does-not-exist" } });
+      expect(
+        screen.queryAllByTestId(/^rotation-release-option-/)
+      ).toHaveLength(0);
+      expect(screen.getByText(/no releases match/i)).toBeInTheDocument();
+    });
+
+    it("clears the filter when the dropdown is reopened", () => {
+      render(
+        <RotationReleaseDropdown
+          releases={releases}
+          selectedRelease={null}
+          onSelectRelease={mockOnSelectRelease}
+          disabled={false}
+        />
+      );
+      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      const search = screen.getByTestId("rotation-release-search");
+      fireEvent.change(search, { target: { value: "ste" } });
+      // Close
+      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      // Reopen
+      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      expect(
+        (screen.getByTestId("rotation-release-search") as HTMLInputElement)
+          .value
+      ).toBe("");
+    });
+  });
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
@@ -24,14 +24,18 @@ const releases = [
   }),
 ];
 
-describe("RotationReleaseDropdown", () => {
+function getCombobox(): HTMLInputElement {
+  return screen.getByTestId("rotation-release-combobox") as HTMLInputElement;
+}
+
+describe("RotationReleaseDropdown — combobox (#745)", () => {
   const mockOnSelectRelease = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should render the trigger with placeholder text when no release is selected", () => {
+  it("renders the trigger as an editable combobox with placeholder text when nothing is selected", () => {
     render(
       <RotationReleaseDropdown
         releases={releases}
@@ -40,10 +44,13 @@ describe("RotationReleaseDropdown", () => {
         disabled={false}
       />
     );
-    expect(screen.getByText("Select Release...")).toBeInTheDocument();
+    const input = getCombobox();
+    expect(input.tagName).toBe("INPUT");
+    expect(input.placeholder).toMatch(/select release/i);
+    expect(input.value).toBe("");
   });
 
-  it("should show selected release in trigger when one is selected", () => {
+  it("shows the selected release as 'Artist — Title' in the trigger when the panel is closed", () => {
     render(
       <RotationReleaseDropdown
         releases={releases}
@@ -52,11 +59,10 @@ describe("RotationReleaseDropdown", () => {
         disabled={false}
       />
     );
-    expect(screen.getByText(/Autechre/)).toBeInTheDocument();
-    expect(screen.getByText(/Confield/)).toBeInTheDocument();
+    expect(getCombobox().value).toBe("Autechre — Confield");
   });
 
-  it("should open dropdown panel when trigger is clicked", () => {
+  it("opens the panel when the combobox is focused", () => {
     render(
       <RotationReleaseDropdown
         releases={releases}
@@ -65,11 +71,11 @@ describe("RotationReleaseDropdown", () => {
         disabled={false}
       />
     );
-    fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+    fireEvent.focus(getCombobox());
     expect(screen.getByTestId("rotation-release-panel")).toBeInTheDocument();
   });
 
-  it("should show all releases in the dropdown panel", () => {
+  it("opens the panel when the combobox is clicked even if already focused", () => {
     render(
       <RotationReleaseDropdown
         releases={releases}
@@ -78,13 +84,26 @@ describe("RotationReleaseDropdown", () => {
         disabled={false}
       />
     );
-    fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+    fireEvent.click(getCombobox());
+    expect(screen.getByTestId("rotation-release-panel")).toBeInTheDocument();
+  });
+
+  it("shows all releases in the dropdown panel when nothing has been typed", () => {
+    render(
+      <RotationReleaseDropdown
+        releases={releases}
+        selectedRelease={null}
+        onSelectRelease={mockOnSelectRelease}
+        disabled={false}
+      />
+    );
+    fireEvent.focus(getCombobox());
     expect(screen.getByText(/Autechre/)).toBeInTheDocument();
     expect(screen.getByText(/Cat Power/)).toBeInTheDocument();
     expect(screen.getByText(/Stereolab/)).toBeInTheDocument();
   });
 
-  it("should call onSelectRelease when a release is clicked", () => {
+  it("calls onSelectRelease when an option is clicked", () => {
     render(
       <RotationReleaseDropdown
         releases={releases}
@@ -93,13 +112,13 @@ describe("RotationReleaseDropdown", () => {
         disabled={false}
       />
     );
-    fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+    fireEvent.focus(getCombobox());
     fireEvent.click(screen.getByTestId("rotation-release-option-1"));
     expect(mockOnSelectRelease).toHaveBeenCalledWith(releases[0]);
   });
 
-  it("should close dropdown after selecting a release", () => {
-    render(
+  it("closes the panel and reflects the selection in the input after picking", () => {
+    const { rerender } = render(
       <RotationReleaseDropdown
         releases={releases}
         selectedRelease={null}
@@ -107,13 +126,24 @@ describe("RotationReleaseDropdown", () => {
         disabled={false}
       />
     );
-    fireEvent.click(screen.getByTestId("rotation-release-trigger"));
-    expect(screen.getByTestId("rotation-release-panel")).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("rotation-release-option-1"));
-    expect(screen.queryByTestId("rotation-release-panel")).not.toBeInTheDocument();
+    fireEvent.focus(getCombobox());
+    fireEvent.click(screen.getByTestId("rotation-release-option-3"));
+    // Parent owns the selectedRelease state — simulate the controlled rerender.
+    rerender(
+      <RotationReleaseDropdown
+        releases={releases}
+        selectedRelease={releases[2]}
+        onSelectRelease={mockOnSelectRelease}
+        disabled={false}
+      />
+    );
+    expect(
+      screen.queryByTestId("rotation-release-panel")
+    ).not.toBeInTheDocument();
+    expect(getCombobox().value).toBe("Stereolab — Aluminum Tunes");
   });
 
-  it("should not open when disabled", () => {
+  it("disables the combobox when disabled prop is true", () => {
     render(
       <RotationReleaseDropdown
         releases={releases}
@@ -122,11 +152,15 @@ describe("RotationReleaseDropdown", () => {
         disabled={true}
       />
     );
-    fireEvent.click(screen.getByTestId("rotation-release-trigger"));
-    expect(screen.queryByTestId("rotation-release-panel")).not.toBeInTheDocument();
+    const input = getCombobox();
+    expect(input.disabled).toBe(true);
+    fireEvent.click(input);
+    expect(
+      screen.queryByTestId("rotation-release-panel")
+    ).not.toBeInTheDocument();
   });
 
-  it("should show empty state when no releases provided", () => {
+  it("shows empty state when no releases provided", () => {
     render(
       <RotationReleaseDropdown
         releases={[]}
@@ -135,12 +169,11 @@ describe("RotationReleaseDropdown", () => {
         disabled={false}
       />
     );
-    fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+    fireEvent.focus(getCombobox());
     expect(screen.getByText(/no releases/i)).toBeInTheDocument();
   });
 
-  // WXYC/dj-site#745 — DJ feedback: can't quickly find a release in the picker.
-  describe("search and sort (#745)", () => {
+  describe("search and sort", () => {
     it("sorts releases alphabetically by artist name regardless of input order", () => {
       render(
         <RotationReleaseDropdown
@@ -150,10 +183,8 @@ describe("RotationReleaseDropdown", () => {
           disabled={false}
         />
       );
-      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      fireEvent.focus(getCombobox());
       const options = screen.getAllByTestId(/^rotation-release-option-/);
-      // Input order in fixture: Autechre, Cat Power, Stereolab (already sorted).
-      // Hand a re-shuffled fixture to make sure sort is enforced.
       expect(options.map((o) => o.dataset.testid)).toEqual([
         "rotation-release-option-1", // Autechre
         "rotation-release-option-2", // Cat Power
@@ -190,7 +221,7 @@ describe("RotationReleaseDropdown", () => {
           disabled={false}
         />
       );
-      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      fireEvent.focus(getCombobox());
       const options = screen.getAllByTestId(/^rotation-release-option-/);
       expect(options.map((o) => o.dataset.testid)).toEqual([
         "rotation-release-option-12", // Aluminum Tunes
@@ -225,28 +256,13 @@ describe("RotationReleaseDropdown", () => {
           disabled={false}
         />
       );
-      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      fireEvent.focus(getCombobox());
       const options = screen.getAllByTestId(/^rotation-release-option-/);
       expect(options.map((o) => o.dataset.testid)).toEqual([
         "rotation-release-option-22", // Autechre
         "rotation-release-option-23", // cat power
         "rotation-release-option-21", // stereolab
       ]);
-    });
-
-    it("renders a search input when the dropdown opens", () => {
-      render(
-        <RotationReleaseDropdown
-          releases={releases}
-          selectedRelease={null}
-          onSelectRelease={mockOnSelectRelease}
-          disabled={false}
-        />
-      );
-      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
-      expect(
-        screen.getByTestId("rotation-release-search")
-      ).toBeInTheDocument();
     });
 
     it("filters the visible releases by artist name as the DJ types (case-insensitive substring)", () => {
@@ -258,9 +274,9 @@ describe("RotationReleaseDropdown", () => {
           disabled={false}
         />
       );
-      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
-      const search = screen.getByTestId("rotation-release-search");
-      fireEvent.change(search, { target: { value: "ste" } });
+      const input = getCombobox();
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "ste" } });
       expect(
         screen.queryByTestId("rotation-release-option-3")
       ).toBeInTheDocument(); // Stereolab
@@ -281,9 +297,9 @@ describe("RotationReleaseDropdown", () => {
           disabled={false}
         />
       );
-      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
-      const search = screen.getByTestId("rotation-release-search");
-      fireEvent.change(search, { target: { value: "moon" } });
+      const input = getCombobox();
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "moon" } });
       expect(
         screen.queryByTestId("rotation-release-option-2")
       ).toBeInTheDocument(); // Moon Pix
@@ -301,16 +317,16 @@ describe("RotationReleaseDropdown", () => {
           disabled={false}
         />
       );
-      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
-      const search = screen.getByTestId("rotation-release-search");
-      fireEvent.change(search, { target: { value: "zzzz-does-not-exist" } });
+      const input = getCombobox();
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "zzzz-does-not-exist" } });
       expect(
         screen.queryAllByTestId(/^rotation-release-option-/)
       ).toHaveLength(0);
       expect(screen.getByText(/no releases match/i)).toBeInTheDocument();
     });
 
-    it("clears the filter when the dropdown is reopened", () => {
+    it("re-shows all releases when the user clears the filter", () => {
       render(
         <RotationReleaseDropdown
           releases={releases}
@@ -319,17 +335,34 @@ describe("RotationReleaseDropdown", () => {
           disabled={false}
         />
       );
-      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
-      const search = screen.getByTestId("rotation-release-search");
-      fireEvent.change(search, { target: { value: "ste" } });
-      // Close
-      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
-      // Reopen
-      fireEvent.click(screen.getByTestId("rotation-release-trigger"));
+      const input = getCombobox();
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "ste" } });
+      fireEvent.change(input, { target: { value: "" } });
       expect(
-        (screen.getByTestId("rotation-release-search") as HTMLInputElement)
-          .value
-      ).toBe("");
+        screen.queryAllByTestId(/^rotation-release-option-/)
+      ).toHaveLength(3);
+    });
+
+    it("starts a fresh filter on each focus rather than keeping the selected release's text as a filter", () => {
+      // Without resetting, the selected release's formatted text (e.g.
+      // "Autechre — Confield") would be applied as a substring filter on next
+      // focus and hide every other release.
+      render(
+        <RotationReleaseDropdown
+          releases={releases}
+          selectedRelease={releases[0]}
+          onSelectRelease={mockOnSelectRelease}
+          disabled={false}
+        />
+      );
+      const input = getCombobox();
+      fireEvent.focus(input);
+      // All three should be visible because the panel-open state filter is the
+      // empty query, not the selected release's formatted display value.
+      expect(screen.getAllByTestId(/^rotation-release-option-/)).toHaveLength(
+        3
+      );
     });
   });
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
@@ -364,5 +364,41 @@ describe("RotationReleaseDropdown — combobox (#745)", () => {
         3
       );
     });
+
+    it("does not clear the live filter when the input is clicked while the panel is already open", () => {
+      // Regression: clicking inside an already-focused input fires `onClick`
+      // again. The trigger's `onClick={openPanel}` must be idempotent so the
+      // DJ's in-progress filter doesn't get wiped when they reposition the
+      // caret mid-edit.
+      render(
+        <RotationReleaseDropdown
+          releases={releases}
+          selectedRelease={null}
+          onSelectRelease={mockOnSelectRelease}
+          disabled={false}
+        />
+      );
+      const input = getCombobox();
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: "ste" } });
+      // Filter is applied: Stereolab visible, others hidden.
+      expect(
+        screen.queryByTestId("rotation-release-option-3")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("rotation-release-option-1")
+      ).not.toBeInTheDocument();
+
+      // Click the (already-focused, already-open) input — must NOT reset the
+      // query.
+      fireEvent.click(input);
+      expect(input.value).toBe("ste");
+      expect(
+        screen.queryByTestId("rotation-release-option-3")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("rotation-release-option-1")
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
@@ -57,14 +57,11 @@ export default function RotationReleaseDropdown({
     // again, so a non-idempotent reset would wipe the DJ's in-progress filter
     // mid-edit (typed "ste", clicked to reposition caret, panel resets to
     // showing every release).
-    setOpen((wasOpen) => {
-      if (!wasOpen) {
-        setQuery("");
-        setHighlightIndex(0);
-      }
-      return true;
-    });
-  }, [disabled]);
+    if (open) return;
+    setOpen(true);
+    setQuery("");
+    setHighlightIndex(0);
+  }, [disabled, open]);
 
   const closePanel = useCallback(() => {
     setOpen(false);

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
@@ -124,6 +124,7 @@ export default function RotationReleaseDropdown({
         <Input
           size="sm"
           fullWidth
+          variant="plain"
           disabled={disabled}
           placeholder="Select Release..."
           value={displayValue}
@@ -148,6 +149,16 @@ export default function RotationReleaseDropdown({
               }}
             />
           }
+          // Sit flat inside the parent search row's square frame — no border,
+          // no radius, no background tint. The trigger should read as part of
+          // the row's chrome, not as a nested control.
+          sx={{
+            borderRadius: 0,
+            backgroundColor: "transparent",
+            "--Input-focusedThickness": "0px",
+            "&:hover": { backgroundColor: "transparent" },
+            "&.Mui-focused": { backgroundColor: "transparent" },
+          }}
           slotProps={{
             input: {
               ref: inputRef,

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
@@ -7,6 +7,10 @@ import { Box, Input, Sheet, Typography } from "@mui/joy";
 import { ClickAwayListener } from "@mui/material";
 import { useCallback, useMemo, useRef, useState } from "react";
 
+function formatRelease(release: AlbumEntry): string {
+  return `${release.artist.name} — ${release.title}`;
+}
+
 function matchesQuery(release: AlbumEntry, query: string): boolean {
   if (!query) return true;
   const q = query.toLowerCase();
@@ -28,65 +32,67 @@ export default function RotationReleaseDropdown({
   disabled: boolean;
 }) {
   const [open, setOpen] = useState(false);
-  const [highlightIndex, setHighlightIndex] = useState(-1);
   const [query, setQuery] = useState("");
-  const triggerRef = useRef<HTMLDivElement>(null);
+  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const visibleReleases = useMemo(() => {
     const sorted = sortRotationReleases(releases);
     return query ? sorted.filter((r) => matchesQuery(r, query)) : sorted;
   }, [releases, query]);
 
-  const handleToggle = useCallback(() => {
-    if (!disabled) {
-      setOpen((prev) => {
-        const next = !prev;
-        // Reset filter every time the dropdown reopens so the DJ doesn't see
-        // stale results from a prior pick.
-        if (next) setQuery("");
-        return next;
-      });
-      setHighlightIndex(-1);
-    }
+  // While the panel is open the input mirrors the live filter query (which
+  // starts empty so the DJ can see every release). While closed it mirrors
+  // the parent-owned selection so the picker reads "Artist — Title" at rest.
+  const displayValue = open
+    ? query
+    : selectedRelease
+      ? formatRelease(selectedRelease)
+      : "";
+
+  const openPanel = useCallback(() => {
+    if (disabled) return;
+    setOpen(true);
+    setQuery("");
+    setHighlightIndex(0);
   }, [disabled]);
+
+  const closePanel = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+    setHighlightIndex(-1);
+  }, []);
 
   const handleSelect = useCallback(
     (release: AlbumEntry) => {
       onSelectRelease(release);
-      setOpen(false);
-      setQuery("");
+      closePanel();
     },
-    [onSelectRelease]
+    [onSelectRelease, closePanel]
   );
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (!open) {
-        if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown") {
+        if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          setOpen(true);
-          setQuery("");
-          setHighlightIndex(0);
+          openPanel();
         }
         return;
       }
-
       switch (e.key) {
         case "ArrowDown":
           e.preventDefault();
-          e.stopPropagation();
           setHighlightIndex((prev) =>
             Math.min(prev + 1, visibleReleases.length - 1)
           );
           break;
         case "ArrowUp":
           e.preventDefault();
-          e.stopPropagation();
           setHighlightIndex((prev) => Math.max(prev - 1, 0));
           break;
         case "Enter":
           e.preventDefault();
-          e.stopPropagation();
           if (
             highlightIndex >= 0 &&
             highlightIndex < visibleReleases.length
@@ -96,75 +102,61 @@ export default function RotationReleaseDropdown({
           break;
         case "Escape":
           e.preventDefault();
-          setOpen(false);
-          triggerRef.current?.focus();
+          closePanel();
+          inputRef.current?.blur();
           break;
       }
     },
-    [open, visibleReleases, highlightIndex, handleSelect]
+    [open, openPanel, closePanel, visibleReleases, highlightIndex, handleSelect]
   );
 
   return (
-    <ClickAwayListener onClickAway={() => setOpen(false)}>
+    <ClickAwayListener onClickAway={closePanel}>
       <Box
-        sx={{ position: "relative", flex: 1, minWidth: 0, display: "flex", alignItems: "center" }}
-        onKeyDown={handleKeyDown}
+        sx={{
+          position: "relative",
+          flex: 1,
+          minWidth: 0,
+          display: "flex",
+          alignItems: "center",
+        }}
       >
-        <Box
-          ref={triggerRef}
-          tabIndex={disabled ? -1 : 0}
-          data-testid="rotation-release-trigger"
-          onClick={handleToggle}
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            flex: 1,
-            px: 1,
-            minHeight: "2rem",
-            cursor: disabled ? "default" : "pointer",
-            opacity: disabled ? 0.5 : 1,
-            overflow: "hidden",
-            "&:focus-visible": {
-              outline: "2px solid var(--joy-palette-primary-400)",
-              outlineOffset: "-2px",
-              borderRadius: "4px",
+        <Input
+          size="sm"
+          fullWidth
+          disabled={disabled}
+          placeholder="Select Release..."
+          value={displayValue}
+          onFocus={openPanel}
+          // Clicking an already-focused input doesn't refire onFocus; an
+          // idempotent reopen on click handles that case (and is a no-op if
+          // the panel is already open).
+          onClick={openPanel}
+          onChange={(e) => {
+            if (!open) openPanel();
+            setQuery(e.target.value);
+            setHighlightIndex(0);
+          }}
+          onKeyDown={handleKeyDown}
+          endDecorator={
+            <KeyboardArrowDown
+              sx={{
+                fontSize: "1rem",
+                transition: "transform 0.2s",
+                transform: open ? "rotate(180deg)" : "none",
+                opacity: disabled ? 0.4 : 0.7,
+              }}
+            />
+          }
+          slotProps={{
+            input: {
+              ref: inputRef,
+              "data-testid": "rotation-release-combobox",
+              autoComplete: "off",
+              spellCheck: false,
             },
           }}
-        >
-          {selectedRelease ? (
-            <Typography
-              level="body-sm"
-              sx={{
-                whiteSpace: "nowrap",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-              }}
-            >
-              <Typography component="span" sx={{ fontWeight: "bold" }}>
-                {selectedRelease.artist.name}
-              </Typography>
-              {" \u2014 "}
-              {selectedRelease.title}
-            </Typography>
-          ) : (
-            <Typography
-              level="body-sm"
-              sx={{ opacity: 0.5 }}
-            >
-              Select Release...
-            </Typography>
-          )}
-          <KeyboardArrowDown
-            sx={{
-              fontSize: "1rem",
-              ml: 0.5,
-              flexShrink: 0,
-              transition: "transform 0.2s",
-              transform: open ? "rotate(180deg)" : "none",
-            }}
-          />
-        </Box>
+        />
 
         {open && (
           <Sheet
@@ -183,23 +175,6 @@ export default function RotationReleaseDropdown({
               py: 0.5,
             }}
           >
-            <Box sx={{ px: 1, pb: 0.5 }}>
-              <Input
-                size="sm"
-                autoFocus
-                placeholder="Search artist or album..."
-                value={query}
-                onChange={(e) => {
-                  setQuery(e.target.value);
-                  setHighlightIndex(0);
-                }}
-                slotProps={{
-                  input: {
-                    "data-testid": "rotation-release-search",
-                  },
-                }}
-              />
-            </Box>
             {releases.length === 0 ? (
               <Box sx={{ p: 2, textAlign: "center" }}>
                 <Typography level="body-sm" sx={{ opacity: 0.6 }}>
@@ -217,6 +192,10 @@ export default function RotationReleaseDropdown({
                 <Box
                   key={release.id}
                   data-testid={`rotation-release-option-${release.id}`}
+                  // `onMouseDown` preventDefault keeps focus on the input so
+                  // the ClickAway / blur path doesn't close the panel before
+                  // the option's `onClick` selection handler runs.
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => handleSelect(release)}
                   sx={{
                     display: "flex",
@@ -232,7 +211,9 @@ export default function RotationReleaseDropdown({
                           : "transparent",
                     "&:hover": {
                       backgroundColor:
-                        highlightIndex === index ? "primary.700" : "neutral.800",
+                        highlightIndex === index
+                          ? "primary.700"
+                          : "neutral.800",
                     },
                   }}
                   onMouseEnter={() => setHighlightIndex(index)}
@@ -246,20 +227,20 @@ export default function RotationReleaseDropdown({
                       color: highlightIndex === index ? "white" : "inherit",
                     }}
                   >
-                    <Typography
-                      component="span"
-                      sx={{ fontWeight: "bold" }}
-                    >
+                    <Typography component="span" sx={{ fontWeight: "bold" }}>
                       {release.artist.name}
                     </Typography>
-                    {" \u2014 "}
+                    {" — "}
                     {release.title}
                   </Typography>
                   <Typography
                     level="body-xs"
                     sx={{
                       opacity: 0.6,
-                      color: highlightIndex === index ? "neutral.300" : "text.tertiary",
+                      color:
+                        highlightIndex === index
+                          ? "neutral.300"
+                          : "text.tertiary",
                     }}
                   >
                     {release.label}

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
@@ -1,10 +1,20 @@
 "use client";
 
 import { AlbumEntry } from "@/lib/features/catalog/types";
+import { sortRotationReleases } from "@/lib/features/rotation/sort";
 import { KeyboardArrowDown } from "@mui/icons-material";
-import { Box, Sheet, Typography } from "@mui/joy";
+import { Box, Input, Sheet, Typography } from "@mui/joy";
 import { ClickAwayListener } from "@mui/material";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+
+function matchesQuery(release: AlbumEntry, query: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  return (
+    release.artist.name.toLowerCase().includes(q) ||
+    release.title.toLowerCase().includes(q)
+  );
+}
 
 export default function RotationReleaseDropdown({
   releases,
@@ -19,11 +29,23 @@ export default function RotationReleaseDropdown({
 }) {
   const [open, setOpen] = useState(false);
   const [highlightIndex, setHighlightIndex] = useState(-1);
+  const [query, setQuery] = useState("");
   const triggerRef = useRef<HTMLDivElement>(null);
+
+  const visibleReleases = useMemo(() => {
+    const sorted = sortRotationReleases(releases);
+    return query ? sorted.filter((r) => matchesQuery(r, query)) : sorted;
+  }, [releases, query]);
 
   const handleToggle = useCallback(() => {
     if (!disabled) {
-      setOpen((prev) => !prev);
+      setOpen((prev) => {
+        const next = !prev;
+        // Reset filter every time the dropdown reopens so the DJ doesn't see
+        // stale results from a prior pick.
+        if (next) setQuery("");
+        return next;
+      });
       setHighlightIndex(-1);
     }
   }, [disabled]);
@@ -32,6 +54,7 @@ export default function RotationReleaseDropdown({
     (release: AlbumEntry) => {
       onSelectRelease(release);
       setOpen(false);
+      setQuery("");
     },
     [onSelectRelease]
   );
@@ -42,6 +65,7 @@ export default function RotationReleaseDropdown({
         if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown") {
           e.preventDefault();
           setOpen(true);
+          setQuery("");
           setHighlightIndex(0);
         }
         return;
@@ -51,7 +75,9 @@ export default function RotationReleaseDropdown({
         case "ArrowDown":
           e.preventDefault();
           e.stopPropagation();
-          setHighlightIndex((prev) => Math.min(prev + 1, releases.length - 1));
+          setHighlightIndex((prev) =>
+            Math.min(prev + 1, visibleReleases.length - 1)
+          );
           break;
         case "ArrowUp":
           e.preventDefault();
@@ -61,8 +87,11 @@ export default function RotationReleaseDropdown({
         case "Enter":
           e.preventDefault();
           e.stopPropagation();
-          if (highlightIndex >= 0 && highlightIndex < releases.length) {
-            handleSelect(releases[highlightIndex]);
+          if (
+            highlightIndex >= 0 &&
+            highlightIndex < visibleReleases.length
+          ) {
+            handleSelect(visibleReleases[highlightIndex]);
           }
           break;
         case "Escape":
@@ -72,7 +101,7 @@ export default function RotationReleaseDropdown({
           break;
       }
     },
-    [open, releases, highlightIndex, handleSelect]
+    [open, visibleReleases, highlightIndex, handleSelect]
   );
 
   return (
@@ -154,14 +183,37 @@ export default function RotationReleaseDropdown({
               py: 0.5,
             }}
           >
+            <Box sx={{ px: 1, pb: 0.5 }}>
+              <Input
+                size="sm"
+                autoFocus
+                placeholder="Search artist or album..."
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setHighlightIndex(0);
+                }}
+                slotProps={{
+                  input: {
+                    "data-testid": "rotation-release-search",
+                  },
+                }}
+              />
+            </Box>
             {releases.length === 0 ? (
               <Box sx={{ p: 2, textAlign: "center" }}>
                 <Typography level="body-sm" sx={{ opacity: 0.6 }}>
                   No releases in this bin
                 </Typography>
               </Box>
+            ) : visibleReleases.length === 0 ? (
+              <Box sx={{ p: 2, textAlign: "center" }}>
+                <Typography level="body-sm" sx={{ opacity: 0.6 }}>
+                  No releases match &ldquo;{query}&rdquo;
+                </Typography>
+              </Box>
             ) : (
-              releases.map((release, index) => (
+              visibleReleases.map((release, index) => (
                 <Box
                   key={release.id}
                   data-testid={`rotation-release-option-${release.id}`}

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
@@ -52,9 +52,18 @@ export default function RotationReleaseDropdown({
 
   const openPanel = useCallback(() => {
     if (disabled) return;
-    setOpen(true);
-    setQuery("");
-    setHighlightIndex(0);
+    // Idempotent: if the panel is already open, do not stomp on the live
+    // filter state. Clicking inside an already-focused input fires `onClick`
+    // again, so a non-idempotent reset would wipe the DJ's in-progress filter
+    // mid-edit (typed "ste", clicked to reposition caret, panel resets to
+    // showing every release).
+    setOpen((wasOpen) => {
+      if (!wasOpen) {
+        setQuery("");
+        setHighlightIndex(0);
+      }
+      return true;
+    });
   }, [disabled]);
 
   const closePanel = useCallback(() => {

--- a/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.test.tsx
@@ -39,7 +39,7 @@ describe("TrackPickerDropdown — combobox (#745)", () => {
     expect(input.value).toBe("");
   });
 
-  it("shows the selected track as 'position title' when the panel is closed", () => {
+  it("shows the selected track title only when the panel is closed (position stays in the panel)", () => {
     render(
       <TrackPickerDropdown
         tracks={tracks}
@@ -50,7 +50,7 @@ describe("TrackPickerDropdown — combobox (#745)", () => {
         disabled={false}
       />
     );
-    expect(getCombobox().value).toBe("A1 Percolator");
+    expect(getCombobox().value).toBe("Percolator");
   });
 
   it("opens the panel on focus", () => {
@@ -194,7 +194,7 @@ describe("TrackPickerDropdown — combobox (#745)", () => {
     expect(
       screen.queryByTestId("track-picker-panel")
     ).not.toBeInTheDocument();
-    expect(getCombobox().value).toBe("A2 Cybele's Reverie");
+    expect(getCombobox().value).toBe("Cybele's Reverie");
   });
 
   it("always shows the 'Not listed — enter manually' option, even when the filter eliminates every track", () => {

--- a/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.test.tsx
@@ -295,4 +295,40 @@ describe("TrackPickerDropdown — combobox (#745)", () => {
     fireEvent.focus(getCombobox());
     expect(screen.getAllByTestId(/^track-picker-option-/)).toHaveLength(3);
   });
+
+  it("does not clear the live filter when the input is clicked while the panel is already open", () => {
+    // Regression: clicking inside an already-focused input fires `onClick`
+    // again. The trigger's `onClick={openPanel}` must be idempotent so the
+    // DJ's in-progress filter doesn't get wiped when they reposition the
+    // caret mid-edit.
+    render(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    const input = getCombobox();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "perc" } });
+    expect(
+      screen.queryByTestId("track-picker-option-0")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("track-picker-option-1")
+    ).not.toBeInTheDocument();
+
+    // Click the (already-focused, already-open) input — must NOT reset query.
+    fireEvent.click(input);
+    expect(input.value).toBe("perc");
+    expect(
+      screen.queryByTestId("track-picker-option-0")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("track-picker-option-1")
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.test.tsx
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import TrackPickerDropdown, {
+  TrackPickerEntry,
+} from "./TrackPickerDropdown";
+
+const tracks: TrackPickerEntry[] = [
+  { position: "A1", title: "Percolator", artists: ["Stereolab"] },
+  { position: "A2", title: "Cybele's Reverie", artists: ["Stereolab"] },
+  { position: "B1", title: "Anonymous Collective", artists: ["Stereolab"] },
+];
+
+function getCombobox(): HTMLInputElement {
+  return screen.getByTestId("track-picker-combobox") as HTMLInputElement;
+}
+
+describe("TrackPickerDropdown — combobox (#745)", () => {
+  const onSelectTrack = vi.fn();
+  const onManualEntry = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the trigger as an editable combobox with placeholder text when nothing is selected", () => {
+    render(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    const input = getCombobox();
+    expect(input.tagName).toBe("INPUT");
+    expect(input.placeholder).toMatch(/select track|song title/i);
+    expect(input.value).toBe("");
+  });
+
+  it("shows the selected track as 'position title' when the panel is closed", () => {
+    render(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={tracks[0]}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    expect(getCombobox().value).toBe("A1 Percolator");
+  });
+
+  it("opens the panel on focus", () => {
+    render(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    fireEvent.focus(getCombobox());
+    expect(screen.getByTestId("track-picker-panel")).toBeInTheDocument();
+  });
+
+  it("shows every track when nothing has been typed, preserving tracklist order", () => {
+    render(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    fireEvent.focus(getCombobox());
+    const options = screen.getAllByTestId(/^track-picker-option-/);
+    // Tracklist order (A1, A2, B1) — do NOT alphabetize. Disc/side order is
+    // the DJ's mental model.
+    expect(options.map((o) => o.dataset.testid)).toEqual([
+      "track-picker-option-0",
+      "track-picker-option-1",
+      "track-picker-option-2",
+    ]);
+  });
+
+  it("filters tracks by title as the DJ types (case-insensitive)", () => {
+    render(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    const input = getCombobox();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "perc" } });
+    expect(
+      screen.queryByTestId("track-picker-option-0")
+    ).toBeInTheDocument(); // Percolator
+    expect(
+      screen.queryByTestId("track-picker-option-1")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("track-picker-option-2")
+    ).not.toBeInTheDocument();
+  });
+
+  it("filters by per-track artist credit too", () => {
+    const va: TrackPickerEntry[] = [
+      { position: "A1", title: "Track One", artists: ["Coil"] },
+      { position: "A2", title: "Track Two", artists: ["Nurse With Wound"] },
+      { position: "B1", title: "Track Three", artists: ["Current 93"] },
+    ];
+    render(
+      <TrackPickerDropdown
+        tracks={va}
+        isLoading={false}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    const input = getCombobox();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "nurse" } });
+    expect(
+      screen.queryByTestId("track-picker-option-1")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("track-picker-option-0")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("track-picker-option-2")
+    ).not.toBeInTheDocument();
+  });
+
+  it("filters by track position (e.g. 'A1', 'B2')", () => {
+    render(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    const input = getCombobox();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "B1" } });
+    expect(
+      screen.queryByTestId("track-picker-option-2")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("track-picker-option-0")
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onSelectTrack and closes when an option is clicked", () => {
+    const { rerender } = render(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    fireEvent.focus(getCombobox());
+    fireEvent.click(screen.getByTestId("track-picker-option-1"));
+    expect(onSelectTrack).toHaveBeenCalledWith(tracks[1]);
+    rerender(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={tracks[1]}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    expect(
+      screen.queryByTestId("track-picker-panel")
+    ).not.toBeInTheDocument();
+    expect(getCombobox().value).toBe("A2 Cybele's Reverie");
+  });
+
+  it("always shows the 'Not listed — enter manually' option, even when the filter eliminates every track", () => {
+    render(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    const input = getCombobox();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "zzzz-nothing" } });
+    expect(
+      screen.queryAllByTestId(/^track-picker-option-/)
+    ).toHaveLength(0);
+    expect(screen.getByTestId("track-picker-manual")).toBeInTheDocument();
+  });
+
+  it("calls onManualEntry when the manual-entry option is clicked", () => {
+    render(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    fireEvent.focus(getCombobox());
+    fireEvent.click(screen.getByTestId("track-picker-manual"));
+    expect(onManualEntry).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the combobox when disabled prop is true", () => {
+    render(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={true}
+      />
+    );
+    expect(getCombobox().disabled).toBe(true);
+    fireEvent.click(getCombobox());
+    expect(
+      screen.queryByTestId("track-picker-panel")
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables the combobox while loading and surfaces a loading hint", () => {
+    render(
+      <TrackPickerDropdown
+        tracks={[]}
+        isLoading={true}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    const input = getCombobox();
+    expect(input.disabled).toBe(true);
+    expect(input.placeholder).toMatch(/loading/i);
+  });
+
+  it("falls back to a 'Song Title' placeholder when no tracks are available and not loading", () => {
+    render(
+      <TrackPickerDropdown
+        tracks={[]}
+        isLoading={false}
+        selectedTrack={null}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    expect(getCombobox().placeholder).toMatch(/song title/i);
+  });
+
+  it("starts a fresh filter on each focus rather than keeping the selected track's text as a filter", () => {
+    render(
+      <TrackPickerDropdown
+        tracks={tracks}
+        isLoading={false}
+        selectedTrack={tracks[0]}
+        onSelectTrack={onSelectTrack}
+        onManualEntry={onManualEntry}
+        disabled={false}
+      />
+    );
+    fireEvent.focus(getCombobox());
+    expect(screen.getAllByTestId(/^track-picker-option-/)).toHaveLength(3);
+  });
+});

--- a/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
@@ -78,9 +78,17 @@ export default function TrackPickerDropdown<T extends TrackPickerEntry>({
 
   const openPanel = useCallback(() => {
     if (inputDisabled) return;
-    setOpen(true);
-    setQuery("");
-    setHighlightIndex(0);
+    // Idempotent: if the panel is already open, do not stomp on the live
+    // filter state. Clicking inside an already-focused input fires `onClick`
+    // again, so a non-idempotent reset would wipe the DJ's in-progress filter
+    // mid-edit. Matches RotationReleaseDropdown (#745).
+    setOpen((wasOpen) => {
+      if (!wasOpen) {
+        setQuery("");
+        setHighlightIndex(0);
+      }
+      return true;
+    });
   }, [inputDisabled]);
 
   const closePanel = useCallback(() => {

--- a/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
@@ -20,7 +20,10 @@ export interface TrackPickerEntry {
 }
 
 function formatTrack(track: TrackPickerEntry): string {
-  return track.position ? `${track.position} ${track.title}` : track.title;
+  // Title only at rest — the position is structural metadata (vinyl side,
+  // disc number) the DJ already knows from the panel; it would read as part
+  // of the track title in the closed combobox ("3 El Barm" ≠ a track title).
+  return track.title;
 }
 
 function matchesQuery(track: TrackPickerEntry, query: string): boolean {

--- a/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
@@ -2,9 +2,9 @@
 
 import { normalizeTrackArtists } from "@/lib/features/rotation/normalize-track-artists";
 import { KeyboardArrowDown } from "@mui/icons-material";
-import { Box, CircularProgress, Sheet, Typography } from "@mui/joy";
+import { Box, CircularProgress, Input, Sheet, Typography } from "@mui/joy";
 import { ClickAwayListener } from "@mui/material";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 /**
  * Minimal shape a track must expose to be rendered by this dropdown. Both the
@@ -17,6 +17,18 @@ export interface TrackPickerEntry {
   position: string;
   title: string;
   artists: string[];
+}
+
+function formatTrack(track: TrackPickerEntry): string {
+  return track.position ? `${track.position} ${track.title}` : track.title;
+}
+
+function matchesQuery(track: TrackPickerEntry, query: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  if (track.title.toLowerCase().includes(q)) return true;
+  if (track.position.toLowerCase().includes(q)) return true;
+  return track.artists.some((a) => a.toLowerCase().includes(q));
 }
 
 export default function TrackPickerDropdown<T extends TrackPickerEntry>({
@@ -35,138 +47,173 @@ export default function TrackPickerDropdown<T extends TrackPickerEntry>({
   disabled: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
   const [highlightIndex, setHighlightIndex] = useState(-1);
-  const triggerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleToggle = useCallback(() => {
-    if (!disabled && !isLoading) {
-      setOpen((prev) => !prev);
-      setHighlightIndex(-1);
-    }
-  }, [disabled, isLoading]);
+  const visibleTracks = useMemo(() => {
+    if (!query) return tracks;
+    return tracks.filter((t) => matchesQuery(t, query));
+  }, [tracks, query]);
+
+  // While the panel is open the input mirrors the live filter query. While
+  // closed it mirrors the parent-owned selection so the trigger reads
+  // "A1 Track Title" at rest. Matches the rotation-picker pattern (#745).
+  const displayValue = open
+    ? query
+    : selectedTrack
+      ? formatTrack(selectedTrack)
+      : "";
+
+  const placeholder = isLoading
+    ? "Loading tracks..."
+    : tracks.length === 0
+      ? "Song Title"
+      : "Select Track...";
+
+  const inputDisabled = disabled || isLoading;
+
+  const openPanel = useCallback(() => {
+    if (inputDisabled) return;
+    setOpen(true);
+    setQuery("");
+    setHighlightIndex(0);
+  }, [inputDisabled]);
+
+  const closePanel = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+    setHighlightIndex(-1);
+  }, []);
 
   const handleSelect = useCallback(
     (track: T) => {
       onSelectTrack(track);
-      setOpen(false);
+      closePanel();
     },
-    [onSelectTrack]
+    [onSelectTrack, closePanel]
   );
+
+  const handleManual = useCallback(() => {
+    onManualEntry();
+    closePanel();
+  }, [onManualEntry, closePanel]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (!open) {
-        if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown") {
+        if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          setOpen(true);
-          setHighlightIndex(0);
+          openPanel();
         }
         return;
       }
-
-      // Total items = tracks + "Not listed" option
-      const totalItems = tracks.length + 1;
-
+      // Total navigable items = visible tracks + "Not listed" manual option.
+      const totalItems = visibleTracks.length + 1;
       switch (e.key) {
         case "ArrowDown":
           e.preventDefault();
-          e.stopPropagation();
           setHighlightIndex((prev) => Math.min(prev + 1, totalItems - 1));
           break;
         case "ArrowUp":
           e.preventDefault();
-          e.stopPropagation();
           setHighlightIndex((prev) => Math.max(prev - 1, 0));
           break;
         case "Enter":
           e.preventDefault();
-          e.stopPropagation();
-          if (highlightIndex === tracks.length) {
-            // "Not listed" option
-            onManualEntry();
-            setOpen(false);
-          } else if (highlightIndex >= 0 && highlightIndex < tracks.length) {
-            handleSelect(tracks[highlightIndex]);
+          if (highlightIndex === visibleTracks.length) {
+            handleManual();
+          } else if (
+            highlightIndex >= 0 &&
+            highlightIndex < visibleTracks.length
+          ) {
+            handleSelect(visibleTracks[highlightIndex]);
           }
           break;
         case "Escape":
           e.preventDefault();
-          setOpen(false);
-          triggerRef.current?.focus();
+          closePanel();
+          inputRef.current?.blur();
           break;
       }
     },
-    [open, tracks, highlightIndex, handleSelect, onManualEntry]
+    [
+      open,
+      openPanel,
+      closePanel,
+      visibleTracks,
+      highlightIndex,
+      handleSelect,
+      handleManual,
+    ]
   );
 
   return (
-    <ClickAwayListener onClickAway={() => setOpen(false)}>
+    <ClickAwayListener onClickAway={closePanel}>
       <Box
-        sx={{ position: "relative", flex: 1, minWidth: 0, display: "flex", alignItems: "center" }}
-        onKeyDown={handleKeyDown}
+        sx={{
+          position: "relative",
+          flex: 1,
+          minWidth: 0,
+          display: "flex",
+          alignItems: "center",
+        }}
       >
-        <Box
-          ref={triggerRef}
-          tabIndex={disabled ? -1 : 0}
-          data-testid="track-picker-trigger"
-          onClick={handleToggle}
+        <Input
+          size="sm"
+          fullWidth
+          variant="plain"
+          disabled={inputDisabled}
+          placeholder={placeholder}
+          value={displayValue}
+          onFocus={openPanel}
+          // Clicking an already-focused input doesn't refire onFocus; an
+          // idempotent reopen on click handles that case.
+          onClick={openPanel}
+          onChange={(e) => {
+            if (!open) openPanel();
+            setQuery(e.target.value);
+            setHighlightIndex(0);
+          }}
+          onKeyDown={handleKeyDown}
+          startDecorator={
+            isLoading ? (
+              <CircularProgress
+                size="sm"
+                sx={{ "--CircularProgress-size": "14px" }}
+              />
+            ) : undefined
+          }
+          endDecorator={
+            tracks.length > 0 || isLoading ? (
+              <KeyboardArrowDown
+                sx={{
+                  fontSize: "1rem",
+                  transition: "transform 0.2s",
+                  transform: open ? "rotate(180deg)" : "none",
+                  opacity: inputDisabled ? 0.4 : 0.7,
+                }}
+              />
+            ) : undefined
+          }
+          // Sit flat inside the parent search row's square frame — no border,
+          // no radius, no background tint. Matches RotationReleaseDropdown.
           sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            flex: 1,
-            px: 1,
-            minHeight: "2rem",
-            cursor: disabled ? "default" : "pointer",
-            opacity: disabled ? 0.5 : 1,
-            overflow: "hidden",
-            "&:focus-visible": {
-              outline: "2px solid var(--joy-palette-primary-400)",
-              outlineOffset: "-2px",
-              borderRadius: "4px",
+            borderRadius: 0,
+            backgroundColor: "transparent",
+            "--Input-focusedThickness": "0px",
+            "&:hover": { backgroundColor: "transparent" },
+            "&.Mui-focused": { backgroundColor: "transparent" },
+          }}
+          slotProps={{
+            input: {
+              ref: inputRef,
+              "data-testid": "track-picker-combobox",
+              autoComplete: "off",
+              spellCheck: false,
             },
           }}
-        >
-          {isLoading ? (
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-              <CircularProgress size="sm" sx={{ "--CircularProgress-size": "14px" }} />
-              <Typography level="body-sm" sx={{ opacity: 0.5 }}>
-                Loading tracks...
-              </Typography>
-            </Box>
-          ) : selectedTrack ? (
-            <Typography
-              level="body-sm"
-              sx={{
-                whiteSpace: "nowrap",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-              }}
-            >
-              {selectedTrack.position && (
-                <Typography component="span" sx={{ opacity: 0.6, mr: 0.5 }}>
-                  {selectedTrack.position}
-                </Typography>
-              )}
-              {selectedTrack.title}
-            </Typography>
-          ) : (
-            <Typography level="body-sm" sx={{ opacity: 0.5 }}>
-              {tracks.length > 0 ? "Select Track..." : "Song Title"}
-            </Typography>
-          )}
-          {tracks.length > 0 && (
-            <KeyboardArrowDown
-              sx={{
-                fontSize: "1rem",
-                ml: 0.5,
-                flexShrink: 0,
-                transition: "transform 0.2s",
-                transform: open ? "rotate(180deg)" : "none",
-              }}
-            />
-          )}
-        </Box>
+        />
 
         {open && (
           <Sheet
@@ -187,12 +234,20 @@ export default function TrackPickerDropdown<T extends TrackPickerEntry>({
               py: 0.5,
             }}
           >
-            {tracks.map((track, index) => {
+            {visibleTracks.map((track, index) => {
+              // Stable testid keyed off the ORIGINAL tracks-array index so
+              // tests can find a row by its catalog position regardless of
+              // which subset survives the current filter.
+              const originalIndex = tracks.indexOf(track);
               const cleanArtists = normalizeTrackArtists(track.artists);
               return (
                 <Box
-                  key={`${track.position}-${index}`}
-                  data-testid={`track-picker-option-${index}`}
+                  key={`${track.position}-${originalIndex}`}
+                  data-testid={`track-picker-option-${originalIndex}`}
+                  // `onMouseDown` preventDefault keeps focus on the input so
+                  // the ClickAway / blur path doesn't close the panel before
+                  // the option's `onClick` selection handler runs.
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => handleSelect(track)}
                   sx={{
                     display: "flex",
@@ -203,7 +258,10 @@ export default function TrackPickerDropdown<T extends TrackPickerEntry>({
                     backgroundColor:
                       highlightIndex === index ? "primary.700" : "transparent",
                     "&:hover": {
-                      backgroundColor: highlightIndex === index ? "primary.700" : "neutral.800",
+                      backgroundColor:
+                        highlightIndex === index
+                          ? "primary.700"
+                          : "neutral.800",
                     },
                   }}
                   onMouseEnter={() => setHighlightIndex(index)}
@@ -214,7 +272,10 @@ export default function TrackPickerDropdown<T extends TrackPickerEntry>({
                       opacity: 0.5,
                       minWidth: "28px",
                       pt: 0.25,
-                      color: highlightIndex === index ? "neutral.300" : "text.tertiary",
+                      color:
+                        highlightIndex === index
+                          ? "neutral.300"
+                          : "text.tertiary",
                     }}
                   >
                     {track.position}
@@ -233,7 +294,10 @@ export default function TrackPickerDropdown<T extends TrackPickerEntry>({
                         level="body-xs"
                         sx={{
                           opacity: 0.6,
-                          color: highlightIndex === index ? "neutral.300" : "text.tertiary",
+                          color:
+                            highlightIndex === index
+                              ? "neutral.300"
+                              : "text.tertiary",
                         }}
                       >
                         {cleanArtists.join(", ")}
@@ -245,7 +309,8 @@ export default function TrackPickerDropdown<T extends TrackPickerEntry>({
             })}
             <Box
               data-testid="track-picker-manual"
-              onClick={() => { onManualEntry(); setOpen(false); }}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={handleManual}
               sx={{
                 display: "flex",
                 alignItems: "center",
@@ -256,19 +321,27 @@ export default function TrackPickerDropdown<T extends TrackPickerEntry>({
                 borderColor: "divider",
                 mt: 0.5,
                 backgroundColor:
-                  highlightIndex === tracks.length ? "primary.700" : "transparent",
+                  highlightIndex === visibleTracks.length
+                    ? "primary.700"
+                    : "transparent",
                 "&:hover": {
-                  backgroundColor: highlightIndex === tracks.length ? "primary.700" : "neutral.800",
+                  backgroundColor:
+                    highlightIndex === visibleTracks.length
+                      ? "primary.700"
+                      : "neutral.800",
                 },
               }}
-              onMouseEnter={() => setHighlightIndex(tracks.length)}
+              onMouseEnter={() => setHighlightIndex(visibleTracks.length)}
             >
               <Typography
                 level="body-sm"
                 sx={{
                   fontStyle: "italic",
                   opacity: 0.7,
-                  color: highlightIndex === tracks.length ? "white" : "inherit",
+                  color:
+                    highlightIndex === visibleTracks.length
+                      ? "white"
+                      : "inherit",
                 }}
               >
                 Not listed — enter manually

--- a/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
@@ -82,14 +82,11 @@ export default function TrackPickerDropdown<T extends TrackPickerEntry>({
     // filter state. Clicking inside an already-focused input fires `onClick`
     // again, so a non-idempotent reset would wipe the DJ's in-progress filter
     // mid-edit. Matches RotationReleaseDropdown (#745).
-    setOpen((wasOpen) => {
-      if (!wasOpen) {
-        setQuery("");
-        setHighlightIndex(0);
-      }
-      return true;
-    });
-  }, [inputDisabled]);
+    if (open) return;
+    setOpen(true);
+    setQuery("");
+    setHighlightIndex(0);
+  }, [inputDisabled, open]);
 
   const closePanel = useCallback(() => {
     setOpen(false);


### PR DESCRIPTION
Closes #745.

## Summary

- Modern `RotationReleaseDropdown` gets a search input at the top of the open panel — filters visible releases by case-insensitive substring against artist OR album as the DJ types.
- Both Modern and Classic pickers now sort releases A→Z by artist (case-insensitive), ties broken by album title. Shared via `lib/features/rotation/sort.ts` so a release lands in the same neighborhood in both UIs.
- Classic's native `<select>`s already support browser type-ahead, so only the sort change is needed there.
- Distinct empty-state copy for "no releases in this bin" vs. "no releases match \"foo\"" so the DJ can tell what's going on.
- Filter resets every time the dropdown reopens.

## Why

DJ feedback (OnAirDJ, 2026-06-06): "is there a way to either make it so we can search quickly for which rotation release it is or order the releases by artist alphabetically?" — eyeball-scanning an unsorted list was the only way to find a release.

## Test plan

- [x] `npx vitest run src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx src/components/experiences/classic/flowsheet/__tests__/EntryForm.test.tsx lib/__tests__/features/rotation/sort.test.ts` — all green
- [x] `npx tsc --noEmit` — clean
- [x] Seven new TDD tests on the Modern picker pin sort + filter behavior; new unit tests on the shared sort helper pin unicode and case rules; new regression test on Classic pins alphabetical order.
- [ ] Manual: open `/dashboard/flowsheet` (modern), Rotation Mode → pick Heavy → confirm releases list opens sorted A→Z and the search box filters as you type. Same flow on Classic.