### PR TITLE
fix(infra): non-JSON GET null payload and E2E CI hardening

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Filter
         if: github.event_name == 'pull_request'
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             app_source:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -196,9 +196,10 @@ jobs:
 
       - name: Install dependencies
         env:
-          # Backend-Service@main resolves @wxyc/shared from GitHub Packages.
-          # GITHUB_TOKEN + packages:read satisfies Backend-Service/.npmrc;
-          # the org NPM_TOKEN secret lacks read:packages on fork/PR runs.
+          # GITHUB_TOKEN + packages:read installs @wxyc/shared from GitHub
+          # Packages on same-repo workflows. Fork-originated PRs cannot access
+          # repo secrets at all — this swap does not change that; it matches
+          # charset-corpus-drift.yml for in-repo PR/push runs.
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           (cd Backend-Service && npm ci) &

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -52,8 +52,11 @@ env:
 # Workflow-level GITHUB_TOKEN scope. No job in this file pushes code,
 # comments on PRs, or creates releases; all writes to external services
 # use their own non-GITHUB_TOKEN secrets. contents:read is the safe floor.
+# packages:read is required to install Backend-Service@main, which pulls
+# @wxyc/shared from npm.pkg.github.com during npm ci (see charset-corpus-drift.yml).
 permissions:
   contents: read
+  packages: read
 
 jobs:
   # See ci.yml for the rationale on the changes-job pattern (issue #731).
@@ -70,7 +73,7 @@ jobs:
       - name: Filter
         if: github.event_name == 'pull_request'
         id: filter
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@v3
         with:
           filters: |
             app_source:
@@ -193,11 +196,17 @@ jobs:
 
       - name: Install dependencies
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Backend-Service@main resolves @wxyc/shared from GitHub Packages.
+          # GITHUB_TOKEN + packages:read satisfies Backend-Service/.npmrc;
+          # the org NPM_TOKEN secret lacks read:packages on fork/PR runs.
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           (cd Backend-Service && npm ci) &
+          PID_BS=$!
           (cd dj-site && npm ci) &
-          wait
+          PID_DJ=$!
+          wait $PID_BS || exit 1
+          wait $PID_DJ || exit 1
 
       - name: Cache dj-site build
         id: nextjs-build-cache
@@ -215,7 +224,7 @@ jobs:
 
       - name: Build and start services
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXTJS_BUILD_CACHE_HIT: ${{ steps.nextjs-build-cache.outputs.cache-hit }}
           PLAYWRIGHT_CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
         run: |

--- a/lib/__tests__/features/backend.test.ts
+++ b/lib/__tests__/features/backend.test.ts
@@ -259,7 +259,7 @@ describe("backend", () => {
         warnSpy.mockRestore();
       });
 
