### PR TITLE
fix(flowsheet): guard null artist in search results to stop the as-you-type white-screen

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
@@ -240,6 +240,26 @@ describe("FlowsheetBackendResult", () => {
     });
   });
 
+  // Regression: a result row can arrive with a null `artist` (LML / catalog
+  // proxy rows where the artist object wasn't populated). The CODE and ARTIST
+  // columns dereferenced `entry.artist.genre` / `entry.artist.name` with no
+  // guard, so one such row threw mid-render and app/global-error white-screened
+  // the whole site as the DJ typed. (dj-site flowsheet entry crash, 2026-06-21)
+  describe("Null artist (regression)", () => {
+    it("does not throw and shows 'Unknown' when artist is null", () => {
+      const entryWithNullArtist = {
+        ...mockEntry,
+        artist: null,
+      } as unknown as AlbumEntry;
+
+      expect(() =>
+        render(<FlowsheetBackendResult entry={entryWithNullArtist} index={1} />)
+      ).not.toThrow();
+
+      expect(screen.getByText("Unknown")).toBeInTheDocument();
+    });
+  });
+
   describe("Different index values", () => {
     it("should work with index 0", () => {
       render(<FlowsheetBackendResult entry={mockEntry} index={0} />);

--- a/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
@@ -70,8 +70,8 @@ export default function FlowsheetBackendResult({
             fontSize: "1rem",
           }}
         >
-          {entry.artist.genre} {entry.artist.lettercode}{" "}
-          {entry.artist.numbercode}/{entry.entry}
+          {entry.artist?.genre} {entry.artist?.lettercode}{" "}
+          {entry.artist?.numbercode}/{entry.entry}
           <Chip
             variant="soft"
             size="sm"
@@ -119,11 +119,11 @@ export default function FlowsheetBackendResult({
             overflow: "hidden",
             textOverflow: "ellipsis",
             color: selected == index ? "white" : "inherit",
-            fontStyle: entry.artist.name ? "normal" : "italic",
-            opacity: entry.artist.name ? 1 : 0.6,
+            fontStyle: entry.artist?.name ? "normal" : "italic",
+            opacity: entry.artist?.name ? 1 : 0.6,
           }}
         >
-          {entry.artist.name || "Unknown"}
+          {entry.artist?.name || "Unknown"}
         </Typography>
       </Stack>
       <Stack direction="column" sx={{ flex: 1, minWidth: 0, px: 1 }}>

--- a/src/utilities/filterBySearchTerms.test.ts
+++ b/src/utilities/filterBySearchTerms.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { filterBySearchTerms } from "./filterBySearchTerms";
+import { createTestAlbum, createTestArtist } from "@/lib/test-utils";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
+
+describe("filterBySearchTerms", () => {
+  const query = { artist: "stereolab", album: "", label: "" };
+
+  it("matches an entry whose artist name contains the search term", () => {
+    const match = createTestAlbum({
+      artist: createTestArtist({ name: "Stereolab" }),
+    });
+    expect(filterBySearchTerms([match], query)).toEqual([match]);
+  });
+
+  it("ignores search terms of 3 characters or fewer", () => {
+    const album = createTestAlbum();
+    expect(filterBySearchTerms([album], { artist: "ste", album: "", label: "" })).toEqual([]);
+  });
+
+  // Regression: the BS catalog/rotation proxy can deliver a row whose `artist`
+  // object is present but `artist.name` is null (library-unlinked rows). The
+  // `item.artist?.name.toLowerCase()` chain only guarded `item.artist`, so the
+  // null `name` threw `TypeError` mid-filter — which, on the live flowsheet
+  // searchbar, bubbled to app/global-error and white-screened the whole site
+  // as the DJ typed. (dj-site flowsheet entry crash, 2026-06-21)
+  it("does not throw when an entry's artist.name is null", () => {
+    const malformed = {
+      ...createTestAlbum(),
+      artist: { ...createTestArtist(), name: null },
+    } as unknown as AlbumEntry;
+
+    expect(() => filterBySearchTerms([malformed], query)).not.toThrow();
+  });
+
+  it("excludes a null-named entry but still returns its valid siblings", () => {
+    const malformed = {
+      ...createTestAlbum({ id: 1 }),
+      artist: { ...createTestArtist(), name: null },
+    } as unknown as AlbumEntry;
+    const valid = createTestAlbum({
+      id: 2,
+      artist: createTestArtist({ name: "Stereolab" }),
+    });
+
+    expect(filterBySearchTerms([malformed, valid], query)).toEqual([valid]);
+  });
+});

--- a/src/utilities/filterBySearchTerms.ts
+++ b/src/utilities/filterBySearchTerms.ts
@@ -21,7 +21,7 @@ export function filterBySearchTerms(items: AlbumEntry[], query: SearchQuery): Al
 
   return items.filter((item) => {
     const fields = [
-      item.artist?.name.toLowerCase() ?? "",
+      item.artist?.name?.toLowerCase() ?? "",
       item.title?.toLowerCase() ?? "",
       item.label?.toLowerCase() ?? "",
     ];


### PR DESCRIPTION
## What

Guards the two unguarded `artist` dereferences in the live flowsheet's as-you-type search-result render path, which white-screened the entire site (via `app/global-error.tsx`) when a result row arrived with a null `artist` — the "website crashes whenever I type into the artist field" report from a DJ on 2026-06-21.

- `FlowsheetBackendResult.tsx` — `entry.artist.{genre,lettercode,numbercode,name}` → `entry.artist?.…` (CODE + ARTIST columns), matching every sibling field.
- `filterBySearchTerms.ts` — `item.artist?.name.toLowerCase()` → `item.artist?.name?.toLowerCase()`.

The `AlbumEntry`/`ArtistEntry` types declare these non-null, but library-unlinked catalog/LML/rotation rows deliver null at runtime, so the compiler never caught it. Backend search is parameterized, so the apostrophe/space correlations in the report were red herrings — see the issue for the full trace of how that was ruled out.

Closes #777

## Test plan

- Red → green TDD: new `filterBySearchTerms.test.ts` and a null-artist regression case in `FlowsheetBackendResult.test.tsx` both reproduce the `TypeError` without the guards and pass with them.
- `npx tsc --noEmit` — clean.
- `npx vitest run --changed origin/main` — 596 tests / 41 files pass.
- `npm run build` not run locally (pure optional-chaining change; no import/type/API surface change). CI covers it.

## Follow-up (separate ticket)

dj-site has no reachable crash telemetry — Sentry `dj-site` is empty; client crashes only reach PostHog via `global-error.tsx`'s `captureException`, which we couldn't pull for this incident. Worth wiring dependable error tracking and optionally a scoped error boundary around the results list so one bad row degrades to "no results" instead of a full-page crash.
