### PR TITLE
feat(auto-dj): greyscale theme + "Auto DJ Enabled" banner driven by orchestrator status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8080
 NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:8082/auth
 
+# Auto-DJ orchestrator base URL. When set, the dashboard polls /api/auto-dj/status
+# and reflects auto-DJ state (greyscale theme + "Auto DJ Enabled" banner). Leave
+# unset to disable the indicator entirely (no polling).
+# NEXT_PUBLIC_ORCHESTRATOR_URL=http://localhost:8090
+
 # Optional server-side override for the /auth/:path* rewrite destination. Set
 # this in containerized deployments where NEXT_PUBLIC_BETTER_AUTH_URL is
 # reachable from the browser but not from inside the dj-site server process

--- a/app/dashboard/@modern/flowsheet/layout.tsx
+++ b/app/dashboard/@modern/flowsheet/layout.tsx
@@ -1,3 +1,4 @@
+import AutoDJBanner from "@/src/components/experiences/modern/autoDJ/AutoDJBanner";
 import FlowsheetSkeletonLoader from "@/src/components/experiences/modern/flowsheet/FlowsheetSkeletonLoader";
 import GoLive from "@/src/components/experiences/modern/flowsheet/GoLive";
 import InfiniteScroller from "@/src/components/experiences/modern/flowsheet/InfiniteScroller";
