### PR TITLE
feat(auth): MD catalog permission gate via JWT org role

### DIFF
--- a/e2e/tests/rbac/role-access.spec.ts
+++ b/e2e/tests/rbac/role-access.spec.ts
@@ -25,22 +25,10 @@ test.describe("Role-Based Access Control", () => {
       await dashboardPage.expectOnCatalog();
     });
 
-    test("should not see catalog Edit control", async ({ page }) => {
-      await dashboardPage.gotoCatalog();
-      await dashboardPage.expectCatalogEditHidden();
-    });
-
     test("should be redirected from admin roster page", async ({ page }) => {
       await dashboardPage.gotoAdminRoster();
       // DJ should be redirected to default dashboard page (insufficient permissions)
       await dashboardPage.expectRedirectedToDefaultDashboard();
-    });
-
-    test("legacy admin catalog URL redirects to Card Catalog", async ({
-      page,
-    }) => {
-      await dashboardPage.gotoLegacyAdminCatalog();
-      await dashboardPage.expectRedirectedToCatalog();
     });
 
     test("should not see admin navigation link", async ({ page }) => {
@@ -67,28 +55,10 @@ test.describe("Role-Based Access Control", () => {
       await dashboardPage.expectOnCatalog();
     });
 
-    test("should see catalog Edit control and open add entry panel", async ({
-      page,
-    }) => {
-      await dashboardPage.gotoCatalog();
-      await dashboardPage.expectCatalogEditVisible();
-      await dashboardPage.catalogEditButton.click();
-      await expect(page.getByText("Add to catalog", { exact: true })).toBeVisible({
-        timeout: 10000,
-      });
-    });
-
     test("should be redirected from admin roster page", async ({ page }) => {
       await dashboardPage.gotoAdminRoster();
       // MD should also be redirected (roster requires SM)
       await dashboardPage.expectRedirectedToDefaultDashboard();
-    });
-
-    test("legacy admin catalog URL redirects to Card Catalog", async ({
-      page,
-    }) => {
-      await dashboardPage.gotoLegacyAdminCatalog();
-      await dashboardPage.expectRedirectedToCatalog();
     });
   });
 
@@ -109,22 +79,10 @@ test.describe("Role-Based Access Control", () => {
       await dashboardPage.expectOnCatalog();
     });
 
-    test("should see catalog Edit control", async ({ page }) => {
-      await dashboardPage.gotoCatalog();
-      await dashboardPage.expectCatalogEditVisible();
-    });
-
     test("should access admin roster page", async ({ page }) => {
       await dashboardPage.gotoAdminRoster();
       // SM should have full access
       await dashboardPage.expectOnAdminRoster();
-    });
-
-    test("legacy admin catalog URL redirects to Card Catalog", async ({
-      page,
-    }) => {
-      await dashboardPage.gotoLegacyAdminCatalog();
-      await dashboardPage.expectRedirectedToCatalog();
     });
 
     test("should see DJ Roster page header", async ({ page }) => {
@@ -154,17 +112,9 @@ test.describe("Role-Based Access Control", () => {
       await dashboardPage.expectRedirectedToDefaultDashboard();
     });
 
-    test("legacy admin catalog URL redirects to Card Catalog", async ({
-      page,
-    }) => {
-      await dashboardPage.gotoLegacyAdminCatalog();
-      await dashboardPage.expectRedirectedToCatalog();
-    });
-
     test("should access catalog page (read only)", async ({ page }) => {
       await dashboardPage.gotoCatalog();
       await dashboardPage.expectOnCatalog();
-      await dashboardPage.expectCatalogEditHidden();
     });
   });
 

--- a/e2e/tests/rbac/role-access.spec.ts
+++ b/e2e/tests/rbac/role-access.spec.ts
@@ -25,10 +25,22 @@ test.describe("Role-Based Access Control", () => {
       await dashboardPage.expectOnCatalog();
     });
 
