### PR TITLE
fix(auth): reject off-origin callbackURL in verify-email

### DIFF
--- a/app/auth/verify-email/__tests__/route.test.ts
+++ b/app/auth/verify-email/__tests__/route.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+/**
+ * Security tests for the `/auth/verify-email` Route Handler (issue #597).
+ *
+ * The handler forwards the verification token to the backend, then 302s the
+ * browser to `callbackURL`. Before the fix, `callbackURL` was resolved with
+ * `new URL(callbackURL, request.url)` and handed straight to
+ * `NextResponse.redirect` — an absolute (`https://evil.example`) or
+ * protocol-relative (`//evil.example`) value overrides the origin entirely,
+ * turning the handler into an open redirect that ALSO forwards the
+ * freshly-minted session cookie off-site. These tests pin that `callbackURL`
+ * is constrained to a same-origin relative path, falling back to `/onboarding`.
+ *
+ * Harness mirrors app/auth/[...path]/__tests__/route.test.ts: direct import of
+ * the handler + a `global.fetch` spy standing in for the backend.
+ */
+
+const FRONTEND_ORIGIN = "https://dj.wxyc.org";
+
+// Backend response that "auto-signed-in" the user: carries a session cookie, so
+// the handler takes the callbackURL branch (the vulnerable one).
+function backendSessionResponse(): Response {
+  const headers = new Headers();
+  headers.append(
+    "set-cookie",
+    "__Secure-better-auth.session_token=abc.sig; Path=/; HttpOnly; Secure; SameSite=Lax",
+  );
+  return new Response(null, { status: 302, headers });
+}
+
+// Backend response with no session cookie: handler falls back to /login.
+function backendNoSessionResponse(): Response {
+  return new Response(null, {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function verifyEmailRequest(callbackURL: string | null): NextRequest {
+  const url = new URL(`${FRONTEND_ORIGIN}/auth/verify-email`);
+  url.searchParams.set("token", "valid-token");
+  if (callbackURL !== null) url.searchParams.set("callbackURL", callbackURL);
+  return new NextRequest(url);
+}
+
+async function invoke(callbackURL: string | null): Promise<Response> {
+  const { GET } = await import("@/app/auth/verify-email/route");
+  return GET(verifyEmailRequest(callbackURL));
+}
+
+describe("/auth/verify-email open-redirect protection (#597)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("coerces an absolute off-origin callbackURL to the safe default", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(backendSessionResponse());
+
+    const response = await invoke("https://evil.example/dj-signin");
+    const location = new URL(response.headers.get("location")!);
+
+    expect(location.origin).toBe(FRONTEND_ORIGIN);
+    expect(location.pathname).toBe("/onboarding");
+  });
+
+  it("rejects a protocol-relative callbackURL", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(backendSessionResponse());
+
+    const response = await invoke("//evil.example");
+    const location = new URL(response.headers.get("location")!);
+
+    expect(location.origin).toBe(FRONTEND_ORIGIN);
+    expect(location.pathname).toBe("/onboarding");
+  });
+
+  it("rejects a backslash-escaped callbackURL", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(backendSessionResponse());
+
+    const response = await invoke("/\\evil.example");
+    const location = new URL(response.headers.get("location")!);
+
+    expect(location.origin).toBe(FRONTEND_ORIGIN);
+    expect(location.pathname).toBe("/onboarding");
+  });
+
+  it("rejects an encoded-slash callbackURL that normalises to off-origin", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(backendSessionResponse());
+
+    const response = await invoke("/%2F%2Fevil.example");
+    const location = new URL(response.headers.get("location")!);
+
+    expect(location.origin).toBe(FRONTEND_ORIGIN);
+  });
+
+  it("honors a legitimate same-origin relative callbackURL", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(backendSessionResponse());
+
+    const response = await invoke("/dashboard/flowsheet");
+    const location = new URL(response.headers.get("location")!);
+
+    expect(location.origin).toBe(FRONTEND_ORIGIN);
+    expect(location.pathname).toBe("/dashboard/flowsheet");
+  });
+
+  it("preserves query and hash on a legitimate relative callbackURL", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(backendSessionResponse());
+
+    const response = await invoke("/dashboard/flowsheet?tab=queue#now");
+    const location = new URL(response.headers.get("location")!);
+
+    expect(location.origin).toBe(FRONTEND_ORIGIN);
+    expect(location.pathname).toBe("/dashboard/flowsheet");
+    expect(location.search).toBe("?tab=queue");
+    expect(location.hash).toBe("#now");
+  });
+
+  it("falls back to /onboarding when callbackURL is absent", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(backendSessionResponse());
+
+    const response = await invoke(null);
+    const location = new URL(response.headers.get("location")!);
+
+    expect(location.origin).toBe(FRONTEND_ORIGIN);
+    expect(location.pathname).toBe("/onboarding");
+  });
+
+  it("does not forward an unsafe callbackURL upstream to the backend", async () => {
+    const fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(backendSessionResponse());
+
+    await invoke("https://evil.example/dj-signin");
+
+    const forwarded = String(fetchMock.mock.calls[0][0]);
+    expect(forwarded).not.toContain("evil.example");
+  });
+
+  it("ignores callbackURL entirely on the no-session branch", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(backendNoSessionResponse());
+
+    const response = await invoke("https://evil.example/dj-signin");
+    const location = new URL(response.headers.get("location")!);
+
+    expect(location.origin).toBe(FRONTEND_ORIGIN);
+    expect(location.pathname).toBe("/login");
+    expect(location.search).toBe("?verified=true");
+  });
+});

