### PR TITLE
feat(auth): device-authorization polling client (PR 1 of 2 for QR sign-in)

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -20,6 +20,11 @@ NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED=false
 # NEXT_PUBLIC_BETTER_AUTH_URL is reachable from the browser but not from inside
 # the dj-site server.
 # AUTH_REWRITE_URL=http://auth:8082/auth
+
+# Optional — OAuth 2.0 Device Authorization Grant (RFC 8628) client_id for the
+# QR shared-computer sign-in. Sent to /auth/device/code and /auth/device/token.
+# Defaults to "dj-site" when unset.
+# NEXT_PUBLIC_DEVICE_AUTH_CLIENT_ID=dj-site
 ```
 
 ## Build-time env in CI/CD

--- a/docs/plans/qr-device-auth-polling-client.md
+++ b/docs/plans/qr-device-auth-polling-client.md
@@ -1,0 +1,117 @@
+# Plan: QR device-authorization polling client (PR 1 of 2)
+
+Part of [WXYC/dj-site#785](https://github.com/WXYC/dj-site/issues/785) — build the RFC 8628 QR shared-computer sign-in flow per [ADR 0005](../adr/0005-qr-device-authorization-shared-computer-signin.md), typed by `@wxyc/shared` `DeviceAuth*`. This PR delivers **only the polling client / state machine + hook + unit tests**. The `QRCodeForm` UI, `qrcode` dependency, login-picker wiring, `login-method-storage` `"qr"` value, and e2e are deferred to PR 2.
+
+## Context / what already exists
+
+- No device-auth code exists in dj-site today (repo-wide grep for `device/code`, `device/token`, `authorization_pending`, `verification_uri_complete`, `QRCodeForm`, `deviceAuthorization` returns only docs/ADRs).
+- `@wxyc/shared` publishes the `DeviceAuth*` types from `@wxyc/shared/dtos` (dj-site's dominant import path, 38 usages). `main` already pins `^1.17.1`, which publishes these types, so **no dependency bump is needed in this PR**. Confirmed present: `DeviceAuthCodeRequest/Response`, `DeviceAuthTokenRequest/Response`, `DeviceAuthTokenErrorCode`, `DeviceAuthVerifyResponse`, `DeviceAuthStatus`.
+- `DeviceAuthTokenErrorCode` const values: `authorization_pending`, `slow_down`, `expired_token`, `access_denied`, `invalid_request`, `invalid_grant`, `server_error`.
+- Existing auth hooks live in `src/hooks/authenticationHooks.ts`, wrap async work in `useAsyncAction`, and route post-login via the shared `redirectAfterAuth(router, user, method)` helper.
+- Raw-fetch helpers already in `lib/features/authentication/client.ts` (`lookupEmailByIdentifier`, `fetchJWTToken`) establish the pattern: `fetch(\`${authBaseURL}/...\`, { credentials: "include" })`. `authBaseURL` is exported from `client.ts`.
+
+## Wire contract (load-bearing)
+
+- POST `/auth/device/code` with `{ client_id }` (snake_case) → 200 `DeviceAuthCodeResponse` `{ device_code, user_code, verification_uri, verification_uri_complete, expires_in, interval }`.
+- POST `/auth/device/token` with `{ grant_type: "urn:ietf:params:oauth:grant-type:device_code", device_code, client_id }` (snake_case).
+  - **200** `DeviceAuthTokenResponse` `{ access_token, token_type: "Bearer", expires_in, scope }` → success. The 200 also sets the better-auth **session cookie** on the browser (the poll runs with `credentials: "include"`); the response body carries no user object.
+  - **400** `DeviceAuthTokenError` `{ error: DeviceAuthTokenErrorCode, error_description }` → the RFC 8628 polling/terminal states are delivered as **400s, not 2xx**.
+  - **500** → `server_error`.
+
+## Decisions (confirmed with user)
+
+1. **Split** — polling client first (this PR), UI + wiring second.
+2. **Raw fetch typed by `@wxyc/shared`** — no `deviceAuthorizationClient()` plugin; explicit control over the 400-as-polling-state branching and easy to mock.
+
+## Design — two seams
+
+### 1. Pure `interpretTokenPoll` (deep module)
+
+`lib/features/authentication/device-auth.ts`
+
+```ts
+import {
+  DeviceAuthCodeRequest,
+  DeviceAuthCodeResponse,
+  DeviceAuthTokenRequest,
+  DeviceAuthTokenResponse,
+  DeviceAuthTokenErrorCode,
+} from "@wxyc/shared/dtos";
+
+export type PollOutcome =
+  | { kind: "pending" }
+  | { kind: "slow_down" }
+  | { kind: "success"; token: DeviceAuthTokenResponse }
+  | { kind: "expired" }
+  | { kind: "denied" }
+  | { kind: "error"; code?: DeviceAuthTokenErrorCode | "network" };
+
+export function interpretTokenPoll(status: number, body: unknown): PollOutcome;
+```
+
+- Switches on `DeviceAuthTokenErrorCode` const members (`authorization_pending` → `pending`, `slow_down` → `slow_down`, `expired_token` → `expired`, `access_denied` → `denied`, everything else / 500 → `error`). **Never** branches on raw string literals.
+- 200 with an `access_token` → `success`.
+- Pure, synchronous, no fetch/timers/React → unit-testable in isolation; survives any refactor of the plumbing around it.
+
+Also in this module: thin typed fetch wrappers `requestDeviceCode(clientId)` → `DeviceAuthCodeResponse` and `pollDeviceToken(deviceCode, clientId)` → `{ status, body }`, request bodies typed by `DeviceAuthCodeRequest` / `DeviceAuthTokenRequest`. These are I/O-only; all decision logic stays in `interpretTokenPoll`.
+
+### 2. `useDeviceAuthorization()` hook
+
+`src/hooks/authenticationHooks.ts` (alongside `useOTPVerify`)
+
+- On start: `requestDeviceCode` → stash `userCode`, `verificationUriComplete`, `expiresIn`; set interval from server `interval`.
+- Poll loop: every `interval` seconds call `pollDeviceToken` → `interpretTokenPoll`:
+  - `pending` → keep polling.
+  - `slow_down` → increase interval by 5s, keep polling.
+  - `success` → derive the user, then `redirectAfterAuth(router, user, "qr")` (see "User derivation" below).
+  - `expired` / `denied` / `error` → set a terminal `status`, stop polling, `toast.error` for parity with the other auth hooks.
+- Exposes `{ userCode, verificationUriComplete, status, restart }` where `status` is a discriminated UI-facing union. **State transitions:** starts `"loading"` while the initial `/device/code` POST is in flight (`userCode`/`verificationUriComplete` still `undefined`) → `"waiting"` once the code returns (QR renderable, poll loop running) → terminal `"expired" | "denied" | "error"`. A failed initial `/device/code` POST goes straight to `"error"`. (`"success"` is not a status — the hook redirects away on success.)
+- `restart()`: resets to `"loading"`, fetches a fresh device code, and restarts the poll loop. PR 2's `QRCodeForm` calls it from the "regenerate" affordance after `"expired"`. Exported now so the hook interface is stable for PR 2.
+- Cleans up its timer on unmount (no leaked intervals).
+
+**State management (resolves review finding):** the polling lifecycle uses direct `useState` + `useEffect` + `useRef` (timer handle + cancellation), **not** `useAsyncAction`. `useAsyncAction` models a single-shot async call (set loading → await → set error); the device flow is a long-lived poll loop with `slow_down` interval mutation and unmount cleanup, which doesn't fit that shape. Terminal errors still surface via `toast.error` so UX matches `useLogin`/`useOTPVerify`.
+
+**`LoginMethod` scope (resolves review finding):** the only PR-1 type change is the hook-internal `LoginMethod` union in `authenticationHooks.ts` (`"password" | "otp" | "onboarding"` → add `"qr"`), needed so `redirectAfterAuth` records the `login_post_redirect` `method` for QR sign-ins. This is **distinct** from `login-method-storage.ts`'s `PreferredLoginMethod` and the `AuthStage` union — those are picker concerns and stay in **PR 2**. No `login-method-storage` change in this PR.
+
+**`client_id` (resolves review finding):** sourced from `NEXT_PUBLIC_DEVICE_AUTH_CLIENT_ID`, defaulting to `"dj-site"` when unset (mirrors the `NEXT_PUBLIC_DASHBOARD_HOME_PAGE` default-constant pattern). Add this row to `docs/env-vars.md` in this PR:
+
+> `NEXT_PUBLIC_DEVICE_AUTH_CLIENT_ID` — OAuth 2.0 Device Authorization Grant `client_id` (RFC 8628) sent to `/auth/device/code` and `/auth/device/token` for the QR shared-computer sign-in. Optional; defaults to `"dj-site"`.
+
+**User derivation on success (resolves review High finding):** the `/device/token` 200 body has no user, but the successful poll has set the better-auth session cookie. So on `success` the hook: (1) `clearTokenCache()` to drop any prior session's cached bearer (parity with `useLogin`/`useOTPVerify`, WXYC/dj-site#596); (2) `const session = await authClient.getSession()`; (3) `redirectAfterAuth(router, session.data?.user, "qr")`. `authClient.getSession()` is the same call other flows use and is **already mocked** (`mockGetSession`) in `authenticationHooks.test.ts`, so test #11 stubs it to return `{ data: { user: { id, hasCompletedOnboarding } } }` and asserts the resulting `mockPush` target — no new mock infrastructure. If `getSession()` returns no user, fall through to the dashboard default (same as `redirectAfterAuth`'s existing null handling).
+
+## Behaviors to test (TDD order)
+
+Pure `interpretTokenPoll` (vertical slices, tracer bullet first):
+1. 400 `authorization_pending` → `pending`  ← tracer bullet
+2. 400 `slow_down` → `slow_down`
+3. 200 + `access_token` → `success` (carries the token)
+4. 400 `expired_token` → `expired`
+5. 400 `access_denied` → `denied`
+6. 500 / `server_error` / unknown code → `error`
+7. uses `DeviceAuthTokenErrorCode` const members, not string literals (guards against contract drift)
+
+`useDeviceAuthorization` (via `renderHook` + a local `createWrapper()` that supplies a `configureStore({ reducer: { [authenticationSlice...] } })` Redux `Provider` — the exact pattern already in `authenticationHooks.test.ts`; with `vi.useFakeTimers()` and the `device-auth.ts` fetch wrappers mocked):
+8. requests a device code on start and exposes `userCode` + `verificationUriComplete`
+9. keeps polling while `pending`, firing at the server `interval`
+10. `slow_down` increases the polling interval
+11. `success` derives the user via `authClient.getSession()` (mocked) and triggers `redirectAfterAuth` — router push to `/dashboard/...` for a complete DJ, `/login?incomplete=true` when `hasCompletedOnboarding === false`
+12. each terminal state surfaces the matching UI `status`
+13. stops polling / clears timer on unmount
+
+## Test file locations
+
+- Pure `interpretTokenPoll` + fetch-wrapper tests → new `lib/features/authentication/device-auth.test.ts` (co-located with the module).
+- `useDeviceAuthorization` tests → appended to the existing `src/hooks/authenticationHooks.test.ts` (co-located with the other auth hooks, reusing its mocks/wrapper).
+
+## Out of scope (→ PR 2)
+
+`QRCodeForm.tsx`, `qrcode` dep, `AuthStage` `"qr"`, `login-method-storage` `"qr"`, `LoginFormSwitcher` branch + "use password instead" affordance, e2e golden path. **No `@wxyc/shared` bump lands in this PR** — `main` already pins `^1.17.1`, which publishes the `DeviceAuth*` DTOs the hook imports.
+
+**PR-2 note — `redirectAfterAuth` recovery on the QR route.** On success the hook derives the user via `authClient.getSession()` and calls `redirectAfterAuth(..., "qr")`. If that read fails *and* `confirmSessionVisible()` can't confirm the session (persistent auth outage right after phone approval), `redirectAfterAuth` falls back to `router.refresh()` rather than `push()`. That `refresh()` only advances the DJ because the `/login` route's layout forwards an authenticated session onward. The QR page must therefore either live under a layout that does the same forwarding, or the flow needs an explicit success navigation — otherwise a signed-in DJ could be left on the QR/"waiting" screen until the outage clears.
+
+## Acceptance for this PR
+
+- `interpretTokenPoll` fully unit-tested with plain `describe`/`it` (pure function, no React); `useDeviceAuthorization` fully unit-tested via `renderHook` + a local `createWrapper()` (Redux `Provider`) with fake timers and mocked fetch wrappers — per the behavior list above.
+- All device-auth request/response handling typed by `@wxyc/shared`; no hand-typed device-auth shapes.
+- `@wxyc/shared` provides the DeviceAuth* DTOs; `main` already pins `^1.17.1`, so no manifest change is needed in this PR.
+- Typecheck + existing unit suite unchanged and green.