@@ -21,6 +22,7 @@ export default function FlowsheetPage({
   return (
     <>
       <SSESubscription surface="dashboard" />
+      <AutoDJBanner />
       <PageHeader title="Flowsheet">
         <SSEConnectionIndicator />
         <GoLive />

--- a/app/dashboard/@modern/layout.tsx
+++ b/app/dashboard/@modern/layout.tsx
@@ -1,10 +1,10 @@
-import { Box } from "@mui/joy";
 import type { JSX, ReactNode } from "react";
 import Main from "@/src/components/experiences/modern/Main";
 import Rightbar from "@/src/components/experiences/modern/Rightbar/Rightbar";
 import MobileHeader from "@/src/components/experiences/modern/Header/MobileHeader";
 import DesktopHeader from "@/src/components/experiences/modern/Header/DesktopHeader";
 import Leftbar from "@/src/components/experiences/modern/Leftbar/Leftbar";
+import AutoDJGreyscale from "@/src/components/experiences/modern/autoDJ/AutoDJGreyscale";
 
 export default function ModernDashboard({
   children,
@@ -12,7 +12,7 @@ export default function ModernDashboard({
   children: ReactNode;
 }): JSX.Element {
   return (
-    <Box sx={{ display: "flex", height: "100dvh", overflow: "hidden" }}>
+    <AutoDJGreyscale>
       <MobileHeader />
       <Leftbar />
       <Main>
@@ -20,6 +20,6 @@ export default function ModernDashboard({
         {children}
       </Main>
       <Rightbar />
-    </Box>
+    </AutoDJGreyscale>
   );
 }

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -11,6 +11,10 @@ NEXT_PUBLIC_ENABLED_EXPERIENCES=modern,classic
 NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING=true
 NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED=false
 
+# Optional — auto-DJ orchestrator base URL. When set, the dashboard polls
+# /api/auto-dj/status and reflects auto-DJ state (greyscale + banner).
+# NEXT_PUBLIC_ORCHESTRATOR_URL=http://localhost:8090
+
 # Optional, server-only — override target for the /auth/:path* rewrite in
 # containerized deployments where NEXT_PUBLIC_BETTER_AUTH_URL is reachable
 # from the browser but not from inside the dj-site server.
@@ -20,3 +24,5 @@ NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED=false
 ## Feature flags
 
 - `NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED` — gates the track-search UI surfaces in catalog search: the `matched_via` track-match chip rendering in result rows (both classic and modern experiences) and the classic `SearchForm` help-text refresh (worked track-lookup example replacing the legacy "Coming later" line). Defaults to OFF; set to `"true"` or `"1"` to enable. Helper: `isCatalogTrackSearchUiEnabled()` in `lib/features/catalog/flags.ts`. Flip on after Backend-Service is serving `matched_via` in prod. See WXYC/dj-site#497 and WXYC/dj-site#498.
+
+- `NEXT_PUBLIC_ORCHESTRATOR_URL` — base URL of the [auto-dj-orchestrator](https://github.com/WXYC/auto-dj-orchestrator). When set, the dashboard polls `GET /api/auto-dj/status` every 10s (better-auth JWT) and reflects auto-DJ state station-wide: the shell greyscales and an "Auto DJ Enabled" banner shows at the top of the flowsheet. Unset disables the indicator and all polling. Helpers: `getOrchestratorUrl()` / `isAutoDJStatusEnabled()` in `lib/features/autoDJ/flags.ts`.

--- a/lib/features/autoDJ/api.test.ts
+++ b/lib/features/autoDJ/api.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { configureStore } from "@reduxjs/toolkit";
+
+// getJWTToken hits the auth client; stub it so the test exercises only the
+// orchestrator base query's error handling.
+vi.mock("../authentication/client", () => ({
+  getJWTToken: vi.fn(async () => null),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  // api.ts reads NEXT_PUBLIC_ORCHESTRATOR_URL at module load; set it before import.
+  process.env.NEXT_PUBLIC_ORCHESTRATOR_URL = "http://localhost:8090";
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  delete process.env.NEXT_PUBLIC_ORCHESTRATOR_URL;
+});
+
+async function loadStore() {
+  const { autoDJApi } = await import("./api");
+  const store = configureStore({
+    reducer: { [autoDJApi.reducerPath]: autoDJApi.reducer },
+    middleware: (gdm) => gdm().concat(autoDJApi.middleware),
+  });
+  return { autoDJApi, store };
+}
+
+describe("autoDJApi", () => {
+  it("swallows orchestrator failures so the 10s poll never surfaces a toast/error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("orchestrator down");
+      }),
+    );
+    const { autoDJApi, store } = await loadStore();
+    const result = await store.dispatch(
+      autoDJApi.endpoints.getAutoDJStatus.initiate(),
+    );
+    // Fail silent: no rejected query (which the global error logger would toast),
+    // just undefined data -> the UI shows no auto-DJ state.
+    expect(result.isError).toBe(false);
+    expect(result.data).toBeUndefined();
+  });
+
+  it("returns the parsed status on success", async () => {
+    const status = { active: true };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify(status), { status: 200 })),
+    );
+    const { autoDJApi, store } = await loadStore();
+    const result = await store.dispatch(
+      autoDJApi.endpoints.getAutoDJStatus.initiate(),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.data).toEqual(status);
+  });
+
+  it("fails silent via the catch path when the base URL is relative (orchestrator URL unset)", async () => {
+    // Unset the URL so the base URL is relative; constructing a Request from a
+    // relative URL THROWS (outside fetchBaseQuery's inner try) — this exercises
+    // the orchestratorBaseQuery catch block, not the returned-error branch.
+    delete process.env.NEXT_PUBLIC_ORCHESTRATOR_URL;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("{}", { status: 200 })),
+    );
+    const { autoDJApi, store } = await loadStore();
+    const result = await store.dispatch(
+      autoDJApi.endpoints.getAutoDJStatus.initiate(),
+    );
+    expect(result.isError).toBe(false);
+    expect(result.data).toBeUndefined();
+  });
+});

--- a/lib/features/autoDJ/api.ts
+++ b/lib/features/autoDJ/api.ts
@@ -4,13 +4,22 @@
  * The orchestrator is a separate service from Backend-Service, so this slice has
  * its own base query pointed at NEXT_PUBLIC_ORCHESTRATOR_URL, reusing the same
  * better-auth JWT (valid across services that share the JWKS endpoint).
+ *
+ * Read-only: the status drives a cosmetic greyscale + banner. Activation is done
+ * elsewhere (the physical button / a future admin UI), not from this slice.
  */
-import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import {
+  createApi,
+  fetchBaseQuery,
+  type BaseQueryFn,
+  type FetchArgs,
+  type FetchBaseQueryError,
+} from "@reduxjs/toolkit/query/react";
 import { getJWTToken } from "../authentication/client";
 import { getOrchestratorUrl } from "./flags";
-import type { AutoDJDeactivateResponse, AutoDJStatus } from "./types";
+import type { AutoDJStatus } from "./types";
 
