### PR TITLE
fix(flowsheet): guard null artist in rotation path + headless artist-search crash-smoke

### DIFF
--- a/e2e/tests/flowsheet/artist-search-crash-smoke.spec.ts
+++ b/e2e/tests/flowsheet/artist-search-crash-smoke.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from "../../fixtures/auth.fixture";
+import { FlowsheetPage } from "../../pages/flowsheet.page";
+import path from "path";
+
+const authDir = path.join(__dirname, "../../.auth");
+
+/**
+ * Regression smoke test for the 2026-06-21 flowsheet crash.
+ *
+ * A DJ reported the site white-screening as they typed into the artist field
+ * while entering a playcut — notably for "The O'Jays", and generally on
+ * apostrophes and spaces ("it also triggered whenever i typed something with a
+ * space", "i couldn't get past The"). The Modern app's only error boundary is
+ * `app/global-error.tsx`, so any uncaught render throw in the live search path
+ * replaces the entire document with its `<h2>Something went wrong</h2>` — which
+ * to the DJ reads as "the website crashes".
+ *
+ * This test drives the real artist-field search path in headless Chromium
+ * against the live E2E backend, typing the exact problem inputs one key at a
+ * time so every intermediate query state fires its debounced searches — the
+ * precise "crashes as I type a few characters" condition. It asserts the global
+ * error boundary never appears, the search UI stays mounted and interactive,
+ * and no null/undefined dereference reaches the console.
+ *
+ * Caveat: this is a smoke test, not a deterministic reproduction. The original
+ * crash is data-dependent (the triggering row must exist in the backend the DJ
+ * was hitting), and dj-site's result conversions coerce missing fields, so this
+ * can't *force* the failure. It pins the live path so a regression on these
+ * inputs — the ones a real DJ hit — is caught in CI.
+ *
+ * The search form is live-only, so this mirrors library-search-proxy.spec.ts:
+ * serial mode, go live once, ensure off-air in afterAll, and the musicDirector
+ * session (kept off dj/dj2, which auth and entry-caching specs own).
+ */
+test.describe("Flowsheet artist search — crash smoke", () => {
+  test.use({ storageState: path.join(authDir, "musicDirector.json") });
+  test.describe.configure({ mode: "serial" });
+  test.setTimeout(60_000);
+
+  let flowsheet: FlowsheetPage;
+  let isLive = false;
+
+  test.beforeEach(async ({ page }) => {
+    flowsheet = new FlowsheetPage(page);
+    await flowsheet.goto();
+    await flowsheet.waitForEntriesLoaded();
+    if (!isLive) {
+      await flowsheet.goLive();
+      isLive = true;
+    }
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const context = await browser.newContext({
+      storageState: path.join(authDir, "musicDirector.json"),
+      baseURL: process.env.E2E_BASE_URL || "http://localhost:3000",
+    });
+    const page = await context.newPage();
+    const fs = new FlowsheetPage(page);
+    await fs.goto();
+    await fs.waitForEntriesLoaded();
+    await fs.ensureOffAir();
+    await context.close();
+  });
+
+  // The reported triggers were an apostrophe ("The O'Jays"), a space, and the
+  // bare prefix "The". The extra names mix spaces, diacritics, and an ampersand
+  // — all from the WXYC example catalog — to exercise the same lexical edges
+  // without leaning on mainstream acts.
+  const PROBLEM_ARTISTS = [
+    "The O'Jays", // the exact reported case: apostrophe + space
+    "The ", // "couldn't get past The" — the space crosses the 3-char search threshold
+    "Hermanos Gutiérrez", // space + diacritics
+    "Duke Ellington & John Coltrane", // multiple spaces + ampersand
+  ];
+
+  for (const artist of PROBLEM_ARTISTS) {
+    test(`typing ${JSON.stringify(artist)} char-by-char never white-screens`, async ({
+      page,
+    }) => {
+      // The boundary that a render throw would surface (its own document root).
+      const crashBoundary = page.getByRole("heading", {
+        name: "Something went wrong",
+      });
+
+      // Capture the crash-class signal even if the boundary swallows the throw:
+      // React logs boundary-caught errors to console.error in prod builds, and
+      // any genuinely uncaught throw lands as a pageerror.
+      const errors: string[] = [];
+      page.on("console", (msg) => {
+        if (msg.type() === "error") errors.push(msg.text());
+      });
+      page.on("pageerror", (err) => errors.push(String(err)));
+
+      // Focus the artist field (opens search) and type one key at a time so the
+      // debounced catalog/LML/rotation/bin/suggest searches fire on every
+      // intermediate state ("t", "th", "the", "the ", "the o", "the o'", …).
+      await expect(flowsheet.artistInput).toBeEnabled({ timeout: 10_000 });
+      await flowsheet.artistInput.click();
+      await flowsheet.artistInput.pressSequentially(artist, { delay: 80 });
+
+      // Let the longest debounce (LML, 350 ms) plus its search and re-render
+      // settle, leaving a beat for any intermediate-state throw to surface.
+      await page.waitForTimeout(800);
+
+      // 1) The error boundary must never have replaced the page.
+      await expect(crashBoundary).toHaveCount(0);
+      // 2) The search input is still mounted and holds exactly what we typed —
+      //    proof the React tree didn't unmount into the boundary mid-type.
+      await expect(flowsheet.artistInput).toBeVisible();
+      await expect(flowsheet.artistInput).toHaveValue(artist);
+
+      // 3) No null/undefined dereference — the specific crash class — reached
+      //    the console or window during the type.
+      const nullDerefs = errors.filter((t) =>
+        /Cannot read propert(?:y|ies) of (?:null|undefined)/i.test(t)
+      );
+      expect(
+        nullDerefs,
+        `null-dereference error(s) during artist type "${artist}":\n${nullDerefs.join("\n")}`
+      ).toEqual([]);
+    });
+  }
+});

