### PR TITLE
feat(login): resume OIDC authorize round-trip after sign-in

### DIFF
--- a/src/components/experiences/modern/login/Forms/LoginFormSwitcher.test.tsx
+++ b/src/components/experiences/modern/login/Forms/LoginFormSwitcher.test.tsx
@@ -10,6 +10,7 @@ vi.mock("next/navigation", () => ({
     push: vi.fn(),
     refresh: vi.fn(),
   }),
+  useSearchParams: () => new URLSearchParams(""),
 }));
 
 vi.mock("@/lib/features/application/login-method-storage", () => ({

--- a/src/components/experiences/modern/login/Forms/OTPCodeForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/OTPCodeForm.test.tsx
@@ -8,6 +8,7 @@ vi.mock("next/navigation", () => ({
     push: vi.fn(),
     refresh: vi.fn(),
   }),
+  useSearchParams: () => new URLSearchParams(""),
 }));
 
 describe("OTPCodeForm", () => {

--- a/src/components/experiences/modern/login/Forms/UserPasswordForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/UserPasswordForm.test.tsx
@@ -9,6 +9,7 @@ vi.mock("next/navigation", () => ({
     push: vi.fn(),
     refresh: vi.fn(),
   }),
+  useSearchParams: () => new URLSearchParams(""),
 }));
 
 describe("UserPasswordForm", () => {

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -61,7 +61,11 @@ vi.mock("@/lib/features/authentication/client", () => ({
     },
     signOut: (...args: any[]) => mockSignOut(...args),
   },
-  authBaseURL: "https://api.wxyc.org/auth",
+  // On the client, getBaseURL() returns the same-origin `/auth` proxy (see
+  // client.ts) — NOT the cross-origin api.wxyc.org URL. Mock the value the
+  // hooks actually see in the browser so the OIDC redirect target is the
+  // same-origin path that router.push would have mishandled.
+  authBaseURL: `${window.location.origin}/auth`,
   clearTokenCache: (...args: any[]) => mockClearTokenCache(...args),
   lookupEmailByIdentifier: (...args: any[]) => mockLookupEmailByIdentifier(...args),
 }));
@@ -117,9 +121,29 @@ function createWrapper() {
   };
 }
 
+// The OIDC resume branch leaves the SPA via window.location.assign (a full
+// document navigation). jsdom's location.assign is non-configurable, so we
+// swap in a plain fake location that forwards the real origin/href and spies
+// on assign, then restore it after each test.
+const realLocation = window.location;
+const mockLocationAssign = vi.fn();
+
 describe("authenticationHooks", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockLocationAssign.mockClear();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        origin: realLocation.origin,
+        href: realLocation.href,
+        pathname: realLocation.pathname,
+        search: realLocation.search,
+        assign: mockLocationAssign,
+        replace: vi.fn(),
+        reload: vi.fn(),
+      },
+    });
     mockSearchParams.mockReturnValue(new URLSearchParams(""));
     process.env.NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD = "temp123";
     process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE = "/dashboard/flowsheet";
@@ -134,6 +158,13 @@ describe("authenticationHooks", () => {
   // fake timers can't leak into and hang the following tests.
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: realLocation,
+    });
   });
 
   describe("useLogin", () => {
@@ -301,12 +332,14 @@ describe("authenticationHooks", () => {
         await result.current.handleLogin(form);
       });
 
-      expect(mockPush).toHaveBeenCalledWith(
-        `https://api.wxyc.org/auth/oauth2/authorize?${search}`
+      expect(mockLocationAssign).toHaveBeenCalledWith(
+        `${window.location.origin}/auth/oauth2/authorize?${search}`
       );
-      expect(mockPush).not.toHaveBeenCalledWith("/dashboard/flowsheet");
-      // OIDC branch leaves the SPA — refresh is a wasted RSC fetch
-      // against a route the user is no longer on. Pin it.
+      // OIDC resume is a hard document navigation out of the SPA: the App
+      // Router must NOT be touched — a same-origin router.push would soft-
+      // navigate and fire a code-consuming RSC fetch — and refresh would be
+      // a wasted fetch against a route the user is leaving.
+      expect(mockPush).not.toHaveBeenCalled();
       expect(mockRefresh).not.toHaveBeenCalled();
     });
 
@@ -904,9 +937,13 @@ describe("authenticationHooks", () => {
         await result.current.handleVerifyOTP("dj@wxyc.org", "123456");
       });
 
-      expect(mockPush).toHaveBeenCalledWith(
-        `https://api.wxyc.org/auth/oauth2/authorize?${search}`
+      expect(mockLocationAssign).toHaveBeenCalledWith(
+        `${window.location.origin}/auth/oauth2/authorize?${search}`
       );
+      // Hard nav here too: no App Router push (guards against a missing
+      // `return` falling through to router.push(dashboardHome)) and no
+      // refresh.
+      expect(mockPush).not.toHaveBeenCalled();
       expect(mockRefresh).not.toHaveBeenCalled();
     });
   });

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -9,12 +9,14 @@ import { authenticationSlice } from "@/lib/features/authentication/frontend";
 const mockPush = vi.fn();
 const mockReplace = vi.fn();
 const mockRefresh = vi.fn();
