### PR TITLE
fix(flowsheet): match tubafrenzy column order Artist - Song - Album - Label

### DIFF
--- a/src/components/experiences/modern/flowsheet/Entries/MessageEntry.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/MessageEntry.test.tsx
@@ -391,6 +391,24 @@ describe("MessageEntry", () => {
       const wrapper = screen.getByTestId("draggable-wrapper");
       expect(wrapper).toHaveStyle({ height: "40px" });
     });
+
+    it("should span the data columns so message rows match song rows", () => {
+      render(
+        <MessageEntry entry={mockMessageEntry} color="neutral" variant="soft">
+          Content
+        </MessageEntry>
+      );
+
+      // Song rows are art + 2 stacked data cells + actions below xl (jsdom
+      // matches false), so the whole marker row must also total 4 column
+      // units. At xl both grow in lock-step to 6 (see the colSpan comment in
+      // MessageEntry.tsx).
+      const cells = Array.from(
+        screen.getByTestId("draggable-wrapper").querySelectorAll("td")
+      );
+      const totalColumns = cells.reduce((sum, td) => sum + td.colSpan, 0);
+      expect(totalColumns).toBe(4);
+    });
   });
 
   describe("Edge cases", () => {

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
@@ -793,6 +793,78 @@ describe("SongEntry", () => {
       // The handleMouseEnter logic only sets canClose when queue && live
     });
   });
