### PR TITLE
test(auth): QR device-authorization sign-in e2e (golden + deny + non-DJ)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,6 +28,12 @@ env:
   NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED: "true"
   NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED: "true"
   NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED: "true"
+  # Build-time gate for the RFC 8628 QR sign-in method. Inlined into the
+  # dj-site build, so it must be present here (the build-cache key hashes this
+  # workflow file, so flipping it auto-invalidates the stale .next/ cache).
+  # Required by e2e/tests/auth/qr-signin.spec.ts — without it the "Sign in with
+  # a QR code" entry link never renders and the spec can't reach the QR stage.
+  NEXT_PUBLIC_QR_LOGIN_ENABLED: "true"
   NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD: temppass123
   NEXT_PUBLIC_APP_ORGANIZATION: test-org
   SESSION_SECRET: e2e-secret-for-testing

--- a/e2e/helpers/device-auth.ts
+++ b/e2e/helpers/device-auth.ts
@@ -1,0 +1,97 @@
+import type { APIRequestContext, APIResponse } from "@playwright/test";
+import type {
+  DeviceAuthApproveRequest,
+  DeviceAuthDenyRequest,
+} from "@wxyc/shared/dtos";
+
+/**
+ * The "phone" side of the RFC 8628 QR sign-in flow, for the two-context e2e
+ * spec (`e2e/tests/auth/qr-signin.spec.ts`). The shared browser (Context A)
+ * polls `/auth/device/token`; a *separate* authenticated principal (Context B,
+ * the phone) claims and then approves/denies the user code. These helpers are
+ * the Context-B calls, mirroring Backend-Service's integration recipe in
+ * `tests/integration/device-authorization.spec.js`.
+ *
+ * Pass the phone context's own `request` (`context.request`) so the session
+ * cookie from its `storageState` attaches automatically — the `dj2.json` /
+ * `member.json` session cookie is scoped to `domain=localhost` (port-agnostic),
+ * so it is sent to the auth service even though login happened on the frontend
+ * port. See the auth-base resolution note below.
+ *
+ * Casing asymmetry (already flagged in #785 and in the @wxyc/shared DTOs):
+ * `/device/code` and `/device/token` bodies are snake_case, but `/device/approve`
+ * and `/device/deny` bodies are camelCase `{ userCode }`.
+ */
+
+/**
+ * Resolve the auth-service base URL (no trailing `/auth`) for the direct,
+ * cross-origin device-flow calls. dj-site does NOT proxy `/auth/*` (see
+ * `next.config.mjs`), so the phone must target the auth service directly rather
+ * than the dj-site origin. Mirrors `getAuthServiceBaseUrl()` in
+ * `e2e/fixtures/auth.fixture.ts`.
+ */
+export function authServiceBaseUrl(): string {
+  const authUrl = process.env.NEXT_PUBLIC_BETTER_AUTH_URL;
+  if (authUrl) {
+    // e.g. "http://localhost:8084/auth" -> "http://localhost:8084"
+    return authUrl.replace(/\/auth\/?$/, "");
+  }
+  const authPort = process.env.E2E_AUTH_PORT;
+  if (authPort) {
+    return `http://localhost:${authPort}`;
+  }
+  throw new Error(
+    "device-auth e2e helper: set NEXT_PUBLIC_BETTER_AUTH_URL or E2E_AUTH_PORT " +
+      "(exported by scripts/e2e-local.sh and the CI workflow)."
+  );
+}
+
+/**
+ * Claim a pending user code as the authenticated principal.
+ *
+ * `GET /auth/device?user_code=<code>` reads the session from the request and,
+ * if the row has no `userId`, atomically binds `userId = session.user.id`.
+ * `/device/approve` and `/device/deny` both require the row to be claimed by the
+ * same session first — approving an unclaimed row 400s.
+ */
+export function claimDeviceCode(
+  request: APIRequestContext,
+  userCode: string
+): Promise<APIResponse> {
+  return request.get(
+    `${authServiceBaseUrl()}/auth/device?user_code=${encodeURIComponent(userCode)}`
+  );
+}
+
+/**
+ * Approve a claimed user code. On success the plugin flips the row to
+ * `approved` and the shared browser's next `/device/token` poll returns a
+ * session. A non-DJ principal is rejected here with a 403 `access_denied`
+ * (Backend-Service's role gate runs before the flip) and the row is un-claimed,
+ * so a legitimate DJ can still approve the same code — see the S1 contract in
+ * `Backend-Service/shared/authentication/src/device-authorization.ts`.
+ */
+export function approveDeviceCode(
+  request: APIRequestContext,
+  userCode: string
+): Promise<APIResponse> {
+  const body: DeviceAuthApproveRequest = { userCode };
+  return request.post(`${authServiceBaseUrl()}/auth/device/approve`, {
+    data: body,
+  });
+}
+
+/**
+ * Deny a claimed user code. The plugin flips the row to `denied` (a terminal
+ * state, unlike the non-DJ-approve reset), so the shared browser's next
+ * `/device/token` poll returns `access_denied`.
+ */
+export function denyDeviceCode(
+  request: APIRequestContext,
+  userCode: string
+): Promise<APIResponse> {
+  const body: DeviceAuthDenyRequest = { userCode };
+  return request.post(`${authServiceBaseUrl()}/auth/device/deny`, {
+    data: body,
+  });
+}

