### PR TITLE
feat(auth): QR device-authorization sign-in UI (PR 2 of 2)

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -10,6 +10,7 @@ NEXT_PUBLIC_DEFAULT_EXPERIENCE=modern
 NEXT_PUBLIC_ENABLED_EXPERIENCES=modern,classic
 NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING=true
 NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED=false
+NEXT_PUBLIC_QR_LOGIN_ENABLED=false
 
 # Optional — auto-DJ orchestrator base URL. When set, the dashboard polls
 # /api/auto-dj/status and reflects auto-DJ state (greyscale + banner).
@@ -41,5 +42,7 @@ Runtime (server-only) settings like `AUTH_REWRITE_URL` are **not** build-time; t
 ## Feature flags
 
 - `NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED` — gates the track-search UI surfaces in catalog search: the `matched_via` track-match chip rendering in result rows (both classic and modern experiences) and the classic `SearchForm` help-text refresh (worked track-lookup example replacing the legacy "Coming later" line). Defaults to OFF; set to `"true"` or `"1"` to enable. Helper: `isCatalogTrackSearchUiEnabled()` in `lib/features/catalog/flags.ts`. Flip on after Backend-Service is serving `matched_via` in prod. See WXYC/dj-site#497 and WXYC/dj-site#498.
+
+- `NEXT_PUBLIC_QR_LOGIN_ENABLED` — gates the RFC 8628 QR ("device authorization") sign-in method on the modern login screen: the "Sign in with a QR code" entry links on the password and email forms, and the restore of a stored `"qr"` login preference. Defaults to OFF; set to `"true"` or `"1"` to enable. Helper: `isQrLoginEnabled()` in `lib/features/authentication/flags.ts`. While off, nothing can navigate to the QR stage, so the client never requests a device code. Flip on per-environment once Backend-Service is serving `/auth/device/code` and `/auth/device/token`. See WXYC/dj-site#785.
 
 - `NEXT_PUBLIC_ORCHESTRATOR_URL` — base URL of the [auto-dj-orchestrator](https://github.com/WXYC/auto-dj-orchestrator). When set, the dashboard polls `GET /api/auto-dj/status` every 10s (better-auth JWT) and reflects auto-DJ state station-wide: the shell greyscales and an "Auto DJ Enabled" banner shows at the top of the flowsheet. Unset disables the indicator and all polling. Helpers: `getOrchestratorUrl()` / `isAutoDJStatusEnabled()` in `lib/features/autoDJ/flags.ts`.

--- a/docs/plans/qr-device-auth-ui.md
+++ b/docs/plans/qr-device-auth-ui.md
@@ -1,0 +1,110 @@
+# PR 2 — QR device-authorization sign-in UI
+
+Part of [WXYC/dj-site#785](https://github.com/WXYC/dj-site/issues/785) — the RFC 8628 QR shared-computer sign-in flow per [ADR 0005](../adr/0005-qr-device-authorization-shared-computer-signin.md). PR 1 ([#835](https://github.com/WXYC/dj-site/pull/835), merged) delivered the polling client: `lib/features/authentication/device-auth.ts` (`interpretTokenPoll`, `requestDeviceCode`, `pollDeviceToken`) and the `useDeviceAuthorization()` hook in `src/hooks/authenticationHooks.ts`. This PR delivers the **UI + login-picker wiring** that consumes that hook. The **e2e golden path is deferred to a follow-up PR** (see "Out of scope" for why).
+
+## Background — what already exists (PR 1)
+
+- `useDeviceAuthorization()` returns `{ userCode, verificationUriComplete, status, restart }` where `status: DeviceAuthorizationStatus = "loading" | "waiting" | "expired" | "denied" | "error"`. On success the hook navigates via `redirectAfterAuth(router, user, "qr")` and never surfaces a `"success"` status — the UI only ever sees the non-terminal / terminal-failure states.
+- The hook starts polling `/auth/device/token` **on mount** (it requests a device code as its first act). So the `/device/code` request fires exactly when the QR form is mounted — mounting is the natural gate.
+- `LoginMethod` (hook-internal) already includes `"qr"`; `redirectAfterAuth` already records `login_post_redirect { method: "qr" }`. No hook change is required for the happy path.
+
+## The login surface today (modern experience)
+
+- `app/login/@modern/layout.tsx` is a **server component**. If `getServerSession()` returns a verified, complete session it `redirect()`s to `NEXT_PUBLIC_DASHBOARD_HOME_PAGE` (default `/dashboard/catalog`); an incomplete session renders onboarding. **This is the forwarding authority** the QR success path depends on (see Design decision 1).
+- `app/login/@modern/@normal/page.tsx` renders `LoginFormSwitcher`.
+- `LoginFormSwitcher.tsx` (`src/components/experiences/modern/login/Forms/`) reads `authStage` from Redux (`applicationSlice.selectors.getAuthStage`) and renders the matching form. On mount it restores the persisted preference via `getPreferredLoginMethod()` in a pre-paint `useLayoutEffect`.
+- `AuthStage = "otp-email" | "otp-verify" | "password" | "forgot" | "reset"` (`lib/features/application/types.ts`).
+- `login-method-storage.ts`: `PreferredLoginMethod = Extract<AuthStage, "otp-email" | "password">`, `VALID_METHODS = ["otp-email", "password"]`, persisted at localStorage key `wxyc_preferred_login_method`.
+- Each form carries a "Sign in with X instead" `<Link>` footer that calls `savePreferredLoginMethod(m)` + `dispatch(setAuthStage(m))` — the exact affordance QR must add and reuse.
+- **Classic experience is password-only** (`ClassicLoginSlotSwitcher` chooses `normal` vs `reset`; no OTP, no method picker). QR is **out of scope for classic** — it would need a picker classic doesn't have, and the shared-control-room browsers run the modern experience.
+
+## Scope
+
+**In:**
+1. `AuthStage` gains `"qr"`.
+2. New `QRCodeForm.tsx` (modern) driven by `useDeviceAuthorization()`, rendering all five statuses + a manual-entry fallback + method-switch affordances.
+3. `LoginFormSwitcher` renders `QRCodeForm` when `authStage === "qr"`.
+4. "Sign in with a QR code" entry-point link added to `UserPasswordForm` and `EmailOTPForm` footers, **gated by a feature flag**.
+5. `login-method-storage` extends `PreferredLoginMethod` / `VALID_METHODS` with `"qr"` so a control-room browser can default to QR; a stored `"qr"` is **ignored when the flag is off**.
+6. Feature flag `NEXT_PUBLIC_QR_LOGIN_ENABLED` (default off) + `docs/env-vars.md` entry.
+7. QR-rendering dependency (`qrcode.react` — see Design decision 4).
+8. Component/unit tests for all of the above.
+
+**Out (this PR):**
+- **e2e golden path → follow-up PR.** The golden path needs the shared browser to reach `waiting`, then a *second* authenticated "phone" context to hit the backend device-**approve** endpoint, then the shared browser to poll to success. Whether that approve endpoint is reachable in the e2e Docker Backend-Service stack is **unverified**, and the flow is inherently cross-context. Bundling it risks blowing the ≤1000-line target and couples this UI PR to backend-e2e readiness. It ships as PR 3 once the backend endpoint is confirmed in the Docker stack. The feature flag lets the UI merge and sit dark until then.
+- Classic experience QR (password-only surface; no picker).
+- Any change to `device-auth.ts` / the hook's happy path.
+
+## Design decisions
+
+### 1. QR is an `AuthStage` inside the modern login switcher — not a standalone route
+
+Putting the QR form *inside* `/login` (as `authStage === "qr"`) is what satisfies the PR-1 forwarding constraint for free. On success, `redirectAfterAuth(..., "qr")` either `router.push(dashboardHome)` or — if `confirmSessionVisible()` fails during an auth outage right after phone approval — `router.refresh()`. A `refresh()` on `/login` re-runs `app/login/@modern/layout.tsx`, which now sees the authenticated session and `redirect()`s to the dashboard. A standalone `/qr-login` route would have to reimplement that server-side forwarding or risk stranding a signed-in DJ on a frozen "waiting" screen. Staying on `/login` inherits it.
+
+### 2. No client-side role gate — `denied` is backend-enforced and rendered, not prevented
+
+The shared control-room browser is **unauthenticated** — there is no session on it to check a role against. The "role ≥ DJ" restriction is enforced **backend-side when the DJ approves on their phone** (a non-DJ approver gets `access_denied`), which the poll surfaces as `status === "denied"`. So PR 2 adds **no** `requireRole`/`checkRole` call; it renders the `denied` state with a clear message and a password/email fallback. (This corrects an over-broad "add server/client role gating" reading — there is no principal to gate on the shared machine.)
+
+### 3. Feature flag `NEXT_PUBLIC_QR_LOGIN_ENABLED` (default off), ship dark
+
+QR sign-in is only usable once the backend device-auth endpoints are live in an environment. The flag gates the **entry-point links** and the **stored-preference restore**, so nothing can navigate to `authStage === "qr"` (and thus fire `/device/code`) until it's turned on per-environment. Follows the existing `NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED` pattern. Read via a tiny `isQrLoginEnabled()` helper that mirrors `isCatalogTrackSearchUiEnabled` exactly (`=== "true" || === "1"`, invoked at render time so the build-inlined value is read per-render).
+
+**Placement (review finding):** the helper lives in a dedicated **`lib/features/authentication/flags.ts`**, mirroring `lib/features/catalog/flags.ts` — auth flags belong in the auth feature module, not a generic `lib/utils/`. This matches the feature-module organization in CLAUDE.md.
+
+### 4. QR rendering: `qrcode.react` (`QRCodeSVG`)
+
+Recommend `qrcode.react` over the bare `qrcode` package (the PR-1 plan named `qrcode` generically):
+- Renders **synchronous SVG** — no `toDataURL` async effect, no image-loading state to manage inside the already-multi-state form.
+- Pure client component, **no Node built-ins** — safe under OpenNext/Cloudflare edge (the bare `qrcode` package pulls Node `Buffer`/`stream` paths that have burned us on the worker before).
+- Themeable `fgColor`/`bgColor` to match the Joy palette; crisp at any size.
+- Small, widely used, TS types bundled.
+
+**Edge-safety verification (review finding) — RESOLVED.** The review flagged that `qrcode.react` might peer-depend on the bare `qrcode` package and drag Node `Buffer`/`stream` into the worker. Verified against the installed `qrcode.react@4.2.0`: it has **zero dependencies** (only a React peer dep), imports no `qrcode`/`buffer`/`stream`, and the bare `qrcode` package is not installed — v4 bundles its own encoder. `npm run build:opennext` completes and emits `.open-next/worker.js` cleanly. No fallback needed. The component still isolates the choice — only `QRCodeForm` imports it.
+
+### 5. Manual-entry fallback
+
+The `waiting` state shows the QR (encoding `verificationUriComplete`) **and** the `userCode` in large mono text for the DJ who'd rather type it. If `DeviceAuthCodeResponse` exposes the base `verification_uri`, surface it too ("go to `<uri>` and enter `<code>`") via a one-line hook addition (`verificationUri`); otherwise derive the base by stripping the query off `verificationUriComplete`. Resolve at implementation time by reading the DTO — low risk either way.
+
+## File-by-file changes
+
+| File | Change |
+|---|---|
+| `lib/features/application/types.ts` | `AuthStage` += `"qr"`, with an inline comment that `PreferredLoginMethod` uses an explicit `Extract` allow-list so a new non-persistable stage (`forgot`/`reset`/etc.) can be added here without leaking into persisted preferences. |
+| `lib/features/application/login-method-storage.ts` | `PreferredLoginMethod = Extract<AuthStage, "otp-email" \| "password" \| "qr">`; `VALID_METHODS` += `"qr"`; on read, if the stored value is `"qr"` and `!isQrLoginEnabled()`, fall through to `"otp-email"`. |
+| `lib/features/authentication/flags.ts` | **New.** `isQrLoginEnabled()` reading `NEXT_PUBLIC_QR_LOGIN_ENABLED`, mirroring `lib/features/catalog/flags.ts`. |
+| `src/components/experiences/modern/login/Forms/QRCodeForm.tsx` | **New.** Consumes `useDeviceAuthorization()`. Renders per status: `loading` → spinner + "Generating a sign-in code…"; `waiting` → `QRCodeSVG(verificationUriComplete)` + big `userCode` + instructions + fallback links; `expired` → message + "Generate a new code" (`restart()`); `denied` → "This account isn't allowed to sign in by QR" + password/email fallback; `error` → generic message + "Try again" (`restart()`) + fallback. Always renders "Sign in with password / email code instead" links (persist method + `setAuthStage`). |
+| `src/components/experiences/modern/login/Forms/LoginFormSwitcher.tsx` | add `if (authStage === "qr") return <><WelcomeQuotes/><QRCodeForm/></>;`. |
+| `src/components/experiences/modern/login/Forms/UserPasswordForm.tsx` | add flag-gated "Sign in with a QR code" link (persist `"qr"` + `setAuthStage("qr")`). |
+| `src/components/experiences/modern/login/Forms/EmailOTPForm.tsx` | same flag-gated QR entry link. |
+| `docs/env-vars.md` | document `NEXT_PUBLIC_QR_LOGIN_ENABLED` in the feature-flag catalog. |
+| `package.json` / `package-lock.json` | add `qrcode.react`. |
+| `src/hooks/authenticationHooks.ts` | *(only if the DTO has `verification_uri`)* surface `verificationUri` from `useDeviceAuthorization()`. Otherwise untouched. |
+
+## Testing plan (TDD, unit/component)
+
+All component tests render through `renderWithProviders`; mock `useDeviceAuthorization` and the `QRCodeSVG` renderer (assert it receives `verificationUriComplete`, not its pixels).
+
+1. **`QRCodeForm.test.tsx`** (new):
+   - `loading` → shows the generating-code affordance, no QR yet.
+   - `waiting` → QR renderer got `verificationUriComplete`; `userCode` is visible; fallback links present.
+   - `expired` → "Generate a new code" calls `restart`.
+   - `denied` → denial copy + password fallback; no `restart` on the primary action (denial is terminal for that account).
+   - `error` → "Try again" calls `restart`.
+   - Fallback links call `savePreferredLoginMethod("password"|"otp-email")` **and** `dispatch(setAuthStage(...))`.
+2. **`LoginFormSwitcher.test.tsx`** (extend): `authStage === "qr"` renders `QRCodeForm`.
+3. **`login-method-storage.test.ts`** (extend): `"qr"` round-trips through save/get when the flag is on; a stored `"qr"` with the flag **off** resolves to `"otp-email"`.
+4. **Entry-point links**: `UserPasswordForm` / `EmailOTPForm` show the QR link only when `isQrLoginEnabled()`; clicking it persists `"qr"` + sets the stage.
+
+## Risks & mitigations
+
+- **Auto-start fires `/device/code` on mount.** Intended (mounting == the DJ chose QR), and unreachable while the flag is off. No extra guard needed.
+- **`qrcode.react` on the edge.** Pure client SVG, no Node built-ins — the reason to prefer it over bare `qrcode`. Build (`build:opennext`) will confirm.
+- **`verification_uri` base may be absent from the DTO.** Fallback derivation from `verificationUriComplete` removes the dependency; decided at implementation from the actual DTO.
+- **e2e coupling.** Explicitly deferred so this PR doesn't block on backend device-approve availability in the Docker stack.
+
+## Acceptance criteria
+
+- Flag **on**: `/login` (modern) shows a "Sign in with a QR code" affordance from password and email forms; choosing it renders a QR + user code; approving on a DJ phone lands on the dashboard; a non-DJ approval shows the `denied` state with a working password fallback; expired/error offer regeneration.
+- Flag **off**: no QR affordance anywhere, a stored `"qr"` preference resolves to the email form, and `/device/code` is never requested.
+- `tsc --noEmit`, `vitest run`, and `npm run build` all pass locally before push.
+- PR delta ≤ ~1000 lines (hand-written; excludes the generated lockfile).

--- a/lib/__tests__/features/application/login-method-storage.test.ts
+++ b/lib/__tests__/features/application/login-method-storage.test.ts
@@ -44,6 +44,26 @@ describe("login-method-storage", () => {
       localStorage.setItem(LOGIN_METHOD_STORAGE_KEY, "something-invalid");
       expect(getPreferredLoginMethod()).toBe("otp-email");
     });
+
+    describe("stored 'qr' preference (flag-gated)", () => {
+      const QR_FLAG_KEY = "NEXT_PUBLIC_QR_LOGIN_ENABLED";
+
+      afterEach(() => {
+        delete process.env[QR_FLAG_KEY];
+      });
+
+      it("returns 'qr' when 'qr' is stored and the QR flag is on", () => {
+        process.env[QR_FLAG_KEY] = "true";
+        localStorage.setItem(LOGIN_METHOD_STORAGE_KEY, "qr");
+        expect(getPreferredLoginMethod()).toBe("qr");
+      });
+
+      it("falls back to 'otp-email' when 'qr' is stored but the QR flag is off", () => {
+        delete process.env[QR_FLAG_KEY];
+        localStorage.setItem(LOGIN_METHOD_STORAGE_KEY, "qr");
+        expect(getPreferredLoginMethod()).toBe("otp-email");
+      });
+    });
   });
 
   describe("savePreferredLoginMethod", () => {
@@ -61,6 +81,11 @@ describe("login-method-storage", () => {
       savePreferredLoginMethod("password");
       savePreferredLoginMethod("otp-email");
       expect(localStorage.getItem(LOGIN_METHOD_STORAGE_KEY)).toBe("otp-email");
+    });
+
+    it("should save 'qr' to localStorage", () => {
+      savePreferredLoginMethod("qr");
+      expect(localStorage.getItem(LOGIN_METHOD_STORAGE_KEY)).toBe("qr");
     });
   });
 });

