### PR TITLE
feat(catalog): RTK Query surface for library search and mutations

### DIFF
--- a/lib/__tests__/features/catalog/adminCreateArtistValidation.test.ts
+++ b/lib/__tests__/features/catalog/adminCreateArtistValidation.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { parseRequiredPositiveInt } from "@/lib/features/catalog/adminCreateArtistValidation";
+
+describe("parseRequiredPositiveInt", () => {
+  it.each([
+    ["42", 42],
+    ["1", 1],
+    ["  99  ", 99],
+  ])("accepts decimal positive integer %j → %i", (raw, expected) => {
+    expect(parseRequiredPositiveInt(raw)).toBe(expected);
+  });
+
+  it.each([
+    "",
+    "   ",
+    "0",
+    "-1",
+    "1.5",
+    "1e3",
+    "0x10",
+    "abc",
+    "12abc",
+  ])("rejects non-decimal or non-positive input %j", (raw) => {
+    expect(parseRequiredPositiveInt(raw)).toBeNull();
+  });
+
+  it("rejects leading-zero decimals (not valid code-number literals)", () => {
+    expect(parseRequiredPositiveInt("007")).toBeNull();
+  });
+});

--- a/lib/__tests__/features/catalog/api.test.tsx
+++ b/lib/__tests__/features/catalog/api.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   catalogApi,
   useSearchCatalogQuery,
+  useSearchLibraryQueryInfiniteQuery,
   useAddAlbumMutation,
   useAddArtistMutation,
   useGetInformationQuery,