--- a/e2e/helpers/device-auth.ts
+++ b/e2e/helpers/device-auth.ts
@@ -24,10 +24,13 @@ import type {
  */
 
 /**
- * Resolve the auth-service base URL (no trailing `/auth`) for the direct,
- * cross-origin device-flow calls. dj-site does NOT proxy `/auth/*` (see
- * `next.config.mjs`), so the phone must target the auth service directly rather
- * than the dj-site origin. Mirrors `getAuthServiceBaseUrl()` in
+ * Resolve the auth-service base URL (no trailing `/auth`) for the phone's
+ * device-flow calls. The phone targets the auth service (`:8084`) directly
+ * rather than dj-site's same-origin `/auth` proxy (`app/auth/[...path]/route.ts`,
+ * which the browser side uses): hitting the auth service directly is the
+ * simplest reliable target and doesn't depend on the dj-site origin, and the
+ * `dj2.json`/`member.json` session cookie is `domain=localhost` (port-agnostic)
+ * so it attaches regardless of port. Mirrors `getAuthServiceBaseUrl()` in
  * `e2e/fixtures/auth.fixture.ts`.
  */
 export function authServiceBaseUrl(): string {

--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -24,6 +24,14 @@ export class LoginPage {
   readonly sendCodeButton: Locator;
   readonly switchToPasswordLink: Locator;
 
+  // QR (RFC 8628 device-authorization) sign-in elements. Present only when the
+  // build sets NEXT_PUBLIC_QR_LOGIN_ENABLED (see e2e-tests.yml / e2e-local.sh).
+  readonly qrLoginLink: Locator;
+  readonly qrScanHeading: Locator;
+  readonly qrUserCode: Locator;
+  readonly qrDeniedHeading: Locator;
+  readonly qrPasswordFallbackLink: Locator;
+
   // Feedback elements
   readonly errorToast: Locator;
   readonly successToast: Locator;
@@ -44,6 +52,21 @@ export class LoginPage {
     this.sendCodeButton = page.locator('button:has-text("Send login code")');
     this.switchToPasswordLink = page.getByRole("button", {
       name: "Sign in with password instead",
+    });
+
+    // QR sign-in. The entry link renders on both the password and OTP-email
+    // forms; /login defaults to the OTP-email form, so it's reachable straight
+    // after goto(). QRCodeForm's waiting state exposes the user code via a
+    // data-testid; the denied state and always-present password fallback are
+    // matched by their visible copy.
+    this.qrLoginLink = page.getByRole("button", {
+      name: "Sign in with a QR code",
+    });
+    this.qrScanHeading = page.getByText("Scan to sign in");
+    this.qrUserCode = page.getByTestId("device-user-code");
+    this.qrDeniedHeading = page.getByText("Sign-in was declined");
+    this.qrPasswordFallbackLink = page.getByRole("button", {
+      name: "Use a password instead",
     });
 
     // Password reset form
@@ -101,6 +124,36 @@ export class LoginPage {
     }
     // Final attempt with a longer timeout to produce a clear error
     await this.usernameInput.waitFor({ state: "visible", timeout: 10000 });
+  }
+
+  /**
+   * From the default (OTP-email) login form, switch to the QR sign-in method
+   * and wait for the waiting state (QR + user code) to render.
+   *
+   * Clicking the entry link dispatches a Redux `setAuthStage("qr")`; on slow CI
+   * runners that dispatch can occasionally miss a re-render, so retry the click
+   * until the user-code element appears. Once the QR form mounts, the entry link
+   * detaches — guard each retry on the link still being visible so we never
+   * click into the void.
+   */
+  async startQrLogin(): Promise<void> {
+    await this.qrLoginLink.waitFor({ state: "visible", timeout: 15000 });
+    for (let attempt = 0; attempt < 3; attempt++) {
+      if (await this.qrUserCode.isVisible()) return;
+      if (await this.qrLoginLink.isVisible()) {
+        await this.qrLoginLink.click().catch(() => {
+          // Element may detach mid-hydration — the waitFor below retries.
+        });
+      }
+      try {
+        await this.qrUserCode.waitFor({ state: "visible", timeout: 8000 });
+        return;
+      } catch {
+        // Stage didn't transition — retry the click.
+      }
+    }
+    // Final attempt with a longer timeout to produce a clear failure message.
+    await this.qrUserCode.waitFor({ state: "visible", timeout: 8000 });
   }
 
   async gotoWithToken(token: string): Promise<void> {
@@ -211,8 +264,8 @@ export class LoginPage {
     return this.page.url().includes("/login");
   }
 
-  async waitForRedirectToDashboard(): Promise<void> {
-    await this.page.waitForURL("**/dashboard/**", { timeout: 10000 });
+  async waitForRedirectToDashboard(timeoutMs = 10000): Promise<void> {
+    await this.page.waitForURL("**/dashboard/**", { timeout: timeoutMs });
   }
 
   async waitForRedirectToOnboarding(): Promise<void> {

--- a/e2e/tests/auth/qr-signin.spec.ts
+++ b/e2e/tests/auth/qr-signin.spec.ts
@@ -18,11 +18,11 @@ import {
  * can't be exercised by the single-page component/hook specs, so it lives here.
  *
  * Context B reuses a saved `storageState` (no interactive login) and talks to
- * the auth service directly, cross-origin — dj-site does NOT proxy `/auth/*`
- * (see `next.config.mjs`), and the session cookie is `domain=localhost`
- * (port-agnostic), so it attaches to the auth-service port regardless of which
- * frontend port minted it. We use `dj2.json`, not `dj.json` (the logout specs
- * invalidate `dj.json` server-side — see `e2e/tests/auth/logout.spec.ts`).
+ * the auth service directly, cross-origin — the session cookie is
+ * `domain=localhost` (port-agnostic), so it attaches to the auth-service port
+ * regardless of which frontend port minted it. We use `dj2.json`, not
+ * `dj.json` (the logout specs invalidate `dj.json` server-side — see
+ * `e2e/tests/auth/logout.spec.ts`).
  *
  * Requires the build-time flag `NEXT_PUBLIC_QR_LOGIN_ENABLED` (set in
  * `e2e-tests.yml` and `scripts/e2e-local.sh`); without it the entry link never
@@ -39,33 +39,71 @@ const DJ_STORAGE = path.join(authDir, "dj2.json");
 const MEMBER_STORAGE = path.join(authDir, "member.json");
 
 /**
- * Open Context A: an unauthenticated shared browser, switch it to QR sign-in,
- * and return the freshly-minted `user_code` (captured from the
- * `POST /auth/device/code` response, which lands before the code renders).
+ * The shared browser reaches the dashboard only after a poll interval (≥5s) +
+ * the post-sign-in `confirmSessionVisible` reads, and a `slow_down` backoff can
+ * add another interval — so give the redirect a generous ceiling (well under
+ * the 60s per-test budget).
  */
-async function openSharedBrowserQr(browser: Browser): Promise<{
-  context: Awaited<ReturnType<Browser["newContext"]>>;
-  loginPage: LoginPage;
-  userCode: string;
-}> {
+const DASHBOARD_REDIRECT_TIMEOUT_MS = 45_000;
+
+/**
+ * Drive Context A — an unauthenticated shared browser — to the QR waiting
+ * state, then run `body` with its {@link LoginPage} and the freshly-minted
+ * `user_code` (captured from the `POST /auth/device/code` response, which
+ * lands before the code renders). Owns the context lifecycle: the context is
+ * always closed, even if `startQrLogin` or `body` throws.
+ */
+async function withSharedBrowserQr(
+  browser: Browser,
+  body: (ctx: { loginPage: LoginPage; userCode: string }) => Promise<void>,
+): Promise<void> {
   const context = await browser.newContext({ baseURL: BASE_URL });
-  const page = await context.newPage();
-  const loginPage = new LoginPage(page);
+  try {
+    const page = await context.newPage();
+    const loginPage = new LoginPage(page);
+    const codeResponse = page.waitForResponse(
+      (r) =>
+        /\/device\/code\b/.test(r.url()) &&
+        r.request().method() === "POST" &&
+        r.status() === 200,
+      { timeout: 20_000 },
+    );
+    // Pre-attach a no-op rejection handler: if a later step throws before we
+    // await this, the `finally` closing the context rejects it — without this
+    // that would surface as an unhandled rejection.
+    void codeResponse.catch(() => {});
 
-  const codeResponse = page.waitForResponse(
-    (r) =>
-      /\/device\/code\b/.test(r.url()) &&
-      r.request().method() === "POST" &&
-      r.status() === 200,
-    { timeout: 20000 }
-  );
+    await loginPage.goto();
+    await loginPage.startQrLogin();
 
-  await loginPage.goto();
-  await loginPage.startQrLogin();
+    const parsed = (await (await codeResponse).json()) as { user_code?: string };
+    expect(typeof parsed.user_code).toBe("string");
+    await body({ loginPage, userCode: parsed.user_code as string });
+  } finally {
+    await context.close();
+  }
+}
 
-  const body = (await (await codeResponse).json()) as { user_code?: string };
-  expect(typeof body.user_code).toBe("string");
-  return { context, loginPage, userCode: body.user_code as string };
+/** A DJ (dj2.json) claims + approves the code on a separate "phone" context. */
+async function djApprovesOnPhone(browser: Browser, userCode: string): Promise<void> {
+  const phone = await browser.newContext({ storageState: DJ_STORAGE });
+  try {
+    expect((await claimDeviceCode(phone.request, userCode)).status()).toBe(200);
+    expect((await approveDeviceCode(phone.request, userCode)).status()).toBe(200);
+  } finally {
+    await phone.close();
+  }
+}
+
+/** A DJ (dj2.json) claims + denies the code on a separate "phone" context. */
+async function djDeniesOnPhone(browser: Browser, userCode: string): Promise<void> {
+  const phone = await browser.newContext({ storageState: DJ_STORAGE });
+  try {
+    expect((await claimDeviceCode(phone.request, userCode)).status()).toBe(200);
+    expect((await denyDeviceCode(phone.request, userCode)).status()).toBe(200);
+  } finally {
+    await phone.close();
+  }
 }
 
 test.describe("QR sign-in (RFC 8628 device authorization)", () => {
@@ -74,7 +112,7 @@ test.describe("QR sign-in (RFC 8628 device authorization)", () => {
   test.describe.configure({ mode: "serial" });
 
   test.beforeEach(() => {
-    // Golden path pays a poll interval (>=5s) + the post-sign-in session-confirm
+    // Golden path pays a poll interval (≥5s) + the post-sign-in session-confirm
     // reads before navigating — well over the 20s default on a loaded CI runner.
     test.setTimeout(60_000);
   });
@@ -82,53 +120,34 @@ test.describe("QR sign-in (RFC 8628 device authorization)", () => {
   test("golden path: a DJ approving on their phone signs the shared browser in", async ({
     browser,
   }) => {
-    const { context, loginPage, userCode } = await openSharedBrowserQr(browser);
-    try {
+    await withSharedBrowserQr(browser, async ({ loginPage, userCode }) => {
       await expect(loginPage.qrScanHeading).toBeVisible();
 
-      const phone = await browser.newContext({ storageState: DJ_STORAGE });
-      try {
-        expect((await claimDeviceCode(phone.request, userCode)).status()).toBe(200);
-        expect((await approveDeviceCode(phone.request, userCode)).status()).toBe(200);
-      } finally {
-        await phone.close();
-      }
+      await djApprovesOnPhone(browser, userCode);
 
       // The shared browser's next 200 poll confirms the session, then navigates.
-      await loginPage.waitForRedirectToDashboard(30000);
-    } finally {
-      await context.close();
-    }
+      await loginPage.waitForRedirectToDashboard(DASHBOARD_REDIRECT_TIMEOUT_MS);
+    });
   });
 
   test("deny path: a DJ denying on their phone surfaces the denied state with a password fallback", async ({
     browser,
   }) => {
-    const { context, loginPage, userCode } = await openSharedBrowserQr(browser);
-    try {
-      const phone = await browser.newContext({ storageState: DJ_STORAGE });
-      try {
-        expect((await claimDeviceCode(phone.request, userCode)).status()).toBe(200);
-        expect((await denyDeviceCode(phone.request, userCode)).status()).toBe(200);
-      } finally {
-        await phone.close();
-      }
+    await withSharedBrowserQr(browser, async ({ loginPage, userCode }) => {
+      await djDeniesOnPhone(browser, userCode);
 
       // `/device/deny` flips the row to a terminal `denied`, so the browser's
       // next poll returns `access_denied` and QRCodeForm shows the denied state.
-      await expect(loginPage.qrDeniedHeading).toBeVisible({ timeout: 30000 });
+      await expect(loginPage.qrDeniedHeading).toBeVisible({ timeout: 30_000 });
       await expect(loginPage.qrPasswordFallbackLink).toBeVisible();
       expect(loginPage.page.url()).toContain("/login");
-    } finally {
-      await context.close();
-    }
+    });
   });
 
   test("a non-DJ approval is rejected phone-side and cannot sign the shared browser in; a DJ can still approve the same code", async ({
     browser,
   }) => {
-    const { context, loginPage, userCode } = await openSharedBrowserQr(browser);
-    try {
+    await withSharedBrowserQr(browser, async ({ loginPage, userCode }) => {
       // Phone 1 — a `member` (authenticated, no DJ role). The claim succeeds,
       // but Backend-Service's role gate rejects the approve with a 403
       // `access_denied` *before* flipping the row, and un-claims it so a real DJ
@@ -146,29 +165,23 @@ test.describe("QR sign-in (RFC 8628 device authorization)", () => {
         await memberPhone.close();
       }
 
-      // The browser is unaffected: its next poll still returns
-      // `authorization_pending` (not `access_denied`), so it stays in the
-      // waiting state on /login rather than the denied state.
+      // The browser is unaffected: its next poll returns a non-terminal "keep
+      // waiting" state, NOT `access_denied`, so it stays on /login in the
+      // waiting state. Accept both `authorization_pending` and `slow_down` —
+      // the plugin returns `slow_down` for any poll landing <5s after the prior
+      // (the client polls on a 5s timer), so pinning the exact code would flake.
       const poll = await loginPage.page.waitForResponse(
         (r) => /\/device\/token\b/.test(r.url()) && r.request().method() === "POST",
-        { timeout: 15000 }
+        { timeout: 20_000 },
       );
-      expect((await poll.json())?.error).toBe("authorization_pending");
+      expect(["authorization_pending", "slow_down"]).toContain((await poll.json())?.error);
       await expect(loginPage.qrDeniedHeading).toBeHidden();
       expect(loginPage.page.url()).toContain("/login");
 
       // Phone 2 — a DJ approves the same still-live code; the browser signs in.
-      const djPhone = await browser.newContext({ storageState: DJ_STORAGE });
-      try {
-        expect((await claimDeviceCode(djPhone.request, userCode)).status()).toBe(200);
-        expect((await approveDeviceCode(djPhone.request, userCode)).status()).toBe(200);
-      } finally {
-        await djPhone.close();
-      }
+      await djApprovesOnPhone(browser, userCode);
 
-      await loginPage.waitForRedirectToDashboard(30000);
-    } finally {
-      await context.close();
-    }
+      await loginPage.waitForRedirectToDashboard(DASHBOARD_REDIRECT_TIMEOUT_MS);
+    });
   });
 });

--- a/e2e/tests/auth/qr-signin.spec.ts
+++ b/e2e/tests/auth/qr-signin.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect, Browser } from "@playwright/test";
+import path from "path";
+import { LoginPage } from "../../pages/login.page";
+import {
+  approveDeviceCode,
+  claimDeviceCode,
+  denyDeviceCode,
+} from "../../helpers/device-auth";
+
+/**
+ * RFC 8628 QR ("device authorization") sign-in — the two-context golden path
+ * and its negative branches (ADR 0005 / #785; follow-up to PR 2 #838).
+ *
+ * The flow is inherently two-context: the shared control-room browser
+ * (Context A, unauthenticated) requests a device code and polls
+ * `/auth/device/token`, while a *separate* authenticated principal (Context B,
+ * the "phone") claims the user code and approves or denies it. That split
+ * can't be exercised by the single-page component/hook specs, so it lives here.
+ *
+ * Context B reuses a saved `storageState` (no interactive login) and talks to
+ * the auth service directly, cross-origin — dj-site does NOT proxy `/auth/*`
+ * (see `next.config.mjs`), and the session cookie is `domain=localhost`
+ * (port-agnostic), so it attaches to the auth-service port regardless of which
+ * frontend port minted it. We use `dj2.json`, not `dj.json` (the logout specs
+ * invalidate `dj.json` server-side — see `e2e/tests/auth/logout.spec.ts`).
+ *
+ * Requires the build-time flag `NEXT_PUBLIC_QR_LOGIN_ENABLED` (set in
+ * `e2e-tests.yml` and `scripts/e2e-local.sh`); without it the entry link never
+ * renders. No DB cleanup: each `/device/code` mints a unique `user_code` with a
+ * 300s TTL, so leftover rows can't collide across tests — serial mode alone
+ * keeps the flow deterministic.
+ */
+
+const authDir = path.join(__dirname, "..", "..", ".auth");
+const BASE_URL = process.env.E2E_BASE_URL || "http://localhost:3000";
+/** The "phone" DJ principal. dj2.json (not dj.json — logout specs kill that). */
+const DJ_STORAGE = path.join(authDir, "dj2.json");
+/** An authenticated account with no DJ org-role — the `access_denied` case. */
+const MEMBER_STORAGE = path.join(authDir, "member.json");
+
+/**
+ * Open Context A: an unauthenticated shared browser, switch it to QR sign-in,
+ * and return the freshly-minted `user_code` (captured from the
+ * `POST /auth/device/code` response, which lands before the code renders).
+ */
+async function openSharedBrowserQr(browser: Browser): Promise<{
+  context: Awaited<ReturnType<Browser["newContext"]>>;
+  loginPage: LoginPage;
+  userCode: string;
+}> {
+  const context = await browser.newContext({ baseURL: BASE_URL });
+  const page = await context.newPage();
+  const loginPage = new LoginPage(page);
+
+  const codeResponse = page.waitForResponse(
+    (r) =>
+      /\/device\/code\b/.test(r.url()) &&
+      r.request().method() === "POST" &&
+      r.status() === 200,
+    { timeout: 20000 }
+  );
+
+  await loginPage.goto();
+  await loginPage.startQrLogin();
+
+  const body = (await (await codeResponse).json()) as { user_code?: string };
+  expect(typeof body.user_code).toBe("string");
+  return { context, loginPage, userCode: body.user_code as string };
+}
+
+test.describe("QR sign-in (RFC 8628 device authorization)", () => {
+  // Independent per test (fresh contexts, unique codes), but kept serial for
+  // determinism and to avoid piling concurrent device flows on the auth service.
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeEach(() => {
+    // Golden path pays a poll interval (>=5s) + the post-sign-in session-confirm
+    // reads before navigating — well over the 20s default on a loaded CI runner.
+    test.setTimeout(60_000);
+  });
+
+  test("golden path: a DJ approving on their phone signs the shared browser in", async ({
+    browser,
+  }) => {
+    const { context, loginPage, userCode } = await openSharedBrowserQr(browser);
+    try {
+      await expect(loginPage.qrScanHeading).toBeVisible();
+
+      const phone = await browser.newContext({ storageState: DJ_STORAGE });
+      try {
+        expect((await claimDeviceCode(phone.request, userCode)).status()).toBe(200);
+        expect((await approveDeviceCode(phone.request, userCode)).status()).toBe(200);
+      } finally {
+        await phone.close();
+      }
+
+      // The shared browser's next 200 poll confirms the session, then navigates.
+      await loginPage.waitForRedirectToDashboard(30000);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("deny path: a DJ denying on their phone surfaces the denied state with a password fallback", async ({
+    browser,
+  }) => {
+    const { context, loginPage, userCode } = await openSharedBrowserQr(browser);
+    try {
+      const phone = await browser.newContext({ storageState: DJ_STORAGE });
+      try {
+        expect((await claimDeviceCode(phone.request, userCode)).status()).toBe(200);
+        expect((await denyDeviceCode(phone.request, userCode)).status()).toBe(200);
+      } finally {
+        await phone.close();
+      }
+
+      // `/device/deny` flips the row to a terminal `denied`, so the browser's
+      // next poll returns `access_denied` and QRCodeForm shows the denied state.
+      await expect(loginPage.qrDeniedHeading).toBeVisible({ timeout: 30000 });
+      await expect(loginPage.qrPasswordFallbackLink).toBeVisible();
+      expect(loginPage.page.url()).toContain("/login");
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("a non-DJ approval is rejected phone-side and cannot sign the shared browser in; a DJ can still approve the same code", async ({
+    browser,
+  }) => {
+    const { context, loginPage, userCode } = await openSharedBrowserQr(browser);
+    try {
+      // Phone 1 — a `member` (authenticated, no DJ role). The claim succeeds,
+      // but Backend-Service's role gate rejects the approve with a 403
+      // `access_denied` *before* flipping the row, and un-claims it so a real DJ
+      // can still approve the same code. This is the S1 contract in
+      // Backend-Service/shared/authentication/src/device-authorization.ts and
+      // its integration spec — the rejection is phone-side only; the browser is
+      // NOT sent to the denied state (that is reserved for an explicit deny).
+      const memberPhone = await browser.newContext({ storageState: MEMBER_STORAGE });
+      try {
+        expect((await claimDeviceCode(memberPhone.request, userCode)).status()).toBe(200);
+        const rejected = await approveDeviceCode(memberPhone.request, userCode);
+        expect(rejected.status()).toBe(403);
+        expect((await rejected.json())?.error).toBe("access_denied");
+      } finally {
+        await memberPhone.close();
+      }
+
+      // The browser is unaffected: its next poll still returns
+      // `authorization_pending` (not `access_denied`), so it stays in the
+      // waiting state on /login rather than the denied state.
+      const poll = await loginPage.page.waitForResponse(
+        (r) => /\/device\/token\b/.test(r.url()) && r.request().method() === "POST",
+        { timeout: 15000 }
+      );
+      expect((await poll.json())?.error).toBe("authorization_pending");
+      await expect(loginPage.qrDeniedHeading).toBeHidden();
+      expect(loginPage.page.url()).toContain("/login");
+
+      // Phone 2 — a DJ approves the same still-live code; the browser signs in.
+      const djPhone = await browser.newContext({ storageState: DJ_STORAGE });
+      try {
+        expect((await claimDeviceCode(djPhone.request, userCode)).status()).toBe(200);
+        expect((await approveDeviceCode(djPhone.request, userCode)).status()).toBe(200);
+      } finally {
+        await djPhone.close();
+      }
+
+      await loginPage.waitForRedirectToDashboard(30000);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -108,6 +108,10 @@ export NEXT_PUBLIC_ONBOARDING_TEMP_PASSWORD=temppass123
 export NEXT_PUBLIC_APP_ORGANIZATION=test-org
 export NEXT_PUBLIC_FLOWSHEET_SSE_DASHBOARD_ENABLED=true
 export NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED=true
+# Build-time gate for the RFC 8628 QR sign-in method — must be exported before
+# the primary build below or the "Sign in with a QR code" entry link won't
+# render and e2e/tests/auth/qr-signin.spec.ts can't reach the QR stage.
+export NEXT_PUBLIC_QR_LOGIN_ENABLED=true
 
 echo "==> Building dj-site (primary)..."
 # Primary build -> .next/

--- a/src/components/experiences/modern/login/Forms/QRCodeForm.tsx
+++ b/src/components/experiences/modern/login/Forms/QRCodeForm.tsx
@@ -112,6 +112,7 @@ export default function QRCodeForm() {
               </Typography>
               <Typography
                 level="h3"
+                data-testid="device-user-code"
                 sx={{ fontFamily: "monospace", letterSpacing: "0.2em", mt: 0.5 }}
               >
                 {userCode}


### PR DESCRIPTION
## Summary

The two-context Playwright e2e for the RFC 8628 QR sign-in flow (ADR 0005; the golden-path follow-up PR 2 (#838) deferred). The unauthenticated shared browser polls `/auth/device/token` while a *separate* authenticated principal (the "phone") claims and approves/denies the user code — a split the single-page component/hook specs can't cover.

Three tests:
- **golden path** — DJ approves → shared browser lands on the dashboard.
- **deny** — DJ denies → browser shows the `denied` state + password fallback.
- **non-DJ** — a `member` approve is rejected phone-side (403 `access_denied`) and the row is un-claimed; the browser keeps polling `pending`, then a DJ approves the same still-live code → dashboard (the backend S1 contract).

## Correction to the ticket

#841's negative path #2 said a non-DJ approve makes the browser show `denied`. It doesn't: that rejection is a **phone-side 403** that un-claims the row (Backend-Service S1), so the browser stays in the waiting state. Only an explicit **deny** drives the browser to `denied`. The spec asserts the real behavior, matching Backend-Service's `device-authorization` integration test.

## Files

- `e2e/tests/auth/qr-signin.spec.ts` — the spec (serial; no DB drain — unique codes + 300s TTL).
- `e2e/helpers/device-auth.ts` — phone-side claim/approve/deny (typed with `@wxyc/shared` DTOs; approve/deny are camelCase `userCode`).
- `e2e/pages/login.page.ts` — QR locators + `startQrLogin()`; `waitForRedirectToDashboard()` gains an optional timeout.
- `QRCodeForm.tsx` — `data-testid` on the user-code element (stable waiting-state locator).
- `e2e-tests.yml` + `scripts/e2e-local.sh` — set build-time `NEXT_PUBLIC_QR_LOGIN_ENABLED` so the entry link renders.

## ⚠️ Depends on WXYC/Backend-Service#1569 — draft until it merges

Writing this e2e surfaced that the QR feature was **broken end-to-end**: `/device/token` returned the session as a bearer token but set **no session cookie**, so the browser never signed in (unit/component tests mock `getSession`, so they missed it). The fix is WXYC/Backend-Service#1569.

dj-site's e2e CI builds `Backend-Service@main`, so the golden path stays **red until #1569 merges**. Verified green locally against that branch: golden path signs in, and the full dj-site auth suite is **61/61**. Mark ready once #1569 is on Backend-Service `main`.

## Test plan

- `tsc --noEmit` — clean. `vitest run --changed origin/main` — green.
- `scripts/e2e-local.sh e2e/tests/auth` against Backend-Service#1569 — 61/61.

Closes #841.