### PR TITLE
feat(auth): instrument requireAuth server bounces with login_server_bounce telemetry

### DIFF
--- a/app/login/LoginBounceTelemetry.test.tsx
+++ b/app/login/LoginBounceTelemetry.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders } from "@/lib/test-utils";
+
+// Mock the query string the server redirect lands on.
+const searchParamsMock = vi.fn<() => URLSearchParams>();
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsMock(),
+}));
+
+// Mock PostHog telemetry so we can inspect the emitted server-bounce event
+// without initialising PostHog (safeCapture already swallows in SSR/tests).
+const mockSafeCapture = vi.fn();
+vi.mock("@/lib/posthog", () => ({
+  safeCapture: (...args: any[]) => mockSafeCapture(...args),
+}));
+
+import LoginBounceTelemetry from "./LoginBounceTelemetry";
+
+describe("LoginBounceTelemetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParamsMock.mockReturnValue(new URLSearchParams(""));
+  });
+
+  it("emits login_server_bounce with the no-session reason (the station-Mac bug)", () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams("bounced=no-session"));
+
+    renderWithProviders(<LoginBounceTelemetry />);
+
+    expect(mockSafeCapture).toHaveBeenCalledWith("login_server_bounce", {
+      reason: "no-session",
+    });
+  });
+
+  it("emits the email-not-verified reason alongside the UI error param", () => {
+    searchParamsMock.mockReturnValue(
+      new URLSearchParams("error=email-not-verified&bounced=email-not-verified"),
+    );
+
+    renderWithProviders(<LoginBounceTelemetry />);
+
+    expect(mockSafeCapture).toHaveBeenCalledWith("login_server_bounce", {
+      reason: "email-not-verified",
+    });
+  });
+
+  it("emits the incomplete reason", () => {
+    searchParamsMock.mockReturnValue(
+      new URLSearchParams("incomplete=true&bounced=incomplete"),
+    );
+
+    renderWithProviders(<LoginBounceTelemetry />);
+
+    expect(mockSafeCapture).toHaveBeenCalledWith("login_server_bounce", {
+      reason: "incomplete",
+    });
+  });
+
+  it("stays silent on a normal login view (no bounce param)", () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams("verified=true"));
+
+    renderWithProviders(<LoginBounceTelemetry />);
+
+    expect(mockSafeCapture).not.toHaveBeenCalled();
+  });
+
+  it("emits at most once for a single bounce", () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams("bounced=no-session"));
+
+    const { rerender } = renderWithProviders(<LoginBounceTelemetry />);
+    rerender(<LoginBounceTelemetry />);
+
+    expect(mockSafeCapture).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing", () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams("bounced=no-session"));
+
+    const { container } = renderWithProviders(<LoginBounceTelemetry />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/app/login/LoginBounceTelemetry.tsx
+++ b/app/login/LoginBounceTelemetry.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { safeCapture } from "@/lib/posthog";
+
+/**
+ * Records when the server-side `requireAuth()` gate bounced a user back to
+ * `/login`. The three `requireAuth` exits append a `bounced=<reason>` query
+ * param (`no-session` | `email-not-verified` | `incomplete`); this component
+ * reads it and emits a single `login_server_bounce` PostHog event.
+ *
+ * This is the missing half of the login funnel. `login_post_redirect` (emitted
+ * in authenticationHooks) records the client's INTENT to send a DJ to the
+ * dashboard after a successful sign-in. `login_server_bounce` records the
+ * server's VERDICT — so a DJ who sees "login successful" but lands back on the
+ * login page (cookie not valid server-side) finally shows up in telemetry
+ * instead of looking "fixed". The `bounced` param is set only by the server,
+ * so this never fires for the client's own onboarding redirect.
+ *
+ * Renders nothing. Mounted once in the shared login layout, so it covers both
+ * the classic and modern experiences.
+ */
+export default function LoginBounceTelemetry(): null {
+  const searchParams = useSearchParams();
+  const reason = searchParams?.get("bounced") ?? null;
+  // Track the last reason we reported so re-renders (and a future second bounce
+  // with a different reason) emit correctly without double-counting.
+  const lastEmitted = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!reason || reason === lastEmitted.current) {
+      return;
+    }
+    lastEmitted.current = reason;
+    safeCapture("login_server_bounce", { reason });
+  }, [reason]);
+
+  return null;
+}

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -1,7 +1,19 @@
-import type { JSX } from "react";
+import { Suspense, type JSX } from "react";
 import ThemedLayout, { LoginLayoutProps } from "@/src/ThemedLayout";