@@ -19,7 +20,15 @@ vi.mock("@/lib/features/authentication/client", () => ({
 
 describe("catalogApi", () => {
   describeApi(catalogApi, {
-    queries: ["searchCatalog", "searchLibraryQuery", "getInformation", "getFormats", "getGenres"],
+    queries: [
+      "searchCatalog",
+      "searchLibraryQuery",
+      "getInformation",
+      "getFormats",
+      "getGenres",
+      "peekArtistCode",
+      "searchArtistsInGenre",
+    ],
     mutations: ["addAlbum", "addArtist", "addFormat", "addGenre"],
     reducerPath: "catalogApi",
   });
@@ -30,7 +39,14 @@ describe("catalogApi", () => {
     });
 
     it("exposes initiate", () => {
-      expect(typeof catalogApi.endpoints.searchLibraryQuery.initiate).toBe("function");
+      expect(
+        typeof catalogApi.endpoints.searchLibraryQuery.initiate,
+      ).toBe("function");
+    });
+
+    it("exports useSearchLibraryQueryInfiniteQuery hook", () => {
+      expect(useSearchLibraryQueryInfiniteQuery).toBeDefined();
+      expect(typeof useSearchLibraryQueryInfiniteQuery).toBe("function");
     });
   });
 

--- a/lib/__tests__/features/catalog/api.test.tsx
+++ b/lib/__tests__/features/catalog/api.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from "vitest";
 import {
   catalogApi,
   useSearchCatalogQuery,
-  useSearchLibraryQueryInfiniteQuery,
   useAddAlbumMutation,
   useAddArtistMutation,
   useGetInformationQuery,
@@ -23,7 +22,6 @@ describe("catalogApi", () => {
     queries: [
       "searchCatalog",
       "searchLibraryQuery",
-      "searchLibraryQueryInfinite",
       "getInformation",
       "getFormats",
       "getGenres",
@@ -43,17 +41,6 @@ describe("catalogApi", () => {
       expect(
         typeof catalogApi.endpoints.searchLibraryQuery.initiate,
       ).toBe("function");
-    });
-  });
-
-  describe("searchLibraryQueryInfinite endpoint", () => {
-    it("is defined", () => {
-      expect(catalogApi.endpoints.searchLibraryQueryInfinite).toBeDefined();
-    });
-
-    it("exports useSearchLibraryQueryInfiniteQuery hook", () => {
-      expect(useSearchLibraryQueryInfiniteQuery).toBeDefined();
-      expect(typeof useSearchLibraryQueryInfiniteQuery).toBe("function");
     });
   });
 

--- a/lib/__tests__/features/catalog/api.test.tsx
+++ b/lib/__tests__/features/catalog/api.test.tsx
@@ -23,6 +23,7 @@ describe("catalogApi", () => {
     queries: [
       "searchCatalog",
       "searchLibraryQuery",
+      "searchLibraryQueryInfinite",
       "getInformation",
       "getFormats",
       "getGenres",
@@ -42,6 +43,12 @@ describe("catalogApi", () => {
       expect(
         typeof catalogApi.endpoints.searchLibraryQuery.initiate,
       ).toBe("function");
+    });
+  });
+
+  describe("searchLibraryQueryInfinite endpoint", () => {
+    it("is defined", () => {
+      expect(catalogApi.endpoints.searchLibraryQueryInfinite).toBeDefined();
     });
 
     it("exports useSearchLibraryQueryInfiniteQuery hook", () => {

--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -15,7 +15,7 @@ import { Rotation } from "@/lib/features/rotation/types";
 
 describe("catalogApi", () => {
   describeApi(catalogApi, {
-    queries: ["searchCatalog", "getInformation", "getFormats", "getGenres"],
+    queries: ["searchCatalog", "getInformation", "getFormats", "getGenres", "peekArtistCode"],
     mutations: ["addAlbum", "addArtist", "addFormat", "addGenre", "markMissing", "markFound"],
     reducerPath: "catalogApi",
   });
@@ -347,16 +347,23 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       expect(state.sortOrder).toBe("asc");
     });
 
-    it("defaults page to 0", () => {
-      expect(harness().initialState.page).toBe(0);
+    it("defaults filters to empty arrays", () => {
+      expect(harness().initialState.filters).toEqual({
+        genres: [],
+        formats: [],
+        tags: [],
+      });
     });
 
-    it("defaults filters to 'All' / undefined", () => {
-      expect(harness().initialState.filters).toEqual({
-        onStreaming: undefined,
-        genre: "All",
-        format: "All",
-      });
+    it("defaults browseEngaged to false", () => {
+      expect(harness().initialState.browseEngaged).toBe(false);
+    });
+  });
+
+  describe("engageBrowse", () => {
+    it("sets browseEngaged", () => {
+      const result = harness().reduce(actions.engageBrowse());
+      expect(result.browseEngaged).toBe(true);
     });
   });
 
@@ -365,11 +372,6 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       const result = harness().reduce(actions.addRow());
       expect(result.rows).toHaveLength(2);
       expect(result.rows[1].field).toBe("artist");
-    });
-
-    it("addRow resets page to 0", () => {
-      const result = harness().chain(actions.nextPage(), actions.addRow());
-      expect(result.page).toBe(0);
     });
 
     it("removeRow drops a row by id", () => {
@@ -399,15 +401,6 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       expect(result.rows[0].value).toBe("Stereolab");
     });
 
-    it("updateRow resets page to 0", () => {
-      const initial = harness().initialState;
-      const id = initial.rows[0].id;
-      const result = harness().chain(
-        actions.nextPage(),
-        actions.updateRow({ id, updates: { value: "x" } })
-      );
-      expect(result.page).toBe(0);
-    });
   });
 
   describe("sort", () => {
@@ -419,48 +412,29 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       expect(result.sortOrder).toBe("desc");
     });
 
-    it("setSort resets page to 0", () => {
-      const result = harness().chain(
-        actions.nextPage(),
-        actions.setSort({ sortBy: "artist", sortOrder: "asc" })
-      );
-      expect(result.page).toBe(0);
-    });
   });
 
   describe("filters", () => {
     it.each([
-      [{ onStreaming: false as boolean | undefined }, "onStreaming", false],
-      [{ genre: "Rock" } as const, "genre", "Rock"],
-      [{ format: "CD" } as const, "format", "CD"],
-    ])("setFilter updates %s", (patch, key, expected) => {
+      [{ tags: ["exclusives"] }, "tags", ["exclusives"]],
+      [{ genres: ["Rock"] }, "genres", ["Rock"]],
+      [{ formats: ["cd"] }, "formats", ["cd"]],
+    ] as const satisfies ReadonlyArray<
+      [Partial<import("@/lib/features/catalog/types").CatalogFilters>, string, string[]]
+    >)("setFilter updates %s", (patch, key, expected) => {
       const result = harness().reduce(actions.setFilter(patch));
-      expect((result.filters as Record<string, unknown>)[key as string]).toBe(expected);
+      expect((result.filters as Record<string, unknown>)[key as string]).toEqual(expected);
     });
 
     it("setFilter merges with existing filters", () => {
       const result = harness().chain(
-        actions.setFilter({ genre: "Rock" }),
-        actions.setFilter({ format: "Vinyl" })
+        actions.setFilter({ genres: ["Rock"] }),
+        actions.setFilter({ formats: ["Vinyl"] })
       );
-      expect(result.filters.genre).toBe("Rock");
-      expect(result.filters.format).toBe("Vinyl");
+      expect(result.filters.genres).toEqual(["Rock"]);
+      expect(result.filters.formats).toEqual(["Vinyl"]);
     });
 
-    it("setFilter resets page to 0", () => {
-      const result = harness().chain(
-        actions.nextPage(),
-        actions.setFilter({ genre: "Rock" })
-      );
-      expect(result.page).toBe(0);
-    });
-  });
-
-  describe("pagination", () => {
-    it("nextPage increments page", () => {
-      const result = harness().chain(actions.nextPage(), actions.nextPage());
-      expect(result.page).toBe(2);
-    });
   });
 
   describe("selection", () => {
@@ -516,8 +490,7 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       const result = harness().chain(
         actions.updateRow({ id, updates: { value: "Cat Power" } }),
         actions.setSort({ sortBy: "plays", sortOrder: "desc" }),
-        actions.setFilter({ genre: "Rock" }),
-        actions.nextPage(),
+        actions.setFilter({ genres: ["Rock"] }),
         actions.setSelection([1, 2, 3]),
         actions.openMobileSearch(),
         actions.reset()
@@ -525,4 +498,5 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       expect(result).toEqual(defaultCatalogFrontendState);
     });
   });
+
 });

--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -347,23 +347,16 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       expect(state.sortOrder).toBe("asc");
     });
 
-    it("defaults filters to empty arrays", () => {
+    it("defaults page to 0", () => {
+      expect(harness().initialState.page).toBe(0);
+    });
+
+    it("defaults filters to 'All' / undefined", () => {
       expect(harness().initialState.filters).toEqual({
-        genres: [],
-        formats: [],
-        tags: [],
+        onStreaming: undefined,
+        genre: "All",
+        format: "All",
       });
-    });
-
-    it("defaults browseEngaged to false", () => {
-      expect(harness().initialState.browseEngaged).toBe(false);
-    });
-  });
-
-  describe("engageBrowse", () => {
-    it("sets browseEngaged", () => {
-      const result = harness().reduce(actions.engageBrowse());
-      expect(result.browseEngaged).toBe(true);
     });
   });
 
@@ -372,6 +365,11 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       const result = harness().reduce(actions.addRow());
       expect(result.rows).toHaveLength(2);
       expect(result.rows[1].field).toBe("artist");
+    });
+
+    it("addRow resets page to 0", () => {
+      const result = harness().chain(actions.nextPage(), actions.addRow());
+      expect(result.page).toBe(0);
     });
 
     it("removeRow drops a row by id", () => {
@@ -401,6 +399,15 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       expect(result.rows[0].value).toBe("Stereolab");
     });
 