+const mockSearchParams = vi.fn<() => URLSearchParams>(() => new URLSearchParams(""));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
     replace: mockReplace,
     refresh: mockRefresh,
   }),
+  useSearchParams: () => mockSearchParams(),
 }));
 
 // Mock sonner
@@ -59,6 +61,7 @@ vi.mock("@/lib/features/authentication/client", () => ({
     },
     signOut: (...args: any[]) => mockSignOut(...args),
   },
+  authBaseURL: "https://api.wxyc.org/auth",
   clearTokenCache: (...args: any[]) => mockClearTokenCache(...args),
   lookupEmailByIdentifier: (...args: any[]) => mockLookupEmailByIdentifier(...args),
 }));
@@ -117,6 +120,7 @@ function createWrapper() {
 describe("authenticationHooks", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchParams.mockReturnValue(new URLSearchParams(""));
     process.env.NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD = "temp123";
     process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE = "/dashboard/flowsheet";
     // Default: the server can see the freshly-established session on the first
@@ -267,6 +271,68 @@ describe("authenticationHooks", () => {
         password: "password123",
       });
       expect(mockSignInEmail).not.toHaveBeenCalled();
+    });
+
+    it("redirects to the OIDC authorize URL when the login page receives OIDC params", async () => {
+      // Resume contract: when `/login` is hit with `client_id` + `response_type=code`,
+      // sign-in is being delegated from `${authBase}/oauth2/authorize`. On success we
+      // must redirect back to `${authBase}/oauth2/authorize?<same-query-string>` so the
+      // Better Auth `oidcProvider` plugin sees the now-established session cookie,
+      // issues the code, and bounces to the registered client redirect URI.
+      const search =
+        "client_id=flowsheet&response_type=code&redirect_uri=https%3A%2F%2Fflowsheet.wxyc.org%2Fauth%2Fcallback&state=xyz&code_challenge=abc&code_challenge_method=S256";
+      mockSearchParams.mockReturnValue(new URLSearchParams(search));
+      mockSignInUsername.mockResolvedValue({
+        data: { user: { id: "user-1", hasCompletedOnboarding: true } },
+      });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "jbromberg" },
+          password: { value: "password123" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleLogin(form);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith(
+        `https://api.wxyc.org/auth/oauth2/authorize?${search}`
+      );
+      expect(mockPush).not.toHaveBeenCalledWith("/dashboard/flowsheet");
+    });
+
+    it("falls back to the dashboard when only one of client_id / response_type is present", async () => {
+      // Stray `client_id` (e.g. a stale link or someone exploring the URL) must
+      // not pull the user away from the dashboard — both signals are required.
+      mockSearchParams.mockReturnValue(
+        new URLSearchParams("client_id=flowsheet")
+      );
+      mockSignInUsername.mockResolvedValue({
+        data: { user: { id: "user-1", hasCompletedOnboarding: true } },
+      });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "jbromberg" },
+          password: { value: "password123" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleLogin(form);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
     });
 
     it("routes to signIn.email when the identifier contains @", async () => {
@@ -812,6 +878,29 @@ describe("authenticationHooks", () => {
 
       expect(mockClearTokenCache).toHaveBeenCalledTimes(1);
       expect(callOrder).toEqual(["clearTokenCache", "signInEmailOtp"]);
+    });
+
+    it("redirects to the OIDC authorize URL when the login page receives OIDC params", async () => {
+      // Same resume contract as `useLogin` — the OIDC bounce path doesn't care
+      // which credential type the user picked; both `signIn.username/email` and
+      // `signIn.emailOtp` are entry points into the same authorize round-trip.
+      const search =
+        "client_id=flowsheet&response_type=code&redirect_uri=https%3A%2F%2Fflowsheet.wxyc.org%2Fauth%2Fcallback&state=xyz";
+      mockSearchParams.mockReturnValue(new URLSearchParams(search));
+      mockSignInEmailOtp.mockResolvedValue({
+        data: { user: { id: "user-1", hasCompletedOnboarding: true } },
+      });
+
+      const { useOTPVerify } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useOTPVerify(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.handleVerifyOTP("dj@wxyc.org", "123456");
+      });
+
+      expect(mockPush).toHaveBeenCalledWith(
+        `https://api.wxyc.org/auth/oauth2/authorize?${search}`
+      );
     });
   });
 

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -305,6 +305,9 @@ describe("authenticationHooks", () => {
         `https://api.wxyc.org/auth/oauth2/authorize?${search}`
       );
       expect(mockPush).not.toHaveBeenCalledWith("/dashboard/flowsheet");
+      // OIDC branch leaves the SPA — refresh is a wasted RSC fetch
+      // against a route the user is no longer on. Pin it.
+      expect(mockRefresh).not.toHaveBeenCalled();
     });
 
     it("falls back to the dashboard when only one of client_id / response_type is present", async () => {
@@ -333,6 +336,9 @@ describe("authenticationHooks", () => {
       });
 
       expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
+      // Dashboard branch stays inside the SPA — refresh is the existing
+      // post-sign-in behavior the OIDC branch deliberately skips.
+      expect(mockRefresh).toHaveBeenCalled();
     });
 
     it("routes to signIn.email when the identifier contains @", async () => {
@@ -901,6 +907,7 @@ describe("authenticationHooks", () => {
       expect(mockPush).toHaveBeenCalledWith(
         `https://api.wxyc.org/auth/oauth2/authorize?${search}`
       );
+      expect(mockRefresh).not.toHaveBeenCalled();
     });
   });
 

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { authenticationSlice } from "@/lib/features/authentication/frontend";
-import { authClient, clearTokenCache, lookupEmailByIdentifier } from "@/lib/features/authentication/client";
+import { authBaseURL, authClient, clearTokenCache, lookupEmailByIdentifier } from "@/lib/features/authentication/client";
 import {
   interpretTokenPoll,
   pollDeviceToken,
@@ -21,11 +21,12 @@ import { betterAuthSessionToAuthenticationData, betterAuthSessionToAuthenticatio
 import { Authorization } from "@/lib/features/admin/types";
 import { applicationSlice } from "@/lib/features/application/frontend";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { resetApplication } from "./applicationHooks";
 import { throwIfBetterAuthError } from "@/src/utilities/throwIfBetterAuthError";
+import { getOidcRedirectTarget } from "@/src/utilities/oidcRedirectTarget";
 import { useAsyncAction } from "./useAsyncAction";
 import { safeCapture } from "@/lib/posthog";
 
@@ -119,6 +120,7 @@ async function redirectAfterAuth(
   router: { push: (href: string) => void; refresh: () => void },
   user: { id?: string; hasCompletedOnboarding?: boolean } | undefined,
   method: LoginMethod,
+  oidcTarget?: string,
 ): Promise<void> {
   const dashboardHome = String(
     process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/catalog",
@@ -129,7 +131,7 @@ async function redirectAfterAuth(
 
   safeCapture(LOGIN_EVENTS.POST_LOGIN_REDIRECT, {
     method,
-    destination: incomplete ? "incomplete" : "dashboard",
+    destination: incomplete ? "incomplete" : oidcTarget ? "oidc" : "dashboard",
     has_completed_onboarding: user?.hasCompletedOnboarding ?? null,
     user_id: user?.id ?? null,
     session_confirmed: sessionConfirmed,
@@ -140,12 +142,25 @@ async function redirectAfterAuth(
     return;
   }
 
+  if (!incomplete && oidcTarget) {
+    // Hand off to the authorize endpoint with a full document navigation.
+    // In production `authBaseURL` is the same-origin `/auth` proxy (a
+    // next.config rewrite, not an app route), so `router.push` would treat
+    // this as an internal soft navigation and fire a background RSC fetch
+    // that hits `/oauth2/authorize` — burning the one-time OIDC code before
+    // the user ever leaves the page. `window.location.assign` leaves the
+    // SPA cleanly, so `router.refresh()` is moot.
+    window.location.assign(oidcTarget);
+    return;
+  }
+
   router.push(incomplete ? "/login?incomplete=true" : dashboardHome);
   router.refresh();
 }
 
 export const useLogin = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { execute, isLoading, error } = useAsyncAction();
 
   const verified = useAppSelector(
@@ -177,7 +192,14 @@ export const useLogin = () => {
       toast.success("Login successful");
 
       const user = (result as any).data?.user;
-      await redirectAfterAuth(router, user, "password");
+      // If we got here as part of an OIDC authorize bounce, resume the
+      // round-trip by handing off to `${authBase}/oauth2/authorize?<original-query>`
+      // instead of the dashboard. See `getOidcRedirectTarget` for the contract.
+      const oidcTarget = getOidcRedirectTarget(
+        new URLSearchParams(searchParams?.toString() ?? ""),
+        authBaseURL,
+      );
+      await redirectAfterAuth(router, user, "password", oidcTarget ?? undefined);
     }, "An unexpected error occurred during login. Please try again.");
   };
 
@@ -226,6 +248,7 @@ export const useOTPRequest = () => {
 
 export const useOTPVerify = () => {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { execute, isLoading, error } = useAsyncAction();
 
   const handleVerifyOTP = (email: string, otp: string) =>
@@ -255,7 +278,13 @@ export const useOTPVerify = () => {
       toast.success("Login successful");
 
       const user = (result as any).data?.user;
-      await redirectAfterAuth(router, user, "otp");
+      // Mirror useLogin's OIDC resume contract — both credential entry
+      // points feed the same authorize round-trip.
+      const oidcTarget = getOidcRedirectTarget(
+        new URLSearchParams(searchParams?.toString() ?? ""),
+        authBaseURL,
+      );
+      await redirectAfterAuth(router, user, "otp", oidcTarget ?? undefined);
     }, "Verification failed. Please try again.");
 
   const handleResendOTP = async (email: string) => {

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -196,7 +196,7 @@ export const useLogin = () => {
       // round-trip by handing off to `${authBase}/oauth2/authorize?<original-query>`
       // instead of the dashboard. See `getOidcRedirectTarget` for the contract.
       const oidcTarget = getOidcRedirectTarget(
-        new URLSearchParams(searchParams?.toString() ?? ""),
+        searchParams ?? new URLSearchParams(),
         authBaseURL,
       );
       await redirectAfterAuth(router, user, "password", oidcTarget ?? undefined);
@@ -281,7 +281,7 @@ export const useOTPVerify = () => {
       // Mirror useLogin's OIDC resume contract — both credential entry
       // points feed the same authorize round-trip.
       const oidcTarget = getOidcRedirectTarget(
-        new URLSearchParams(searchParams?.toString() ?? ""),
+        searchParams ?? new URLSearchParams(),
         authBaseURL,
       );
       await redirectAfterAuth(router, user, "otp", oidcTarget ?? undefined);

--- a/src/utilities/oidcRedirectTarget.test.ts
+++ b/src/utilities/oidcRedirectTarget.test.ts
@@ -72,17 +72,20 @@ describe("getOidcRedirectTarget", () => {
     expect(getOidcRedirectTarget(params, AUTH_BASE)).toBeNull();
   });
 
-  it("accepts a ReadonlyURLSearchParams-shaped argument (from next/navigation)", () => {
-    // `useSearchParams()` returns a `ReadonlyURLSearchParams`, which extends
-    // `URLSearchParams` and exposes `.get` / `.toString`. Helper must accept
-    // that shape so the call site doesn't have to round-trip through the
-    // `URLSearchParams` constructor (which would also be a defensive clone
-    // not needed here — the helper never mutates the input).
-    const params: Pick<URLSearchParams, "get" | "toString"> = new URLSearchParams(
-      "client_id=flowsheet&response_type=code"
+  it("strips a trailing slash on the auth base URL", () => {
+    // `getBaseURL()` in `lib/features/authentication/client.ts` passes
+    // `NEXT_PUBLIC_BETTER_AUTH_URL` through untouched, so a trailing slash
+    // from `.env` survives into `authBaseURL`. Defend here.
+    const params = new URLSearchParams("client_id=flowsheet&response_type=code");
+    expect(getOidcRedirectTarget(params, "https://api.wxyc.org/auth/")).toBe(
+      `https://api.wxyc.org/auth/oauth2/authorize?${params.toString()}`
     );
-    expect(getOidcRedirectTarget(params as URLSearchParams, AUTH_BASE)).toBe(
-      `${AUTH_BASE}/oauth2/authorize?${(params as URLSearchParams).toString()}`
+  });
+
+  it("strips multiple trailing slashes", () => {
+    const params = new URLSearchParams("client_id=flowsheet&response_type=code");
+    expect(getOidcRedirectTarget(params, "https://api.wxyc.org/auth///")).toBe(
+      `https://api.wxyc.org/auth/oauth2/authorize?${params.toString()}`
     );
   });
 });

--- a/src/utilities/oidcRedirectTarget.test.ts
+++ b/src/utilities/oidcRedirectTarget.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { getOidcRedirectTarget } from "./oidcRedirectTarget";
+
+const AUTH_BASE = "https://api.wxyc.org/auth";
+
+describe("getOidcRedirectTarget", () => {
+  it("returns the authorize URL when client_id and response_type=code are both present", () => {
+    const params = new URLSearchParams(
+      "client_id=flowsheet&response_type=code&redirect_uri=https://flowsheet.wxyc.org/auth/callback&state=xyz&code_challenge=abc&code_challenge_method=S256"
+    );
+
+    expect(getOidcRedirectTarget(params, AUTH_BASE)).toBe(
+      `${AUTH_BASE}/oauth2/authorize?${params.toString()}`
+    );
+  });
+
+  it("preserves every query param the authorize endpoint sent here (round-trip contract)", () => {
+    // Better Auth's `oidcProvider` redirects to `${loginPage}?${full original
+    // query string}` and expects the loginPage to bounce back to authorize
+    // with the same params so it can re-run with the now-established session.
+    // Dropping or mutating params here breaks PKCE / state binding.
+    const params = new URLSearchParams(
+      "client_id=flowsheet&response_type=code&scope=openid+profile&state=opaque%2Btoken&redirect_uri=https%3A%2F%2Fexample%2Fcb"
+    );
+
+    const target = getOidcRedirectTarget(params, AUTH_BASE);
+    expect(target).not.toBeNull();
+    const back = new URL(target!);
+    expect(back.searchParams.get("client_id")).toBe("flowsheet");
+    expect(back.searchParams.get("response_type")).toBe("code");
+    expect(back.searchParams.get("state")).toBe("opaque+token");
+    expect(back.searchParams.get("redirect_uri")).toBe("https://example/cb");
+    expect(back.searchParams.get("scope")).toBe("openid profile");
+  });
+
+  it("returns null when client_id is missing", () => {
+    const params = new URLSearchParams("response_type=code");
+    expect(getOidcRedirectTarget(params, AUTH_BASE)).toBeNull();
+  });
+
+  it("returns null when response_type is missing", () => {
+    const params = new URLSearchParams("client_id=flowsheet");
+    expect(getOidcRedirectTarget(params, AUTH_BASE)).toBeNull();
+  });
+
+  it("returns null when response_type is something other than code", () => {
+    // `response_type=token` is the OAuth implicit flow. The Better Auth
+    // `oidcProvider` plugin only supports `code`, so a bare `response_type`
+    // value of anything else means this isn't an authorize bounce we should
+    // honor — fall back to the normal dashboard redirect.
+    const params = new URLSearchParams(
+      "client_id=flowsheet&response_type=token"
+    );
+    expect(getOidcRedirectTarget(params, AUTH_BASE)).toBeNull();
+  });
+
+  it("returns null for an unrelated /login visit with no OIDC params", () => {
+    const params = new URLSearchParams("incomplete=true");
+    expect(getOidcRedirectTarget(params, AUTH_BASE)).toBeNull();
+  });
+
+  it("strips a trailing slash on the auth base URL before appending /oauth2/authorize", () => {
+    // Operators routinely paste `https://api.wxyc.org/auth/` with a trailing
+    // slash. A doubled slash (`/auth//oauth2/authorize`) silently breaks the
+    // round-trip on some proxies. Normalize at the boundary.
+    const params = new URLSearchParams(
+      "client_id=flowsheet&response_type=code"
+    );
+
+    expect(getOidcRedirectTarget(params, "https://api.wxyc.org/auth/")).toBe(
+      `https://api.wxyc.org/auth/oauth2/authorize?${params.toString()}`
+    );
+  });
+});

--- a/src/utilities/oidcRedirectTarget.test.ts
+++ b/src/utilities/oidcRedirectTarget.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { getOidcRedirectTarget } from "./oidcRedirectTarget";
 
+// At runtime `authBaseURL` (exported from `lib/features/authentication/client`)
+// is derived from `window.location.origin + "/auth"` on the client and
+// `process.env.NEXT_PUBLIC_BETTER_AUTH_URL || "https://api.wxyc.org/auth"`
+// on the server — see `lib/features/authentication/client.ts:getBaseURL()`.
+// The helper itself doesn't care which value it receives; these tests pin
+// the concatenation behavior with a representative string. The actual hook
+// integration tests in `authenticationHooks.test.ts` exercise the call
+// with whatever value the mock for that module returns.
 const AUTH_BASE = "https://api.wxyc.org/auth";
 
 describe("getOidcRedirectTarget", () => {
@@ -54,21 +62,27 @@ describe("getOidcRedirectTarget", () => {
     expect(getOidcRedirectTarget(params, AUTH_BASE)).toBeNull();
   });
 
-  it("returns null for an unrelated /login visit with no OIDC params", () => {
+  it("returns null when only unrelated params are present", () => {
+    // e.g. `/login?incomplete=true` (the existing onboarding redirect) — no
+    // OIDC signals, so the helper must not pull the user away from the
+    // dashboard fallback. Tested as one of several disjoint param families
+    // (`token`, `error`, `verified`, `incomplete`) the existing /login flow
+    // uses.
     const params = new URLSearchParams("incomplete=true");
     expect(getOidcRedirectTarget(params, AUTH_BASE)).toBeNull();
   });
 
-  it("strips a trailing slash on the auth base URL before appending /oauth2/authorize", () => {
-    // Operators routinely paste `https://api.wxyc.org/auth/` with a trailing
-    // slash. A doubled slash (`/auth//oauth2/authorize`) silently breaks the
-    // round-trip on some proxies. Normalize at the boundary.
-    const params = new URLSearchParams(
+  it("accepts a ReadonlyURLSearchParams-shaped argument (from next/navigation)", () => {
+    // `useSearchParams()` returns a `ReadonlyURLSearchParams`, which extends
+    // `URLSearchParams` and exposes `.get` / `.toString`. Helper must accept
+    // that shape so the call site doesn't have to round-trip through the
+    // `URLSearchParams` constructor (which would also be a defensive clone
+    // not needed here — the helper never mutates the input).
+    const params: Pick<URLSearchParams, "get" | "toString"> = new URLSearchParams(
       "client_id=flowsheet&response_type=code"
     );
-
-    expect(getOidcRedirectTarget(params, "https://api.wxyc.org/auth/")).toBe(
-      `https://api.wxyc.org/auth/oauth2/authorize?${params.toString()}`
+    expect(getOidcRedirectTarget(params as URLSearchParams, AUTH_BASE)).toBe(
+      `${AUTH_BASE}/oauth2/authorize?${(params as URLSearchParams).toString()}`
     );
   });
 });

--- a/src/utilities/oidcRedirectTarget.ts
+++ b/src/utilities/oidcRedirectTarget.ts
@@ -1,0 +1,34 @@
+/**
+ * If `params` look like the search-param tail of an OIDC authorize bounce,
+ * return the URL we should redirect to on successful sign-in so the OIDC
+ * round-trip resumes. Returns `null` otherwise (the caller should fall back
+ * to its default post-sign-in target, e.g. the dashboard).
+ *
+ * Contract — Better Auth's `oidcProvider` plugin (api.wxyc.org/auth):
+ * authorize redirects an unauthenticated user to `${loginPage}?${original
+ * query string}` and sets a signed `oidc_login_prompt` cookie (TTL 600s).
+ * The loginPage's job is to authenticate the user and bounce back to
+ * `${authBase}/oauth2/authorize?<original-query>`. Authorize re-runs, sees
+ * the session cookie, issues the code, redirects to the client.
+ *
+ * Detection: require both `client_id` and `response_type=code` to be present.
+ * That's the minimum signal that distinguishes an authorize bounce from a
+ * plain `/login` visit (or the existing reset / verification / incomplete
+ * flows, which use disjoint param names — `token`, `error`, `verified`,
+ * `incomplete`). `response_type=token` (the OAuth implicit flow) is not
+ * supported by `oidcProvider`, so we treat anything other than `code` as
+ * a non-OIDC visit.
+ */
+export function getOidcRedirectTarget(
+  params: URLSearchParams,
+  authBaseUrl: string
+): string | null {
+  const clientId = params.get("client_id");
+  const responseType = params.get("response_type");
+  if (!clientId || responseType !== "code") {
+    return null;
+  }
+
+  const base = authBaseUrl.replace(/\/+$/, "");
+  return `${base}/oauth2/authorize?${params.toString()}`;
+}

--- a/src/utilities/oidcRedirectTarget.ts
+++ b/src/utilities/oidcRedirectTarget.ts
@@ -35,5 +35,10 @@ export function getOidcRedirectTarget(
   if (!clientId || responseType !== "code") {
     return null;
   }
-  return `${authBaseUrl}/oauth2/authorize?${params.toString()}`;
+  // `getBaseURL()` in `lib/features/authentication/client.ts` does not
+  // strip trailing slashes from `NEXT_PUBLIC_BETTER_AUTH_URL`. Defend at
+  // the boundary so an operator who pastes `https://api.wxyc.org/auth/`
+  // doesn't produce `auth//oauth2/authorize`. Cheap and local.
+  const base = authBaseUrl.replace(/\/+$/, "");
+  return `${base}/oauth2/authorize?${params.toString()}`;
 }

--- a/src/utilities/oidcRedirectTarget.ts
+++ b/src/utilities/oidcRedirectTarget.ts
@@ -1,3 +1,5 @@
+import type { ReadonlyURLSearchParams } from "next/navigation";
+
 /**
  * If `params` look like the search-param tail of an OIDC authorize bounce,
  * return the URL we should redirect to on successful sign-in so the OIDC
@@ -18,9 +20,14 @@
  * `incomplete`). `response_type=token` (the OAuth implicit flow) is not
  * supported by `oidcProvider`, so we treat anything other than `code` as
  * a non-OIDC visit.
+ *
+ * Param type is `URLSearchParams | ReadonlyURLSearchParams` so the call
+ * site can hand the value from `useSearchParams()` straight in without
+ * round-tripping through a string clone. The helper only calls `.get()`
+ * and `.toString()`, both of which exist on the readonly type.
  */
 export function getOidcRedirectTarget(
-  params: URLSearchParams,
+  params: URLSearchParams | ReadonlyURLSearchParams,
   authBaseUrl: string
 ): string | null {
   const clientId = params.get("client_id");
@@ -28,7 +35,5 @@ export function getOidcRedirectTarget(
   if (!clientId || responseType !== "code") {
     return null;
   }
-
-  const base = authBaseUrl.replace(/\/+$/, "");
-  return `${base}/oauth2/authorize?${params.toString()}`;
+  return `${authBaseUrl}/oauth2/authorize?${params.toString()}`;
 }


### PR DESCRIPTION
Closes #760. Companion PR: WXYC/Backend-Service#1396.

## Summary

- Resume the Better Auth `oidcProvider` authorize round-trip after `/login` succeeds. When `/login` is reached as the user-facing leg of an OIDC bounce (search params carry `client_id` + `response_type=code`), the post-sign-in redirect now targets `${authBase}/oauth2/authorize?<original-query>` instead of the dashboard, so authorize re-runs against the now-established session and issues the code.
- Both `useLogin` and `useOTPVerify` consume the helper — both credential entry points feed the same authorize round-trip.
- Sign-up / password-reset / first-time onboarding are deliberately out of scope. Existing users only.

## Test plan

- [x] `getOidcRedirectTarget` unit tests cover: round-trip param fidelity (PKCE, state, scope), one-param probes, `response_type=token` (implicit flow) rejected, trailing-slash normalization on the auth base URL, and the no-OIDC-params fallback.
- [x] `useLogin` test pins both the OIDC redirect and the dashboard fallback paths.
- [x] `useOTPVerify` test pins the OIDC redirect path.
- [x] Full vitest run: 3259/3259 passing across 224 files.
- [x] `tsc --noEmit` clean.
- [ ] Manual end-to-end against staging once the BS companion deploys: open `${authBase}/oauth2/authorize?client_id=flowsheet&response_type=code&...`, confirm the bounce to dj-site `/login`, sign in, confirm the round-trip back to authorize and the final redirect to the flowsheet verifier.