### PR TITLE
fix(login): resume OIDC authorize round-trip for signed-in users

### DIFF
--- a/app/login/@modern/@normal/page.test.tsx
+++ b/app/login/@modern/@normal/page.test.tsx
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/features/authentication/server-utils", () => ({
+  getServerSession: vi.fn(),
+  isUserIncomplete: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock(
+  "@/src/components/experiences/modern/login/Forms/LoginFormSwitcher",
+  () => ({ default: () => null }),
+);
+
+import {
+  getServerSession,
+  isUserIncomplete,
+} from "@/lib/features/authentication/server-utils";
+import { redirect } from "next/navigation";
+import LoginPage from "./page";
+
+const mockGetServerSession = vi.mocked(getServerSession);
+const mockIsUserIncomplete = vi.mocked(isUserIncomplete);
+const mockRedirect = vi.mocked(redirect);
+
+const completeSession = {
+  user: { emailVerified: true },
+} as unknown as Awaited<ReturnType<typeof getServerSession>>;
+
+function run(search: Record<string, string | string[] | undefined>) {
+  return LoginPage({ searchParams: Promise.resolve(search) });
+}
+
+describe("@modern/@normal login page — OIDC-aware redirect (#762)", () => {
+  beforeEach(() => {
+    mockGetServerSession.mockReset();
+    mockIsUserIncomplete.mockReset();
+    mockIsUserIncomplete.mockReturnValue(false);
+    mockRedirect.mockClear();
+  });
+
+  it("resumes the OIDC authorize round-trip for a signed-in complete user", async () => {
+    mockGetServerSession.mockResolvedValue(completeSession);
+
+    await expect(
+      run({
+        client_id: "flowsheet",
+        response_type: "code",
+        state: "xyz",
+        code_challenge: "abc",
+      }),
+    ).rejects.toThrow(/NEXT_REDIRECT:\/auth\/oauth2\/authorize/);
+
+    const target = String(mockRedirect.mock.calls[0][0]);
+    const url = new URL(target, "https://dj.wxyc.org");
+    expect(url.pathname).toBe("/auth/oauth2/authorize");
+    expect(url.searchParams.get("client_id")).toBe("flowsheet");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("state")).toBe("xyz");
+    expect(url.searchParams.get("code_challenge")).toBe("abc");
+  });
+
+  it("redirects a signed-in complete user with no OIDC params to the dashboard", async () => {
+    mockGetServerSession.mockResolvedValue(completeSession);
+
+    await expect(run({})).rejects.toThrow(/NEXT_REDIRECT:/);
+
+    const target = String(mockRedirect.mock.calls[0][0]);
+    expect(target).not.toContain("/auth/oauth2/authorize");
+  });
+
+  it("treats a non-code response_type as a non-OIDC visit (dashboard)", async () => {
+    mockGetServerSession.mockResolvedValue(completeSession);
+
+    await expect(
+      run({ client_id: "flowsheet", response_type: "token" }),
+    ).rejects.toThrow(/NEXT_REDIRECT:/);
+
+    const target = String(mockRedirect.mock.calls[0][0]);
+    expect(target).not.toContain("/auth/oauth2/authorize");
+  });
+
+  it("renders the login form for an unauthenticated visitor (no redirect)", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const result = await run({ client_id: "flowsheet", response_type: "code" });
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(result).not.toBeNull();
+  });
+
+  it("does not redirect an onboarding-incomplete user", async () => {
+    mockGetServerSession.mockResolvedValue(completeSession);
+    mockIsUserIncomplete.mockReturnValue(true);
+
+    const result = await run({ client_id: "flowsheet", response_type: "code" });
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(result).not.toBeNull();
+  });
+});

--- a/app/login/@modern/@normal/page.tsx
+++ b/app/login/@modern/@normal/page.tsx
@@ -1,5 +1,63 @@
+import { redirect } from "next/navigation";
+import {
+  getServerSession,
+  isUserIncomplete,
+} from "@/lib/features/authentication/server-utils";
+import { getOidcRedirectTarget } from "@/src/utilities/oidcRedirectTarget";
 import LoginFormSwitcher from "@/src/components/experiences/modern/login/Forms/LoginFormSwitcher";
 
-export default function LoginPage() {
+const DASHBOARD_HOME_PAGE =
+  process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/catalog";
+
+/**
+ * The @normal slot renders for every /login visit — its output is passed to the
+ * client LoginSlotSwitcher as the `normal` prop regardless of which slot is
+ * ultimately shown — and, unlike a layout, a page receives `searchParams`. That
+ * makes it the right place to resume an OIDC authorize round-trip for an
+ * already-signed-in user.
+ *
+ * Previously app/login/@modern/layout.tsx unconditionally redirected a
+ * signed-in, verified, onboarding-complete user to the dashboard. That fired
+ * before anything could read the query string, so an OIDC "Sign in with WXYC"
+ * bounce to /login?client_id=…&response_type=code lost its params and the
+ * authorize round-trip was abandoned (#762). A layout cannot read searchParams,
+ * and Next 16 middleware/proxy runs only on the Node.js runtime, which the
+ * OpenNext/Cloudflare adapter rejects — so the decision lives here instead.
+ *
+ * When the visitor is authenticated, verified, and complete we redirect
+ * server-side: to the OIDC authorize endpoint when the request carries
+ * authorize params, otherwise to the dashboard as before. A 307 is a real
+ * top-level navigation, so — unlike router.push — it neither flashes the login
+ * form nor fires a background RSC fetch that would burn the one-time OIDC code
+ * (see #761). The same-origin /auth target is served by
+ * app/auth/[...path]/route.ts, which forwards session cookies intact.
+ */
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const session = await getServerSession();
+
+  if (session?.user?.emailVerified && !isUserIncomplete(session)) {
+    const params = toSearchParams(await searchParams);
+    const oidcTarget = getOidcRedirectTarget(params, "/auth");
+    redirect(oidcTarget ?? DASHBOARD_HOME_PAGE);
+  }
+
   return <LoginFormSwitcher />;
+}
+
+function toSearchParams(raw: {
+  [key: string]: string | string[] | undefined;
+}): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(raw)) {
+    if (Array.isArray(value)) {
+      for (const item of value) params.append(key, item);
+    } else if (value !== undefined) {
+      params.set(key, value);
+    }
+  }
+  return params;
 }