--- a/lib/features/authentication/device-auth.test.ts
+++ b/lib/features/authentication/device-auth.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { DeviceAuthTokenErrorCode } from "@wxyc/shared/dtos";
+import {
+  interpretTokenPoll,
+  pollDeviceToken,
+  requestDeviceCode,
+  type PollOutcome,
+} from "./device-auth";
+
+// device-auth.ts imports `authBaseURL` from ./client, which constructs the
+// better-auth client at module load; stub the plugins so the import is cheap.
+vi.mock("better-auth/react", () => ({
+  createAuthClient: vi.fn(() => ({})),
+}));
+vi.mock("better-auth/client/plugins", () => ({
+  adminClient: vi.fn(),
+  emailOTPClient: vi.fn(),
+  usernameClient: vi.fn(),
+  jwtClient: vi.fn(),
+  organizationClient: vi.fn(),
+}));
+
+describe("interpretTokenPoll", () => {
+  it("treats a 400 authorization_pending as a non-terminal 'pending' poll", () => {
+    const outcome = interpretTokenPoll(400, {
+      error: DeviceAuthTokenErrorCode.authorization_pending,
+      error_description: "Authorization pending",
+    });
+
+    expect(outcome).toEqual({ kind: "pending" });
+  });
+
+  it("treats a 400 slow_down as a non-terminal 'slow_down' poll", () => {
+    const outcome = interpretTokenPoll(400, {
+      error: DeviceAuthTokenErrorCode.slow_down,
+      error_description: "Slow down",
+    });
+
+    expect(outcome).toEqual({ kind: "slow_down" });
+  });
+
+  it("treats a 200 with an access_token as 'success', carrying the token", () => {
+    const token = {
+      access_token: "sess_abc123",
+      token_type: "Bearer" as const,
+      expires_in: 43200,
+      scope: "",
+    };
+
+    const outcome = interpretTokenPoll(200, token);
+
+    expect(outcome).toEqual({ kind: "success", token });
+  });
+
+  it("treats any 200 as success even when the body did not parse (null)", () => {
+    // A truncated/empty 200 still means the grant issued and the cookie is set;
+    // a signed-in DJ must not be shown an error. pollDeviceToken yields
+    // body:null on a parse failure.
+    expect(interpretTokenPoll(200, null)).toEqual({ kind: "success", token: {} });
+  });
+
+  it("treats a 200 with an empty access_token as success (200 = grant issued)", () => {
+    const token = {
+      access_token: "",
+      token_type: "Bearer" as const,
+      expires_in: 43200,
+      scope: "",
+    };
+
+    expect(interpretTokenPoll(200, token)).toEqual({ kind: "success", token });
+  });
+
+  it("treats a 400 expired_token as the terminal 'expired' state", () => {
+    const outcome = interpretTokenPoll(400, {
+      error: DeviceAuthTokenErrorCode.expired_token,
+      error_description: "Device code expired",
+    });
+
+    expect(outcome).toEqual({ kind: "expired" });
+  });
+
+  it("treats a 400 access_denied as the terminal 'denied' state", () => {
+    const outcome = interpretTokenPoll(400, {
+      error: DeviceAuthTokenErrorCode.access_denied,
+      error_description: "Sign-in declined on phone",
+    });
+
+    expect(outcome).toEqual({ kind: "denied" });
+  });
+
+  it.each([
+    { status: 500, code: DeviceAuthTokenErrorCode.server_error },
+    { status: 400, code: DeviceAuthTokenErrorCode.invalid_request },
+    { status: 400, code: DeviceAuthTokenErrorCode.invalid_grant },
+  ])(
+    "treats $status $code as a terminal 'error' that surfaces the code",
+    ({ status, code }) => {
+      const outcome = interpretTokenPoll(status, {
+        error: code,
+        error_description: "boom",
+      });
+
+      expect(outcome).toEqual({ kind: "error", code });
+    },
+  );
+
+  it("treats an unrecognized error code as a terminal 'error'", () => {
+    const outcome = interpretTokenPoll(400, {
+      error: "totally_unexpected",
+      error_description: "???",
+    });
+
+    expect(outcome).toEqual({ kind: "error" });
+  });
+
+  // The Record key type is `DeviceAuthTokenErrorCode`, so adding a member to the
+  // shared enum without mapping it here fails to compile — a contract-drift guard.
+  // Iterating the const's own values (not string literals) proves the function
+  // branches on the typed enum.
+  it("maps every DeviceAuthTokenErrorCode member to a defined outcome kind", () => {
+    const expectedKind: Record<DeviceAuthTokenErrorCode, PollOutcome["kind"]> = {
+      [DeviceAuthTokenErrorCode.authorization_pending]: "pending",
+      [DeviceAuthTokenErrorCode.slow_down]: "slow_down",
+      [DeviceAuthTokenErrorCode.expired_token]: "expired",
+      [DeviceAuthTokenErrorCode.access_denied]: "denied",
+      [DeviceAuthTokenErrorCode.invalid_request]: "error",
+      [DeviceAuthTokenErrorCode.invalid_grant]: "error",
+      [DeviceAuthTokenErrorCode.server_error]: "error",
+    };
+
+    for (const code of Object.values(DeviceAuthTokenErrorCode)) {
+      expect(interpretTokenPoll(400, { error: code }).kind).toBe(
+        expectedKind[code],
+      );
+    }
+  });
+});
+
+describe("requestDeviceCode", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("POSTs a snake_case client_id to /device/code and returns the parsed response", async () => {
+    const codeResponse = {
+      device_code: "dev_123",
+      user_code: "WDPL-XK9R",
+      verification_uri: "https://dj.wxyc.org/auth/device",
+      verification_uri_complete:
+        "https://dj.wxyc.org/auth/device?user_code=WDPL-XK9R",
+      expires_in: 300,
+      interval: 5,
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(codeResponse),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await requestDeviceCode("dj-site");
+
+    expect(result).toEqual(codeResponse);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/device/code");
+    expect(init).toMatchObject({ method: "POST", credentials: "include" });
+    expect(JSON.parse(init.body)).toEqual({ client_id: "dj-site" });
+  });
+});
+
+describe("pollDeviceToken", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("POSTs the RFC 8628 snake_case token body to /device/token", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ access_token: "t" }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await pollDeviceToken("dev_123", "dj-site");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/device/token");
+    expect(init).toMatchObject({ method: "POST", credentials: "include" });
+    expect(JSON.parse(init.body)).toEqual({
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      device_code: "dev_123",
+      client_id: "dj-site",
+    });
+  });
+
+  it("passes the status and parsed body through unchanged on a 400 polling state", async () => {
+    const errorBody = {
+      error: DeviceAuthTokenErrorCode.authorization_pending,
+      error_description: "Authorization pending",
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      status: 400,
+      json: () => Promise.resolve(errorBody),
+    }) as unknown as typeof fetch;
+
+    const result = await pollDeviceToken("dev_123", "dj-site");
+
+    expect(result).toEqual({ status: 400, body: errorBody });
+  });
+});

