### PR TITLE
fix(classic): guard null artist in EntryForm rotation dropdown + catalog SearchResults

### DIFF
--- a/src/components/experiences/classic/catalog/SearchResults.tsx
+++ b/src/components/experiences/classic/catalog/SearchResults.tsx
@@ -107,7 +107,7 @@ export default function SearchResults() {
         <tbody>
           {results.map((result) => (
             <tr key={result.id} className="text">
-              <td align="left">{result.album_artist ? "Various Artists" : result.artist.name}</td>
+              <td align="left">{result.album_artist ? "Various Artists" : (result.artist?.name || "Unknown")}</td>
               <td align="left">
                 {result.title}
                 {result.on_streaming === false && (
@@ -120,7 +120,7 @@ export default function SearchResults() {
               </td>
               <td align="left">{result.format}</td>
               <td align="left">
-                {result.artist.lettercode} {result.entry}
+                {result.artist?.lettercode} {result.entry}
               </td>
             </tr>
           ))}

--- a/src/components/experiences/classic/catalog/__tests__/SearchResults.test.tsx
+++ b/src/components/experiences/classic/catalog/__tests__/SearchResults.test.tsx
@@ -108,3 +108,39 @@ describe("Classic SearchResults EXCLUSIVE capsule", () => {
     expect(screen.queryByText("EXCLUSIVE")).toBeNull();
   });
 });
+
+// Regression: a library-unlinked / LML-proxy catalog row can arrive with no
+// `artist` object. The Artist column (`result.artist.name`) and the Library
+// Code column (`result.artist.lettercode`) dereferenced it unguarded, so one
+// such row threw mid-render and the only error boundary (app/global-error)
+// white-screened the whole page. Same null-artist class guarded for the Modern
+// experience in #778 (search results). Pair the null-artist row with a normal
+// one so the table renders a realistic multi-row list.
+describe("Classic SearchResults — null artist (regression)", () => {
+  it("does not throw and shows a fallback when a result row has a null artist", () => {
+    const nullArtistRow = {
+      ...createTestAlbum({ id: 9001, title: "Untitled" }),
+      artist: null,
+    } as unknown as ReturnType<typeof createTestAlbum>;
+    const goodRow = createTestAlbum({
+      id: 9002,
+      title: "DOGA",
+      artist: createTestArtist({
+        name: "Juana Molina",
+        lettercode: "RO",
+        numbercode: 34,
+      }),
+    });
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [nullArtistRow, goodRow],
+      isLoading: false,
+      error: undefined,
+    });
+
+    expect(() => renderWithProviders(<SearchResults />)).not.toThrow();
+    // The normal row still renders its artist; the null-artist row shows the
+    // "Unknown" fallback instead of crashing.
+    expect(screen.getByText("Juana Molina")).toBeDefined();
+    expect(screen.getByText("Unknown")).toBeDefined();
+  });
+});

--- a/src/components/experiences/classic/flowsheet/EntryForm.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryForm.tsx
@@ -78,7 +78,7 @@ export default function EntryForm({
     setSelectedRotationId(rotationId);
     const release = rotationData?.find((r) => r.rotation_id === rotationId);
     if (release) {
-      setArtistName(release.artist.name);
+      setArtistName(release.artist?.name ?? "");
       setReleaseTitle(release.title);
       setLabelName(release.label);
     }
@@ -150,7 +150,7 @@ export default function EntryForm({
         };
       } else {
         submissionData = {
-          artist_name: release.artist.name,
+          artist_name: release.artist?.name ?? "",
           album_title: release.title,
           track_title: songTitle,
           request_flag: requestFlag,
@@ -269,7 +269,7 @@ export default function EntryForm({
                           key={release.rotation_id}
                           value={release.rotation_id}
                         >
-                          {release.artist.name} - {release.title}
+                          {release.artist?.name ?? ""} - {release.title}
                         </option>
                       ))}
                     </select>
@@ -292,7 +292,7 @@ export default function EntryForm({
                           key={release.rotation_id}
                           value={release.rotation_id}
                         >
-                          {release.artist.name} - {release.title}
+                          {release.artist?.name ?? ""} - {release.title}
                         </option>
                       ))}
                     </select>
@@ -315,7 +315,7 @@ export default function EntryForm({
                           key={release.rotation_id}
                           value={release.rotation_id}
                         >
-                          {release.artist.name} - {release.title}
+                          {release.artist?.name ?? ""} - {release.title}
                         </option>
                       ))}
                     </select>
@@ -341,7 +341,7 @@ export default function EntryForm({
                           key={release.rotation_id}
                           value={release.rotation_id}
                         >
-                          {release.artist.name} - {release.title}
+                          {release.artist?.name ?? ""} - {release.title}
                         </option>
                       ))}
                     </select>

--- a/src/components/experiences/classic/flowsheet/__tests__/EntryForm.test.tsx
+++ b/src/components/experiences/classic/flowsheet/__tests__/EntryForm.test.tsx
@@ -450,6 +450,86 @@ describe("Classic EntryForm — Rotation submission payload", () => {
   });
 });
 
