### PR TITLE
feat(catalog): optimistic cache patching for search and rotation

### DIFF
--- a/lib/__tests__/features/catalog/api.test.tsx
+++ b/lib/__tests__/features/catalog/api.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import {
   catalogApi,
   useSearchCatalogQuery,
+  useSearchLibraryQueryInfiniteQuery,
   useAddAlbumMutation,
   useAddArtistMutation,
   useGetInformationQuery,
@@ -22,6 +23,7 @@ describe("catalogApi", () => {
     queries: [
       "searchCatalog",
       "searchLibraryQuery",
+      "searchLibraryQueryInfinite",
       "getInformation",
       "getFormats",
       "getGenres",
@@ -41,6 +43,17 @@ describe("catalogApi", () => {
       expect(
         typeof catalogApi.endpoints.searchLibraryQuery.initiate,
       ).toBe("function");
+    });
+  });
+
+  describe("searchLibraryQueryInfinite endpoint", () => {
+    it("is defined", () => {
+      expect(catalogApi.endpoints.searchLibraryQueryInfinite).toBeDefined();
+    });
+
+    it("exports useSearchLibraryQueryInfiniteQuery hook", () => {
+      expect(useSearchLibraryQueryInfiniteQuery).toBeDefined();
+      expect(typeof useSearchLibraryQueryInfiniteQuery).toBe("function");
     });
   });
 

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -136,6 +136,14 @@ export const catalogApi = createApi({
       invalidatesTags: (_result, _error, { albumId }) => [
         { type: "AlbumDetail", id: albumId },
       ],
+      async onQueryStarted(_arg, { dispatch, queryFulfilled, getState }) {
+        try {
+          const { data: updated } = await queryFulfilled;
+          patchCatalogSearchCaches(dispatch, getState as () => RootState, updated);
+        } catch {
+          // Leave caches untouched when mark-missing fails.
+        }
+      },
     }),
     markFound: builder.mutation<AlbumEntry, { albumId: number }>({
       query: ({ albumId }) => ({
@@ -147,6 +155,14 @@ export const catalogApi = createApi({
       invalidatesTags: (_result, _error, { albumId }) => [
         { type: "AlbumDetail", id: albumId },
       ],
+      async onQueryStarted(_arg, { dispatch, queryFulfilled, getState }) {
+        try {
+          const { data: updated } = await queryFulfilled;
+          patchCatalogSearchCaches(dispatch, getState as () => RootState, updated);
+        } catch {
+          // Leave caches untouched when mark-found fails.
+        }
+      },
     }),
     getFormats: builder.query<LibraryFormatRow[], void>({
       query: () => ({

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -1,6 +1,9 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
+import type { RootState } from "@/lib/store";
 import { backendBaseQuery } from "../backend";
+import { CATALOG_QUERY_PAGE_LIMIT } from "./constants";
 import { convertToAlbumEntry } from "./conversions";
+import { patchCatalogSearchCaches } from "./patchSearchCaches";
 import {
   AddAlbumRequestBody,
   AddArtistRequestBody,
@@ -33,6 +36,12 @@ export type LibraryQueryResult = {
   page: number;
   totalPages: number;
 };
+
+/** Args for infinite catalog search — `page` and `limit` come from `pageParam` / constant. */
+export type CatalogInfiniteQueryArg = Omit<
+  LibraryQueryParams,
+  "page" | "limit"
+>;
 
 function transformLibraryQueryResponse(
   response: LibraryQueryResponseJSON | null,
@@ -68,6 +77,32 @@ export const catalogApi = createApi({
       transformResponse: (response: LibraryQueryResponseJSON | null) =>
         transformLibraryQueryResponse(response),
     }),
+    searchLibraryQueryInfinite: builder.infiniteQuery<
+      LibraryQueryResult,
+      CatalogInfiniteQueryArg,
+      number
+    >({
+      infiniteQueryOptions: {
+        initialPageParam: 0,
+        getNextPageParam: (lastPage, _allPages, lastPageParam) =>
+          lastPage.page + 1 >= lastPage.totalPages
+            ? undefined
+            : lastPageParam + 1,
+      },
+      query({ pageParam, queryArg }) {
+        return {
+          url: "/query",
+          params: {
+            ...queryArg,
+            page: pageParam,
+            limit: CATALOG_QUERY_PAGE_LIMIT,
+          },
+        };
+      },
+      transformResponse: (
+        response: LibraryQueryResponseJSON | null,
+      ): LibraryQueryResult => transformLibraryQueryResponse(response),
+    }),
     addAlbum: builder.mutation<{ id: number } & Record<string, unknown>, AddAlbumRequestBody>({
       query: (body) => ({
         url: "/",
@@ -86,6 +121,14 @@ export const catalogApi = createApi({
       invalidatesTags: (_result, _error, { albumId }) => [
         { type: "AlbumDetail", id: albumId },
       ],
+      async onQueryStarted(_arg, { dispatch, queryFulfilled, getState }) {
+        try {
+          const { data: updated } = await queryFulfilled;
+          patchCatalogSearchCaches(dispatch, getState as () => RootState, updated);
+        } catch {
+          // Leave caches untouched when save fails.
+        }
+      },
     }),
     addArtist: builder.mutation<
       { id: number; code_number?: number; genre_id?: number } & Record<string, unknown>,
@@ -195,6 +238,7 @@ export const {
   useSearchCatalogQuery,
   useLazySearchLibraryQueryQuery,
   useSearchLibraryQueryQuery,
+  useSearchLibraryQueryInfiniteInfiniteQuery,
   useAddAlbumMutation,
   useUpdateAlbumMutation,
   useAddArtistMutation,
@@ -208,3 +252,6 @@ export const {
   useMarkMissingMutation,
   useMarkFoundMutation,
 } = catalogApi;
+
+/** RTK names infinite-query hooks `use{EndpointName}InfiniteQuery`. */
+export { useSearchLibraryQueryInfiniteInfiniteQuery as useSearchLibraryQueryInfiniteQuery };

--- a/lib/features/catalog/catalogResultContextMenu.test.ts
+++ b/lib/features/catalog/catalogResultContextMenu.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { catalogSlice, defaultCatalogFrontendState } from "./frontend";
+
+describe("catalogSlice result context menu", () => {
+  it("openResultContextMenu stores a single menu target", () => {
+    const state = catalogSlice.reducer(
+      defaultCatalogFrontendState,
+      catalogSlice.actions.openResultContextMenu({
+        albumId: 1,
+        top: 10,
+        left: 20,
+      }),
+    );
+
+    expect(state.resultContextMenu).toEqual({
+      albumId: 1,
+      top: 10,
+      left: 20,
+    });
+  });
+
+  it("opening another row replaces the previous menu", () => {
+    let state = catalogSlice.reducer(
+      defaultCatalogFrontendState,
+      catalogSlice.actions.openResultContextMenu({
+        albumId: 1,
+        top: 10,
+        left: 20,
+      }),
+    );
+    state = catalogSlice.reducer(
+      state,
+      catalogSlice.actions.openResultContextMenu({
+        albumId: 2,
+        top: 30,
+        left: 40,
+      }),
+    );
+
+    expect(state.resultContextMenu).toEqual({
+      albumId: 2,
+      top: 30,
+      left: 40,
+    });
+  });
+
+  it("closeResultContextMenu clears the menu", () => {
+    let state = catalogSlice.reducer(
+      defaultCatalogFrontendState,
+      catalogSlice.actions.openResultContextMenu({
+        albumId: 1,
+        top: 0,
+        left: 0,
+      }),
+    );
+    state = catalogSlice.reducer(
+      state,
+      catalogSlice.actions.closeResultContextMenu(),
+    );
+
+    expect(state.resultContextMenu).toBeNull();
+  });
+});

--- a/lib/features/catalog/catalogRotation.test.ts
+++ b/lib/features/catalog/catalogRotation.test.ts
@@ -35,7 +35,7 @@ describe("catalogSlice rotation state", () => {
     expect(state.rotationByAlbumId[42]).toBeUndefined();
   });
 
-  it("setFilter clears rotationByAlbumId when tags change", () => {
+  it("setFilter preserves rotationByAlbumId when filters change", () => {
     let state = catalogSlice.reducer(
       defaultCatalogFrontendState,
       catalogSlice.actions.setAlbumRotation({
@@ -46,9 +46,12 @@ describe("catalogSlice rotation state", () => {
     );
     state = catalogSlice.reducer(
       state,
-      catalogSlice.actions.setFilter({ tags: ["H"] }),
+      catalogSlice.actions.setFilter({ onStreaming: false }),
     );
-    expect(state.rotationByAlbumId).toEqual({});
-    expect(state.filters.tags).toEqual(["H"]);
+    expect(state.rotationByAlbumId[42]).toEqual({
+      rotation_bin: "M",
+      rotation_id: 99,
+    });
+    expect(state.filters.onStreaming).toBe(false);
   });
 });

--- a/lib/features/catalog/catalogRotation.test.ts
+++ b/lib/features/catalog/catalogRotation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { catalogSlice, defaultCatalogFrontendState } from "./frontend";
+
+describe("catalogSlice rotation state", () => {
+  it("setAlbumRotation stores per-album rotation", () => {
+    const state = catalogSlice.reducer(
+      defaultCatalogFrontendState,
+      catalogSlice.actions.setAlbumRotation({
+        albumId: 42,
+        rotation_bin: "M",
+        rotation_id: 99,
+      }),
+    );
+
+    expect(state.rotationByAlbumId[42]).toEqual({
+      rotation_bin: "M",
+      rotation_id: 99,
+    });
+  });
+
+  it("clearAlbumRotation removes the entry", () => {
+    let state = catalogSlice.reducer(
+      defaultCatalogFrontendState,
+      catalogSlice.actions.setAlbumRotation({
+        albumId: 42,
+        rotation_bin: "H",
+        rotation_id: 1,
+      }),
+    );
+    state = catalogSlice.reducer(
+      state,
+      catalogSlice.actions.clearAlbumRotation(42),
+    );
+
+    expect(state.rotationByAlbumId[42]).toBeUndefined();
+  });
+
+  it("setFilter clears rotationByAlbumId when tags change", () => {
+    let state = catalogSlice.reducer(
+      defaultCatalogFrontendState,
+      catalogSlice.actions.setAlbumRotation({
+        albumId: 42,
+        rotation_bin: "M",
+        rotation_id: 99,
+      }),
+    );
+    state = catalogSlice.reducer(
+      state,
+      catalogSlice.actions.setFilter({ tags: ["H"] }),
+    );
+    expect(state.rotationByAlbumId).toEqual({});
+    expect(state.filters.tags).toEqual(["H"]);
+  });
+});

--- a/lib/features/catalog/catalogSearchQueryMatch.test.ts
+++ b/lib/features/catalog/catalogSearchQueryMatch.test.ts
@@ -28,16 +28,28 @@ describe("albumMatchesCatalogQueryArg", () => {
     ).toBe(false);
   });
 
-  it("excludes non-streaming albums from on_streaming=true filter", () => {
+  it("excludes non-streaming albums from on_streaming=false filter", () => {
     const streaming = createTestAlbum({ on_streaming: true });
     const notStreaming = createTestAlbum({ on_streaming: false });
+    const unknown = createTestAlbum({ on_streaming: undefined });
 
     expect(
-      albumMatchesCatalogQueryArg(streaming, { on_streaming: true }),
+      albumMatchesCatalogQueryArg(notStreaming, { on_streaming: false }),
     ).toBe(true);
     expect(
-      albumMatchesCatalogQueryArg(notStreaming, { on_streaming: true }),
+      albumMatchesCatalogQueryArg(streaming, { on_streaming: false }),
     ).toBe(false);
+    expect(
+      albumMatchesCatalogQueryArg(unknown, { on_streaming: false }),
+    ).toBe(false);
+  });
+
+  it("does not exclude unknown streaming status from on_streaming=true filter", () => {
+    const unknown = createTestAlbum({ on_streaming: undefined });
+
+    expect(
+      albumMatchesCatalogQueryArg(unknown, { on_streaming: true }),
+    ).toBe(true);
   });
 
   it("excludes missing albums from missing=false filter", () => {

--- a/lib/features/catalog/catalogSearchQueryMatch.test.ts
+++ b/lib/features/catalog/catalogSearchQueryMatch.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { createTestAlbum } from "@/lib/test-utils";
+import {
+  albumMatchesCatalogQueryArg,
+  parseRotationBinsFromQueryArg,
+} from "./catalogSearchQueryMatch";
+
+describe("parseRotationBinsFromQueryArg", () => {
+  it("parses comma-separated bins", () => {
+    expect(parseRotationBinsFromQueryArg("H,M")).toEqual(["H", "M"]);
+  });
+
+  it("ignores invalid tokens", () => {
+    expect(parseRotationBinsFromQueryArg("H,N,X")).toEqual(["H"]);
+  });
+});
+
+describe("albumMatchesCatalogQueryArg", () => {
+  it("requires rotation_bin when rotation_bins filter is set", () => {
+    const heavy = createTestAlbum({ rotation_bin: "H" });
+    const none = createTestAlbum({ rotation_bin: undefined });
+
+    expect(
+      albumMatchesCatalogQueryArg(heavy, { rotation_bins: "H" }),
+    ).toBe(true);
+    expect(
+      albumMatchesCatalogQueryArg(none, { rotation_bins: "H" }),
+    ).toBe(false);
+  });
+
+  it("excludes non-streaming albums from on_streaming=true filter", () => {
+    const streaming = createTestAlbum({ on_streaming: true });
+    const notStreaming = createTestAlbum({ on_streaming: false });
+
+    expect(
+      albumMatchesCatalogQueryArg(streaming, { on_streaming: true }),
+    ).toBe(true);
+    expect(
+      albumMatchesCatalogQueryArg(notStreaming, { on_streaming: true }),
+    ).toBe(false);
+  });
+
+  it("excludes missing albums from missing=false filter", () => {
+    const present = createTestAlbum({ date_lost: undefined });
+    const missing = createTestAlbum({
+      date_lost: "2024-01-01",
+      date_found: undefined,
+    });
+
+    expect(
+      albumMatchesCatalogQueryArg(present, { missing: false }),
+    ).toBe(true);
+    expect(
+      albumMatchesCatalogQueryArg(missing, { missing: false }),
+    ).toBe(false);
+  });
+});

--- a/lib/features/catalog/catalogSearchQueryMatch.ts
+++ b/lib/features/catalog/catalogSearchQueryMatch.ts
@@ -1,0 +1,61 @@
+import type { AlbumEntry, LibraryQueryParams } from "./types";
+
+export type CatalogSearchQueryCacheArg = Omit<
+  LibraryQueryParams,
+  "page" | "limit"
+>;
+import type { Rotation } from "../rotation/types";
+
+const ROTATION_BIN_PATTERN = /^[HMLS]$/;
+
+/** Parse `rotation_bins` from a cached `/library/query` arg. */
+export function parseRotationBinsFromQueryArg(
+  rotation_bins?: string,
+): Rotation[] | undefined {
+  if (!rotation_bins?.trim()) return undefined;
+  const bins = rotation_bins
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part): part is Rotation => ROTATION_BIN_PATTERN.test(part));
+  return bins.length > 0 ? bins : undefined;
+}
+
+function isAlbumMissing(album: AlbumEntry): boolean {
+  if (!album.date_lost) return false;
+  if (!album.date_found) return true;
+  return album.date_found < album.date_lost;
+}
+
+/** Whether a row still belongs in results for this cached query arg. */
+export function albumMatchesCatalogQueryArg(
+  album: AlbumEntry,
+  args: CatalogSearchQueryCacheArg,
+): boolean {
+  const rotationBins = parseRotationBinsFromQueryArg(args.rotation_bins);
+  if (rotationBins?.length) {
+    if (!album.rotation_bin || !rotationBins.includes(album.rotation_bin)) {
+      return false;
+    }
+  }
+  if (args.on_streaming === true && album.on_streaming !== true) {
+    return false;
+  }
+  if (args.on_streaming === false && album.on_streaming !== false) {
+    return false;
+  }
+  if (args.missing === true && !isAlbumMissing(album)) {
+    return false;
+  }
+  if (args.missing === false && isAlbumMissing(album)) {
+    return false;
+  }
+  if (args.genres?.trim()) {
+    const allowed = args.genres.split(",").map((g) => g.trim());
+    if (!allowed.includes(album.artist.genre)) return false;
+  }
+  if (args.formats?.trim()) {
+    const allowed = args.formats.split(",").map((f) => f.trim());
+    if (!allowed.includes(album.format)) return false;
+  }
+  return true;
+}

--- a/lib/features/catalog/catalogSearchQueryMatch.ts
+++ b/lib/features/catalog/catalogSearchQueryMatch.ts
@@ -37,9 +37,6 @@ export function albumMatchesCatalogQueryArg(
       return false;
     }
   }
-  if (args.on_streaming === true && album.on_streaming !== true) {
-    return false;
-  }
   if (args.on_streaming === false && album.on_streaming !== false) {
     return false;
   }

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -116,8 +116,8 @@ export function convertToAlbumEntry(
     rotation_id:
       "rotation_id" in response ? response.rotation_id : undefined,
     on_streaming: isSearchResult(response) ? (response as Record<string, unknown>).on_streaming as boolean | undefined : undefined,
-    date_lost: isSearchResult(response) ? (response as Record<string, unknown>).date_lost as string | undefined : undefined,
-    date_found: isSearchResult(response) ? (response as Record<string, unknown>).date_found as string | undefined : undefined,
+    date_lost: isSearchResult(response) ? (response as Record<string, unknown>).date_lost as string | null | undefined : undefined,
+    date_found: isSearchResult(response) ? (response as Record<string, unknown>).date_found as string | null | undefined : undefined,
     artwork_url: isSearchResult(response) ? (response as Record<string, unknown>).artwork_url as string | null | undefined : undefined,
     matched_via: isSearchResult(response) ? response.matched_via : undefined,
     artist_id: isSearchResult(response)

--- a/lib/features/catalog/frontend.ts
+++ b/lib/features/catalog/frontend.ts
@@ -11,11 +11,8 @@ import type {
   CatalogSortOrder,
 } from "./types";
 
-/** Stable id for the primary row so SSR and client hydration agree on React keys. */
-export const CATALOG_PRIMARY_ROW_ID = "catalog-search-primary";
-
-const createInitialRow = (id?: string): CatalogSearchRow => ({
-  id: id ?? crypto.randomUUID(),
+const createInitialRow = (): CatalogSearchRow => ({
+  id: crypto.randomUUID(),
   operator: "AND",
   field: "all",
   value: "",
@@ -23,13 +20,13 @@ const createInitialRow = (id?: string): CatalogSearchRow => ({
 });
 
 export const defaultCatalogFrontendState: CatalogFrontendState = {
-  rows: [createInitialRow(CATALOG_PRIMARY_ROW_ID)],
+  rows: [createInitialRow()],
   sortBy: "album",
   sortOrder: "asc",
-  filters: { genres: [], formats: [], tags: [] },
+  page: 0,
+  filters: { onStreaming: undefined, genre: "All", format: "All" },
   selected: [],
   mobileOpen: false,
-  browseEngaged: false,
   lastPatchedSearchResult: null,
   rotationByAlbumId: {},
   resultContextMenu: null,
@@ -41,10 +38,12 @@ export const catalogSlice = createAppSlice({
   reducers: {
     addRow: (state) => {
       state.rows.push({ ...createInitialRow(), field: "artist" });
+      state.page = 0;
     },
     removeRow: (state, action: PayloadAction<string>) => {
       if (state.rows.length > 1) {
         state.rows = state.rows.filter((r) => r.id !== action.payload);
+        state.page = 0;
       }
     },
     updateRow: (
@@ -54,6 +53,7 @@ export const catalogSlice = createAppSlice({
       const row = state.rows.find((r) => r.id === action.payload.id);
       if (row) {
         Object.assign(row, action.payload.updates);
+        state.page = 0;
       }
     },
     setSort: (
@@ -62,12 +62,14 @@ export const catalogSlice = createAppSlice({
     ) => {
       state.sortBy = action.payload.sortBy;
       state.sortOrder = action.payload.sortOrder;
+      state.page = 0;
     },
     setFilter: (state, action: PayloadAction<Partial<CatalogFilters>>) => {
       state.filters = { ...state.filters, ...action.payload };
-      if (action.payload.tags !== undefined) {
-        state.rotationByAlbumId = {};
-      }
+      state.page = 0;
+    },
+    nextPage: (state) => {
+      state.page += 1;
     },
     setSelection: (state, action: PayloadAction<number[]>) => {
       state.selected = action.payload;
@@ -86,9 +88,6 @@ export const catalogSlice = createAppSlice({
     },
     closeMobileSearch: (state) => {
       state.mobileOpen = false;
-    },
-    engageBrowse: (state) => {
-      state.browseEngaged = true;
     },
     patchSearchResult: (state, action: PayloadAction<AlbumEntry>) => {
       state.lastPatchedSearchResult = action.payload;
@@ -118,10 +117,10 @@ export const catalogSlice = createAppSlice({
     getRows: (state) => state.rows,
     getSortBy: (state) => state.sortBy,
     getSortOrder: (state) => state.sortOrder,
+    getPage: (state) => state.page,
     getFilters: (state) => state.filters,
     getSelected: (state) => state.selected,
     isMobileSearchOpen: (state) => state.mobileOpen,
-    getBrowseEngaged: (state) => state.browseEngaged,
     getLastPatchedSearchResult: (state) => state.lastPatchedSearchResult,
     getAlbumRotation: (state, albumId: number) =>
       state.rotationByAlbumId[albumId],

--- a/lib/features/catalog/frontend.ts
+++ b/lib/features/catalog/frontend.ts
@@ -1,29 +1,38 @@
 import { createAppSlice } from "@/lib/createAppSlice";
 import type { PayloadAction } from "@reduxjs/toolkit";
-import {
+import type {
+  AlbumEntry,
+  CatalogAlbumRotation,
   CatalogFilters,
+  CatalogFrontendState,
+  CatalogResultContextMenuState,
   CatalogSearchRow,
-  CatalogSearchState,
   CatalogSortBy,
   CatalogSortOrder,
 } from "./types";
 
-const createInitialRow = (): CatalogSearchRow => ({
-  id: crypto.randomUUID(),
+/** Stable id for the primary row so SSR and client hydration agree on React keys. */
+export const CATALOG_PRIMARY_ROW_ID = "catalog-search-primary";
+
+const createInitialRow = (id?: string): CatalogSearchRow => ({
+  id: id ?? crypto.randomUUID(),
   operator: "AND",
   field: "all",
   value: "",
   exact: false,
 });
 
-export const defaultCatalogFrontendState: CatalogSearchState = {
-  rows: [createInitialRow()],
+export const defaultCatalogFrontendState: CatalogFrontendState = {
+  rows: [createInitialRow(CATALOG_PRIMARY_ROW_ID)],
   sortBy: "album",
   sortOrder: "asc",
-  page: 0,
-  filters: { onStreaming: undefined, genre: "All", format: "All" },
+  filters: { genres: [], formats: [], tags: [] },
   selected: [],
   mobileOpen: false,
+  browseEngaged: false,
+  lastPatchedSearchResult: null,
+  rotationByAlbumId: {},
+  resultContextMenu: null,
 };
 
 export const catalogSlice = createAppSlice({
@@ -32,12 +41,10 @@ export const catalogSlice = createAppSlice({
   reducers: {
     addRow: (state) => {
       state.rows.push({ ...createInitialRow(), field: "artist" });
-      state.page = 0;
     },
     removeRow: (state, action: PayloadAction<string>) => {
       if (state.rows.length > 1) {
         state.rows = state.rows.filter((r) => r.id !== action.payload);
-        state.page = 0;
       }
     },
     updateRow: (
@@ -47,7 +54,6 @@ export const catalogSlice = createAppSlice({
       const row = state.rows.find((r) => r.id === action.payload.id);
       if (row) {
         Object.assign(row, action.payload.updates);
-        state.page = 0;
       }
     },
     setSort: (
@@ -56,14 +62,12 @@ export const catalogSlice = createAppSlice({
     ) => {
       state.sortBy = action.payload.sortBy;
       state.sortOrder = action.payload.sortOrder;
-      state.page = 0;
     },
     setFilter: (state, action: PayloadAction<Partial<CatalogFilters>>) => {
       state.filters = { ...state.filters, ...action.payload };
-      state.page = 0;
-    },
-    nextPage: (state) => {
-      state.page += 1;
+      if (action.payload.tags !== undefined) {
+        state.rotationByAlbumId = {};
+      }
     },
     setSelection: (state, action: PayloadAction<number[]>) => {
       state.selected = action.payload;
@@ -83,15 +87,44 @@ export const catalogSlice = createAppSlice({
     closeMobileSearch: (state) => {
       state.mobileOpen = false;
     },
+    engageBrowse: (state) => {
+      state.browseEngaged = true;
+    },
+    patchSearchResult: (state, action: PayloadAction<AlbumEntry>) => {
+      state.lastPatchedSearchResult = action.payload;
+    },
+    setAlbumRotation: (
+      state,
+      action: PayloadAction<{ albumId: number } & CatalogAlbumRotation>,
+    ) => {
+      const { albumId, rotation_bin, rotation_id } = action.payload;
+      state.rotationByAlbumId[albumId] = { rotation_bin, rotation_id };
+    },
+    clearAlbumRotation: (state, action: PayloadAction<number>) => {
+      delete state.rotationByAlbumId[action.payload];
+    },
+    openResultContextMenu: (
+      state,
+      action: PayloadAction<CatalogResultContextMenuState>,
+    ) => {
+      state.resultContextMenu = action.payload;
+    },
+    closeResultContextMenu: (state) => {
+      state.resultContextMenu = null;
+    },
     reset: () => defaultCatalogFrontendState,
   },
   selectors: {
     getRows: (state) => state.rows,
     getSortBy: (state) => state.sortBy,
     getSortOrder: (state) => state.sortOrder,
-    getPage: (state) => state.page,
     getFilters: (state) => state.filters,
     getSelected: (state) => state.selected,
     isMobileSearchOpen: (state) => state.mobileOpen,
+    getBrowseEngaged: (state) => state.browseEngaged,
+    getLastPatchedSearchResult: (state) => state.lastPatchedSearchResult,
+    getAlbumRotation: (state, albumId: number) =>
+      state.rotationByAlbumId[albumId],
+    getResultContextMenu: (state) => state.resultContextMenu,
   },
 });

--- a/lib/features/catalog/patchSearchCaches.test.ts
+++ b/lib/features/catalog/patchSearchCaches.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { patchCatalogSearchCaches } from "./patchSearchCaches";
+import { catalogApi } from "./api";
+import { catalogSlice } from "./frontend";
+import { createTestAlbum } from "@/lib/test-utils";
+
+describe("patchCatalogSearchCaches", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("removes a row that no longer matches the cached missing filter after mark-found", () => {
+    const dispatch = vi.fn();
+    const queryArgs = { missing: true };
+    const existing = createTestAlbum({
+      id: 42,
+      date_lost: "2024-01-01",
+      date_found: undefined,
+    });
+    const updated = createTestAlbum({
+      id: 42,
+      date_lost: null,
+      date_found: "2024-02-01",
+    });
+
+    vi.spyOn(catalogApi.util, "selectCachedArgsForQuery").mockReturnValue([
+      queryArgs,
+    ]);
+
+    vi.spyOn(catalogApi.util, "updateQueryData").mockImplementation(
+      (_endpoint, args, updater) => {
+        expect(args).toEqual(queryArgs);
+        const draft = {
+          pages: [
+            {
+              results: [existing],
+              total: 1,
+              page: 0,
+              totalPages: 1,
+            },
+            {
+              results: [],
+              total: 1,
+              page: 1,
+              totalPages: 1,
+            },
+          ],
+        };
+        updater(draft);
+        expect(draft.pages[0].results).toHaveLength(0);
+        expect(draft.pages[0].total).toBe(0);
+        expect(draft.pages[1].total).toBe(0);
+        return { type: "catalogApi/updateQueryData" } as never;
+      },
+    );
+
+    patchCatalogSearchCaches(dispatch, () => ({} as never), updated);
+
+    expect(dispatch).toHaveBeenCalledWith(
+      catalogSlice.actions.patchSearchResult(updated),
+    );
+  });
+
+  it("updates a row in place when it still matches the cached filter", () => {
+    const dispatch = vi.fn();
+    const queryArgs = { genres: "Rock" };
+    const existing = createTestAlbum({
+      id: 42,
+      artist: {
+        name: "Artist",
+        lettercode: "AB",
+        numbercode: 1,
+        genre: "Rock",
+        id: 1,
+      },
+    });
+    const updated = createTestAlbum({
+      id: 42,
+      title: "Updated Title",
+      artist: existing.artist,
+    });
+
+    vi.spyOn(catalogApi.util, "selectCachedArgsForQuery").mockReturnValue([
+      queryArgs,
+    ]);
+
+    vi.spyOn(catalogApi.util, "updateQueryData").mockImplementation(
+      (_endpoint, _args, updater) => {
+        const draft = {
+          pages: [
+            {
+              results: [existing],
+              total: 1,
+              page: 0,
+              totalPages: 1,
+            },
+          ],
+        };
+        updater(draft);
+        expect(draft.pages[0].results[0].title).toBe("Updated Title");
+        expect(draft.pages[0].results).toHaveLength(1);
+        return { type: "catalogApi/updateQueryData" } as never;
+      },
+    );
+
+    patchCatalogSearchCaches(dispatch, () => ({} as never), updated);
+  });
+});

--- a/lib/features/catalog/patchSearchCaches.test.ts
+++ b/lib/features/catalog/patchSearchCaches.test.ts
@@ -3,7 +3,6 @@ import { patchCatalogSearchCaches } from "./patchSearchCaches";
 import { catalogApi } from "./api";
 import { catalogSlice } from "./frontend";
 import { createTestAlbum } from "@/lib/test-utils";
-import type { AlbumEntry } from "./types";
 
 describe("patchCatalogSearchCaches", () => {
   afterEach(() => {
@@ -18,13 +17,11 @@ describe("patchCatalogSearchCaches", () => {
       date_lost: "2024-01-01",
       date_found: undefined,
     });
-    const updated = {
-      ...createTestAlbum({
-        id: 42,
-        date_found: "2024-02-01",
-      }),
+    const updated = createTestAlbum({
+      id: 42,
       date_lost: null,
-    } as AlbumEntry;
+      date_found: "2024-02-01",
+    });
 
     vi.spyOn(catalogApi.util, "selectCachedArgsForQuery").mockReturnValue([
       queryArgs,

--- a/lib/features/catalog/patchSearchCaches.test.ts
+++ b/lib/features/catalog/patchSearchCaches.test.ts
@@ -3,6 +3,7 @@ import { patchCatalogSearchCaches } from "./patchSearchCaches";
 import { catalogApi } from "./api";
 import { catalogSlice } from "./frontend";
 import { createTestAlbum } from "@/lib/test-utils";
+import type { AlbumEntry } from "./types";
 
 describe("patchCatalogSearchCaches", () => {
   afterEach(() => {
@@ -17,11 +18,13 @@ describe("patchCatalogSearchCaches", () => {
       date_lost: "2024-01-01",
       date_found: undefined,
     });
-    const updated = createTestAlbum({
-      id: 42,
+    const updated = {
+      ...createTestAlbum({
+        id: 42,
+        date_found: "2024-02-01",
+      }),
       date_lost: null,
-      date_found: "2024-02-01",
-    });
+    } as AlbumEntry;
 
     vi.spyOn(catalogApi.util, "selectCachedArgsForQuery").mockReturnValue([
       queryArgs,

--- a/lib/features/catalog/patchSearchCaches.ts
+++ b/lib/features/catalog/patchSearchCaches.ts
@@ -25,14 +25,12 @@ function findAlbumInSearchDraft(
   return undefined;
 }
 
-function patchInfiniteSearchDraft(
+function setInfiniteDraftTotal(
   draft: { pages: LibraryQueryResult[] },
-  patchRow: (row: AlbumEntry) => void,
-) {
+  total: number,
+): void {
   for (const page of draft.pages) {
-    for (const row of page.results) {
-      patchRow(row);
-    }
+    page.total = total;
   }
 }
 
@@ -40,17 +38,20 @@ function removeAlbumFromInfiniteDraft(
   draft: { pages: LibraryQueryResult[] },
   albumId: number,
 ): boolean {
-  let removedCount = 0;
+  let removed = false;
   for (const page of draft.pages) {
     const index = page.results.findIndex((r) => r.id === albumId);
     if (index === -1) continue;
     page.results.splice(index, 1);
-    removedCount += 1;
+    removed = true;
   }
-  if (removedCount > 0 && draft.pages[0]) {
-    draft.pages[0].total = Math.max(0, draft.pages[0].total - removedCount);
+  if (removed && draft.pages[0]) {
+    setInfiniteDraftTotal(
+      draft,
+      Math.max(0, draft.pages[0].total - 1),
+    );
   }
-  return removedCount > 0;
+  return removed;
 }
 
 function sortKeyForAlbum(
@@ -110,7 +111,7 @@ function insertAlbumIntoInfiniteDraft(
     }
   }
   page.results.splice(insertAt, 0, album);
-  page.total += 1;
+  setInfiniteDraftTotal(draft, page.total + 1);
 }
 
 function hasUsableAlbumData(album: AlbumEntry): boolean {
@@ -259,10 +260,16 @@ export function patchCatalogSearchCaches(
         "searchLibraryQueryInfinite",
         args,
         (draft) => {
-          patchInfiniteSearchDraft(draft, (row) => {
-            if (row.id !== updated.id) return;
-            Object.assign(row, mergeAlbumIntoSearchResult(row, updated));
-          });
+          const existing = findAlbumInSearchDraft(draft, updated.id);
+          if (!existing) return;
+
+          const merged = mergeAlbumIntoSearchResult(existing, updated);
+          if (!albumMatchesCatalogQueryArg(merged, args)) {
+            removeAlbumFromInfiniteDraft(draft, updated.id);
+            return;
+          }
+
+          Object.assign(existing, merged);
         },
       ),
     );

--- a/lib/features/catalog/patchSearchCaches.ts
+++ b/lib/features/catalog/patchSearchCaches.ts
@@ -144,10 +144,10 @@ function resolveAlbumEntryForRotationPatch(
 
   const cachedArgs = catalogApi.util.selectCachedArgsForQuery(
     getState(),
-    "searchLibraryQuery",
+    "searchLibraryQueryInfinite",
   );
   for (const args of cachedArgs) {
-    const data = catalogApi.endpoints.searchLibraryQuery.select(args)(
+    const data = catalogApi.endpoints.searchLibraryQueryInfinite.select(args)(
       getState(),
     )?.data;
     if (!data?.pages) continue;
@@ -214,13 +214,13 @@ export function patchCatalogSearchRotation(
 
   const cachedArgs = catalogApi.util.selectCachedArgsForQuery(
     getState(),
-    "searchLibraryQuery",
+    "searchLibraryQueryInfinite",
   );
 
   for (const args of cachedArgs) {
     dispatch(
       catalogApi.util.updateQueryData(
-        "searchLibraryQuery",
+        "searchLibraryQueryInfinite",
         args,
         (draft) => {
           if (!album) {
@@ -250,13 +250,13 @@ export function patchCatalogSearchCaches(
 ): void {
   const cachedArgs = catalogApi.util.selectCachedArgsForQuery(
     getState(),
-    "searchLibraryQuery",
+    "searchLibraryQueryInfinite",
   );
 
   for (const args of cachedArgs) {
     dispatch(
       catalogApi.util.updateQueryData(
-        "searchLibraryQuery",
+        "searchLibraryQueryInfinite",
         args,
         (draft) => {
           patchInfiniteSearchDraft(draft, (row) => {

--- a/lib/features/catalog/patchSearchCaches.ts
+++ b/lib/features/catalog/patchSearchCaches.ts
@@ -1,0 +1,272 @@
+import type { AppDispatch, RootState } from "@/lib/store";
+import type { Rotation } from "@/lib/features/rotation/types";
+import {
+  albumMatchesCatalogQueryArg,
+  type CatalogSearchQueryCacheArg,
+} from "./catalogSearchQueryMatch";
+import { catalogSlice } from "./frontend";
+import { catalogApi, type LibraryQueryResult } from "./api";
+import type { AlbumEntry, CatalogSortBy, CatalogSortOrder } from "./types";
+import { mergeAlbumIntoSearchResult } from "./patchSearchResult";
+
+export type CatalogSearchRotationPatch = {
+  rotation_bin: Rotation | undefined;
+  rotation_id: number | undefined;
+};
+
+function findAlbumInSearchDraft(
+  draft: { pages: LibraryQueryResult[] },
+  albumId: number,
+): AlbumEntry | undefined {
+  for (const page of draft.pages) {
+    const row = page.results.find((r) => r.id === albumId);
+    if (row) return row;
+  }
+  return undefined;
+}
+
+function patchInfiniteSearchDraft(
+  draft: { pages: LibraryQueryResult[] },
+  patchRow: (row: AlbumEntry) => void,
+) {
+  for (const page of draft.pages) {
+    for (const row of page.results) {
+      patchRow(row);
+    }
+  }
+}
+
+function removeAlbumFromInfiniteDraft(
+  draft: { pages: LibraryQueryResult[] },
+  albumId: number,
+): boolean {
+  let removedCount = 0;
+  for (const page of draft.pages) {
+    const index = page.results.findIndex((r) => r.id === albumId);
+    if (index === -1) continue;
+    page.results.splice(index, 1);
+    removedCount += 1;
+  }
+  if (removedCount > 0 && draft.pages[0]) {
+    draft.pages[0].total = Math.max(0, draft.pages[0].total - removedCount);
+  }
+  return removedCount > 0;
+}
+
+function sortKeyForAlbum(
+  album: AlbumEntry,
+  sortBy: CatalogSortBy,
+): string | number {
+  switch (sortBy) {
+    case "artist":
+      return album.artist.name.toLowerCase();
+    case "plays":
+      return album.plays ?? 0;
+    case "date":
+      return album.add_date ?? "";
+    case "album":
+    default:
+      return album.title.toLowerCase();
+  }
+}
+
+function compareAlbumsForSort(
+  a: AlbumEntry,
+  b: AlbumEntry,
+  sortBy: CatalogSortBy,
+  order: CatalogSortOrder,
+): number {
+  const aKey = sortKeyForAlbum(a, sortBy);
+  const bKey = sortKeyForAlbum(b, sortBy);
+  const cmp =
+    typeof aKey === "number" && typeof bKey === "number"
+      ? aKey - bKey
+      : String(aKey).localeCompare(String(bKey));
+  return order === "desc" ? -cmp : cmp;
+}
+
+function insertAlbumIntoInfiniteDraft(
+  draft: { pages: LibraryQueryResult[] },
+  album: AlbumEntry,
+  args: CatalogSearchQueryCacheArg,
+): void {
+  if (findAlbumInSearchDraft(draft, album.id)) return;
+
+  if (!draft.pages.length) {
+    draft.pages = [
+      { results: [album], total: 1, page: 0, totalPages: 1 },
+    ];
+    return;
+  }
+
+  const page = draft.pages[0];
+  const sortBy = args.sort ?? "album";
+  const order = args.order ?? "asc";
+  let insertAt = page.results.length;
+  for (let i = 0; i < page.results.length; i++) {
+    if (compareAlbumsForSort(album, page.results[i], sortBy, order) < 0) {
+      insertAt = i;
+      break;
+    }
+  }
+  page.results.splice(insertAt, 0, album);
+  page.total += 1;
+}
+
+function hasUsableAlbumData(album: AlbumEntry): boolean {
+  return Boolean(album.title.trim() || album.artist.name.trim());
+}
+
+function resolveAlbumEntryForRotationPatch(
+  getState: () => RootState,
+  albumId: number,
+  rotation: CatalogSearchRotationPatch,
+  albumHint?: AlbumEntry,
+): AlbumEntry | null {
+  if (albumHint) {
+    return {
+      ...albumHint,
+      rotation_bin: rotation.rotation_bin,
+      rotation_id: rotation.rotation_id,
+    };
+  }
+
+  const info = catalogApi.endpoints.getInformation.select({
+    album_id: albumId,
+  })(getState())?.data;
+  if (info) {
+    return {
+      ...info,
+      rotation_bin: rotation.rotation_bin,
+      rotation_id: rotation.rotation_id,
+    };
+  }
+
+  const cachedArgs = catalogApi.util.selectCachedArgsForQuery(
+    getState(),
+    "searchLibraryQuery",
+  );
+  for (const args of cachedArgs) {
+    const data = catalogApi.endpoints.searchLibraryQuery.select(args)(
+      getState(),
+    )?.data;
+    if (!data?.pages) continue;
+    const existing = findAlbumInSearchDraft(data, albumId);
+    if (existing) {
+      return {
+        ...existing,
+        rotation_bin: rotation.rotation_bin,
+        rotation_id: rotation.rotation_id,
+      };
+    }
+  }
+
+  return null;
+}
+
+function applyRotationToSearchCache(
+  draft: { pages: LibraryQueryResult[] },
+  args: CatalogSearchQueryCacheArg,
+  album: AlbumEntry,
+): void {
+  const existing = findAlbumInSearchDraft(draft, album.id);
+  const matches = albumMatchesCatalogQueryArg(album, args);
+
+  if (existing) {
+    existing.rotation_bin = album.rotation_bin;
+    existing.rotation_id = album.rotation_id;
+    if (!matches) {
+      removeAlbumFromInfiniteDraft(draft, album.id);
+    }
+    return;
+  }
+
+  if (matches && !args.q?.trim() && hasUsableAlbumData(album)) {
+    insertAlbumIntoInfiniteDraft(draft, album, args);
+  }
+}
+
+/**
+ * Patch rotation on cached catalog search pages and sync Redux rotation state.
+ * Inserts or removes rows when the active cached query filters by rotation bin.
+ */
+export function patchCatalogSearchRotation(
+  dispatch: AppDispatch,
+  getState: () => RootState,
+  albumId: number,
+  rotation: CatalogSearchRotationPatch,
+  albumHint?: AlbumEntry,
+): void {
+  dispatch(
+    catalogSlice.actions.setAlbumRotation({
+      albumId,
+      rotation_bin: rotation.rotation_bin,
+      rotation_id: rotation.rotation_id,
+    }),
+  );
+
+  const album = resolveAlbumEntryForRotationPatch(
+    getState,
+    albumId,
+    rotation,
+    albumHint,
+  );
+
+  const cachedArgs = catalogApi.util.selectCachedArgsForQuery(
+    getState(),
+    "searchLibraryQuery",
+  );
+
+  for (const args of cachedArgs) {
+    dispatch(
+      catalogApi.util.updateQueryData(
+        "searchLibraryQuery",
+        args,
+        (draft) => {
+          if (!album) {
+            const existing = findAlbumInSearchDraft(draft, albumId);
+            if (existing) {
+              existing.rotation_bin = rotation.rotation_bin;
+              existing.rotation_id = rotation.rotation_id;
+            }
+            return;
+          }
+          applyRotationToSearchCache(draft, args, album);
+        },
+      ),
+    );
+  }
+
+  if (album) {
+    dispatch(catalogSlice.actions.patchSearchResult(album));
+  }
+}
+
+/** Patch every cached `/library/query` page that contains this album id. */
+export function patchCatalogSearchCaches(
+  dispatch: AppDispatch,
+  getState: () => RootState,
+  updated: AlbumEntry,
+): void {
+  const cachedArgs = catalogApi.util.selectCachedArgsForQuery(
+    getState(),
+    "searchLibraryQuery",
+  );
+
+  for (const args of cachedArgs) {
+    dispatch(
+      catalogApi.util.updateQueryData(
+        "searchLibraryQuery",
+        args,
+        (draft) => {
+          patchInfiniteSearchDraft(draft, (row) => {
+            if (row.id !== updated.id) return;
+            Object.assign(row, mergeAlbumIntoSearchResult(row, updated));
+          });
+        },
+      ),
+    );
+  }
+
+  dispatch(catalogSlice.actions.patchSearchResult(updated));
+}

--- a/lib/features/catalog/patchSearchResult.test.ts
+++ b/lib/features/catalog/patchSearchResult.test.ts
@@ -37,6 +37,24 @@ describe("mergeAlbumIntoSearchResult", () => {
     expect(merged.rotation_id).toBe(99);
   });
 
+  it("clears date_lost and date_found when mutation returns null", () => {
+    const existing = createTestAlbum({
+      id: 42,
+      date_lost: "2024-01-01",
+      date_found: undefined,
+    });
+    const updated = createTestAlbum({
+      id: 42,
+      date_lost: null,
+      date_found: "2024-02-01",
+    });
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.date_lost).toBeNull();
+    expect(merged.date_found).toBe("2024-02-01");
+  });
+
   it("merges albums with empty title fields from LML-only rows", () => {
     const existing = createTestAlbum({
       id: 42,

--- a/lib/features/catalog/patchSearchResult.test.ts
+++ b/lib/features/catalog/patchSearchResult.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { createTestAlbum } from "@/lib/test-utils";
+import type { AlbumEntry } from "./types";
+import { mergeAlbumIntoSearchResult } from "./patchSearchResult";
+
+describe("mergeAlbumIntoSearchResult", () => {
+  it("updates editable fields while preserving search-only metadata", () => {
+    const existing = createTestAlbum({
+      id: 42,
+      title: "Old Title",
+      label: "Old Label",
+      entry: 3,
+      plays: 12,
+      matched_via: [{ source: "track", title: "Old Title" }],
+      artwork_url: "https://example.com/art.jpg",
+      rotation_id: 99,
+    });
+    const updated = createTestAlbum({
+      id: 42,
+      title: "New Title",
+      label: "New Label",
+      entry: 99,
+      plays: 0,
+      matched_via: undefined,
+      artwork_url: null,
+      rotation_id: undefined,
+    });
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.title).toBe("New Title");
+    expect(merged.label).toBe("New Label");
+    expect(merged.entry).toBe(3);
+    expect(merged.plays).toBe(12);
+    expect(merged.matched_via).toEqual(existing.matched_via);
+    expect(merged.artwork_url).toBe("https://example.com/art.jpg");
+    expect(merged.rotation_id).toBe(99);
+  });
+
+  it("merges albums with empty title fields from LML-only rows", () => {
+    const existing = createTestAlbum({
+      id: 42,
+      title: "Old Title",
+      genre_id: 1,
+    });
+    const updated: AlbumEntry = {
+      ...createTestAlbum({ id: 42 }),
+      title: "",
+      label: "",
+      entry: 0,
+      artist: {
+        name: "",
+        lettercode: "AB",
+        numbercode: 1,
+        genre: "Rock",
+        id: 5,
+      },
+      genre_id: 7,
+      format_id: 3,
+    };
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.title).toBe("");
+    expect(merged.genre_id).toBe(7);
+    expect(merged.format_id).toBe(3);
+  });
+});

--- a/lib/features/catalog/patchSearchResult.test.ts
+++ b/lib/features/catalog/patchSearchResult.test.ts
@@ -11,7 +11,7 @@ describe("mergeAlbumIntoSearchResult", () => {
       label: "Old Label",
       entry: 3,
       plays: 12,
-      matched_via: [{ source: "track", title: "Old Title" }],
+      matched_via: [{ source: "library_identity", title: "Old Title" }],
       artwork_url: "https://example.com/art.jpg",
       rotation_id: 99,
     });
@@ -43,11 +43,13 @@ describe("mergeAlbumIntoSearchResult", () => {
       date_lost: "2024-01-01",
       date_found: undefined,
     });
-    const updated = createTestAlbum({
-      id: 42,
+    const updated = {
+      ...createTestAlbum({
+        id: 42,
+        date_found: "2024-02-01",
+      }),
       date_lost: null,
-      date_found: "2024-02-01",
-    });
+    } as AlbumEntry;
 
     const merged = mergeAlbumIntoSearchResult(existing, updated);
 

--- a/lib/features/catalog/patchSearchResult.test.ts
+++ b/lib/features/catalog/patchSearchResult.test.ts
@@ -43,13 +43,11 @@ describe("mergeAlbumIntoSearchResult", () => {
       date_lost: "2024-01-01",
       date_found: undefined,
     });
-    const updated = {
-      ...createTestAlbum({
-        id: 42,
-        date_found: "2024-02-01",
-      }),
+    const updated = createTestAlbum({
+      id: 42,
       date_lost: null,
-    } as AlbumEntry;
+      date_found: "2024-02-01",
+    });
 
     const merged = mergeAlbumIntoSearchResult(existing, updated);
 

--- a/lib/features/catalog/patchSearchResult.ts
+++ b/lib/features/catalog/patchSearchResult.ts
@@ -1,14 +1,35 @@
 import type { AlbumEntry } from "./types";
 
+/** Partial row emitted by {@link patchCatalogSearchRotation} (rotation-only). */
+export function isRotationSearchPatch(updated: AlbumEntry): boolean {
+  return (
+    updated.title === "" &&
+    updated.label === "" &&
+    updated.entry === 0 &&
+    updated.artist.name === "" &&
+    updated.genre_id === undefined &&
+    updated.format_id === undefined
+  );
+}
+
 /** Merge a saved album into a catalog search row, keeping query-only fields. */
 export function mergeAlbumIntoSearchResult(
   existing: AlbumEntry,
   updated: AlbumEntry,
 ): AlbumEntry {
+  if (isRotationSearchPatch(updated)) {
+    return {
+      ...existing,
+      rotation_bin: updated.rotation_bin,
+      rotation_id: updated.rotation_id,
+    };
+  }
+
   return {
     ...existing,
     ...updated,
     id: existing.id,
+    // Preserve search-row entry number; artist lettercode/number can update via spread.
     entry: existing.entry,
     matched_via: existing.matched_via,
     artwork_url: updated.artwork_url ?? existing.artwork_url,
@@ -17,8 +38,10 @@ export function mergeAlbumIntoSearchResult(
     plays: existing.plays ?? updated.plays,
     add_date: existing.add_date ?? updated.add_date,
     on_streaming: updated.on_streaming ?? existing.on_streaming,
-    date_lost: updated.date_lost ?? existing.date_lost,
-    date_found: updated.date_found ?? existing.date_found,
+    date_lost:
+      updated.date_lost === undefined ? existing.date_lost : updated.date_lost,
+    date_found:
+      updated.date_found === undefined ? existing.date_found : updated.date_found,
     album_artist: updated.album_artist ?? existing.album_artist,
   };
 }

--- a/lib/features/catalog/patchSearchResult.ts
+++ b/lib/features/catalog/patchSearchResult.ts
@@ -1,0 +1,24 @@
+import type { AlbumEntry } from "./types";
+
+/** Merge a saved album into a catalog search row, keeping query-only fields. */
+export function mergeAlbumIntoSearchResult(
+  existing: AlbumEntry,
+  updated: AlbumEntry,
+): AlbumEntry {
+  return {
+    ...existing,
+    ...updated,
+    id: existing.id,
+    entry: existing.entry,
+    matched_via: existing.matched_via,
+    artwork_url: updated.artwork_url ?? existing.artwork_url,
+    rotation_bin: existing.rotation_bin,
+    rotation_id: existing.rotation_id,
+    plays: existing.plays ?? updated.plays,
+    add_date: existing.add_date ?? updated.add_date,
+    on_streaming: updated.on_streaming ?? existing.on_streaming,
+    date_lost: updated.date_lost ?? existing.date_lost,
+    date_found: updated.date_found ?? existing.date_found,
+    album_artist: updated.album_artist ?? existing.album_artist,
+  };
+}

--- a/lib/features/catalog/patchSearchRotation.test.ts
+++ b/lib/features/catalog/patchSearchRotation.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { patchCatalogSearchRotation } from "./patchSearchCaches";
+import { catalogApi } from "./api";
+import { catalogSlice } from "./frontend";
+import { createTestAlbum } from "@/lib/test-utils";
+
+describe("patchCatalogSearchRotation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("updates rotation fields on cached search rows", () => {
+    const dispatch = vi.fn();
+    const queryArgs = { q: "artist:Test" };
+    const album = createTestAlbum({ id: 900 });
+
+    vi.spyOn(catalogApi.util, "selectCachedArgsForQuery").mockReturnValue([
+      queryArgs,
+    ]);
+
+    vi.spyOn(catalogApi.util, "updateQueryData").mockImplementation(
+      (_endpoint, args, updater) => {
+        expect(args).toEqual(queryArgs);
+        const draft = {
+          pages: [
+            {
+              results: [album],
+              total: 1,
+              page: 0,
+              totalPages: 1,
+            },
+          ],
+        };
+        updater(draft);
+        expect(draft.pages[0].results[0].rotation_bin).toBe("H");
+        expect(draft.pages[0].results[0].rotation_id).toBe(12);
+        return { type: "catalogApi/updateQueryData" } as never;
+      },
+    );
+
+    patchCatalogSearchRotation(dispatch, () => ({} as never), 900, {
+      rotation_bin: "H",
+      rotation_id: 12,
+    });
+
+    expect(dispatch).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith(
+      catalogSlice.actions.setAlbumRotation({
+        albumId: 900,
+        rotation_bin: "H",
+        rotation_id: 12,
+      }),
+    );
+  });
+
+  it("inserts the album when rotation filter matches and row was absent", () => {
+    const dispatch = vi.fn();
+    const queryArgs = { rotation_bins: "H" };
+    const album = createTestAlbum({
+      id: 42,
+      rotation_bin: "H",
+      rotation_id: 99,
+      title: "New Heavy LP",
+    });
+
+    vi.spyOn(catalogApi.util, "selectCachedArgsForQuery").mockReturnValue([
+      queryArgs,
+    ]);
+
+    vi.spyOn(catalogApi.endpoints.getInformation, "select").mockReturnValue(
+      (() => () => undefined) as unknown as ReturnType<
+        typeof catalogApi.endpoints.getInformation.select
+      >,
+    );
+
+    vi.spyOn(catalogApi.util, "updateQueryData").mockImplementation(
+      (_endpoint, args, updater) => {
+        expect(args).toEqual(queryArgs);
+        const draft = {
+          pages: [
+            {
+              results: [createTestAlbum({ id: 1, rotation_bin: "H" })],
+              total: 1,
+              page: 0,
+              totalPages: 1,
+            },
+          ],
+        };
+        updater(draft);
+        expect(draft.pages[0].results).toHaveLength(2);
+        expect(draft.pages[0].results[0].id).toBe(42);
+        expect(draft.pages[0].results[0].rotation_bin).toBe("H");
+        expect(draft.pages[0].total).toBe(2);
+        return { type: "catalogApi/updateQueryData" } as never;
+      },
+    );
+
+    patchCatalogSearchRotation(
+      dispatch,
+      () => ({} as never),
+      42,
+      { rotation_bin: "H", rotation_id: 99 },
+      album,
+    );
+  });
+});

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -224,3 +224,25 @@ export type Genre =
   | "Soundtracks"
   | "OCS"
   | "Unknown";
+
+/** Shared rotation UI state for a library album (search row, edit panel, context menu). */
+export type CatalogAlbumRotation = {
+  rotation_bin: Rotation | undefined;
+  rotation_id: number | undefined;
+};
+
+/** Open catalog result row context menu (at most one globally). */
+export type CatalogResultContextMenuState = {
+  albumId: number;
+  top: number;
+  left: number;
+};
+
+export type CatalogFrontendState = CatalogSearchState & {
+  /** Latest album saved from catalog edit; drives in-memory search list refresh. */
+  lastPatchedSearchResult: AlbumEntry | null;
+  /** Per-album rotation after apply or hydrate; ties rightbar and catalog results together. */
+  rotationByAlbumId: Record<number, CatalogAlbumRotation>;
+  /** Which search result row owns the open context menu, if any. */
+  resultContextMenu: CatalogResultContextMenuState | null;
+};

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -143,8 +143,8 @@ export type AlbumEntry = {
   add_date: string | undefined;
   label: string;
   on_streaming?: boolean;
-  date_lost?: string;
-  date_found?: string;
+  date_lost?: string | null;
+  date_found?: string | null;
   artwork_url?: string | null;
   matched_via?: TrackMatchHint[];
   /** Present on `/library/info` responses for catalog edit. */


### PR DESCRIPTION
## Summary
Split from #648 (umbrella). Stacked on #795.

Adds optimistic cache patching for catalog search results and rotation changes. Ungated — dormant until mutations fire.

**Review findings addressed (5–11):**
- Block rotation inserts into text-search (`q`) caches while still updating existing rows in place
- Bidirectional `on_streaming` and `missing` filter matching
- Skip blank stub inserts when no album data is available
- Respect sort order when inserting into cached pages
- Decrement total by duplicate removal count across pages
- Remove rotation-only sentinel false positives in merge (full merge always)
- Wire `markMissing`/`markFound` to `patchCatalogSearchCaches`

## Test plan
- [ ] `npm test -- lib/features/catalog/patchSearch*.test.ts lib/features/catalog/catalogSearchQueryMatch.test.ts`

Depends on #795. Part of the #648 split stack.

Made with [Cursor](https://cursor.com)