--- a/app/auth/verify-email/__tests__/route.test.ts
+++ b/app/auth/verify-email/__tests__/route.test.ts
@@ -91,13 +91,33 @@ describe("/auth/verify-email open-redirect protection (#597)", () => {
     expect(location.pathname).toBe("/onboarding");
   });
 
-  it("rejects an encoded-slash callbackURL that normalises to off-origin", async () => {
+  // A tab-prefixed protocol-relative value passes the primary string guard
+  // (it starts with "/", and the second char is a tab, not another "/") but the
+  // WHATWG URL parser strips the tab and normalises it to "//evil.example", so
+  // ONLY the belt-and-suspenders origin re-check can reject it. This isolates
+  // that second layer: if it were removed, this test — and only this test —
+  // would go red.
+  it("rejects a tab-obscured protocol-relative callbackURL (origin-check layer)", async () => {
     vi.spyOn(global, "fetch").mockResolvedValue(backendSessionResponse());
 
+    const response = await invoke("/\t//evil.example");
+    const location = new URL(response.headers.get("location")!);
+
+    expect(location.origin).toBe(FRONTEND_ORIGIN);
+    expect(location.pathname).toBe("/onboarding");
+  });
+
+  it("keeps an encoded-slash callbackURL same-origin without decoding it to //", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue(backendSessionResponse());
+
+    // "/%2F%2Fevil.example" stays same-origin: the parser keeps %2F encoded in
+    // the path rather than treating it as a "//" authority separator, so it is
+    // a legitimate (if odd) same-origin path — never an off-origin redirect.
     const response = await invoke("/%2F%2Fevil.example");
     const location = new URL(response.headers.get("location")!);
 
     expect(location.origin).toBe(FRONTEND_ORIGIN);
+    expect(location.pathname).toBe("/%2F%2Fevil.example");
   });
 
   it("honors a legitimate same-origin relative callbackURL", async () => {
@@ -141,6 +161,30 @@ describe("/auth/verify-email open-redirect protection (#597)", () => {
 
     const forwarded = String(fetchMock.mock.calls[0][0]);
     expect(forwarded).not.toContain("evil.example");
+  });
+
+  it("forwards the sanitised callbackURL upstream on the safe path", async () => {
+    const fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(backendSessionResponse());
+
+    await invoke("/dashboard/flowsheet");
+
+    const forwarded = new URL(String(fetchMock.mock.calls[0][0]));
+    // The sanitised (not raw) value is what reaches the backend — guards against
+    // a regression that forwards rawCallbackURL or the fallback instead.
+    expect(forwarded.searchParams.get("callbackURL")).toBe("/dashboard/flowsheet");
+  });
+
+  it("forwards the fallback upstream when an unsafe callbackURL is supplied", async () => {
+    const fetchMock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(backendSessionResponse());
+
+    await invoke("https://evil.example/dj-signin");
+
+    const forwarded = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(forwarded.searchParams.get("callbackURL")).toBe("/onboarding");
   });
 
   it("ignores callbackURL entirely on the no-session branch", async () => {

--- a/app/auth/verify-email/route.ts
+++ b/app/auth/verify-email/route.ts
@@ -52,6 +52,39 @@ function extractSetCookieHeaders(headers: Headers): string[] {
   return raw.split(/,\s*(?=[A-Za-z0-9_.-]+=)/).map((s) => s.trim());
 }
 
+/**
+ * Constrain a caller-supplied `callbackURL` to a safe, same-origin *relative*
+ * path. Absolute URLs, protocol-relative `//host`, and backslash-escaped
+ * `/\host` values (which browsers may treat as `//host`) are rejected in
+ * favour of `fallback`. As a second layer the value is normalised through the
+ * URL parser and its resolved origin is confirmed to match the request origin,
+ * catching tab / encoded-slash tricks the parser rewrites to `//host` (#597).
+ */
+function safeCallbackPath(
+  raw: string | null,
+  requestUrl: string,
+  fallback: string,
+): string {
+  if (!raw) return fallback;
+
+  // Primary guard: a root-relative path that is neither protocol-relative
+  // (`//`) nor backslash-escaped (`/\`).
+  if (!raw.startsWith("/") || raw.startsWith("//") || raw.startsWith("/\\")) {
+    return fallback;
+  }
+
+  // Belt-and-suspenders: resolve against the request origin, confirm the
+  // result did not escape it, then keep only path + query + hash.
+  try {
+    const requestOrigin = new URL(requestUrl).origin;
+    const resolved = new URL(raw, requestUrl);
+    if (resolved.origin !== requestOrigin) return fallback;
+    return resolved.pathname + resolved.search + resolved.hash;
+  } catch {
+    return fallback;
+  }
+}
+
 // Explicitly handle HEAD so email-client link previews get a cheap 200
 // without consuming the token or triggering verification.
 export function HEAD() {
@@ -61,9 +94,13 @@ export function HEAD() {
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const token = searchParams.get("token");
-  // The callbackURL arrives as a relative path (e.g. "/onboarding") because
-  // the backend rewrites only the host, leaving query params untouched.
-  const callbackURL = searchParams.get("callbackURL");
+  // Constrain callbackURL to a same-origin relative path. It normally arrives
+  // as a relative path (e.g. "/onboarding") because the backend rewrites only
+  // the host, but nothing guarantees that — an absolute or protocol-relative
+  // value would override the origin in the redirect below, turning this route
+  // into an open redirect that also leaks the session cookie off-site (#597).
+  const rawCallbackURL = searchParams.get("callbackURL");
+  const callbackURL = safeCallbackPath(rawCallbackURL, request.url, "/onboarding");
 
   if (!token) {
     const dest = new URL("/login?error=missing-verification-token", request.url);
@@ -78,7 +115,9 @@ export async function GET(request: NextRequest) {
   // Set-Cookie) instead of following the redirect blindly.
   const backendURL = new URL(`${backendBaseURL}/verify-email`);
   backendURL.searchParams.set("token", token);
-  if (callbackURL) {
+  if (rawCallbackURL) {
+    // Forward the sanitised value (a rejected callback becomes the fallback),
+    // never the attacker-supplied raw one.
     backendURL.searchParams.set("callbackURL", callbackURL);
   }
 
@@ -136,7 +175,7 @@ export async function GET(request: NextRequest) {
     // callbackURL is a relative path like "/onboarding", resolved against the
     // frontend origin by the URL constructor.
     const destination = hasSessionCookies
-      ? new URL(callbackURL || "/onboarding", request.url)
+      ? new URL(callbackURL, request.url)
       : new URL("/login?verified=true", request.url);
 
     const response = NextResponse.redirect(destination);


### PR DESCRIPTION
Closes #597

## Problem
`/auth/verify-email` resolved the caller-supplied `callbackURL` with `new URL(callbackURL, request.url)` and handed it straight to `NextResponse.redirect`. An absolute or protocol-relative value overrides the origin, so a crafted link like `/auth/verify-email?token=<valid>&callbackURL=https://evil.example/…` 302s the browser off-site — and because the handler forwards the backend's freshly minted session `Set-Cookie` on that same response, the victim is signed in *and* bounced to the attacker's page. That is the P0 open redirect.

## Fix
A `safeCallbackPath()` sanitizer at the single choke point constrains `callbackURL` to a same-origin relative path:
- Primary guard: must be root-relative (`/…`), not protocol-relative (`//host`), not backslash-escaped (`/\host`).
- Belt-and-suspenders: normalize through the URL parser and confirm the resolved origin still matches the request origin — catching tab / encoded-slash tricks the parser rewrites to `//host`.

Rejected values fall back to `/onboarding` and are never forwarded upstream. The route's other two redirect targets are constant strings and already safe.

## Tests
New `app/auth/verify-email/__tests__/route.test.ts` (direct-import + `fetch`-spy harness, mirroring the `[...path]` proxy test): absolute / protocol-relative / backslash off-origin values coerced to the safe default; legitimate same-origin paths (including query + hash) preserved; unsafe value not forwarded upstream; no-session branch unaffected. Verified RED→GREEN. `tsc` clean; full unit suite green.