### PR TITLE
fix(auth): resume OIDC round-trip for onboarding-incomplete users

### DIFF
--- a/lib/features/authentication/server-utils.ts
+++ b/lib/features/authentication/server-utils.ts
@@ -62,6 +62,14 @@ export async function requireAuth(): Promise<BetterAuthSession> {
   }
 
   // Incomplete until explicitly marked complete.
+  //
+  // This redirect intentionally carries no OIDC authorize params, and doing so
+  // does not strand a "Sign in with WXYC" round-trip (#836 AC2): an authorize
+  // bounce targets `/login` directly, whose only incomplete-user render paths
+  // are the login layout (`app/login/@modern/layout.tsx`, session-mode
+  // onboarding) and the invite page (`app/onboarding/**`) — neither gates
+  // through `requireAuth()`. So a pending authorize resume target never reaches
+  // this code path; the client preserves it in the `/login` URL instead.
   if (isUserIncomplete(session)) {
     redirect("/login?incomplete=true&bounced=incomplete");
   }

--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -380,6 +380,66 @@ describe("authenticationHooks", () => {
       expect(mockRefresh).toHaveBeenCalled();
     });
 
+    it("preserves the OIDC authorize query through the onboarding detour when hasCompletedOnboarding is false (#836 Bug A)", async () => {
+      // An invited DJ who follows a "Sign in with WXYC" bounce before finishing
+      // onboarding must not lose the authorize query. Keep it in the /login URL
+      // so useNewUser can resume the round-trip on completion — do NOT drop it
+      // (old behavior: /login?incomplete=true) or mint a code prematurely.
+      const search =
+        "client_id=flowsheet&response_type=code&redirect_uri=https%3A%2F%2Fflowsheet.wxyc.org%2Fauth%2Fcallback&state=xyz&code_challenge=abc&code_challenge_method=S256";
+      mockSearchParams.mockReturnValue(new URLSearchParams(search));
+      mockSignInUsername.mockResolvedValue({
+        data: { user: { id: "user-1", hasCompletedOnboarding: false } },
+      });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "jbromberg" },
+          password: { value: "password123" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleLogin(form);
+      });
+
+      expect(mockPush).toHaveBeenCalledWith(`/login?${search}`);
+      expect(mockLocationAssign).not.toHaveBeenCalled();
+    });
+
+    it("does not delegate an absent-flag user into authorize; keeps the query for onboarding (#836 Bug B)", async () => {
+      // Sign-in omits hasCompletedOnboarding entirely. An absent flag must be
+      // treated as incomplete when an authorize bounce is live: no code is
+      // minted for an un-onboarded account, and the query is preserved so
+      // onboarding can resume it.
+      const search = "client_id=flowsheet&response_type=code&state=xyz";
+      mockSearchParams.mockReturnValue(new URLSearchParams(search));
+      mockSignInUsername.mockResolvedValue({ data: { user: { id: "user-1" } } });
+      mockGetSession.mockResolvedValue({ data: { user: { id: "user-1" } } });
+
+      const { useLogin } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useLogin(), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          username: { value: "jbromberg" },
+          password: { value: "password123" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleLogin(form);
+      });
+
+      expect(mockLocationAssign).not.toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith(`/login?${search}`);
+    });
+
     it("routes to signIn.email when the identifier contains @", async () => {
       mockSignInEmail.mockResolvedValue({ data: { user: { id: "user-1" } } });
 
@@ -484,6 +544,27 @@ describe("authenticationHooks", () => {
         user_id: "user-1",
         session_confirmed: true,
       });
+    });
+
+    it("preserves the OIDC authorize query through the onboarding detour when hasCompletedOnboarding is false (#836 Bug A)", async () => {
+      // Parity with useLogin: both credential entry points feed the same
+      // authorize round-trip, so both must keep the query across onboarding.
+      const search =
+        "client_id=flowsheet&response_type=code&redirect_uri=https%3A%2F%2Fflowsheet.wxyc.org%2Fauth%2Fcallback&state=xyz&code_challenge=abc&code_challenge_method=S256";
+      mockSearchParams.mockReturnValue(new URLSearchParams(search));
+      mockSignInEmailOtp.mockResolvedValue({
+        data: { user: { id: "user-1", hasCompletedOnboarding: false } },
+      });
+
+      const { useOTPVerify } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useOTPVerify(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.handleVerifyOTP("dj@wxyc.org", "123456");
+      });
+
+      expect(mockPush).toHaveBeenCalledWith(`/login?${search}`);
+      expect(mockLocationAssign).not.toHaveBeenCalled();
     });
   });
 