--- a/lib/features/application/login-method-storage.ts
+++ b/lib/features/application/login-method-storage.ts
@@ -1,20 +1,30 @@
+import { isQrLoginEnabled } from "@/lib/features/authentication/flags";
 import { AuthStage } from "./types";
 
 export const LOGIN_METHOD_STORAGE_KEY = "wxyc_preferred_login_method";
 
-type PreferredLoginMethod = Extract<AuthStage, "otp-email" | "password">;
+type PreferredLoginMethod = Extract<AuthStage, "otp-email" | "password" | "qr">;
 
-const VALID_METHODS: PreferredLoginMethod[] = ["otp-email", "password"];
+const VALID_METHODS: PreferredLoginMethod[] = ["otp-email", "password", "qr"];
 
 /**
  * Read the user's preferred login method from localStorage.
- * Returns "otp-email" if nothing is stored or the value is unrecognized.
+ *
+ * Returns "otp-email" if nothing is stored or the value is unrecognized. A
+ * stored "qr" is only honored when {@link isQrLoginEnabled} is on — otherwise
+ * (feature off / not yet live in this environment) it falls back to "otp-email"
+ * so a control-room browser that opted into QR can't be stranded on a disabled
+ * method, and the QR stage (which requests a device code on mount) is never
+ * reached while the flag is off.
  */
 export function getPreferredLoginMethod(): PreferredLoginMethod {
   if (typeof window === "undefined") return "otp-email";
   try {
     const stored = localStorage.getItem(LOGIN_METHOD_STORAGE_KEY);
     if (stored && VALID_METHODS.includes(stored as PreferredLoginMethod)) {
+      if (stored === "qr" && !isQrLoginEnabled()) {
+        return "otp-email";
+      }
       return stored as PreferredLoginMethod;
     }
     return "otp-email";

--- a/lib/features/application/types.ts
+++ b/lib/features/application/types.ts
@@ -24,7 +24,11 @@ export interface RightbarState {
     panel: RightbarPanel;
 }
 
-export type AuthStage = "otp-email" | "otp-verify" | "password" | "forgot" | "reset";
+// Adding a stage here does NOT make it a persistable login preference:
+// `login-method-storage.ts`'s `PreferredLoginMethod` uses an explicit
+// `Extract<AuthStage, ...>` allow-list, so state-only stages (`otp-verify`,
+// `forgot`, `reset`) stay out of what gets written to localStorage.
+export type AuthStage = "otp-email" | "otp-verify" | "password" | "forgot" | "reset" | "qr";
 
 export interface AuthFlowState {
     stage: AuthStage;

--- a/lib/features/authentication/flags.test.ts
+++ b/lib/features/authentication/flags.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach } from "vitest";
+
+import { isQrLoginEnabled } from "@/lib/features/authentication/flags";
+
+const ENV_KEY = "NEXT_PUBLIC_QR_LOGIN_ENABLED";
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+});
+
+describe("isQrLoginEnabled", () => {
+  it("returns false when the env var is undefined (default off)", () => {
+    delete process.env[ENV_KEY];
+    expect(isQrLoginEnabled()).toBe(false);
+  });
+
+  it.each(["true", "1"])("returns true when env var is %s", (value) => {
+    process.env[ENV_KEY] = value;
+    expect(isQrLoginEnabled()).toBe(true);
+  });
+
+  it.each(["false", "0", "", "yes", "TRUE", "  true  "])(
+    "returns false when env var is %s (only exact 'true'/'1' opt in)",
+    (value) => {
+      process.env[ENV_KEY] = value;
+      expect(isQrLoginEnabled()).toBe(false);
+    }
+  );
+});