--- a/app/login/@modern/layout.tsx
+++ b/app/login/@modern/layout.tsx
@@ -1,5 +1,7 @@
-import { getServerSession, isUserIncomplete } from "@/lib/features/authentication/server-utils";
-import { redirect } from "next/navigation";
+import {
+  getServerSession,
+  isUserIncomplete,
+} from "@/lib/features/authentication/server-utils";
 import WXYCPage from "@/src/Layout/WXYCPage";
 import LoginSlotSwitcher from "./LoginSlotSwitcher";
 import { Metadata } from "next";
@@ -21,25 +23,26 @@ export default async function ModernLoginLayout({
   // Check if user is already authenticated and email-verified
   const session = await getServerSession();
 
-  if (session?.user?.emailVerified) {
-    // If user is incomplete (missing realName), show onboarding form
-    if (isUserIncomplete(session)) {
-      return (
-        <WXYCPage>
-          <LoginSlotSwitcher
-            normal={normal}
-            newuser={newuser}
-            reset={reset}
-            isIncomplete={true}
-          />
-        </WXYCPage>
-      );
-    }
-    // User is authenticated, verified, and complete — redirect to dashboard
-    redirect(String(process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/catalog"));
+  // Incomplete (verified but missing realName): show the onboarding form.
+  if (session?.user?.emailVerified && isUserIncomplete(session)) {
+    return (
+      <WXYCPage>
+        <LoginSlotSwitcher
+          normal={normal}
+          newuser={newuser}
+          reset={reset}
+          isIncomplete={true}
+        />
+      </WXYCPage>
+    );
   }
-  // If authenticated but NOT verified, stay on login to show verification message
 
+  // A signed-in, verified, onboarding-complete user is redirected by the
+  // @normal slot page (a server component that CAN read searchParams), not
+  // here: a layout cannot see searchParams, so redirecting to the dashboard
+  // here dropped OIDC authorize params and abandoned the "Sign in with WXYC"
+  // round-trip (#762). Unverified users fall through to the login form to see
+  // the verification message.
   return (
     <WXYCPage>
       <LoginSlotSwitcher


### PR DESCRIPTION
Closes #762

## Problem
An already-signed-in, verified, onboarding-complete DJ who follows an OIDC "Sign in with WXYC" bounce to `/login?client_id=…&response_type=code&…` is server-redirected to the dashboard by `app/login/@modern/layout.tsx` before any code can read the query string. The OIDC params are dropped and Better Auth's authorize round-trip is abandoned — the downstream client never receives its code.

## Why not middleware/proxy
An earlier revision of this PR used a Next `proxy.ts`. That is a dead end on this deployment: Next 16 runs `proxy`/`middleware` on the **Node.js runtime only** (`export const runtime = "edge"` is rejected — *"Route segment config is not allowed in Proxy file"*), and the OpenNext/Cloudflare adapter **hard-refuses Node.js middleware** (`build:opennext` exits 1: *"Node.js middleware is not currently supported"*). `next build` passes but the adapter build fails, so no middleware/proxy approach can deploy here.

## Fix
Relocate the redirect from the layout (which cannot read `searchParams`) into the `@modern/@normal` slot **page** — a server component that receives `searchParams` and always renders for `/login` (its output is the `normal` prop handed to `LoginSlotSwitcher`), so it governs both experiences exactly as the layout redirect did. When the visitor is authenticated, verified, and complete it server-`redirect()`s to `/auth/oauth2/authorize?<original params>` if OIDC params are present (reusing `getOidcRedirectTarget`), otherwise to the dashboard as before.

- A 307 is a real top-level navigation — no login-form flash, and no background RSC fetch that would burn the one-time OIDC code (the reason #761's credential hooks use `window.location.assign`).
- The same-origin `/auth` target is served by `app/auth/[...path]/route.ts`, which forwards session cookies intact.
- `app/login/@modern/layout.tsx` keeps only its incomplete-onboarding branch; the unconditional dashboard `redirect()` is gone.

## Scope
Onboarding-incomplete / absent-`hasCompletedOnboarding` cohorts are out of scope and tracked in #836.

## Tests
New `app/login/@modern/@normal/page.test.tsx` (5 cases): signed-in complete + OIDC params → redirect to `/auth/oauth2/authorize` with `client_id` / `response_type` / `state` / `code_challenge` preserved; signed-in complete + no OIDC params → dashboard; `response_type=token` → dashboard (non-OIDC); unauthenticated → renders the form, no redirect; onboarding-incomplete → no redirect. `tsc` clean; full unit suite green (244 files / 3425 tests); `build:opennext` compiles clean (`ƒ /login`, Worker saved) — validated locally, since the worktree build failure that surfaced the proxy problem only appears in the adapter build.

## Follow-up
The issue's E2E round-trip acceptance criterion needs a registered OIDC client seeded in the E2E auth stack (a cross-repo Backend-Service dependency); deferred as a follow-up so this PR does not ship a spec that fails CI. The page unit tests cover the dj-site fix boundary.