@@ -601,6 +682,35 @@ describe("authenticationHooks", () => {
       expect(mockSignInEmail).not.toHaveBeenCalled();
       expect(mockSignInUsername).not.toHaveBeenCalled();
       expect(mockPush).toHaveBeenCalledWith("/dashboard/flowsheet");
+    });
+
+    it("session mode: resumes the OIDC authorize round-trip after onboarding when the login URL carries authorize params (#836 Bug A)", async () => {
+      // The incomplete-user detour preserved the authorize query in the /login
+      // URL (see useLogin/useOTPVerify tests). On completion we hand off to
+      // authorize with a hard navigation instead of stranding at the dashboard.
+      const search =
+        "client_id=flowsheet&response_type=code&redirect_uri=https%3A%2F%2Fflowsheet.wxyc.org%2Fauth%2Fcallback&state=xyz&code_challenge=abc&code_challenge_method=S256";
+      mockSearchParams.mockReturnValue(new URLSearchParams(search));
+
+      const { useNewUser } = await import("./authenticationHooks");
+      const { result } = renderHook(() => useNewUser("session"), { wrapper: createWrapper() });
+
+      const form = {
+        preventDefault: vi.fn(),
+        currentTarget: {
+          realName: { value: "Real Name" },
+          djName: { value: "DJ Name" },
+        },
+      } as any;
+
+      await act(async () => {
+        await result.current.handleNewUser(form);
+      });
+
+      expect(mockLocationAssign).toHaveBeenCalledWith(
+        `${window.location.origin}/auth/oauth2/authorize?${search}`
+      );
+      expect(mockPush).not.toHaveBeenCalledWith("/dashboard/flowsheet");
     });
 
     it("does not navigate when complete-onboarding fails", async () => {

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -20,7 +20,7 @@ import { betterAuthSessionToAuthenticationData, betterAuthSessionToAuthenticatio
 import { Authorization } from "@/lib/features/admin/types";
 import { applicationSlice } from "@/lib/features/application/frontend";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams, type ReadonlyURLSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { resetApplication } from "./applicationHooks";
@@ -119,12 +119,19 @@ async function redirectAfterAuth(
   router: { push: (href: string) => void; refresh: () => void },
   user: { id?: string; hasCompletedOnboarding?: boolean } | undefined,
   method: LoginMethod,
-  oidcTarget?: string,
+  oidcParams?: URLSearchParams | ReadonlyURLSearchParams,
 ): Promise<void> {
   const dashboardHome = String(
     process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/catalog",
   );
   const incomplete = user?.hasCompletedOnboarding !== true;
+  // Resolve a live OIDC authorize bounce (`client_id` + `response_type=code`)
+  // to its resume target, or null. Computed here — not at the call site — so
+  // every credential entry point (useLogin/useOTPVerify/useNewUser) shares one
+  // definition of what a bounce is and how it's resumed (#836).
+  const oidcTarget = oidcParams
+    ? getOidcRedirectTarget(oidcParams, authBaseURL)
+    : null;
 
   const sessionConfirmed = await confirmSessionVisible();
 
@@ -153,7 +160,19 @@ async function redirectAfterAuth(
     return;
   }
 
-  router.push(incomplete ? "/login?incomplete=true" : dashboardHome);
+  if (incomplete) {
+    // Preserve a live authorize bounce verbatim across the onboarding detour
+    // (#836 Bug A): the invited DJ lands on the onboarding form still carrying
+    // the authorize query, so useNewUser can resume the round-trip on
+    // completion instead of stranding at the dashboard. The onboarding form
+    // renders off session state (`isUserIncomplete`), so we don't need the
+    // non-load-bearing `incomplete=true` marker when we have real params to
+    // keep. An absent onboarding flag with a live bounce lands here too — it is
+    // routed to onboarding rather than delegated a code (#836 Bug B).
+    router.push(oidcTarget ? `/login?${oidcParams!.toString()}` : "/login?incomplete=true");
+  } else {
+    router.push(dashboardHome);
+  }
   router.refresh();
 }
 
@@ -198,14 +217,11 @@ export const useLogin = () => {
           user = { ...signInUser, ...session.data.user };
         }
       }
-      // If we got here as part of an OIDC authorize bounce, resume the
-      // round-trip by handing off to `${authBase}/oauth2/authorize?<original-query>`
-      // instead of the dashboard. See `getOidcRedirectTarget` for the contract.
-      const oidcTarget = getOidcRedirectTarget(
-        searchParams ?? new URLSearchParams(),
-        authBaseURL,
-      );
-      await redirectAfterAuth(router, user, "password", oidcTarget ?? undefined);
+      // If we got here as part of an OIDC authorize bounce, redirectAfterAuth
+      // resumes the round-trip from these params (handing off to
+      // `${authBase}/oauth2/authorize?<original-query>` on completion, or
+      // preserving them across the onboarding detour). See `getOidcRedirectTarget`.
+      await redirectAfterAuth(router, user, "password", searchParams ?? undefined);
     }, "An unexpected error occurred during login. Please try again.");
   };
 
