### PR TITLE
feat(auth): publish AASA for WXYC DJ Tool Password AutoFill

### DIFF
--- a/app/.well-known/apple-app-site-association/route.ts
+++ b/app/.well-known/apple-app-site-association/route.ts
@@ -1,0 +1,24 @@
+// Apple App Site Association file. Serves the JSON Apple's CDN fetches to
+// link this origin to native apps for Universal Links and Password AutoFill.
+// `webcredentials` enables iOS Keychain to surface dj.wxyc.org credentials
+// in the WXYC DJ Tool app's username/password fields.
+//
+// Apple requires Content-Type: application/json and no redirects.
+// The path is required to be exactly `/.well-known/apple-app-site-association`.
+
+import { NextResponse } from "next/server";
+
+const AASA = {
+  webcredentials: {
+    apps: ["92V374HC38.org.wxyc.dj-tool"],
+  },
+};
+
+export function GET() {
+  return NextResponse.json(AASA, {
+    status: 200,
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Add `app/.well-known/apple-app-site-association/route.ts` — Next.js App Router handler serving the webcredentials AASA JSON for `org.wxyc.dj-tool` as `application/json`.
- Lets iOS link dj.wxyc.org to the WXYC DJ Tool app so saved Keychain credentials surface in the login screen's QuickType AutoFill bar.

Site-side half only. The app-side entitlement is at https://github.com/WXYC/wxyc-dj-tool-ios/pull/17.

Route-handler vs. static `public/.well-known/...` chosen because OpenNext on Cloudflare Workers handles header setting more reliably for route handlers; this guarantees the `Content-Type: application/json` Apple's swcutil expects.

Closes #756

## Test plan

- [ ] Local: `npm run build && npm start`, then `curl -i http://localhost:3000/.well-known/apple-app-site-association` returns 200 with `Content-Type: application/json` and the expected body.
- [ ] After deploy: `curl -I https://dj.wxyc.org/.well-known/apple-app-site-association` returns 200 with `Content-Type: application/json`.
- [ ] `xcrun swcutil dl -d dj.wxyc.org` on macOS Sequoia returns a record listing `92V374HC38.org.wxyc.dj-tool`.