+    it("updateRow resets page to 0", () => {
+      const initial = harness().initialState;
+      const id = initial.rows[0].id;
+      const result = harness().chain(
+        actions.nextPage(),
+        actions.updateRow({ id, updates: { value: "x" } })
+      );
+      expect(result.page).toBe(0);
+    });
   });
 
   describe("sort", () => {
@@ -412,29 +419,48 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       expect(result.sortOrder).toBe("desc");
     });
 
+    it("setSort resets page to 0", () => {
+      const result = harness().chain(
+        actions.nextPage(),
+        actions.setSort({ sortBy: "artist", sortOrder: "asc" })
+      );
+      expect(result.page).toBe(0);
+    });
   });
 
   describe("filters", () => {
     it.each([
-      [{ tags: ["exclusives"] }, "tags", ["exclusives"]],
-      [{ genres: ["Rock"] }, "genres", ["Rock"]],
-      [{ formats: ["cd"] }, "formats", ["cd"]],
-    ] as const satisfies ReadonlyArray<
-      [Partial<import("@/lib/features/catalog/types").CatalogFilters>, string, string[]]
-    >)("setFilter updates %s", (patch, key, expected) => {
+      [{ onStreaming: false as boolean | undefined }, "onStreaming", false],
+      [{ genre: "Rock" } as const, "genre", "Rock"],
+      [{ format: "CD" } as const, "format", "CD"],
+    ])("setFilter updates %s", (patch, key, expected) => {
       const result = harness().reduce(actions.setFilter(patch));
-      expect((result.filters as Record<string, unknown>)[key as string]).toEqual(expected);
+      expect((result.filters as Record<string, unknown>)[key as string]).toBe(expected);
     });
 
     it("setFilter merges with existing filters", () => {
       const result = harness().chain(
-        actions.setFilter({ genres: ["Rock"] }),
-        actions.setFilter({ formats: ["Vinyl"] })
+        actions.setFilter({ genre: "Rock" }),
+        actions.setFilter({ format: "Vinyl" })
       );
-      expect(result.filters.genres).toEqual(["Rock"]);
-      expect(result.filters.formats).toEqual(["Vinyl"]);
+      expect(result.filters.genre).toBe("Rock");
+      expect(result.filters.format).toBe("Vinyl");
     });
 
+    it("setFilter resets page to 0", () => {
+      const result = harness().chain(
+        actions.nextPage(),
+        actions.setFilter({ genre: "Rock" })
+      );
+      expect(result.page).toBe(0);
+    });
+  });
+
+  describe("pagination", () => {
+    it("nextPage increments page", () => {
+      const result = harness().chain(actions.nextPage(), actions.nextPage());
+      expect(result.page).toBe(2);
+    });
   });
 
   describe("selection", () => {
@@ -490,7 +516,8 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       const result = harness().chain(
         actions.updateRow({ id, updates: { value: "Cat Power" } }),
         actions.setSort({ sortBy: "plays", sortOrder: "desc" }),
-        actions.setFilter({ genres: ["Rock"] }),
+        actions.setFilter({ genre: "Rock" }),
+        actions.nextPage(),
         actions.setSelection([1, 2, 3]),
         actions.openMobileSearch(),
         actions.reset()
@@ -498,5 +525,4 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       expect(result).toEqual(defaultCatalogFrontendState);
     });
   });
-
 });

--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -15,8 +15,24 @@ import { Rotation } from "@/lib/features/rotation/types";
 
 describe("catalogApi", () => {
   describeApi(catalogApi, {
-    queries: ["searchCatalog", "getInformation", "getFormats", "getGenres", "peekArtistCode"],
-    mutations: ["addAlbum", "addArtist", "addFormat", "addGenre", "markMissing", "markFound"],
+    queries: [
+      "searchCatalog",
+      "searchLibraryQuery",
+      "getInformation",
+      "getFormats",
+      "getGenres",
+      "peekArtistCode",
+      "searchArtistsInGenre",
+    ],
+    mutations: [
+      "addAlbum",
+      "addArtist",
+      "addFormat",
+      "addGenre",
+      "updateAlbum",
+      "markMissing",
+      "markFound",
+    ],
     reducerPath: "catalogApi",
   });
 });