+    test("should not see catalog Edit control", async ({ page }) => {
+      await dashboardPage.gotoCatalog();
+      await dashboardPage.expectCatalogEditHidden();
+    });
+
     test("should be redirected from admin roster page", async ({ page }) => {
       await dashboardPage.gotoAdminRoster();
       // DJ should be redirected to default dashboard page (insufficient permissions)
       await dashboardPage.expectRedirectedToDefaultDashboard();
+    });
+
+    test("legacy admin catalog URL redirects to Card Catalog", async ({
+      page,
+    }) => {
+      await dashboardPage.gotoLegacyAdminCatalog();
+      await dashboardPage.expectRedirectedToCatalog();
     });
 
     test("should not see admin navigation link", async ({ page }) => {
@@ -55,10 +67,28 @@ test.describe("Role-Based Access Control", () => {
       await dashboardPage.expectOnCatalog();
     });
 
+    test("should see catalog Edit control and open add entry panel", async ({
+      page,
+    }) => {
+      await dashboardPage.gotoCatalog();
+      await dashboardPage.expectCatalogEditVisible();
+      await dashboardPage.catalogEditButton.click();
+      await expect(page.getByText("Add to catalog", { exact: true })).toBeVisible({
+        timeout: 10000,
+      });
+    });
+
     test("should be redirected from admin roster page", async ({ page }) => {
       await dashboardPage.gotoAdminRoster();
       // MD should also be redirected (roster requires SM)
       await dashboardPage.expectRedirectedToDefaultDashboard();
+    });
+
+    test("legacy admin catalog URL redirects to Card Catalog", async ({
+      page,
+    }) => {
+      await dashboardPage.gotoLegacyAdminCatalog();
+      await dashboardPage.expectRedirectedToCatalog();
     });
   });
 
@@ -79,10 +109,22 @@ test.describe("Role-Based Access Control", () => {
       await dashboardPage.expectOnCatalog();
     });
 
+    test("should see catalog Edit control", async ({ page }) => {
+      await dashboardPage.gotoCatalog();
+      await dashboardPage.expectCatalogEditVisible();
+    });
+
     test("should access admin roster page", async ({ page }) => {
       await dashboardPage.gotoAdminRoster();
       // SM should have full access
       await dashboardPage.expectOnAdminRoster();
+    });
+
+    test("legacy admin catalog URL redirects to Card Catalog", async ({
+      page,
+    }) => {
+      await dashboardPage.gotoLegacyAdminCatalog();
+      await dashboardPage.expectRedirectedToCatalog();
     });
 
     test("should see DJ Roster page header", async ({ page }) => {
@@ -112,9 +154,17 @@ test.describe("Role-Based Access Control", () => {
       await dashboardPage.expectRedirectedToDefaultDashboard();
     });
 
+    test("legacy admin catalog URL redirects to Card Catalog", async ({
+      page,
+    }) => {
+      await dashboardPage.gotoLegacyAdminCatalog();
+      await dashboardPage.expectRedirectedToCatalog();
+    });
+
     test("should access catalog page (read only)", async ({ page }) => {
       await dashboardPage.gotoCatalog();
       await dashboardPage.expectOnCatalog();
+      await dashboardPage.expectCatalogEditHidden();
     });
   });
 

