### PR TITLE
fix(infra): align wrangler.jsonc name with live Pages project wxyc-dj

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "wxyc-dj-site",
+	"name": "wxyc-dj",
 	"compatibility_date": "2025-10-11",
 	"compatibility_flags": [
 		"nodejs_compat_v2",


### PR DESCRIPTION
## Problem

`wrangler.jsonc` declares `name: "wxyc-dj-site"`, but the live Cloudflare Pages project is `wxyc-dj` — confirmed via `wrangler pages project list` (project `wxyc-dj`, domains `dj-site.pages.dev` + `dj.wxyc.org`). A repo-wide grep shows `wrangler.jsonc:3` was the only tracked file carrying the wrong name; both monitoring workflows (`pr-preview-smoke.yml`, `cloudflare-deploy-status.yml`), `staging-gate.yml`, and the staging-gate scripts/tests already reference `wxyc-dj`.

## Why now

Under the Git-build integration the mismatch is harmless (the GitHub App binds the project independently of the config), but `wrangler pages deploy` resolves the target project from the config `name` — so the Direct Upload migration (#810) would deploy to a wrong, freshly created `wxyc-dj-site` project with default compat flags (the 522-at-boot scenario) while dj.wxyc.org kept serving stale deployments. #810 is blocked-by #601 in the issue graph; this PR clears it.

## Change

One line: `wrangler.jsonc` `name` → `wxyc-dj`. Compat flags, date, and output dir untouched.

## Verification

- Live project name confirmed against the Pages API (acceptance criterion 1 of #601).
- This PR's own preview build exercises the Pages Git build with the corrected name; the preview smoke check gates merge on it.
- `cloudflare-deploy-status.yml` manual run (acceptance criterion 3) to be dispatched alongside this PR — it queries `wxyc-dj` directly, unchanged by this diff.

Closes #601

## Related

- WXYC/dj-site#810 — Direct Upload migration this unblocks