### PR TITLE
fix(auth): don't route an unreadable QR user to the onboarding form

### DIFF
--- a/src/hooks/authenticationHooks.test.ts
+++ b/src/hooks/authenticationHooks.test.ts
@@ -1304,6 +1304,34 @@ describe("authenticationHooks", () => {
       // stranding the DJ.
       expect(mockClearTokenCache).toHaveBeenCalled();
       expect(mockRefresh).toHaveBeenCalled();
+      // refresh() is a SHARED outcome — it fires on every redirectAfterAuth
+      // branch — so it does not distinguish "deferred to the server" from the
+      // #849 misroute. The differentiator is the push DESTINATION: an
+      // unreadable user is unknown, not onboarding-incomplete, and must never
+      // be dumped on the new-user form.
+      expect(mockPush).not.toHaveBeenCalledWith("/login?incomplete=true");
+    });
+
+    it("does not treat an unreadable user as onboarding-incomplete when the getSession read resolves without a user (#849)", async () => {
+      mockPollDeviceToken.mockResolvedValue(SUCCESS_POLL);
+      // The poll set the session cookie, but the follow-up read comes back
+      // empty (no user). That is "unknown onboarding status", not "incomplete"
+      // — the DJ must not be routed to the new-user onboarding form.
+      mockGetSession.mockResolvedValue({ data: { user: undefined } });
+
+      const { useDeviceAuthorization } = await import("./authenticationHooks");
+      renderHook(() => useDeviceAuthorization(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20000);
+      });
+
+      expect(mockClearTokenCache).toHaveBeenCalled();
+      expect(mockRefresh).toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalledWith("/login?incomplete=true");
     });
 
     it("defaults to a 5s poll interval when the server omits `interval`", async () => {

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -124,7 +124,13 @@ async function redirectAfterAuth(
   const dashboardHome = String(
     process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || "/dashboard/catalog",
   );
-  const incomplete = user?.hasCompletedOnboarding !== true;
+  // "incomplete" means we affirmatively KNOW onboarding isn't done: a present
+  // user whose flag is false or absent (the latter is the #836 Bug B case). An
+  // absent user OBJECT is unknown, not incomplete — the post-auth read failed
+  // (e.g. the QR flow's getSession hiccup), so defer to the server's
+  // requireAuth to resolve the real onboarding status rather than forcing the
+  // onboarding form on a DJ who just authenticated successfully (#849).
+  const incomplete = !!user && user.hasCompletedOnboarding !== true;
   // Resolve a live OIDC authorize bounce (`client_id` + `response_type=code`)
   // to its resume target, or null. Computed here — not at the call site — so
   // every credential entry point (useLogin/useOTPVerify/useNewUser) shares one


### PR DESCRIPTION
Fixes the QR sign-in path routing a successfully-authenticated DJ to the onboarding form when the post-auth `getSession()` read fails.

## Problem

In `useDeviceAuthorization`, a successful token poll sets the session cookie, then the client reads the user back with `getSession()`. If that read throws or returns no `user`, the code sets `user = undefined` and calls `redirectAfterAuth(router, undefined, "qr")`. The shared gate `incomplete = user?.hasCompletedOnboarding !== true` treats `undefined` as `true` (incomplete), so the DJ is pushed to `/login?incomplete=true` — the new-user onboarding form — instead of the dashboard. It self-heals server-side (the `/login` layout re-evaluates the real session), but the DJ can flash the onboarding screen after a successful QR sign-in.

## Fix

The gate conflated two states: *known-incomplete* (a present user whose flag is `false` or absent — the #836 Bug B case) and *unknown* (no user object, because the read failed). Only the former should force onboarding.

```
- const incomplete = user?.hasCompletedOnboarding !== true;
+ const incomplete = !!user && user.hasCompletedOnboarding !== true;
```

An absent user object is now "unknown", not "incomplete", so it defers to the dashboard/refresh path where the destination's `requireAuth` resolves the real onboarding status server-side — exactly the intent already documented in the QR success branch.

## Blast radius

Only the `undefined`-user case changes. `useLogin` / `useOTPVerify` / `useNewUser` all pass a present user on success; Bug B (present user, absent flag) stays incomplete. The existing "complete DJ → dashboard" and "incomplete DJ → onboarding" QR tests (both present users) are unaffected.

## Tests

Strengthened the QR getSession-rejects test to assert the push destination (it previously checked only `mockRefresh` — a shared outcome that fires on every branch), and added a resolves-without-a-user case. Both were RED before the fix.

Verified locally: `tsc --noEmit` clean, full unit suite green, `next build` compiles.

Closes #849.