--- a/lib/features/authentication/device-auth.ts
+++ b/lib/features/authentication/device-auth.ts
@@ -1,0 +1,140 @@
+import {
+  DeviceAuthCodeRequest,
+  DeviceAuthCodeResponse,
+  DeviceAuthTokenErrorCode,
+  DeviceAuthTokenRequest,
+  DeviceAuthTokenResponse,
+} from "@wxyc/shared/dtos";
+import { authBaseURL } from "./client";
+
+/**
+ * The decision a single `/auth/device/token` poll resolves to.
+ *
+ * RFC 8628 delivers the non-terminal polling states (`authorization_pending`,
+ * `slow_down`) and most terminal states as HTTP 400s, not 2xx — so the caller
+ * cannot branch on `response.ok` alone. `interpretTokenPoll` collapses the
+ * `(status, body)` pair into this small union; the polling loop acts on `kind`
+ * and never re-inspects the raw wire shape.
+ */
+export type PollOutcome =
+  | { kind: "pending" }
+  | { kind: "slow_down" }
+  | { kind: "success"; token: DeviceAuthTokenResponse }
+  | { kind: "expired" }
+  | { kind: "denied" }
+  | { kind: "error"; code?: DeviceAuthTokenErrorCode | "network" };
+
+/**
+ * Map an `/auth/device/token` HTTP response to a {@link PollOutcome}.
+ *
+ * Branches exclusively on {@link DeviceAuthTokenErrorCode} const members, never
+ * on raw string literals, so a contract change surfaces as a type error.
+ */
+export function interpretTokenPoll(status: number, body: unknown): PollOutcome {
+  // RFC 8628: any 200 from the token endpoint means the grant was issued and
+  // the session cookie is now set — so a 200 is success by status alone, even
+  // if the body did not parse (`pollDeviceToken` yields `body: null` on a
+  // truncated/empty 200). Gating on a truthy `access_token` would misreport a
+  // genuinely signed-in DJ as an error. The token is not consumed downstream
+  // (the hook re-reads the user via `getSession`); it is carried for completeness.
+  if (status === 200) {
+    return { kind: "success", token: (body ?? {}) as DeviceAuthTokenResponse };
+  }
+
+  const error = (body as { error?: unknown } | null)?.error;
+
+  if (error === DeviceAuthTokenErrorCode.authorization_pending) {
+    return { kind: "pending" };
+  }
+
+  if (error === DeviceAuthTokenErrorCode.slow_down) {
+    return { kind: "slow_down" };
+  }
+
+  if (error === DeviceAuthTokenErrorCode.expired_token) {
+    return { kind: "expired" };
+  }
+
+  if (error === DeviceAuthTokenErrorCode.access_denied) {
+    return { kind: "denied" };
+  }
+
+  return isDeviceAuthTokenErrorCode(error)
+    ? { kind: "error", code: error }
+    : { kind: "error" };
+}
+
+const TOKEN_ERROR_CODES = new Set<string>(
+  Object.values(DeviceAuthTokenErrorCode),
+);
+
+function isDeviceAuthTokenErrorCode(
+  value: unknown,
+): value is DeviceAuthTokenErrorCode {
+  return typeof value === "string" && TOKEN_ERROR_CODES.has(value);
+}
+
+/**
+ * POST `/auth/device/code` to begin a device-authorization flow.
+ *
+ * The body is the snake_case {@link DeviceAuthCodeRequest} (`client_id` only —
+ * WXYC's shared-computer flow identifies the DJ later, at `/device/approve`).
+ * Throws on a non-2xx response; the caller surfaces an error state.
+ */
+export async function requestDeviceCode(
+  clientId: string,
+): Promise<DeviceAuthCodeResponse> {
+  const body: DeviceAuthCodeRequest = { client_id: clientId };
+
+  const response = await fetch(`${authBaseURL}/device/code`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to start device authorization (${response.status})`);
+  }
+
+  return (await response.json()) as DeviceAuthCodeResponse;
+}
+
+/** The fixed RFC 8628 device-flow grant type. */
+const DEVICE_CODE_GRANT_TYPE =
+  "urn:ietf:params:oauth:grant-type:device_code" as const;
+
+/**
+ * POST one `/auth/device/token` poll.
+ *
+ * Returns the raw `{ status, body }` without judging it — RFC 8628 delivers
+ * polling/terminal states as 400s, so the decision is left to
+ * {@link interpretTokenPoll}. The body is the snake_case
+ * {@link DeviceAuthTokenRequest}. A `json()` parse failure yields `body: null`.
+ */
+export async function pollDeviceToken(
+  deviceCode: string,
+  clientId: string,
+): Promise<{ status: number; body: unknown }> {
+  const body: DeviceAuthTokenRequest = {
+    grant_type: DEVICE_CODE_GRANT_TYPE,
+    device_code: deviceCode,
+    client_id: clientId,
+  };
+
+  const response = await fetch(`${authBaseURL}/device/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(body),
+  });
+
+  let parsed: unknown = null;
+  try {
+    parsed = await response.json();
+  } catch {
+    parsed = null;
+  }
+
+  return { status: response.status, body: parsed };
+}

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -73,6 +73,32 @@ vi.mock("./applicationHooks", () => ({
   resetApplication: vi.fn(),
 }));
 