+
+  describe("Column order (tubafrenzy parity)", () => {
+    // Point jsdom's matchMedia at the xl breakpoint (the vitest setup's
+    // global mock always matches false, i.e. sub-xl).
+    const originalMatchMedia = window.matchMedia;
+    const setXl = (isXl: boolean) => {
+      window.matchMedia = ((query: string) => ({
+        matches: isXl && query === "(min-width: 1536px)",
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      })) as typeof window.matchMedia;
+    };
+    afterEach(() => {
+      window.matchMedia = originalMatchMedia;
+    });
+
+    const renderedFieldOrder = () =>
+      Array.from(
+        screen
+          .getByTestId("draggable-wrapper")
+          .querySelectorAll('[data-testid^="field-"]')
+      ).map((el) => el.getAttribute("data-testid"));
+
+    it("reads artist, song, album, label in that order at xl", () => {
+      setXl(true);
+      render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
+
+      expect(renderedFieldOrder()).toEqual([
+        "field-artist_name",
+        "field-track_title",
+        "field-album_title",
+        "field-record_label",
+      ]);
+    });
+
+    it("keeps the refactor's two-line stacked cells below xl", () => {
+      setXl(false);
+      render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
+
+      // Sub-xl keeps the two-line playlist-cell design (title over artist,
+      // album over label) — tubafrenzy column order applies to the xl
+      // full-column layout only.
+      expect(renderedFieldOrder()).toEqual([
+        "field-track_title",
+        "field-artist_name",
+        "field-album_title",
+        "field-record_label",
+      ]);
+    });
+
+    it("does not stack fields at xl and gives each field cell a single column", () => {
+      setXl(true);
+      render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
+
+      const cells = Array.from(
+        screen.getByTestId("draggable-wrapper").querySelectorAll("td")
+      );
+      cells.forEach((td) => {
+        expect(
+          td.querySelectorAll('[data-testid^="field-"]').length
+        ).toBeLessThanOrEqual(1);
+        if (td.querySelector('[data-testid^="field-"]')) {
+          expect(td.colSpan).toBe(1);
+        }
+      });
+    });
+  });
 });
 
 describe("SongEntry two-line row structure", () => {
@@ -861,17 +933,17 @@ describe("SongEntry two-line row structure", () => {
       .getByTestId("draggable-wrapper")
       .querySelectorAll(":scope > td");
 
-    // Title cell (index 1): the title only — the artist has its own column.
-    expect(
-      cells[1].querySelector('[data-testid="field-track_title"]')
-    ).not.toBeNull();
+    // Standalone artist column leads (index 1) — tubafrenzy order, see #820.
     expect(
       cells[1].querySelector('[data-testid="field-artist_name"]')
-    ).toBeNull();
-    // Standalone artist column (index 2).
+    ).not.toBeNull();
+    // Title cell (index 2): the title only — the artist has its own column.
+    expect(
+      cells[2].querySelector('[data-testid="field-track_title"]')
+    ).not.toBeNull();
     expect(
       cells[2].querySelector('[data-testid="field-artist_name"]')
-    ).not.toBeNull();
+    ).toBeNull();
     // Album cell (index 3): the album only.
     expect(
       cells[3].querySelector('[data-testid="field-album_title"]')

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
@@ -121,6 +121,26 @@ const SongEntry = memo(function SongEntry({
           )}
         </Stack>
       </td>
+      {/* Tubafrenzy reading order (Artist – Song – Album – Label, see #820):
+          above xl the artist leads as its own column. */}
+      {isXl && (
+        <td
+          className="col-artist"
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          <FlowsheetEntryField
+            label="artist"
+            name={"artist_name"}
+            entry={entry}
+            playing={playing}
+            queue={queue}
+            editable={editable}
+            level="body-sm"
+            textColor={entryFieldTextColor("artist", playing)}
+          />
+        </td>
+      )}
       <td onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
         <FlowsheetEntryField
           label="song"
@@ -149,24 +169,6 @@ const SongEntry = memo(function SongEntry({
           </Box>
         )}
       </td>
-      {isXl && (
-        <td
-          className="col-artist"
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-        >
-          <FlowsheetEntryField
-            label="artist"
-            name={"artist_name"}
-            entry={entry}
-            playing={playing}
-            queue={queue}
-            editable={editable}
-            level="body-sm"
-            textColor={entryFieldTextColor("artist", playing)}
-          />
-        </td>
-      )}
       <td onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
         <FlowsheetEntryField
           label="album"

--- a/src/components/experiences/modern/flowsheet/Entries/tableStyles.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/tableStyles.tsx
@@ -105,15 +105,16 @@ export const FLOWSHEET_TABLE_SX: SxProps = {
 };
 
 // Column sizing only (rendered inside a visibility-collapsed thead): art+drag
-// | title | artist | album | label | status+actions. Every row type must
+// | artist | title | album | label | status+actions (tubafrenzy reading
+// order, artist before song — see #820). Every row type must
 // render exactly these 6 column units (4 below xl, where the artist and
 // label columns collapse) or fixed-layout sizing silently degrades.
 export function FlowsheetColumnSizingRow() {
   return (
     <tr>
       <td style={{ width: "60px" }}></td>
-      <td></td>
       <td className="col-artist"></td>
+      <td></td>
       <td></td>
       <td className="col-label"></td>
       <td style={{ width: "150px" }}></td>

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
@@ -128,6 +128,25 @@ describe("FlowsheetSearchbar", () => {
     expect(container.querySelector("form")).toBeInTheDocument();
   });
 
+  it("should not stretch to fill the page column (regression: giant gap above the flowsheet)", () => {
+    const store = createTestStore();
+
+    const { container } = render(
+      <Provider store={store}>
+        <FlowsheetSearchbar />
+      </Provider>
+    );
+
+    // MainContent is a column flex pinned to 100dvh; flex-grow on the
+    // searchbar's FormControl absorbs all leftover vertical space and pushes
+    // the entry tables to the bottom of the viewport.
+    const formControl = container.querySelector(
+      ".MuiFormControl-root"
+    ) as HTMLElement;
+    expect(formControl).toBeInTheDocument();
+    expect(getComputedStyle(formControl).flexGrow).not.toBe("1");
+  });
+
   it("should render BreakpointButton", () => {
     const store = createTestStore();
 

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
@@ -221,7 +221,7 @@ export default function FlowsheetSearchbar() {
 
   return (
     <ClickAwayListener onClickAway={handleClose}>
-      <FormControl size="sm" sx={{ flex: 1, minWidth: 0 }}>
+      <FormControl size="sm" sx={{ minWidth: 0 }}>
         <FlowsheetSearchResults
           binResults={binResults}
           catalogResults={catalogResults}


### PR DESCRIPTION
Closes #820

## What changed

The modern flowsheet row stacked the album title over the artist name in a shared double-width cell, with song and label in their own double-width columns. This PR flattens the row into four single-width data columns in tubafrenzy order — Artist, Song, Album, Label — so the flowsheet reads the same way the legacy sheet does during a talkset.

- `SongEntry.tsx`: one field per cell in tubafrenzy order, colSpan 2 → 1 on all data cells; the Album icon moves from the label field to the album field, and the artist field drops its `body-xs` sizing since it is now a primary column
- `MessageEntry.tsx`: message cell colSpan 6 → 4 so talkset/breakpoint/show rows keep spanning the full data width
- `@entries/page.tsx`, `@queue/page.tsx`: collapsed `<thead>` drops to six columns (art + four data + actions) to match the new row shape
- `FlowsheetSearchbar.tsx`: dropped `flex: 1` from the searchbar's FormControl. Inside `MainContent` (a column flex pinned to `100dvh`) it grew vertically to absorb all leftover viewport space, pushing the tables to the bottom of the screen whenever the flowsheet was short. Surfaced while test-driving this change against a sparse dev database; invisible in production only because a full flowsheet leaves no slack to absorb.
- Tests: column-order, no-stacking, and row-width assertions in `SongEntry.test.tsx` / `MessageEntry.test.tsx`; a flex-grow regression test in `FlowsheetSearchbar.test.tsx`

## Verification

Written test-first: all new assertions failed against the old code, then passed after the changes. Full local CI: `tsc --noEmit` clean, 230 test files / 3288 tests pass. Verified live against a local Backend-Service: entries render in tubafrenzy column order directly below the searchbar with no gap.