--- a/lib/__tests__/features/authentication/organization-utils.test.ts
+++ b/lib/__tests__/features/authentication/organization-utils.test.ts
@@ -15,6 +15,7 @@ vi.mock("@/lib/features/authentication/server-client", () => ({
 // Mock auth client (client-side)
 const mockClientListMembers = vi.fn();
 const mockGetFullOrganization = vi.fn();
+const mockGetJWTToken = vi.fn();
 vi.mock("@/lib/features/authentication/client", () => ({
   authClient: {
     organization: {
@@ -23,6 +24,7 @@ vi.mock("@/lib/features/authentication/client", () => ({
     },
   },
   authBaseURL: "https://api.wxyc.org/auth",
+  getJWTToken: () => mockGetJWTToken(),
 }));
 
 // Mock fetch for organization slug resolution (used by server-side tests)
@@ -32,7 +34,9 @@ vi.stubGlobal("fetch", mockFetch);
 import {
   getAppOrganizationId,
   getAppOrganizationIdClient,
+  fetchOrganizationRoleForUserClient,
   getUserRoleInOrganizationClient,
+  organizationRoleFromJwtToken,
   resolveOrganizationIdAdmin,
   _resetOrgCacheForTesting,
 } from "@/lib/features/authentication/organization-utils";
@@ -164,11 +168,35 @@ describe("organization-utils", () => {
   describe("getUserRoleInOrganization", () => {
     beforeEach(() => {
       process.env.NEXT_PUBLIC_BETTER_AUTH_URL = "https://api.wxyc.org/auth";
-      // Mock successful organization slug resolution
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ id: "resolved-org-id" }),
+      mockFetch.mockImplementation((input: RequestInfo) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/token")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ token: null }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ id: "resolved-org-id" }),
+        });
       });
+    });
+
+    it("should return role from JWT without calling listMembers", async () => {
+      const payload = Buffer.from(
+        JSON.stringify({ sub: "user-123", role: "musicDirector" })
+      ).toString("base64url");
+      server.use(
+        http.get("https://api.wxyc.org/auth/token", () =>
+          HttpResponse.json({ token: `header.${payload}.sig` })
+        )
+      );
+
+      const result = await getUserRoleInOrganization("user-123", "wxyc", "cookie");
+
+      expect(result).toBe("musicDirector");
+      expect(mockListMembers).not.toHaveBeenCalled();
     });
 
     it("should return user role when member exists", async () => {
@@ -281,12 +309,60 @@ describe("organization-utils", () => {
     });
   });
 
+  describe("organizationRoleFromJwtToken", () => {
+    it("returns normalized role when JWT matches user", () => {
+      const payload = Buffer.from(
+        JSON.stringify({ sub: "user-123", role: "musicDirector" })
+      ).toString("base64url");
+      const token = `header.${payload}.sig`;
+
+      expect(organizationRoleFromJwtToken(token, "user-123")).toBe("musicDirector");
+    });
+
+    it("returns undefined when JWT user id does not match", () => {
+      const payload = Buffer.from(
+        JSON.stringify({ sub: "other-user", role: "musicDirector" })
+      ).toString("base64url");
+      const token = `header.${payload}.sig`;
+
+      expect(organizationRoleFromJwtToken(token, "user-123")).toBeUndefined();
+    });
+  });
+
+  describe("fetchOrganizationRoleForUserClient", () => {
+    it("should return role from JWT without an organization slug", async () => {
+      const payload = Buffer.from(
+        JSON.stringify({ sub: "user-123", role: "musicDirector" })
+      ).toString("base64url");
+      mockGetJWTToken.mockResolvedValue(`header.${payload}.sig`);
+
+      const result = await fetchOrganizationRoleForUserClient("user-123");
+
+      expect(result).toBe("musicDirector");
+      expect(mockClientListMembers).not.toHaveBeenCalled();
+    });
+  });
+
   describe("getUserRoleInOrganizationClient", () => {
     beforeEach(() => {
+      mockGetJWTToken.mockResolvedValue(null);
       mockGetFullOrganization.mockResolvedValue({
         data: { id: "resolved-org-id" },
         error: null,
       });
+    });
+
+    it("should return role from JWT without calling listMembers", async () => {
+      const payload = Buffer.from(
+        JSON.stringify({ sub: "user-123", role: "musicDirector" })
+      ).toString("base64url");
+      mockGetJWTToken.mockResolvedValue(`header.${payload}.sig`);
+
+      const result = await getUserRoleInOrganizationClient("user-123", "wxyc");
+
+      expect(result).toBe("musicDirector");
+      expect(mockClientListMembers).not.toHaveBeenCalled();
+      expect(mockGetFullOrganization).not.toHaveBeenCalled();
     });
 
     it("should return user role when member exists", async () => {

--- a/lib/__tests__/features/authentication/organization-utils.test.ts
+++ b/lib/__tests__/features/authentication/organization-utils.test.ts
@@ -199,6 +199,28 @@ describe("organization-utils", () => {
       expect(mockListMembers).not.toHaveBeenCalled();
     });
 
+    it("falls through to listMembers when JWT role is unrecognized", async () => {
+      const payload = Buffer.from(
+        JSON.stringify({ sub: "user-123", role: "superuser" })
+      ).toString("base64url");
+      server.use(
+        http.get("https://api.wxyc.org/auth/token", () =>
+          HttpResponse.json({ token: `header.${payload}.sig` })
+        )
+      );
+      mockListMembers.mockResolvedValue({
+        data: {
+          members: [{ userId: "user-123", role: "dj" }],
+        },
+        error: null,
+      });
+
+      const result = await getUserRoleInOrganization("user-123", "wxyc", "cookie");
+
+      expect(result).toBe("dj");
+      expect(mockListMembers).toHaveBeenCalled();
+    });
+
     it("should return user role when member exists", async () => {
       mockListMembers.mockResolvedValue({
         data: {
@@ -322,6 +344,28 @@ describe("organization-utils", () => {
     it("returns undefined when JWT user id does not match", () => {
       const payload = Buffer.from(
         JSON.stringify({ sub: "other-user", role: "musicDirector" })
+      ).toString("base64url");
+      const token = `header.${payload}.sig`;
+
+      expect(organizationRoleFromJwtToken(token, "user-123")).toBeUndefined();
+    });
+
+    it("returns undefined for expired JWTs", () => {
+      const payload = Buffer.from(
+        JSON.stringify({
+          sub: "user-123",
+          role: "musicDirector",
+          exp: Math.floor(Date.now() / 1000) - 60,
+        })
+      ).toString("base64url");
+      const token = `header.${payload}.sig`;
+
+      expect(organizationRoleFromJwtToken(token, "user-123")).toBeUndefined();
+    });
+
+    it("returns undefined for unrecognized JWT roles", () => {
+      const payload = Buffer.from(
+        JSON.stringify({ sub: "user-123", role: "superuser" })
       ).toString("base64url");
       const token = `header.${payload}.sig`;
 

--- a/lib/features/authentication/organization-utils.server.ts
+++ b/lib/features/authentication/organization-utils.server.ts
@@ -1,6 +1,23 @@
 import { serverAuthClient } from "./server-client";
-import { normalizeRole } from "./organization-utils";
+import { normalizeRole, organizationRoleFromJwtToken } from "./organization-utils";
 import { WXYCRole } from "./types";
+
+async function fetchAuthJwtToken(cookieHeader?: string): Promise<string | null> {
+  const baseURL = process.env.NEXT_PUBLIC_BETTER_AUTH_URL || "http://localhost:8082/auth";
+  try {
+    const response = await fetch(`${baseURL}/token`, {
+      method: "GET",
+      headers: cookieHeader ? { cookie: cookieHeader } : {},
+    });
+    if (!response.ok) {
+      return null;
+    }
+    const data = await response.json();
+    return typeof data.token === "string" ? data.token : null;
+  } catch {
+    return null;
+  }
+}
 
 // Re-export client-safe functions for convenience
 export { getAppOrganizationId, getAppOrganizationIdClient } from "./organization-utils";
@@ -69,6 +86,16 @@ export async function getUserRoleInOrganization(
   cookieHeader?: string
 ): Promise<WXYCRole | undefined> {
   try {
+    if (cookieHeader) {
+      const jwtToken = await fetchAuthJwtToken(cookieHeader);
+      if (jwtToken) {
+        const jwtRole = organizationRoleFromJwtToken(jwtToken, userId);
+        if (jwtRole) {
+          return jwtRole;
+        }
+      }
+    }
+
     // Resolve slug to ID if needed
     const organizationId = await resolveOrganizationId(organizationSlugOrId, cookieHeader);
     

--- a/lib/features/authentication/organization-utils.ts
+++ b/lib/features/authentication/organization-utils.ts
@@ -78,6 +78,22 @@ async function resolveOrganizationIdClient(
   }
 }
 
+/** Whether a normalized role string is a known WXYC org role we trust from JWT claims. */
+export function isRecognizedOrganizationRole(role: string): boolean {
+  switch (normalizeRole(role)) {
+    case "member":
+    case "dj":
+    case "musicDirector":
+    case "stationManager":
+    case "owner":
+    case "admin":
+    case "user":
+      return true;
+    default:
+      return false;
+  }
+}
+
 /**
  * Read the current user's organization role from a better-auth JWT.
  * JWTs include member role for all authenticated users; organization.listMembers
@@ -89,8 +105,14 @@ export function organizationRoleFromJwtToken(
 ): WXYCRole | undefined {
   try {
     const decoded = jwtDecode<BetterAuthJwtPayload>(token);
+    if (typeof decoded.exp === "number" && decoded.exp * 1000 <= Date.now()) {
+      return undefined;
+    }
     const tokenUserId = decoded.id || decoded.sub;
     if (!tokenUserId || tokenUserId !== userId || !decoded.role) {
+      return undefined;
+    }
+    if (!isRecognizedOrganizationRole(decoded.role)) {
       return undefined;
     }
     return normalizeRole(decoded.role) as WXYCRole;

--- a/lib/features/authentication/organization-utils.ts
+++ b/lib/features/authentication/organization-utils.ts
@@ -1,6 +1,7 @@
-import { authClient, authBaseURL } from "./client";
+import { jwtDecode } from "jwt-decode";
+import { authClient, authBaseURL, getJWTToken } from "./client";
 import { getAppOrganizationId, getAppOrganizationIdClient } from "./organization-config";
-import { WXYCRole } from "./types";
+import { BetterAuthJwtPayload, WXYCRole } from "./types";
 
 /**
  * Module-level cache for the organization ID resolved via the admin endpoint.
@@ -78,6 +79,51 @@ async function resolveOrganizationIdClient(
 }
 
 /**
+ * Read the current user's organization role from a better-auth JWT.
+ * JWTs include member role for all authenticated users; organization.listMembers
+ * is restricted to admins and returns nothing useful for DJs and music directors.
+ */
+export function organizationRoleFromJwtToken(
+  token: string,
+  userId: string
+): WXYCRole | undefined {
+  try {
+    const decoded = jwtDecode<BetterAuthJwtPayload>(token);
+    const tokenUserId = decoded.id || decoded.sub;
+    if (!tokenUserId || tokenUserId !== userId || !decoded.role) {
+      return undefined;
+    }
+    return normalizeRole(decoded.role) as WXYCRole;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the current user's organization role on the client.
+ * Prefers the JWT (available to every authenticated member); falls back to
+ * organization.listMembers when a slug/id is provided (admin-only in practice).
+ */
+export async function fetchOrganizationRoleForUserClient(
+  userId: string,
+  organizationSlugOrId?: string
+): Promise<WXYCRole | undefined> {
+  const jwtToken = await getJWTToken();
+  if (jwtToken) {
+    const jwtRole = organizationRoleFromJwtToken(jwtToken, userId);
+    if (jwtRole) {
+      return jwtRole;
+    }
+  }
+
+  if (!organizationSlugOrId) {
+    return undefined;
+  }
+
+  return getUserRoleInOrganizationClient(userId, organizationSlugOrId);
+}
+
+/**
  * Client-side: Get user's role in a specific organization
  * @param userId - The user ID to look up
  * @param organizationSlugOrId - The organization slug (e.g., "wxyc") or ID
@@ -88,6 +134,14 @@ export async function getUserRoleInOrganizationClient(
   organizationSlugOrId: string
 ): Promise<WXYCRole | undefined> {
   try {
+    const jwtToken = await getJWTToken();
+    if (jwtToken) {
+      const jwtRole = organizationRoleFromJwtToken(jwtToken, userId);
+      if (jwtRole) {
+        return jwtRole;
+      }
+    }
+
     // Resolve slug to ID if needed
     const organizationId = await resolveOrganizationIdClient(organizationSlugOrId);
 

--- a/lib/features/authentication/utilities.ts
+++ b/lib/features/authentication/utilities.ts
@@ -162,24 +162,22 @@ export async function betterAuthSessionToAuthenticationDataAsync(
 
   let roleToMap: string | undefined;
 
-  // Try to get role from APP_ORGANIZATION first
-  // Use client-safe function that checks NEXT_PUBLIC_APP_ORGANIZATION first, then server-side APP_ORGANIZATION
   const organizationId = typeof window !== "undefined"
     ? getAppOrganizationIdClient()
     : getAppOrganizationId();
 
   if (organizationId && typeof window !== "undefined") {
     try {
-      // Client-side only: dynamically import to avoid server-side import issues
-      // The client function uses authClient which is marked "use client" and can't be imported on server
-      const { getUserRoleInOrganizationClient } = await import("./organization-utils");
-      const orgRole = await getUserRoleInOrganizationClient(session.user.id, organizationId);
+      const { fetchOrganizationRoleForUserClient } = await import("./organization-utils");
+      const orgRole = await fetchOrganizationRoleForUserClient(
+        session.user.id,
+        organizationId
+      );
 
       if (orgRole !== undefined) {
         roleToMap = orgRole;
       }
     } catch (error) {
-      // If organization query fails, fall back to session-based role extraction
       console.warn("Failed to fetch organization role, falling back to session data:", error);
     }
   }

--- a/src/hooks/useCanEditCatalog.ts
+++ b/src/hooks/useCanEditCatalog.ts
@@ -11,28 +11,39 @@ export function useCanEditCatalog(): boolean {
   const { data: session } = authClient.useSession();
   const { data } = useAuthentication();
   const [jwtAllowsEdit, setJwtAllowsEdit] = useState(false);
+  const [jwtUserId, setJwtUserId] = useState<string | undefined>();
 
   const userId =
     session?.user?.id ??
     (isAuthenticated(data) ? data.user?.id : undefined);
 
-  useEffect(() => {
-    setJwtAllowsEdit(false);
+  // Render-time gate: ignore JWT edit state until it is resolved for userId.
+  const jwtEditAllowed =
+    userId != null && userId === jwtUserId ? jwtAllowsEdit : false;
 
+  useEffect(() => {
     if (!userId) {
+      setJwtUserId(undefined);
+      setJwtAllowsEdit(false);
       return;
     }
 
     let cancelled = false;
     void (async () => {
       const token = await getJWTToken();
-      if (cancelled || !token) {
+      if (cancelled) {
+        return;
+      }
+      if (!token) {
+        setJwtUserId(userId);
+        setJwtAllowsEdit(false);
         return;
       }
       const role = organizationRoleFromJwtToken(token, userId);
-      if (!cancelled && role) {
-        setJwtAllowsEdit(roleToAuthorization(role) >= Authorization.MD);
-      }
+      setJwtUserId(userId);
+      setJwtAllowsEdit(
+        role ? roleToAuthorization(role) >= Authorization.MD : false,
+      );
     })();
 
     return () => {
@@ -40,7 +51,7 @@ export function useCanEditCatalog(): boolean {
     };
   }, [userId]);
 
-  if (jwtAllowsEdit) {
+  if (jwtEditAllowed) {
     return true;
   }
   if (isAuthenticated(data) && data.user) {

--- a/src/hooks/useCanEditCatalog.ts
+++ b/src/hooks/useCanEditCatalog.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { Authorization } from "@/lib/features/admin/types";
+import { authClient, getJWTToken } from "@/lib/features/authentication/client";
+import { organizationRoleFromJwtToken } from "@/lib/features/authentication/organization-utils";
+import { isAuthenticated, roleToAuthorization } from "@/lib/features/authentication/types";
+import { useEffect, useState } from "react";
+import { useAuthentication } from "./authenticationHooks";
+
+export function useCanEditCatalog(): boolean {
+  const { data: session } = authClient.useSession();
+  const { data } = useAuthentication();
+  const [jwtAllowsEdit, setJwtAllowsEdit] = useState(false);
+
+  const userId =
+    session?.user?.id ??
+    (isAuthenticated(data) ? data.user?.id : undefined);
+
+  useEffect(() => {
+    setJwtAllowsEdit(false);
+
+    if (!userId) {
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      const token = await getJWTToken();
+      if (cancelled || !token) {
+        return;
+      }
+      const role = organizationRoleFromJwtToken(token, userId);
+      if (!cancelled && role) {
+        setJwtAllowsEdit(roleToAuthorization(role) >= Authorization.MD);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  if (jwtAllowsEdit) {
+    return true;
+  }
+  if (isAuthenticated(data) && data.user) {
+    return data.user.authority >= Authorization.MD;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
Split from #648 (umbrella). Independent permission gate — no catalog UI yet.

- Extract `useCanEditCatalog` to `src/hooks/useCanEditCatalog.ts`
- JWT-based org role resolution (`organizationRoleFromJwtToken`, server JWT path)
- E2E RBAC coverage for catalog edit access

**Review findings addressed:**
- **#4:** Reset `jwtAllowsEdit` immediately on any `userId` change (prevents privilege leak on user switch)
- **#15:** Restore `organizationId &&` guard before client org-role fetch

## Test plan
- [ ] `npm test -- lib/__tests__/features/authentication/organization-utils.test.ts`
- [ ] `e2e/tests/rbac/role-access.spec.ts`

Part of the #648 split stack.

Made with [Cursor](https://cursor.com)