+import LoginBounceTelemetry from "./LoginBounceTelemetry";
 
-const Layout = async (props: LoginLayoutProps): Promise<JSX.Element> =>
-  ThemedLayout(props);
+const Layout = async (props: LoginLayoutProps): Promise<JSX.Element> => {
+  const themed = await ThemedLayout(props);
+  return (
+    <>
+      {/* Server-bounce telemetry. useSearchParams requires a Suspense
+          boundary; the component renders nothing so the fallback is null. */}
+      <Suspense fallback={null}>
+        <LoginBounceTelemetry />
+      </Suspense>
+      {themed}
+    </>
+  );
+};
 
 export default Layout;

--- a/lib/__tests__/features/authentication/server-session.test.ts
+++ b/lib/__tests__/features/authentication/server-session.test.ts
@@ -150,7 +150,7 @@ describe("requireAuth", () => {
   it("should redirect to /login when not authenticated", async () => {
     mockGetSession.mockResolvedValue({ data: null, error: null });
 
-    await expect(requireAuth()).rejects.toThrow("REDIRECT:/login");
-    expect(mockRedirect).toHaveBeenCalledWith("/login");
+    await expect(requireAuth()).rejects.toThrow("REDIRECT:/login?bounced=no-session");
+    expect(mockRedirect).toHaveBeenCalledWith("/login?bounced=no-session");
   });
 });