+// Mock only the device-auth fetch wrappers; keep the real interpretTokenPoll so
+// the hook's branching is exercised against the genuine state machine.
+const mockRequestDeviceCode = vi.fn();
+const mockPollDeviceToken = vi.fn();
+vi.mock("@/lib/features/authentication/device-auth", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/lib/features/authentication/device-auth")
+    >();
+  return {
+    ...actual,
+    requestDeviceCode: (...args: any[]) => mockRequestDeviceCode(...args),
+    pollDeviceToken: (...args: any[]) => mockPollDeviceToken(...args),
+  };
+});
+
+const DEVICE_CODE_RESPONSE = {
+  device_code: "dev_123",
+  user_code: "WDPL-XK9R",
+  verification_uri: "https://dj.wxyc.org/auth/device",
+  verification_uri_complete:
+    "https://dj.wxyc.org/auth/device?user_code=WDPL-XK9R",
+  expires_in: 300,
+  interval: 5,
+};
+
 function createTestStore() {
   return configureStore({
     reducer: {
@@ -786,6 +812,322 @@ describe("authenticationHooks", () => {
 
       expect(mockClearTokenCache).toHaveBeenCalledTimes(1);
       expect(callOrder).toEqual(["clearTokenCache", "signInEmailOtp"]);
+    });
+  });
+
+  describe("useDeviceAuthorization", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      mockRequestDeviceCode.mockResolvedValue(DEVICE_CODE_RESPONSE);
+      mockPollDeviceToken.mockResolvedValue({
+        status: 400,
+        body: {
+          error: "authorization_pending",
+          error_description: "Authorization pending",
+        },
+      });
+    });
+
+    afterEach(() => {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    });
+
+    it("requests a device code on mount and exposes the user_code + verification URI", async () => {
+      const { useDeviceAuthorization } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useDeviceAuthorization(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockRequestDeviceCode).toHaveBeenCalledWith("dj-site");
+      expect(result.current.userCode).toBe("WDPL-XK9R");
+      expect(result.current.verificationUriComplete).toBe(
+        DEVICE_CODE_RESPONSE.verification_uri_complete,
+      );
+      expect(result.current.status).toBe("waiting");
+    });
+
+    it("polls /device/token at the server interval while pending", async () => {
+      const { useDeviceAuthorization } = await import("./authenticationHooks");
+      renderHook(() => useDeviceAuthorization(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(mockPollDeviceToken).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      expect(mockPollDeviceToken).toHaveBeenCalledTimes(1);
+      expect(mockPollDeviceToken).toHaveBeenCalledWith("dev_123", "dj-site");
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      expect(mockPollDeviceToken).toHaveBeenCalledTimes(2);
+    });
+
+    it("increases the polling interval after a slow_down", async () => {
+      mockPollDeviceToken
+        .mockResolvedValueOnce({
+          status: 400,
+          body: { error: "slow_down", error_description: "Slow down" },
+        })
+        .mockResolvedValue({
+          status: 400,
+          body: {
+            error: "authorization_pending",
+            error_description: "Authorization pending",
+          },
+        });
+
+      const { useDeviceAuthorization } = await import("./authenticationHooks");
+      renderHook(() => useDeviceAuthorization(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // First poll fires at the 5s server interval and returns slow_down.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      expect(mockPollDeviceToken).toHaveBeenCalledTimes(1);
+
+      // 5s is no longer enough — the interval was bumped to 10s.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      expect(mockPollDeviceToken).toHaveBeenCalledTimes(1);
+
+      // 10s after the slow_down, the next poll fires.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      expect(mockPollDeviceToken).toHaveBeenCalledTimes(2);
+    });
+
+    const SUCCESS_POLL = {
+      status: 200,
+      body: {
+        access_token: "sess_abc",
+        token_type: "Bearer",
+        expires_in: 43200,
+        scope: "",
+      },
+    };
+
+    it("on success, derives the user via getSession and routes a complete DJ to the dashboard", async () => {
+      mockPollDeviceToken.mockResolvedValue(SUCCESS_POLL);
+      mockGetSession.mockResolvedValue({
+        data: { user: { id: "dj-1", hasCompletedOnboarding: true } },
+      });
+
+      const { useDeviceAuthorization } = await import("./authenticationHooks");
+      renderHook(() => useDeviceAuthorization(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+
+      expect(mockClearTokenCache).toHaveBeenCalled();
+      expect(mockGetSession).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
+      expect(mockSafeCapture).toHaveBeenCalledWith("login_post_redirect", {
+        method: "qr",
+        destination: "dashboard",
+        has_completed_onboarding: true,
+        user_id: "dj-1",
+        session_confirmed: true,
+      });
+    });
+
+    it("on success, routes an incomplete DJ to the onboarding screen", async () => {
+      mockPollDeviceToken.mockResolvedValue(SUCCESS_POLL);
+      mockGetSession.mockResolvedValue({
+        data: { user: { id: "dj-2", hasCompletedOnboarding: false } },
+      });
+
+      const { useDeviceAuthorization } = await import("./authenticationHooks");
+      renderHook(() => useDeviceAuthorization(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith("/login?incomplete=true");
+    });
+
+    it.each([
+      { httpStatus: 400, code: "expired_token", expected: "expired" },
+      { httpStatus: 400, code: "access_denied", expected: "denied" },
+      { httpStatus: 500, code: "server_error", expected: "error" },
+    ])(
+      "surfaces the '$expected' status on a terminal $code poll",
+      async ({ httpStatus, code, expected }) => {
+        mockPollDeviceToken.mockResolvedValue({
+          status: httpStatus,
+          body: { error: code, error_description: "terminal" },
+        });
+
+        const { useDeviceAuthorization } = await import("./authenticationHooks");
+        const { result } = renderHook(() => useDeviceAuthorization(), {
+          wrapper: createWrapper(),
+        });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(5000);
+        });
+
+        expect(result.current.status).toBe(expected);
+
+        // A terminal state stops the loop — no further polls.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(30000);
+        });
+        expect(mockPollDeviceToken).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it("stops polling after unmount", async () => {
+      const { useDeviceAuthorization } = await import("./authenticationHooks");
+      const { unmount } = renderHook(() => useDeviceAuthorization(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      unmount();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30000);
+      });
+
+      expect(mockPollDeviceToken).not.toHaveBeenCalled();
+    });
+
+    it("restart fetches a fresh device code and resumes from 'loading'", async () => {
+      mockPollDeviceToken.mockResolvedValue({
+        status: 400,
+        body: { error: "expired_token", error_description: "expired" },
+      });
+
+      const { useDeviceAuthorization } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useDeviceAuthorization(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      expect(result.current.status).toBe("expired");
+      expect(mockRequestDeviceCode).toHaveBeenCalledTimes(1);
+
+      mockPollDeviceToken.mockResolvedValue({
+        status: 400,
+        body: {
+          error: "authorization_pending",
+          error_description: "Authorization pending",
+        },
+      });
+
+      await act(async () => {
+        result.current.restart();
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(mockRequestDeviceCode).toHaveBeenCalledTimes(2);
+      expect(result.current.status).toBe("waiting");
+    });
+
+    it("still navigates when the post-success getSession read rejects, instead of stalling", async () => {
+      mockPollDeviceToken.mockResolvedValue(SUCCESS_POLL);
+      // Both the hook's own user read and confirmSessionVisible's read reject.
+      mockGetSession.mockRejectedValue(new Error("network"));
+
+      const { useDeviceAuthorization } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useDeviceAuthorization(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      // Fire the success poll, then drain redirectAfterAuth's confirm-gate
+      // retries (which also see the rejecting getSession).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20000);
+      });
+
+      // Auth already succeeded (the poll set the cookie); the flow must not
+      // freeze on "waiting". With no readable user and an unconfirmable
+      // session, redirectAfterAuth falls back to refresh() rather than
+      // stranding the DJ.
+      expect(mockClearTokenCache).toHaveBeenCalled();
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+
+    it("defaults to a 5s poll interval when the server omits `interval`", async () => {
+      // A missing `interval` must not become NaN and make setTimeout fire at
+      // 0ms, flooding the token endpoint.
+      mockRequestDeviceCode.mockResolvedValue({
+        ...DEVICE_CODE_RESPONSE,
+        interval: undefined,
+      });
+
+      const { useDeviceAuthorization } = await import("./authenticationHooks");
+      renderHook(() => useDeviceAuthorization(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      // No busy-loop: nothing polls before the 5s default elapses.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4999);
+      });
+      expect(mockPollDeviceToken).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(mockPollDeviceToken).toHaveBeenCalledTimes(1);
+    });
+
+    it("surfaces the 'error' status when a poll throws (network failure)", async () => {
+      mockPollDeviceToken.mockRejectedValue(new Error("network down"));
+
+      const { useDeviceAuthorization } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useDeviceAuthorization(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+
+      expect(result.current.status).toBe("error");
     });
   });
 });

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -2,6 +2,12 @@
 
 import { authenticationSlice } from "@/lib/features/authentication/frontend";
 import { authClient, clearTokenCache, lookupEmailByIdentifier } from "@/lib/features/authentication/client";
+import {
+  interpretTokenPoll,
+  pollDeviceToken,
+  requestDeviceCode,
+  type PollOutcome,
+} from "@/lib/features/authentication/device-auth";
 import { isValidEmail } from "@wxyc/shared/validation";
 import {
   AuthenticatedUser,
@@ -16,7 +22,7 @@ import { Authorization } from "@/lib/features/admin/types";
 import { applicationSlice } from "@/lib/features/application/frontend";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { resetApplication } from "./applicationHooks";
 import { throwIfBetterAuthError } from "@/src/utilities/throwIfBetterAuthError";
@@ -29,7 +35,7 @@ const LOGIN_EVENTS = {
   POST_LOGIN_REDIRECT: "login_post_redirect",
 } as const;
 
-type LoginMethod = "password" | "otp" | "onboarding";
+type LoginMethod = "password" | "otp" | "onboarding" | "qr";
 
 /**
  * How hard we try to confirm the freshly-established session is visible
@@ -265,6 +271,136 @@ export const useOTPVerify = () => {
   };
 
   return { handleVerifyOTP, handleResendOTP, isLoading, error };
+};
+
+/** UI-facing lifecycle state of the QR device-authorization flow. */
+export type DeviceAuthorizationStatus =
+  | "loading"
+  | "waiting"
+  | "expired"
+  | "denied"
+  | "error";
+
+/**
+ * Drive the RFC 8628 QR sign-in flow for the shared control-room browser.
+ *
+ * On mount (and on {@link restart}) it POSTs `/auth/device/code`, surfaces the
+ * `user_code` + `verification_uri_complete` for the QR, then polls
+ * `/auth/device/token` at the server-returned interval until the DJ approves
+ * on their phone or the code reaches a terminal state.
+ */
+export const useDeviceAuthorization = () => {
+  const router = useRouter();
+  const [status, setStatus] = useState<DeviceAuthorizationStatus>("loading");
+  const [userCode, setUserCode] = useState<string | undefined>(undefined);
+  const [verificationUriComplete, setVerificationUriComplete] = useState<
+    string | undefined
+  >(undefined);
+  const [restartNonce, setRestartNonce] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const clientId =
+      process.env.NEXT_PUBLIC_DEVICE_AUTH_CLIENT_ID || "dj-site";
+
+    // Reset to a clean slate so a restart visibly returns to "loading".
+    setStatus("loading");
+    setUserCode(undefined);
+    setVerificationUriComplete(undefined);
+
+    (async () => {
+      let code;
+      try {
+        code = await requestDeviceCode(clientId);
+      } catch {
+        if (!cancelled) setStatus("error");
+        return;
+      }
+      if (cancelled) return;
+
+      setUserCode(code.user_code);
+      setVerificationUriComplete(code.verification_uri_complete);
+      setStatus("waiting");
+
+      // Fall back to the RFC 8628 default (5s) if the server omits or garbles
+      // `interval`: a NaN/0 here would make `setTimeout(poll, …)` fire at 0ms
+      // and flood the token endpoint.
+      let intervalMs =
+        (Number.isFinite(code.interval) && code.interval > 0
+          ? code.interval
+          : 5) * 1000;
+
+      const schedule = () => {
+        timer = setTimeout(poll, intervalMs);
+      };
+
+      const poll = async () => {
+        let outcome: PollOutcome;
+        try {
+          const { status: httpStatus, body } = await pollDeviceToken(
+            code.device_code,
+            clientId,
+          );
+          outcome = interpretTokenPoll(httpStatus, body);
+        } catch {
+          outcome = { kind: "error", code: "network" };
+        }
+        if (cancelled) return;
+
+        if (outcome.kind === "pending") {
+          schedule();
+        } else if (outcome.kind === "slow_down") {
+          intervalMs += 5000;
+          schedule();
+        } else if (outcome.kind === "success") {
+          // The successful poll set the session cookie; drop any stale cached
+          // bearer (WXYC/dj-site#596), then read the user back off the session.
+          clearTokenCache();
+          let user:
+            | { id?: string; hasCompletedOnboarding?: boolean }
+            | undefined;
+          try {
+            const session = (await authClient.getSession()) as {
+              data?: { user?: { id?: string; hasCompletedOnboarding?: boolean } };
+            };
+            user = session?.data?.user;
+          } catch {
+            // Auth already succeeded (the poll set the session cookie); if the
+            // user read fails, still navigate. redirectAfterAuth's confirm gate
+            // and the destination's own requireAuth resolve the session
+            // server-side — never strand the DJ on a frozen QR after sign-in.
+            user = undefined;
+          }
+          if (cancelled) return;
+          await redirectAfterAuth(router, user, "qr");
+        } else if (outcome.kind === "expired") {
+          setStatus("expired");
+        } else if (outcome.kind === "denied") {
+          setStatus("denied");
+        } else {
+          toast.error("Something went wrong signing in. Please try again.");
+          setStatus("error");
+        }
+      };
+
+      schedule();
+    })();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+    // Intentionally keyed only on `restartNonce`: the flow must start exactly
+    // once per mount and once per restart(). `router` is deliberately omitted —
+    // its identity is not guaranteed stable, and re-running this effect (which
+    // requests a fresh device code) whenever the router changes would restart
+    // the QR flow mid-poll.
+  }, [restartNonce]);
+
+  const restart = useCallback(() => setRestartNonce((n) => n + 1), []);
+
+  return { userCode, verificationUriComplete, status, restart };
 };
 
 export const useLogout = () => {


### PR DESCRIPTION
Closes #834. Part of #785 (RFC 8628 QR shared-computer sign-in) — **PR 1 of 2**.

## What

The polling client for the QR device-authorization flow. **No UI in this PR** — it lands the pure state machine, the typed fetch wrappers, and the driving hook, all typed by `@wxyc/shared` `DeviceAuth*`.

## Design — two seams

**`interpretTokenPoll(status, body): PollOutcome`** — pure, in `lib/features/authentication/device-auth.ts`. Collapses one `/auth/device/token` response into a discriminated union. RFC 8628 delivers `authorization_pending` / `slow_down` and terminal states as **HTTP 400s, not 2xx**, so a caller can't branch on `response.ok`. The function switches **exclusively on `DeviceAuthTokenErrorCode` const members** (never raw string literals) — a contract change becomes a type error, and an exhaustiveness test keyed by the enum won't compile until a new member is mapped. Pure/synchronous → unit-testable in isolation and unaffected by any refactor of the plumbing around it. Alongside it: thin typed `requestDeviceCode` / `pollDeviceToken` fetch wrappers (snake_case bodies typed by `DeviceAuthCodeRequest` / `DeviceAuthTokenRequest`), mirroring the existing `client.ts` helpers.

**`useDeviceAuthorization()`** — in `src/hooks/authenticationHooks.ts`. Requests a device code on mount, exposes `user_code` + `verification_uri_complete` for the QR, and polls at the server `interval` (bumped +5s on `slow_down`). On success it reads the user back via `authClient.getSession()` — the successful poll sets the better-auth session cookie, and the 200 token body carries no user object — then routes through the shared `redirectAfterAuth(..., "qr")` (which now also runs the session-confirm gate added on `main`). Terminal states surface `expired` / `denied` / `error`; `restart()` re-fetches; the poll timer is torn down on unmount.

## Notes

- **No dependency change**: the `DeviceAuth*` DTOs are already on `main` via `@wxyc/shared@^1.17.1`.
- `docs/env-vars.md` documents the optional `NEXT_PUBLIC_DEVICE_AUTH_CLIENT_ID` (defaults `"dj-site"`).
- Deferred to **PR 2**: `QRCodeForm` UI, the `qrcode` dep, `AuthStage` / `login-method-storage` `"qr"` values, the login-picker branch + "use password instead" affordance, and the e2e golden path.

## Tests

23 new tests, built test-first (red→green per behavior): 13 for `interpretTokenPoll` + the fetch wrappers (incl. an exhaustiveness case keyed by `DeviceAuthTokenErrorCode`), 10 for `useDeviceAuthorization` (`renderHook` + a local Redux `createWrapper()`, fake timers, mocked fetch wrappers).

Local checks: `tsc --noEmit` clean · full unit suite **242 files / 3404 tests** green · `npm run build` clean.