### PR TITLE
feat(catalog): search and filter UI rewrite

### DIFF
--- a/e2e/tests/catalog/query-builder.spec.ts
+++ b/e2e/tests/catalog/query-builder.spec.ts
@@ -47,34 +47,37 @@ test.describe("Catalog query builder", () => {
     await dashboard.gotoCatalog();
     await dashboard.waitForPageLoad();
 
-    // Row 0 layout: [SortBy combobox] [Field combobox] [Input] [+/-]
-    // The first combobox is SortBy (renders sort-asc/sort-desc options like
-    // "Artist (A-Z)"). The second combobox is the field selector — that's
-    // the one whose options are "All / Artist / Album / Label".
-    const firstRowCombos = page.getByRole("combobox");
-    await firstRowCombos.nth(1).click();
-    await page.getByRole("option", { name: "Artist", exact: true }).click();
+    const fieldSelect = page.getByTestId("catalog-search-field");
+    await fieldSelect.click();
+    const artistsOption = page.getByRole("option", { name: "Artists", exact: true });
+    await artistsOption.waitFor({ state: "visible", timeout: 10000 });
+    await artistsOption.click();
 
-    const firstInput = page.getByPlaceholder("Search the catalog").first();
+    const firstInput = page.getByTestId("catalog-search-input");
     await firstInput.fill("Juana Molina");
 
     await expect.poll(() => queryHits).toBeGreaterThan(0);
 
-    // Add a second row, set its field to Label and value to Sonamos.
-    await page.getByRole("button", { name: "Add row" }).click();
+    await page.getByTestId("catalog-search-add-row").click();
 
-    const secondInput = page.getByPlaceholder("Search the catalog").nth(1);
-    // After the operator combobox, row 1's second combobox is the field.
-    // The simplest way to disambiguate: find combobox by its current text.
-    const row1FieldCombo = page.getByRole("combobox").filter({ hasText: "Artist" }).last();
+    const textboxes = page.getByRole("textbox");
+    const secondInput = textboxes.nth(1);
+    const row1FieldCombo = page
+      .getByRole("combobox")
+      .filter({ hasText: "Artists" })
+      .last();
     await row1FieldCombo.click();
-    await page.getByRole("option", { name: "Label", exact: true }).click();
+    const labelsOption = page.getByRole("option", { name: "Labels", exact: true });
+    await labelsOption.waitFor({ state: "visible", timeout: 10000 });
+    await labelsOption.click();
     await secondInput.fill("Sonamos");
 
-    await expect(page.getByText("DOGA")).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText("Juana Molina")).toBeVisible();
+    const resultRow = page
+      .locator("#OrderTableContainer tbody tr")
+      .filter({ hasText: "DOGA" });
+    await expect(resultRow).toBeVisible({ timeout: 10000 });
+    await expect(resultRow.getByText("Juana Molina", { exact: true })).toBeVisible();
 
-    // The final issued q should carry both terms joined with AND.
     await expect.poll(() => lastQ ?? "").toMatch(/artist:Juana Molina/);
     await expect.poll(() => lastQ ?? "").toMatch(/AND/);
     await expect.poll(() => lastQ ?? "").toMatch(/label:Sonamos/);

--- a/lib/__tests__/features/catalog/catalog.test.ts
+++ b/lib/__tests__/features/catalog/catalog.test.ts
@@ -363,16 +363,23 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       expect(state.sortOrder).toBe("asc");
     });
 
-    it("defaults page to 0", () => {
-      expect(harness().initialState.page).toBe(0);
+    it("defaults filters to empty arrays", () => {
+      expect(harness().initialState.filters).toEqual({
+        genres: [],
+        formats: [],
+        tags: [],
+      });
     });
 
-    it("defaults filters to 'All' / undefined", () => {
-      expect(harness().initialState.filters).toEqual({
-        onStreaming: undefined,
-        genre: "All",
-        format: "All",
-      });
+    it("defaults browseEngaged to false", () => {
+      expect(harness().initialState.browseEngaged).toBe(false);
+    });
+  });
+
+  describe("engageBrowse", () => {
+    it("sets browseEngaged", () => {
+      const result = harness().reduce(actions.engageBrowse());
+      expect(result.browseEngaged).toBe(true);
     });
   });
 
@@ -381,11 +388,6 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       const result = harness().reduce(actions.addRow());
       expect(result.rows).toHaveLength(2);
       expect(result.rows[1].field).toBe("artist");
-    });
-
-    it("addRow resets page to 0", () => {
-      const result = harness().chain(actions.nextPage(), actions.addRow());
-      expect(result.page).toBe(0);
     });
 
     it("removeRow drops a row by id", () => {
@@ -415,15 +417,6 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       expect(result.rows[0].value).toBe("Stereolab");
     });
 
-    it("updateRow resets page to 0", () => {
-      const initial = harness().initialState;
-      const id = initial.rows[0].id;
-      const result = harness().chain(
-        actions.nextPage(),
-        actions.updateRow({ id, updates: { value: "x" } })
-      );
-      expect(result.page).toBe(0);
-    });
   });
 
   describe("sort", () => {
@@ -435,48 +428,29 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       expect(result.sortOrder).toBe("desc");
     });
 
-    it("setSort resets page to 0", () => {
-      const result = harness().chain(
-        actions.nextPage(),
-        actions.setSort({ sortBy: "artist", sortOrder: "asc" })
-      );
-      expect(result.page).toBe(0);
-    });
   });
 
   describe("filters", () => {
     it.each([
-      [{ onStreaming: false as boolean | undefined }, "onStreaming", false],
-      [{ genre: "Rock" } as const, "genre", "Rock"],
-      [{ format: "CD" } as const, "format", "CD"],
-    ])("setFilter updates %s", (patch, key, expected) => {
+      [{ tags: ["exclusives"] }, "tags", ["exclusives"]],
+      [{ genres: ["Rock"] }, "genres", ["Rock"]],
+      [{ formats: ["cd"] }, "formats", ["cd"]],
+    ] as const satisfies ReadonlyArray<
+      [Partial<import("@/lib/features/catalog/types").CatalogFilters>, string, string[]]
+    >)("setFilter updates %s", (patch, key, expected) => {
       const result = harness().reduce(actions.setFilter(patch));
-      expect((result.filters as Record<string, unknown>)[key as string]).toBe(expected);
+      expect((result.filters as Record<string, unknown>)[key as string]).toEqual(expected);
     });
 
     it("setFilter merges with existing filters", () => {
       const result = harness().chain(
-        actions.setFilter({ genre: "Rock" }),
-        actions.setFilter({ format: "Vinyl" })
+        actions.setFilter({ genres: ["Rock"] }),
+        actions.setFilter({ formats: ["Vinyl"] })
       );
-      expect(result.filters.genre).toBe("Rock");
-      expect(result.filters.format).toBe("Vinyl");
+      expect(result.filters.genres).toEqual(["Rock"]);
+      expect(result.filters.formats).toEqual(["Vinyl"]);
     });
 
-    it("setFilter resets page to 0", () => {
-      const result = harness().chain(
-        actions.nextPage(),
-        actions.setFilter({ genre: "Rock" })
-      );
-      expect(result.page).toBe(0);
-    });
-  });
-
-  describe("pagination", () => {
-    it("nextPage increments page", () => {
-      const result = harness().chain(actions.nextPage(), actions.nextPage());
-      expect(result.page).toBe(2);
-    });
   });
 
   describe("selection", () => {
@@ -532,8 +506,7 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       const result = harness().chain(
         actions.updateRow({ id, updates: { value: "Cat Power" } }),
         actions.setSort({ sortBy: "plays", sortOrder: "desc" }),
-        actions.setFilter({ genre: "Rock" }),
-        actions.nextPage(),
+        actions.setFilter({ genres: ["Rock"] }),
         actions.setSelection([1, 2, 3]),
         actions.openMobileSearch(),
         actions.reset()
@@ -541,4 +514,5 @@ describeSlice(catalogSlice, defaultCatalogFrontendState, ({ harness, actions }) 
       expect(result).toEqual(defaultCatalogFrontendState);
     });
   });
+
 });

--- a/lib/features/catalog/catalogRotation.test.ts
+++ b/lib/features/catalog/catalogRotation.test.ts
@@ -35,7 +35,7 @@ describe("catalogSlice rotation state", () => {
     expect(state.rotationByAlbumId[42]).toBeUndefined();
   });
 