--- a/lib/__tests__/features/authentication/server-utils.test.ts
+++ b/lib/__tests__/features/authentication/server-utils.test.ts
@@ -126,8 +126,8 @@ describe("server-utils", () => {
     it("should redirect to /login when not authenticated", async () => {
       mockGetSession.mockResolvedValue({ data: null, error: null });
 
-      await expect(requireAuth()).rejects.toThrow("REDIRECT:/login");
-      expect(mockRedirect).toHaveBeenCalledWith("/login");
+      await expect(requireAuth()).rejects.toThrow("REDIRECT:/login?bounced=no-session");
+      expect(mockRedirect).toHaveBeenCalledWith("/login?bounced=no-session");
     });
 
     it("should redirect to /login when email is not verified", async () => {
@@ -143,16 +143,16 @@ describe("server-utils", () => {
       });
       mockGetSession.mockResolvedValue({ data: session, error: null });
 
-      await expect(requireAuth()).rejects.toThrow("REDIRECT:/login?error=email-not-verified");
-      expect(mockRedirect).toHaveBeenCalledWith("/login?error=email-not-verified");
+      await expect(requireAuth()).rejects.toThrow("REDIRECT:/login?error=email-not-verified&bounced=email-not-verified");
+      expect(mockRedirect).toHaveBeenCalledWith("/login?error=email-not-verified&bounced=email-not-verified");
     });
 
     it("should redirect to /login?incomplete=true when user is incomplete", async () => {
       const session = createTestIncompleteSession(["realName"]);
       mockGetSession.mockResolvedValue({ data: session, error: null });
 
-      await expect(requireAuth()).rejects.toThrow("REDIRECT:/login?incomplete=true");
-      expect(mockRedirect).toHaveBeenCalledWith("/login?incomplete=true");
+      await expect(requireAuth()).rejects.toThrow("REDIRECT:/login?incomplete=true&bounced=incomplete");
+      expect(mockRedirect).toHaveBeenCalledWith("/login?incomplete=true&bounced=incomplete");
     });
 
     it("should redirect when hasCompletedOnboarding is false even with all profile fields filled", async () => {
@@ -169,8 +169,8 @@ describe("server-utils", () => {
       });
       mockGetSession.mockResolvedValue({ data: session, error: null });
 
-      await expect(requireAuth()).rejects.toThrow("REDIRECT:/login?incomplete=true");
-      expect(mockRedirect).toHaveBeenCalledWith("/login?incomplete=true");
+      await expect(requireAuth()).rejects.toThrow("REDIRECT:/login?incomplete=true&bounced=incomplete");
+      expect(mockRedirect).toHaveBeenCalledWith("/login?incomplete=true&bounced=incomplete");
     });
 
     it("should not redirect when hasCompletedOnboarding is not in session", async () => {

--- a/lib/features/authentication/server-utils.ts
+++ b/lib/features/authentication/server-utils.ts
@@ -48,19 +48,24 @@ export async function getServerSession(): Promise<BetterAuthSession | null> {
  */
 export async function requireAuth(): Promise<BetterAuthSession> {
   const session = await getServerSession();
+  // Each exit carries a server-only `bounced` param so the client can emit a
+  // `login_server_bounce` PostHog event. This records the server's VERDICT,
+  // which is distinct from the client's post-login redirect INTENT
+  // (`login_post_redirect`): a DJ can be told "login successful" client-side
+  // and still get bounced here when the session cookie isn't valid server-side.
   if (!session) {
-    redirect("/login");
+    redirect("/login?bounced=no-session");
   }
 
   if (!session.user.emailVerified) {
-    redirect("/login?error=email-not-verified");
+    redirect("/login?error=email-not-verified&bounced=email-not-verified");
   }
 
   // Redirect incomplete users back to login for onboarding.
   // Only check if hasCompletedOnboarding is explicitly present as a key in the user object
   // (better-auth includes additional fields when configured).
   if ("hasCompletedOnboarding" in session.user && isUserIncomplete(session)) {
-    redirect("/login?incomplete=true");
+    redirect("/login?incomplete=true&bounced=incomplete");
   }
 
   return session;


### PR DESCRIPTION
## Summary

Makes the dashboard's server-side `requireAuth()` login bounce observable in PostHog. `login_post_redirect` records the client's *intent* to route to the dashboard after sign-in; nothing recorded the server's *verdict* when `requireAuth()` bounced the user back to `/login`. That blind spot is why the station-computer login failure looked "fixed" — the success toast and redirect event both fired while the server silently rejected the session (cookie not valid server-side).

This is **observability only.** It makes the bounce countable; it does not fix the underlying session-cookie failure on the affected machine, which is a separate follow-up.

## Changes

- **`lib/features/authentication/server-utils.ts`** — all three `requireAuth()` redirect-to-login exits now carry a server-only `bounced=<reason>` param: `no-session` (the station-Mac case), `email-not-verified`, `incomplete`.
- **`app/login/LoginBounceTelemetry.tsx`** (new) — `"use client"`, null-rendering; reads `bounced`, fires `safeCapture("login_server_bounce", { reason })` once. `bounced` is set only by the server, so it never fires for the client's own onboarding redirect.
- **`app/login/layout.tsx`** — mounts the component (Suspense-wrapped) once in the shared layout, covering both classic + modern experiences.

Existing UI params preserved: `error=email-not-verified` is still consumed by `LoginSlotSwitcher`; `incomplete=true` is untouched (the E2E `.includes("incomplete=true")` checks still hold).

## Resulting signal

Funnel `login_post_redirect` (`destination=dashboard`) → `login_server_bounce` (`reason=no-session`) makes the station-Mac loop directly countable, per-machine, instead of invisible.

## Tests (TDD, red → green)

- `server-utils.test.ts` / `server-session.test.ts` — updated the four redirect assertions to the new URLs.
- `LoginBounceTelemetry.test.tsx` (new, 6 cases) — emits the right reason for each bounce, stays silent on a normal login view, emits at most once, renders nothing.

Local CI gates green: `tsc --noEmit` (exit 0), changed-test suite (108/108), `next build` (`/login` is dynamic / server-rendered, so the `useSearchParams` path is never prerendered).

Closes #786
