### PR TITLE
fix(flowsheet): auto-populate album and label as the song narrows to a track

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
@@ -5,6 +5,8 @@ import FlowsheetSearchbar from "./FlowsheetSearchbar";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { useGhostText } from "@/src/hooks/useGhostText";
+import { useFlowsheetSearch } from "@/src/hooks/flowsheetHooks";
 
 // Mock hook return values that can be changed per test
 let mockLive = false;
@@ -578,6 +580,87 @@ describe("FlowsheetSearchbar", () => {
       );
 
       removeEventListenerSpy.mockRestore();
+    });
+  });
+
+  describe("album/label autopopulate from track suggestion", () => {
+    const trackResult = {
+      track_title: "Technopolis",
+      album_title: "Solid State Survivor",
+      record_label: "Alfa",
+    };
+    const songGhostWithTrack = {
+      ghostSuffix: "polis",
+      acceptGhostText: () => "Technopolis",
+      trackResult,
+    };
+    const emptyGhost = {
+      ghostSuffix: "",
+      acceptGhostText: () => null,
+      trackResult: null,
+    };
+
+    // Make the song-field ghost surface a confident track suggestion; the
+    // artist-field ghost stays empty.
+    const mockSongGhost = () =>
+      vi
+        .mocked(useGhostText)
+        .mockImplementation((field) =>
+          field === "song" ? songGhostWithTrack : emptyGhost
+        );
+
+    afterEach(() => {
+      // Restore the file-default ghost (no suggestion) for later suites.
+      vi.mocked(useGhostText).mockImplementation(() => emptyGhost);
+    });
+
+    it("fills empty album and label from the confident suggestion without Tab", () => {
+      mockSongGhost();
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <FlowsheetSearchbar />
+        </Provider>
+      );
+
+      expect(mockSetSearchProperty).toHaveBeenCalledWith(
+        "album",
+        "Solid State Survivor"
+      );
+      expect(mockSetSearchProperty).toHaveBeenCalledWith("label", "Alfa");
+    });
+
+    it("does not overwrite an album the DJ has already typed", () => {
+      mockSongGhost();
+      vi.mocked(useFlowsheetSearch).mockReturnValueOnce({
+        live: mockLive,
+        searchOpen: mockSearchOpen,
+        setSearchOpen: mockSetSearchOpen,
+        resetSearch: mockResetSearch,
+        searchQuery: {
+          song: "Techno",
+          artist: "Yellow Magic Orchestra",
+          album: "My Own Album",
+          label: "",
+          request: false,
+        },
+        setSearchProperty: mockSetSearchProperty,
+      } as unknown as ReturnType<typeof useFlowsheetSearch>);
+      const store = createTestStore();
+
+      render(
+        <Provider store={store}>
+          <FlowsheetSearchbar />
+        </Provider>
+      );
+
+      expect(mockSetSearchProperty).not.toHaveBeenCalledWith(
+        "album",
+        "Solid State Survivor"
+      );
+      // The label was still empty, so it auto-fills.
+      expect(mockSetSearchProperty).toHaveBeenCalledWith("label", "Alfa");
     });
   });
 });

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
@@ -610,8 +610,26 @@ describe("FlowsheetSearchbar", () => {
         );
 
     afterEach(() => {
-      // Restore the file-default ghost (no suggestion) for later suites.
+      // Restore the file-default hooks (no suggestion, empty query) for later
+      // suites — tests here drive both via mockImplementation.
       vi.mocked(useGhostText).mockImplementation(() => emptyGhost);
+      vi.mocked(useFlowsheetSearch).mockImplementation(
+        () =>
+          ({
+            live: mockLive,
+            searchOpen: mockSearchOpen,
+            setSearchOpen: mockSetSearchOpen,
+            resetSearch: mockResetSearch,
+            searchQuery: {
+              song: "",
+              artist: "",
+              album: "",
+              label: "",
+              request: false,
+            },
+            setSearchProperty: mockSetSearchProperty,
+          }) as unknown as ReturnType<typeof useFlowsheetSearch>
+      );
     });
 
     it("fills empty album and label from the confident suggestion without Tab", () => {
@@ -661,6 +679,101 @@ describe("FlowsheetSearchbar", () => {
       );
       // The label was still empty, so it auto-fills.
       expect(mockSetSearchProperty).toHaveBeenCalledWith("label", "Alfa");
+    });
+
+    it("clears its auto-fill memory on reset so a later manual album survives", () => {
+      // A confident song suggestion whose album we vary across renders.
+      let trackAlbum = "Solid State Survivor";
+      // Mutable search state so we can drive artist/song/album across rerenders.
+      let searchState = {
+        live: mockLive,
+        searchOpen: mockSearchOpen,
+        setSearchOpen: mockSetSearchOpen,
+        resetSearch: mockResetSearch,
+        searchQuery: {
+          song: "Techno",
+          artist: "Yellow Magic Orchestra",
+          album: "",
+          label: "",
+          request: false,
+        },
+        setSearchProperty: mockSetSearchProperty,
+      };
+      vi.mocked(useFlowsheetSearch).mockImplementation(
+        () => searchState as unknown as ReturnType<typeof useFlowsheetSearch>
+      );
+      // The song ghost only carries a track while a song is being typed, which
+      // mirrors useGhostText returning null once the song field is empty.
+      vi.mocked(useGhostText).mockImplementation((field) =>
+        field === "song" && searchState.searchQuery.song
+          ? {
+              ghostSuffix: "",
+              acceptGhostText: () => "Technopolis",
+              trackResult: {
+                track_title: "Technopolis",
+                album_title: trackAlbum,
+                record_label: "Alfa",
+              },
+            }
+          : emptyGhost
+      );
+
+      const store = createTestStore();
+      const { rerender } = render(
+        <Provider store={store}>
+          <FlowsheetSearchbar />
+        </Provider>
+      );
+
+      // Phase 1: the empty album auto-fills from the suggestion.
+      expect(mockSetSearchProperty).toHaveBeenCalledWith(
+        "album",
+        "Solid State Survivor"
+      );
+
+      // Phase 2: the search resets (artist + song cleared) — the auto-fill
+      // memory must be forgotten here.
+      searchState = {
+        ...searchState,
+        searchQuery: {
+          song: "",
+          artist: "",
+          album: "",
+          label: "",
+          request: false,
+        },
+      };
+      rerender(
+        <Provider store={store}>
+          <FlowsheetSearchbar />
+        </Provider>
+      );
+
+      // Phase 3: a new entry where the DJ hand-types the same album string the
+      // previous entry auto-filled, while a *different* suggestion is active.
+      // The manual value must survive — the stale ref must not overwrite it.
+      mockSetSearchProperty.mockClear();
+      trackAlbum = "Naughty Boys";
+      searchState = {
+        ...searchState,
+        searchQuery: {
+          song: "Ki",
+          artist: "Yellow Magic Orchestra",
+          album: "Solid State Survivor",
+          label: "",
+          request: false,
+        },
+      };
+      rerender(
+        <Provider store={store}>
+          <FlowsheetSearchbar />
+        </Provider>
+      );
+
+      expect(mockSetSearchProperty).not.toHaveBeenCalledWith(
+        "album",
+        "Naughty Boys"
+      );
     });
   });
 });

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
@@ -140,6 +140,18 @@ export default function FlowsheetSearchbar() {
     setSearchProperty,
   ]);
 
