### PR TITLE
feat(catalog): split call number from release chips, stop truncation

### DIFF
--- a/e2e/tests/catalog/album-detail.spec.ts
+++ b/e2e/tests/catalog/album-detail.spec.ts
@@ -109,7 +109,9 @@ async function openAlbumViaCatalog(
 
   const searchInput = page.getByPlaceholder("Search the catalog").first();
   await searchInput.fill("Juana Molina");
-  await expect(page.getByText("DOGA")).toBeVisible({ timeout: 10000 });
+  // .first(): the album title renders in both the desktop table and the
+  // (mounted-but-hidden) mobile card list below the sm breakpoint.
+  await expect(page.getByText("DOGA").first()).toBeVisible({ timeout: 10000 });
 
   const infoButton = page.locator('button[aria-label="More information"]').first();
   await infoButton.click();

--- a/e2e/tests/catalog/album-detail.spec.ts
+++ b/e2e/tests/catalog/album-detail.spec.ts
@@ -109,9 +109,7 @@ async function openAlbumViaCatalog(
 
   const searchInput = page.getByPlaceholder("Search the catalog").first();
   await searchInput.fill("Juana Molina");
-  // .first(): the album title renders in both the desktop table and the
-  // (mounted-but-hidden) mobile card list below the sm breakpoint.
-  await expect(page.getByText("DOGA").first()).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText("DOGA")).toBeVisible({ timeout: 10000 });
 
   // The desktop row actions are hover-revealed, so hover the row before
   // clicking its "More information" icon. Scope to the desktop table row

--- a/e2e/tests/catalog/album-detail.spec.ts
+++ b/e2e/tests/catalog/album-detail.spec.ts
@@ -113,8 +113,15 @@ async function openAlbumViaCatalog(
   // (mounted-but-hidden) mobile card list below the sm breakpoint.
   await expect(page.getByText("DOGA").first()).toBeVisible({ timeout: 10000 });
 
-  const infoButton = page.locator('button[aria-label="More information"]').first();
-  await infoButton.click();
+  // The desktop row actions are hover-revealed, so hover the row before
+  // clicking its "More information" icon. Scope to the desktop table row
+  // (the mobile card list is not a <tr>).
+  const resultRow = page
+    .locator("#OrderTableContainer tbody tr")
+    .filter({ hasText: "DOGA" })
+    .first();
+  await resultRow.hover();
+  await resultRow.locator('button[aria-label="More information"]').click();
 
   await albumDetail.waitForModal();
   await albumDetail.waitForAlbumLoaded();

--- a/e2e/tests/catalog/catalog-track-search.spec.ts
+++ b/e2e/tests/catalog/catalog-track-search.spec.ts
@@ -78,7 +78,7 @@ test.describe("Catalog track search — matched_via chip rendering", () => {
     const searchInput = page.getByPlaceholder("Search the catalog").first();
     await searchInput.fill("vi scose poise");
 
-    await expect(page.getByText("Confield")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("Confield").first()).toBeVisible({ timeout: 10000 });
     await expect(page.getByText("Autechre").first()).toBeVisible();
 
     await expect(
@@ -99,7 +99,7 @@ test.describe("Catalog track search — matched_via chip rendering", () => {
     await searchInput.fill(COMP_TRACK_TITLE);
 
     await expect(
-      page.getByText(wxycExampleSearchResults.variousArtistsComp.album_title),
+      page.getByText(wxycExampleSearchResults.variousArtistsComp.album_title).first(),
     ).toBeVisible({ timeout: 10000 });
     await expect(page.getByText("Various Artists").first()).toBeVisible();
 

--- a/e2e/tests/catalog/catalog-track-search.spec.ts
+++ b/e2e/tests/catalog/catalog-track-search.spec.ts
@@ -80,10 +80,11 @@ test.describe("Catalog track search — matched_via chip rendering", () => {
 
     await expect(page.getByText("Confield")).toBeVisible({ timeout: 10000 });
     // The artist renders twice within a desktop row (stacked in the Album
-    // column below xl, its own column at xl); target the visible copy so the
-    // assertion is viewport-independent.
+    // column below xl, its own column at xl); target a visible copy so the
+    // assertion is viewport-independent. .first() also covers the case where
+    // the artist name and its detail sub-line are the same string.
     await expect(
-      page.getByText("Autechre").filter({ visible: true }),
+      page.getByText("Autechre").filter({ visible: true }).first(),
     ).toBeVisible();
 
     await expect(
@@ -107,7 +108,7 @@ test.describe("Catalog track search — matched_via chip rendering", () => {
       page.getByText(wxycExampleSearchResults.variousArtistsComp.album_title),
     ).toBeVisible({ timeout: 10000 });
     await expect(
-      page.getByText("Various Artists").filter({ visible: true }),
+      page.getByText("Various Artists").filter({ visible: true }).first(),
     ).toBeVisible();
 
     await expect(

--- a/e2e/tests/catalog/catalog-track-search.spec.ts
+++ b/e2e/tests/catalog/catalog-track-search.spec.ts
@@ -78,8 +78,13 @@ test.describe("Catalog track search — matched_via chip rendering", () => {
     const searchInput = page.getByPlaceholder("Search the catalog").first();
     await searchInput.fill("vi scose poise");
 
-    await expect(page.getByText("Confield").first()).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText("Autechre").first()).toBeVisible();
+    await expect(page.getByText("Confield")).toBeVisible({ timeout: 10000 });
+    // The artist renders twice within a desktop row (stacked in the Album
+    // column below xl, its own column at xl); target the visible copy so the
+    // assertion is viewport-independent.
+    await expect(
+      page.getByText("Autechre").filter({ visible: true }),
+    ).toBeVisible();
 
     await expect(
       page.getByLabel(/matched on track: vi scose poise/i).first(),
@@ -99,9 +104,11 @@ test.describe("Catalog track search — matched_via chip rendering", () => {
     await searchInput.fill(COMP_TRACK_TITLE);
 
     await expect(
-      page.getByText(wxycExampleSearchResults.variousArtistsComp.album_title).first(),
+      page.getByText(wxycExampleSearchResults.variousArtistsComp.album_title),
     ).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText("Various Artists").first()).toBeVisible();
+    await expect(
+      page.getByText("Various Artists").filter({ visible: true }),
+    ).toBeVisible();
 
     await expect(
       page

--- a/e2e/tests/catalog/query-builder.spec.ts
+++ b/e2e/tests/catalog/query-builder.spec.ts
@@ -80,7 +80,10 @@ test.describe("Catalog query builder", () => {
     // column below xl, its own column at xl); target the visible copy so the
     // assertion is viewport-independent.
     await expect(
-      resultRow.getByText("Juana Molina", { exact: true }).filter({ visible: true }),
+      resultRow
+        .getByText("Juana Molina", { exact: true })
+        .filter({ visible: true })
+        .first(),
     ).toBeVisible();
 
     await expect.poll(() => lastQ ?? "").toMatch(/artist:Juana Molina/);

--- a/e2e/tests/catalog/query-builder.spec.ts
+++ b/e2e/tests/catalog/query-builder.spec.ts
@@ -76,10 +76,11 @@ test.describe("Catalog query builder", () => {
       .locator("#OrderTableContainer tbody tr")
       .filter({ hasText: "DOGA" });
     await expect(resultRow).toBeVisible({ timeout: 10000 });
-    // .first(): within a desktop row the artist renders twice — stacked in
-    // the Album column below xl, and in its own Artist column at xl.
+    // The artist renders twice within a desktop row (stacked in the Album
+    // column below xl, its own column at xl); target the visible copy so the
+    // assertion is viewport-independent.
     await expect(
-      resultRow.getByText("Juana Molina", { exact: true }).first(),
+      resultRow.getByText("Juana Molina", { exact: true }).filter({ visible: true }),
     ).toBeVisible();
 
     await expect.poll(() => lastQ ?? "").toMatch(/artist:Juana Molina/);

--- a/e2e/tests/catalog/query-builder.spec.ts
+++ b/e2e/tests/catalog/query-builder.spec.ts
@@ -76,7 +76,11 @@ test.describe("Catalog query builder", () => {
       .locator("#OrderTableContainer tbody tr")
       .filter({ hasText: "DOGA" });
     await expect(resultRow).toBeVisible({ timeout: 10000 });
-    await expect(resultRow.getByText("Juana Molina", { exact: true })).toBeVisible();
+    // .first(): within a desktop row the artist renders twice — stacked in
+    // the Album column below xl, and in its own Artist column at xl.
+    await expect(
+      resultRow.getByText("Juana Molina", { exact: true }).first(),
+    ).toBeVisible();
 
     await expect.poll(() => lastQ ?? "").toMatch(/artist:Juana Molina/);
     await expect.poll(() => lastQ ?? "").toMatch(/AND/);

--- a/src/components/experiences/modern/catalog/Results/MobileResult.tsx
+++ b/src/components/experiences/modern/catalog/Results/MobileResult.tsx
@@ -2,7 +2,6 @@
 
 import { AlbumEntry, Genre } from "@/lib/features/catalog/types";
 import Box from "@mui/joy/Box";
-import Checkbox from "@mui/joy/Checkbox";
 import IconButton from "@mui/joy/IconButton";
 import Sheet from "@mui/joy/Sheet";
 import Stack from "@mui/joy/Stack";
@@ -12,7 +11,6 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { QueueMusic } from "@mui/icons-material";
 
 import { applicationSlice } from "@/lib/features/application/frontend";
-import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
 import { useQueue, useShowControl } from "@/src/hooks/flowsheetHooks";
 import { useAppDispatch } from "@/lib/hooks";
 import { convertBinToQueue } from "@/lib/features/bin/conversions";
@@ -24,16 +22,13 @@ import { toast } from "sonner";
 
 // Below the `sm` breakpoint the desktop table is hidden and the results
 // render as this Apple-Music-style stacked card instead: artwork on the
-// left, everything else stacked vertically, actions trailing.
+// left, everything else stacked vertically, actions in the top-right corner.
 export default function CatalogMobileResult({ album }: { album: AlbumEntry }) {
   const { live } = useShowControl();
   const { addToQueue } = useQueue();
   const dispatch = useAppDispatch();
 
-  const { selected, setSelection } = useCatalogQuerySearch();
-
   const genreColor = GENRE_COLORS[(album.artist.genre as Genre) ?? "Unknown"] ?? "neutral";
-  const isSelected = selected.includes(album.id);
 
   const artistDisplay = album.album_artist ? "Various Artists" : album.artist.name;
 
@@ -42,8 +37,8 @@ export default function CatalogMobileResult({ album }: { album: AlbumEntry }) {
 
   // The actions sit in the top-right corner, so only the top text lines
   // (title, artist) need to reserve room for them; everything below runs
-  // full width. Three icons when live, two otherwise.
-  const actionClearance = live ? "108px" : "76px";
+  // full width. Three compact icons when live, two otherwise.
+  const actionClearance = live ? "92px" : "62px";
 
   const meta = [
     `${album.artist.lettercode} ${album.artist.numbercode}/${album.entry}`,
@@ -64,23 +59,10 @@ export default function CatalogMobileResult({ album }: { album: AlbumEntry }) {
         gap: 1.5,
         p: 1.25,
         borderRadius: "md",
-        bgcolor: isSelected ? "background.level2" : "background.level1",
+        bgcolor: "background.level1",
         cursor: "pointer",
       }}
     >
-      <Checkbox
-        checked={isSelected}
-        color={isSelected ? "primary" : undefined}
-        onClick={(e) => e.stopPropagation()}
-        onChange={(event) => {
-          setSelection(
-            event.target.checked
-              ? [...selected, album.id]
-              : selected.filter((item) => item !== album.id)
-          );
-        }}
-        sx={{ flexShrink: 0 }}
-      />
       {album.artwork_url ? (
         <Box
           component="img"
@@ -132,29 +114,44 @@ export default function CatalogMobileResult({ album }: { album: AlbumEntry }) {
           {artistDisplay}
         </Typography>
         <MatchedTrackChips matched_via={album.matched_via} />
-        <ReleaseChips
-          genre={album.artist.genre}
-          format={album.format}
-          rotation={album.rotation_bin}
-          onStreaming={album.on_streaming}
-        />
-        <Typography level="body-xs" textColor="text.tertiary" noWrap sx={{ mt: 0.25 }}>
-          {meta}
-        </Typography>
+        {/* Pills share the metadata line with the call number / plays /
+            label to keep the card compact. */}
+        <Stack
+          direction="row"
+          alignItems="center"
+          gap={0.75}
+          flexWrap="wrap"
+          sx={{ mt: 0.25 }}
+        >
+          <ReleaseChips
+            genre={album.artist.genre}
+            format={album.format}
+            rotation={album.rotation_bin}
+            onStreaming={album.on_streaming}
+          />
+          <Typography level="body-xs" textColor="text.tertiary">
+            {meta}
+          </Typography>
+        </Stack>
       </Stack>
 
       <Stack
         direction="row"
         gap={0.25}
         alignItems="center"
-        sx={{ position: "absolute", top: 6, right: 6 }}
+        sx={{
+          position: "absolute",
+          top: 6,
+          right: 6,
+          "--IconButton-size": "28px",
+          "--Icon-fontSize": "18px",
+        }}
         onClick={(e) => e.stopPropagation()}
       >
         <IconButton
           aria-label="More information"
           variant="plain"
           color="neutral"
-          size="sm"
           onClick={openDetail}
         >
           <InfoOutlinedIcon />
@@ -164,7 +161,6 @@ export default function CatalogMobileResult({ album }: { album: AlbumEntry }) {
             aria-label="Add to Queue"
             variant="plain"
             color="neutral"
-            size="sm"
             onClick={() => {
               addToQueue(convertBinToQueue(album));
               toast.success(`Added ${album.title} to queue`);

--- a/src/components/experiences/modern/catalog/Results/MobileResult.tsx
+++ b/src/components/experiences/modern/catalog/Results/MobileResult.tsx
@@ -11,7 +11,7 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { QueueMusic } from "@mui/icons-material";
 
 import { applicationSlice } from "@/lib/features/application/frontend";
-import { useQueue, useShowControl } from "@/src/hooks/flowsheetHooks";
+import { FlowsheetQuery } from "@/lib/features/flowsheet/types";
 import { useAppDispatch } from "@/lib/hooks";
 import { convertBinToQueue } from "@/lib/features/bin/conversions";
 import { GENRE_COLORS } from "../ArtistAvatar";
@@ -19,13 +19,22 @@ import AddRemoveBin from "./AddRemoveBin";
 import { MatchedTrackChips } from "./MatchedTrackChips";
 import { ReleaseChips } from "./ReleaseChips";
 import { toast } from "sonner";
+import { memo } from "react";
 
 // Below the `sm` breakpoint the desktop table is hidden and the results
 // render as this Apple-Music-style stacked card instead: artwork on the
 // left, everything else stacked vertically, actions in the top-right corner.
-export default function CatalogMobileResult({ album }: { album: AlbumEntry }) {
-  const { live } = useShowControl();
-  const { addToQueue } = useQueue();
+// `live`/`addToQueue` are hoisted into Results (shared across rows); memoized
+// so a query keystroke doesn't re-render unchanged cards.
+function CatalogMobileResult({
+  album,
+  live,
+  addToQueue,
+}: {
+  album: AlbumEntry;
+  live: boolean;
+  addToQueue: (entry: FlowsheetQuery) => void;
+}) {
   const dispatch = useAppDispatch();
 
   const genreColor = GENRE_COLORS[(album.artist.genre as Genre) ?? "Unknown"] ?? "neutral";
@@ -174,3 +183,5 @@ export default function CatalogMobileResult({ album }: { album: AlbumEntry }) {
     </Sheet>
   );
 }
+
+export default memo(CatalogMobileResult);

--- a/src/components/experiences/modern/catalog/Results/MobileResult.tsx
+++ b/src/components/experiences/modern/catalog/Results/MobileResult.tsx
@@ -40,6 +40,11 @@ export default function CatalogMobileResult({ album }: { album: AlbumEntry }) {
   const openDetail = () =>
     dispatch(applicationSlice.actions.openPanel({ type: "album-detail", albumId: album.id }));
 
+  // The actions sit in the top-right corner, so only the top text lines
+  // (title, artist) need to reserve room for them; everything below runs
+  // full width. Three icons when live, two otherwise.
+  const actionClearance = live ? "108px" : "76px";
+
   const meta = [
     `${album.artist.lettercode} ${album.artist.numbercode}/${album.entry}`,
     album.plays != null && album.plays > 0 ? `${album.plays} plays` : null,
@@ -53,6 +58,7 @@ export default function CatalogMobileResult({ album }: { album: AlbumEntry }) {
       variant="soft"
       onClick={openDetail}
       sx={{
+        position: "relative",
         display: "flex",
         alignItems: "center",
         gap: 1.5,
@@ -107,10 +113,22 @@ export default function CatalogMobileResult({ album }: { album: AlbumEntry }) {
       )}
 
       <Stack sx={{ flex: 1, minWidth: 0 }} gap={0.25}>
-        <Typography level="title-sm" textColor="text.primary" noWrap title={album.title}>
+        <Typography
+          level="title-sm"
+          textColor="text.primary"
+          noWrap
+          title={album.title}
+          sx={{ pr: actionClearance }}
+        >
           {album.title}
         </Typography>
-        <Typography level="body-sm" textColor="text.secondary" noWrap title={artistDisplay}>
+        <Typography
+          level="body-sm"
+          textColor="text.secondary"
+          noWrap
+          title={artistDisplay}
+          sx={{ pr: actionClearance }}
+        >
           {artistDisplay}
         </Typography>
         <MatchedTrackChips matched_via={album.matched_via} />
@@ -129,7 +147,7 @@ export default function CatalogMobileResult({ album }: { album: AlbumEntry }) {
         direction="row"
         gap={0.25}
         alignItems="center"
-        sx={{ flexShrink: 0 }}
+        sx={{ position: "absolute", top: 6, right: 6 }}
         onClick={(e) => e.stopPropagation()}
       >
         <IconButton

--- a/src/components/experiences/modern/catalog/Results/MobileResult.tsx
+++ b/src/components/experiences/modern/catalog/Results/MobileResult.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { AlbumEntry, Genre } from "@/lib/features/catalog/types";
+import Box from "@mui/joy/Box";
+import Checkbox from "@mui/joy/Checkbox";
+import IconButton from "@mui/joy/IconButton";
+import Sheet from "@mui/joy/Sheet";
+import Stack from "@mui/joy/Stack";
+import Typography from "@mui/joy/Typography";
+
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { QueueMusic } from "@mui/icons-material";
+
+import { applicationSlice } from "@/lib/features/application/frontend";
+import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
+import { useQueue, useShowControl } from "@/src/hooks/flowsheetHooks";
+import { useAppDispatch } from "@/lib/hooks";
+import { convertBinToQueue } from "@/lib/features/bin/conversions";
+import { GENRE_COLORS } from "../ArtistAvatar";
+import AddRemoveBin from "./AddRemoveBin";
+import { MatchedTrackChips } from "./MatchedTrackChips";
+import { ReleaseChips } from "./ReleaseChips";
+import { toast } from "sonner";
+
+// Below the `sm` breakpoint the desktop table is hidden and the results
+// render as this Apple-Music-style stacked card instead: artwork on the
+// left, everything else stacked vertically, actions trailing.
+export default function CatalogMobileResult({ album }: { album: AlbumEntry }) {
+  const { live } = useShowControl();
+  const { addToQueue } = useQueue();
+  const dispatch = useAppDispatch();
+
+  const { selected, setSelection } = useCatalogQuerySearch();
+
+  const genreColor = GENRE_COLORS[(album.artist.genre as Genre) ?? "Unknown"] ?? "neutral";
+  const isSelected = selected.includes(album.id);
+
+  const artistDisplay = album.album_artist ? "Various Artists" : album.artist.name;
+
+  const openDetail = () =>
+    dispatch(applicationSlice.actions.openPanel({ type: "album-detail", albumId: album.id }));
+
+  const meta = [
+    `${album.artist.lettercode} ${album.artist.numbercode}/${album.entry}`,
+    album.plays != null && album.plays > 0 ? `${album.plays} plays` : null,
+    album.label || null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <Sheet
+      variant="soft"
+      onClick={openDetail}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1.5,
+        p: 1.25,
+        borderRadius: "md",
+        bgcolor: isSelected ? "background.level2" : "background.level1",
+        cursor: "pointer",
+      }}
+    >
+      <Checkbox
+        checked={isSelected}
+        color={isSelected ? "primary" : undefined}
+        onClick={(e) => e.stopPropagation()}
+        onChange={(event) => {
+          setSelection(
+            event.target.checked
+              ? [...selected, album.id]
+              : selected.filter((item) => item !== album.id)
+          );
+        }}
+        sx={{ flexShrink: 0 }}
+      />
+      {album.artwork_url ? (
+        <Box
+          component="img"
+          src={album.artwork_url}
+          alt={`${album.artist.name} - ${album.title}`}
+          sx={{ width: 56, height: 56, borderRadius: "sm", objectFit: "cover", flexShrink: 0 }}
+        />
+      ) : (
+        <Box
+          aria-hidden
+          sx={{
+            width: 56,
+            height: 56,
+            borderRadius: "sm",
+            flexShrink: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: (theme) =>
+              `linear-gradient(135deg, ${theme.vars.palette[genreColor][400]}, ${theme.vars.palette[genreColor][700]})`,
+          }}
+        >
+          <Typography
+            level="title-sm"
+            sx={{ color: "#fff", opacity: 0.9, fontWeight: 700, letterSpacing: "0.08em" }}
+          >
+            {album.artist.lettercode}
+          </Typography>
+        </Box>
+      )}
+
+      <Stack sx={{ flex: 1, minWidth: 0 }} gap={0.25}>
+        <Typography level="title-sm" textColor="text.primary" noWrap title={album.title}>
+          {album.title}
+        </Typography>
+        <Typography level="body-sm" textColor="text.secondary" noWrap title={artistDisplay}>
+          {artistDisplay}
+        </Typography>
+        <MatchedTrackChips matched_via={album.matched_via} />
+        <ReleaseChips
+          genre={album.artist.genre}
+          format={album.format}
+          rotation={album.rotation_bin}
+          onStreaming={album.on_streaming}
+        />
+        <Typography level="body-xs" textColor="text.tertiary" noWrap sx={{ mt: 0.25 }}>
+          {meta}
+        </Typography>
+      </Stack>
+
+      <Stack
+        direction="row"
+        gap={0.25}
+        alignItems="center"
+        sx={{ flexShrink: 0 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <IconButton
+          aria-label="More information"
+          variant="plain"
+          color="neutral"
+          size="sm"
+          onClick={openDetail}
+        >
+          <InfoOutlinedIcon />
+        </IconButton>
+        {live && (
+          <IconButton
+            aria-label="Add to Queue"
+            variant="plain"
+            color="neutral"
+            size="sm"
+            onClick={() => {
+              addToQueue(convertBinToQueue(album));
+              toast.success(`Added ${album.title} to queue`);
+            }}
+          >
+            <QueueMusic />
+          </IconButton>
+        )}
+        <AddRemoveBin album={album} />
+      </Stack>
+    </Sheet>
+  );
+}

--- a/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
+++ b/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
@@ -129,7 +129,7 @@ export function ReleaseChips({
       direction="row"
       gap={0.75}
       alignItems="center"
-      sx={{ flexShrink: 0 }}
+      flexWrap="wrap"
       onClick={(e) => e.stopPropagation()}
     >
       {visible.map((item) => item.node)}

--- a/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
+++ b/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
@@ -2,50 +2,99 @@
 
 import Chip from "@mui/joy/Chip";
 import Stack from "@mui/joy/Stack";
+import Tooltip from "@mui/joy/Tooltip";
 
 import { Format, Genre } from "@/lib/features/catalog/types";
+import { Rotation } from "@/lib/features/rotation/types";
+import { getStyleForRotation } from "@/src/utilities/modern/rotationstyles";
 import { GENRE_COLORS } from "../ArtistAvatar";
 
-// Always soft in the table — GENRE_VARIANTS' solid chips read louder than
-// the row's own text and made rows look uneven.
+// Descriptor pills are tiny caption-scale and quieter than the artist text;
+// only operational status (rotation, exclusive) earns stronger color. The
+// row must still read well with all pills removed.
 const chipSx = {
-  fontSize: "0.7rem",
+  fontSize: "0.65rem",
   fontWeight: 500,
-  "--Chip-minHeight": "18px",
+  "--Chip-minHeight": "16px",
+  "--Chip-paddingInline": "6px",
 } as const;
+
+const VISIBLE_LIMIT = 3;
 
 function formatLabel(format: Format): string {
   if (/^cd$/i.test(format)) return "CD";
   return format.charAt(0).toUpperCase() + format.slice(1).toLowerCase();
 }
 
+type ChipItem = {
+  key: string;
+  label: string;
+  priority: number;
+  node: React.ReactNode;
+};
+
 export function ReleaseChips({
   genre,
   format,
+  rotation,
   onStreaming,
 }: {
   genre: Genre;
   format: Format;
+  rotation?: Rotation;
   onStreaming: boolean | undefined;
 }) {
   const genreColor = GENRE_COLORS[genre ?? "Unknown"] ?? "neutral";
 
-  return (
-    <Stack
-      direction="row"
-      gap={0.5}
-      flexWrap="wrap"
-      sx={{ marginTop: 0.75 }}
-      onClick={(e) => e.stopPropagation()}
-    >
-      <Chip variant="soft" color={genreColor} size="sm" sx={chipSx}>
-        {genre}
-      </Chip>
-      <Chip variant="soft" color="neutral" size="sm" sx={chipSx}>
-        {formatLabel(format)}
-      </Chip>
-      {onStreaming === false && (
+  const items: ChipItem[] = [
+    {
+      key: "genre",
+      label: genre,
+      priority: 2,
+      node: (
+        <Chip key="genre" variant="soft" color={genreColor} size="sm" sx={chipSx}>
+          {genre}
+        </Chip>
+      ),
+    },
+    {
+      key: "format",
+      label: formatLabel(format),
+      priority: 1,
+      node: (
+        <Chip key="format" variant="soft" color="neutral" size="sm" sx={chipSx}>
+          {formatLabel(format)}
+        </Chip>
+      ),
+    },
+  ];
+  if (rotation) {
+    items.push({
+      key: "rotation",
+      label: `Rotation ${rotation}`,
+      priority: 3,
+      node: (
         <Chip
+          key="rotation"
+          variant="solid"
+          color={getStyleForRotation(rotation)}
+          size="sm"
+          sx={chipSx}
+          aria-label={`Rotation ${rotation}`}
+        >
+          {rotation}
+        </Chip>
+      ),
+    });
+  }
+  if (onStreaming === false) {
+    items.push({
+      key: "exclusive",
+      label: "WXYC EXCLUSIVE",
+      priority: 3,
+      node: (
+        <Chip
+          key="exclusive"
           variant="soft"
           size="sm"
           sx={{
@@ -57,6 +106,52 @@ export function ReleaseChips({
         >
           WXYC EXCLUSIVE
         </Chip>
+      ),
+    });
+  }
+
+  // Cap the cluster: keep the most important pills, fold the rest into +N.
+  let visible = items;
+  let hidden: ChipItem[] = [];
+  if (items.length > VISIBLE_LIMIT) {
+    const keep = new Set(
+      [...items]
+        .sort((a, b) => b.priority - a.priority)
+        .slice(0, VISIBLE_LIMIT)
+        .map((item) => item.key)
+    );
+    visible = items.filter((item) => keep.has(item.key));
+    hidden = items.filter((item) => !keep.has(item.key));
+  }
+
+  return (
+    <Stack
+      direction="row"
+      gap={0.75}
+      alignItems="center"
+      sx={{ flexShrink: 0 }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {visible.map((item) => item.node)}
+      {hidden.length > 0 && (
+        <Tooltip
+          title={hidden.map((item) => item.label).join(", ")}
+          variant="outlined"
+          size="sm"
+        >
+          <Chip
+            variant="soft"
+            color="neutral"
+            size="sm"
+            tabIndex={0}
+            sx={chipSx}
+            aria-label={`${hidden.length} more: ${hidden
+              .map((item) => item.label)
+              .join(", ")}`}
+          >
+            +{hidden.length}
+          </Chip>
+        </Tooltip>
       )}
     </Stack>
   );

--- a/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
+++ b/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
@@ -20,11 +20,16 @@ const chipSx = {
 } as const;
 
 // `Format` is a cast string, not a real closed union (conversions.ts casts
-// `format_name as Format`), so only normalize the attested lowercase "cd";
-// preserve any other value's casing rather than title-case-mangling it
-// (e.g. "CD-R", "LP", "7-inch Single").
+// `format_name as Format`), so normalize only the attested bare lowercase
+// values ("cd" -> "CD", "vinyl" -> "Vinyl") and preserve anything that
+// already carries casing or punctuation ("CD-R", "LP", "7-inch Single",
+// "Unknown") rather than title-case-mangling it.
 function formatLabel(format: Format): string {
-  return /^cd$/i.test(format) ? "CD" : format;
+  if (/^cd$/i.test(format)) return "CD";
+  if (/^[a-z]+$/.test(format)) {
+    return format.charAt(0).toUpperCase() + format.slice(1);
+  }
+  return format;
 }
 
 export function ReleaseChips({

--- a/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
+++ b/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
@@ -2,12 +2,12 @@
 
 import Chip from "@mui/joy/Chip";
 import Stack from "@mui/joy/Stack";
-import Tooltip from "@mui/joy/Tooltip";
 
 import { Format, Genre } from "@/lib/features/catalog/types";
 import { Rotation } from "@/lib/features/rotation/types";
 import { getStyleForRotation } from "@/src/utilities/modern/rotationstyles";
 import { GENRE_COLORS } from "../ArtistAvatar";
+import { EXCLUSIVES_PURPLE } from "../Search/catalogFilterStyles";
 
 // Descriptor pills are tiny caption-scale and quieter than the artist text;
 // only operational status (rotation, exclusive) earns stronger color. The
@@ -19,19 +19,13 @@ const chipSx = {
   "--Chip-paddingInline": "6px",
 } as const;
 
-const VISIBLE_LIMIT = 3;
-
+// `Format` is a cast string, not a real closed union (conversions.ts casts
+// `format_name as Format`), so only normalize the attested lowercase "cd";
+// preserve any other value's casing rather than title-case-mangling it
+// (e.g. "CD-R", "LP", "7-inch Single").
 function formatLabel(format: Format): string {
-  if (/^cd$/i.test(format)) return "CD";
-  return format.charAt(0).toUpperCase() + format.slice(1).toLowerCase();
+  return /^cd$/i.test(format) ? "CD" : format;
 }
-
-type ChipItem = {
-  key: string;
-  label: string;
-  priority: number;
-  node: React.ReactNode;
-};
 
 export function ReleaseChips({
   genre,
@@ -46,36 +40,20 @@ export function ReleaseChips({
 }) {
   const genreColor = GENRE_COLORS[genre ?? "Unknown"] ?? "neutral";
 
-  const items: ChipItem[] = [
-    {
-      key: "genre",
-      label: genre,
-      priority: 2,
-      node: (
-        <Chip key="genre" variant="soft" color={genreColor} size="sm" sx={chipSx}>
-          {genre}
-        </Chip>
-      ),
-    },
-    {
-      key: "format",
-      label: formatLabel(format),
-      priority: 1,
-      node: (
-        <Chip key="format" variant="soft" color="neutral" size="sm" sx={chipSx}>
-          {formatLabel(format)}
-        </Chip>
-      ),
-    },
-  ];
-  if (rotation) {
-    items.push({
-      key: "rotation",
-      label: `Rotation ${rotation}`,
-      priority: 3,
-      node: (
+  // At most four small pills (genre, format, rotation, exclusive) — they wrap,
+  // so there's no overflow to collapse. Format stays visible so the DJ can
+  // always see Vinyl vs CD. No stopPropagation: clicking a pill bubbles to the
+  // row/card and opens album detail, as it did before the redesign.
+  return (
+    <Stack direction="row" gap={0.75} alignItems="center" flexWrap="wrap">
+      <Chip variant="soft" color={genreColor} size="sm" sx={chipSx}>
+        {genre}
+      </Chip>
+      <Chip variant="soft" color="neutral" size="sm" sx={chipSx}>
+        {formatLabel(format)}
+      </Chip>
+      {rotation && (
         <Chip
-          key="rotation"
           variant="solid"
           color={getStyleForRotation(rotation)}
           size="sm"
@@ -84,74 +62,20 @@ export function ReleaseChips({
         >
           {rotation}
         </Chip>
-      ),
-    });
-  }
-  if (onStreaming === false) {
-    items.push({
-      key: "exclusive",
-      label: "WXYC EXCLUSIVE",
-      priority: 3,
-      node: (
+      )}
+      {onStreaming === false && (
         <Chip
-          key="exclusive"
           variant="soft"
           size="sm"
           sx={{
             ...chipSx,
-            backgroundColor: "#7B2D8E",
+            backgroundColor: EXCLUSIVES_PURPLE,
             color: "#fff",
             letterSpacing: "0.5px",
           }}
         >
           WXYC EXCLUSIVE
         </Chip>
-      ),
-    });
-  }
-
-  // Cap the cluster: keep the most important pills, fold the rest into +N.
-  let visible = items;
-  let hidden: ChipItem[] = [];
-  if (items.length > VISIBLE_LIMIT) {
-    const keep = new Set(
-      [...items]
-        .sort((a, b) => b.priority - a.priority)
-        .slice(0, VISIBLE_LIMIT)
-        .map((item) => item.key)
-    );
-    visible = items.filter((item) => keep.has(item.key));
-    hidden = items.filter((item) => !keep.has(item.key));
-  }
-
-  return (
-    <Stack
-      direction="row"
-      gap={0.75}
-      alignItems="center"
-      flexWrap="wrap"
-      onClick={(e) => e.stopPropagation()}
-    >
-      {visible.map((item) => item.node)}
-      {hidden.length > 0 && (
-        <Tooltip
-          title={hidden.map((item) => item.label).join(", ")}
-          variant="outlined"
-          size="sm"
-        >
-          <Chip
-            variant="soft"
-            color="neutral"
-            size="sm"
-            tabIndex={0}
-            sx={chipSx}
-            aria-label={`${hidden.length} more: ${hidden
-              .map((item) => item.label)
-              .join(", ")}`}
-          >
-            +{hidden.length}
-          </Chip>
-        </Tooltip>
       )}
     </Stack>
   );

--- a/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
+++ b/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Chip from "@mui/joy/Chip";
+import Stack from "@mui/joy/Stack";
+
+import { Format, Genre } from "@/lib/features/catalog/types";
+import { GENRE_COLORS } from "../ArtistAvatar";
+
+// Always soft in the table — GENRE_VARIANTS' solid chips read louder than
+// the row's own text and made rows look uneven.
+const chipSx = {
+  fontSize: "0.7rem",
+  fontWeight: 500,
+  "--Chip-minHeight": "18px",
+} as const;
+
+function formatLabel(format: Format): string {
+  if (/^cd$/i.test(format)) return "CD";
+  return format.charAt(0).toUpperCase() + format.slice(1).toLowerCase();
+}
+
+export function ReleaseChips({
+  genre,
+  format,
+  onStreaming,
+}: {
+  genre: Genre;
+  format: Format;
+  onStreaming: boolean | undefined;
+}) {
+  const genreColor = GENRE_COLORS[genre ?? "Unknown"] ?? "neutral";
+
+  return (
+    <Stack
+      direction="row"
+      gap={0.5}
+      flexWrap="wrap"
+      sx={{ marginTop: 0.75 }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <Chip variant="soft" color={genreColor} size="sm" sx={chipSx}>
+        {genre}
+      </Chip>
+      <Chip variant="soft" color="neutral" size="sm" sx={chipSx}>
+        {formatLabel(format)}
+      </Chip>
+      {onStreaming === false && (
+        <Chip
+          variant="soft"
+          size="sm"
+          sx={{
+            ...chipSx,
+            backgroundColor: "#7B2D8E",
+            color: "#fff",
+            letterSpacing: "0.5px",
+          }}
+        >
+          WXYC EXCLUSIVE
+        </Chip>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -173,7 +173,7 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
           {album.plays != null && album.plays > 0 ? album.plays : "—"}
         </Typography>
       </td>
-      <td style={{ position: "relative" }}>
+      <td>
         <Typography
           level="body-sm"
           textColor="text.tertiary"
@@ -182,6 +182,11 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
         >
           {album.label || "—"}
         </Typography>
+      </td>
+      {/* Zero-width sticky cell pinned to the scroll container's right edge,
+          so the hover actions always sit at the visible edge regardless of
+          horizontal scroll. */}
+      <td className="actions-cell">
         <Stack
           direction="row"
           gap={0.25}

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -3,7 +3,6 @@
 import { AlbumEntry, Genre } from "@/lib/features/catalog/types";
 import Box from "@mui/joy/Box";
 import Checkbox from "@mui/joy/Checkbox";
-import Chip from "@mui/joy/Chip";
 import IconButton from "@mui/joy/IconButton";
 import Typography from "@mui/joy/Typography";
 
@@ -17,9 +16,10 @@ import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
 import { QueueMusic } from "@mui/icons-material";
 import { useQueue, useShowControl } from "@/src/hooks/flowsheetHooks";
 import { useAppDispatch } from "@/lib/hooks";
-import { GENRE_COLORS, GENRE_VARIANTS } from "../ArtistAvatar";
+import { GENRE_COLORS } from "../ArtistAvatar";
 import AddRemoveBin from "./AddRemoveBin";
 import { MatchedTrackChips } from "./MatchedTrackChips";
+import { ReleaseChips } from "./ReleaseChips";
 import { convertBinToQueue } from "@/lib/features/bin/conversions";
 import { toast } from "sonner";
 
@@ -31,7 +31,16 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
   const { selected, setSelection, sortBy } = useCatalogQuerySearch();
 
   const genreColor = GENRE_COLORS[(album.artist.genre as Genre) ?? "Unknown"] ?? "neutral";
-  const genreVariant = GENRE_VARIANTS[(album.artist.genre as Genre) ?? "Unknown"] ?? "soft";
+
+  // Clamp instead of ellipsizing a single line; full text stays recoverable
+  // via the title attribute.
+  const lineClampSx = {
+    display: "-webkit-box",
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: "vertical",
+    overflow: "hidden",
+    overflowWrap: "anywhere",
+  } as const;
 
   return (
     <tr
@@ -91,10 +100,16 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
               fontWeight={sortBy === "artist" ? "bold" : "normal"}
               level="body-sm"
               textColor="text.primary"
+              title={album.album_artist ? "Various Artists" : album.artist.name}
+              sx={lineClampSx}
             >
               {album.album_artist ? "Various Artists" : album.artist.name}
             </Typography>
-            <Typography level="body-sm">
+            <Typography
+              level="body-sm"
+              title={album.album_artist ?? album.alternate_artist}
+              sx={lineClampSx}
+            >
               {album.album_artist ?? album.alternate_artist}
             </Typography>
           </div>
@@ -105,46 +120,25 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
           fontWeight={sortBy === "album" ? "bold" : "normal"}
           level="body-sm"
           textColor="text.primary"
+          title={album.title}
+          sx={lineClampSx}
         >
           {album.title}
         </Typography>
+        <ReleaseChips
+          genre={album.artist.genre}
+          format={album.format}
+          onStreaming={album.on_streaming}
+        />
         <MatchedTrackChips matched_via={album.matched_via} />
       </td>
       <td>
-        <Stack direction="row" gap={0.75} alignItems="center" flexWrap="nowrap">
-          <Chip
-            variant={genreVariant}
-            color={genreColor}
-            size="sm"
-          >
-            {album.artist.genre}
-          </Chip>
-          <Chip
-            variant="soft"
-            size="sm"
-            color={album.format.includes("Vinyl") ? "primary" : "warning"}
-          >
-            {album.format}
-          </Chip>
-          {album.on_streaming === false && (
-            <Chip
-              variant="soft"
-              size="sm"
-              sx={{
-                backgroundColor: "#7B2D8E",
-                color: "#fff",
-                fontWeight: "bold",
-                fontSize: "0.65rem",
-                letterSpacing: "0.5px",
-              }}
-            >
-              WXYC EXCLUSIVE
-            </Chip>
-          )}
-          <Typography level="body-sm" noWrap>
-            {album.artist.lettercode} {album.artist.numbercode}/{album.entry}
-          </Typography>
-        </Stack>
+        <Typography
+          level="body-sm"
+          sx={{ fontFamily: "code", whiteSpace: "nowrap" }}
+        >
+          {album.artist.lettercode} {album.artist.numbercode}/{album.entry}
+        </Typography>
       </td>
       <td>
         <Typography level="body-sm">

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -121,9 +121,27 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
         >
           {album.title}
         </Typography>
+        {/* Below xl the artist stacks under the album title in this single
+            column; at xl it moves out to its own Artist column instead. */}
+        <Box sx={{ display: { xs: "block", xl: "none" } }}>
+          <Typography
+            level="body-sm"
+            fontWeight={sortBy === "artist" ? "bold" : "md"}
+            textColor="text.secondary"
+            noWrap
+            title={artistDisplay}
+          >
+            {artistDisplay}
+          </Typography>
+          {artistDetail && (
+            <Typography level="body-xs" textColor="text.tertiary" noWrap title={artistDetail}>
+              {artistDetail}
+            </Typography>
+          )}
+        </Box>
         <MatchedTrackChips matched_via={album.matched_via} />
       </td>
-      <td>
+      <td className="col-artist">
         <Typography
           level="body-sm"
           fontWeight={sortBy === "artist" ? "bold" : "md"}

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -131,9 +131,8 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
             level="body-sm"
             fontWeight={sortBy === "artist" ? "bold" : "md"}
             textColor="text.secondary"
-            noWrap
             title={artistDisplay}
-            sx={{ flexShrink: 1, minWidth: 0 }}
+            sx={{ ...lineClampSx, flexShrink: 1, minWidth: 0 }}
           >
             {artistDisplay}
           </Typography>
@@ -145,9 +144,8 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
               <Typography
                 level="body-sm"
                 textColor="text.tertiary"
-                noWrap
                 title={artistDetail}
-                sx={{ flexShrink: 1, minWidth: 0 }}
+                sx={{ ...lineClampSx, flexShrink: 1, minWidth: 0 }}
               >
                 {artistDetail}
               </Typography>

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -6,10 +6,9 @@ import Checkbox from "@mui/joy/Checkbox";
 import IconButton from "@mui/joy/IconButton";
 import Typography from "@mui/joy/Typography";
 
-import { Album as AlbumIcon } from "@mui/icons-material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 
-import { Avatar, Stack, Tooltip } from "@mui/joy";
+import { Stack, Tooltip } from "@mui/joy";
 
 import { applicationSlice } from "@/lib/features/application/frontend";
 import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
@@ -31,6 +30,10 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
   const { selected, setSelection, sortBy } = useCatalogQuerySearch();
 
   const genreColor = GENRE_COLORS[(album.artist.genre as Genre) ?? "Unknown"] ?? "neutral";
+  const isSelected = selected.includes(album.id);
+
+  const artistDisplay = album.album_artist ? "Various Artists" : album.artist.name;
+  const artistDetail = album.album_artist ?? album.alternate_artist;
 
   // Clamp instead of ellipsizing a single line; full text stays recoverable
   // via the title attribute.
@@ -45,6 +48,7 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
   return (
     <tr
       key={album.id}
+      className={isSelected ? "row-selected" : undefined}
       onClick={() => dispatch(applicationSlice.actions.openPanel({ type: "album-detail", albumId: album.id }))}
       style={{ cursor: "pointer" }}
     >
@@ -53,8 +57,8 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
         onClick={(e) => e.stopPropagation()}
       >
         <Checkbox
-          checked={selected.includes(album.id)}
-          color={selected.includes(album.id) ? "primary" : undefined}
+          checked={isSelected}
+          color={isSelected ? "primary" : undefined}
           onChange={(event) => {
             setSelection(
               event.target.checked
@@ -73,80 +77,130 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
             src={album.artwork_url}
             alt={`${album.artist.name} - ${album.title}`}
             sx={{
-              width: 40,
-              height: 40,
+              width: 48,
+              height: 48,
               borderRadius: "sm",
               objectFit: "cover",
             }}
           />
         ) : (
-          <Avatar
-            variant="soft"
-            color={genreColor}
+          <Box
+            aria-hidden
             sx={{
-              width: 40,
-              height: 40,
+              width: 48,
+              height: 48,
               borderRadius: "sm",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              background: (theme) =>
+                `linear-gradient(135deg, ${theme.vars.palette[genreColor][400]}, ${theme.vars.palette[genreColor][700]})`,
             }}
           >
-            <AlbumIcon />
-          </Avatar>
+            <Typography
+              level="title-sm"
+              sx={{
+                color: "#fff",
+                opacity: 0.9,
+                fontWeight: 700,
+                letterSpacing: "0.08em",
+              }}
+            >
+              {album.artist.lettercode}
+            </Typography>
+          </Box>
         )}
       </td>
       <td>
-        <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
-          <div>
-            <Typography
-              fontWeight={sortBy === "artist" ? "bold" : "normal"}
-              level="body-sm"
-              textColor="text.primary"
-              title={album.album_artist ? "Various Artists" : album.artist.name}
-              sx={lineClampSx}
-            >
-              {album.album_artist ? "Various Artists" : album.artist.name}
-            </Typography>
-            <Typography
-              level="body-sm"
-              title={album.album_artist ?? album.alternate_artist}
-              sx={lineClampSx}
-            >
-              {album.album_artist ?? album.alternate_artist}
-            </Typography>
-          </div>
-        </Box>
-      </td>
-      <td>
         <Typography
-          fontWeight={sortBy === "album" ? "bold" : "normal"}
-          level="body-sm"
+          level="title-sm"
+          fontWeight={sortBy === "album" ? "lg" : "md"}
           textColor="text.primary"
           title={album.title}
           sx={lineClampSx}
         >
           {album.title}
         </Typography>
+        <Stack
+          direction="row"
+          gap={0.75}
+          alignItems="center"
+          sx={{ marginTop: 0.25, minWidth: 0 }}
+        >
+          <Typography
+            level="body-sm"
+            fontWeight={sortBy === "artist" ? "bold" : "md"}
+            textColor="text.secondary"
+            noWrap
+            title={artistDisplay}
+            sx={{ flexShrink: 1, minWidth: 0 }}
+          >
+            {artistDisplay}
+          </Typography>
+          {artistDetail && (
+            <>
+              <Typography level="body-sm" textColor="text.tertiary" sx={{ flexShrink: 0 }}>
+                ·
+              </Typography>
+              <Typography
+                level="body-sm"
+                textColor="text.tertiary"
+                noWrap
+                title={artistDetail}
+                sx={{ flexShrink: 1, minWidth: 0 }}
+              >
+                {artistDetail}
+              </Typography>
+            </>
+          )}
+        </Stack>
+        <MatchedTrackChips matched_via={album.matched_via} />
+      </td>
+      <td>
         <ReleaseChips
           genre={album.artist.genre}
           format={album.format}
+          rotation={album.rotation_bin}
           onStreaming={album.on_streaming}
         />
-        <MatchedTrackChips matched_via={album.matched_via} />
       </td>
       <td>
         <Typography
           level="body-sm"
+          textColor="text.secondary"
           sx={{ fontFamily: "code", whiteSpace: "nowrap" }}
         >
           {album.artist.lettercode} {album.artist.numbercode}/{album.entry}
         </Typography>
       </td>
       <td>
-        <Typography level="body-sm">
+        <Typography
+          level="body-sm"
+          textColor={
+            album.plays != null && album.plays > 0
+              ? "text.secondary"
+              : "text.tertiary"
+          }
+        >
           {album.plays != null && album.plays > 0 ? album.plays : "—"}
         </Typography>
       </td>
-      <td onClick={(e) => e.stopPropagation()}>
-        <Stack direction="row" gap={0.25}>
+      <td style={{ position: "relative" }}>
+        <Stack
+          direction="row"
+          gap={0.25}
+          className="row-actions"
+          onClick={(e) => e.stopPropagation()}
+          sx={{
+            position: "absolute",
+            right: 8,
+            top: "50%",
+            transform: "translateY(-50%)",
+            borderRadius: "sm",
+            pl: 3,
+            pr: 0.5,
+          }}
+        >
           <Tooltip variant="outlined" size="sm" title="More information">
             <IconButton
               aria-label="More information"

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -13,7 +13,7 @@ import { Stack, Tooltip } from "@mui/joy";
 import { applicationSlice } from "@/lib/features/application/frontend";
 import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
 import { QueueMusic } from "@mui/icons-material";
-import { useQueue, useShowControl } from "@/src/hooks/flowsheetHooks";
+import { FlowsheetQuery } from "@/lib/features/flowsheet/types";
 import { useAppDispatch } from "@/lib/hooks";
 import { GENRE_COLORS } from "../ArtistAvatar";
 import AddRemoveBin from "./AddRemoveBin";
@@ -21,10 +21,20 @@ import { MatchedTrackChips } from "./MatchedTrackChips";
 import { ReleaseChips } from "./ReleaseChips";
 import { convertBinToQueue } from "@/lib/features/bin/conversions";
 import { toast } from "sonner";
+import { memo } from "react";
 
-export default function CatalogResult({ album }: { album: AlbumEntry }) {
-  const { live } = useShowControl();
-  const { addToQueue } = useQueue();
+// `live` and `addToQueue` are hoisted into Results and passed down so every
+// row shares one useShowControl/useQueue subscription; memoized so a query
+// keystroke doesn't re-render rows whose album is unchanged.
+function CatalogResult({
+  album,
+  live,
+  addToQueue,
+}: {
+  album: AlbumEntry;
+  live: boolean;
+  addToQueue: (entry: FlowsheetQuery) => void;
+}) {
   const dispatch = useAppDispatch();
 
   const { selected, setSelection, sortBy } = useCatalogQuerySearch();
@@ -252,3 +262,5 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
     </tr>
   );
 }
+
+export default memo(CatalogResult);

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -121,38 +121,28 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
         >
           {album.title}
         </Typography>
-        <Stack
-          direction="row"
-          gap={0.75}
-          alignItems="center"
-          sx={{ marginTop: 0.25, minWidth: 0 }}
-        >
-          <Typography
-            level="body-sm"
-            fontWeight={sortBy === "artist" ? "bold" : "md"}
-            textColor="text.secondary"
-            title={artistDisplay}
-            sx={{ ...lineClampSx, flexShrink: 1, minWidth: 0 }}
-          >
-            {artistDisplay}
-          </Typography>
-          {artistDetail && (
-            <>
-              <Typography level="body-sm" textColor="text.tertiary" sx={{ flexShrink: 0 }}>
-                ·
-              </Typography>
-              <Typography
-                level="body-sm"
-                textColor="text.tertiary"
-                title={artistDetail}
-                sx={{ ...lineClampSx, flexShrink: 1, minWidth: 0 }}
-              >
-                {artistDetail}
-              </Typography>
-            </>
-          )}
-        </Stack>
         <MatchedTrackChips matched_via={album.matched_via} />
+      </td>
+      <td>
+        <Typography
+          level="body-sm"
+          fontWeight={sortBy === "artist" ? "bold" : "md"}
+          textColor="text.secondary"
+          title={artistDisplay}
+          sx={lineClampSx}
+        >
+          {artistDisplay}
+        </Typography>
+        {artistDetail && (
+          <Typography
+            level="body-xs"
+            textColor="text.tertiary"
+            title={artistDetail}
+            sx={lineClampSx}
+          >
+            {artistDetail}
+          </Typography>
+        )}
       </td>
       <td>
         <ReleaseChips
@@ -184,6 +174,14 @@ export default function CatalogResult({ album }: { album: AlbumEntry }) {
         </Typography>
       </td>
       <td style={{ position: "relative" }}>
+        <Typography
+          level="body-sm"
+          textColor="text.tertiary"
+          title={album.label}
+          sx={lineClampSx}
+        >
+          {album.label || "—"}
+        </Typography>
         <Stack
           direction="row"
           gap={0.25}

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -49,44 +49,46 @@ export default function Results({
         sx={{
           // Below this the container's overflow:auto takes over as a
           // horizontal scroll; columns never get crushed.
-          minWidth: 760,
+          minWidth: 700,
           "--TableCell-headBackground": (theme) =>
             theme.vars.palette.background.level1,
           "--Table-headerUnderlineThickness": "1px",
           "--TableRow-hoverBackground": (theme) =>
             theme.vars.palette.background.level1,
-          "& thead tr > *:last-child": {
-            position: "sticky",
-            right: 0,
-            bgcolor: "var(--TableCell-headBackground)",
-            borderLeft: "1px solid",
-            borderLeftColor: (theme) => theme.vars.palette.divider,
+          // Media-list rows: taller than a data grid, everything vertically
+          // centered on the artwork.
+          "& tbody tr > td": {
+            height: "68px",
+            verticalAlign: "middle",
           },
-          // Opaque background is load-bearing: the theme's cssVarPrefix is
-          // "wxyc", so a hardcoded --joy-* var resolves to nothing and the
-          // pinned cell turns transparent over the columns it covers.
-          "& tbody tr > *:last-child": {
-            position: "sticky",
-            right: 0,
-            bgcolor: (theme) => theme.vars.palette.background.surface,
-            borderLeft: "1px solid",
-            borderLeftColor: (theme) => theme.vars.palette.divider,
+          // Selected rows read as intentional: subtle fill + left accent rail.
+          "& tbody tr.row-selected > td": {
+            bgcolor: (theme) => theme.vars.palette.background.level1,
           },
-          "& tbody tr:hover > *:last-child": {
-            bgcolor: "var(--TableRow-hoverBackground)",
+          "& tbody tr.row-selected > td:first-of-type": {
+            boxShadow: (theme) =>
+              `inset 2px 0 0 ${theme.vars.palette.primary[500]}`,
           },
-          // Text cells top-align so artist, title, call # and plays share a
-          // first-line baseline even when a cell grows a second line; the
-          // checkbox, artwork and actions cells stay vertically centered.
-          "& tbody td": {
-            verticalAlign: "top",
-            paddingTop: "12px",
-            paddingBottom: "12px",
+          // Actions are a right-edge overlay, not a reserved column: no dead
+          // space when hidden. Revealed on row hover/focus on pointer
+          // devices; always visible on touch. The hover-bg backdrop keeps
+          // them legible over the stats they cover.
+          "& tbody tr .row-actions": {
+            background:
+              "linear-gradient(to right, transparent, var(--TableRow-hoverBackground) 18px)",
           },
-          "& tbody td:nth-of-type(1), & tbody td:nth-of-type(2), & tbody td:last-child":
-            {
-              verticalAlign: "middle",
+          "@media (hover: hover)": {
+            "& tbody tr .row-actions": {
+              opacity: 0,
+              pointerEvents: "none",
+              transition: "opacity 120ms",
             },
+            "& tbody tr:hover .row-actions, & tbody tr:focus-within .row-actions":
+              {
+                opacity: 1,
+                pointerEvents: "auto",
+              },
+          },
         }}
       >
         <thead>
@@ -116,22 +118,28 @@ export default function Results({
                 sx={{ verticalAlign: "text-bottom" }}
               />
             </th>
-            <th scope="col" style={{ width: 56, padding: 12 }}></th>
-            {/* Artist and Title carry no width: with tableLayout fixed they
-                split the remaining space, so nothing truncates invisibly. */}
-            <th scope="col" aria-sort={ariaSort("artist")} style={{ padding: 12 }}>
+            <th scope="col" style={{ width: 64, padding: 12 }}></th>
+            {/* Fixed-width metadata columns keep call #s, chips and plays
+                vertically aligned; the trailing width-less filler column
+                absorbs all leftover space so the content stays packed left
+                instead of spreading across the table. */}
+            <th
+              scope="col"
+              aria-sort={ariaSort("album") ?? ariaSort("artist")}
+              style={{ width: 300, padding: 12 }}
+            >
+              <TableHeader textValue="Title" />
+              <span style={{ margin: "0 6px", opacity: 0.4 }}>/</span>
               <TableHeader textValue="Artist" />
             </th>
-            <th scope="col" aria-sort={ariaSort("album")} style={{ padding: 12 }}>
-              <TableHeader textValue="Title" />
-            </th>
-            <th scope="col" style={{ width: 110, padding: 12 }}>
+            <th scope="col" style={{ width: 180, padding: 12 }}></th>
+            <th scope="col" style={{ width: 90, padding: 12 }}>
               <TableHeader textValue="Call #" />
             </th>
-            <th scope="col" aria-sort={ariaSort("plays")} style={{ width: 72, padding: 12 }}>
+            <th scope="col" aria-sort={ariaSort("plays")} style={{ width: 70, padding: 12 }}>
               <TableHeader textValue="Plays" />
             </th>
-            <th scope="col" style={{ width: 120, padding: 12 }}></th>
+            <th scope="col" style={{ padding: 12 }}></th>
           </tr>
         </thead>
         <tbody>

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -133,7 +133,7 @@ export default function Results({
               <TableHeader textValue="Artist" />
             </th>
             <th scope="col" style={{ width: 180, padding: 12 }}></th>
-            <th scope="col" style={{ width: 90, padding: 12 }}>
+            <th scope="col" style={{ width: 110, padding: 12 }}>
               <TableHeader textValue="Call #" />
             </th>
             <th scope="col" aria-sort={ariaSort("plays")} style={{ width: 70, padding: 12 }}>

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -53,7 +53,14 @@ export default function Results({
           display: { xs: "none", sm: "table" },
           // Album/Artist have a floor here; below this the container's
           // overflow:auto becomes a horizontal scroll rather than crushing.
-          minWidth: 900,
+          // Lower below xl since Artist collapses into the Album column.
+          minWidth: { xs: 760, xl: 900 },
+          // Below xl the Artist gets its own column; at and below the xl
+          // breakpoint it collapses (the artist stacks under the album title
+          // in the Album column instead) to fit narrower laptops.
+          "& .col-artist": {
+            display: { xs: "none", xl: "table-cell" },
+          },
           "--TableCell-headBackground": (theme) =>
             theme.vars.palette.background.level1,
           "--Table-headerUnderlineThickness": "1px",
@@ -140,10 +147,25 @@ export default function Results({
             {/* Album and Artist carry no width: with table-layout fixed they
                 split the leftover space, so they grow to fill wide screens
                 while the metadata columns stay compact on the right. */}
-            <th scope="col" aria-sort={ariaSort("album")} style={{ padding: 12 }}>
+            <th
+              scope="col"
+              aria-sort={ariaSort("album") ?? ariaSort("artist")}
+              style={{ padding: 12 }}
+            >
               <TableHeader textValue="Album" />
+              {/* Below xl the Artist sort lives here, since the artist is
+                  stacked into this column. */}
+              <Box component="span" sx={{ display: { xs: "inline", xl: "none" } }}>
+                <span style={{ margin: "0 6px", opacity: 0.4 }}>/</span>
+                <TableHeader textValue="Artist" />
+              </Box>
             </th>
-            <th scope="col" aria-sort={ariaSort("artist")} style={{ padding: 12 }}>
+            <th
+              className="col-artist"
+              scope="col"
+              aria-sort={ariaSort("artist")}
+              style={{ padding: 12 }}
+            >
               <TableHeader textValue="Artist" />
             </th>
             <th scope="col" style={{ width: 140, padding: 12 }}></th>

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -73,10 +73,24 @@ export default function Results({
             boxShadow: (theme) =>
               `inset 2px 0 0 ${theme.vars.palette.primary[500]}`,
           },
-          // Actions are a right-edge overlay, not a reserved column: no dead
-          // space when hidden. Revealed on row hover/focus on pointer
-          // devices; always visible on touch. The hover-bg backdrop keeps
-          // them legible over the stats they cover.
+          // The actions live in a zero-width cell pinned (sticky) to the
+          // scroll container's right edge, so they stay at the visible edge
+          // no matter the horizontal scroll — no reserved column, no dead
+          // space, and no need to scroll right to reach them.
+          "& tbody tr > td.actions-cell": {
+            position: "sticky",
+            right: 0,
+            zIndex: 3,
+            width: 0,
+            minWidth: 0,
+            maxWidth: 0,
+            padding: 0,
+            overflow: "visible",
+            background: "transparent",
+          },
+          // Actions are revealed on row hover/focus on pointer devices;
+          // always visible on touch. The hover-bg backdrop keeps them
+          // legible over the stats they cover.
           "& tbody tr .row-actions": {
             background:
               "linear-gradient(to right, transparent, var(--TableRow-hoverBackground) 18px)",
@@ -142,13 +156,15 @@ export default function Results({
             <th scope="col" style={{ width: 160, padding: 12 }}>
               <TableHeader textValue="Label" />
             </th>
+            {/* Zero-width column hosting the sticky hover-actions overlay. */}
+            <th aria-hidden style={{ width: 0, padding: 0 }}></th>
           </tr>
         </thead>
         <tbody>
           {loading ? (
             <tr style={{ background: "transparent" }}>
               <td
-                colSpan={8}
+                colSpan={9}
                 style={{
                   textAlign: "center",
                   paddingTop: "3rem",
@@ -166,7 +182,7 @@ export default function Results({
 
           {!loading && hasMore && (
             <tr>
-              <td colSpan={8} style={{ textAlign: "center" }}>
+              <td colSpan={9} style={{ textAlign: "center" }}>
                 <Button
                   variant="solid"
                   color="primary"

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -5,7 +5,7 @@ import Checkbox from "@mui/joy/Checkbox";
 import CircularProgress from "@mui/joy/CircularProgress";
 import { ChangeEvent } from "react";
 
-import { Table } from "@mui/joy";
+import { Box, Table } from "@mui/joy";
 
 import {
   useCatalogQueryResults,
@@ -13,6 +13,7 @@ import {
 } from "@/src/hooks/catalogHooks";
 import { ColorPaletteProp } from "@mui/joy";
 import CatalogResult from "./Result";
+import CatalogMobileResult from "./MobileResult";
 import ResultsContainer from "./ResultsContainer";
 import TableHeader from "./TableHeader";
 
@@ -47,9 +48,12 @@ export default function Results({
         stickyHeader
         hoverRow
         sx={{
-          // Below this the container's overflow:auto takes over as a
-          // horizontal scroll; columns never get crushed.
-          minWidth: 700,
+          // The table is the desktop layout only; below `sm` the stacked
+          // mobile card list takes over (see below).
+          display: { xs: "none", sm: "table" },
+          // Album/Artist have a floor here; below this the container's
+          // overflow:auto becomes a horizontal scroll rather than crushing.
+          minWidth: 900,
           "--TableCell-headBackground": (theme) =>
             theme.vars.palette.background.level1,
           "--Table-headerUnderlineThickness": "1px",
@@ -119,34 +123,32 @@ export default function Results({
               />
             </th>
             <th scope="col" style={{ width: 64, padding: 12 }}></th>
-            {/* Fixed-width metadata columns keep call #s, chips and plays
-                vertically aligned; the trailing width-less filler column
-                absorbs all leftover space so the content stays packed left
-                instead of spreading across the table. */}
-            <th
-              scope="col"
-              aria-sort={ariaSort("album") ?? ariaSort("artist")}
-              style={{ width: 300, padding: 12 }}
-            >
-              <TableHeader textValue="Title" />
-              <span style={{ margin: "0 6px", opacity: 0.4 }}>/</span>
+            {/* Album and Artist carry no width: with table-layout fixed they
+                split the leftover space, so they grow to fill wide screens
+                while the metadata columns stay compact on the right. */}
+            <th scope="col" aria-sort={ariaSort("album")} style={{ padding: 12 }}>
+              <TableHeader textValue="Album" />
+            </th>
+            <th scope="col" aria-sort={ariaSort("artist")} style={{ padding: 12 }}>
               <TableHeader textValue="Artist" />
             </th>
-            <th scope="col" style={{ width: 180, padding: 12 }}></th>
-            <th scope="col" style={{ width: 110, padding: 12 }}>
+            <th scope="col" style={{ width: 140, padding: 12 }}></th>
+            <th scope="col" style={{ width: 100, padding: 12 }}>
               <TableHeader textValue="Call #" />
             </th>
-            <th scope="col" aria-sort={ariaSort("plays")} style={{ width: 70, padding: 12 }}>
+            <th scope="col" aria-sort={ariaSort("plays")} style={{ width: 60, padding: 12 }}>
               <TableHeader textValue="Plays" />
             </th>
-            <th scope="col" style={{ padding: 12 }}></th>
+            <th scope="col" style={{ width: 160, padding: 12 }}>
+              <TableHeader textValue="Label" />
+            </th>
           </tr>
         </thead>
         <tbody>
           {loading ? (
             <tr style={{ background: "transparent" }}>
               <td
-                colSpan={7}
+                colSpan={8}
                 style={{
                   textAlign: "center",
                   paddingTop: "3rem",
@@ -164,7 +166,7 @@ export default function Results({
 
           {!loading && hasMore && (
             <tr>
-              <td colSpan={7} style={{ textAlign: "center" }}>
+              <td colSpan={8} style={{ textAlign: "center" }}>
                 <Button
                   variant="solid"
                   color="primary"
@@ -182,6 +184,39 @@ export default function Results({
           )}
         </tbody>
       </Table>
+
+      {/* Mobile: the table is hidden below `sm`; results render as a
+          vertical list of stacked cards (Apple-Music-style) instead. */}
+      <Box
+        sx={{
+          display: { xs: "flex", sm: "none" },
+          flexDirection: "column",
+          gap: 1,
+          p: 1,
+        }}
+      >
+        {loading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", pt: "3rem" }}>
+            <CircularProgress color="primary" size="md" />
+          </Box>
+        ) : (
+          releaseList?.map((album) => (
+            <CatalogMobileResult album={album} key={`mobile-result-${album.id}`} />
+          ))
+        )}
+        {!loading && hasMore && (
+          <Button
+            variant="solid"
+            color="primary"
+            size="lg"
+            loading={isFetchingMore}
+            onClick={loadNextPage}
+            sx={{ alignSelf: "center", mt: 1 }}
+          >
+            Load more
+          </Button>
+        )}
+      </Box>
     </ResultsContainer>
   );
 }

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -21,7 +21,14 @@ export default function Results({
 }: {
   color: ColorPaletteProp | undefined;
 }) {
-  const { selected, setSelection } = useCatalogQuerySearch();
+  const { selected, setSelection, sortBy, sortOrder } = useCatalogQuerySearch();
+
+  const ariaSort = (field: string) =>
+    sortBy === field
+      ? sortOrder === "asc"
+        ? ("ascending" as const)
+        : ("descending" as const)
+      : undefined;
 
   const {
     results: releaseList,
@@ -40,6 +47,9 @@ export default function Results({
         stickyHeader
         hoverRow
         sx={{
+          // Below this the container's overflow:auto takes over as a
+          // horizontal scroll; columns never get crushed.
+          minWidth: 760,
           "--TableCell-headBackground": (theme) =>
             theme.vars.palette.background.level1,
           "--Table-headerUnderlineThickness": "1px",
@@ -49,20 +59,39 @@ export default function Results({
             position: "sticky",
             right: 0,
             bgcolor: "var(--TableCell-headBackground)",
+            borderLeft: "1px solid",
+            borderLeftColor: (theme) => theme.vars.palette.divider,
           },
+          // Opaque background is load-bearing: the theme's cssVarPrefix is
+          // "wxyc", so a hardcoded --joy-* var resolves to nothing and the
+          // pinned cell turns transparent over the columns it covers.
           "& tbody tr > *:last-child": {
             position: "sticky",
             right: 0,
-            bgcolor: "var(--joy-palette-background-surface)",
+            bgcolor: (theme) => theme.vars.palette.background.surface,
+            borderLeft: "1px solid",
+            borderLeftColor: (theme) => theme.vars.palette.divider,
           },
           "& tbody tr:hover > *:last-child": {
             bgcolor: "var(--TableRow-hoverBackground)",
           },
+          // Text cells top-align so artist, title, call # and plays share a
+          // first-line baseline even when a cell grows a second line; the
+          // checkbox, artwork and actions cells stay vertically centered.
+          "& tbody td": {
+            verticalAlign: "top",
+            paddingTop: "12px",
+            paddingBottom: "12px",
+          },
+          "& tbody td:nth-of-type(1), & tbody td:nth-of-type(2), & tbody td:last-child":
+            {
+              verticalAlign: "middle",
+            },
         }}
       >
         <thead>
           <tr>
-            <th style={{ width: 48, textAlign: "center", padding: 12 }}>
+            <th scope="col" style={{ width: 48, textAlign: "center", padding: 12 }}>
               <Checkbox
                 indeterminate={
                   selected.length > 0 && selected.length !== releaseList?.length
@@ -87,20 +116,22 @@ export default function Results({
                 sx={{ verticalAlign: "text-bottom" }}
               />
             </th>
-            <th style={{ width: 50, padding: 12 }}></th>
-            <th style={{ width: 180, padding: 12 }}>
+            <th scope="col" style={{ width: 56, padding: 12 }}></th>
+            {/* Artist and Title carry no width: with tableLayout fixed they
+                split the remaining space, so nothing truncates invisibly. */}
+            <th scope="col" aria-sort={ariaSort("artist")} style={{ padding: 12 }}>
               <TableHeader textValue="Artist" />
             </th>
-            <th style={{ width: 180, padding: 12 }}>
+            <th scope="col" aria-sort={ariaSort("album")} style={{ padding: 12 }}>
               <TableHeader textValue="Title" />
             </th>
-            <th style={{ width: 280, padding: 12 }}>
-              <TableHeader textValue="Code" />
+            <th scope="col" style={{ width: 110, padding: 12 }}>
+              <TableHeader textValue="Call #" />
             </th>
-            <th style={{ width: 80, padding: 12 }}>
+            <th scope="col" aria-sort={ariaSort("plays")} style={{ width: 72, padding: 12 }}>
               <TableHeader textValue="Plays" />
             </th>
-            <th style={{ width: 120, padding: 12 }}></th>
+            <th scope="col" style={{ width: 120, padding: 12 }}></th>
           </tr>
         </thead>
         <tbody>

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -11,11 +11,18 @@ import {
   useCatalogQueryResults,
   useCatalogQuerySearch,
 } from "@/src/hooks/catalogHooks";
+import { useQueue, useShowControl } from "@/src/hooks/flowsheetHooks";
+import { useMediaQuery } from "@/src/hooks/useMediaQuery";
 import { ColorPaletteProp } from "@mui/joy";
 import CatalogResult from "./Result";
 import CatalogMobileResult from "./MobileResult";
 import ResultsContainer from "./ResultsContainer";
 import TableHeader from "./TableHeader";
+
+// Below Joy's `sm` breakpoint (600px) the results render as stacked cards
+// instead of the table. Only one layout is rendered at a time (not both
+// CSS-hidden), so a page of N results never mounts 2N component trees.
+const MOBILE_QUERY = "(max-width: 599.95px)";
 
 export default function Results({
   color,
@@ -41,6 +48,54 @@ export default function Results({
   const loading = isLoadingInitial;
   const hasMore = hasNextPage;
   const loadNextPage = fetchNextPage;
+
+  const isMobile = useMediaQuery(MOBILE_QUERY);
+
+  // Hoisted once for the whole list instead of per row: every row shares this
+  // `live` flag and the stable `addToQueue` callback rather than each mounting
+  // its own useShowControl + useQueue (polling-query) subscriptions.
+  const { live } = useShowControl();
+  const { addToQueue } = useQueue();
+
+  const loadMoreButton = hasMore ? (
+    <Button
+      variant="solid"
+      color="primary"
+      size="lg"
+      loading={isFetchingMore}
+      onClick={loadNextPage}
+      sx={{ alignSelf: "center", mt: 1 }}
+    >
+      Load more
+    </Button>
+  ) : null;
+
+  if (isMobile) {
+    return (
+      <ResultsContainer>
+        <Box
+          sx={{ display: "flex", flexDirection: "column", gap: 1, p: 1 }}
+        >
+          {loading ? (
+            <Box sx={{ display: "flex", justifyContent: "center", pt: "3rem" }}>
+              <CircularProgress color="primary" size="md" />
+            </Box>
+          ) : (
+            releaseList?.map((album) => (
+              <CatalogMobileResult
+                album={album}
+                live={live}
+                addToQueue={addToQueue}
+                key={`mobile-result-${album.id}`}
+              />
+            ))
+          )}
+          {!loading && loadMoreButton}
+        </Box>
+      </ResultsContainer>
+    );
+  }
+
   return (
     <ResultsContainer>
       <Table
@@ -48,16 +103,13 @@ export default function Results({
         stickyHeader
         hoverRow
         sx={{
-          // The table is the desktop layout only; below `sm` the stacked
-          // mobile card list takes over (see below).
-          display: { xs: "none", sm: "table" },
           // Album/Artist have a floor here; below this the container's
           // overflow:auto becomes a horizontal scroll rather than crushing.
           // Lower below xl since Artist collapses into the Album column.
           minWidth: { xs: 760, xl: 900 },
-          // Below xl the Artist gets its own column; at and below the xl
-          // breakpoint it collapses (the artist stacks under the album title
-          // in the Album column instead) to fit narrower laptops.
+          // The Artist gets its own column only at and above xl; below xl it
+          // collapses (the artist stacks under the album title in the Album
+          // column instead) to fit narrower laptops.
           "& .col-artist": {
             display: { xs: "none", xl: "table-cell" },
           },
@@ -147,11 +199,7 @@ export default function Results({
             {/* Album and Artist carry no width: with table-layout fixed they
                 split the leftover space, so they grow to fill wide screens
                 while the metadata columns stay compact on the right. */}
-            <th
-              scope="col"
-              aria-sort={ariaSort("album") ?? ariaSort("artist")}
-              style={{ padding: 12 }}
-            >
+            <th scope="col" aria-sort={ariaSort("album")} style={{ padding: 12 }}>
               <TableHeader textValue="Album" />
               {/* Below xl the Artist sort lives here, since the artist is
                   stacked into this column. */}
@@ -168,7 +216,9 @@ export default function Results({
             >
               <TableHeader textValue="Artist" />
             </th>
-            <th scope="col" style={{ width: 140, padding: 12 }}></th>
+            <th scope="col" style={{ width: 140, padding: 12 }}>
+              <TableHeader textValue="Tags" />
+            </th>
             <th scope="col" style={{ width: 100, padding: 12 }}>
               <TableHeader textValue="Call #" />
             </th>
@@ -198,7 +248,12 @@ export default function Results({
             </tr>
           ) : (
             releaseList?.map((album) => (
-              <CatalogResult album={album} key={`result-${album.id}`} />
+              <CatalogResult
+                album={album}
+                live={live}
+                addToQueue={addToQueue}
+                key={`result-${album.id}`}
+              />
             ))
           )}
 
@@ -222,39 +277,6 @@ export default function Results({
           )}
         </tbody>
       </Table>
-
-      {/* Mobile: the table is hidden below `sm`; results render as a
-          vertical list of stacked cards (Apple-Music-style) instead. */}
-      <Box
-        sx={{
-          display: { xs: "flex", sm: "none" },
-          flexDirection: "column",
-          gap: 1,
-          p: 1,
-        }}
-      >
-        {loading ? (
-          <Box sx={{ display: "flex", justifyContent: "center", pt: "3rem" }}>
-            <CircularProgress color="primary" size="md" />
-          </Box>
-        ) : (
-          releaseList?.map((album) => (
-            <CatalogMobileResult album={album} key={`mobile-result-${album.id}`} />
-          ))
-        )}
-        {!loading && hasMore && (
-          <Button
-            variant="solid"
-            color="primary"
-            size="lg"
-            loading={isFetchingMore}
-            onClick={loadNextPage}
-            sx={{ alignSelf: "center", mt: 1 }}
-          >
-            Load more
-          </Button>
-        )}
-      </Box>
     </ResultsContainer>
   );
 }

--- a/src/components/experiences/modern/catalog/Results/TableHeader.tsx
+++ b/src/components/experiences/modern/catalog/Results/TableHeader.tsx
@@ -11,7 +11,7 @@ import { Link } from "@mui/joy";
 
 const SORT_FIELDS: Record<string, CatalogSortBy> = {
   Artist: "artist",
-  Title: "album",
+  Album: "album",
   Plays: "plays",
 };
 

--- a/src/components/experiences/modern/catalog/Results/__tests__/MobileResult.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/MobileResult.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { fireEvent, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { createTestAlbum, createTestArtist } from "@/lib/test-utils";
 import { renderWithProviders } from "@/lib/test-utils/render";
 
@@ -16,15 +16,6 @@ vi.mock("next/link", () => ({
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
   useShowControl: () => ({ live: false }),
   useQueue: () => ({ addToQueue: vi.fn() }),
-}));
-
-const setSelection = vi.fn();
-vi.mock("@/src/hooks/catalogHooks", () => ({
-  useCatalogQuerySearch: () => ({
-    selected: [],
-    setSelection,
-    sortBy: "album",
-  }),
 }));
 
 import CatalogMobileResult from "../MobileResult";
@@ -65,11 +56,9 @@ describe("CatalogMobileResult", () => {
     expect(meta.textContent?.trim()).toBe("RO 87/4");
   });
 
-  it("toggles selection via the checkbox without opening the detail panel", () => {
+  it("does not render a selection checkbox on mobile", () => {
     renderWithProviders(<CatalogMobileResult album={album} />);
-    const checkbox = screen.getByRole("checkbox");
-    fireEvent.click(checkbox);
-    expect(setSelection).toHaveBeenCalledWith([album.id]);
+    expect(screen.queryByRole("checkbox")).toBeNull();
   });
 
   it("shows the WXYC EXCLUSIVE chip when not on streaming", () => {

--- a/src/components/experiences/modern/catalog/Results/__tests__/MobileResult.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/MobileResult.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { createTestAlbum, createTestArtist } from "@/lib/test-utils";
+import { renderWithProviders } from "@/lib/test-utils/render";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/dashboard/catalog",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useShowControl: () => ({ live: false }),
+  useQueue: () => ({ addToQueue: vi.fn() }),
+}));
+
+const setSelection = vi.fn();
+vi.mock("@/src/hooks/catalogHooks", () => ({
+  useCatalogQuerySearch: () => ({
+    selected: [],
+    setSelection,
+    sortBy: "album",
+  }),
+}));
+
+import CatalogMobileResult from "../MobileResult";
+
+describe("CatalogMobileResult", () => {
+  const album = createTestAlbum({
+    title: "On Your Own Love Again",
+    artist: createTestArtist({ name: "Jessica Pratt", lettercode: "RO", numbercode: 87 }),
+    entry: 4,
+    format: "Vinyl",
+    plays: 42,
+    label: "Drag City",
+  });
+
+  it("renders album title, artist, and the stacked metadata line", () => {
+    renderWithProviders(<CatalogMobileResult album={album} />);
+
+    expect(screen.getByText("On Your Own Love Again")).toBeDefined();
+    expect(screen.getByText("Jessica Pratt")).toBeDefined();
+    // call # · plays · label all on one stacked metadata line
+    const meta = screen.getByText(/RO 87\/4/);
+    expect(meta.textContent).toContain("42 plays");
+    expect(meta.textContent).toContain("Drag City");
+  });
+
+  it("renders genre and format chips", () => {
+    renderWithProviders(<CatalogMobileResult album={album} />);
+    expect(screen.getByText(album.artist.genre)).toBeDefined();
+    expect(screen.getByText("Vinyl")).toBeDefined();
+  });
+
+  it("omits empty metadata segments", () => {
+    renderWithProviders(
+      <CatalogMobileResult album={createTestAlbum({ ...album, plays: 0, label: "" })} />
+    );
+    const meta = screen.getByText(/RO 87\/4/);
+    expect(meta.textContent).not.toContain("plays");
+    expect(meta.textContent?.trim()).toBe("RO 87/4");
+  });
+
+  it("toggles selection via the checkbox without opening the detail panel", () => {
+    renderWithProviders(<CatalogMobileResult album={album} />);
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.click(checkbox);
+    expect(setSelection).toHaveBeenCalledWith([album.id]);
+  });
+
+  it("shows the WXYC EXCLUSIVE chip when not on streaming", () => {
+    renderWithProviders(
+      <CatalogMobileResult album={createTestAlbum({ ...album, on_streaming: false })} />
+    );
+    expect(screen.getByText("WXYC EXCLUSIVE")).toBeDefined();
+  });
+});

--- a/src/components/experiences/modern/catalog/Results/__tests__/MobileResult.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/MobileResult.test.tsx
@@ -31,7 +31,7 @@ describe("CatalogMobileResult", () => {
   });
 
   it("renders album title, artist, and the stacked metadata line", () => {
-    renderWithProviders(<CatalogMobileResult album={album} />);
+    renderWithProviders(<CatalogMobileResult album={album} live={false} addToQueue={vi.fn()} />);
 
     expect(screen.getByText("On Your Own Love Again")).toBeDefined();
     expect(screen.getByText("Jessica Pratt")).toBeDefined();
@@ -42,14 +42,14 @@ describe("CatalogMobileResult", () => {
   });
 
   it("renders genre and format chips", () => {
-    renderWithProviders(<CatalogMobileResult album={album} />);
+    renderWithProviders(<CatalogMobileResult album={album} live={false} addToQueue={vi.fn()} />);
     expect(screen.getByText(album.artist.genre)).toBeDefined();
     expect(screen.getByText("Vinyl")).toBeDefined();
   });
 
   it("omits empty metadata segments", () => {
     renderWithProviders(
-      <CatalogMobileResult album={createTestAlbum({ ...album, plays: 0, label: "" })} />
+      <CatalogMobileResult album={createTestAlbum({ ...album, plays: 0, label: "" })} live={false} addToQueue={vi.fn()} />
     );
     const meta = screen.getByText(/RO 87\/4/);
     expect(meta.textContent).not.toContain("plays");
@@ -57,13 +57,13 @@ describe("CatalogMobileResult", () => {
   });
 
   it("does not render a selection checkbox on mobile", () => {
-    renderWithProviders(<CatalogMobileResult album={album} />);
+    renderWithProviders(<CatalogMobileResult album={album} live={false} addToQueue={vi.fn()} />);
     expect(screen.queryByRole("checkbox")).toBeNull();
   });
 
   it("shows the WXYC EXCLUSIVE chip when not on streaming", () => {
     renderWithProviders(
-      <CatalogMobileResult album={createTestAlbum({ ...album, on_streaming: false })} />
+      <CatalogMobileResult album={createTestAlbum({ ...album, on_streaming: false })} live={false} addToQueue={vi.fn()} />
     );
     expect(screen.getByText("WXYC EXCLUSIVE")).toBeDefined();
   });

--- a/src/components/experiences/modern/catalog/Results/__tests__/ReleaseChips.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/ReleaseChips.test.tsx
@@ -40,11 +40,18 @@ describe("ReleaseChips", () => {
     expect(screen.queryByText("+1")).toBeNull();
   });
 
-  it("should preserve casing on arbitrary format strings", () => {
+  it("should tidy attested lowercase formats but preserve arbitrary ones", () => {
+    const { unmount } = renderWithProviders(
+      <ReleaseChips genre="Rock" format={"vinyl" as never} onStreaming={undefined} />
+    );
+    // Bare lowercase "vinyl" is presented as "Vinyl".
+    expect(screen.getByText("Vinyl")).toBeDefined();
+    unmount();
+
     renderWithProviders(
       <ReleaseChips genre="Rock" format={"CD-R" as never} onStreaming={undefined} />
     );
-    // Not case-mangled to "Cd-r".
+    // Anything with existing casing/punctuation is preserved, not "Cd-r".
     expect(screen.getByText("CD-R")).toBeDefined();
   });
 

--- a/src/components/experiences/modern/catalog/Results/__tests__/ReleaseChips.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/ReleaseChips.test.tsx
@@ -27,13 +27,29 @@ describe("ReleaseChips", () => {
     expect(screen.queryByText("WXYC EXCLUSIVE")).toBeNull();
   });
 
-  it("should wrap chips instead of forcing one line", () => {
+  it("should collapse past three pills into a +N overflow chip", () => {
     renderWithProviders(
-      <ReleaseChips genre="Jazz" format="Vinyl" onStreaming={false} />
+      <ReleaseChips genre="Jazz" format="Vinyl" rotation="H" onStreaming={false} />
     );
 
-    const stack = screen.getByText("Jazz").closest(".MuiStack-root");
-    expect(stack).not.toBeNull();
-    expect(getComputedStyle(stack!).flexWrap).toBe("wrap");
+    // format is lowest priority: folded into the overflow chip
+    expect(screen.getByText("Jazz")).toBeDefined();
+    expect(screen.getByText("H")).toBeDefined();
+    expect(screen.getByText("WXYC EXCLUSIVE")).toBeDefined();
+    expect(screen.queryByText("Vinyl")).toBeNull();
+    expect(screen.getByText("+1")).toBeDefined();
+  });
+
+  it("should render the rotation pill only when a rotation is provided", () => {
+    const { unmount } = renderWithProviders(
+      <ReleaseChips genre="Jazz" format="Vinyl" rotation="H" onStreaming={undefined} />
+    );
+    expect(screen.getByText("H")).toBeDefined();
+    unmount();
+
+    renderWithProviders(
+      <ReleaseChips genre="Jazz" format="Vinyl" onStreaming={undefined} />
+    );
+    expect(screen.queryByText("H")).toBeNull();
   });
 });

--- a/src/components/experiences/modern/catalog/Results/__tests__/ReleaseChips.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/ReleaseChips.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+
+import { ReleaseChips } from "../ReleaseChips";
+
+describe("ReleaseChips", () => {
+  it("should render genre and format chips", () => {
+    renderWithProviders(
+      <ReleaseChips genre="Rock" format="Vinyl" onStreaming={undefined} />
+    );
+
+    expect(screen.getByText("Rock")).toBeDefined();
+    expect(screen.getByText("Vinyl")).toBeDefined();
+  });
+
+  it("should render the WXYC EXCLUSIVE chip only when onStreaming is false", () => {
+    const { unmount } = renderWithProviders(
+      <ReleaseChips genre="Electronic" format="CD" onStreaming={false} />
+    );
+    expect(screen.getByText("WXYC EXCLUSIVE")).toBeDefined();
+    unmount();
+
+    renderWithProviders(
+      <ReleaseChips genre="Electronic" format="CD" onStreaming={true} />
+    );
+    expect(screen.queryByText("WXYC EXCLUSIVE")).toBeNull();
+  });
+
+  it("should wrap chips instead of forcing one line", () => {
+    renderWithProviders(
+      <ReleaseChips genre="Jazz" format="Vinyl" onStreaming={false} />
+    );
+
+    const stack = screen.getByText("Jazz").closest(".MuiStack-root");
+    expect(stack).not.toBeNull();
+    expect(getComputedStyle(stack!).flexWrap).toBe("wrap");
+  });
+});

--- a/src/components/experiences/modern/catalog/Results/__tests__/ReleaseChips.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/ReleaseChips.test.tsx
@@ -27,17 +27,25 @@ describe("ReleaseChips", () => {
     expect(screen.queryByText("WXYC EXCLUSIVE")).toBeNull();
   });
 
-  it("should collapse past three pills into a +N overflow chip", () => {
+  it("should show all four pills (no overflow) so format stays visible", () => {
     renderWithProviders(
       <ReleaseChips genre="Jazz" format="Vinyl" rotation="H" onStreaming={false} />
     );
 
-    // format is lowest priority: folded into the overflow chip
+    // All four wrap; format (Vinyl vs CD) is never folded away.
     expect(screen.getByText("Jazz")).toBeDefined();
+    expect(screen.getByText("Vinyl")).toBeDefined();
     expect(screen.getByText("H")).toBeDefined();
     expect(screen.getByText("WXYC EXCLUSIVE")).toBeDefined();
-    expect(screen.queryByText("Vinyl")).toBeNull();
-    expect(screen.getByText("+1")).toBeDefined();
+    expect(screen.queryByText("+1")).toBeNull();
+  });
+
+  it("should preserve casing on arbitrary format strings", () => {
+    renderWithProviders(
+      <ReleaseChips genre="Rock" format={"CD-R" as never} onStreaming={undefined} />
+    );
+    // Not case-mangled to "Cd-r".
+    expect(screen.getByText("CD-R")).toBeDefined();
   });
 
   it("should render the rotation pill only when a rotation is provided", () => {

--- a/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
@@ -183,6 +183,82 @@ describe("CatalogResult Various Artists display", () => {
   });
 });
 
+describe("CatalogResult call number column", () => {
+  const album = createTestAlbum({
+    artist: createTestArtist({ name: "Stereolab", lettercode: "RO", numbercode: 87 }),
+    entry: 4,
+  });
+
+  it("should render the call number in its own cell with no chips", () => {
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    const callCell = Array.from(document.querySelectorAll("td")).find((cell) =>
+      cell.textContent?.includes("RO 87/4")
+    );
+    expect(callCell).toBeDefined();
+    expect(callCell!.textContent?.trim()).toBe("RO 87/4");
+    expect(callCell!.querySelectorAll(".MuiChip-root")).toHaveLength(0);
+  });
+
+  it("should never wrap the call number", () => {
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    const callNumber = screen.getByText("RO 87/4");
+    expect(getComputedStyle(callNumber).whiteSpace).toBe("nowrap");
+  });
+
+  it("should render genre and format chips inside the title cell", () => {
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    const titleCell = Array.from(document.querySelectorAll("td")).find((cell) =>
+      cell.textContent?.includes(album.title)
+    );
+    expect(titleCell).toBeDefined();
+    expect(titleCell!.textContent).toContain(album.artist.genre);
+    expect(titleCell!.textContent).toContain(album.format);
+  });
+});
+
+describe("CatalogResult text clamping", () => {
+  it("should expose full artist and title text via the title attribute", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Chuquimamani-Condori", lettercode: "EL", numbercode: 12 }),
+      title: "DJ E",
+    });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByText("Chuquimamani-Condori").getAttribute("title")).toBe(
+      "Chuquimamani-Condori"
+    );
+    expect(screen.getByText("DJ E").getAttribute("title")).toBe("DJ E");
+  });
+});
+
 describe("CatalogResult album artwork", () => {
   it("should render album artwork when artwork_url is provided", () => {
     const album = createTestAlbum({

--- a/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
@@ -35,7 +35,7 @@ describe("CatalogResult plays metadata (Bug 12)", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -49,7 +49,7 @@ describe("CatalogResult plays metadata (Bug 12)", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -63,7 +63,7 @@ describe("CatalogResult plays metadata (Bug 12)", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -79,7 +79,7 @@ describe("CatalogResult WXYC Exclusive badge", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -93,7 +93,7 @@ describe("CatalogResult WXYC Exclusive badge", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -107,7 +107,7 @@ describe("CatalogResult WXYC Exclusive badge", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -127,7 +127,7 @@ describe("CatalogResult Various Artists display", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -146,7 +146,7 @@ describe("CatalogResult Various Artists display", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -162,7 +162,7 @@ describe("CatalogResult Various Artists display", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -182,7 +182,7 @@ describe("CatalogResult call number column", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -197,7 +197,7 @@ describe("CatalogResult call number column", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -210,7 +210,7 @@ describe("CatalogResult call number column", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -233,7 +233,7 @@ describe("CatalogResult text clamping", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -255,7 +255,7 @@ describe("CatalogResult record label column", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -266,19 +266,25 @@ describe("CatalogResult record label column", () => {
     expect(labelCell!.textContent).not.toContain(album.title);
   });
 
-  it("should show a dash when the label is empty", () => {
-    const album = createTestAlbum({ label: "" });
+  it("should show a dash in the label cell when the label is empty", () => {
+    // Give plays a nonzero value so its cell doesn't also render "—"; then the
+    // only dash is the label fallback, so this test can actually fail if that
+    // fallback regresses.
+    const album = createTestAlbum({ label: "", plays: 12 });
 
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
 
-    // plays default 0 also renders "—", so expect two dashes (plays + label)
-    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+    const labelCell = screen.getByText("—").closest("td");
+    expect(labelCell).not.toBeNull();
+    // The dash is in the label cell, not the plays cell (which shows "12").
+    expect(labelCell!.textContent).not.toContain("12");
+    expect(screen.getByText("12")).toBeDefined();
   });
 });
 
@@ -291,7 +297,7 @@ describe("CatalogResult album artwork", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -307,7 +313,7 @@ describe("CatalogResult album artwork", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );
@@ -321,7 +327,7 @@ describe("CatalogResult album artwork", () => {
     renderWithProviders(
       <table>
         <tbody>
-          <CatalogResult album={album} />
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
         </tbody>
       </table>
     );

--- a/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
@@ -132,7 +132,8 @@ describe("CatalogResult Various Artists display", () => {
       </table>
     );
 
-    expect(screen.getByText("Various Artists")).toBeDefined();
+    // Rendered in both the stacked (< xl) and separate-column (xl) layouts.
+    expect(screen.getAllByText("Various Artists").length).toBeGreaterThan(0);
   });
 
   it("should display the album_artist as subtext when set", () => {
@@ -150,7 +151,7 @@ describe("CatalogResult Various Artists display", () => {
       </table>
     );
 
-    expect(screen.getByText("Autechre")).toBeDefined();
+    expect(screen.getAllByText("Autechre").length).toBeGreaterThan(0);
   });
 
   it("should display artist name normally when album_artist is not set", () => {
@@ -166,7 +167,7 @@ describe("CatalogResult Various Artists display", () => {
       </table>
     );
 
-    expect(screen.getByText("Stereolab")).toBeDefined();
+    expect(screen.getAllByText("Stereolab").length).toBeGreaterThan(0);
     expect(screen.queryByText("Various Artists")).toBeNull();
   });
 });
@@ -237,7 +238,7 @@ describe("CatalogResult text clamping", () => {
       </table>
     );
 
-    expect(screen.getByText("Chuquimamani-Condori").getAttribute("title")).toBe(
+    expect(screen.getAllByText("Chuquimamani-Condori")[0].getAttribute("title")).toBe(
       "Chuquimamani-Condori"
     );
     expect(screen.getByText("DJ E").getAttribute("title")).toBe("DJ E");

--- a/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
@@ -244,6 +244,43 @@ describe("CatalogResult text clamping", () => {
   });
 });
 
+describe("CatalogResult record label column", () => {
+  it("should render the record label in its own cell, separate from the album", () => {
+    const album = createTestAlbum({
+      title: "On Your Own Love Again",
+      label: "Drag City",
+    });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    const labelCell = screen.getByText("Drag City").closest("td");
+    expect(labelCell).not.toBeNull();
+    // Label is its own column, not bundled with the album title
+    expect(labelCell!.textContent).not.toContain(album.title);
+  });
+
+  it("should show a dash when the label is empty", () => {
+    const album = createTestAlbum({ label: "" });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} />
+        </tbody>
+      </table>
+    );
+
+    // plays default 0 also renders "—", so expect two dashes (plays + label)
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+});
+
 describe("CatalogResult album artwork", () => {
   it("should render album artwork when artwork_url is provided", () => {
     const album = createTestAlbum({

--- a/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
+++ b/src/components/experiences/modern/catalog/Results/__tests__/Result.test.tsx
@@ -28,7 +28,7 @@ vi.mock("@/src/hooks/catalogHooks", () => ({
 
 import CatalogResult from "../Result";
 
-describe("CatalogResult plays column (Bug 12)", () => {
+describe("CatalogResult plays metadata (Bug 12)", () => {
   it("should display the actual play count, not hardcoded 0", () => {
     const album = createTestAlbum({ plays: 42 });
 
@@ -40,11 +40,7 @@ describe("CatalogResult plays column (Bug 12)", () => {
       </table>
     );
 
-    const cells = document.querySelectorAll("td");
-    const playsCell = Array.from(cells).find(
-      (cell) => cell.textContent?.trim() === "42"
-    );
-    expect(playsCell).toBeDefined();
+    expect(screen.getByText("42")).toBeDefined();
   });
 
   it("should display dash when plays is 0", () => {
@@ -58,11 +54,7 @@ describe("CatalogResult plays column (Bug 12)", () => {
       </table>
     );
 
-    const cells = document.querySelectorAll("td");
-    const playsCell = Array.from(cells).find(
-      (cell) => cell.textContent?.trim() === "—"
-    );
-    expect(playsCell).toBeDefined();
+    expect(screen.getByText("—")).toBeDefined();
   });
 
   it("should display dash when plays is undefined", () => {
@@ -76,11 +68,7 @@ describe("CatalogResult plays column (Bug 12)", () => {
       </table>
     );
 
-    const cells = document.querySelectorAll("td");
-    const playsCell = Array.from(cells).find(
-      (cell) => cell.textContent?.trim() === "—"
-    );
-    expect(playsCell).toBeDefined();
+    expect(screen.getByText("—")).toBeDefined();
   });
 });
 
@@ -189,7 +177,7 @@ describe("CatalogResult call number column", () => {
     entry: 4,
   });
 
-  it("should render the call number in its own cell with no chips", () => {
+  it("should render the call number in its own aligned cell with no chips", () => {
     renderWithProviders(
       <table>
         <tbody>
@@ -198,10 +186,8 @@ describe("CatalogResult call number column", () => {
       </table>
     );
 
-    const callCell = Array.from(document.querySelectorAll("td")).find((cell) =>
-      cell.textContent?.includes("RO 87/4")
-    );
-    expect(callCell).toBeDefined();
+    const callCell = screen.getByText("RO 87/4").closest("td");
+    expect(callCell).not.toBeNull();
     expect(callCell!.textContent?.trim()).toBe("RO 87/4");
     expect(callCell!.querySelectorAll(".MuiChip-root")).toHaveLength(0);
   });
@@ -219,7 +205,7 @@ describe("CatalogResult call number column", () => {
     expect(getComputedStyle(callNumber).whiteSpace).toBe("nowrap");
   });
 
-  it("should render genre and format chips inside the title cell", () => {
+  it("should render genre and format chips in their own aligned cell", () => {
     renderWithProviders(
       <table>
         <tbody>
@@ -228,12 +214,11 @@ describe("CatalogResult call number column", () => {
       </table>
     );
 
-    const titleCell = Array.from(document.querySelectorAll("td")).find((cell) =>
-      cell.textContent?.includes(album.title)
-    );
-    expect(titleCell).toBeDefined();
-    expect(titleCell!.textContent).toContain(album.artist.genre);
-    expect(titleCell!.textContent).toContain(album.format);
+    const chipsCell = screen.getByText(album.artist.genre).closest("td");
+    expect(chipsCell).not.toBeNull();
+    expect(chipsCell!.textContent).toContain(album.format);
+    // Chips column, not mixed into the release identity
+    expect(chipsCell!.textContent).not.toContain(album.title);
   });
 });
 

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Subscribe to a CSS media query. SSR-safe: returns `defaultValue` on the
+ * server and the first client render, then reconciles after mount. Safe for
+ * client-fetched UI where the first paint is a spinner (no server-rendered
+ * content to mismatch).
+ */
+export function useMediaQuery(query: string, defaultValue = false): boolean {
+  const [matches, setMatches] = useState(defaultValue);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+    const onChange = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- Call number (`R 123/4`) gets its own narrow monospace column that never truncates; "Code" header renamed "Call #"
- Genre/format/WXYC-EXCLUSIVE chips move out of the code cell into a wrapping row under the title (new `ReleaseChips`, same grammar as `MatchedTrackChips`); always-soft variant with normalized format casing
- Artist/Title become flexible-width columns with a 2-line clamp; full text stays available via the `title` attribute
- Table `minWidth: 760` makes the container's `overflow: auto` a horizontal-scroll fallback at narrow widths; the sticky actions cell gets an opaque theme-safe background (the hardcoded `--joy-*` var never resolved under the `wxyc` cssVarPrefix, leaving it transparent) plus a left divider
- Text cells top-align so first lines share a baseline; `scope="col"` and `aria-sort` on headers

## Note on base
Includes `feat/onboarding-token-flow` (merged in for working local auth, per Jackson); the catalog changes themselves are the last commit.

## Test plan
- `npm run test:run src/components/experiences/modern/catalog` — 61 pass (7 new)
- `npx tsc --noEmit` clean
- Visually verified on localhost:3000 (wide + 900px compressed, dark mode) with user sign-off on the polish pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)