--- a/e2e/tests/flowsheet/artist-search-crash-smoke.spec.ts
+++ b/e2e/tests/flowsheet/artist-search-crash-smoke.spec.ts
@@ -101,19 +101,20 @@ test.describe("Flowsheet artist search — crash smoke", () => {
       // debounced catalog/LML/rotation/bin/suggest searches fire on every
       // intermediate state ("t", "th", "the", "the ", "the o", "the o'", …).
       await expect(flowsheet.artistInput).toBeEnabled({ timeout: 10_000 });
-      // Arm a wait for the search response the LAST keystroke triggers, so the
-      // conversion + result render a crash would happen in has actually run
-      // before we assert — a fixed timeout can assert before the render lands.
-      // `.catch` so a short query that fires no search doesn't fail the wait.
-      const searchSettled = page
-        .waitForResponse((r) => /\/(library|suggest)\b/.test(r.url()), {
-          timeout: 6_000,
-        })
-        .catch(() => undefined);
       await flowsheet.artistInput.click();
       await flowsheet.artistInput.pressSequentially(artist, { delay: 80 });
-      await searchSettled;
-      await page.waitForTimeout(400); // let React commit the post-response render
+
+      // Settle the crash window after the last keystroke: the longest debounce
+      // (LML, 350 ms) + its search round-trip against the local E2E backend +
+      // the React commit. A white-screen, once mounted, persists — global-error
+      // replaces the document and only reset() clears it — so a generous fixed
+      // wait reliably surfaces any crash that lands in this window, and the
+      // assertions below also auto-retry up to the 10 s expect timeout. (A
+      // response-keyed wait was rejected: the search URLs overlap page-load
+      // traffic like /library/rotation and the early /suggest prefix calls, so
+      // it resolved on the wrong request; and the bin/rotation filter crash
+      // path is client-side, with no response to await.)
+      await page.waitForTimeout(1_500);
 
       // 1) Primary: the error boundary must never have replaced the page — a
       //    render throw mounts global-error.tsx's own document root.

--- a/e2e/tests/flowsheet/artist-search-crash-smoke.spec.ts
+++ b/e2e/tests/flowsheet/artist-search-crash-smoke.spec.ts
@@ -22,15 +22,21 @@ const authDir = path.join(__dirname, "../../.auth");
  * error boundary never appears, the search UI stays mounted and interactive,
  * and no null/undefined dereference reaches the console.
  *
- * Caveat: this is a smoke test, not a deterministic reproduction. The original
- * crash is data-dependent (the triggering row must exist in the backend the DJ
- * was hitting), and dj-site's result conversions coerce missing fields, so this
- * can't *force* the failure. It pins the live path so a regression on these
- * inputs — the ones a real DJ hit — is caught in CI.
+ * Scope + caveat: this is a smoke test of the NORMAL (non-rotation) artist
+ * field — the path the DJ reported — not a deterministic reproduction. The
+ * original crash is data-dependent (the triggering row must exist in the
+ * backend the DJ was hitting) and dj-site's result conversions coerce missing
+ * fields, so this can't *force* the failure. The rotation-mode null-artist
+ * guards that ship alongside it are covered by their own unit tests
+ * (RotationReleaseDropdown / RotationEntryFields / sortRotationReleases). This
+ * pins the live normal-entry path so a regression on these inputs — the ones a
+ * real DJ hit — is caught in CI.
  *
  * The search form is live-only, so this mirrors library-search-proxy.spec.ts:
- * serial mode, go live once, ensure off-air in afterAll, and the musicDirector
- * session (kept off dj/dj2, which auth and entry-caching specs own).
+ * serial mode, ensure-live per test, ensure off-air in afterAll, and the
+ * musicDirector session (kept off dj/dj2, which auth and entry-caching specs
+ * own). ensureLive (not a once-only goLive) self-heals if a sibling spec
+ * sharing the musicDirector session flipped it off-air between tests.
  */
 test.describe("Flowsheet artist search — crash smoke", () => {
   test.use({ storageState: path.join(authDir, "musicDirector.json") });
@@ -38,16 +44,14 @@ test.describe("Flowsheet artist search — crash smoke", () => {
   test.setTimeout(60_000);
 
   let flowsheet: FlowsheetPage;
-  let isLive = false;
 
   test.beforeEach(async ({ page }) => {
     flowsheet = new FlowsheetPage(page);
     await flowsheet.goto();
     await flowsheet.waitForEntriesLoaded();
-    if (!isLive) {
-      await flowsheet.goLive();
-      isLive = true;
-    }
+    // ensureLive (not a once-only goLive flag): self-heals if a sibling spec
+    // sharing the musicDirector session flipped it off-air between tests.
+    await flowsheet.ensureLive();
   });
 
   test.afterAll(async ({ browser }) => {
@@ -83,9 +87,10 @@ test.describe("Flowsheet artist search — crash smoke", () => {
         name: "Something went wrong",
       });
 
-      // Capture the crash-class signal even if the boundary swallows the throw:
-      // React logs boundary-caught errors to console.error in prod builds, and
-      // any genuinely uncaught throw lands as a pageerror.
+      // Best-effort secondary crash signal — a console.error or uncaught
+      // pageerror during the type. The primary guarantee is the boundary
+      // assertion below; a prod build may not surface a boundary-caught throw
+      // here, so this only ever adds signal, never removes it.
       const errors: string[] = [];
       page.on("console", (msg) => {
         if (msg.type() === "error") errors.push(msg.text());
@@ -96,19 +101,29 @@ test.describe("Flowsheet artist search — crash smoke", () => {
       // debounced catalog/LML/rotation/bin/suggest searches fire on every
       // intermediate state ("t", "th", "the", "the ", "the o", "the o'", …).
       await expect(flowsheet.artistInput).toBeEnabled({ timeout: 10_000 });
+      // Arm a wait for the search response the LAST keystroke triggers, so the
+      // conversion + result render a crash would happen in has actually run
+      // before we assert — a fixed timeout can assert before the render lands.
+      // `.catch` so a short query that fires no search doesn't fail the wait.
+      const searchSettled = page
+        .waitForResponse((r) => /\/(library|suggest)\b/.test(r.url()), {
+          timeout: 6_000,
+        })
+        .catch(() => undefined);
       await flowsheet.artistInput.click();
       await flowsheet.artistInput.pressSequentially(artist, { delay: 80 });
+      await searchSettled;
+      await page.waitForTimeout(400); // let React commit the post-response render
 
-      // Let the longest debounce (LML, 350 ms) plus its search and re-render
-      // settle, leaving a beat for any intermediate-state throw to surface.
-      await page.waitForTimeout(800);
-
-      // 1) The error boundary must never have replaced the page.
+      // 1) Primary: the error boundary must never have replaced the page — a
+      //    render throw mounts global-error.tsx's own document root.
       await expect(crashBoundary).toHaveCount(0);
-      // 2) The search input is still mounted and holds exactly what we typed —
-      //    proof the React tree didn't unmount into the boundary mid-type.
+      // 2) The search input is still mounted and interactive — proof the React
+      //    tree didn't unmount into the boundary mid-type. (We don't assert the
+      //    exact value: against the live backend a matched result can auto-fill
+      //    the field, so the typed string isn't guaranteed to survive.)
       await expect(flowsheet.artistInput).toBeVisible();
-      await expect(flowsheet.artistInput).toHaveValue(artist);
+      await expect(flowsheet.artistInput).toBeEnabled();
 
       // 3) No null/undefined dereference — the specific crash class — reached
       //    the console or window during the type.

--- a/lib/__tests__/features/rotation/sort.test.ts
+++ b/lib/__tests__/features/rotation/sort.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { sortRotationReleases } from "@/lib/features/rotation/sort";
 import { createTestAlbum, createTestArtist } from "@/lib/test-utils";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
 
 describe("sortRotationReleases", () => {
   it("sorts alphabetically by artist name", () => {
@@ -106,5 +107,27 @@ describe("sortRotationReleases", () => {
     ];
     const sorted = sortRotationReleases(releases);
     expect(sorted[0].artist.name).toBe("Emilie Levienaise-Farrouch");
+  });
+
+  // Regression: a library-unlinked rotation row can arrive with a null `artist`
+  // object. The comparator runs on every RotationReleaseDropdown render
+  // (visibleReleases memo), so an unguarded `a.artist.name` threw and
+  // white-screened the page via app/global-error. A 0/1-element list dodges the
+  // comparator, so this list has two entries to force it. (dj-site#779)
+  it("does not throw when a release has a null artist, sorting it as empty", () => {
+    const releases = [
+      createTestAlbum({
+        id: 1,
+        title: "Confield",
+        artist: createTestArtist({ name: "Autechre" }),
+      }),
+      {
+        ...createTestAlbum({ id: 2, title: "Untitled" }),
+        artist: null,
+      } as unknown as AlbumEntry,
+    ];
+    expect(() => sortRotationReleases(releases)).not.toThrow();
+    // The null artist coalesces to "" and sorts ahead of "Autechre".
+    expect(sortRotationReleases(releases).map((r) => r.id)).toEqual([2, 1]);
   });
 });

--- a/lib/features/rotation/sort.ts
+++ b/lib/features/rotation/sort.ts
@@ -12,9 +12,14 @@ import type { AlbumEntry } from "../catalog/types";
  */
 export function sortRotationReleases(releases: AlbumEntry[]): AlbumEntry[] {
   return [...releases].sort((a, b) => {
-    const artistCmp = a.artist.name.localeCompare(b.artist.name, undefined, {
-      sensitivity: "base",
-    });
+    // `artist` can be absent on library-unlinked rotation rows; coalesce to ""
+    // so the comparator never dereferences null (same guard class as the
+    // RotationReleaseDropdown / RotationEntryFields fixes).
+    const artistCmp = (a.artist?.name ?? "").localeCompare(
+      b.artist?.name ?? "",
+      undefined,
+      { sensitivity: "base" }
+    );
     if (artistCmp !== 0) return artistCmp;
     return a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
   });

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -119,7 +119,9 @@ describe("RotationEntryFields", () => {
       }),
       artist: null,
     } as unknown as ReturnType<typeof createTestAlbum>;
-    mockRotationData = [nullArtistRelease];
+    // Pair it with a normal release in the same bin so the dropdown's
+    // sortRotationReleases comparator actually runs over the null-artist row.
+    mockRotationData = [lightningBoltOoioo, nullArtistRelease];
 
     const { store } = renderWithProviders(<RotationEntryFields disabled={false} />);
     const dispatchSpy = vi.spyOn(store, "dispatch");

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -104,6 +104,37 @@ describe("RotationEntryFields", () => {
     mockTracksLoading = false;
   });
 
+  // Regression: a library-unlinked rotation release can arrive with no `artist`
+  // object. handleSelectRelease seeded the search query with
+  // `release.artist.name`, throwing on select. The dropdown render guard lets
+  // the option appear; this guards the seed so it falls back to an empty artist
+  // instead of crashing. Same null-artist class as the sibling guards.
+  it("selects a null-artist release without throwing and seeds an empty artist", () => {
+    const nullArtistRelease = {
+      ...createTestAlbum({
+        id: 8,
+        title: "Untitled",
+        rotation_id: 43,
+        rotation_bin: "H",
+      }),
+      artist: null,
+    } as unknown as ReturnType<typeof createTestAlbum>;
+    mockRotationData = [nullArtistRelease];
+
+    const { store } = renderWithProviders(<RotationEntryFields disabled={false} />);
+    const dispatchSpy = vi.spyOn(store, "dispatch");
+
+    expect(() => {
+      fireEvent.click(screen.getByRole("radio", { name: "H" }));
+      fireEvent.focus(screen.getByTestId("rotation-release-combobox"));
+      fireEvent.click(screen.getByTestId("rotation-release-option-8"));
+    }).not.toThrow();
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      flowsheetSlice.actions.setSearchProperty({ name: "artist", value: "" })
+    );
+  });
+
   it("never renders an artist input — rotation mode has no override UI", () => {
     renderWithProviders(<RotationEntryFields disabled={false} />);
     expect(

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -74,7 +74,7 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
       setManualEntry(false);
       setSearchOpen(true);
       dispatch(flowsheetSlice.actions.setSearchProperty({ name: "song", value: "" }));
-      dispatch(flowsheetSlice.actions.setSearchProperty({ name: "artist", value: release.artist.name }));
+      dispatch(flowsheetSlice.actions.setSearchProperty({ name: "artist", value: release.artist?.name ?? "" }));
       dispatch(flowsheetSlice.actions.setSearchProperty({ name: "album", value: release.title }));
       dispatch(flowsheetSlice.actions.setSearchProperty({ name: "label", value: release.label }));
       dispatch(

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
@@ -419,6 +419,17 @@ describe("RotationReleaseDropdown — null artist (regression)", () => {
     artist: null,
   } as unknown as AlbumEntry;
 
+  // A real bin holds more than one release, so the panel runs the list through
+  // `sortRotationReleases` — whose comparator dereferences `artist.name`.
+  // `Array.sort` skips the comparator for a 0/1-element array, so a single
+  // null-artist release would dodge that crash path; pair it with a normal
+  // release to exercise the sort.
+  const goodRelease = createTestAlbum({
+    id: 1,
+    title: "Confield",
+    artist: createTestArtist({ name: "Autechre" }),
+  });
+
   it("renders a selected null-artist release in the trigger without throwing", () => {
     expect(() =>
       render(
@@ -433,17 +444,17 @@ describe("RotationReleaseDropdown — null artist (regression)", () => {
     expect(getCombobox().value).toBe(" — Untitled");
   });
 
-  it("opens the panel and filters a null-artist release without throwing", () => {
+  it("opens, sorts, and filters a list containing a null-artist release without throwing", () => {
     render(
       <RotationReleaseDropdown
-        releases={[nullArtist]}
+        releases={[goodRelease, nullArtist]}
         selectedRelease={null}
         onSelectRelease={onSelect}
         disabled={false}
       />
     );
     expect(() => {
-      fireEvent.focus(getCombobox()); // renders the option (was: release.artist.name)
+      fireEvent.focus(getCombobox()); // sortRotationReleases comparator + option render
       fireEvent.change(getCombobox(), { target: { value: "unt" } }); // matchesQuery
     }).not.toThrow();
     expect(screen.getByTestId("rotation-release-panel")).toBeInTheDocument();

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import RotationReleaseDropdown from "./RotationReleaseDropdown";
 import { createTestAlbum, createTestArtist } from "@/lib/test-utils";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
 
 const releases = [
   createTestAlbum({
@@ -400,5 +401,51 @@ describe("RotationReleaseDropdown — combobox (#745)", () => {
         screen.queryByTestId("rotation-release-option-1")
       ).not.toBeInTheDocument();
     });
+  });
+});
+
+// Regression: a library-unlinked rotation release can arrive with no `artist`
+// object. formatRelease (the combobox value), matchesQuery (the type-ahead
+// filter), and the option render all dereferenced `release.artist.name`
+// unguarded — any one throws mid-render and bubbles to app/global-error,
+// white-screening the page. Same null-artist class as the FlowsheetBackendResult
+// and filterBySearchTerms guards.
+describe("RotationReleaseDropdown — null artist (regression)", () => {
+  const onSelect = vi.fn();
+  beforeEach(() => vi.clearAllMocks());
+
+  const nullArtist = {
+    ...createTestAlbum({ id: 9, title: "Untitled" }),
+    artist: null,
+  } as unknown as AlbumEntry;
+
+  it("renders a selected null-artist release in the trigger without throwing", () => {
+    expect(() =>
+      render(
+        <RotationReleaseDropdown
+          releases={[]}
+          selectedRelease={nullArtist}
+          onSelectRelease={onSelect}
+          disabled={false}
+        />
+      )
+    ).not.toThrow();
+    expect(getCombobox().value).toBe(" — Untitled");
+  });
+
+  it("opens the panel and filters a null-artist release without throwing", () => {
+    render(
+      <RotationReleaseDropdown
+        releases={[nullArtist]}
+        selectedRelease={null}
+        onSelectRelease={onSelect}
+        disabled={false}
+      />
+    );
+    expect(() => {
+      fireEvent.focus(getCombobox()); // renders the option (was: release.artist.name)
+      fireEvent.change(getCombobox(), { target: { value: "unt" } }); // matchesQuery
+    }).not.toThrow();
+    expect(screen.getByTestId("rotation-release-panel")).toBeInTheDocument();
   });
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
@@ -8,14 +8,14 @@ import { ClickAwayListener } from "@mui/material";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 function formatRelease(release: AlbumEntry): string {
-  return `${release.artist.name} — ${release.title}`;
+  return `${release.artist?.name ?? ""} — ${release.title}`;
 }
 
 function matchesQuery(release: AlbumEntry, query: string): boolean {
   if (!query) return true;
   const q = query.toLowerCase();
   return (
-    release.artist.name.toLowerCase().includes(q) ||
+    (release.artist?.name ?? "").toLowerCase().includes(q) ||
     release.title.toLowerCase().includes(q)
   );
 }
@@ -245,7 +245,7 @@ export default function RotationReleaseDropdown({
                     }}
                   >
                     <Typography component="span" sx={{ fontWeight: "bold" }}>
-                      {release.artist.name}
+                      {release.artist?.name}
                     </Typography>
                     {" — "}
                     {release.title}

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
@@ -245,7 +245,7 @@ export default function RotationReleaseDropdown({
                     }}
                   >
                     <Typography component="span" sx={{ fontWeight: "bold" }}>
-                      {release.artist?.name}
+                      {release.artist?.name ?? ""}
                     </Typography>
                     {" — "}
                     {release.title}


### PR DESCRIPTION
Two follow-ups to #777 / #778, in one PR.

## 1. fix: guard null artist in the rotation entry path

A code review of #778 surfaced the same null-`artist` dereference class in the rotation path, which #778 didn't touch. `RotationReleaseDropdown`'s `formatRelease`, `matchesQuery`, and the option render all dereferenced `release.artist.name` in the **render** path — a null-artist rotation release throws mid-render and bubbles to `app/global-error.tsx`, white-screening the whole page. `RotationEntryFields.handleSelectRelease` seeds the search query with `release.artist.name` on select. All four are now guarded with optional chaining (`release.artist?.name`), matching the #778 pattern.

## 2. test: headless crash-smoke for the artist-search white-screen

A new Playwright spec (`e2e/tests/flowsheet/artist-search-crash-smoke.spec.ts`) drives the live artist-field search in headless Chromium with the reported problem inputs — `"The O'Jays"`, a bare `"The "`, `"Hermanos Gutiérrez"`, `"Duke Ellington & John Coltrane"` — typed character-by-character so every intermediate debounced query fires, and asserts the `global-error.tsx` boundary never appears and the search input stays mounted and editable.

Closes #779

## Test plan

- TDD red→green: rotation regression tests (`RotationReleaseDropdown` ×2 — selected-in-trigger and in-list-with-panel-open + type-ahead; `RotationEntryFields` ×1 — seed-on-select) reproduce `TypeError: Cannot read properties of null (reading 'name')` without the guards and pass with them.
- `npx tsc --noEmit` — clean.
- Search neighborhood unit suite — 191 tests green.
- E2E crash-smoke spec — verified locally against the real Backend-Service + headless Chromium E2E stack, 4/4 green.

## Note

Defensive, like #778: `convertToAlbumEntry` coerces `artist_name ?? ""` on the standard wire, so a null `artist` object shouldn't reach these today. The guards close the same class everywhere; the smoke test is forward regression protection — it passes today and would catch a future white-screen on these everyday inputs. It is not a reproduction of the original (still-undiagnosed) #777 crash.