--- a/lib/features/authentication/flags.ts
+++ b/lib/features/authentication/flags.ts
@@ -1,0 +1,21 @@
+/**
+ * Authentication feature flags read from public Next.js env vars.
+ *
+ * Values are inlined at build time, so callers must invoke these helpers at
+ * render time rather than at module init.
+ */
+
+/**
+ * Gates the RFC 8628 QR ("device authorization") sign-in method on the login
+ * screen: the "Sign in with a QR code" entry links and the restore of a stored
+ * "qr" login preference.
+ *
+ * Defaults to OFF; flip on by setting NEXT_PUBLIC_QR_LOGIN_ENABLED to "true"
+ * (or "1") once Backend-Service is serving the device-authorization endpoints
+ * in that environment. While off, nothing can navigate to the QR stage, so the
+ * client never requests a device code.
+ */
+export function isQrLoginEnabled(): boolean {
+  const envValue = process.env.NEXT_PUBLIC_QR_LOGIN_ENABLED;
+  return envValue === "true" || envValue === "1";
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "opennext-1.20",
+  "name": "qr-device-auth-ui",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -22,6 +22,7 @@
         "motion": "^12.42.0",
         "next": "^16.2.10",
         "posthog-js": "^1.395.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-fast-marquee": "^1.6.5",
@@ -9613,6 +9614,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "motion": "^12.42.0",
     "next": "^16.2.10",
     "posthog-js": "^1.395.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-fast-marquee": "^1.6.5",

--- a/src/components/experiences/modern/login/Forms/EmailOTPForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/EmailOTPForm.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { screen } from "@testing-library/react";
 import EmailOTPForm from "./EmailOTPForm";
 import { renderWithProviders } from "@/lib/test-utils";
+import { applicationSlice } from "@/lib/features/application/frontend";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -9,6 +10,8 @@ vi.mock("next/navigation", () => ({
     refresh: vi.fn(),
   }),
 }));
