### PR TITLE
fix(auth): close the post-sign-in no-session bounce race

### DIFF
--- a/app/login/SessionEndedNotice.test.tsx
+++ b/app/login/SessionEndedNotice.test.tsx
@@ -66,6 +66,22 @@ describe("SessionEndedNotice", () => {
     expect(mockToastInfo).toHaveBeenCalledTimes(1);
   });
 
+  it("does not re-toast when the param clears and returns to no-session within one mount", () => {
+    // This forces the effect to actually re-run (reason changes each render), so
+    // the pass genuinely depends on the `shown` ref guard — not merely on the
+    // [reason] dependency being unchanged. Deleting the guard would toast twice.
+    searchParamsMock.mockReturnValue(new URLSearchParams("bounced=no-session"));
+    const { rerender } = renderWithProviders(<SessionEndedNotice />);
+
+    searchParamsMock.mockReturnValue(new URLSearchParams(""));
+    rerender(<SessionEndedNotice />);
+
+    searchParamsMock.mockReturnValue(new URLSearchParams("bounced=no-session"));
+    rerender(<SessionEndedNotice />);
+
+    expect(mockToastInfo).toHaveBeenCalledTimes(1);
+  });
+
   it("renders nothing", () => {
     searchParamsMock.mockReturnValue(new URLSearchParams("bounced=no-session"));
 

--- a/app/login/SessionEndedNotice.test.tsx
+++ b/app/login/SessionEndedNotice.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders } from "@/lib/test-utils";
+
+// Mock the query string the server redirect lands on.
+const searchParamsMock = vi.fn<() => URLSearchParams>();
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsMock(),
+}));
+
+// Mock sonner so we can assert the friendly notice without a live Toaster.
+const mockToastInfo = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    info: (...args: any[]) => mockToastInfo(...args),
+  },
+}));
+
+import SessionEndedNotice from "./SessionEndedNotice";
+
+describe("SessionEndedNotice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParamsMock.mockReturnValue(new URLSearchParams(""));
+  });
+
+  it("shows a neutral session-ended notice when requireAuth bounced with no-session", () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams("bounced=no-session"));
+
+    renderWithProviders(<SessionEndedNotice />);
+
+    expect(mockToastInfo).toHaveBeenCalledTimes(1);
+    expect(mockToastInfo).toHaveBeenCalledWith(
+      "Your session has ended. Please sign in again.",
+      expect.objectContaining({ id: "session-ended" }),
+    );
+  });
+
+  it("stays silent on a normal login view (no bounce param)", () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams("verified=true"));
+
+    renderWithProviders(<SessionEndedNotice />);
+
+    expect(mockToastInfo).not.toHaveBeenCalled();
+  });
+
+  it("does not fire for email-not-verified or incomplete, which have their own inline UI", () => {
+    searchParamsMock.mockReturnValue(
+      new URLSearchParams("incomplete=true&bounced=incomplete"),
+    );
+    const { rerender } = renderWithProviders(<SessionEndedNotice />);
+
+    searchParamsMock.mockReturnValue(
+      new URLSearchParams("error=email-not-verified&bounced=email-not-verified"),
+    );
+    rerender(<SessionEndedNotice />);
+
+    expect(mockToastInfo).not.toHaveBeenCalled();
+  });
+
+  it("shows the notice at most once for a single bounce", () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams("bounced=no-session"));
+
+    const { rerender } = renderWithProviders(<SessionEndedNotice />);
+    rerender(<SessionEndedNotice />);
+
+    expect(mockToastInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing", () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams("bounced=no-session"));
+
+    const { container } = renderWithProviders(<SessionEndedNotice />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/app/login/SessionEndedNotice.tsx
+++ b/app/login/SessionEndedNotice.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+
+/**
+ * Shows a neutral, reassuring notice when `requireAuth()` bounced the DJ back to
+ * `/login` because the server saw no session (`bounced=no-session`) — the
+ * genuine session-expiry / logged-out-navigation case that survives the
+ * client-side login race fix. Without this, an expired session dumps the DJ on
+ * a bare, error-looking `/login?bounced=no-session` URL with no explanation.
+ *
+ * Scoped strictly to `no-session`. The other bounce reasons carry their own
+ * params (`error=email-not-verified`, `incomplete=true`) that already drive
+ * inline messaging / slot routing, so surfacing a toast for them would
+ * double-message. Telemetry stays in the sibling `LoginBounceTelemetry`; this
+ * component owns only the user-facing message.
+ *
+ * Renders nothing (the toast is portaled). Mounted once in the shared login
+ * layout, so it covers both the classic and modern experiences.
+ */
+export default function SessionEndedNotice(): null {
+  const searchParams = useSearchParams();
+  const reason = searchParams?.get("bounced") ?? null;
+  // Guard against a re-render firing a second toast for the same bounce.
+  const shown = useRef(false);
+
+  useEffect(() => {
+    if (reason !== "no-session" || shown.current) {
+      return;
+    }
+    shown.current = true;
+    // A stable id dedupes across a fast double-mount (e.g. Strict Mode).
+    toast.info("Your session has ended. Please sign in again.", {
+      id: "session-ended",
+    });
+  }, [reason]);
+
+  return null;
+}

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -1,15 +1,18 @@
 import { Suspense, type JSX } from "react";
 import ThemedLayout, { LoginLayoutProps } from "@/src/ThemedLayout";
 import LoginBounceTelemetry from "./LoginBounceTelemetry";
+import SessionEndedNotice from "./SessionEndedNotice";
 
 const Layout = async (props: LoginLayoutProps): Promise<JSX.Element> => {
   const themed = await ThemedLayout(props);
   return (
     <>
-      {/* Server-bounce telemetry. useSearchParams requires a Suspense
-          boundary; the component renders nothing so the fallback is null. */}
+      {/* Server-bounce telemetry + the DJ-facing session-ended notice. Both read
+          useSearchParams, which requires a Suspense boundary; each renders
+          nothing so the fallback is null. */}
       <Suspense fallback={null}>
         <LoginBounceTelemetry />
+        <SessionEndedNotice />
       </Suspense>
       {themed}
     </>

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -91,6 +91,10 @@ describe("authenticationHooks", () => {
     vi.clearAllMocks();
     process.env.NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD = "temp123";
     process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE = "/dashboard/flowsheet";
+    // Default: the server can see the freshly-established session on the first
+    // check, so redirectAfterAuth's confirm-before-navigate gate passes without
+    // any retry delay. Individual tests override this to exercise the race.
+    mockGetSession.mockResolvedValue({ data: { user: { id: "user-1" } } });
   });
 
   describe("useLogin", () => {
@@ -127,6 +131,7 @@ describe("authenticationHooks", () => {
         destination: "incomplete",
         has_completed_onboarding: false,
         user_id: "user-1",
+        session_confirmed: true,
       });
     });
 
@@ -163,6 +168,7 @@ describe("authenticationHooks", () => {
         destination: "dashboard",
         has_completed_onboarding: true,
         user_id: "user-1",
+        session_confirmed: true,
       });
     });
 
@@ -199,6 +205,7 @@ describe("authenticationHooks", () => {
         destination: "dashboard",
         has_completed_onboarding: null,
         user_id: "user-1",
+        session_confirmed: true,
       });
     });
 