+  // Forget what we auto-filled once the search resets (a new entry begins), so
+  // the auto-fill memory can't outlive its session and later overwrite an
+  // album/label the DJ types by hand. resetSearch clears artist + song, so an
+  // empty artist-and-song is the reset signal shared by every reset path (the
+  // ClickAway close here and the post-submit resets in useFlowsheetSubmit).
+  useEffect(() => {
+    if (!searchQuery.artist && !searchQuery.song) {
+      autoFilledAlbumRef.current = null;
+      autoFilledLabelRef.current = null;
+    }
+  }, [searchQuery.artist, searchQuery.song]);
+
   const handleClose = useCallback(
     (event: any) => {
       resetSearch();

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
@@ -53,6 +53,12 @@ export default function FlowsheetSearchbar() {
   const albumRef = useRef<HTMLInputElement>(null);
   const labelRef = useRef<HTMLInputElement>(null);
 
+  // Remember the album/label we auto-filled from a track suggestion so we can
+  // keep them in sync as the song narrows, without ever clobbering a value the
+  // DJ typed themselves.
+  const autoFilledAlbumRef = useRef<string | null>(null);
+  const autoFilledLabelRef = useRef<string | null>(null);
+
   // Ghost text for artist field
   const artistGhost = useGhostText(
     "artist",
@@ -97,6 +103,42 @@ export default function FlowsheetSearchbar() {
       dispatch(flowsheetSlice.actions.setConfirmedArtist(currentArtist));
     }
   }, [searchQuery.artist, confirmedArtist, dispatch]);
+
+  // Auto-populate album + label from the confident track suggestion as the song
+  // narrows to a match — without requiring the DJ to press Tab. A field is only
+  // (re)filled while it is empty or still holds the value we last auto-filled,
+  // so a manually typed album/label is never overwritten.
+  useEffect(() => {
+    const track = songGhost.trackResult;
+    if (!track) return;
+
+    const album = (searchQuery.album as string) ?? "";
+    if (
+      track.album_title &&
+      (album === "" || album === autoFilledAlbumRef.current)
+    ) {
+      if (album !== track.album_title) {
+        setSearchProperty("album", track.album_title);
+      }
+      autoFilledAlbumRef.current = track.album_title;
+    }
+
+    const label = (searchQuery.label as string) ?? "";
+    if (
+      track.record_label &&
+      (label === "" || label === autoFilledLabelRef.current)
+    ) {
+      if (label !== track.record_label) {
+        setSearchProperty("label", track.record_label);
+      }
+      autoFilledLabelRef.current = track.record_label;
+    }
+  }, [
+    songGhost.trackResult,
+    searchQuery.album,
+    searchQuery.label,
+    setSearchProperty,
+  ]);
 
   const handleClose = useCallback(
     (event: any) => {


### PR DESCRIPTION
Closes #813

## What

In the modern flowsheet searchbar, album and label now auto-populate from the confident track suggestion as the song narrows to a match, without requiring the DJ to press Tab. Previously album/label were only filled inside the Tab-accept handler (`handleAcceptSongGhost`), so typing an artist and then a track showed the track ghost but left album and label empty until Tab was pressed.

## How

A guarded `useEffect` in `FlowsheetSearchbar` fills album + label reactively from `songGhost.trackResult` (which already carries `album_title` and `record_label`) and keeps them in sync as the suggestion changes. Two refs (`autoFilledAlbumRef` / `autoFilledLabelRef`) record the last auto-filled values so a manually typed album or label is never overwritten. The existing Tab-accept path is unchanged. Reuses the already-fetched suggestion instead of the unused `getTrackDetails` endpoint, avoiding an extra round-trip.

## Testing

Two new tests in `FlowsheetSearchbar.test.tsx` (verified red without the effect, green with it): album + label fill from a confident suggestion without Tab, and a manually typed album is not overwritten. Full modern flowsheet Search suite plus `useGhostText` pass (212 tests); the changed files typecheck clean.

## Not in this PR (data-quality, follow-ups)

Track suggestions come from flowsheet play-history, not the card catalog, and that history is inconsistent. For the reported track the most-recent row has a typo'd album, which the backend's `LIMIT 1 ORDER BY track_title` will surface. Tracked as follow-ups in #813: rank album/label by most-frequent or most-recent-non-empty in `suggestTracks`, and relax the exact `artist_name ILIKE` match.
