### PR TITLE
fix(#641): seed AppbarWrapper from server-resolved experience prop

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,7 +54,7 @@ export default async function RootLayout({ children }: Props) {
               <div id="root" style={{ height: "100%", overflow: "hidden" }}>
                 <main>
                   {children}
-                  <AppbarWrapper />
+                  <AppbarWrapper experience={serverSideProps.application.experience} />
                 </main>
               </div>
             </body>

--- a/src/components/shared/Theme/AppbarWrapper.test.tsx
+++ b/src/components/shared/Theme/AppbarWrapper.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// The live experience query is mocked so each test controls whether API data
+// is present. Default: no data loaded yet (the first-paint scenario).
+vi.mock("@/lib/features/experiences/api", () => ({
+  useGetActiveExperienceQuery: vi.fn(() => ({ data: undefined })),
+}));
+
+// Stub the two appbars so tests can assert which one rendered without pulling
+// in their full dependency trees.
+vi.mock("./Appbar", () => ({
+  default: () => <div data-testid="appbar-modern" />,
+}));
+vi.mock("./AppbarClassic", () => ({
+  default: () => <div data-testid="appbar-classic" />,
+}));
+
+import AppbarWrapper from "./AppbarWrapper";
+import { useGetActiveExperienceQuery } from "@/lib/features/experiences/api";
+
+describe("AppbarWrapper", () => {
+  beforeEach(() => {
+    // Reset to "no API data yet" before each test.
+    vi.mocked(useGetActiveExperienceQuery).mockReturnValue({
+      data: undefined,
+    } as unknown as ReturnType<typeof useGetActiveExperienceQuery>);
+  });
+
+  it("renders the classic appbar on first paint when the server-resolved experience is classic", () => {
+    // Regression guard for the modern→classic flash: with no live API data yet,
+    // the server-resolved prop must drive the very first render synchronously —
+    // no transient modern appbar.
+    render(<AppbarWrapper experience="classic" />);
+
+    expect(screen.getByTestId("appbar-classic")).toBeInTheDocument();
+    expect(screen.queryByTestId("appbar-modern")).not.toBeInTheDocument();
+  });
+
+  it("renders the modern appbar when the server-resolved experience is modern", () => {
+    render(<AppbarWrapper experience="modern" />);
+
+    expect(screen.getByTestId("appbar-modern")).toBeInTheDocument();
+    expect(screen.queryByTestId("appbar-classic")).not.toBeInTheDocument();
+  });
+
+  it("prefers the live API experience over the server-resolved prop once it loads", () => {
+    // Existing behavior: a runtime experience switch (reflected by the API)
+    // wins over the SSR snapshot, so switching does not require a reload.
+    vi.mocked(useGetActiveExperienceQuery).mockReturnValue({
+      data: "modern",
+    } as unknown as ReturnType<typeof useGetActiveExperienceQuery>);
+
+    render(<AppbarWrapper experience="classic" />);
+
+    expect(screen.getByTestId("appbar-modern")).toBeInTheDocument();
+    expect(screen.queryByTestId("appbar-classic")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/Theme/AppbarWrapper.tsx
+++ b/src/components/shared/Theme/AppbarWrapper.tsx
@@ -1,31 +1,31 @@
 "use client";
 
 import { useGetActiveExperienceQuery } from "@/lib/features/experiences/api";
-import { useEffect, useState } from "react";
+import { ExperienceId } from "@/lib/features/experiences/types";
 import Appbar from "./Appbar";
 import AppbarClassic from "./AppbarClassic";
 
-export default function AppbarWrapper() {
+interface AppbarWrapperProps {
+  /**
+   * Server-resolved experience, threaded down from RootLayout. Seeding the
+   * first render from this prop (rather than reading `data-experience` in an
+   * effect) keeps SSR and client hydration in agreement, so classic users no
+   * longer see a modern→classic appbar flash on first paint.
+   */
+  experience: ExperienceId;
+}
+
+export default function AppbarWrapper({ experience }: AppbarWrapperProps) {
   const { data: experienceFromApi } = useGetActiveExperienceQuery();
-  const [experienceFromDOM, setExperienceFromDOM] = useState<string | null>(null);
 
-  // Read from data-experience attribute on HTML element (set by server)
-  useEffect(() => {
-    if (typeof document !== "undefined") {
-      const htmlElement = document.documentElement;
-      const dataExperience = htmlElement.getAttribute("data-experience");
-      if (dataExperience) {
-        setExperienceFromDOM(dataExperience);
-      }
-    }
-  }, []);
+  // The live API value wins once loaded (so a runtime experience switch is
+  // reflected without a reload); until then the server-resolved prop drives
+  // the render synchronously.
+  const activeExperience = experienceFromApi || experience;
 
-  // Use API data if available, otherwise fall back to DOM attribute
-  const activeExperience = experienceFromApi || experienceFromDOM || "modern";
-  
   if (activeExperience === "classic") {
     return <AppbarClassic />;
   }
-  
+
   return <Appbar />;
 }


### PR DESCRIPTION
## Problem

`AppbarWrapper` initialized its experience to `null` and read `data-experience` inside a `useEffect`, so the fallback chain (`experienceFromApi || experienceFromDOM || "modern"`) defaulted to `"modern"` on the first synchronous render (SSR and initial CSR hydration). After the effect ran and read the attribute, state updated and re-rendered to the correct experience — for classic users this produced a visible modern→classic appbar swap on every page load.

## Fix

The server already resolves the experience in `RootLayout` (`serverSideProps.application.experience`, set on `<html data-experience>`). Thread that value down to `AppbarWrapper` as a required `experience: ExperienceId` prop and seed the render from it, dropping the `useState`/`useEffect` DOM read entirely. SSR and client hydration now agree on the first paint — no flash.

The live API value (`useGetActiveExperienceQuery`) still takes precedence once loaded, so a runtime experience switch is reflected without a reload.

### Why option (a), not (b)

The issue offered two fixes. A lazy initializer reading `document.documentElement.getAttribute("data-experience")` (option b) would still return nothing during SSR (server renders modern), then read classic on the client's first render — a **hydration mismatch**. Passing the server-resolved value as a prop (option a) keeps SSR and client first render in agreement.

## Tests

New `AppbarWrapper.test.tsx`:
- classic-experience prop renders the classic appbar synchronously on first paint (regression guard for the flash)
- modern-experience prop renders the modern appbar (existing behavior unchanged)
- live API experience takes precedence over the prop once loaded

## Local CI

- `tsc --noEmit` — clean
- `vitest run --changed origin/main` — 3 passed
- `next build` — succeeds

## Acceptance criteria

- [x] No modern→classic flash on first paint for classic users
- [x] Existing modern-user behavior unchanged
- [x] Test verifies the appbar is correct on first paint

Closes #641.