-const orchestratorBaseQuery = fetchBaseQuery({
+const rawBaseQuery = fetchBaseQuery({
   baseUrl: `${getOrchestratorUrl() ?? ""}/api/auto-dj`,
   prepareHeaders: async (headers) => {
     const token = await getJWTToken();
@@ -18,6 +27,29 @@ const orchestratorBaseQuery = fetchBaseQuery({
     return headers;
   },
 });
+
+/**
+ * The status indicator is purely cosmetic and polled every 10s, so an
+ * orchestrator outage / CORS / 401 / timeout must NOT surface as a user-facing
+ * toast or PostHog exception (the global `rtkQueryErrorLogger` fires on every
+ * rejected query). Swallow errors to `{ data: undefined }` — the UI simply shows
+ * no auto-DJ state, exactly like when the feature is disabled.
+ */
+const orchestratorBaseQuery: BaseQueryFn<
+  string | FetchArgs,
+  unknown,
+  FetchBaseQueryError
+> = async (args, store, extraOptions) => {
+  try {
+    const result = await rawBaseQuery(args, store, extraOptions);
+    if (result.error) return { data: undefined };
+    return result;
+  } catch {
+    // A thrown error (e.g. a bad/relative base URL when the feature is unset)
+    // must also fail silent, not reject.
+    return { data: undefined };
+  }
+};
 
 export const autoDJApi = createApi({
   reducerPath: "autoDJApi",
@@ -28,19 +60,7 @@ export const autoDJApi = createApi({
       query: () => "/status",
       providesTags: ["AutoDJStatus"],
     }),
-    activateAutoDJ: builder.mutation<AutoDJStatus, void>({
-      query: () => ({ url: "/activate", method: "POST" }),
-      invalidatesTags: ["AutoDJStatus"],
-    }),
-    deactivateAutoDJ: builder.mutation<AutoDJDeactivateResponse, void>({
-      query: () => ({ url: "/deactivate", method: "POST" }),
-      invalidatesTags: ["AutoDJStatus"],
-    }),
   }),
 });
 
-export const {
-  useGetAutoDJStatusQuery,
-  useActivateAutoDJMutation,
-  useDeactivateAutoDJMutation,
-} = autoDJApi;
+export const { useGetAutoDJStatusQuery } = autoDJApi;

--- a/lib/features/autoDJ/api.ts
+++ b/lib/features/autoDJ/api.ts
@@ -1,0 +1,46 @@
+/**
+ * Auto-DJ status API slice.
+ *
+ * The orchestrator is a separate service from Backend-Service, so this slice has
+ * its own base query pointed at NEXT_PUBLIC_ORCHESTRATOR_URL, reusing the same
+ * better-auth JWT (valid across services that share the JWKS endpoint).
+ */
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import { getJWTToken } from "../authentication/client";
+import { getOrchestratorUrl } from "./flags";
+import type { AutoDJDeactivateResponse, AutoDJStatus } from "./types";
+
+const orchestratorBaseQuery = fetchBaseQuery({
+  baseUrl: `${getOrchestratorUrl() ?? ""}/api/auto-dj`,
+  prepareHeaders: async (headers) => {
+    const token = await getJWTToken();
+    if (token) headers.set("Authorization", `Bearer ${token}`);
+    return headers;
+  },
+});
+
+export const autoDJApi = createApi({
+  reducerPath: "autoDJApi",
+  baseQuery: orchestratorBaseQuery,
+  tagTypes: ["AutoDJStatus"],
+  endpoints: (builder) => ({
+    getAutoDJStatus: builder.query<AutoDJStatus, void>({
+      query: () => "/status",
+      providesTags: ["AutoDJStatus"],
+    }),
+    activateAutoDJ: builder.mutation<AutoDJStatus, void>({
+      query: () => ({ url: "/activate", method: "POST" }),
+      invalidatesTags: ["AutoDJStatus"],
+    }),
+    deactivateAutoDJ: builder.mutation<AutoDJDeactivateResponse, void>({
+      query: () => ({ url: "/deactivate", method: "POST" }),
+      invalidatesTags: ["AutoDJStatus"],
+    }),
+  }),
+});
+
+export const {
+  useGetAutoDJStatusQuery,
+  useActivateAutoDJMutation,
+  useDeactivateAutoDJMutation,
+} = autoDJApi;

--- a/lib/features/autoDJ/flags.test.ts
+++ b/lib/features/autoDJ/flags.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { getOrchestratorUrl, isAutoDJStatusEnabled } from "./flags";
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("auto-dj flags", () => {
+  it("is disabled when NEXT_PUBLIC_ORCHESTRATOR_URL is unset or empty", () => {
+    vi.stubEnv("NEXT_PUBLIC_ORCHESTRATOR_URL", "");
+    expect(getOrchestratorUrl()).toBeUndefined();
+    expect(isAutoDJStatusEnabled()).toBe(false);
+  });
+
+  it("is enabled and returns the URL when set", () => {
+    vi.stubEnv("NEXT_PUBLIC_ORCHESTRATOR_URL", "http://localhost:8090");
+    expect(getOrchestratorUrl()).toBe("http://localhost:8090");
+    expect(isAutoDJStatusEnabled()).toBe(true);
+  });
+});

--- a/lib/features/autoDJ/flags.ts
+++ b/lib/features/autoDJ/flags.ts
@@ -1,0 +1,14 @@
+/**
+ * Auto-DJ status feature gate.
+ *
+ * The status indicator (greyscale + banner) only runs when the orchestrator URL
+ * is configured. Read at render time — `NEXT_PUBLIC_*` is inlined at build time.
+ */
+export function getOrchestratorUrl(): string | undefined {
+  const url = process.env.NEXT_PUBLIC_ORCHESTRATOR_URL;
+  return url && url.length > 0 ? url : undefined;
+}
+
+export function isAutoDJStatusEnabled(): boolean {
+  return getOrchestratorUrl() !== undefined;
+}

--- a/lib/features/autoDJ/hooks.ts
+++ b/lib/features/autoDJ/hooks.ts
@@ -1,0 +1,25 @@
+"use client";
+/**
+ * Shared auto-DJ status hooks. Both the greyscale shell and the flowsheet banner
+ * call these; RTK Query dedupes the `getAutoDJStatus` query so there is a single
+ * 10s poll regardless of how many components subscribe. Polling is skipped
+ * entirely when the orchestrator URL is not configured.
+ */
+import { useGetAutoDJStatusQuery } from "./api";
+import { isAutoDJStatusEnabled } from "./flags";
+import type { AutoDJStatus } from "./types";
+
+const POLL_INTERVAL_MS = 10_000;
+
+export function useAutoDJStatus(): AutoDJStatus | undefined {
+  const enabled = isAutoDJStatusEnabled();
+  const { data } = useGetAutoDJStatusQuery(undefined, {
+    pollingInterval: POLL_INTERVAL_MS,
+    skip: !enabled,
+  });
+  return enabled ? data : undefined;
+}
+
+export function useAutoDJActive(): boolean {
+  return Boolean(useAutoDJStatus()?.active);
+}

--- a/lib/features/autoDJ/types.ts
+++ b/lib/features/autoDJ/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Auto-DJ status types.
+ *
+ * Vendored subset of the `@wxyc/shared/auto-dj` surface (networking-spec §5.2)
+ * so dj-site isn't blocked on the shared-package publish (WXYC/wxyc-shared#203).
+ * Swap these for `import { ... } from "@wxyc/shared/auto-dj"` once published.
+ */
+
+export type AutoDJActivationSourceType = "virtual_switch" | "button" | "relay";
+
+export interface AutoDJActivationSource {
+  source: AutoDJActivationSourceType;
+  userId?: string;
+  userName?: string;
+  detail?: string;
+}
+
+export interface AutoDJCurrentTrack {
+  artist: string;
+  title: string;
+  album: string;
+  detectedAt: string;
+}
+
+export interface AutoDJDeviceSummary {
+  online: boolean;
+  transport: "ethernet" | "wifi";
+  lastHeartbeat: string;
+  relayState: "auto_dj_active" | "dj_live";
+}
+
+export interface AutoDJStatus {
+  active: boolean;
+  activatedBy?: AutoDJActivationSource;
+  activatedAt?: string;
+  showId?: number;
+  currentTrack?: AutoDJCurrentTrack | null;
+  lastDeactivatedAt?: string;
+  lastDeactivatedBy?: AutoDJActivationSource;
+  device?: AutoDJDeviceSummary | null;
+}
+
+export interface AutoDJDeactivateResponse {
+  active: false;
+  deactivatedBy: AutoDJActivationSource;
+  deactivatedAt: string;
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -15,6 +15,7 @@ import { adminSlice } from "./features/admin/frontend";
 import { applicationApi } from "./features/application/api";
 import { applicationSlice } from "./features/application/frontend";
 import { authenticationSlice } from "./features/authentication/frontend";
+import { autoDJApi } from "./features/autoDJ/api";
 import { binApi } from "./features/bin/api";
 import { catalogApi } from "./features/catalog/api";
 import { catalogSlice } from "./features/catalog/frontend";
@@ -34,6 +35,7 @@ const rootReducer = combineSlices(
   authenticationSlice,
   applicationSlice,
   applicationApi,
+  autoDJApi,
   experienceApi,
   catalogSlice,
   catalogApi,
@@ -60,6 +62,7 @@ export const makeStore = () => {
         .prepend(liveUpdatesListenerMiddleware.middleware)
         .concat(rtkQueryErrorLogger)
         .concat(applicationApi.middleware)
+        .concat(autoDJApi.middleware)
         .concat(experienceApi.middleware)
         .concat(catalogApi.middleware)
         .concat(binApi.middleware)

--- a/src/components/experiences/modern/autoDJ/AutoDJBanner.test.tsx
+++ b/src/components/experiences/modern/autoDJ/AutoDJBanner.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AutoDJBanner from "./AutoDJBanner";
+import { useAutoDJStatus } from "@/lib/features/autoDJ/hooks";
+import type { AutoDJStatus } from "@/lib/features/autoDJ/types";
+
+vi.mock("@/lib/features/autoDJ/hooks", () => ({ useAutoDJStatus: vi.fn() }));
+const mockStatus = vi.mocked(useAutoDJStatus);
+
+describe("AutoDJBanner", () => {
+  beforeEach(() => mockStatus.mockReset());
+
+  it("renders nothing when auto-DJ is inactive", () => {
+    mockStatus.mockReturnValue({ active: false } as AutoDJStatus);
+    const { container } = render(<AutoDJBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when there is no status yet", () => {
+    mockStatus.mockReturnValue(undefined);
+    const { container } = render(<AutoDJBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the 'Auto DJ Enabled' message and current track when active", () => {
+    mockStatus.mockReturnValue({
+      active: true,
+      currentTrack: {
+        artist: "Juana Molina",
+        title: "la paradoja",
+        album: "DOGA",
+        detectedAt: "2026-03-07T23:42:18Z",
+      },
+    } as AutoDJStatus);
+    render(<AutoDJBanner />);
+    expect(screen.getByText("Auto DJ Enabled")).toBeTruthy();
+    expect(screen.getByText(/Juana Molina/)).toBeTruthy();
+    expect(screen.getByText(/la paradoja/)).toBeTruthy();
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
+
+  it("renders the message without a track when none is detected yet", () => {
+    mockStatus.mockReturnValue({
+      active: true,
+      currentTrack: null,
+    } as AutoDJStatus);
+    render(<AutoDJBanner />);
+    expect(screen.getByText("Auto DJ Enabled")).toBeTruthy();
+  });
+});

--- a/src/components/experiences/modern/autoDJ/AutoDJBanner.tsx
+++ b/src/components/experiences/modern/autoDJ/AutoDJBanner.tsx
@@ -1,0 +1,43 @@
+"use client";
+/**
+ * "Auto DJ Enabled" banner shown at the top of the flowsheet page while auto-DJ
+ * is on the air. Uses a solid Sheet so it stays legible even though the shell is
+ * greyscaled (see AutoDJGreyscale).
+ */
+import { Sheet, Typography } from "@mui/joy";
+import { useAutoDJStatus } from "@/lib/features/autoDJ/hooks";
+
+export default function AutoDJBanner() {
+  const status = useAutoDJStatus();
+  if (!status?.active) return null;
+
+  const track = status.currentTrack;
+  return (
+    <Sheet
+      role="status"
+      aria-live="polite"
+      variant="solid"
+      color="warning"
+      sx={{
+        mb: 1,
+        px: 2,
+        py: 1,
+        borderRadius: "sm",
+        display: "flex",
+        alignItems: "center",
+        gap: 1.5,
+        flexWrap: "wrap",
+      }}
+    >
+      <Typography level="title-md" sx={{ color: "inherit", fontWeight: "lg" }}>
+        Auto DJ Enabled
+      </Typography>
+      {track ? (
+        <Typography level="body-sm" sx={{ color: "inherit", opacity: 0.9 }}>
+          {track.artist}
+          {track.title ? ` — ${track.title}` : ""}
+        </Typography>
+      ) : null}
+    </Sheet>
+  );
+}

--- a/src/components/experiences/modern/autoDJ/AutoDJGreyscale.test.tsx
+++ b/src/components/experiences/modern/autoDJ/AutoDJGreyscale.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AutoDJGreyscale from "./AutoDJGreyscale";
+import { useAutoDJActive } from "@/lib/features/autoDJ/hooks";
+
+vi.mock("@/lib/features/autoDJ/hooks", () => ({ useAutoDJActive: vi.fn() }));
+const mockActive = vi.mocked(useAutoDJActive);
+
+describe("AutoDJGreyscale", () => {
+  beforeEach(() => mockActive.mockReset());
+
+  it("marks the shell active and applies a greyscale filter when auto-DJ is on", () => {
+    mockActive.mockReturnValue(true);
+    render(
+      <AutoDJGreyscale>
+        <span>content</span>
+      </AutoDJGreyscale>,
+    );
+    const shell = screen.getByText("content").parentElement!;
+    expect(shell.getAttribute("data-auto-dj-active")).toBe("true");
+    expect(shell.style.filter).toBe("grayscale(1)");
+  });
+
+  it("does not greyscale when auto-DJ is off", () => {
+    mockActive.mockReturnValue(false);
+    render(
+      <AutoDJGreyscale>
+        <span>content</span>
+      </AutoDJGreyscale>,
+    );
+    const shell = screen.getByText("content").parentElement!;
+    expect(shell.getAttribute("data-auto-dj-active")).toBe("false");
+    expect(shell.style.filter).toBe("none");
+  });
+});

--- a/src/components/experiences/modern/autoDJ/AutoDJGreyscale.tsx
+++ b/src/components/experiences/modern/autoDJ/AutoDJGreyscale.tsx
@@ -1,0 +1,27 @@
+"use client";
+/**
+ * Greyscales the entire dashboard shell while auto-DJ is on the air. Auto-DJ is
+ * a station-wide state, so every dj-site user sees the theme shift. Wraps the
+ * modern dashboard's flex shell (replaces its outer Box).
+ */
+import { Box } from "@mui/joy";
+import type { ReactNode } from "react";
+import { useAutoDJActive } from "@/lib/features/autoDJ/hooks";
+
+export default function AutoDJGreyscale({ children }: { children: ReactNode }) {
+  const active = useAutoDJActive();
+  return (
+    <Box
+      data-auto-dj-active={active ? "true" : "false"}
+      // Filter goes on inline `style` (not `sx`) so the greyscale toggle is a
+      // plain DOM style — simple and directly assertable.
+      style={{
+        filter: active ? "grayscale(1)" : "none",
+        transition: "filter 0.4s ease",
+      }}
+      sx={{ display: "flex", height: "100dvh", overflow: "hidden" }}
+    >
+      {children}
+    </Box>
+  );
+}


### PR DESCRIPTION
When auto-DJ is on the air, the dashboard shell greyscales and an "Auto DJ Enabled" banner appears at the top of the flowsheet page. Auto-DJ is a station-wide state, so every dj-site user sees the shift.

## What

- New `autoDJApi` RTK Query slice (`lib/features/autoDJ/`) pointed at `NEXT_PUBLIC_ORCHESTRATOR_URL` with its own base query reusing the better-auth JWT; `getAutoDJStatus` query + `activate`/`deactivate` mutations. Registered in the store.
- Shared hooks (`useAutoDJStatus` / `useAutoDJActive`) poll `/status` every 10s; RTK Query dedupes so both consumers share one poll, and polling is **skipped entirely** when the orchestrator URL is unset (no errors in environments without an orchestrator).
- `AutoDJGreyscale` wraps the modern dashboard shell and applies `filter: grayscale(1)` when active. `AutoDJBanner` renders a solid Sheet (legible under greyscale) with the current track at the top of the flowsheet layout.
- Types vendored in `lib/features/autoDJ/types.ts` until `@wxyc/shared/auto-dj` publishes (WXYC/wxyc-shared#203) — so this PR adds **no** dependency on the unpublished package.
- `NEXT_PUBLIC_ORCHESTRATOR_URL` documented in `.env.example` + `docs/env-vars.md`.

## Verification

8 new tests (banner shows iff active with/without track; greyscale toggles the filter; flag gating). Full suite green (3280 tests), `tsc --noEmit` clean.

Closes #792