-      it("returns { data: undefined } when the backend returns HTML 404", async () => {
+      it("returns { data: null } when the backend returns HTML 404", async () => {
         // Simulate what fetchBaseQuery emits when responseHandler='json' chokes
         // on `<!DOCTYPE html>…` from Express's default 404.
         mockInnerBaseQuery.mockResolvedValueOnce({
@@ -280,7 +280,7 @@ describe("backend", () => {
         );
 
         expect(result).toEqual(
-          expect.objectContaining({ data: undefined })
+          expect.objectContaining({ data: null })
         );
         // Should NOT propagate the error — that's what produced the global toast.
         expect((result as { error?: unknown }).error).toBeUndefined();
@@ -368,7 +368,7 @@ describe("backend", () => {
         const baseQuery = backendBaseQuery("library/rotation");
         await expect(
           baseQuery({ url: "/42/tracks" }, fakeApi, fakeExtra)
-        ).resolves.toEqual(expect.objectContaining({ data: undefined }));
+        ).resolves.toEqual(expect.objectContaining({ data: null }));
       });
 
       // Mutations must keep surfacing the error loudly. Soft-handling a POST
@@ -454,7 +454,7 @@ describe("backend", () => {
           fakeExtra
         );
 
-        expect((result as { data?: unknown }).data).toBeUndefined();
+        expect((result as { data?: unknown }).data).toBeNull();
         expect((result as { error?: unknown }).error).toBeUndefined();
       });
 
@@ -474,7 +474,7 @@ describe("backend", () => {
         const baseQuery = backendBaseQuery("library/rotation");
         const result = await baseQuery("/42/tracks", fakeApi, fakeExtra);
 
-        expect((result as { data?: unknown }).data).toBeUndefined();
+        expect((result as { data?: unknown }).data).toBeNull();
         expect((result as { error?: unknown }).error).toBeUndefined();
       });
     });

--- a/lib/features/backend.ts
+++ b/lib/features/backend.ts
@@ -44,10 +44,10 @@ const innerBaseQuery = (domain: string): BackendBaseQuery =>
  * resulting `SyntaxError: Unrecognized token '<'` bubbles up as a useless
  * global toast (see WXYC/dj-site#519).
  *
- * Returning `{ data: undefined }` here makes the calling query succeed with no
- * data. List-shaped queries (e.g. `getRotationTracks`) can fall through their
- * existing empty-state branch; object-shaped queries see `undefined` and can
- * gate UI off `data`. Structured JSON 4xx responses are *not* affected — they
+ * Returning `{ data: null }` here makes the calling query succeed with no
+ * payload. RTK Query rejects `{ data: undefined }` (it becomes `{}` and
+ * triggers "neither error nor result"). Callers should treat null/undefined
+ * data as empty. Structured JSON 4xx responses are *not* affected — they
  * still flow through `validateStatus` and surface as normal errors.
  */
 const isNonJsonParsingError = (
@@ -118,7 +118,7 @@ const isGetRequest = (args: string | FetchArgs): boolean => {
  * 1. Adds the JWT bearer token and a request id (in `prepareHeaders`).
  * 2. Soft-handles non-JSON responses (most notably Express's HTML 404s)
  *    **for GET requests by default**: the query resolves with
- *    `{ data: undefined }` instead of throwing the cryptic
+ *    `{ data: null }` instead of throwing the cryptic
  *    `Unrecognized token '<'` JSON-parse error up to the global error toast.
  *    See WXYC/dj-site#519.
  *
@@ -137,7 +137,7 @@ export const backendBaseQuery = (domain: string): BackendBaseQuery => {
       const optOut = (extraOptions as BackendExtraOptions | undefined)?.surfaceNonJsonAsError === true;
       if (isGetRequest(args) && !optOut) {
         logNonJsonResponse(domain, args, result.error);
-        return { data: undefined, meta: result.meta };
+        return { data: null, meta: result.meta };
       }
     }
 

--- a/lib/features/backend.ts
+++ b/lib/features/backend.ts
@@ -44,11 +44,15 @@ const innerBaseQuery = (domain: string): BackendBaseQuery =>
  * resulting `SyntaxError: Unrecognized token '<'` bubbles up as a useless
  * global toast (see WXYC/dj-site#519).
  *
- * Returning `{ data: null }` here makes the calling query succeed with no
- * payload. RTK Query rejects `{ data: undefined }` (it becomes `{}` and
- * triggers "neither error nor result"). Callers should treat null/undefined
- * data as empty. Structured JSON 4xx responses are *not* affected — they
- * still flow through `validateStatus` and surface as normal errors.
+ * Returning `{ data: null }` here makes the calling query succeed with an
+ * empty payload instead of surfacing PARSING_ERROR as a global toast (#519).
+ * We use `null` (not `undefined`) so hook consumers can treat a completed
+ * soft-fail with nullish checks (`?? []`, `!data`) without conflating it
+ * with RTK's in-flight `undefined`. Avoid strict `data === undefined`
+ * guards on GET results — they miss soft-failed `null` (#606). Endpoints
+ * whose `transformResponse` assumes a parsed body must still guard nullish
+ * input. Structured JSON 4xx responses are *not* affected — they still
+ * flow through `validateStatus` and surface as normal errors.
  */
 const isNonJsonParsingError = (
   error: FetchBaseQueryError
@@ -118,9 +122,10 @@ const isGetRequest = (args: string | FetchArgs): boolean => {
  * 1. Adds the JWT bearer token and a request id (in `prepareHeaders`).
  * 2. Soft-handles non-JSON responses (most notably Express's HTML 404s)
  *    **for GET requests by default**: the query resolves with
- *    `{ data: null }` instead of throwing the cryptic
+ *    `{ data: null }` (hook `data` may be `null` even when the endpoint
+ *    type is `T | undefined`) instead of throwing the cryptic
  *    `Unrecognized token '<'` JSON-parse error up to the global error toast.
- *    See WXYC/dj-site#519.
+ *    See WXYC/dj-site#519 and #606.
  *
  * Mutations (POST/PATCH/DELETE/PUT) **never** get the soft-handle treatment —
  * a silently-"succeeding" `addToFlowsheet` or `addAlbum` is a worse UX than a


### PR DESCRIPTION
## Summary
Split from #648 (umbrella). Mechanical infra slice with no catalog UI behavior.

- Return `{ data: null }` instead of `{ data: undefined }` for non-JSON GET responses in `backendBaseQuery` (RTK Query compatibility)
- E2E workflow: `packages: read` permission, `GITHUB_TOKEN` for `@wxyc/shared` install, wait on parallel `npm ci` PIDs separately

## Test plan
- [ ] `npm test -- lib/__tests__/features/backend.test.ts`
- [ ] E2E workflow passes on this branch

Part of the #648 split stack. See draft umbrella PR #648 for full decomposition.

Made with [Cursor](https://cursor.com)