### PR TITLE
feat(admin): allow editing real name and DJ name from the roster account panel

### DIFF
--- a/e2e/pages/roster.page.ts
+++ b/e2e/pages/roster.page.ts
@@ -281,6 +281,8 @@ export class RosterPage {
     await this.openEditModal(username);
     const { sendPasswordReset } = this.getModalActionButtons();
     await sendPasswordReset.waitFor({ state: "visible", timeout: 10000 });
+    await this.waitForToastsToClear();
+    await this.page.waitForTimeout(300);
     await sendPasswordReset.click({ force: true });
   }
 
@@ -289,10 +291,21 @@ export class RosterPage {
     await this.sendPasswordResetEmail(username);
   }
 
+  /**
+   * Wait for lingering toasts to auto-dismiss. The action buttons sit at the
+   * bottom of the edit panel where sonner toasts stack, and force-clicks
+   * bypass Playwright's overlay checks — a toast covering a button swallows
+   * the click silently.
+   */
+  async waitForToastsToClear(): Promise<void> {
+    await expect(this.page.locator("[data-sonner-toast]")).toHaveCount(0, { timeout: 15000 });
+  }
+
   async deleteUser(username: string): Promise<void> {
     await this.openEditModal(username);
     const { delete: deleteBtn } = this.getModalActionButtons();
     await deleteBtn.waitFor({ state: "visible", timeout: 5000 });
+    await this.waitForToastsToClear();
     await deleteBtn.click({ force: true });
   }
 