+
+const QR_FLAG_KEY = "NEXT_PUBLIC_QR_LOGIN_ENABLED";
 
 describe("EmailOTPForm", () => {
   const defaultProps = { onCodeSent: vi.fn() };
@@ -57,5 +60,35 @@ describe("EmailOTPForm", () => {
 
     const form = container.querySelector("form");
     expect(form).toHaveAttribute("method", "post");
+  });
+
+  describe("QR entry link (flag-gated)", () => {
+    afterEach(() => {
+      delete process.env[QR_FLAG_KEY];
+    });
+
+    it("is hidden when the QR flag is off", () => {
+      delete process.env[QR_FLAG_KEY];
+      renderWithProviders(<EmailOTPForm {...defaultProps} />);
+
+      expect(
+        screen.queryByRole("button", { name: "Sign in with a QR code" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("switches to the qr stage when the flag is on", async () => {
+      process.env[QR_FLAG_KEY] = "true";
+      const { user, store } = renderWithProviders(
+        <EmailOTPForm {...defaultProps} />
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: "Sign in with a QR code" })
+      );
+
+      expect(applicationSlice.selectors.getAuthStage(store.getState())).toBe(
+        "qr"
+      );
+    });
   });
 });

--- a/src/components/experiences/modern/login/Forms/EmailOTPForm.tsx
+++ b/src/components/experiences/modern/login/Forms/EmailOTPForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { applicationSlice } from "@/lib/features/application/frontend";
+import { isQrLoginEnabled } from "@/lib/features/authentication/flags";
 import { savePreferredLoginMethod } from "@/lib/features/application/login-method-storage";
 import { useAppDispatch } from "@/lib/hooks";
 import { useOTPRequest } from "@/src/hooks/authenticationHooks";
@@ -32,6 +33,12 @@ export default function EmailOTPForm({
     event.preventDefault();
     savePreferredLoginMethod("password");
     dispatch(applicationSlice.actions.setAuthStage("password"));
+  };
+
+  const handleSwitchToQr = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    savePreferredLoginMethod("qr");
+    dispatch(applicationSlice.actions.setAuthStage("qr"));
   };
 
   return (
@@ -70,6 +77,18 @@ export default function EmailOTPForm({
           Sign in with password instead
         </Link>
       </Typography>
+      {isQrLoginEnabled() && (
+        <Typography level="body-sm" sx={{ mt: 1, textAlign: "center" }}>
+          <Link
+            component="button"
+            type="button"
+            onClick={handleSwitchToQr}
+            disabled={isLoading}
+          >
+            Sign in with a QR code
+          </Link>
+        </Typography>
+      )}
     </form>
   );
 }

--- a/src/components/experiences/modern/login/Forms/LoginFormSwitcher.test.tsx
+++ b/src/components/experiences/modern/login/Forms/LoginFormSwitcher.test.tsx
@@ -18,6 +18,23 @@ vi.mock("@/lib/features/application/login-method-storage", () => ({
   savePreferredLoginMethod: vi.fn(),
 }));
 
+// Stub only the device-auth hook (which would otherwise fetch a device code on
+// mount); the other stages keep the real useLogin/useOTPRequest hooks.
+vi.mock("@/src/hooks/authenticationHooks", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/src/hooks/authenticationHooks")
+  >();
+  return {
+    ...actual,
+    useDeviceAuthorization: () => ({
+      status: "waiting" as const,
+      userCode: "WDPL-XK9R",
+      verificationUriComplete: "https://dj.wxyc.org/device?user_code=WDPL-XK9R",
+      restart: vi.fn(),
+    }),
+  };
+});
+
 let mockPreferredMethod: AuthStage = "otp-email";
 
 const renderWithAuthStage = (stage: AuthStage) => {
@@ -52,5 +69,11 @@ describe("LoginFormSwitcher", () => {
 
     expect(screen.getByText("Username or email")).toBeInTheDocument();
     expect(screen.getByText("Password")).toBeInTheDocument();
+  });
+
+  it("should render the QR form for qr stage", () => {
+    renderWithAuthStage("qr");
+
+    expect(screen.getByText("Scan to sign in")).toBeInTheDocument();
   });
 });

--- a/src/components/experiences/modern/login/Forms/LoginFormSwitcher.tsx
+++ b/src/components/experiences/modern/login/Forms/LoginFormSwitcher.tsx
@@ -8,6 +8,7 @@ import { isValidEmail } from "@wxyc/shared/validation";
 import { useLayoutEffect, useRef, useState } from "react";
 import EmailOTPForm from "./EmailOTPForm";
 import OTPCodeForm from "./OTPCodeForm";
+import QRCodeForm from "./QRCodeForm";
 import UserPasswordForm from "./UserPasswordForm";
 
 export default function LoginFormSwitcher() {
@@ -38,6 +39,15 @@ export default function LoginFormSwitcher() {
         displayTarget={displayTarget}
         onChangeIdentifier={() => dispatch(applicationSlice.actions.setAuthStage("otp-email"))}
       />
+    );
+  }
+
+  if (authStage === "qr") {
+    return (
+      <>
+        <WelcomeQuotes />
+        <QRCodeForm />
+      </>
     );
   }
 

--- a/src/components/experiences/modern/login/Forms/QRCodeForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/QRCodeForm.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils";
+import { applicationSlice } from "@/lib/features/application/frontend";
+import { savePreferredLoginMethod } from "@/lib/features/application/login-method-storage";
+import QRCodeForm from "./QRCodeForm";
+import type { DeviceAuthorizationStatus } from "@/src/hooks/authenticationHooks";
+
+const mockRestart = vi.fn();
+
+// Controllable stand-in for the PR-1 polling hook. Each test sets `hookState`
+// before rendering to exercise one status of the flow.
+let hookState: {
+  userCode?: string;
+  verificationUriComplete?: string;
+  status: DeviceAuthorizationStatus;
+  restart: () => void;
+};
+
+vi.mock("@/src/hooks/authenticationHooks", () => ({
+  useDeviceAuthorization: () => hookState,
+}));
+
+// Assert what the QR encodes without depending on SVG pixels.
+vi.mock("qrcode.react", () => ({
+  QRCodeSVG: (props: { value: string }) => (
+    <div data-testid="qr-code" data-value={props.value} />
+  ),
+}));
+
+vi.mock("@/lib/features/application/login-method-storage", () => ({
+  savePreferredLoginMethod: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hookState = { status: "loading", restart: mockRestart };
+});
+
+describe("QRCodeForm", () => {
+  it("shows a generating affordance and no QR while loading", () => {
+    hookState = { status: "loading", restart: mockRestart };
+    renderWithProviders(<QRCodeForm />);
+
+    expect(screen.getByText(/Generating a sign-in code/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("qr-code")).not.toBeInTheDocument();
+  });
+
+  it("renders the QR encoding the verification URI and the user code while waiting", () => {
+    hookState = {
+      status: "waiting",
+      userCode: "WDPL-XK9R",
+      verificationUriComplete:
+        "https://dj.wxyc.org/device?user_code=WDPL-XK9R",
+      restart: mockRestart,
+    };
+    renderWithProviders(<QRCodeForm />);
+
+    expect(screen.getByText("Scan to sign in")).toBeInTheDocument();
+    expect(screen.getByTestId("qr-code")).toHaveAttribute(
+      "data-value",
+      "https://dj.wxyc.org/device?user_code=WDPL-XK9R"
+    );
+    expect(screen.getByText("WDPL-XK9R")).toBeInTheDocument();
+    // Manual-entry hint derives the typable base from the complete URI.
+    expect(screen.getByText(/dj\.wxyc\.org\/device/)).toBeInTheDocument();
+  });
+
+  it("offers regeneration when the code has expired", async () => {
+    hookState = { status: "expired", restart: mockRestart };
+    const { user } = renderWithProviders(<QRCodeForm />);
+
+    expect(screen.getByText(/expired/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Generate a new code" }));
+    expect(mockRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a terminal decline with no regenerate button when denied", () => {
+    hookState = { status: "denied", restart: mockRestart };
+    renderWithProviders(<QRCodeForm />);
+
+    expect(screen.getByText("Sign-in was declined")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Generate a new code" })
+    ).not.toBeInTheDocument();
+    // Regenerating can't fix an account-level denial, so no restart is offered.
+    expect(
+      screen.queryByRole("button", { name: "Try again" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers a retry on error", async () => {
+    hookState = { status: "error", restart: mockRestart };
+    const { user } = renderWithProviders(<QRCodeForm />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    expect(mockRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to password: persists the choice and switches stage", async () => {
+    hookState = { status: "denied", restart: mockRestart };
+    const { user, store } = renderWithProviders(<QRCodeForm />);
+
+    await user.click(screen.getByRole("button", { name: "Use a password instead" }));
+
+    expect(savePreferredLoginMethod).toHaveBeenCalledWith("password");
+    expect(applicationSlice.selectors.getAuthStage(store.getState())).toBe(
+      "password"
+    );
+  });
+
+  it("falls back to email code: persists the choice and switches stage", async () => {
+    hookState = { status: "waiting", userCode: "WDPL-XK9R", restart: mockRestart };
+    const { user, store } = renderWithProviders(<QRCodeForm />);
+
+    await user.click(screen.getByRole("button", { name: "Email me a code" }));
+
+    expect(savePreferredLoginMethod).toHaveBeenCalledWith("otp-email");
+    expect(applicationSlice.selectors.getAuthStage(store.getState())).toBe(
+      "otp-email"
+    );
+  });
+});

--- a/src/components/experiences/modern/login/Forms/QRCodeForm.tsx
+++ b/src/components/experiences/modern/login/Forms/QRCodeForm.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { applicationSlice } from "@/lib/features/application/frontend";
+import { savePreferredLoginMethod } from "@/lib/features/application/login-method-storage";
+import { useAppDispatch } from "@/lib/hooks";
+import { useDeviceAuthorization } from "@/src/hooks/authenticationHooks";
+import { Box, Button, CircularProgress, Link, Typography } from "@mui/joy";
+import { QRCodeSVG } from "qrcode.react";
+
+/**
+ * Derive the human-typable base of the verification URL from the QR's
+ * `verification_uri_complete` (which embeds the user code as a query param) so
+ * the manual-entry hint can say "go to <base> and enter <code>". Returns
+ * `undefined` if the value is missing or unparseable, in which case the hint is
+ * simply omitted.
+ */
+function verificationUriBase(complete: string | undefined): string | undefined {
+  if (!complete) return undefined;
+  try {
+    const url = new URL(complete);
+    return `${url.host}${url.pathname}`;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The RFC 8628 QR sign-in form for the shared control-room browser.
+ *
+ * Driven entirely by {@link useDeviceAuthorization}: on mount the hook requests
+ * a device code and begins polling, and on approval it navigates away itself
+ * (this component never sees a "success" state). The five states it does render
+ * are the waiting screen (QR + user code) and the four non-happy outcomes.
+ *
+ * A password/email fallback is always offered — critical when a non-DJ approves
+ * on their phone and the backend returns `access_denied` (the `denied` state).
+ */
+export default function QRCodeForm() {
+  const dispatch = useAppDispatch();
+  const { userCode, verificationUriComplete, status, restart } =
+    useDeviceAuthorization();
+
+  const switchToPassword = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    savePreferredLoginMethod("password");
+    dispatch(applicationSlice.actions.setAuthStage("password"));
+  };
+
+  const switchToEmail = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    savePreferredLoginMethod("otp-email");
+    dispatch(applicationSlice.actions.setAuthStage("otp-email"));
+  };
+
+  const fallbackLinks = (
+    <Typography
+      level="body-sm"
+      sx={{ mt: 3, display: "flex", justifyContent: "center", gap: 2 }}
+    >
+      <Link component="button" type="button" onClick={switchToPassword}>
+        Use a password instead
+      </Link>
+      <Link component="button" type="button" onClick={switchToEmail}>
+        Email me a code
+      </Link>
+    </Typography>
+  );
+
+  return (
+    <Box sx={{ textAlign: "center" }}>
+      {status === "loading" && (
+        <Box sx={{ py: 4 }}>
+          <CircularProgress />
+          <Typography level="body-sm" sx={{ mt: 2 }}>
+            Generating a sign-in code&hellip;
+          </Typography>
+        </Box>
+      )}
+
+      {status === "waiting" && (
+        <Box>
+          <Typography level="title-md" sx={{ mb: 1 }}>
+            Scan to sign in
+          </Typography>
+          <Typography level="body-sm" sx={{ mb: 2 }}>
+            Open the camera on your phone and scan this code to approve sign-in.
+          </Typography>
+          {verificationUriComplete && (
+            <Box
+              sx={{
+                display: "inline-flex",
+                p: 2,
+                bgcolor: "common.white",
+                borderRadius: "md",
+              }}
+            >
+              <QRCodeSVG
+                value={verificationUriComplete}
+                size={200}
+                aria-label="QR code to approve sign-in"
+              />
+            </Box>
+          )}
+          {userCode && (
+            <Box sx={{ mt: 2 }}>
+              <Typography level="body-xs">
+                Or enter this code
+                {verificationUriBase(verificationUriComplete)
+                  ? ` at ${verificationUriBase(verificationUriComplete)}`
+                  : ""}
+                :
+              </Typography>
+              <Typography
+                level="h3"
+                sx={{ fontFamily: "monospace", letterSpacing: "0.2em", mt: 0.5 }}
+              >
+                {userCode}
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      )}
+
+      {status === "expired" && (
+        <Box sx={{ py: 3 }}>
+          <Typography level="title-md" sx={{ mb: 1 }}>
+            This code expired
+          </Typography>
+          <Typography level="body-sm" sx={{ mb: 2 }}>
+            Sign-in codes are only valid for a few minutes.
+          </Typography>
+          <Button onClick={restart}>Generate a new code</Button>
+        </Box>
+      )}
+
+      {status === "denied" && (
+        <Box sx={{ py: 3 }}>
+          <Typography level="title-md" sx={{ mb: 1 }}>
+            Sign-in was declined
+          </Typography>
+          <Typography level="body-sm">
+            That account isn&apos;t allowed to sign in with a QR code. Sign in
+            with your password, or ask a station manager for access.
+          </Typography>
+        </Box>
+      )}
+
+      {status === "error" && (
+        <Box sx={{ py: 3 }}>
+          <Typography level="title-md" sx={{ mb: 1 }}>
+            Something went wrong
+          </Typography>
+          <Typography level="body-sm" sx={{ mb: 2 }}>
+            We couldn&apos;t start the QR sign-in. Please try again.
+          </Typography>
+          <Button onClick={restart}>Try again</Button>
+        </Box>
+      )}
+
+      {fallbackLinks}
+    </Box>
+  );
+}

--- a/src/components/experiences/modern/login/Forms/UserPasswordForm.test.tsx
+++ b/src/components/experiences/modern/login/Forms/UserPasswordForm.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { screen } from "@testing-library/react";
 import UserPasswordForm from "./UserPasswordForm";
 import { renderWithProviders } from "@/lib/test-utils";
+import { applicationSlice } from "@/lib/features/application/frontend";
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
@@ -11,6 +12,8 @@ vi.mock("next/navigation", () => ({
   }),
   useSearchParams: () => new URLSearchParams(""),
 }));
+
+const QR_FLAG_KEY = "NEXT_PUBLIC_QR_LOGIN_ENABLED";
 
 describe("UserPasswordForm", () => {
   it("should render identifier and password fields", () => {
@@ -72,5 +75,33 @@ describe("UserPasswordForm", () => {
 
     const form = container.querySelector("form");
     expect(form).toHaveAttribute("method", "post");
+  });
+
+  describe("QR entry link (flag-gated)", () => {
+    afterEach(() => {
+      delete process.env[QR_FLAG_KEY];
+    });
+
+    it("is hidden when the QR flag is off", () => {
+      delete process.env[QR_FLAG_KEY];
+      renderWithProviders(<UserPasswordForm />);
+
+      expect(
+        screen.queryByRole("button", { name: "Sign in with a QR code" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("switches to the qr stage when the flag is on", async () => {
+      process.env[QR_FLAG_KEY] = "true";
+      const { user, store } = renderWithProviders(<UserPasswordForm />);
+
+      await user.click(
+        screen.getByRole("button", { name: "Sign in with a QR code" })
+      );
+
+      expect(applicationSlice.selectors.getAuthStage(store.getState())).toBe(
+        "qr"
+      );
+    });
   });
 });

--- a/src/components/experiences/modern/login/Forms/UserPasswordForm.tsx
+++ b/src/components/experiences/modern/login/Forms/UserPasswordForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { applicationSlice } from "@/lib/features/application/frontend";
+import { isQrLoginEnabled } from "@/lib/features/authentication/flags";
 import { savePreferredLoginMethod } from "@/lib/features/application/login-method-storage";
 import { useAppDispatch } from "@/lib/hooks";
 import { useLogin } from "@/src/hooks/authenticationHooks";
@@ -63,6 +64,22 @@ export default function UserPasswordForm() {
           Sign in with email code instead
         </Link>
       </Typography>
+      {isQrLoginEnabled() && (
+        <Typography level="body-sm" sx={{ mt: 1, textAlign: "center" }}>
+          <Link
+            component="button"
+            type="button"
+            onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+              event.preventDefault();
+              savePreferredLoginMethod("qr");
+              dispatch(applicationSlice.actions.setAuthStage("qr"));
+            }}
+            disabled={authenticating}
+          >
+            Sign in with a QR code
+          </Link>
+        </Typography>
+      )}
     </form>
   );
 }


### PR DESCRIPTION
## What

PR 2 of 2 for the RFC 8628 QR shared-computer sign-in flow (#785, per [ADR 0005](https://github.com/WXYC/dj-site/blob/main/docs/adr/0005-qr-device-authorization-shared-computer-signin.md)). PR 1 (#835) landed the polling client + `useDeviceAuthorization()` hook; this PR is the **UI + login-picker wiring** that consumes it, behind the `NEXT_PUBLIC_QR_LOGIN_ENABLED` flag (default off).

On the modern login screen, a DJ can choose "Sign in with a QR code", scan it with their phone, approve, and land on the dashboard. A non-DJ approval, an expired code, or an error each render a clear state with a password/email fallback.

## Design decisions

- **QR is an `AuthStage` inside `/login`, not a standalone route.** It inherits `app/login/@modern/layout.tsx`'s server-side `redirect()` of authenticated sessions — exactly the forwarding that PR 1's `redirectAfterAuth(..., "qr")` `router.refresh()` recovery depends on. A standalone route would have to reimplement it or risk stranding a signed-in DJ on the "waiting" screen during an auth-read outage.
- **No client-side role gate.** The shared browser is unauthenticated, so there is no principal to gate. The "role ≥ DJ" restriction is enforced backend-side on the phone approval and surfaces as the `denied` poll state, which the UI renders with a password fallback.
- **Ship dark.** While the flag is off, nothing can navigate to the QR stage (a stored `"qr"` preference falls back to `otp-email`), so the client never requests a device code.
- **`qrcode.react@4.2.0`** is dependency-free (no `qrcode`/`buffer`/`stream`), so it adds no Node builtins to the OpenNext worker; `build:opennext` emits a clean worker.

## Changes

- `lib/features/authentication/flags.ts` (+ test) — `isQrLoginEnabled()`, mirrors `catalog/flags.ts`
- `AuthStage` += `"qr"`; `login-method-storage` `"qr"` with flag-off fallback (+ tests)
- `QRCodeForm.tsx` (+ 7 tests) — renders loading/waiting/expired/denied/error, QR + user code + manual-entry hint + fallback links
- `LoginFormSwitcher` `"qr"` branch; flag-gated entry links on the password + email forms (+ tests)
- `docs/env-vars.md` documents `NEXT_PUBLIC_QR_LOGIN_ENABLED`
- Design doc: `docs/plans/qr-device-auth-ui.md`

## Out of scope (follow-up)

- **e2e golden path** — needs a backend device-*approve* endpoint reachable in the e2e Docker stack (unverified) and a two-context (shared browser + "phone") flow. Deferred so this UI PR doesn't block on backend-e2e readiness; the flag keeps it dark until then.
- Classic experience QR (password-only surface, no picker).

## Testing

`tsc --noEmit` ✓ · full unit suite (3444 tests / 245 files) ✓ · `npm run build` ✓ · `npm run build:opennext` ✓ — all run locally before push.

Closes #837