@@ -293,11 +309,7 @@ export const useOTPVerify = () => {
       }
       // Mirror useLogin's OIDC resume contract — both credential entry
       // points feed the same authorize round-trip.
-      const oidcTarget = getOidcRedirectTarget(
-        searchParams ?? new URLSearchParams(),
-        authBaseURL,
-      );
-      await redirectAfterAuth(router, user, "otp", oidcTarget ?? undefined);
+      await redirectAfterAuth(router, user, "otp", searchParams ?? undefined);
     }, "Verification failed. Please try again.");
 
   const handleResendOTP = async (email: string) => {
@@ -599,10 +611,15 @@ export const useNewUser = (mode: "invite" | "session") => {
       }
 
       toast.success("Account setup complete. Welcome!");
+      // Resume a live OIDC authorize round-trip that was preserved in the
+      // /login URL across the onboarding detour (#836). For the invite flow the
+      // URL carries only the setup `token` (no authorize params), so this is a
+      // no-op and the DJ lands on the dashboard as before.
       await redirectAfterAuth(
         router,
         { id: response.userId, hasCompletedOnboarding: true },
         "onboarding",
+        searchParams ?? undefined,
       );
     }, "Failed to complete onboarding. Please try again.");
   };


### PR DESCRIPTION
Closes #836.

## Problem

PR #761 added OIDC continuation to `/login` (resume `${authBase}/oauth2/authorize?<query>` on sign-in), and #762 handled the already-signed-in case. This closes the remaining gap for the **invitee cohort** — a DJ who follows a "Sign in with WXYC" bounce before finishing onboarding.

- **Bug A — the authorize query was dropped through the onboarding detour.** When sign-in resolved as onboarding-incomplete, `redirectAfterAuth` pushed `/login?incomplete=true`, discarding `client_id` / `response_type` / `state` / `code_challenge` / `redirect_uri`. Onboarding completion (`useNewUser`) then sent the DJ to the dashboard with no OIDC awareness — the round-trip was gone and the downstream client never got its code.
- **Bug B — an absent onboarding flag with a live bounce.** Already mitigated on `main` by the `hasCompletedOnboarding !== true` incomplete gate (an absent flag is treated as incomplete), so no code is minted for an un-onboarded account. This PR keeps that behavior and adds the query-preservation on top, plus a regression test.

## Fix

Keep the authorize query in the `/login` URL across the onboarding detour, then resume via the existing hard-nav mechanism — no new persistence, no re-threading through every redirect.

- `redirectAfterAuth` now takes the raw search params and resolves the resume target internally (one shared definition of what a bounce is). Its incomplete branch preserves a live bounce verbatim (`/login?<authorize query>`) instead of `/login?incomplete=true`. The onboarding form renders off session state (`isUserIncomplete`), so the non-load-bearing `incomplete=true` marker isn't needed when real params are present.
- `useNewUser` (session mode) passes its search params through, so onboarding completion resumes the round-trip with a full-document navigation (matching #761 — a soft `router.push` would fire a code-burning RSC fetch).
- `useLogin` / `useOTPVerify` simplified to pass params straight through.
- `requireAuth`'s incomplete redirect is documented as **not** a stranding path: authorize bounces target `/login` directly (login layout / onboarding page), neither of which gates through `requireAuth`, so no pending resume target reaches it (AC2).

## Tests (TDD)

Added, RED-first, to `src/hooks/authenticationHooks.test.ts`:
- `useLogin` / `useOTPVerify`: incomplete + authorize query → query preserved in the `/login` push, no premature `assign`.
- `useLogin`: absent flag + live bounce → no code minted, query preserved.
- `useNewUser` (session): authorize query in the URL → resume via `window.location.assign(${origin}/auth/oauth2/authorize?<query>)`, not the dashboard.

Local checks green: `tsc --noEmit`, full unit suite (250 files / 3468 tests), `npm run build` (`ƒ /login`, `ƒ /onboarding`).

## Out of scope

- The signed `oidc_login_prompt` cookie TTL (600s, backend) still bounds how long onboarding can take before the resume fails.
- Server-side `authorize` does not itself check `hasCompletedOnboarding` (an already-signed-in incomplete user could be issued a code without bouncing to `/login`) — cross-repo, Backend-Service `oidcProvider`.