--- a/e2e/pages/roster.page.ts
+++ b/e2e/pages/roster.page.ts
@@ -507,6 +507,7 @@ export class RosterPage {
   async confirmEmailChange(username: string): Promise<void> {
     const saveButton = this.getEmailConfirmButton(username);
     await saveButton.waitFor({ state: "visible", timeout: 5000 });
+    await this.waitForToastsToClear();
     await saveButton.click({ force: true });
   }
 

--- a/src/components/experiences/modern/Rightbar/panels/AccountEditPanel.test.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/AccountEditPanel.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, act } from "@testing-library/react";
+import AccountEditPanel from "./AccountEditPanel";
+import {
+  renderWithProviders,
+  createTestStore,
+  createTestAccountResult,
+} from "@/lib/test-utils";
+import { applicationSlice } from "@/lib/features/application/frontend";
+import type { Account } from "@/lib/features/admin/types";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: {
+    admin: { listUsers: vi.fn(), updateUser: vi.fn(), removeUser: vi.fn(), setUserPassword: vi.fn() },
+    organization: { listMembers: vi.fn(), updateMemberRole: vi.fn() },
+    requestPasswordReset: vi.fn(),
+  },
+  authBaseURL: "http://localhost:8082/auth",
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  resolveOrganizationIdAdmin: vi.fn(() => Promise.resolve("resolved-org-id")),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/features/admin/roster-events", () => ({
+  invalidateRoster: vi.fn(),
+}));
+
+function openAccountEditPanel(account: Account) {
+  return applicationSlice.actions.openPanel({
+    type: "account-edit",
+    account,
+    isSelf: false,
+    organizationSlug: "wxyc",
+  });
+}
+
+describe("AccountEditPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should reset form state when the panel switches to a different account", async () => {
+    const juana = createTestAccountResult({
+      id: "user-juana",
+      userName: "juana",
+      realName: "Juana Molina",
+      djName: "DJ Juana",
+    });
+    const jessica = createTestAccountResult({
+      id: "user-jessica",
+      userName: "jessica",
+      realName: "Jessica Pratt",
+      djName: "DJ Jess",
+    });
+
+    const store = createTestStore();
+    store.dispatch(openAccountEditPanel(juana));
+    const { user } = renderWithProviders(<AccountEditPanel />, { store });
+
+    expect(screen.getByLabelText("Real Name")).toHaveValue("Juana Molina");
+
+    // Dirty the first account's form so stale state would be visible
+    await user.type(screen.getByLabelText("Real Name"), " Edited");
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+
+    // Switch to editing a different account without closing the panel
+    act(() => {
+      store.dispatch(openAccountEditPanel(jessica));
+    });
+
+    expect(screen.getByLabelText("Real Name")).toHaveValue("Jessica Pratt");
+    expect(screen.getByLabelText("DJ Name")).toHaveValue("DJ Jess");
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/experiences/modern/Rightbar/panels/AccountEditPanel.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/AccountEditPanel.tsx
@@ -22,6 +22,9 @@ export default function AccountEditPanel() {
       onClose={handleClose}
     >
       <AccountEditForm
+        // Remount when the target account changes so field state seeded from
+        // `account` (names, email) never leaks across accounts.
+        key={account.id ?? account.userName}
         account={account}
         isSelf={isSelf}
         onClose={handleClose}

--- a/src/components/experiences/modern/admin/roster/AccountEditForm.test.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEditForm.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import AccountEditForm from "./AccountEditForm";
-import { renderWithProviders, createTestAccountResult } from "@/lib/test-utils";
+import { createComponentHarness, createTestAccountResult } from "@/lib/test-utils";
+import type { Account } from "@/lib/features/admin/types";
 
 vi.mock("@/lib/features/authentication/client", () => ({
   authClient: {
@@ -34,26 +35,21 @@ import { toast } from "sonner";
 const mockUpdateUser = authClient.admin.updateUser as ReturnType<typeof vi.fn>;
 const mockListUsers = authClient.admin.listUsers as ReturnType<typeof vi.fn>;
 
-function renderForm(
-  accountOverrides: Parameters<typeof createTestAccountResult>[0] = {},
-  isSelf = false
-) {
-  const account = createTestAccountResult({
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return createTestAccountResult({
     id: "user-123",
     realName: "Juana Molina",
     djName: "DJ Juana",
-    ...accountOverrides,
+    ...overrides,
   });
-  const result = renderWithProviders(
-    <AccountEditForm
-      account={account}
-      isSelf={isSelf}
-      onClose={vi.fn()}
-      organizationSlug="wxyc"
-    />
-  );
-  return { account, ...result };
 }
+
+const setup = createComponentHarness(AccountEditForm, {
+  account: makeAccount(),
+  isSelf: false,
+  onClose: () => {},
+  organizationSlug: "wxyc",
+});
 
 describe("AccountEditForm name editing", () => {
   beforeEach(() => {
@@ -62,26 +58,26 @@ describe("AccountEditForm name editing", () => {
   });
 
   it("should render real name and DJ name inputs prefilled from the account", () => {
-    renderForm();
+    setup();
 
     expect(screen.getByLabelText("Real Name")).toHaveValue("Juana Molina");
     expect(screen.getByLabelText("DJ Name")).toHaveValue("DJ Juana");
   });
 
   it("should render an empty DJ name input when the account has no DJ name", () => {
-    renderForm({ djName: undefined });
+    setup({ account: makeAccount({ djName: undefined }) });
 
     expect(screen.getByLabelText("DJ Name")).toHaveValue("");
   });
 
   it("should not show a Save button until a field is edited", () => {
-    renderForm();
+    setup();
 
     expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
   });
 
   it("should not show a Save button when the edit is only surrounding whitespace", async () => {
-    const { user } = renderForm();
+    const { user } = setup();
 
     await user.type(screen.getByLabelText("Real Name"), "  ");
 
@@ -89,7 +85,7 @@ describe("AccountEditForm name editing", () => {
   });
 
   it("should not offer Save when the real name is cleared", async () => {
-    const { user } = renderForm();
+    const { user } = setup();
 
     await user.clear(screen.getByLabelText("Real Name"));
 
@@ -97,7 +93,7 @@ describe("AccountEditForm name editing", () => {
   });
 
   it("should save an edited real name via admin.updateUser", async () => {
-    const { user } = renderForm();
+    const { user } = setup();
 
     const input = screen.getByLabelText("Real Name");
     await user.clear(input);
@@ -116,7 +112,7 @@ describe("AccountEditForm name editing", () => {
   });
 
   it("should save an edited DJ name via admin.updateUser", async () => {
-    const { user } = renderForm();
+    const { user } = setup();
 
     const input = screen.getByLabelText("DJ Name");
     await user.clear(input);
@@ -134,7 +130,7 @@ describe("AccountEditForm name editing", () => {
   });
 
   it("should trim surrounding whitespace before saving", async () => {
-    const { user } = renderForm();
+    const { user } = setup();
 
     const input = screen.getByLabelText("Real Name");
     await user.clear(input);
@@ -150,7 +146,7 @@ describe("AccountEditForm name editing", () => {
   });
 
   it("should allow clearing the DJ name", async () => {
-    const { user } = renderForm();
+    const { user } = setup();
 
     await user.clear(screen.getByLabelText("DJ Name"));
     await user.click(screen.getByRole("button", { name: "Save" }));
@@ -164,7 +160,7 @@ describe("AccountEditForm name editing", () => {
   });
 
   it("should hide the Save button after a successful save", async () => {
-    const { user } = renderForm();
+    const { user } = setup();
 
     const input = screen.getByLabelText("Real Name");
     await user.clear(input);
@@ -178,7 +174,7 @@ describe("AccountEditForm name editing", () => {
   });
 
   it("should hide the Save button after clearing the DJ name and saving", async () => {
-    const { user } = renderForm();
+    const { user } = setup();
 
     await user.clear(screen.getByLabelText("DJ Name"));
     await user.click(screen.getByRole("button", { name: "Save" }));
@@ -189,7 +185,7 @@ describe("AccountEditForm name editing", () => {
   });
 
   it("should disable name inputs when editing your own account", () => {
-    renderForm({}, true);
+    setup({ isSelf: true });
 
     expect(screen.getByLabelText("Real Name")).toBeDisabled();
     expect(screen.getByLabelText("DJ Name")).toBeDisabled();
@@ -197,7 +193,7 @@ describe("AccountEditForm name editing", () => {
 
   it("should show an error toast and not refresh the roster when the update fails", async () => {
     mockUpdateUser.mockResolvedValue({ error: { message: "Update rejected" } });
-    const { user } = renderForm();
+    const { user } = setup();
 
     const input = screen.getByLabelText("Real Name");
     await user.clear(input);

--- a/src/components/experiences/modern/admin/roster/AccountEditForm.test.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEditForm.test.tsx
@@ -163,6 +163,31 @@ describe("AccountEditForm name editing", () => {
     });
   });
 
+  it("should hide the Save button after a successful save", async () => {
+    const { user } = renderForm();
+
+    const input = screen.getByLabelText("Real Name");
+    await user.clear(input);
+    await user.type(input, "Jessica Pratt");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+    });
+    expect(input).toHaveValue("Jessica Pratt");
+  });
+
+  it("should hide the Save button after clearing the DJ name and saving", async () => {
+    const { user } = renderForm();
+
+    await user.clear(screen.getByLabelText("DJ Name"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+    });
+  });
+
   it("should disable name inputs when editing your own account", () => {
     renderForm({}, true);
 

--- a/src/components/experiences/modern/admin/roster/AccountEditForm.test.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEditForm.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import AccountEditForm from "./AccountEditForm";
+import { renderWithProviders, createTestAccountResult } from "@/lib/test-utils";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: {
+    admin: { listUsers: vi.fn(), updateUser: vi.fn(), removeUser: vi.fn(), setUserPassword: vi.fn() },
+    organization: { listMembers: vi.fn(), updateMemberRole: vi.fn() },
+    requestPasswordReset: vi.fn(),
+  },
+  authBaseURL: "http://localhost:8082/auth",
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  resolveOrganizationIdAdmin: vi.fn(() => Promise.resolve("resolved-org-id")),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/features/admin/roster-events", () => ({
+  invalidateRoster: vi.fn(),
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+import { invalidateRoster } from "@/lib/features/admin/roster-events";
+import { toast } from "sonner";
+
+const mockUpdateUser = authClient.admin.updateUser as ReturnType<typeof vi.fn>;
+const mockListUsers = authClient.admin.listUsers as ReturnType<typeof vi.fn>;
+
+function renderForm(
+  accountOverrides: Parameters<typeof createTestAccountResult>[0] = {},
+  isSelf = false
+) {
+  const account = createTestAccountResult({
+    id: "user-123",
+    realName: "Juana Molina",
+    djName: "DJ Juana",
+    ...accountOverrides,
+  });
+  const result = renderWithProviders(
+    <AccountEditForm
+      account={account}
+      isSelf={isSelf}
+      onClose={vi.fn()}
+      organizationSlug="wxyc"
+    />
+  );
+  return { account, ...result };
+}
+
+describe("AccountEditForm name editing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateUser.mockResolvedValue({ data: {} });
+  });
+
+  it("should render real name and DJ name inputs prefilled from the account", () => {
+    renderForm();
+
+    expect(screen.getByLabelText("Real Name")).toHaveValue("Juana Molina");
+    expect(screen.getByLabelText("DJ Name")).toHaveValue("DJ Juana");
+  });
+
+  it("should render an empty DJ name input when the account has no DJ name", () => {
+    renderForm({ djName: undefined });
+
+    expect(screen.getByLabelText("DJ Name")).toHaveValue("");
+  });
+
+  it("should not show a Save button until a field is edited", () => {
+    renderForm();
+
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+  });
+
+  it("should not show a Save button when the edit is only surrounding whitespace", async () => {
+    const { user } = renderForm();
+
+    await user.type(screen.getByLabelText("Real Name"), "  ");
+
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+  });
+
+  it("should not offer Save when the real name is cleared", async () => {
+    const { user } = renderForm();
+
+    await user.clear(screen.getByLabelText("Real Name"));
+
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+  });
+
+  it("should save an edited real name via admin.updateUser", async () => {
+    const { user } = renderForm();
+
+    const input = screen.getByLabelText("Real Name");
+    await user.clear(input);
+    await user.type(input, "Jessica Pratt");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        data: { realName: "Jessica Pratt" },
+      });
+    });
+    expect(mockListUsers).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalled();
+    expect(invalidateRoster).toHaveBeenCalled();
+  });
+
+  it("should save an edited DJ name via admin.updateUser", async () => {
+    const { user } = renderForm();
+
+    const input = screen.getByLabelText("DJ Name");
+    await user.clear(input);
+    await user.type(input, "DJ Cat");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        data: { djName: "DJ Cat" },
+      });
+    });
+    expect(toast.success).toHaveBeenCalled();
+    expect(invalidateRoster).toHaveBeenCalled();
+  });
+
+  it("should trim surrounding whitespace before saving", async () => {
+    const { user } = renderForm();
+
+    const input = screen.getByLabelText("Real Name");
+    await user.clear(input);
+    await user.type(input, "  Jessica Pratt  ");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        data: { realName: "Jessica Pratt" },
+      });
+    });
+  });
+
+  it("should allow clearing the DJ name", async () => {
+    const { user } = renderForm();
+
+    await user.clear(screen.getByLabelText("DJ Name"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        userId: "user-123",
+        data: { djName: "" },
+      });
+    });
+  });
+
+  it("should disable name inputs when editing your own account", () => {
+    renderForm({}, true);
+
+    expect(screen.getByLabelText("Real Name")).toBeDisabled();
+    expect(screen.getByLabelText("DJ Name")).toBeDisabled();
+  });
+
+  it("should show an error toast and not refresh the roster when the update fails", async () => {
+    mockUpdateUser.mockResolvedValue({ error: { message: "Update rejected" } });
+    const { user } = renderForm();
+
+    const input = screen.getByLabelText("Real Name");
+    await user.clear(input);
+    await user.type(input, "Jessica Pratt");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Update rejected");
+    });
+    expect(invalidateRoster).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/experiences/modern/admin/roster/AccountEditForm.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEditForm.tsx
@@ -50,6 +50,10 @@ export default function AccountEditForm({
   const [isUpdatingName, setIsUpdatingName] = useState(false);
   const [newRealName, setNewRealName] = useState(account.realName ?? "");
   const [newDjName, setNewDjName] = useState(account.djName ?? "");
+  // Last-saved baselines: `account` is a snapshot from when the panel opened,
+  // so after a successful save we compare against these instead.
+  const [savedRealName, setSavedRealName] = useState(account.realName ?? "");
+  const [savedDjName, setSavedDjName] = useState(account.djName ?? "");
 
   const userCapabilities = (account.capabilities ?? []) as ("editor" | "webmaster")[];
   const isIncomplete = account.hasCompletedOnboarding !== true;
@@ -58,8 +62,8 @@ export default function AccountEditForm({
   const trimmedDjName = newDjName.trim();
   // realName is the roster display name, so it can be changed but never cleared
   const realNameChanged =
-    trimmedRealName.length > 0 && trimmedRealName !== account.realName;
-  const djNameChanged = trimmedDjName !== (account.djName ?? "");
+    trimmedRealName.length > 0 && trimmedRealName !== savedRealName;
+  const djNameChanged = trimmedDjName !== savedDjName;
 
   const resolveUserId = async () => {
     if (account.id) {
@@ -211,13 +215,21 @@ export default function AccountEditForm({
     try {
       const targetUserId = await resolveUserId();
 
-      const result = await (authClient.admin as any).updateUser({
+      const result = await authClient.admin.updateUser({
         userId: targetUserId,
         data: { [field]: value },
       });
 
       if (result.error) {
         throw new Error(result.error.message || "Failed to update name");
+      }
+
+      if (field === "realName") {
+        setSavedRealName(value);
+        setNewRealName(value);
+      } else {
+        setSavedDjName(value);
+        setNewDjName(value);
       }
 
       const label = field === "realName" ? "Real name" : "DJ name";

--- a/src/components/experiences/modern/admin/roster/AccountEditForm.tsx
+++ b/src/components/experiences/modern/admin/roster/AccountEditForm.tsx
@@ -47,9 +47,19 @@ export default function AccountEditForm({
   const [isUpdatingEmail, setIsUpdatingEmail] = useState(false);
   const [isSendingEmail, setIsSendingEmail] = useState(false);
   const [newEmail, setNewEmail] = useState(account.email ?? "");
+  const [isUpdatingName, setIsUpdatingName] = useState(false);
+  const [newRealName, setNewRealName] = useState(account.realName ?? "");
+  const [newDjName, setNewDjName] = useState(account.djName ?? "");
 
   const userCapabilities = (account.capabilities ?? []) as ("editor" | "webmaster")[];
   const isIncomplete = account.hasCompletedOnboarding !== true;
+
+  const trimmedRealName = newRealName.trim();
+  const trimmedDjName = newDjName.trim();
+  // realName is the roster display name, so it can be changed but never cleared
+  const realNameChanged =
+    trimmedRealName.length > 0 && trimmedRealName !== account.realName;
+  const djNameChanged = trimmedDjName !== (account.djName ?? "");
 
   const resolveUserId = async () => {
     if (account.id) {
@@ -193,6 +203,31 @@ export default function AccountEditForm({
       toast.error(errorMessage);
     } finally {
       setIsUpdatingCapabilities(false);
+    }
+  };
+
+  const handleNameUpdate = async (field: "realName" | "djName", value: string) => {
+    setIsUpdatingName(true);
+    try {
+      const targetUserId = await resolveUserId();
+
+      const result = await (authClient.admin as any).updateUser({
+        userId: targetUserId,
+        data: { [field]: value },
+      });
+
+      if (result.error) {
+        throw new Error(result.error.message || "Failed to update name");
+      }
+
+      const label = field === "realName" ? "Real name" : "DJ name";
+      toast.success(value ? `${label} updated to ${value}` : `${label} cleared`);
+      invalidateRoster();
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to update name";
+      toast.error(errorMessage);
+    } finally {
+      setIsUpdatingName(false);
     }
   };
 
@@ -383,6 +418,56 @@ export default function AccountEditForm({
               Webmaster
             </Chip>
           </Tooltip>
+        </Stack>
+      </FormControl>
+
+      {/* Real Name */}
+      <FormControl>
+        <FormLabel>Real Name</FormLabel>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Input
+            size="sm"
+            value={newRealName}
+            onChange={(e) => setNewRealName(e.target.value)}
+            disabled={isSelf || isUpdatingName}
+            sx={{ flex: 1 }}
+          />
+          {!isSelf && realNameChanged && (
+            <Button
+              size="sm"
+              color="success"
+              variant="solid"
+              loading={isUpdatingName}
+              onClick={() => handleNameUpdate("realName", trimmedRealName)}
+            >
+              Save
+            </Button>
+          )}
+        </Stack>
+      </FormControl>
+
+      {/* DJ Name */}
+      <FormControl>
+        <FormLabel>DJ Name</FormLabel>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Input
+            size="sm"
+            value={newDjName}
+            onChange={(e) => setNewDjName(e.target.value)}
+            disabled={isSelf || isUpdatingName}
+            sx={{ flex: 1 }}
+          />
+          {!isSelf && djNameChanged && (
+            <Button
+              size="sm"
+              color="success"
+              variant="solid"
+              loading={isUpdatingName}
+              onClick={() => handleNameUpdate("djName", trimmedDjName)}
+            >
+              Save
+            </Button>
+          )}
         </Stack>
       </FormControl>
 


### PR DESCRIPTION
Closes #803

## What

Adds **Real Name** and **DJ Name** fields to the admin roster's account edit panel. Admins could set both at provisioning (Add DJ form, CSV import) but had no way to fix a typo afterward.

## How

Frontend-only change mirroring the panel's existing email-field pattern:

- Inline Save button that renders only when the trimmed value differs from the current account value
- `authClient.admin.updateUser({ userId, data: { realName | djName } })` — both are better-auth `additionalFields` the backend already supports (the capabilities handler in this form already updates an additional field the same way), so no server changes
- Success toast + `invalidateRoster()` to refresh the table; error toast on failure
- Real name cannot be cleared (it is the roster display name); DJ name can be cleared since it is optional
- Inputs disabled when editing your own account, consistent with every other control in the panel
- No `confirm()` dialog: unlike email/role/delete, a name edit is low-stakes and trivially reversible
- Follows the self-service settings convention of updating only `realName`/`djName` and leaving the base better-auth `name` field alone (roster conversion falls back `realName || name`)

## Tests

New colocated `AccountEditForm.test.tsx` (11 cases) via `renderWithProviders` + `createTestAccountResult`: prefill, Save-button visibility (unchanged / whitespace-only / cleared real name), successful updates for both fields with `account.id` short-circuit, trimming, DJ-name clearing, `isSelf` disabling, and the error path (error toast, no roster invalidation).

Local checks: `tsc --noEmit` clean, full vitest suite green (3283 tests / 227 files), `next build` succeeds.