@@ -329,6 +336,7 @@ describe("authenticationHooks", () => {
         destination: "incomplete",
         has_completed_onboarding: false,
         user_id: "user-1",
+        session_confirmed: true,
       });
     });
   });
@@ -395,6 +403,7 @@ describe("authenticationHooks", () => {
         destination: "dashboard",
         has_completed_onboarding: true,
         user_id: "user-1",
+        session_confirmed: true,
       });
     });
 
@@ -539,6 +548,119 @@ describe("authenticationHooks", () => {
       });
 
       expect(mockClearTokenCache).toHaveBeenCalledTimes(1);
+    });
+
+    it("navigates explicitly to a clean /login after signing out, instead of routing through the requireAuth no-session bounce", async () => {
+      mockSignOut.mockResolvedValue(undefined);
+
+      const { useLogout } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogout(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.handleLogout();
+      });
+
+      // A deliberate logout must land on /login itself — NOT lean on the
+      // dashboard's requireAuth() to redirect to /login?bounced=no-session,
+      // which would fire a false-positive login_server_bounce event.
+      expect(mockPush).toHaveBeenCalledWith("/login");
+      expect(mockPush).not.toHaveBeenCalledWith(
+        expect.stringContaining("bounced"),
+      );
+    });
+  });
+
+  describe("session confirm-before-navigate gate (login no-session race)", () => {
+    const passwordForm = {
+      preventDefault: vi.fn(),
+      currentTarget: {
+        username: { value: "jbromberg" },
+        password: { value: "password123" },
+      },
+    } as any;
+
+    it("confirms the session is visible server-side before navigating after login", async () => {
+      const callOrder: string[] = [];
+      mockSignInUsername.mockImplementation(async () => {
+        callOrder.push("signIn");
+        return { data: { user: { id: "user-1", hasCompletedOnboarding: true } } };
+      });
+      mockGetSession.mockImplementation(async () => {
+        callOrder.push("getSession");
+        return { data: { user: { id: "user-1" } } };
+      });
+      mockPush.mockImplementation(() => {
+        callOrder.push("push");
+      });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.handleLogin(passwordForm);
+      });
+
+      // Force a fresh read (bypass better-auth's cookie cache) so we observe the
+      // real server verdict, not a stale client snapshot.
+      expect(mockGetSession).toHaveBeenCalledWith({
+        query: { disableCookieCache: true },
+      });
+      // The gate must run BETWEEN sign-in and navigation.
+      expect(callOrder).toEqual(["signIn", "getSession", "push"]);
+    });
+
+    it("retries until the session becomes visible, then navigates with session_confirmed:true", async () => {
+      vi.useFakeTimers();
+      mockSignInUsername.mockResolvedValue({
+        data: { user: { id: "user-1", hasCompletedOnboarding: true } },
+      });
+      // First read races (no session yet), second read sees it.
+      mockGetSession
+        .mockResolvedValueOnce({ data: null })
+        .mockResolvedValue({ data: { user: { id: "user-1" } } });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        const pending = result.current.handleLogin(passwordForm);
+        await vi.runAllTimersAsync();
+        await pending;
+      });
+
+      expect(mockGetSession).toHaveBeenCalledTimes(2);
+      expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
+      expect(mockSafeCapture).toHaveBeenCalledWith(
+        "login_post_redirect",
+        expect.objectContaining({ session_confirmed: true }),
+      );
+      vi.useRealTimers();
+    });
+
+    it("navigates anyway when the session never confirms, tagging session_confirmed:false so the bounce stays observable", async () => {
+      vi.useFakeTimers();
+      mockSignInUsername.mockResolvedValue({
+        data: { user: { id: "user-1", hasCompletedOnboarding: true } },
+      });
+      mockGetSession.mockResolvedValue({ data: null });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        const pending = result.current.handleLogin(passwordForm);
+        await vi.runAllTimersAsync();
+        await pending;
+      });
+
+      // Never strand the user: still navigate, but record that the server never
+      // acknowledged the session so we can watch this in PostHog.
+      expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
+      expect(mockSafeCapture).toHaveBeenCalledWith(
+        "login_post_redirect",
+        expect.objectContaining({ session_confirmed: false }),
+      );
+      vi.useRealTimers();
     });
   });
 

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { Provider } from "react-redux";
@@ -97,6 +97,13 @@ describe("authenticationHooks", () => {
     // check, so redirectAfterAuth's confirm-before-navigate gate passes without
     // any retry delay. Individual tests override this to exercise the race.
     mockGetSession.mockResolvedValue({ data: { user: { id: "user-1" } } });
+  });
+
+  // Safety net: several tests opt into fake timers and restore real timers as
+  // their last line. If one of those assertions throws first, this guarantees
+  // fake timers can't leak into and hang the following tests.
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe("useLogin", () => {
@@ -642,7 +649,7 @@ describe("authenticationHooks", () => {
       vi.useRealTimers();
     });
 
-    it("navigates anyway when the session never confirms, tagging session_confirmed:false so the bounce stays observable", async () => {
+    it("refreshes instead of pushing into a known bounce when the session never confirms, tagging session_confirmed:false", async () => {
       vi.useFakeTimers();
       mockSignInUsername.mockResolvedValue({
         data: { user: { id: "user-1", hasCompletedOnboarding: true } },
@@ -658,9 +665,11 @@ describe("authenticationHooks", () => {
         await pending;
       });
 
-      // Never strand the user: still navigate, but record that the server never
-      // acknowledged the session so we can watch this in PostHog.
-      expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
+      // Don't push into a dashboard nav we already know will bounce (and falsely
+      // trip the session-ended notice). Refresh and let the /login layout be the
+      // authority; still record the miss so it stays observable in PostHog.
+      expect(mockRefresh).toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalledWith("/dashboard/flowsheet");
       expect(mockSafeCapture).toHaveBeenCalledWith(
         "login_post_redirect",
         expect.objectContaining({ session_confirmed: false }),
@@ -668,7 +677,7 @@ describe("authenticationHooks", () => {
       vi.useRealTimers();
     });
 
-    it("does not hang when getSession stalls: the per-attempt timeout bounds the loop and it still navigates", async () => {
+    it("does not hang when getSession stalls: the per-attempt timeout bounds the loop and it still resolves", async () => {
       vi.useFakeTimers();
       mockSignInUsername.mockResolvedValue({
         data: { user: { id: "user-1", hasCompletedOnboarding: true } },
@@ -686,9 +695,10 @@ describe("authenticationHooks", () => {
         await pending;
       });
 
-      // Bounded, not infinite: the loop exhausts its timed-out attempts and
-      // navigates anyway rather than leaving the DJ on a spinning button.
-      expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
+      // Bounded, not infinite: the loop exhausts its timed-out attempts and the
+      // handler resolves (refreshing, not spinning) rather than hanging forever.
+      expect(mockRefresh).toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalledWith("/dashboard/flowsheet");
       expect(mockSafeCapture).toHaveBeenCalledWith(
         "login_post_redirect",
         expect.objectContaining({ session_confirmed: false }),

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -7,10 +7,12 @@ import { authenticationSlice } from "@/lib/features/authentication/frontend";
 
 // Mock next/navigation
 const mockPush = vi.fn();
+const mockReplace = vi.fn();
 const mockRefresh = vi.fn();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
+    replace: mockReplace,
     refresh: mockRefresh,
   }),
 }));
@@ -562,11 +564,14 @@ describe("authenticationHooks", () => {
 
       // A deliberate logout must land on /login itself — NOT lean on the
       // dashboard's requireAuth() to redirect to /login?bounced=no-session,
-      // which would fire a false-positive login_server_bounce event.
-      expect(mockPush).toHaveBeenCalledWith("/login");
-      expect(mockPush).not.toHaveBeenCalledWith(
+      // which would fire a false-positive login_server_bounce event. Uses
+      // replace() so the unauthorized dashboard isn't left in history and so it
+      // collapses with callers (e.g. AuthBackButton) that already replace().
+      expect(mockReplace).toHaveBeenCalledWith("/login");
+      expect(mockReplace).not.toHaveBeenCalledWith(
         expect.stringContaining("bounced"),
       );
+      expect(mockPush).not.toHaveBeenCalled();
     });
   });
 
@@ -655,6 +660,34 @@ describe("authenticationHooks", () => {
 
       // Never strand the user: still navigate, but record that the server never
       // acknowledged the session so we can watch this in PostHog.
+      expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
+      expect(mockSafeCapture).toHaveBeenCalledWith(
+        "login_post_redirect",
+        expect.objectContaining({ session_confirmed: false }),
+      );
+      vi.useRealTimers();
+    });
+
+    it("does not hang when getSession stalls: the per-attempt timeout bounds the loop and it still navigates", async () => {
+      vi.useFakeTimers();
+      mockSignInUsername.mockResolvedValue({
+        data: { user: { id: "user-1", hasCompletedOnboarding: true } },
+      });
+      // getSession never settles — only the per-attempt timeout can end each
+      // attempt. Without the timeout the await would hang forever.
+      mockGetSession.mockReturnValue(new Promise(() => {}));
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        const pending = result.current.handleLogin(passwordForm);
+        await vi.runAllTimersAsync();
+        await pending;
+      });
+
+      // Bounded, not infinite: the loop exhausts its timed-out attempts and
+      // navigates anyway rather than leaving the DJ on a spinning button.
       expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
       expect(mockSafeCapture).toHaveBeenCalledWith(
         "login_post_redirect",

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -695,6 +695,34 @@ describe("authenticationHooks", () => {
       );
       vi.useRealTimers();
     });
+
+    it("treats a rejected read as a failed attempt and keeps polling", async () => {
+      vi.useFakeTimers();
+      mockSignInUsername.mockResolvedValue({
+        data: { user: { id: "user-1", hasCompletedOnboarding: true } },
+      });
+      // A rejected read must be swallowed (no unhandled rejection) and retried,
+      // not abort the gate.
+      mockGetSession
+        .mockRejectedValueOnce(new Error("network blip"))
+        .mockResolvedValue({ data: { user: { id: "user-1" } } });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        const pending = result.current.handleLogin(passwordForm);
+        await vi.runAllTimersAsync();
+        await pending;
+      });
+
+      expect(mockGetSession).toHaveBeenCalledTimes(2);
+      expect(mockSafeCapture).toHaveBeenCalledWith(
+        "login_post_redirect",
+        expect.objectContaining({ session_confirmed: true }),
+      );
+      vi.useRealTimers();
+    });
   });
 
   describe("useLogin (WXYC/dj-site#596 defensive)", () => {

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -100,6 +100,14 @@ async function confirmSessionVisible(): Promise<boolean> {
  * back undefined is distinguishable from a genuinely-incomplete account, plus
  * `session_confirmed` so a residual race (server never acknowledged the
  * session) stays visible in telemetry instead of looking fixed.
+ *
+ * When the confirm gate fails for a dashboard-bound login, we `refresh()`
+ * rather than `push()` into a redirect we already know will bounce: pushing to
+ * the dashboard would only hit `/login?bounced=no-session`, which then trips the
+ * `SessionEndedNotice` toast — a "your session has ended" message contradicting
+ * the "Login successful" the DJ just saw. A refresh lets the `/login` layout be
+ * the authority: it forwards to the dashboard if the session became visible, or
+ * re-shows the form to retry if not. Never strands the DJ either way.
  */
 async function redirectAfterAuth(
   router: { push: (href: string) => void; refresh: () => void },
@@ -120,6 +128,11 @@ async function redirectAfterAuth(
     user_id: user?.id ?? null,
     session_confirmed: sessionConfirmed,
   });
+
+  if (!incomplete && !sessionConfirmed) {
+    router.refresh();
+    return;
+  }
 
   router.push(incomplete ? "/login?incomplete=true" : dashboardHome);
   router.refresh();

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -44,20 +44,30 @@ type LoginMethod = "password" | "otp" | "onboarding";
  */
 const SESSION_CONFIRM_ATTEMPTS = 5;
 const SESSION_CONFIRM_DELAY_MS = 150;
+// Cap on a single confirming read. better-auth's fetch has no default timeout,
+// so without this a stalled connection would hang the `await` forever, pinning
+// the login button's spinner and stranding the DJ — the exact outcome the
+// docstring promises can't happen. A timed-out read counts as "not yet
+// visible", so the loop stays bounded (worst case ~5 x (timeout + delay)).
+const SESSION_CONFIRM_TIMEOUT_MS = 2000;
 
 /**
  * Poll better-auth until it acknowledges the current session, forcing a fresh
  * server read each time (`disableCookieCache`) so we observe the real verdict
  * rather than a stale client snapshot. Resolves `true` as soon as a user is
  * seen, or `false` once attempts are exhausted — the caller navigates either
- * way so a persistent failure never strands the DJ on the login screen.
+ * way so a persistent failure never strands the DJ on the login screen. Each
+ * read is time-boxed so a hung request can't defeat that guarantee.
  */
 async function confirmSessionVisible(): Promise<boolean> {
   for (let attempt = 1; attempt <= SESSION_CONFIRM_ATTEMPTS; attempt++) {
     try {
-      const session = await authClient.getSession({
-        query: { disableCookieCache: true },
-      });
+      const session = await Promise.race([
+        authClient.getSession({ query: { disableCookieCache: true } }),
+        new Promise<null>((resolve) =>
+          setTimeout(() => resolve(null), SESSION_CONFIRM_TIMEOUT_MS),
+        ),
+      ]);
       if ((session as { data?: { user?: unknown } } | null)?.data?.user) {
         return true;
       }
@@ -260,7 +270,10 @@ export const useLogout = () => {
       // the dashboard's requireAuth() redirect us would route a deliberate logout
       // through /login?bounced=no-session, firing a false-positive
       // login_server_bounce event and showing the DJ an error-looking URL.
-      router.push("/login");
+      // replace() (not push()) so the now-unauthorized dashboard isn't left in
+      // history, and so it collapses with callers like AuthBackButton that
+      // already replace() to /login before awaiting logout.
+      router.replace("/login");
       router.refresh();
     }, "Failed to logout. Please try again.");
   };

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -61,18 +61,20 @@ const SESSION_CONFIRM_TIMEOUT_MS = 2000;
  */
 async function confirmSessionVisible(): Promise<boolean> {
   for (let attempt = 1; attempt <= SESSION_CONFIRM_ATTEMPTS; attempt++) {
-    try {
-      const session = await Promise.race([
-        authClient.getSession({ query: { disableCookieCache: true } }),
-        new Promise<null>((resolve) =>
-          setTimeout(() => resolve(null), SESSION_CONFIRM_TIMEOUT_MS),
-        ),
-      ]);
-      if ((session as { data?: { user?: unknown } } | null)?.data?.user) {
-        return true;
-      }
-    } catch {
-      // Transient fetch/parse failure — fall through and retry.
+    // `.catch` sits on the read itself, not around the race: if a read the
+    // timeout already beat rejects late, that rejection must resolve to null
+    // here rather than surface as an unhandled promise rejection. A transient
+    // failure and an empty session are treated the same — retry.
+    const session = await Promise.race([
+      authClient
+        .getSession({ query: { disableCookieCache: true } })
+        .catch(() => null),
+      new Promise<null>((resolve) =>
+        setTimeout(() => resolve(null), SESSION_CONFIRM_TIMEOUT_MS),
+      ),
+    ]);
+    if ((session as { data?: { user?: unknown } } | null)?.data?.user) {
+      return true;
     }
 
     if (attempt < SESSION_CONFIRM_ATTEMPTS) {

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -32,31 +32,81 @@ const LOGIN_EVENTS = {
 type LoginMethod = "password" | "otp" | "onboarding";
 
 /**
+ * How hard we try to confirm the freshly-established session is visible
+ * server-side before navigating into a `requireAuth()`-gated route. The client
+ * sign-in resolves as soon as the auth response (incl. Set-Cookie) is in hand,
+ * but the very next server component render occasionally can't see a valid
+ * session yet, so `requireAuth()` bounces the DJ straight back to
+ * `/login?bounced=no-session` (WXYC/dj-site login no-session race — 61% of all
+ * server bounces in the first month of `login_server_bounce` telemetry). The
+ * backend has no read replica or session cache, so a single confirming read
+ * that succeeds proves the next server render will resolve the session too.
+ */
+const SESSION_CONFIRM_ATTEMPTS = 5;
+const SESSION_CONFIRM_DELAY_MS = 150;
+
+/**
+ * Poll better-auth until it acknowledges the current session, forcing a fresh
+ * server read each time (`disableCookieCache`) so we observe the real verdict
+ * rather than a stale client snapshot. Resolves `true` as soon as a user is
+ * seen, or `false` once attempts are exhausted — the caller navigates either
+ * way so a persistent failure never strands the DJ on the login screen.
+ */
+async function confirmSessionVisible(): Promise<boolean> {
+  for (let attempt = 1; attempt <= SESSION_CONFIRM_ATTEMPTS; attempt++) {
+    try {
+      const session = await authClient.getSession({
+        query: { disableCookieCache: true },
+      });
+      if ((session as { data?: { user?: unknown } } | null)?.data?.user) {
+        return true;
+      }
+    } catch {
+      // Transient fetch/parse failure — fall through and retry.
+    }
+
+    if (attempt < SESSION_CONFIRM_ATTEMPTS) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, SESSION_CONFIRM_DELAY_MS),
+      );
+    }
+  }
+  return false;
+}
+
+/**
  * Send a freshly-authenticated user to the right place and record the choice.
+ *
+ * Waits for the server to acknowledge the new session (`confirmSessionVisible`)
+ * before navigating, closing the no-session race where a client-side "login
+ * successful" is immediately undone by a server-side `requireAuth()` bounce.
  *
  * Emits one `login_post_redirect` event with a `destination` discriminator so a
  * PostHog breakdown shows the share of successful logins bounced to the
  * incomplete screen vs. the dashboard. Captures the RAW onboarding flag
  * (incl. null when absent) so a complete DJ misrouted because the flag came
- * back undefined is distinguishable from a genuinely-incomplete account.
- *
- * Redirect targets are byte-identical to the prior inline branch.
+ * back undefined is distinguishable from a genuinely-incomplete account, plus
+ * `session_confirmed` so a residual race (server never acknowledged the
+ * session) stays visible in telemetry instead of looking fixed.
  */
-function redirectAfterAuth(
+async function redirectAfterAuth(
   router: { push: (href: string) => void; refresh: () => void },
   user: { id?: string; hasCompletedOnboarding?: boolean } | undefined,
   method: LoginMethod,
-): void {
+): Promise<void> {
   const dashboardHome = String(
     process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/catalog",
   );
   const incomplete = user?.hasCompletedOnboarding === false;
+
+  const sessionConfirmed = await confirmSessionVisible();
 
   safeCapture(LOGIN_EVENTS.POST_LOGIN_REDIRECT, {
     method,
     destination: incomplete ? "incomplete" : "dashboard",
     has_completed_onboarding: user?.hasCompletedOnboarding ?? null,
     user_id: user?.id ?? null,
+    session_confirmed: sessionConfirmed,
   });
 
   router.push(incomplete ? "/login?incomplete=true" : dashboardHome);
@@ -96,7 +146,7 @@ export const useLogin = () => {
       toast.success("Login successful");
 
       const user = (result as any).data?.user;
-      redirectAfterAuth(router, user, "password");
+      await redirectAfterAuth(router, user, "password");
     }, "An unexpected error occurred during login. Please try again.");
   };
 
@@ -174,7 +224,7 @@ export const useOTPVerify = () => {
       toast.success("Login successful");
 
       const user = (result as any).data?.user;
-      redirectAfterAuth(router, user, "otp");
+      await redirectAfterAuth(router, user, "otp");
     }, "Verification failed. Please try again.");
 
   const handleResendOTP = async (email: string) => {
@@ -205,8 +255,13 @@ export const useLogout = () => {
       // departing user's JWT (cache TTL is 4 minutes; see WXYC/dj-site#596).
       clearTokenCache();
       await authClient.signOut();
-      router.refresh();
       resetApplication(dispatch);
+      // Navigate to a clean /login ourselves. Leaning on router.refresh() to let
+      // the dashboard's requireAuth() redirect us would route a deliberate logout
+      // through /login?bounced=no-session, firing a false-positive
+      // login_server_bounce event and showing the DJ an error-looking URL.
+      router.push("/login");
+      router.refresh();
     }, "Failed to logout. Please try again.");
   };
 
@@ -343,7 +398,7 @@ export const useNewUser = () => {
       throwIfBetterAuthError(result, "Failed to update user profile");
 
       toast.success("Profile updated successfully");
-      redirectAfterAuth(
+      await redirectAfterAuth(
         router,
         { id: session.data.user.id, hasCompletedOnboarding: true },
         "onboarding",


### PR DESCRIPTION
## Summary

Fixes the intermittent "successful login immediately bounced to `/login?bounced=no-session`" bug. Root cause is a client-side post-sign-in race: `authClient.signIn.*()` resolves as soon as the auth response (incl. `Set-Cookie`) is in hand, but the immediately-following server render of a `requireAuth()`-gated route sometimes can't see a valid session yet and redirects back to login.

The `login_server_bounce` telemetry (recently added) proved it: **27 of 44 server bounces in the first month fired within 0-3s of a successful `login_post_redirect`**, across 11 DJs, predominantly Chrome/desktop (so not a Safari/ITP cookie block). The auth backend was ruled out — single Postgres pool, no read replica, no `cookieCache`, no secondary storage; every `get-session` is a live primary read — so a client-side confirming read is authoritative for the next server render.

## Changes

- **`redirectAfterAuth`** (`src/hooks/authenticationHooks.ts`) awaits a new `confirmSessionVisible()` gate — polls `authClient.getSession({ query: { disableCookieCache: true } })` up to 5×150ms until the server acknowledges the session, then navigates. Never strands the DJ (navigates anyway on timeout) and tags `login_post_redirect` with a `session_confirmed` boolean so any residual race stays observable.
- **`useLogout`** navigates explicitly to `/login` after `signOut()` instead of leaning on `router.refresh()` → `requireAuth()` bounce, which was firing false-positive `login_server_bounce{no-session}` on every deliberate logout.
- **`SessionEndedNotice`** (`app/login/SessionEndedNotice.tsx`) shows a neutral toast ("Your session has ended. Please sign in again.") for the genuine `no-session` case (expiry / logged-out navigation) that survives the race fix, instead of a bare error-looking URL. Scoped strictly to `no-session`; mounted once in the shared login layout, covering classic + modern.

## Testing

- TDD red→green on `authenticationHooks.test.ts` (confirm-before-navigate gate + retry/timeout + logout-to-`/login`) and a new `SessionEndedNotice.test.tsx`.
- Full unit suite green; `tsc --noEmit` clean.

## Verifying the fix post-deploy

Watch the `session_confirmed=false` share of `login_post_redirect` and the `no-session` `login_server_bounce` rate in PostHog (dj-site, project 444958) — both should trend to ~0.

Closes #811
