### PR TITLE
fix(flowsheet): allow a null OnAirDJResponse.id for legacy DJs (#828)

### DIFF
--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -294,6 +294,17 @@ describe("flowsheet conversions", () => {
       expect(result.djs[0].id).toBe("42");
       expect(result.djs[0].dj_name).toBe("Test");
     });
+
+    // Legacy/tubafrenzy-mirrored shows have no Backend-Service account, so the
+    // DJ arrives from /flowsheet/djs-on-air with a null id (BS#1547). The banner
+    // keys on dj_name, so a null id must still render the DJ as live, not "Off Air".
+    it("should render a legacy DJ with a null id as on air", () => {
+      const response = [createTestOnAirDJResponse({ id: null, dj_name: "DJ MONSTER" })];
+      const result = convertDJsOnAir(response);
+
+      expect(result.djs[0].id).toBeNull();
+      expect(result.onAir).toBe("DJ MONSTER");
+    });
   });
 
   describe("V2 flowsheet conversions", () => {

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -169,7 +169,10 @@ export function isFlowsheetBreakpointEntry(
 }
 
 export type OnAirDJResponse = {
-  id: string; // User ID from better-auth (string)
+  // better-auth user id (string) for account DJs; null for legacy/tubafrenzy
+  // shows whose on-air DJ has no Backend-Service account (BS#1547). The banner
+  // keys on dj_name, so a null id is display-irrelevant.
+  id: string | null;
   dj_name: string;
 };
 

--- a/lib/test-utils/fixtures.ts
+++ b/lib/test-utils/fixtures.ts
@@ -511,10 +511,12 @@ export function createTestBinResponse(
 
 // On-air DJ fixtures
 export function createTestOnAirDJResponse(
-  overrides: { id?: string; dj_name?: string } = {}
+  overrides: { id?: string | null; dj_name?: string } = {}
 ) {
   return {
-    id: overrides.id ?? "1",
+    // `?? "1"` would clobber an explicit null (a legacy DJ, BS#1547); default
+    // only when the caller omitted id entirely.
+    id: overrides.id === undefined ? "1" : overrides.id,
     dj_name: overrides.dj_name ?? "Test DJ",
   };
 }


### PR DESCRIPTION
Closes #828

## What

Widens `OnAirDJResponse.id` from `string` to `string | null`. WXYC/Backend-Service#1547 makes `GET /flowsheet/djs-on-air` surface legacy/tubafrenzy-mirrored shows, whose on-air DJ has no better-auth account and arrives with a `null` id (matching the corrected nullable `OnAirDJ.id` contract in `@wxyc/shared`).

The NowPlaying banner keys on `dj_name` and never reads `id`, so there is no runtime logic change — `convertDJsOnAir` already renders a null-id DJ as live. The `createTestOnAirDJResponse` fixture accepts a null id (defaulting only when id is omitted, so `?? "1"` no longer clobbers an explicit null).

## Test plan

- New `convertDJsOnAir` test: a `{ id: null, dj_name: "DJ MONSTER" }` response renders live (`onAir: "DJ MONSTER"`), not "Off Air"
- `npx tsc --noEmit` — clean
- `npm run test:run` — 3381/3381 pass

## Related (cross-repo on-air fix)

- Backend-Service returns legacy DJs with a null id: WXYC/Backend-Service#1547
- wxyc-shared OnAirDJ.id nullable string: WXYC/wxyc-shared#210