+// Regression: a library-unlinked rotation row can arrive with no `artist`
+// object. The bin option list (`{release.artist.name} - {release.title}`), the
+// select handler (`setArtistName(release.artist.name)`), and the freeform
+// submission payload (`artist_name: release.artist.name`) all dereferenced it
+// unguarded — any one throws mid-render/handler and app/global-error
+// white-screens the page. Same null-artist class guarded for the Modern
+// experience in #779/#780 (rotation entry/release path). `sortRotationReleases`
+// (the comparator) was already guarded in #780; this exercises the components'
+// own derefs.
+describe("Classic EntryForm — null artist (regression)", () => {
+  async function selectByText(
+    user: ReturnType<typeof renderWithProviders>["user"],
+    select: HTMLSelectElement,
+    textContains: string
+  ): Promise<void> {
+    const option = Array.from(select.options).find((o) =>
+      o.text.includes(textContains)
+    );
+    if (!option) throw new Error(`No option text contains: ${textContains}`);
+    await user.selectOptions(select, option);
+  }
+
+  // Pair the null-artist release with a normal one so the bin list runs through
+  // `sortRotationReleases` (Array.sort skips the comparator for a 0/1-element
+  // list — the #780 lesson) and the option .map() renders both. The null-artist
+  // row carries a synthesized *negative* `id` (library-unlinked) and a positive
+  // `rotation_id`, so it's selectable and takes the freeform submit branch.
+  function rotationWithNullArtistRow(): ReturnType<
+    typeof createTestRotationAlbum
+  >[] {
+    return [
+      {
+        ...createTestRotationAlbum(Rotation.H, {
+          id: -55,
+          rotation_id: 8101,
+          title: "Untitled",
+          label: "self-released",
+        }),
+        artist: null,
+      } as unknown as ReturnType<typeof createTestRotationAlbum>,
+      createTestRotationAlbum(Rotation.H, {
+        id: 8002,
+        rotation_id: 8002,
+        title: "Confield",
+        artist: createTestArtist({ name: "Autechre" }),
+      }),
+    ];
+  }
+
+  it("renders a bin containing a null-artist release without throwing", async () => {
+    rotationDataMock = rotationWithNullArtistRow();
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("rotationType"), "heavy");
+    const heavy = getNamedSelect("heavyRelease");
+    const texts = Array.from(heavy.options).map((o) => o.textContent ?? "");
+    // The normal release renders with its artist; the null-artist row renders
+    // with an empty artist instead of crashing.
+    expect(texts.some((t) => t.includes("Autechre - Confield"))).toBe(true);
+    expect(texts.some((t) => t.includes("- Untitled"))).toBe(true);
+  });
+
+  it("seeds an empty artist and submits freeform when a null-artist release is selected", async () => {
+    rotationDataMock = rotationWithNullArtistRow();
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("rotationType"), "heavy");
+    await selectByText(user, getNamedSelect("heavyRelease"), "Untitled");
+    await user.type(getNamedInput("songTitle"), "Charcoal Bow");
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    await waitFor(() => {
+      expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+    });
+    const payload = addToFlowsheetMock.mock.calls[0][0];
+    expect(payload.track_title).toBe("Charcoal Bow");
+    // Unlinked row (negative id) → freeform variant; null artist coalesces to "".
+    expect(payload.artist_name).toBe("");
+    expect(payload.album_title).toBe("Untitled");
+  });
+});
+
 describe("Classic EntryForm — Breakpoint message format", () => {
   it("formats the breakpoint message as 'H:MM AM/PM Breakpoint'", async () => {
     // mockCurrentTime() can't be used here because it installs fake timers,


### PR DESCRIPTION
## Summary

Guards the null-`artist` render-crash class — fixed for the **Modern** experience in #778 (search results) and #779/#780 (rotation entry/release) — at the equivalent unguarded sites in the **Classic** experience. A rotation/catalog row whose `artist` is null dereferenced in a Classic render path threw mid-render; the app's only error boundary (`app/global-error.tsx`) then replaced the entire document — the same white-screen DJs reported.

The shared comparator `sortRotationReleases` was already guarded in #780, so the Classic rotation picker's *sort* crash is already fixed. This PR hardens the Classic components' own render/handler derefs.

## Changes

`src/components/experiences/classic/flowsheet/EntryForm.tsx`
- Render: the four bin option lists → `{release.artist?.name ?? ""} - {release.title}`
- Handler: `setArtistName(release.artist?.name ?? "")`
- Submission payload (library-unlinked freeform branch): `artist_name: release.artist?.name ?? ""`

These match the Modern `?? ""` rotation pattern (`RotationReleaseDropdown` / `RotationEntryFields`).

`src/components/experiences/classic/catalog/SearchResults.tsx`
- Artist column → `result.artist?.name || "Unknown"` (matching Modern `FlowsheetBackendResult`, which uses `|| \"Unknown\"` so an empty name also reads "Unknown"; the issue text suggested `?? \"Unknown\"`, but `||` is the closer analog and handles the empty-string case too)
- Library Code column → `result.artist?.lettercode`

## Reachability

**Defensive hardening, not a reproduced live crash.** `convertToAlbumEntry` coerces `artist_name ?? ""` and always builds a non-null `artist` object, and rotation data is mapped through it (`lib/features/rotation/api.ts`), so these components don't receive a null `artist` today. `AlbumEntry.artist` / `ArtistEntry.name` are declared non-null, so the compiler won't flag the derefs — the regression tests force the null shape via `as unknown as` casts, exactly as the Modern tests do.

## Tests

- Classic `SearchResults`: rendering a results list containing a null-`artist` row does not throw; the normal row still renders and the null row shows the "Unknown" fallback.
- Classic `EntryForm`: rendering a bin that contains a null-`artist` release does not throw, and selecting it seeds an empty artist + submits the freeform variant with `artist_name: ""`. The null-artist row is paired with a normal release so the sorted bin list still runs the comparator (the #780 single-element-dodges-`Array.sort` lesson).

`npx tsc --noEmit` and the full unit suite (3264 tests) pass locally.

## Related

- #778 — Modern search-results guard
- #779 / #780 — Modern rotation guard + `sortRotationReleases` + headless crash-smoke

Closes #781