--- a/lib/features/catalog/adminCreateArtistValidation.ts
+++ b/lib/features/catalog/adminCreateArtistValidation.ts
@@ -1,0 +1,8 @@
+/** Empty or non-numeric strings must not become 0 (Number("") === 0). */
+export function parseRequiredPositiveInt(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  const n = Number(trimmed);
+  if (!Number.isInteger(n) || n < 1) return null;
+  return n;
+}

--- a/lib/features/catalog/adminCreateArtistValidation.ts
+++ b/lib/features/catalog/adminCreateArtistValidation.ts
@@ -1,8 +1,7 @@
 /** Empty or non-numeric strings must not become 0 (Number("") === 0). */
 export function parseRequiredPositiveInt(raw: string): number | null {
   const trimmed = raw.trim();
-  if (trimmed === "") return null;
-  const n = Number(trimmed);
-  if (!Number.isInteger(n) || n < 1) return null;
-  return n;
+  // Base-10 positive integers only — reject scientific/hex (Number("1e3") === 1000).
+  if (trimmed === "" || !/^[1-9]\d*$/.test(trimmed)) return null;
+  return Number(trimmed);
 }

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -1,9 +1,7 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
-import type { RootState } from "@/lib/store";
 import { backendBaseQuery } from "../backend";
 import { CATALOG_QUERY_PAGE_LIMIT } from "./constants";
 import { convertToAlbumEntry } from "./conversions";