-  it("setFilter preserves rotationByAlbumId when filters change", () => {
+  it("setFilter preserves rotationByAlbumId when non-tag filters change", () => {
     let state = catalogSlice.reducer(
       defaultCatalogFrontendState,
       catalogSlice.actions.setAlbumRotation({
@@ -46,12 +46,29 @@ describe("catalogSlice rotation state", () => {
     );
     state = catalogSlice.reducer(
       state,
-      catalogSlice.actions.setFilter({ onStreaming: false }),
+      catalogSlice.actions.setFilter({ genres: ["Rock"] }),
     );
     expect(state.rotationByAlbumId[42]).toEqual({
       rotation_bin: "M",
       rotation_id: 99,
     });
-    expect(state.filters.onStreaming).toBe(false);
+    expect(state.filters.genres).toEqual(["Rock"]);
+  });
+
+  it("setFilter clears rotationByAlbumId when tags change", () => {
+    let state = catalogSlice.reducer(
+      defaultCatalogFrontendState,
+      catalogSlice.actions.setAlbumRotation({
+        albumId: 42,
+        rotation_bin: "M",
+        rotation_id: 99,
+      }),
+    );
+    state = catalogSlice.reducer(
+      state,
+      catalogSlice.actions.setFilter({ tags: ["H"] }),
+    );
+    expect(state.rotationByAlbumId).toEqual({});
+    expect(state.filters.tags).toEqual(["H"]);
   });
 });

--- a/lib/features/catalog/frontend.ts
+++ b/lib/features/catalog/frontend.ts
@@ -11,8 +11,11 @@ import type {
   CatalogSortOrder,
 } from "./types";
 
-const createInitialRow = (): CatalogSearchRow => ({
-  id: crypto.randomUUID(),
+/** Stable id for the primary row so SSR and client hydration agree on React keys. */
+export const CATALOG_PRIMARY_ROW_ID = "catalog-search-primary";
+
+const createInitialRow = (id?: string): CatalogSearchRow => ({
+  id: id ?? crypto.randomUUID(),
   operator: "AND",
   field: "all",
   value: "",
@@ -20,13 +23,13 @@ const createInitialRow = (): CatalogSearchRow => ({
 });
 
 export const defaultCatalogFrontendState: CatalogFrontendState = {
-  rows: [createInitialRow()],
+  rows: [createInitialRow(CATALOG_PRIMARY_ROW_ID)],
   sortBy: "album",
   sortOrder: "asc",
-  page: 0,
-  filters: { onStreaming: undefined, genre: "All", format: "All" },
+  filters: { genres: [], formats: [], tags: [] },
   selected: [],
   mobileOpen: false,
+  browseEngaged: false,
   lastPatchedSearchResult: null,
   rotationByAlbumId: {},
   resultContextMenu: null,
@@ -38,12 +41,10 @@ export const catalogSlice = createAppSlice({
   reducers: {
     addRow: (state) => {
       state.rows.push({ ...createInitialRow(), field: "artist" });
-      state.page = 0;
     },
     removeRow: (state, action: PayloadAction<string>) => {
       if (state.rows.length > 1) {
         state.rows = state.rows.filter((r) => r.id !== action.payload);
-        state.page = 0;
       }
     },
     updateRow: (
@@ -53,7 +54,6 @@ export const catalogSlice = createAppSlice({
       const row = state.rows.find((r) => r.id === action.payload.id);
       if (row) {
         Object.assign(row, action.payload.updates);
-        state.page = 0;
       }
     },
     setSort: (
@@ -62,14 +62,12 @@ export const catalogSlice = createAppSlice({
     ) => {
       state.sortBy = action.payload.sortBy;
       state.sortOrder = action.payload.sortOrder;
-      state.page = 0;
     },
     setFilter: (state, action: PayloadAction<Partial<CatalogFilters>>) => {
       state.filters = { ...state.filters, ...action.payload };
-      state.page = 0;
-    },
-    nextPage: (state) => {
-      state.page += 1;
+      if (action.payload.tags !== undefined) {
+        state.rotationByAlbumId = {};
+      }
     },
     setSelection: (state, action: PayloadAction<number[]>) => {
       state.selected = action.payload;
@@ -88,6 +86,9 @@ export const catalogSlice = createAppSlice({
     },
     closeMobileSearch: (state) => {
       state.mobileOpen = false;
+    },
+    engageBrowse: (state) => {
+      state.browseEngaged = true;
     },
     patchSearchResult: (state, action: PayloadAction<AlbumEntry>) => {
       state.lastPatchedSearchResult = action.payload;
@@ -117,10 +118,10 @@ export const catalogSlice = createAppSlice({
     getRows: (state) => state.rows,
     getSortBy: (state) => state.sortBy,
     getSortOrder: (state) => state.sortOrder,
-    getPage: (state) => state.page,
     getFilters: (state) => state.filters,
     getSelected: (state) => state.selected,
     isMobileSearchOpen: (state) => state.mobileOpen,
+    getBrowseEngaged: (state) => state.browseEngaged,
     getLastPatchedSearchResult: (state) => state.lastPatchedSearchResult,
     getAlbumRotation: (state, albumId: number) =>
       state.rotationByAlbumId[albumId],

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -1,9 +1,21 @@
-import type { AlbumSearchResult, TrackMatchHint } from "@wxyc/shared/dtos";
-import { TrackMatchSource } from "@wxyc/shared/dtos";
+import type { AlbumSearchResult } from "@wxyc/shared/dtos";
 import { Rotation } from "../rotation/types";
 
-export type { AlbumSearchResult, TrackMatchHint };
-export { TrackMatchSource };
+export type { AlbumSearchResult };
+
+/** Track-level match hints returned by catalog track search (not yet in @wxyc/shared). */
+export type TrackMatchHint = {
+  source: string;
+  title: string;
+  confidence?: number;
+  position?: string;
+  artist_credit?: string;
+};
+
+export const TrackMatchSource = {
+  cta: "cta",
+  discogs_master: "discogs_master",
+} as const;
 
 /**
  * JSON boundary adapter for AlbumSearchResult.
@@ -108,26 +120,15 @@ export type AddGenreRequestBody = {
   description: string;
 };
 
-export type AlbumParams = {
-  album_title: string;
-  artist_name: string | undefined;
-  artist_id: string | undefined;
-  label: string;
-  genre_id: string;
-  format_id: string;
-  disc_quantity: number | undefined;
-  alternate_artist_name: string | undefined;
-};
-
 export type AlbumRequestParams = {
   album_id: number;
 };
 
-export type ArtistParams = {
-  artist_name: string;
-  code_letters: string;
-  genre_id: string;
-};
+/** @deprecated use AddAlbumRequestBody */
+export type AlbumParams = AddAlbumRequestBody;
+
+/** @deprecated use AddArtistRequestBody */
+export type ArtistParams = AddArtistRequestBody;
 
 export type AlbumEntry = {
   id: number;
@@ -178,19 +179,20 @@ export type CatalogSearchRow = {
 };
 
 export type CatalogFilters = {
-  onStreaming: boolean | undefined; // undefined = no filter
-  genre: Genre | "All"; // 'All' = no filter
-  format: Format | "All"; // 'All' = no filter
+  genres: string[]; // empty = no genre filter
+  formats: string[]; // empty = no format filter
+  tags: string[]; // status: exclusives, missing; rotation bins: H, M, L, S
 };
 
 export type CatalogSearchState = {
   rows: CatalogSearchRow[];
   sortBy: CatalogSortBy;
   sortOrder: CatalogSortOrder;
-  page: number;
   filters: CatalogFilters;
   selected: number[];
   mobileOpen: boolean;
+  /** User chose to browse the full catalog (empty query) without typing a search. */
+  browseEngaged: boolean;
 };
 
 // --- Request envelope for /library/query ---
@@ -202,8 +204,6 @@ export type LibraryQueryParams = {
   sort?: CatalogSortBy;
   order?: CatalogSortOrder;
   on_streaming?: boolean;
-  genre?: string;
-  format?: string;
   missing?: boolean;
   genres?: string;
   formats?: string;
@@ -224,6 +224,8 @@ export type Genre =
   | "Soundtracks"
   | "OCS"
   | "Unknown";
+
+export type SearchIn = "Artists" | "Albums" | "All";
 
 /** Shared rotation UI state for a library album (search row, edit panel, context menu). */
 export type CatalogAlbumRotation = {

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -25,10 +25,14 @@ export default function Results({
 
   const {
     results: releaseList,
-    isLoading: loading,
-    hasMore,
-    loadNextPage,
+    isLoadingInitial,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingMore,
   } = useCatalogQueryResults();
+  const loading = isLoadingInitial;
+  const hasMore = hasNextPage;
+  const loadNextPage = fetchNextPage;
   return (
     <ResultsContainer>
       <Table
@@ -126,6 +130,7 @@ export default function Results({
                   variant="solid"
                   color="primary"
                   size="lg"
+                  loading={isFetchingMore}
                   sx={{
                     marginRight: "1rem",
                   }}

--- a/src/components/experiences/modern/catalog/Search/CatalogFilterAutocomplete.tsx
+++ b/src/components/experiences/modern/catalog/Search/CatalogFilterAutocomplete.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import Close from "@mui/icons-material/Close";
+import Autocomplete, {
+  type AutocompleteRenderGetTagProps,
+} from "@mui/joy/Autocomplete";
+import AutocompleteOption from "@mui/joy/AutocompleteOption";
+import Chip from "@mui/joy/Chip";
+import Skeleton from "@mui/joy/Skeleton";
+import type { Key, ReactNode } from "react";
+
+import { catalogFilterAutocompleteSx } from "./catalogFilterStyles";
+import {
+  catalogFilterTagFontSx,
+  type CatalogFilterTagChipProps,
+} from "./catalogFilterChipStyles";
+
+type CatalogFilterAutocompleteProps = {
+  options: string[];
+  value: string[];
+  onChange: (value: string[]) => void;
+  placeholder: string;
+  ariaLabel: string;
+  isLoading: boolean;
+  getTagChipProps?: (item: string) => CatalogFilterTagChipProps;
+  getOptionLabel?: (option: string) => string;
+  renderTags?: (
+    tags: string[],
+    getTagProps: AutocompleteRenderGetTagProps,
+  ) => ReactNode;
+};
+
+export function CatalogFilterAutocomplete({
+  options,
+  value,
+  onChange,
+  placeholder,
+  ariaLabel,
+  isLoading,
+  getTagChipProps,
+  getOptionLabel = (option) => option,
+  renderTags: renderTagsProp,
+}: CatalogFilterAutocompleteProps) {
+  if (isLoading) {
+    return <Skeleton variant="rectangular" width="100%" height={28} sx={{ borderRadius: "sm" }} />;
+  }
+
+  return (
+    <Autocomplete
+      multiple
+      disableCloseOnSelect
+      size="sm"
+      variant="plain"
+      placeholder={value.length === 0 ? placeholder : undefined}
+      options={options}
+      value={value}
+      loading={isLoading}
+      aria-label={ariaLabel}
+      limitTags={3}
+      getOptionLabel={getOptionLabel}
+      isOptionEqualToValue={(a, b) => a === b}
+      onChange={(_, newValue) => onChange(newValue ?? [])}
+      renderOption={
+        getTagChipProps
+          ? (props, option) => {
+              const chipStyle = getTagChipProps(option);
+              const { key, ...optionProps } = props as typeof props & {
+                key: Key;
+              };
+              return (
+                <AutocompleteOption key={key} {...optionProps}>
+                  <Chip
+                    size="sm"
+                    variant={chipStyle.variant ?? "soft"}
+                    {...(chipStyle.color ? { color: chipStyle.color } : {})}
+                    sx={chipStyle.sx}
+                  >
+                    {getOptionLabel(option)}
+                  </Chip>
+                </AutocompleteOption>
+              );
+            }
+          : undefined
+      }
+      renderTags={
+        renderTagsProp ??
+        ((tags, getTagProps) =>
+          tags.map((item, index) => {
+            const { key, ...tagProps } = getTagProps({ index });
+            const chipStyle = getTagChipProps?.(item) ?? {
+              color: "neutral" as const,
+              variant: "soft" as const,
+            };
+            return (
+              <Chip
+                key={key}
+                {...tagProps}
+                variant={chipStyle.variant ?? "soft"}
+                {...(chipStyle.color ? { color: chipStyle.color } : {})}
+                size="sm"
+                endDecorator={<Close sx={{ fontSize: "0.875rem" }} />}
+                sx={{
+                  minWidth: 0,
+                  ...catalogFilterTagFontSx,
+                  ...chipStyle.sx,
+                }}
+              >
+                {getOptionLabel(item)}
+              </Chip>
+            );
+          }))
+      }
+      slotProps={{
+        input: {
+          sx: catalogFilterTagFontSx,
+        },
+        listbox: {
+          sx: catalogFilterTagFontSx,
+        },
+      }}
+      sx={catalogFilterAutocompleteSx}
+    />
+  );
+}

--- a/src/components/experiences/modern/catalog/Search/CatalogFilterSection.tsx
+++ b/src/components/experiences/modern/catalog/Search/CatalogFilterSection.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Box, Typography } from "@mui/joy";
+import type { ReactNode } from "react";
+
+type CatalogFilterSectionProps = {
+  label?: string;
+  children: ReactNode;
+};
+
+export function CatalogFilterSection({ label, children }: CatalogFilterSectionProps) {
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        minWidth: 0,
+        px: 0.25,
+        py: 0.125,
+      }}
+    >
+      {label ? (
+        <Typography
+          level="body-xs"
+          sx={{
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color: "text.tertiary",
+            mb: 0.125,
+            lineHeight: 1,
+          }}
+        >
+          {label}
+        </Typography>
+      ) : null}
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 0.375,
+          width: "100%",
+          minWidth: 0,
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/experiences/modern/catalog/Search/Filters.test.tsx
+++ b/src/components/experiences/modern/catalog/Search/Filters.test.tsx
@@ -1,50 +1,125 @@
-import { describe, it, expect } from "vitest";
-import { screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, within } from "@testing-library/react";
 import { Filters } from "./Filters";
-import {
-  createComponentHarnessWithQueries,
-  componentQueries,
-} from "@/lib/test-utils";
+import { createComponentHarnessWithQueries } from "@/lib/test-utils";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
-import type { ColorPaletteProp } from "@mui/joy";
+
+const mockGenres = [
+  { id: 1, genre_name: "Rock" },
+  { id: 2, genre_name: "Jazz" },
+];
+
+const mockFormats = [
+  { id: 1, format_name: "cd" },
+  { id: 2, format_name: "Vinyl" },
+];
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return {
+    ...actual,
+    useGetGenresQuery: vi.fn(() => ({
+      data: mockGenres,
+      isLoading: false,
+    })),
+    useGetFormatsQuery: vi.fn(() => ({
+      data: mockFormats,
+      isLoading: false,
+    })),
+  };
+});
 
 const setup = createComponentHarnessWithQueries(
   Filters,
-  { color: "primary" as ColorPaletteProp | undefined },
+  {},
   {
-    exclusiveCheckbox: componentQueries.byRole("checkbox", {
-      name: "Exclusives Only",
-    }),
-  }
+    tagInput: () => screen.getByRole("combobox", { name: "Tag" }),
+    genreInput: () => screen.getByRole("combobox", { name: "Genre" }),
+    formatInput: () => screen.getByRole("combobox", { name: "Format" }),
+    gutter: () => screen.getByTestId("catalog-search-filters"),
+  },
 );
 
 describe("Filters", () => {
-  it("renders the Exclusives Only checkbox", () => {
-    const { exclusiveCheckbox } = setup();
-    expect(exclusiveCheckbox()).toBeInTheDocument();
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it("defaults Exclusives Only to unchecked (onStreaming = undefined)", () => {
-    const { exclusiveCheckbox, getState } = setup();
-    expect(exclusiveCheckbox()).not.toBeChecked();
-    expect(catalogSlice.selectors.getFilters(getState()).onStreaming).toBeUndefined();
+  it("renders three sections separated by vertical dividers", () => {
+    const { gutter } = setup();
+    expect(gutter().querySelectorAll("hr")).toHaveLength(2);
+    expect(screen.getByRole("combobox", { name: "Genre" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Format" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Tag" })).toBeInTheDocument();
   });
 
-  it("toggles onStreaming filter when Exclusives Only is clicked", async () => {
-    const { exclusiveCheckbox, user, getState } = setup();
-    await user.click(exclusiveCheckbox());
-    expect(exclusiveCheckbox()).toBeChecked();
-    expect(catalogSlice.selectors.getFilters(getState()).onStreaming).toBe(false);
-
-    await user.click(exclusiveCheckbox());
-    expect(exclusiveCheckbox()).not.toBeChecked();
-    expect(catalogSlice.selectors.getFilters(getState()).onStreaming).toBeUndefined();
-  });
-
-  it("renders Genre and Format selects (no Search In)", () => {
+  it("does not render section header labels", () => {
     setup();
-    expect(screen.getByText("Genre")).toBeInTheDocument();
-    expect(screen.getByText("Format")).toBeInTheDocument();
-    expect(screen.queryByText("Search In")).not.toBeInTheDocument();
+    expect(screen.queryByText("Genres")).not.toBeInTheDocument();
+    expect(screen.queryByText("Formats")).not.toBeInTheDocument();
+    expect(screen.queryByText("Labels")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tags")).not.toBeInTheDocument();
+  });
+
+  it("shows tag autocomplete placeholder when empty", () => {
+    const { tagInput } = setup();
+    expect(tagInput()).toHaveAttribute("placeholder", "All tags...");
+  });
+
+  it("defaults tags to empty", () => {
+    const { getState } = setup();
+    expect(catalogSlice.selectors.getFilters(getState()).tags).toEqual([]);
+  });
+
+  it("selects exclusives via tag autocomplete", async () => {
+    const { tagInput, user, getState } = setup();
+    await user.click(tagInput());
+    await user.click(await screen.findByRole("option", { name: "exclusives" }));
+    expect(catalogSlice.selectors.getFilters(getState()).tags).toEqual([
+      "exclusives",
+    ]);
+  });
+
+  it("selects missing via tag autocomplete", async () => {
+    const { tagInput, user, getState } = setup();
+    await user.click(tagInput());
+    await user.click(await screen.findByRole("option", { name: "missing" }));
+    expect(catalogSlice.selectors.getFilters(getState()).tags).toEqual([
+      "missing",
+    ]);
+  });
+
+  it("selects heavy rotation via tag autocomplete", async () => {
+    const { tagInput, user, getState } = setup();
+    await user.click(tagInput());
+    await user.click(
+      await screen.findByRole("option", { name: "Heavy Rotation" }),
+    );
+    expect(catalogSlice.selectors.getFilters(getState()).tags).toEqual(["H"]);
+  });
+
+  it("shows genre and format autocomplete placeholders when empty", () => {
+    const { genreInput, formatInput } = setup();
+    expect(genreInput()).toHaveAttribute("placeholder", "All genres...");
+    expect(formatInput()).toHaveAttribute("placeholder", "All formats...");
+  });
+
+  it("selects multiple genres via autocomplete", async () => {
+    const { genreInput, user, getState } = setup();
+    await user.click(genreInput());
+    await user.click(await screen.findByRole("option", { name: "Rock" }));
+    await user.click(await screen.findByRole("option", { name: "Jazz" }));
+    expect(catalogSlice.selectors.getFilters(getState()).genres).toEqual([
+      "Rock",
+      "Jazz",
+    ]);
+  });
+
+  it("selects formats via autocomplete", async () => {
+    const { formatInput, user, getState } = setup();
+    await user.click(formatInput());
+    const listbox = screen.getByRole("listbox");
+    await user.click(within(listbox).getByRole("option", { name: "cd" }));
+    expect(catalogSlice.selectors.getFilters(getState()).formats).toEqual(["cd"]);
   });
 });

--- a/src/components/experiences/modern/catalog/Search/Filters.tsx
+++ b/src/components/experiences/modern/catalog/Search/Filters.tsx
@@ -1,90 +1,56 @@
 "use client";
 
-import { Format, Genre } from "@/lib/features/catalog/types";
-import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
 import {
-  Checkbox,
-  ColorPaletteProp,
-  FormControl,
-  FormLabel,
-  Option,
-  Select,
-} from "@mui/joy";
-import { Fragment } from "react";
+  useGetFormatsQuery,
+  useGetGenresQuery,
+} from "@/lib/features/catalog/api";
+import { Box, Divider } from "@mui/joy";
 
-const GENRE_OPTIONS: (Genre | "All")[] = [
-  "All",
-  "Rock",
-  "Hiphop",
-  "Electronic",
-  "Jazz",
-  "Classical",
-  "Reggae",
-  "Soundtracks",
-];
+import { CatalogFilterSection } from "./CatalogFilterSection";
+import { FormatFilterAutocomplete } from "./FormatFilterAutocomplete";
+import { GenreFilterAutocomplete } from "./GenreFilterAutocomplete";
+import { TagFilterAutocomplete } from "./TagFilterAutocomplete";
 
-const FORMAT_OPTIONS: (Format | "All")[] = ["All", "CD", "Vinyl"];
+export function catalogFiltersActive(filters: {
+  genres: string[];
+  formats: string[];
+  tags: string[];
+}): boolean {
+  return (
+    filters.genres.length > 0 ||
+    filters.formats.length > 0 ||
+    filters.tags.length > 0
+  );
+}
 
-export const Filters = ({ color }: { color: ColorPaletteProp | undefined }) => {
-  const { filters, setFilter } = useCatalogQuerySearch();
+export const Filters = () => {
+  const { data: genres, isLoading: genresLoading } = useGetGenresQuery();
+  const { data: formats, isLoading: formatsLoading } = useGetFormatsQuery();
 
   return (
-    <Fragment>
-      <FormControl size="sm" sx={{ flex: 1 }}>
-        <FormLabel>Genre</FormLabel>
-        <Select
-          color={color || "neutral"}
-          value={filters.genre}
-          slotProps={{ button: { sx: { whiteSpace: "nowrap" } } }}
-          onChange={(_, newValue) =>
-            setFilter({ genre: (newValue as Genre | "All") ?? "All" })
-          }
-        >
-          {GENRE_OPTIONS.map((g) => (
-            <Option key={g} value={g}>
-              {g}
-            </Option>
-          ))}
-        </Select>
-      </FormControl>
-      <FormControl size="sm" sx={{ flex: 1 }}>
-        <FormLabel>Format</FormLabel>
-        <Select
-          color={color || "neutral"}
-          value={filters.format}
-          slotProps={{ button: { sx: { whiteSpace: "nowrap" } } }}
-          onChange={(_, newValue) =>
-            setFilter({ format: (newValue as Format | "All") ?? "All" })
-          }
-        >
-          {FORMAT_OPTIONS.map((f) => (
-            <Option key={f} value={f}>
-              {f}
-            </Option>
-          ))}
-        </Select>
-      </FormControl>
-      <FormControl size="sm" sx={{ flex: "none", justifyContent: "flex-end" }}>
-        <Checkbox
-          label="Exclusives Only"
-          checked={filters.onStreaming === false}
-          onChange={(e) =>
-            setFilter({ onStreaming: e.target.checked ? false : undefined })
-          }
-          sx={{
-            "& .MuiCheckbox-checkbox": {
-              "&.Mui-checked": {
-                backgroundColor: "#7B2D8E",
-                borderColor: "#7B2D8E",
-              },
-              "&.Mui-checked:hover": {
-                backgroundColor: "#6a2479",
-                borderColor: "#6a2479",
-              },
-            },
-          }}
-        />
-      </FormControl>
-    </Fragment>
+    <Box
+      data-testid="catalog-search-filters"
+      sx={{
+        display: "flex",
+        alignItems: "stretch",
+        width: "100%",
+      }}
+    >
+      <CatalogFilterSection>
+        <GenreFilterAutocomplete genres={genres} isLoading={genresLoading} />
+      </CatalogFilterSection>
+
+      <Divider orientation="vertical" />
+
+      <CatalogFilterSection>
+        <FormatFilterAutocomplete formats={formats} isLoading={formatsLoading} />
+      </CatalogFilterSection>
+
+      <Divider orientation="vertical" />
+
+      <CatalogFilterSection>
+        <TagFilterAutocomplete />
+      </CatalogFilterSection>
+    </Box>
   );
 };

--- a/src/components/experiences/modern/catalog/Search/FormatFilterAutocomplete.tsx
+++ b/src/components/experiences/modern/catalog/Search/FormatFilterAutocomplete.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { LibraryFormatRow } from "@/lib/features/catalog/types";
+import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
+import { useMemo } from "react";
+
+import { CatalogFilterAutocomplete } from "./CatalogFilterAutocomplete";
+import { getFormatFilterChipProps } from "./catalogFilterChipStyles";
+
+type FormatFilterAutocompleteProps = {
+  formats: LibraryFormatRow[] | undefined;
+  isLoading: boolean;
+};
+
+export function FormatFilterAutocomplete({
+  formats,
+  isLoading,
+}: FormatFilterAutocompleteProps) {
+  const { filters, setFilter } = useCatalogQuerySearch();
+  const options = useMemo(
+    () => formats?.map((f) => f.format_name) ?? [],
+    [formats],
+  );
+
+  return (
+    <CatalogFilterAutocomplete
+      options={options}
+      value={filters.formats}
+      onChange={(formats) => setFilter({ formats })}
+      placeholder="All formats..."
+      ariaLabel="Format"
+      isLoading={isLoading}
+      getTagChipProps={getFormatFilterChipProps}
+    />
+  );
+}

--- a/src/components/experiences/modern/catalog/Search/GenreFilterAutocomplete.tsx
+++ b/src/components/experiences/modern/catalog/Search/GenreFilterAutocomplete.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { LibraryGenreRow } from "@/lib/features/catalog/types";
+import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
+import { useMemo } from "react";
+
+import { CatalogFilterAutocomplete } from "./CatalogFilterAutocomplete";
+import { getGenreFilterChipProps } from "./catalogFilterChipStyles";
+
+type GenreFilterAutocompleteProps = {
+  genres: LibraryGenreRow[] | undefined;
+  isLoading: boolean;
+};
+
+export function GenreFilterAutocomplete({
+  genres,
+  isLoading,
+}: GenreFilterAutocompleteProps) {
+  const { filters, setFilter } = useCatalogQuerySearch();
+  const options = useMemo(
+    () => genres?.map((g) => g.genre_name) ?? [],
+    [genres],
+  );
+
+  return (
+    <CatalogFilterAutocomplete
+      options={options}
+      value={filters.genres}
+      onChange={(genres) => setFilter({ genres })}
+      placeholder="All genres..."
+      ariaLabel="Genre"
+      isLoading={isLoading}
+      getTagChipProps={getGenreFilterChipProps}
+    />
+  );
+}

--- a/src/components/experiences/modern/catalog/Search/MobileSearchBar.tsx
+++ b/src/components/experiences/modern/catalog/Search/MobileSearchBar.tsx
@@ -1,19 +1,20 @@
 "use client";
 
+import { catalogSlice } from "@/lib/features/catalog/frontend";
 import { useAppSelector } from "@/lib/hooks";
 import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
-import { FilterAlt } from "@mui/icons-material";
+import { Troubleshoot } from "@mui/icons-material";
 import {
+  Box,
   Button,
   ColorPaletteProp,
-  IconButton,
   Modal,
   ModalClose,
   ModalDialog,
   Sheet,
+  Typography,
 } from "@mui/joy";
-import { catalogSlice } from "@/lib/features/catalog/frontend";
-import { Filters } from "./Filters";
+import { catalogFiltersActive } from "./Filters";
 import QueryBuilder from "./QueryBuilder";
 
 export default function MobileSearchBar({
@@ -21,8 +22,13 @@ export default function MobileSearchBar({
 }: {
   color: ColorPaletteProp | undefined;
 }) {
-  const { openMobileSearch, closeMobileSearch } = useCatalogQuerySearch();
+  const { openMobileSearch, closeMobileSearch, filters, effectiveQuery } =
+    useCatalogQuerySearch();
   const isOpen = useAppSelector(catalogSlice.selectors.isMobileSearchOpen);
+  const filtersActive = catalogFiltersActive(filters);
+  const preview =
+    effectiveQuery.trim() ||
+    (filtersActive ? "Filters active" : "Search the catalog");
 
   return (
     <Sheet
@@ -34,30 +40,29 @@ export default function MobileSearchBar({
           sm: "none",
         },
         my: 1,
-        gap: 1,
       }}
     >
       <Button
         size="sm"
         variant="outlined"
         color={color ?? "primary"}
-        sx={{ flexGrow: 1 }}
+        sx={{
+          flexGrow: 1,
+          justifyContent: "flex-start",
+          gap: 1,
+          fontWeight: "normal",
+          color: effectiveQuery.trim() ? "text.primary" : "text.tertiary",
+        }}
         onClick={openMobileSearch}
+        startDecorator={<Troubleshoot />}
       >
-        Build a catalog query
+        <Typography level="body-sm" noWrap sx={{ flex: 1, textAlign: "left" }}>
+          {preview}
+        </Typography>
       </Button>
-      <IconButton
-        size="sm"
-        variant="outlined"
-        color="neutral"
-        onClick={openMobileSearch}
-        aria-label="Open filters"
-      >
-        <FilterAlt />
-      </IconButton>
       <Modal open={isOpen} onClose={closeMobileSearch}>
         <ModalDialog
-          aria-labelledby="filter-modal"
+          aria-labelledby="catalog-search-modal"
           layout="fullscreen"
           sx={{
             paddingTop: "7rem",
@@ -65,14 +70,15 @@ export default function MobileSearchBar({
         >
           <ModalClose
             variant="soft"
-            color="primary"
+            color={color ?? "primary"}
             sx={{ marginTop: "var(--Header-height)" }}
           />
           <Sheet sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-            <QueryBuilder />
-            <Filters color={color} />
+            <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+              <QueryBuilder color={color} />
+            </Box>
             <Button color={color ?? "primary"} onClick={closeMobileSearch}>
-              Submit
+              Done
             </Button>
           </Sheet>
         </ModalDialog>

--- a/src/components/experiences/modern/catalog/Search/QueryBuilder.test.tsx
+++ b/src/components/experiences/modern/catalog/Search/QueryBuilder.test.tsx
@@ -1,15 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { screen, within } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import QueryBuilder from "./QueryBuilder";
 import { createComponentHarnessWithQueries } from "@/lib/test-utils";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 
-const firstInput = (): HTMLElement | null =>
-  screen.queryAllByPlaceholderText("Search the catalog")[0] ?? null;
-const firstAddButton = (): HTMLElement | null =>
-  screen.queryAllByRole("button", { name: "Add row" })[0] ?? null;
+const firstInput = (): HTMLElement =>
+  screen.getByTestId("catalog-search-input");
+const firstAddButton = (): HTMLElement =>
+  screen.getByTestId("catalog-search-add-row");
 const firstRemoveButton = (): HTMLElement | null =>
-  screen.queryAllByRole("button", { name: "Remove row" })[0] ?? null;
+  screen.queryByRole("button", { name: "Remove row" });
 
 const setup = createComponentHarnessWithQueries(QueryBuilder, {}, {
   firstInput,
@@ -17,28 +17,34 @@ const setup = createComponentHarnessWithQueries(QueryBuilder, {}, {
   firstRemoveButton,
 });
 
-const countInputs = () =>
-  screen.queryAllByPlaceholderText("Search the catalog").length;
-
 describe("QueryBuilder", () => {
-  it("renders a single input on first mount", () => {
+  it("renders a single primary input on first mount", () => {
     setup();
-    expect(countInputs()).toBe(1);
+    expect(screen.getByTestId("catalog-search-input")).toBeInTheDocument();
+    expect(screen.getAllByRole("textbox")).toHaveLength(1);
   });
 
   it("clicking Add row appends a new row", async () => {
     const { firstAddButton, user } = setup();
-    const button = firstAddButton();
-    expect(button).not.toBeNull();
-    await user.click(button!);
-    expect(countInputs()).toBe(2);
+    await user.click(firstAddButton());
+    expect(screen.getAllByRole("textbox")).toHaveLength(2);
+  });
+
+  it("changing field does not clear row text", async () => {
+    const { firstInput, user, getState, store } = setup();
+    await user.type(firstInput(), "Stereolab");
+    const rowId = catalogSlice.selectors.getRows(getState())[0].id;
+    store.dispatch(
+      catalogSlice.actions.updateRow({ id: rowId, updates: { field: "artist" } }),
+    );
+    const rows = catalogSlice.selectors.getRows(getState());
+    expect(rows[0].value).toBe("Stereolab");
+    expect(rows[0].field).toBe("artist");
   });
 
   it("typing into a row updates the slice", async () => {
     const { firstInput, user, getState } = setup();
-    const input = firstInput();
-    expect(input).not.toBeNull();
-    await user.type(input!, "Stereolab");
+    await user.type(firstInput(), "Stereolab");
     const rows = catalogSlice.selectors.getRows(getState());
     expect(rows[0].value).toBe("Stereolab");
   });

--- a/src/components/experiences/modern/catalog/Search/QueryBuilder.tsx
+++ b/src/components/experiences/modern/catalog/Search/QueryBuilder.tsx
@@ -1,16 +1,44 @@
 "use client";
 
-import type { CatalogSearchField } from "@/lib/features/catalog/types";
+import type { CatalogSearchField, CatalogSearchRow } from "@/lib/features/catalog/types";
 import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
 import { Add, Cancel, Remove, Troubleshoot } from "@mui/icons-material";
-import { Box, IconButton, Input, Option, Select, Stack } from "@mui/joy";
-import SortBySelect from "./SortBySelect";
+import {
+  Box,
+  ColorPaletteProp,
+  Divider,
+  IconButton,
+  Option,
+  Select,
+  Sheet,
+  Typography,
+} from "@mui/joy";
+import { Filters } from "./Filters";
+import {
+  catalogFieldSelectButtonSx,
+  catalogFieldSelectSx,
+  catalogInFieldClusterSx,
+  catalogInLabelSx,
+  catalogSearchActionSlotSx,
+  catalogSearchBoxSx,
+  catalogSearchFiltersGutterSx,
+  catalogSearchIconLeadingSlotSx,
+  catalogSearchIconSx,
+  catalogSearchInputSlotSx,
+  catalogSearchLeadingSlotSx,
+  catalogSearchOperatorSelectButtonSx,
+  catalogSearchOperatorColWidth,
+  catalogSearchRowColumnsSx,
+  catalogSearchRowRevealSx,
+  catalogSearchRowSx,
+  catalogSearchRowsAnimatedSx,
+} from "./catalogSearchBoxStyles";
 
 const FIELD_OPTIONS: { value: CatalogSearchField; label: string }[] = [
   { value: "all", label: "All" },
-  { value: "artist", label: "Artist" },
-  { value: "album", label: "Album" },
-  { value: "label", label: "Label" },
+  { value: "artist", label: "Artists" },
+  { value: "album", label: "Albums" },
+  { value: "label", label: "Labels" },
 ];
 
 const OPERATOR_OPTIONS = [
@@ -19,122 +47,259 @@ const OPERATOR_OPTIONS = [
   { value: "NOT" as const, label: "NOT" },
 ];
 
-export default function QueryBuilder() {
-  const { rows, addRow, removeRow, updateRow } = useCatalogQuerySearch();
+function handleValueChange(
+  row: CatalogSearchRow,
+  next: string,
+  updateRow: (id: string, updates: Partial<CatalogSearchRow>) => void,
+) {
+  const trimmed = next.trim();
+  const exact =
+    trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2;
+  updateRow(row.id, {
+    value: next,
+    exact,
+  });
+}
+
+function CatalogSearchInFieldCluster({
+  rowId,
+  testId,
+}: {
+  rowId: string;
+  testId?: string;
+}) {
+  const { rows, updateRow } = useCatalogQuerySearch();
+  const field =
+    rows.find((r) => r.id === rowId)?.field ?? ("all" as CatalogSearchField);
 
   return (
-    // Responsive show/hide is the caller's responsibility — SearchBar hides
-    // this on xs (the mobile modal renders it back in instead).
-    <Box sx={{ py: 1 }}>
-      <Stack spacing={1}>
-        {rows.map((row, index) => {
-          const isFirst = index === 0;
-          return (
-            <Stack
-              key={row.id}
-              direction="row"
-              spacing={1}
-              sx={{ alignItems: "center" }}
-            >
-              {!isFirst && (
-                <Select
-                  value={row.operator}
-                  onChange={(_, value) =>
-                    value && updateRow(row.id, { operator: value })
-                  }
-                  size="sm"
-                  color="primary"
-                  sx={{ minWidth: 80, flexShrink: 0 }}
-                >
-                  {OPERATOR_OPTIONS.map((opt) => (
-                    <Option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </Option>
-                  ))}
-                </Select>
-              )}
+    <Box
+      sx={catalogInFieldClusterSx}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <Typography component="span" level="body-xs" sx={catalogInLabelSx}>
+        in
+      </Typography>
+      <Select
+        data-testid={testId}
+        value={field}
+        variant="plain"
+        color="neutral"
+        onChange={(_event, newValue) => {
+          if (newValue == null) return;
+          updateRow(rowId, { field: newValue as CatalogSearchField });
+        }}
+        slotProps={{
+          button: { sx: catalogFieldSelectButtonSx },
+          indicator: { sx: { fontSize: "0.75rem", opacity: 0.65 } },
+          listbox: {
+            onClick: (e) => e.stopPropagation(),
+          },
+        }}
+        sx={catalogFieldSelectSx}
+      >
+        {FIELD_OPTIONS.map((opt) => (
+          <Option
+            key={opt.value}
+            value={opt.value}
+            sx={{
+              fontSize: "var(--joy-fontSize-xs)",
+              letterSpacing: "0.04em",
+            }}
+          >
+            {opt.label}
+          </Option>
+        ))}
+      </Select>
+    </Box>
+  );
+}
 
-              {isFirst && <SortBySelect />}
+function CatalogSearchRowSegment({
+  row,
+  isFirst,
+  multiRow,
+  showAdd,
+  showRemove,
+  onAdd,
+  onRemove,
+  updateRow,
+}: {
+  row: CatalogSearchRow;
+  isFirst: boolean;
+  multiRow: boolean;
+  showAdd: boolean;
+  showRemove: boolean;
+  onAdd: () => void;
+  onRemove: () => void;
+  updateRow: (id: string, updates: Partial<CatalogSearchRow>) => void;
+}) {
+  const hasValue = row.value !== "";
+  const operatorCol = catalogSearchOperatorColWidth(multiRow);
 
-              <Select
-                value={row.field}
-                onChange={(_, value) =>
-                  value &&
-                  updateRow(row.id, {
-                    field: value,
-                    value: "",
-                  })
-                }
-                size="sm"
-                color="primary"
-                slotProps={{ button: { sx: { whiteSpace: "nowrap" } } }}
-                sx={{ minWidth: 100, flexShrink: 0 }}
+  return (
+    <Box sx={{ ...catalogSearchRowSx, ...catalogSearchRowColumnsSx(operatorCol) }}>
+      <Box
+        sx={
+          isFirst ? catalogSearchIconLeadingSlotSx : catalogSearchLeadingSlotSx
+        }
+      >
+        {!isFirst ? (
+          <Select
+            value={row.operator}
+            onChange={(_, value) =>
+              value && updateRow(row.id, { operator: value })
+            }
+            size="sm"
+            variant="plain"
+            color="primary"
+            sx={{ width: "100%", minWidth: 0 }}
+            slotProps={{
+              button: { onMouseDown: (e) => e.stopPropagation() },
+              listbox: { onClick: (e) => e.stopPropagation() },
+            }}
+          >
+            {OPERATOR_OPTIONS.map((opt) => (
+              <Option key={opt.value} value={opt.value}>
+                {opt.label}
+              </Option>
+            ))}
+          </Select>
+        ) : (
+          <Box sx={catalogSearchIconSx}>
+            <Troubleshoot sx={{ fontSize: "1.25rem" }} />
+          </Box>
+        )}
+      </Box>
+
+      <Box sx={catalogSearchInputSlotSx}>
+        <input
+          data-testid={isFirst ? "catalog-search-input" : undefined}
+          type="text"
+          placeholder={isFirst ? "Search the catalog" : undefined}
+          value={row.value}
+          autoComplete="off"
+          onChange={(e) => handleValueChange(row, e.target.value, updateRow)}
+          onClick={(e) => e.stopPropagation()}
+        />
+
+        {row.exact && (
+          <Typography
+            component="span"
+            level="body-xs"
+            sx={{ flexShrink: 0, color: "primary.500", px: 0.5 }}
+          >
+            Exact
+          </Typography>
+        )}
+
+        {hasValue && (
+          <IconButton
+            variant="plain"
+            color="neutral"
+            size="sm"
+            aria-label="Clear search"
+            sx={{ "--IconButton-size": "1.75rem", flexShrink: 0 }}
+            onClick={() => updateRow(row.id, { value: "", exact: false })}
+          >
+            <Cancel fontSize="small" />
+          </IconButton>
+        )}
+      </Box>
+
+      <CatalogSearchInFieldCluster
+        rowId={row.id}
+        testId={isFirst ? "catalog-search-field" : undefined}
+      />
+
+      <Box sx={catalogSearchActionSlotSx}>
+        {isFirst && showAdd && (
+          <IconButton
+            data-testid="catalog-search-add-row"
+            size="sm"
+            variant="plain"
+            color="primary"
+            aria-label="Add row"
+            sx={{ "--IconButton-size": "1.75rem" }}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onAdd();
+            }}
+          >
+            <Add sx={{ fontSize: "1.125rem" }} />
+          </IconButton>
+        )}
+
+        {!isFirst && showRemove && (
+          <IconButton
+            size="sm"
+            variant="plain"
+            color="danger"
+            aria-label="Remove row"
+            sx={{ "--IconButton-size": "1.75rem" }}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+          >
+            <Remove fontSize="small" />
+          </IconButton>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+export type QueryBuilderProps = {
+  color?: ColorPaletteProp;
+};
+
+export default function QueryBuilder({ color = "primary" }: QueryBuilderProps) {
+  const { rows, addRow, removeRow, updateRow } = useCatalogQuerySearch();
+
+  const multiRow = rows.length > 1;
+
+  return (
+    <Box sx={{ py: 0.5, flexShrink: 0, minWidth: 0 }}>
+      <Sheet
+        variant="outlined"
+        data-testid="catalog-search-box"
+        sx={{
+          ...catalogSearchBoxSx,
+        }}
+        suppressHydrationWarning
+      >
+        <Box sx={catalogSearchRowsAnimatedSx(rows.length)}>
+          {rows.map((row, index) => {
+            const isFirst = index === 0;
+            return (
+              <Box
+                key={row.id}
+                sx={index > 0 ? catalogSearchRowRevealSx : undefined}
               >
-                {FIELD_OPTIONS.map((opt) => (
-                  <Option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </Option>
-                ))}
-              </Select>
-
-              <Input
-                color="primary"
-                placeholder="Search the catalog"
-                startDecorator={isFirst ? <Troubleshoot /> : undefined}
-                endDecorator={
-                  row.value !== "" ? (
-                    <IconButton
-                      variant="plain"
-                      color="primary"
-                      size="sm"
-                      onClick={() => updateRow(row.id, { value: "" })}
-                    >
-                      <Cancel />
-                    </IconButton>
-                  ) : undefined
-                }
-                value={row.value}
-                onChange={(e) => {
-                  // Quoted input toggles the row's exact-match flag. The
-                  // service-side parser will still see the quotes if the user
-                  // typed them, but tracking `exact` on the row lets the UI
-                  // surface it (and lets buildCatalogQuery re-quote on submit).
-                  const next = e.target.value;
-                  const exact = next.startsWith('"') && next.endsWith('"') && next.length >= 2;
-                  updateRow(row.id, { value: exact ? next.slice(1, -1) : next, exact });
-                }}
-                size="sm"
-                sx={{ flex: 1 }}
-              />
-
-              <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}>
-                {rows.length > 1 && (
-                  <IconButton
-                    size="sm"
-                    variant="outlined"
-                    color="danger"
-                    onClick={() => removeRow(row.id)}
-                    sx={{ aspectRatio: 1 }}
-                    aria-label="Remove row"
-                  >
-                    <Remove />
-                  </IconButton>
-                )}
-                <IconButton
-                  size="sm"
-                  variant="outlined"
-                  color="primary"
-                  onClick={addRow}
-                  sx={{ aspectRatio: 1 }}
-                  aria-label="Add row"
-                >
-                  <Add />
-                </IconButton>
-              </Stack>
-            </Stack>
-          );
-        })}
-      </Stack>
+                {index > 0 && <Divider sx={{ my: 0.25 }} />}
+                <CatalogSearchRowSegment
+                  row={row}
+                  isFirst={isFirst}
+                  multiRow={multiRow}
+                  showAdd={isFirst}
+                  showRemove={!isFirst}
+                  onAdd={addRow}
+                  onRemove={() => removeRow(row.id)}
+                  updateRow={updateRow}
+                />
+              </Box>
+            );
+          })}
+        </Box>
+        <Divider sx={{ my: 0.25 }} />
+        <Box sx={catalogSearchFiltersGutterSx}>
+          <Filters />
+        </Box>
+      </Sheet>
     </Box>
   );
 }

--- a/src/components/experiences/modern/catalog/Search/SearchBar.test.tsx
+++ b/src/components/experiences/modern/catalog/Search/SearchBar.test.tsx
@@ -1,15 +1,30 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { screen } from "@testing-library/react";
 import SearchBar from "./SearchBar";
 import { createComponentHarnessWithQueries } from "@/lib/test-utils";
 import type { ColorPaletteProp } from "@mui/joy";
 
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return {
+    ...actual,
+    useGetGenresQuery: vi.fn(() => ({
+      data: [{ id: 1, genre_name: "Rock" }],
+      isLoading: false,
+    })),
+    useGetFormatsQuery: vi.fn(() => ({
+      data: [{ id: 1, format_name: "cd" }],
+      isLoading: false,
+    })),
+  };
+});
+
 const setup = createComponentHarnessWithQueries(
   SearchBar,
   { color: "primary" as ColorPaletteProp | undefined },
   {
-    input: () => screen.getByPlaceholderText("Search the catalog"),
-  }
+    input: () => screen.getByTestId("catalog-search-input"),
+  },
 );
 
 describe("SearchBar", () => {
@@ -18,14 +33,9 @@ describe("SearchBar", () => {
     expect(input()).toBeInTheDocument();
   });
 
-  it("renders the Genre and Format filter selects", () => {
+  it("renders filters in the attached gutter", () => {
     setup();
-    expect(screen.getByText("Genre")).toBeInTheDocument();
-    expect(screen.getByText("Format")).toBeInTheDocument();
-  });
-
-  it("renders the Exclusives Only checkbox", () => {
-    setup();
-    expect(screen.getByLabelText("Exclusives Only")).toBeInTheDocument();
+    expect(screen.getByTestId("catalog-search-filters")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Tag" })).toBeInTheDocument();
   });
 });

--- a/src/components/experiences/modern/catalog/Search/SearchBar.tsx
+++ b/src/components/experiences/modern/catalog/Search/SearchBar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Box, ColorPaletteProp } from "@mui/joy";
-import { Filters } from "./Filters";
 import QueryBuilder from "./QueryBuilder";
 
 export default function SearchBar({
@@ -14,31 +13,16 @@ export default function SearchBar({
       className="SearchAndFilters-tabletUp"
       sx={{
         borderRadius: "sm",
-        py: 2,
+        py: 1,
         display: {
           xs: "none",
-          sm: "flex",
+          sm: "block",
         },
-        flexDirection: "column",
-        gap: 1.5,
+        flexShrink: 0,
+        minWidth: 0,
       }}
     >
-      <QueryBuilder />
-      <Box
-        sx={{
-          display: "flex",
-          flexWrap: "wrap",
-          gap: 1.5,
-          "& > *": {
-            minWidth: {
-              xs: "180px",
-              md: "200px",
-            },
-          },
-        }}
-      >
-        <Filters color={color} />
-      </Box>
+      <QueryBuilder color={color} />
     </Box>
   );
 }

--- a/src/components/experiences/modern/catalog/Search/TagFilterAutocomplete.tsx
+++ b/src/components/experiences/modern/catalog/Search/TagFilterAutocomplete.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
+
+import { CatalogFilterAutocomplete } from "./CatalogFilterAutocomplete";
+import {
+  CATALOG_TAG_FILTER_OPTIONS,
+  getCatalogTagLabel,
+} from "./catalogTagFilters";
+import { getTagFilterChipProps } from "./catalogFilterChipStyles";
+
+export function TagFilterAutocomplete() {
+  const { filters, setFilter } = useCatalogQuerySearch();
+
+  return (
+    <CatalogFilterAutocomplete
+      options={[...CATALOG_TAG_FILTER_OPTIONS]}
+      value={filters.tags}
+      onChange={(tags) => setFilter({ tags })}
+      placeholder="All tags..."
+      ariaLabel="Tag"
+      isLoading={false}
+      getTagChipProps={getTagFilterChipProps}
+      getOptionLabel={getCatalogTagLabel}
+    />
+  );
+}

--- a/src/components/experiences/modern/catalog/Search/catalogFilterChipStyles.test.ts
+++ b/src/components/experiences/modern/catalog/Search/catalogFilterChipStyles.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+  genreNameToGenreKey,
+  getFormatFilterChipProps,
+  getGenreFilterChipProps,
+  getTagFilterChipProps,
+} from "./catalogFilterChipStyles";
+
+describe("catalogFilterChipStyles", () => {
+  it("maps genre names case-insensitively", () => {
+    expect(genreNameToGenreKey("rock")).toBe("Rock");
+    expect(genreNameToGenreKey("JAZZ")).toBe("Jazz");
+    expect(genreNameToGenreKey("Not Real")).toBe("Unknown");
+  });
+
+  it("uses ArtistAvatar genre palettes", () => {
+    expect(getGenreFilterChipProps("Rock")).toEqual({
+      color: "primary",
+      variant: "solid",
+    });
+    expect(getGenreFilterChipProps("Jazz")).toEqual({
+      color: "warning",
+      variant: "solid",
+    });
+  });
+
+  it("uses catalog result format colors", () => {
+    expect(getFormatFilterChipProps("Vinyl")).toEqual({
+      color: "primary",
+      variant: "soft",
+    });
+    expect(getFormatFilterChipProps("cd")).toEqual({
+      color: "warning",
+      variant: "soft",
+    });
+  });
+
+  it("styles exclusives tag with WXYC purple", () => {
+    const props = getTagFilterChipProps("exclusives");
+    expect(props.variant).toBe("soft");
+    expect(props.sx).toMatchObject({
+      bgcolor: "#7B2D8E",
+      color: "#fff",
+    });
+    expect(props.color).toBeUndefined();
+  });
+
+  it("styles missing tag as neutral outlined (not exclusives purple)", () => {
+    expect(getTagFilterChipProps("missing")).toEqual({
+      color: "neutral",
+      variant: "outlined",
+    });
+    expect(getTagFilterChipProps("missing").sx).toBeUndefined();
+  });
+});

--- a/src/components/experiences/modern/catalog/Search/catalogFilterChipStyles.ts
+++ b/src/components/experiences/modern/catalog/Search/catalogFilterChipStyles.ts
@@ -1,0 +1,88 @@
+import type { Genre } from "@/lib/features/catalog/types";
+import type { ColorPaletteProp, VariantProp } from "@mui/joy";
+import type { SxProps } from "@mui/joy/styles/types";
+
+import { GENRE_COLORS, GENRE_VARIANTS, ROTATION_STYLES } from "../ArtistAvatar";
+import type { Rotation } from "@/lib/features/rotation/types";
+import {
+  EXCLUSIVES_PURPLE,
+  EXCLUSIVES_PURPLE_HOVER,
+  filterControlFontSx,
+} from "./catalogFilterStyles";
+import { isCatalogRotationTag } from "./catalogTagFilters";
+
+const GENRE_KEYS: Genre[] = [
+  "Rock",
+  "Blues",
+  "Electronic",
+  "Hiphop",
+  "Jazz",
+  "Classical",
+  "Reggae",
+  "Soundtracks",
+  "OCS",
+  "Unknown",
+];
+
+/** Map API `genre_name` to the `Genre` union used for palette lookup. */
+export function genreNameToGenreKey(name: string): Genre {
+  const trimmed = name.trim();
+  if (!trimmed) return "Unknown";
+  const hit = GENRE_KEYS.find((k) => k.toLowerCase() === trimmed.toLowerCase());
+  return hit ?? "Unknown";
+}
+
+export type CatalogFilterTagChipProps = {
+  color?: ColorPaletteProp;
+  variant?: VariantProp;
+  sx?: SxProps;
+};
+
+/** Matches catalog result genre chips (`Result.tsx`). */
+export function getGenreFilterChipProps(genreName: string): CatalogFilterTagChipProps {
+  const key = genreNameToGenreKey(genreName);
+  return {
+    color: GENRE_COLORS[key] ?? "neutral",
+    variant: GENRE_VARIANTS[key] ?? "soft",
+  };
+}
+
+/** Matches catalog result format chips (`Result.tsx`: vinyl primary, else warning). */
+export function getFormatFilterChipProps(formatName: string): CatalogFilterTagChipProps {
+  const isVinyl = formatName.toLowerCase().includes("vinyl");
+  return {
+    color: isVinyl ? "primary" : "warning",
+    variant: "soft",
+  };
+}
+
+/** Tag filter chips (v1: exclusives uses WXYC exclusive purple). */
+export function getTagFilterChipProps(tagId: string): CatalogFilterTagChipProps {
+  if (tagId === "exclusives") {
+    return {
+      variant: "soft",
+      sx: {
+        bgcolor: EXCLUSIVES_PURPLE,
+        color: "#fff",
+        fontWeight: 600,
+        "--Chip-focusedInset": "transparent",
+        "--Chip-focusedThickness": "0px",
+        "&:hover": {
+          bgcolor: EXCLUSIVES_PURPLE_HOVER,
+        },
+      },
+    };
+  }
+  if (tagId === "missing") {
+    return { color: "neutral", variant: "outlined" };
+  }
+  if (isCatalogRotationTag(tagId)) {
+    return {
+      color: ROTATION_STYLES[tagId as Rotation] ?? "neutral",
+      variant: "soft",
+    };
+  }
+  return { color: "neutral", variant: "soft" };
+}
+
+export const catalogFilterTagFontSx = filterControlFontSx;

--- a/src/components/experiences/modern/catalog/Search/catalogFilterStyles.ts
+++ b/src/components/experiences/modern/catalog/Search/catalogFilterStyles.ts
@@ -1,0 +1,44 @@
+/** ~11px controls — smaller than Joy `sm`, borderless plain selects. */
+export const filterControlFontSx = {
+  fontSize: "0.75rem",
+  lineHeight: 1.2,
+  fontWeight: 500,
+  letterSpacing: "0.01em",
+} as const;
+
+export const plainFilterSelectButtonSx = {
+  ...filterControlFontSx,
+  minHeight: 0,
+  height: "auto",
+  py: 0,
+  px: 0.25,
+  "--Button-minHeight": "1.125rem",
+  whiteSpace: "nowrap",
+  border: "none",
+  bgcolor: "transparent",
+  boxShadow: "none",
+  "&:hover": {
+    bgcolor: "transparent",
+    boxShadow: "none",
+  },
+  "&:active": {
+    bgcolor: "transparent",
+  },
+} as const;
+
+export const plainFilterSelectSx = {
+  minWidth: 0,
+  minHeight: 0,
+  "--Select-gap": "0.125rem",
+  "--Select-decoratorChildHeight": "0.75rem",
+} as const;
+
+export const catalogFilterAutocompleteSx = {
+  width: "100%",
+  minWidth: 0,
+  "--Autocomplete-wrapperGap": "0.25rem",
+  "--Input-minHeight": "1.375rem",
+} as const;
+
+export const EXCLUSIVES_PURPLE = "#7B2D8E";
+export const EXCLUSIVES_PURPLE_HOVER = "#6a2479";

--- a/src/components/experiences/modern/catalog/Search/catalogSearchBoxStyles.ts
+++ b/src/components/experiences/modern/catalog/Search/catalogSearchBoxStyles.ts
@@ -1,0 +1,232 @@
+import type { SxProps } from "@mui/joy/styles/types";
+
+/**
+ * Outlined search shell — border from Joy `Sheet variant="outlined"`.
+ * Padding lives on the query rows block; filters sit in the gutter below.
+ */
+export const catalogSearchBoxSx: SxProps = {
+  display: "flex",
+  flexDirection: "column",
+  flexShrink: 0,
+  zIndex: 1,
+  borderRadius: "md",
+  p: 0,
+  overflow: "hidden",
+  cursor: "text",
+  bgcolor: "background.surface",
+  "& input": {
+    background: "transparent !important",
+    outline: "none !important",
+    border: "none !important",
+    fontFamily: "inherit !important",
+    fontSize: "var(--joy-fontSize-sm)",
+    lineHeight: 1.25,
+    minWidth: "0 !important",
+    px: 0.75,
+    py: 0,
+    flex: 1,
+    minHeight: 0,
+    height: "1.5rem",
+    cursor: "text",
+  },
+  "&:focus-within": {
+    borderColor: "var(--joy-palette-primary-300)",
+    boxShadow: "0 0 0 2px var(--joy-palette-primary-100)",
+  },
+};
+
+export const catalogSearchRowsSx: SxProps = {
+  pl: 0.75,
+  pr: 0.5,
+};
+
+/** Leading column width: narrow for a single query row, wider when AND/OR/NOT shows. */
+export const CATALOG_SEARCH_OPERATOR_COL_SINGLE = "2.25rem";
+export const CATALOG_SEARCH_OPERATOR_COL_MULTI = "4.25rem";
+
+/** Horizontal inset for AND/OR/NOT operator select label in the leading column. */
+export const CATALOG_SEARCH_LEADING_INSET = 0.75;
+
+/** Trailing add/remove control column. */
+export const CATALOG_SEARCH_ACTION_COL = "1.75rem";
+
+/** Fixed width so IN + field align on every query row. */
+export const CATALOG_IN_FIELD_CLUSTER_WIDTH = "8rem";
+
+export const CATALOG_SEARCH_ROW_GRID_TRANSITION =
+  "grid-template-columns 0.4s cubic-bezier(0.4, 0, 0.2, 1)";
+
+export function catalogSearchOperatorColWidth(multiRow: boolean): string {
+  return multiRow
+    ? CATALOG_SEARCH_OPERATOR_COL_MULTI
+    : CATALOG_SEARCH_OPERATOR_COL_SINGLE;
+}
+
+export function catalogSearchRowColumnsSx(operatorCol: string): SxProps {
+  return {
+    gridTemplateColumns: `${operatorCol} minmax(0, 1fr) ${CATALOG_IN_FIELD_CLUSTER_WIDTH} ${CATALOG_SEARCH_ACTION_COL}`,
+  };
+}
+
+/** Divider between query rows (Joy Divider `my: 0.25` plus 1px rule). */
+export const CATALOG_SEARCH_ROW_DIVIDER_REM = 0.5625;
+
+export const CATALOG_SEARCH_ROWS_PADDING_SINGLE_REM = 0.5;
+export const CATALOG_SEARCH_ROWS_PADDING_MULTI_REM = 0.75;
+
+export const CATALOG_SEARCH_ROWS_TRANSITION =
+  "height 0.4s cubic-bezier(0.4, 0, 0.2, 1), padding-block 0.4s cubic-bezier(0.4, 0, 0.2, 1)";
+
+/** Per query row line (input + grid alignment). */
+export const SEARCH_ADVANCED_ROW_HEIGHT_REM = 2.125;
+
+/** Total block height for the query-rows area (padding + rows + dividers). */
+export function catalogSearchRowsHeightRem(rowCount: number): number {
+  const count = Math.max(1, rowCount);
+  const padding =
+    count > 1
+      ? CATALOG_SEARCH_ROWS_PADDING_MULTI_REM
+      : CATALOG_SEARCH_ROWS_PADDING_SINGLE_REM;
+  const dividers =
+    count > 1 ? (count - 1) * CATALOG_SEARCH_ROW_DIVIDER_REM : 0;
+  return padding + count * SEARCH_ADVANCED_ROW_HEIGHT_REM + dividers;
+}
+
+export function catalogSearchRowsAnimatedSx(rowCount: number) {
+  const multiRow = rowCount > 1;
+  return {
+    pl: 0.75,
+    pr: 0.5,
+    height: `${catalogSearchRowsHeightRem(rowCount)}rem`,
+    minHeight: 0,
+    overflow: "hidden",
+    boxSizing: "border-box",
+    paddingBlock: multiRow ? "0.375rem" : "0.25rem",
+    transition: CATALOG_SEARCH_ROWS_TRANSITION,
+  };
+}
+
+export const catalogInFieldClusterSx = {
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  gap: 0.375,
+  width: CATALOG_IN_FIELD_CLUSTER_WIDTH,
+  minWidth: CATALOG_IN_FIELD_CLUSTER_WIDTH,
+  flexShrink: 0,
+} as const;
+
+export const catalogInLabelSx = {
+  color: "text.tertiary",
+  fontSize: "var(--joy-fontSize-xs)",
+  lineHeight: 1,
+  letterSpacing: "0.04em",
+  userSelect: "none",
+  flexShrink: 0,
+} as const;
+
+export const catalogFieldSelectButtonSx = {
+  color: "text.tertiary",
+  fontSize: "var(--joy-fontSize-xs)",
+  lineHeight: 1,
+  letterSpacing: "0.04em",
+  fontWeight: 500,
+  minHeight: 0,
+  py: 0,
+  px: 0,
+  flex: 1,
+  minWidth: 0,
+  justifyContent: "flex-start",
+  "--Button-minHeight": "1.25rem",
+  whiteSpace: "nowrap",
+  border: "none",
+  bgcolor: "transparent",
+  boxShadow: "none",
+  "&:hover": {
+    bgcolor: "transparent",
+    boxShadow: "none",
+  },
+} as const;
+
+export const catalogFieldSelectSx = {
+  flex: 1,
+  minWidth: 0,
+  "--Select-gap": "0.125rem",
+} as const;
+
+export const catalogSearchLeadingSlotSx = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-start",
+  minWidth: 0,
+} as const;
+
+export const catalogSearchIconLeadingSlotSx = {
+  ...catalogSearchLeadingSlotSx,
+  width: "100%",
+  boxSizing: "border-box",
+  justifyContent: "center",
+} as const;
+
+export const catalogSearchOperatorSelectButtonSx = {
+  justifyContent: "flex-start",
+  px: CATALOG_SEARCH_LEADING_INSET,
+} as const;
+
+export const catalogSearchInputSlotSx = {
+  display: "flex",
+  alignItems: "center",
+  minWidth: 0,
+  gap: 0.5,
+} as const;
+
+export const catalogSearchActionSlotSx = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: CATALOG_SEARCH_ACTION_COL,
+  minWidth: CATALOG_SEARCH_ACTION_COL,
+  flexShrink: 0,
+} as const;
+
+export const catalogSearchIconSx = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flexShrink: 0,
+  pointerEvents: "none",
+  "& svg": {
+    fill: "var(--wxyc-palette-neutral-400) !important",
+  },
+} as const;
+
+/** Muted seam between query rows and filter gutter (softer than outer sheet border). */
+export const catalogSearchFiltersGutterSx: SxProps = {
+  px: 0.5,
+  py: 0.375,
+  minHeight: "2rem",
+  flexShrink: 0,
+  display: "flex",
+  alignItems: "stretch",
+  justifyContent: "stretch",
+  width: "100%",
+};
+
+export const catalogSearchRowSx = {
+  display: "grid",
+  alignItems: "center",
+  columnGap: 0.5,
+  flex: "0 0 auto",
+  minWidth: 0,
+  minHeight: 0,
+  transition: CATALOG_SEARCH_ROW_GRID_TRANSITION,
+} as const;
+
+/** Fade-in for rows revealed as the query block height expands. */
+export const catalogSearchRowRevealSx: SxProps = {
+  animation: "catalogSearchRowReveal 0.4s cubic-bezier(0.4, 0, 0.2, 1)",
+  "@keyframes catalogSearchRowReveal": {
+    from: { opacity: 0.35 },
+    to: { opacity: 1 },
+  },
+};

--- a/src/components/experiences/modern/catalog/Search/catalogTagFilters.test.ts
+++ b/src/components/experiences/modern/catalog/Search/catalogTagFilters.test.ts
@@ -53,8 +53,9 @@ describe("getCatalogTagLabel", () => {
     expect(getCatalogTagLabel("S")).toBe("Singles Rotation");
   });
 
-  it("passes through status tag ids", () => {
-    expect(getCatalogTagLabel("exclusives")).toBe("exclusives");
+  it("title-cases status tags for the autocomplete", () => {
+    expect(getCatalogTagLabel("exclusives")).toBe("Exclusives");
+    expect(getCatalogTagLabel("missing")).toBe("Missing");
   });
 });
 

--- a/src/components/experiences/modern/catalog/Search/catalogTagFilters.test.ts
+++ b/src/components/experiences/modern/catalog/Search/catalogTagFilters.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+  catalogTagsToQueryFlags,
+  getCatalogTagLabel,
+  isCatalogRotationTag,
+} from "./catalogTagFilters";
+
+describe("catalogTagsToQueryFlags", () => {
+  it("returns false on_streaming when exclusives is selected", () => {
+    expect(catalogTagsToQueryFlags(["exclusives"])).toEqual({
+      on_streaming: false,
+      missing: undefined,
+      rotation_bins: undefined,
+    });
+  });
+
+  it("returns missing true when missing is selected", () => {
+    expect(catalogTagsToQueryFlags(["missing"])).toEqual({
+      on_streaming: undefined,
+      missing: true,
+      rotation_bins: undefined,
+    });
+  });
+
+  it("returns rotation_bins when rotation tags are selected", () => {
+    expect(catalogTagsToQueryFlags(["H", "M"])).toEqual({
+      on_streaming: undefined,
+      missing: undefined,
+      rotation_bins: ["H", "M"],
+    });
+  });
+
+  it("returns undefined flags when no tags are selected", () => {
+    expect(catalogTagsToQueryFlags([])).toEqual({
+      on_streaming: undefined,
+      missing: undefined,
+      rotation_bins: undefined,
+    });
+  });
+
+  it("supports exclusives, missing, and rotation together", () => {
+    expect(catalogTagsToQueryFlags(["exclusives", "missing", "H"])).toEqual({
+      on_streaming: false,
+      missing: true,
+      rotation_bins: ["H"],
+    });
+  });
+});
+
+describe("getCatalogTagLabel", () => {
+  it("labels rotation bins for the autocomplete", () => {
+    expect(getCatalogTagLabel("H")).toBe("Heavy Rotation");
+    expect(getCatalogTagLabel("S")).toBe("Singles Rotation");
+  });
+
+  it("passes through status tag ids", () => {
+    expect(getCatalogTagLabel("exclusives")).toBe("exclusives");
+  });
+});
+
+describe("isCatalogRotationTag", () => {
+  it("recognizes rotation bin codes only", () => {
+    expect(isCatalogRotationTag("M")).toBe(true);
+    expect(isCatalogRotationTag("exclusives")).toBe(false);
+  });
+});

--- a/src/components/experiences/modern/catalog/Search/catalogTagFilters.ts
+++ b/src/components/experiences/modern/catalog/Search/catalogTagFilters.ts
@@ -1,0 +1,53 @@
+import type { Rotation } from "@/lib/features/rotation/types";
+import { ROTATION_BIN_LABELS } from "@/src/utilities/modern/rotationBinColors";
+
+/** Status / boolean tag filters (not rotation bins). */
+export const CATALOG_STATUS_TAG_OPTIONS = ["exclusives", "missing"] as const;
+
+export type CatalogStatusTagId = (typeof CATALOG_STATUS_TAG_OPTIONS)[number];
+
+/** Rotation bin codes stored in `filters.tags` alongside status tags. */
+export const CATALOG_ROTATION_TAG_BINS = ["H", "M", "L", "S"] as const;
+
+export type CatalogRotationTagBin = (typeof CATALOG_ROTATION_TAG_BINS)[number];
+
+export const CATALOG_TAG_FILTER_OPTIONS = [
+  ...CATALOG_STATUS_TAG_OPTIONS,
+  ...CATALOG_ROTATION_TAG_BINS,
+] as const;
+
+export type CatalogTagFilterId = (typeof CATALOG_TAG_FILTER_OPTIONS)[number];
+
+const ROTATION_TAG_BIN_SET = new Set<string>(CATALOG_ROTATION_TAG_BINS);
+
+export function isCatalogRotationTag(tagId: string): tagId is CatalogRotationTagBin {
+  return ROTATION_TAG_BIN_SET.has(tagId);
+}
+
+export function getCatalogTagLabel(tagId: string): string {
+  if (tagId === "exclusives" || tagId === "missing") return tagId;
+  if (isCatalogRotationTag(tagId)) {
+    return `${ROTATION_BIN_LABELS[tagId]} Rotation`;
+  }
+  return tagId;
+}
+
+export function catalogTagsToRotationBins(tags: string[]): Rotation[] {
+  return tags.filter(isCatalogRotationTag) as Rotation[];
+}
+
+export type CatalogTagQueryFlags = {
+  on_streaming?: boolean;
+  missing?: boolean;
+  rotation_bins?: Rotation[];
+};
+
+/** Map selected tag filters to `/library/query` params. */
+export function catalogTagsToQueryFlags(tags: string[]): CatalogTagQueryFlags {
+  const rotation_bins = catalogTagsToRotationBins(tags);
+  return {
+    on_streaming: tags.includes("exclusives") ? false : undefined,
+    missing: tags.includes("missing") ? true : undefined,
+    rotation_bins: rotation_bins.length > 0 ? rotation_bins : undefined,
+  };
+}

--- a/src/components/experiences/modern/catalog/Search/catalogTagFilters.ts
+++ b/src/components/experiences/modern/catalog/Search/catalogTagFilters.ts
@@ -25,7 +25,8 @@ export function isCatalogRotationTag(tagId: string): tagId is CatalogRotationTag
 }
 
 export function getCatalogTagLabel(tagId: string): string {
-  if (tagId === "exclusives" || tagId === "missing") return tagId;
+  if (tagId === "exclusives") return "Exclusives";
+  if (tagId === "missing") return "Missing";
   if (isCatalogRotationTag(tagId)) {
     return `${ROTATION_BIN_LABELS[tagId]} Rotation`;
   }

--- a/src/hooks/__tests__/catalogHooks.test.ts
+++ b/src/hooks/__tests__/catalogHooks.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { buildCatalogQuery, toLibraryQueryParams } from "../catalogHooks";
+import {
+  buildCatalogQuery,
+  dedupeAlbumEntriesById,
+  toLibraryQueryParams,
+} from "../catalogHooks";
+import { createTestAlbum } from "@/lib/test-utils";
 import type {
   CatalogFilters,
   CatalogSearchRow,
@@ -15,10 +20,23 @@ const row = (overrides: Partial<CatalogSearchRow>): CatalogSearchRow => ({
 });
 
 const defaultFilters: CatalogFilters = {
-  onStreaming: undefined,
-  genre: "All",
-  format: "All",
+  genres: [],
+  formats: [],
+  tags: [],
 };
+
+describe("dedupeAlbumEntriesById", () => {
+  it("keeps the first row for each album id", () => {
+    const first = createTestAlbum({ id: 7000, title: "First" });
+    const second = createTestAlbum({ id: 7000, title: "Second" });
+    const other = createTestAlbum({ id: 2 });
+    const deduped = dedupeAlbumEntriesById([first, second, other]);
+    expect(deduped).toHaveLength(2);
+    expect(deduped[0].title).toBe("First");
+    expect(deduped[1].id).toBe(2);
+  });
+
+});
 
 describe("buildCatalogQuery", () => {
   it("returns empty string for one empty row", () => {
@@ -72,7 +90,7 @@ describe("toLibraryQueryParams", () => {
   it("threads slice state into the request params", () => {
     const params = toLibraryQueryParams(
       [row({ field: "artist", value: "Stereolab" })],
-      { ...defaultFilters, genre: "Rock", onStreaming: false },
+      { ...defaultFilters, genres: ["Rock", "Jazz"], tags: ["exclusives"] },
       2,
       "plays",
       "desc"
@@ -83,10 +101,34 @@ describe("toLibraryQueryParams", () => {
       sort: "plays",
       order: "desc",
       on_streaming: false,
-      genre: "Rock",
-      format: undefined,
+      missing: undefined,
+      genres: "Rock,Jazz",
+      formats: undefined,
     });
     expect(params.limit).toBeGreaterThan(0);
+  });
+
+  it("maps missing tag to missing=true", () => {
+    const params = toLibraryQueryParams(
+      [row({})],
+      { ...defaultFilters, tags: ["missing"] },
+      0,
+      "album",
+      "asc"
+    );
+    expect(params.missing).toBe(true);
+    expect(params.on_streaming).toBeUndefined();
+  });
+
+  it("maps rotation tags to comma-separated rotation_bins", () => {
+    const params = toLibraryQueryParams(
+      [row({})],
+      { ...defaultFilters, tags: ["H", "M"] },
+      0,
+      "album",
+      "asc"
+    );
+    expect(params.rotation_bins).toBe("H,M");
   });
 
   it("omits empty q when all rows are blank", () => {
@@ -100,7 +142,7 @@ describe("toLibraryQueryParams", () => {
     expect(params.q).toBeUndefined();
   });
 
-  it("maps 'All' filter sentinels to undefined", () => {
+  it("omits empty genre and format arrays from params", () => {
     const params = toLibraryQueryParams(
       [row({})],
       defaultFilters,
@@ -108,8 +150,22 @@ describe("toLibraryQueryParams", () => {
       "album",
       "asc"
     );
-    expect(params.genre).toBeUndefined();
-    expect(params.format).toBeUndefined();
+    expect(params.genres).toBeUndefined();
+    expect(params.formats).toBeUndefined();
     expect(params.on_streaming).toBeUndefined();
+    expect(params.genres).toBeUndefined();
+    expect(params.formats).toBeUndefined();
+  });
+
+  it("emits comma-separated genres and formats", () => {
+    const params = toLibraryQueryParams(
+      [row({})],
+      { ...defaultFilters, genres: ["Rock"], formats: ["cd", "Vinyl"] },
+      0,
+      "album",
+      "asc"
+    );
+    expect(params.genres).toBe("Rock");
+    expect(params.formats).toBe("cd,Vinyl");
   });
 });

--- a/src/hooks/__tests__/catalogHooks.test.ts
+++ b/src/hooks/__tests__/catalogHooks.test.ts
@@ -84,6 +84,11 @@ describe("buildCatalogQuery", () => {
     ]);
     expect(result).toBe("artist:Stereolab AND label:Drag City");
   });
+
+  it("drops rows whose inner term is empty after quote stripping", () => {
+    expect(buildCatalogQuery([row({ value: '""', exact: true })])).toBe("");
+    expect(buildCatalogQuery([row({ value: '"', exact: true })])).toBe("");
+  });
 });
 
 describe("toLibraryQueryParams", () => {

--- a/src/hooks/__tests__/useCatalogQueryResults.test.tsx
+++ b/src/hooks/__tests__/useCatalogQueryResults.test.tsx
@@ -267,4 +267,87 @@ describe("useCatalogQueryResults", () => {
     });
     expect(result.current.isLoadingInitial).toBe(false);
   });
+
+  it("uses filtered result count and auto-fetches when rotation filter empties a page", async () => {
+    const store = makeStore();
+    const fetchNextPage = vi.fn();
+    nextInfiniteResult = {
+      data: {
+        pages: [
+          {
+            results: [
+              createTestAlbum({ id: 1, rotation_bin: "M" }),
+              createTestAlbum({ id: 2, rotation_bin: undefined }),
+            ],
+            total: 100,
+            page: 0,
+            totalPages: 5,
+          },
+        ],
+      },
+      isFetching: false,
+      isError: false,
+      hasNextPage: true,
+      fetchNextPage,
+    };
+
+    act(() => {
+      store.dispatch(catalogSlice.actions.engageBrowse());
+      store.dispatch(
+        catalogSlice.actions.setFilter({ tags: ["H"] }),
+      );
+    });
+
+    const { result } = renderHook(() => useCatalogQueryResults(), {
+      wrapper: Wrapper({ store }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.results).toHaveLength(0);
+      expect(fetchNextPage).toHaveBeenCalled();
+    });
+    expect(result.current.total).toBe(0);
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("keeps only rotation rows matching selected bins", async () => {
+    const store = makeStore();
+    nextInfiniteResult = {
+      data: {
+        pages: [
+          {
+            results: [
+              createTestAlbum({ id: 1, rotation_bin: "H" }),
+              createTestAlbum({ id: 2, rotation_bin: "M" }),
+            ],
+            total: 2,
+            page: 0,
+            totalPages: 1,
+          },
+        ],
+      },
+      isFetching: false,
+      isError: false,
+      hasNextPage: false,
+      fetchNextPage: vi.fn(),
+    };
+
+    act(() => {
+      store.dispatch(catalogSlice.actions.engageBrowse());
+      store.dispatch(
+        catalogSlice.actions.setFilter({ tags: ["H"] }),
+      );
+    });
+
+    const { result } = renderHook(() => useCatalogQueryResults(), {
+      wrapper: Wrapper({ store }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.results).toHaveLength(1);
+    });
+    expect(result.current.results[0].id).toBe(1);
+    expect(result.current.total).toBe(1);
+    expect(result.current.hasNextPage).toBe(false);
+  });
 });

--- a/src/hooks/__tests__/useCatalogQueryResults.test.tsx
+++ b/src/hooks/__tests__/useCatalogQueryResults.test.tsx
@@ -6,19 +6,24 @@ import { CssVarsProvider } from "@mui/joy/styles";
 import { makeStore } from "@/lib/store";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 import { createTestAlbum } from "@/lib/test-utils";
-import type { LibraryQueryParams } from "@/lib/features/catalog/types";
+import type { CatalogInfiniteQueryArg } from "@/lib/features/catalog/api";
 
-type LazyResult = {
-  data: unknown;
+type InfiniteQueryResult = {
+  data: { pages: Array<{ results: ReturnType<typeof createTestAlbum>[]; total: number; page: number; totalPages: number }> } | undefined;
   isFetching: boolean;
   isError: boolean;
+  hasNextPage: boolean;
+  fetchNextPage: ReturnType<typeof vi.fn>;
 };
 
-const triggerCalls: LibraryQueryParams[] = [];
-let nextLazyResult: LazyResult = {
+let infiniteQueryEnabled = false;
+let lastQueryArg: CatalogInfiniteQueryArg | undefined;
+let nextInfiniteResult: InfiniteQueryResult = {
   data: undefined,
   isFetching: false,
   isError: false,
+  hasNextPage: false,
+  fetchNextPage: vi.fn(),
 };
 
 vi.mock("@/lib/features/catalog/api", () => ({
@@ -33,11 +38,22 @@ vi.mock("@/lib/features/catalog/api", () => ({
     endpoints: {},
     util: { resetApiState: () => ({ type: "noop" }) },
   },
-  useLazySearchLibraryQueryQuery: () => {
-    const trigger = (params: LibraryQueryParams) => {
-      triggerCalls.push(params);
-    };
-    return [trigger, nextLazyResult];
+  useSearchLibraryQueryInfiniteQuery: (
+    queryArg: CatalogInfiniteQueryArg,
+    options?: { skip?: boolean },
+  ) => {
+    lastQueryArg = queryArg;
+    if (options?.skip) {
+      return {
+        data: undefined,
+        isFetching: false,
+        isError: false,
+        hasNextPage: false,
+        fetchNextPage: vi.fn(),
+      };
+    }
+    infiniteQueryEnabled = true;
+    return nextInfiniteResult;
   },
   useSearchCatalogQuery: () => ({
     data: undefined,
@@ -76,15 +92,34 @@ function setRowValue(store: ReturnType<typeof makeStore>, value: string) {
 
 describe("useCatalogQueryResults", () => {
   beforeEach(() => {
-    triggerCalls.length = 0;
-    nextLazyResult = { data: undefined, isFetching: false, isError: false };
+    infiniteQueryEnabled = false;
+    lastQueryArg = undefined;
+    nextInfiniteResult = {
+      data: undefined,
+      isFetching: false,
+      isError: false,
+      hasNextPage: false,
+      fetchNextPage: vi.fn(),
+    };
   });
 
-  it("fires the query immediately on mount when default state is empty", () => {
+  it("skips the infinite query until browse or filters/search intent", () => {
     const store = makeStore();
     renderHook(() => useCatalogQueryResults(), { wrapper: Wrapper({ store }) });
-    expect(triggerCalls.length).toBe(1);
-    expect(triggerCalls[0].q).toBeUndefined();
+    expect(infiniteQueryEnabled).toBe(false);
+  });
+
+  it("enables the query when browse is engaged with an empty query", () => {
+    const store = makeStore();
+    const { rerender } = renderHook(() => useCatalogQueryResults(), {
+      wrapper: Wrapper({ store }),
+    });
+    act(() => {
+      store.dispatch(catalogSlice.actions.engageBrowse());
+    });
+    rerender();
+    expect(infiniteQueryEnabled).toBe(true);
+    expect(lastQueryArg?.q).toBeUndefined();
   });
 
   it("skips single-character partial queries", () => {
@@ -93,76 +128,51 @@ describe("useCatalogQueryResults", () => {
       wrapper: Wrapper({ store }),
     });
 
-    triggerCalls.length = 0;
     act(() => {
+      store.dispatch(catalogSlice.actions.engageBrowse());
       setRowValue(store, "a");
     });
     rerender();
-    expect(triggerCalls).toHaveLength(0);
+    expect(infiniteQueryEnabled).toBe(false);
   });
 
-  it("fires once when the query stabilizes at >= 2 chars", () => {
+  it("enables the query when the query stabilizes at >= 2 chars", () => {
     const store = makeStore();
     const { rerender } = renderHook(() => useCatalogQueryResults(), {
       wrapper: Wrapper({ store }),
     });
 
-    triggerCalls.length = 0;
     act(() => {
       setRowValue(store, "Stereolab");
     });
     rerender();
-    expect(triggerCalls).toHaveLength(1);
-    expect(triggerCalls[0].q).toBe("artist:Stereolab");
+    expect(infiniteQueryEnabled).toBe(true);
+    expect(lastQueryArg?.q).toBe("artist:Stereolab");
   });
 
-  it("dedupes consecutive renders with the same params", () => {
+  it("dedupes duplicate album ids across flattened pages", async () => {
     const store = makeStore();
-    const { rerender } = renderHook(() => useCatalogQueryResults(), {
-      wrapper: Wrapper({ store }),
-    });
-
-    triggerCalls.length = 0;
-    act(() => {
-      setRowValue(store, "Stereolab");
-    });
-    rerender();
-    rerender();
-    rerender();
-    expect(triggerCalls).toHaveLength(1);
-  });
-
-  it("queues the latest params while a fetch is in flight, drains when it finishes", () => {
-    const store = makeStore();
-    nextLazyResult = { data: undefined, isFetching: true, isError: false };
-
-    const { rerender } = renderHook(() => useCatalogQueryResults(), {
-      wrapper: Wrapper({ store }),
-    });
-
-    triggerCalls.length = 0;
-    act(() => {
-      setRowValue(store, "Stereolab");
-    });
-    rerender();
-    // In-flight: trigger should not be called again
-    expect(triggerCalls).toHaveLength(0);
-
-    // Flip to !isFetching and re-render — pending should drain.
-    nextLazyResult = { data: undefined, isFetching: false, isError: false };
-    rerender();
-    expect(triggerCalls).toHaveLength(1);
-    expect(triggerCalls[0].q).toBe("artist:Stereolab");
-  });
-
-  it("accumulates additional pages when data is returned, deduping by id", async () => {
-    const store = makeStore();
-    const pageZero = [createTestAlbum({ id: 1 }), createTestAlbum({ id: 2 })];
-    nextLazyResult = {
-      data: { results: pageZero, total: 4, page: 0, totalPages: 2 },
+    const duplicate = createTestAlbum({ id: 7000 });
+    nextInfiniteResult = {
+      data: {
+        pages: [
+          {
+            results: [duplicate, duplicate, createTestAlbum({ id: 2 })],
+            total: 2,
+            page: 0,
+            totalPages: 1,
+          },
+        ],
+      },
       isFetching: false,
       isError: false,
+      hasNextPage: false,
+      fetchNextPage: vi.fn(),
     };
+
+    act(() => {
+      store.dispatch(catalogSlice.actions.engageBrowse());
+    });
 
     const { result } = renderHook(() => useCatalogQueryResults(), {
       wrapper: Wrapper({ store }),
@@ -171,41 +181,90 @@ describe("useCatalogQueryResults", () => {
     await waitFor(() => {
       expect(result.current.results).toHaveLength(2);
     });
-    expect(result.current.results.map((r) => r.id)).toEqual([1, 2]);
-    expect(result.current.hasMore).toBe(true);
+    expect(result.current.results.map((r) => r.id)).toEqual([7000, 2]);
   });
 
-  it("resets the accumulator when the query changes", async () => {
+  it("flattens multiple pages and exposes hasNextPage", async () => {
     const store = makeStore();
-    nextLazyResult = {
+    const pageZero = [createTestAlbum({ id: 1 }), createTestAlbum({ id: 2 })];
+    nextInfiniteResult = {
       data: {
-        results: [createTestAlbum({ id: 1 })],
-        total: 1,
-        page: 0,
-        totalPages: 1,
+        pages: [{ results: pageZero, total: 4, page: 0, totalPages: 2 }],
       },
       isFetching: false,
       isError: false,
+      hasNextPage: true,
+      fetchNextPage: vi.fn(),
     };
 
-    const { result, rerender } = renderHook(() => useCatalogQueryResults(), {
+    act(() => {
+      store.dispatch(catalogSlice.actions.engageBrowse());
+    });
+
+    const { result } = renderHook(() => useCatalogQueryResults(), {
       wrapper: Wrapper({ store }),
     });
 
     await waitFor(() => {
-      expect(result.current.results).toHaveLength(1);
+      expect(result.current.results).toHaveLength(2);
+    });
+    expect(result.current.hasNextPage).toBe(true);
+    expect(result.current.isLoadingInitial).toBe(false);
+    expect(result.current.isFetchingMore).toBe(false);
+  });
+
+  it("sets isLoadingInitial while fetching with no pages yet", () => {
+    const store = makeStore();
+    nextInfiniteResult = {
+      data: undefined,
+      isFetching: true,
+      isError: false,
+      hasNextPage: false,
+      fetchNextPage: vi.fn(),
+    };
+
+    act(() => {
+      store.dispatch(catalogSlice.actions.engageBrowse());
     });
 
-    // Change the query (which mutates the accumulation key). Accumulator clears.
+    const { result } = renderHook(() => useCatalogQueryResults(), {
+      wrapper: Wrapper({ store }),
+    });
+
+    expect(result.current.isLoadingInitial).toBe(true);
+    expect(result.current.isFetchingMore).toBe(false);
+  });
+
+  it("sets isFetchingMore while fetching with existing pages", async () => {
+    const store = makeStore();
+    nextInfiniteResult = {
+      data: {
+        pages: [
+          {
+            results: [createTestAlbum({ id: 1 })],
+            total: 2,
+            page: 0,
+            totalPages: 2,
+          },
+        ],
+      },
+      isFetching: true,
+      isError: false,
+      hasNextPage: true,
+      fetchNextPage: vi.fn(),
+    };
+
     act(() => {
-      setRowValue(store, "Cat Power");
+      store.dispatch(catalogSlice.actions.engageBrowse());
     });
-    rerender();
+
+    const { result } = renderHook(() => useCatalogQueryResults(), {
+      wrapper: Wrapper({ store }),
+    });
+
     await waitFor(() => {
-      // After reset and before the new page lands (still the page-0 data above
-      // for a different key), accumulator is at least empty briefly.
-      // We assert the *final* state: the next data drop replaces, not appends.
-      expect(result.current.results.length).toBeLessThanOrEqual(1);
+      expect(result.current.isFetchingMore).toBe(true);
     });
+    expect(result.current.isLoadingInitial).toBe(false);
   });
 });

--- a/src/hooks/catalogHooks.ts
+++ b/src/hooks/catalogHooks.ts
@@ -67,6 +67,9 @@ function queryTermInnerValue(value: string): string {
   ) {
     return trimmed.slice(1, -1);
   }
+  if (trimmed.includes('"')) {
+    return "";
+  }
   return trimmed;
 }
 
@@ -76,6 +79,7 @@ export function buildCatalogQuery(rows: CatalogSearchRow[]): string {
     const row = rows[i];
     if (!row.value.trim()) continue;
     const inner = queryTermInnerValue(row.value);
+    if (!inner) continue;
     const value = row.exact ? `"${inner}"` : inner;
     const prefix = CATALOG_FIELD_PREFIXES[row.field] ?? "";
     const fullTerm = `${prefix}${value}`;
@@ -298,14 +302,38 @@ export function useCatalogQueryResults() {
     );
   }, [data?.pages, rotationFilterBins]);
 
-  const total = data?.pages?.[0]?.total ?? 0;
+  const hasRotationClientFilter = rotationFilterBins.length > 0;
+  const rtkHasNextPage = hasNextPage ?? false;
+
+  useEffect(() => {
+    if (!queryEnabled || !hasRotationClientFilter) return;
+    if (isFetching || !rtkHasNextPage) return;
+    if (results.length > 0) return;
+    void fetchNextPage();
+  }, [
+    queryEnabled,
+    hasRotationClientFilter,
+    isFetching,
+    rtkHasNextPage,
+    results.length,
+    fetchNextPage,
+  ]);
+
+  const total = useMemo(() => {
+    if (hasRotationClientFilter) return results.length;
+    return data?.pages?.[0]?.total ?? 0;
+  }, [hasRotationClientFilter, results.length, data?.pages]);
+
   const isLoadingInitial = isFetching && !data?.pages?.length;
   const isFetchingMore = isFetching && (data?.pages?.length ?? 0) > 0;
+  const effectiveHasNextPage = hasRotationClientFilter
+    ? rtkHasNextPage && (results.length > 0 || isFetching)
+    : rtkHasNextPage;
 
   return {
     results,
     total,
-    hasNextPage: hasNextPage ?? false,
+    hasNextPage: effectiveHasNextPage,
     isLoadingInitial,
     isFetchingMore,
     isError,

--- a/src/hooks/catalogHooks.ts
+++ b/src/hooks/catalogHooks.ts
@@ -1,9 +1,11 @@
 "use client";
 
 import {
-  useLazySearchLibraryQueryQuery,
   useSearchCatalogQuery,
+  useSearchLibraryQueryInfiniteQuery,
+  type CatalogInfiniteQueryArg,
 } from "@/lib/features/catalog/api";
+import { CATALOG_QUERY_PAGE_LIMIT } from "@/lib/features/catalog/constants";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 import { isCompilationArtistName } from "@/lib/features/catalog/is-compilation-artist";
 import {
@@ -18,12 +20,28 @@ import {
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { useGetRotationQuery } from "@/lib/features/rotation/api";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuthentication } from "./authenticationHooks";
 import { filterBySearchTerms } from "@/src/utilities/filterBySearchTerms";
+import {
+  catalogTagsToQueryFlags,
+  catalogTagsToRotationBins,
+} from "@/src/components/experiences/modern/catalog/Search/catalogTagFilters";
+import type { Rotation } from "@/lib/features/rotation/types";
 
 const MIN_QUERY_LENGTH = 2;
-const PAGE_LIMIT = 50;
+
+/** Keep first occurrence per album id (backend may return duplicates in one page). */
+export function dedupeAlbumEntriesById(entries: AlbumEntry[]): AlbumEntry[] {
+  const seen = new Set<number>();
+  const out: AlbumEntry[] = [];
+  for (const entry of entries) {
+    if (seen.has(entry.id)) continue;
+    seen.add(entry.id);
+    out.push(entry);
+  }
+  return out;
+}
 
 /** UI-side field-prefix map (mirrors the backend's CATALOG_PARSER_CONFIG). */
 const CATALOG_FIELD_PREFIXES: Record<CatalogSearchField, string | null> = {
@@ -39,12 +57,26 @@ const CATALOG_FIELD_PREFIXES: Record<CatalogSearchField, string | null> = {
  * playlist-search hook's `buildQuery` so the two surfaces stay structurally
  * similar without prematurely sharing code.
  */
+/** Strip surrounding quotes when building API query from exact-mode input. */
+function queryTermInnerValue(value: string): string {
+  const trimmed = value.trim();
+  if (
+    trimmed.startsWith('"') &&
+    trimmed.endsWith('"') &&
+    trimmed.length >= 2
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
 export function buildCatalogQuery(rows: CatalogSearchRow[]): string {
   const parts: string[] = [];
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
     if (!row.value.trim()) continue;
-    const value = row.exact ? `"${row.value.trim()}"` : row.value.trim();
+    const inner = queryTermInnerValue(row.value);
+    const value = row.exact ? `"${inner}"` : inner;
     const prefix = CATALOG_FIELD_PREFIXES[row.field] ?? "";
     const fullTerm = `${prefix}${value}`;
     parts.push(i === 0 ? fullTerm : `${row.operator} ${fullTerm}`);
@@ -53,8 +85,7 @@ export function buildCatalogQuery(rows: CatalogSearchRow[]): string {
 }
 
 /**
- * Map UI state to the request shape. `'All'` enum sentinels become
- * `undefined` so they're omitted from the URL.
+ * Map UI state to the request shape. Empty genre/format arrays are omitted.
  */
 export function toLibraryQueryParams(
   rows: CatalogSearchRow[],
@@ -64,16 +95,41 @@ export function toLibraryQueryParams(
   sortOrder: CatalogSortOrder,
 ): LibraryQueryParams {
   const q = buildCatalogQuery(rows);
+  const tagFlags = catalogTagsToQueryFlags(filters.tags);
   return {
     q: q || undefined,
     page,
-    limit: PAGE_LIMIT,
+    limit: CATALOG_QUERY_PAGE_LIMIT,
     sort: sortBy,
     order: sortOrder,
-    on_streaming: filters.onStreaming,
-    genre: filters.genre === "All" ? undefined : filters.genre,
-    format: filters.format === "All" ? undefined : filters.format,
+    on_streaming: tagFlags.on_streaming,
+    missing: tagFlags.missing,
+    rotation_bins:
+      tagFlags.rotation_bins && tagFlags.rotation_bins.length > 0
+        ? tagFlags.rotation_bins.join(",")
+        : undefined,
+    genres:
+      filters.genres.length > 0 ? filters.genres.join(",") : undefined,
+    formats:
+      filters.formats.length > 0 ? filters.formats.join(",") : undefined,
   };
+}
+
+/** Build infinite-query args (page/limit are supplied by RTK `pageParam`). */
+export function toCatalogInfiniteQueryArg(
+  rows: CatalogSearchRow[],
+  filters: CatalogFilters,
+  sortBy: CatalogSortBy,
+  sortOrder: CatalogSortOrder,
+): CatalogInfiniteQueryArg {
+  const { page: _page, limit: _limit, ...rest } = toLibraryQueryParams(
+    rows,
+    filters,
+    0,
+    sortBy,
+    sortOrder,
+  );
+  return rest;
 }
 
 /**
@@ -88,6 +144,7 @@ export function useCatalogQuerySearch() {
   const sortBy = useAppSelector(catalogSlice.selectors.getSortBy);
   const sortOrder = useAppSelector(catalogSlice.selectors.getSortOrder);
   const filters = useAppSelector(catalogSlice.selectors.getFilters);
+  const browseEngaged = useAppSelector(catalogSlice.selectors.getBrowseEngaged);
   const selected = useAppSelector(catalogSlice.selectors.getSelected);
 
   const addRow = useCallback(
@@ -141,26 +198,35 @@ export function useCatalogQuerySearch() {
     [dispatch],
   );
 
+  const engageBrowse = useCallback(
+    () => dispatch(catalogSlice.actions.engageBrowse()),
+    [dispatch],
+  );
+
   const reset = useCallback(
     () => dispatch(catalogSlice.actions.reset()),
     [dispatch],
   );
 
   const effectiveQuery = useMemo(() => buildCatalogQuery(rows), [rows]);
-  const hasActiveQuery =
+  const hasFilterOrSearch =
     effectiveQuery.length > 0 ||
-    filters.onStreaming !== undefined ||
-    filters.genre !== "All" ||
-    filters.format !== "All";
+    filters.genres.length > 0 ||
+    filters.formats.length > 0 ||
+    filters.tags.length > 0;
+  const hasActiveQuery = browseEngaged || hasFilterOrSearch;
 
   return {
     rows,
     sortBy,
     sortOrder,
     filters,
+    browseEngaged,
     selected,
     effectiveQuery,
     hasActiveQuery,
+    hasFilterOrSearch,
+    engageBrowse,
     addRow,
     removeRow,
     updateRow,
@@ -179,113 +245,71 @@ export function useCatalogQuerySearch() {
 }
 
 /**
- * Data-fetching hook for the catalog query builder. Reads slice state from
- * {@link useCatalogQuerySearch}, fires `/library/query`, and accumulates
- * pages for infinite scroll. Response-based throttling mirrors
- * `usePlaylistSearch` — at most one in-flight request, the next-query queues.
+ * Data-fetching hook for the catalog query builder. Uses RTK infinite query
+ * on `/library/query` (same pattern as flowsheet `getInfiniteEntries`).
  */
 export function useCatalogQueryResults() {
-  const { rows, sortBy, sortOrder, filters, effectiveQuery } =
+  const { rows, sortBy, sortOrder, filters, hasActiveQuery } =
     useCatalogQuerySearch();
-  const dispatch = useAppDispatch();
-  const page = useAppSelector(catalogSlice.selectors.getPage);
 
   const { authenticating, authenticated } = useAuthentication();
   const ready = !authenticating && authenticated;
 
-  const params = useMemo(
-    () => toLibraryQueryParams(rows, filters, page, sortBy, sortOrder),
-    [rows, filters, page, sortBy, sortOrder],
+  const hasPartialRow = useMemo(
+    () =>
+      rows.some((r) => {
+        const v = r.value.trim();
+        return v.length > 0 && v.length < MIN_QUERY_LENGTH;
+      }),
+    [rows],
   );
 
-  const pendingQueryRef = useRef<LibraryQueryParams | null>(null);
-  // null sentinel — distinguish "never fired" from "fired with empty q"
-  const lastFiredRef = useRef<string | null>(null);
+  const queryArg = useMemo(
+    () => toCatalogInfiniteQueryArg(rows, filters, sortBy, sortOrder),
+    [rows, filters, sortBy, sortOrder],
+  );
 
-  // Accumulated results held in state so a new page or a query-reset triggers
-  // a re-render. A ref-based store wouldn't — the Results component reads
-  // straight from this hook, and React only re-renders on state changes.
-  const [accumulated, setAccumulated] = useState<AlbumEntry[]>([]);
-  const lastAccumulatedKeyRef = useRef<string>("");
+  const queryEnabled = ready && hasActiveQuery && !hasPartialRow;
 
-  const [trigger, { data, isFetching, isError }] =
-    useLazySearchLibraryQueryQuery();
+  const {
+    data,
+    isFetching,
+    isError,
+    hasNextPage,
+    fetchNextPage,
+  } = useSearchLibraryQueryInfiniteQuery(queryArg, {
+    skip: !queryEnabled,
+  });
 
-  // Reset accumulated rows when the query or sort changes (any param except page).
-  useEffect(() => {
-    const key = `${effectiveQuery}|${sortBy}|${sortOrder}|${filters.onStreaming}|${filters.genre}|${filters.format}`;
-    if (key !== lastAccumulatedKeyRef.current) {
-      lastAccumulatedKeyRef.current = key;
-      setAccumulated([]);
-    }
-  }, [effectiveQuery, sortBy, sortOrder, filters]);
+  const rotationFilterBins = useMemo(
+    () => catalogTagsToRotationBins(filters.tags),
+    [filters.tags],
+  );
 
-  // Append the latest page (or replace, for page 0) into the accumulator.
-  useEffect(() => {
-    if (!data?.results) return;
-    setAccumulated((prev) => {
-      if (data.page === 0) return data.results;
-      const seen = new Set(prev.map((r) => r.id));
-      return [...prev, ...data.results.filter((r) => !seen.has(r.id))];
-    });
-  }, [data]);
+  const results = useMemo(() => {
+    if (!data?.pages?.length) return [];
+    const flat = dedupeAlbumEntriesById(
+      data.pages.flatMap((page) => page.results),
+    );
+    if (rotationFilterBins.length === 0) return flat;
+    const allowed = new Set(rotationFilterBins);
+    return flat.filter(
+      (row) => row.rotation_bin != null && allowed.has(row.rotation_bin),
+    );
+  }, [data?.pages, rotationFilterBins]);
 
-  // Fire the search when params change. Suppress while any row holds a single-
-  // character partial — typing "a" into a field shouldn't fire a query before
-  // the user finishes the word. Empty rows don't count as partial.
-  useEffect(() => {
-    if (!ready) return;
-    const hasPartialRow = rows.some((r) => {
-      const v = r.value.trim();
-      return v.length > 0 && v.length < MIN_QUERY_LENGTH;
-    });
-    if (hasPartialRow) {
-      pendingQueryRef.current = null;
-      return;
-    }
-
-    const fingerprint = JSON.stringify(params);
-    if (isFetching) {
-      pendingQueryRef.current = params;
-      return;
-    }
-    if (fingerprint !== lastFiredRef.current) {
-      lastFiredRef.current = fingerprint;
-      pendingQueryRef.current = null;
-      trigger(params);
-    }
-  }, [params, ready, rows, isFetching, trigger]);
-
-  // Drain pending query once the in-flight request finishes.
-  useEffect(() => {
-    if (isFetching) return;
-    const pending = pendingQueryRef.current;
-    if (!pending) return;
-    const fingerprint = JSON.stringify(pending);
-    if (fingerprint === lastFiredRef.current) {
-      pendingQueryRef.current = null;
-      return;
-    }
-    lastFiredRef.current = fingerprint;
-    pendingQueryRef.current = null;
-    trigger(pending);
-  }, [isFetching, trigger]);
-
-  const loadNextPage = useCallback(() => {
-    if (!data) return;
-    if (data.page + 1 >= data.totalPages) return;
-    dispatch(catalogSlice.actions.nextPage());
-  }, [data, dispatch]);
-
-  const hasMore = data ? data.page + 1 < data.totalPages : false;
+  const total = data?.pages?.[0]?.total ?? 0;
+  const isLoadingInitial = isFetching && !data?.pages?.length;
+  const isFetchingMore = isFetching && (data?.pages?.length ?? 0) > 0;
 
   return {
-    results: accumulated,
-    total: data?.total ?? 0,
-    hasMore,
-    isLoading: isFetching,
+    results,
+    total,
+    hasNextPage: hasNextPage ?? false,
+    isLoadingInitial,
+    isFetchingMore,
     isError,
-    loadNextPage,
+    fetchNextPage,
   };
 }
 

--- a/src/utilities/modern/rotationBinColors.ts
+++ b/src/utilities/modern/rotationBinColors.ts
@@ -1,0 +1,95 @@
+import type { Rotation } from "@/lib/features/rotation/types";
+
+export type RotationBinColorSet = {
+  bg: string;
+  bgSelected: string;
+  bgHover: string;
+  text: string;
+  textSelected: string;
+  border: string;
+};
+
+export const ROTATION_BINS: Rotation[] = ["H", "M", "L", "S"];
+
+export const ROTATION_BIN_LABELS: Record<Rotation, string> = {
+  H: "Heavy",
+  M: "Medium",
+  L: "Light",
+  S: "Singles",
+};
+
+export const LIGHT_ROTATION_BIN_COLORS: Record<Rotation, RotationBinColorSet> = {
+  H: {
+    bg: "#fce4ec",
+    bgSelected: "#e53935",
+    bgHover: "#f8bbd0",
+    text: "#b71c1c",
+    textSelected: "#fff",
+    border: "#ef9a9a",
+  },
+  M: {
+    bg: "#fff9c4",
+    bgSelected: "#f9a825",
+    bgHover: "#fff176",
+    text: "#f57f17",
+    textSelected: "#fff",
+    border: "#fdd835",
+  },
+  L: {
+    bg: "#e0f2f1",
+    bgSelected: "#00897b",
+    bgHover: "#b2dfdb",
+    text: "#004d40",
+    textSelected: "#fff",
+    border: "#80cbc4",
+  },
+  S: {
+    bg: "#e8eaf6",
+    bgSelected: "#5c6bc0",
+    bgHover: "#c5cae9",
+    text: "#283593",
+    textSelected: "#fff",
+    border: "#9fa8da",
+  },
+};
+
+export const DARK_ROTATION_BIN_COLORS: Record<Rotation, RotationBinColorSet> = {
+  H: {
+    bg: "#4a1a1a",
+    bgSelected: "#e53935",
+    bgHover: "#5c2020",
+    text: "#ef9a9a",
+    textSelected: "#fff",
+    border: "#7f3333",
+  },
+  M: {
+    bg: "#4a3a0a",
+    bgSelected: "#f9a825",
+    bgHover: "#5c4810",
+    text: "#fdd835",
+    textSelected: "#fff",
+    border: "#7f6820",
+  },
+  L: {
+    bg: "#1a3a36",
+    bgSelected: "#00897b",
+    bgHover: "#204a44",
+    text: "#80cbc4",
+    textSelected: "#fff",
+    border: "#336a60",
+  },
+  S: {
+    bg: "#262a4a",
+    bgSelected: "#5c6bc0",
+    bgHover: "#30365c",
+    text: "#9fa8da",
+    textSelected: "#fff",
+    border: "#4a5090",
+  },
+};
+
+export function getRotationBinColors(
+  mode: "light" | "dark" | "system" | undefined,
+): Record<Rotation, RotationBinColorSet> {
+  return mode === "dark" ? DARK_ROTATION_BIN_COLORS : LIGHT_ROTATION_BIN_COLORS;
+}


### PR DESCRIPTION
## Summary
Split from #648 (umbrella). Stacked on #796 (#795 → #796).

Catalog search/filter UI rewrite — read-only, no MD edit affordances.

- `Search/*` query builder, facet autocompletes, tag filters, chip styles
- `useCatalogQuerySearch` / `useCatalogQueryResults` in `catalogHooks.ts`
- `rotationBinColors.ts`, query-builder unit + E2E tests

**Review finding addressed:**
- **#14:** Preserve quoted input in the field; show "Exact" indicator; strip quotes only when building API query string

## Test plan
- [ ] `npm test -- src/components/experiences/modern/catalog/Search/ src/hooks/__tests__/`
- [ ] `e2e/tests/catalog/query-builder.spec.ts`

Depends on #796. Part of the #648 split stack.

Made with [Cursor](https://cursor.com)