-import { patchCatalogSearchCaches } from "./patchSearchCaches";
 import {
   AddAlbumRequestBody,
   AddArtistRequestBody,
@@ -113,14 +111,6 @@ export const catalogApi = createApi({
       invalidatesTags: (_result, _error, { albumId }) => [
         { type: "AlbumDetail", id: albumId },
       ],
-      async onQueryStarted(_arg, { dispatch, queryFulfilled, getState }) {
-        try {
-          const { data: updated } = await queryFulfilled;
-          patchCatalogSearchCaches(dispatch, getState as () => RootState, updated);
-        } catch {
-          // Leave caches untouched when save fails.
-        }
-      },
     }),
     addArtist: builder.mutation<
       { id: number; code_number?: number; genre_id?: number } & Record<string, unknown>,

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -1,6 +1,5 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import { backendBaseQuery } from "../backend";
-import { CATALOG_QUERY_PAGE_LIMIT } from "./constants";
 import { convertToAlbumEntry } from "./conversions";
 import {
   AddAlbumRequestBody,
@@ -35,12 +34,6 @@ export type LibraryQueryResult = {
   totalPages: number;
 };
 
-/** Args for infinite catalog search — `page` and `limit` come from `pageParam` / constant. */
-export type CatalogInfiniteQueryArg = Omit<
-  LibraryQueryParams,
-  "page" | "limit"
->;
-
 function transformLibraryQueryResponse(
   response: LibraryQueryResponseJSON | null,
 ): LibraryQueryResult {
@@ -74,32 +67,6 @@ export const catalogApi = createApi({
       }),
       transformResponse: (response: LibraryQueryResponseJSON | null) =>
         transformLibraryQueryResponse(response),
-    }),
-    searchLibraryQueryInfinite: builder.infiniteQuery<
-      LibraryQueryResult,
-      CatalogInfiniteQueryArg,
-      number
-    >({
-      infiniteQueryOptions: {
-        initialPageParam: 0,
-        getNextPageParam: (lastPage, _allPages, lastPageParam) =>
-          lastPage.page + 1 >= lastPage.totalPages
-            ? undefined
-            : lastPageParam + 1,
-      },
-      query({ pageParam, queryArg }) {
-        return {
-          url: "/query",
-          params: {
-            ...queryArg,
-            page: pageParam,
-            limit: CATALOG_QUERY_PAGE_LIMIT,
-          },
-        };
-      },
-      transformResponse: (
-        response: LibraryQueryResponseJSON | null,
-      ): LibraryQueryResult => transformLibraryQueryResponse(response),
     }),
     addAlbum: builder.mutation<{ id: number } & Record<string, unknown>, AddAlbumRequestBody>({
       query: (body) => ({
@@ -212,7 +179,6 @@ export const {
   useSearchCatalogQuery,
   useLazySearchLibraryQueryQuery,
   useSearchLibraryQueryQuery,
-  useSearchLibraryQueryInfiniteQuery,
   useAddAlbumMutation,
   useUpdateAlbumMutation,
   useAddArtistMutation,

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -1,14 +1,26 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
+import type { RootState } from "@/lib/store";
 import { backendBaseQuery } from "../backend";
+import { CATALOG_QUERY_PAGE_LIMIT } from "./constants";
 import { convertToAlbumEntry } from "./conversions";
+import { patchCatalogSearchCaches } from "./patchSearchCaches";
 import {
+  AddAlbumRequestBody,
+  AddArtistRequestBody,
+  AddFormatRequestBody,
+  AddGenreRequestBody,
   AlbumEntry,
-  AlbumParams,
   AlbumSearchResultJSON,
   AlbumRequestParams,
-  ArtistParams,
+  LibraryFormatRow,
+  LibraryGenreRow,
   LibraryQueryParams,
+  PeekArtistCodeQuery,
+  PeekArtistCodeResponse,
+  SearchArtistsInGenreParams,
+  SearchArtistsInGenreResponse,
   SearchCatalogQueryParams,
+  UpdateAlbumRequestBody,
 } from "./types";
 
 type LibraryQueryResponseJSON = {
@@ -25,6 +37,25 @@ export type LibraryQueryResult = {
   totalPages: number;
 };
 
+/** Args for infinite catalog search — `page` and `limit` come from `pageParam` / constant. */
+export type CatalogInfiniteQueryArg = Omit<
+  LibraryQueryParams,
+  "page" | "limit"
+>;
+
+function transformLibraryQueryResponse(
+  response: LibraryQueryResponseJSON | null,
+): LibraryQueryResult {
+  return response?.results
+    ? {
+        results: response.results.map(convertToAlbumEntry),
+        total: response.total ?? 0,
+        page: response.page ?? 0,
+        totalPages: response.totalPages ?? 0,
+      }
+    : { results: [], total: 0, page: 0, totalPages: 0 };
+}
+
 export const catalogApi = createApi({
   reducerPath: "catalogApi",
   baseQuery: backendBaseQuery("library"),
@@ -38,31 +69,87 @@ export const catalogApi = createApi({
       transformResponse: (response: AlbumSearchResultJSON[]) =>
         response.map(convertToAlbumEntry),
     }),
-    searchLibraryQuery: builder.query<LibraryQueryResult, LibraryQueryParams>({
-      query: (params) => ({
-        url: "/query",
-        params,
-      }),
-      transformResponse: (response: LibraryQueryResponseJSON): LibraryQueryResult => ({
-        results: response.results.map(convertToAlbumEntry),
-        total: response.total,
-        page: response.page,
-        totalPages: response.totalPages,
-      }),
+    searchLibraryQuery: builder.infiniteQuery<
+      LibraryQueryResult,
+      CatalogInfiniteQueryArg,
+      number
+    >({
+      infiniteQueryOptions: {
+        initialPageParam: 0,
+        getNextPageParam: (lastPage, _allPages, lastPageParam) =>
+          lastPage.page + 1 >= lastPage.totalPages
+            ? undefined
+            : lastPageParam + 1,
+      },
+      query({ pageParam, queryArg }) {
+        return {
+          url: "/query",
+          params: {
+            ...queryArg,
+            page: pageParam,
+            limit: CATALOG_QUERY_PAGE_LIMIT,
+          },
+        };
+      },
+      transformResponse: (
+        response: LibraryQueryResponseJSON | null,
+      ): LibraryQueryResult => transformLibraryQueryResponse(response),
     }),
-    addAlbum: builder.mutation<any, AlbumParams>({
-      query: (album) => ({
+    addAlbum: builder.mutation<{ id: number } & Record<string, unknown>, AddAlbumRequestBody>({
+      query: (body) => ({
         url: "/",
         method: "POST",
-        body: album,
+        body,
       }),
     }),
-    addArtist: builder.mutation<any, ArtistParams>({
-      query: (artist) => ({
+    updateAlbum: builder.mutation<AlbumEntry, { albumId: number; body: UpdateAlbumRequestBody }>({
+      query: ({ albumId, body }) => ({
+        url: `/${albumId}`,
+        method: "PATCH",
+        body,
+      }),
+      transformResponse: (response: AlbumSearchResultJSON) =>
+        convertToAlbumEntry(response),
+      invalidatesTags: (_result, _error, { albumId }) => [
+        { type: "AlbumDetail", id: albumId },
+      ],
+      async onQueryStarted(_arg, { dispatch, queryFulfilled, getState }) {
+        try {
+          const { data: updated } = await queryFulfilled;
+          patchCatalogSearchCaches(dispatch, getState as () => RootState, updated);
+        } catch {
+          // Leave caches untouched when save fails.
+        }
+      },
+    }),
+    addArtist: builder.mutation<
+      { id: number; code_number?: number; genre_id?: number } & Record<string, unknown>,
+      AddArtistRequestBody
+    >({
+      query: (body) => ({
         url: "/artists",
         method: "POST",
-        body: artist,
+        body,
       }),
+    }),
+    peekArtistCode: builder.query<PeekArtistCodeResponse, PeekArtistCodeQuery>({
+      query: ({ code_letters, genre_id }) => ({
+        url: "/artists/peek-code",
+        params: { code_letters, genre_id },
+      }),
+    }),
+    searchArtistsInGenre: builder.query<
+      SearchArtistsInGenreResponse,
+      SearchArtistsInGenreParams
+    >({
+      query: ({ genre_id, q, limit }) => ({
+        url: "/artists/search",
+        params: { genre_id, q, limit },
+      }),
+      transformResponse: (
+        response: SearchArtistsInGenreResponse | null,
+      ): SearchArtistsInGenreResponse =>
+        response?.artists ? response : { artists: [] },
     }),
     getInformation: builder.query<AlbumEntry, AlbumRequestParams>({
       query: ({ album_id }) => ({
@@ -96,28 +183,28 @@ export const catalogApi = createApi({
         { type: "AlbumDetail", id: albumId },
       ],
     }),
-    getFormats: builder.query<any, void>({
+    getFormats: builder.query<LibraryFormatRow[], void>({
       query: () => ({
         url: "/formats",
       }),
     }),
-    addFormat: builder.mutation<any, string>({
-      query: (format) => ({
+    addFormat: builder.mutation<LibraryFormatRow, AddFormatRequestBody>({
+      query: (body) => ({
         url: "/formats",
         method: "POST",
-        body: format,
+        body,
       }),
     }),
-    getGenres: builder.query<any, void>({
+    getGenres: builder.query<LibraryGenreRow[], void>({
       query: () => ({
         url: "/genres",
       }),
     }),
-    addGenre: builder.mutation<any, string>({
-      query: (genre) => ({
+    addGenre: builder.mutation<LibraryGenreRow, AddGenreRequestBody>({
+      query: (body) => ({
         url: "/genres",
         method: "POST",
-        body: genre,
+        body,
       }),
     }),
   }),
@@ -125,10 +212,12 @@ export const catalogApi = createApi({
 
 export const {
   useSearchCatalogQuery,
-  useLazySearchLibraryQueryQuery,
-  useSearchLibraryQueryQuery,
+  useSearchLibraryQueryInfiniteQuery,
   useAddAlbumMutation,
+  useUpdateAlbumMutation,
   useAddArtistMutation,
+  useLazyPeekArtistCodeQuery,
+  useLazySearchArtistsInGenreQuery,
   useGetInformationQuery,
   useGetFormatsQuery,
   useAddFormatMutation,

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -67,7 +67,15 @@ export const catalogApi = createApi({
       transformResponse: (response: AlbumSearchResultJSON[]) =>
         response.map(convertToAlbumEntry),
     }),
-    searchLibraryQuery: builder.infiniteQuery<
+    searchLibraryQuery: builder.query<LibraryQueryResult, LibraryQueryParams>({
+      query: (params) => ({
+        url: "/query",
+        params,
+      }),
+      transformResponse: (response: LibraryQueryResponseJSON | null) =>
+        transformLibraryQueryResponse(response),
+    }),
+    searchLibraryQueryInfinite: builder.infiniteQuery<
       LibraryQueryResult,
       CatalogInfiniteQueryArg,
       number
@@ -202,6 +210,8 @@ export const catalogApi = createApi({
 
 export const {
   useSearchCatalogQuery,
+  useLazySearchLibraryQueryQuery,
+  useSearchLibraryQueryQuery,
   useSearchLibraryQueryInfiniteQuery,
   useAddAlbumMutation,
   useUpdateAlbumMutation,

--- a/lib/features/catalog/constants.ts
+++ b/lib/features/catalog/constants.ts
@@ -1,0 +1,2 @@
+/** Page size for GET /library/query (must match backend default/limit handling). */
+export const CATALOG_QUERY_PAGE_LIMIT = 50;

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -72,11 +72,15 @@ export function convertToAlbumEntry(
       lettercode: response.code_letters ?? "",
       numbercode: response.code_artist_number ?? 0,
       genre: (response.genre_name as Genre) ?? "Unknown",
-      id: undefined,
+      id: isSearchResult(response)
+        ? ((response as Record<string, unknown>).artist_id as number | undefined)
+        : undefined,
     },
     entry: response.code_number ?? 0,
     format: (response.format_name as Format) ?? "Unknown",
-    alternate_artist: "",
+    alternate_artist: isSearchResult(response)
+      ? ((response as Record<string, unknown>).alternate_artist_name as string | undefined) ?? ""
+      : "",
     album_artist: isSearchResult(response) ? response.album_artist : undefined,
     // `rotation_bin` and `rotation_id` come from the `rotation` table on the BS
     // /library/rotation read path (see `getRotationFromDB` in
@@ -116,6 +120,18 @@ export function convertToAlbumEntry(
     date_found: isSearchResult(response) ? (response as Record<string, unknown>).date_found as string | undefined : undefined,
     artwork_url: isSearchResult(response) ? (response as Record<string, unknown>).artwork_url as string | null | undefined : undefined,
     matched_via: isSearchResult(response) ? response.matched_via : undefined,
+    artist_id: isSearchResult(response)
+      ? (response as Record<string, unknown>).artist_id as number | undefined
+      : undefined,
+    genre_id: isSearchResult(response)
+      ? (response as Record<string, unknown>).genre_id as number | undefined
+      : undefined,
+    format_id: isSearchResult(response)
+      ? (response as Record<string, unknown>).format_id as number | undefined
+      : undefined,
+    disc_quantity: isSearchResult(response)
+      ? (response as Record<string, unknown>).disc_quantity as number | undefined
+      : undefined,
   };
 }
 

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -1,9 +1,21 @@
-import type { AlbumSearchResult, TrackMatchHint } from "@wxyc/shared/dtos";
-import { TrackMatchSource } from "@wxyc/shared/dtos";
+import type { AlbumSearchResult } from "@wxyc/shared/dtos";
 import { Rotation } from "../rotation/types";
 
-export type { AlbumSearchResult, TrackMatchHint };
-export { TrackMatchSource };
+export type { AlbumSearchResult };
+
+/** Track-level match hints returned by catalog track search (not yet in @wxyc/shared). */
+export type TrackMatchHint = {
+  source: string;
+  title: string;
+  confidence?: number;
+  position?: string;
+  artist_credit?: string;
+};
+
+export const TrackMatchSource = {
+  cta: "cta",
+  discogs_master: "discogs_master",
+} as const;
 
 /**
  * JSON boundary adapter for AlbumSearchResult.
@@ -11,6 +23,7 @@ export { TrackMatchSource };
  */
 export type AlbumSearchResultJSON = Omit<AlbumSearchResult, "add_date"> & {
   add_date: string;
+  matched_via?: TrackMatchHint[];
 };
 
 export type SearchCatalogQueryParams = {
@@ -20,26 +33,102 @@ export type SearchCatalogQueryParams = {
   on_streaming?: boolean;
 };
 
-export type AlbumParams = {
+/**
+ * POST /library — matches Backend-Service `NewAlbumRequest` (JSON uses numbers for ids).
+ */
+export type AddAlbumRequestBody = {
   album_title: string;
-  artist_name: string | undefined;
-  artist_id: string | undefined;
   label: string;
-  genre_id: string;
-  format_id: string;
-  disc_quantity: number | undefined;
-  alternate_artist_name: string | undefined;
+  genre_id: number;
+  format_id: number;
+  artist_name?: string;
+  artist_id?: number;
+  alternate_artist_name?: string;
+  disc_quantity?: number;
+  label_id?: number;
+};
+
+export type UpdateAlbumRequestBody = {
+  album_title: string;
+  label: string;
+  genre_id: number;
+  format_id: number;
+  artist_id: number;
+  alternate_artist_name?: string;
+  disc_quantity?: number;
+  label_id?: number;
+};
+
+/**
+ * POST /library/artists
+ */
+export type AddArtistRequestBody = {
+  artist_name: string;
+  code_letters: string;
+  genre_id: number;
+  code_number: number;
+  alphabetical_name?: string;
+};
+
+export type PeekArtistCodeQuery = {
+  code_letters: string;
+  genre_id: number;
+};
+
+export type PeekArtistCodeResponse = {
+  next_code_number: number;
+};
+
+export type ArtistInGenreOption = {
+  id: number;
+  artist_name: string;
+  code_letters: string;
+  code_number: number;
+};
+
+export type SearchArtistsInGenreParams = {
+  genre_id: number;
+  q: string;
+  limit?: number;
+};
+
+export type SearchArtistsInGenreResponse = {
+  artists: ArtistInGenreOption[];
+};
+
+export type LibraryFormatRow = {
+  id: number;
+  format_name: string;
+  add_date?: string;
+};
+
+export type LibraryGenreRow = {
+  id: number;
+  genre_name: string;
+  description?: string | null;
+  plays?: number;
+  add_date?: string;
+  last_modified?: string;
+};
+
+export type AddFormatRequestBody = {
+  name: string;
+};
+
+export type AddGenreRequestBody = {
+  name: string;
+  description: string;
 };
 
 export type AlbumRequestParams = {
   album_id: number;
 };
 
-export type ArtistParams = {
-  artist_name: string;
-  code_letters: string;
-  genre_id: string;
-};
+/** @deprecated use AddAlbumRequestBody */
+export type AlbumParams = AddAlbumRequestBody;
+
+/** @deprecated use AddArtistRequestBody */
+export type ArtistParams = AddArtistRequestBody;
 
 export type AlbumEntry = {
   id: number;
@@ -59,6 +148,11 @@ export type AlbumEntry = {
   date_found?: string;
   artwork_url?: string | null;
   matched_via?: TrackMatchHint[];
+  /** Present on `/library/info` responses for catalog edit. */
+  artist_id?: number;
+  genre_id?: number;
+  format_id?: number;
+  disc_quantity?: number;
 };
 
 export type ArtistEntry = {
@@ -85,19 +179,20 @@ export type CatalogSearchRow = {
 };
 
 export type CatalogFilters = {
-  onStreaming: boolean | undefined; // undefined = no filter
-  genre: Genre | "All"; // 'All' = no filter
-  format: Format | "All"; // 'All' = no filter
+  genres: string[]; // empty = no genre filter
+  formats: string[]; // empty = no format filter
+  tags: string[]; // status: exclusives, missing; rotation bins: H, M, L, S
 };
 
 export type CatalogSearchState = {
   rows: CatalogSearchRow[];
   sortBy: CatalogSortBy;
   sortOrder: CatalogSortOrder;
-  page: number;
   filters: CatalogFilters;
   selected: number[];
   mobileOpen: boolean;
+  /** User chose to browse the full catalog (empty query) without typing a search. */
+  browseEngaged: boolean;
 };
 
 // --- Request envelope for /library/query ---
@@ -109,8 +204,11 @@ export type LibraryQueryParams = {
   sort?: CatalogSortBy;
   order?: CatalogSortOrder;
   on_streaming?: boolean;
-  genre?: string;
-  format?: string;
+  missing?: boolean;
+  genres?: string;
+  formats?: string;
+  /** Comma-separated active rotation bins (H, M, L, S). */
+  rotation_bins?: string;
 };
 
 export type Format = "Vinyl" | "CD" | "Unknown";
@@ -126,3 +224,27 @@ export type Genre =
   | "Soundtracks"
   | "OCS"
   | "Unknown";
+
+export type SearchIn = "Artists" | "Albums" | "All";
+
+/** Shared rotation UI state for a library album (search row, edit panel, context menu). */
+export type CatalogAlbumRotation = {
+  rotation_bin: Rotation | undefined;
+  rotation_id: number | undefined;
+};
+
+/** Open catalog result row context menu (at most one globally). */
+export type CatalogResultContextMenuState = {
+  albumId: number;
+  top: number;
+  left: number;
+};
+
+export type CatalogFrontendState = CatalogSearchState & {
+  /** Latest album saved from catalog edit; drives in-memory search list refresh. */
+  lastPatchedSearchResult: AlbumEntry | null;
+  /** Per-album rotation after apply or hydrate; ties rightbar and catalog results together. */
+  rotationByAlbumId: Record<number, CatalogAlbumRotation>;
+  /** Which search result row owns the open context menu, if any. */
+  resultContextMenu: CatalogResultContextMenuState | null;
+};

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -1,21 +1,9 @@
-import type { AlbumSearchResult } from "@wxyc/shared/dtos";
+import type { AlbumSearchResult, TrackMatchHint } from "@wxyc/shared/dtos";
+import { TrackMatchSource } from "@wxyc/shared/dtos";
 import { Rotation } from "../rotation/types";
 
-export type { AlbumSearchResult };
-
-/** Track-level match hints returned by catalog track search (not yet in @wxyc/shared). */
-export type TrackMatchHint = {
-  source: string;
-  title: string;
-  confidence?: number;
-  position?: string;
-  artist_credit?: string;
-};
-
-export const TrackMatchSource = {
-  cta: "cta",
-  discogs_master: "discogs_master",
-} as const;
+export type { AlbumSearchResult, TrackMatchHint };
+export { TrackMatchSource };
 
 /**
  * JSON boundary adapter for AlbumSearchResult.
@@ -120,15 +108,26 @@ export type AddGenreRequestBody = {
   description: string;
 };
 
+export type AlbumParams = {
+  album_title: string;
+  artist_name: string | undefined;
+  artist_id: string | undefined;
+  label: string;
+  genre_id: string;
+  format_id: string;
+  disc_quantity: number | undefined;
+  alternate_artist_name: string | undefined;
+};
+
 export type AlbumRequestParams = {
   album_id: number;
 };
 
-/** @deprecated use AddAlbumRequestBody */
-export type AlbumParams = AddAlbumRequestBody;
-
-/** @deprecated use AddArtistRequestBody */
-export type ArtistParams = AddArtistRequestBody;
+export type ArtistParams = {
+  artist_name: string;
+  code_letters: string;
+  genre_id: string;
+};
 
 export type AlbumEntry = {
   id: number;
@@ -179,20 +178,19 @@ export type CatalogSearchRow = {
 };
 
 export type CatalogFilters = {
-  genres: string[]; // empty = no genre filter
-  formats: string[]; // empty = no format filter
-  tags: string[]; // status: exclusives, missing; rotation bins: H, M, L, S
+  onStreaming: boolean | undefined; // undefined = no filter
+  genre: Genre | "All"; // 'All' = no filter
+  format: Format | "All"; // 'All' = no filter
 };
 
 export type CatalogSearchState = {
   rows: CatalogSearchRow[];
   sortBy: CatalogSortBy;
   sortOrder: CatalogSortOrder;
+  page: number;
   filters: CatalogFilters;
   selected: number[];
   mobileOpen: boolean;
-  /** User chose to browse the full catalog (empty query) without typing a search. */
-  browseEngaged: boolean;
 };
 
 // --- Request envelope for /library/query ---
@@ -204,6 +202,8 @@ export type LibraryQueryParams = {
   sort?: CatalogSortBy;
   order?: CatalogSortOrder;
   on_streaming?: boolean;
+  genre?: string;
+  format?: string;
   missing?: boolean;
   genres?: string;
   formats?: string;
@@ -224,27 +224,3 @@ export type Genre =
   | "Soundtracks"
   | "OCS"
   | "Unknown";
-
-export type SearchIn = "Artists" | "Albums" | "All";
-
-/** Shared rotation UI state for a library album (search row, edit panel, context menu). */
-export type CatalogAlbumRotation = {
-  rotation_bin: Rotation | undefined;
-  rotation_id: number | undefined;
-};
-
-/** Open catalog result row context menu (at most one globally). */
-export type CatalogResultContextMenuState = {
-  albumId: number;
-  top: number;
-  left: number;
-};
-
-export type CatalogFrontendState = CatalogSearchState & {
-  /** Latest album saved from catalog edit; drives in-memory search list refresh. */
-  lastPatchedSearchResult: AlbumEntry | null;
-  /** Per-album rotation after apply or hydrate; ties rightbar and catalog results together. */
-  rotationByAlbumId: Record<number, CatalogAlbumRotation>;
-  /** Which search result row owns the open context menu, if any. */
-  resultContextMenu: CatalogResultContextMenuState | null;
-};


### PR DESCRIPTION
## Summary
Split from #648 (umbrella). Ungated catalog API layer — backend endpoints already exist; no UI consumes these yet.

- `searchLibraryQuery`, `addAlbum`, `updateAlbum`, `addArtist`, `peekArtistCode`, `searchArtistsInGenre`, `addFormat`, `addGenre`, `markMissing`, `markFound`
- Types, conversions, constants, admin artist validation
- Unit tests

Cache patching for `markMissing`/`markFound` lands in #TBD (PR 3).

## Test plan
- [ ] `npm test -- lib/__tests__/features/catalog/`

Part of the #648 split stack.

Made with [Cursor](https://cursor.com)