### PR TITLE
fix(flowsheet): four viewport/theme UI bug fixes

### DIFF
--- a/lib/features/experiences/modern/themes/definitions.ts
+++ b/lib/features/experiences/modern/themes/definitions.ts
@@ -37,7 +37,11 @@ const STONE: PaletteScale = { 50: "#fafaf9", 100: "#f5f5f4", 200: "#e7e5e4", 300
 // Warm greige neutral so incidental greys (outlined borders, muted text, neutral
 // chips) harmonize with the chocolate surfaces instead of reading as cool grey.
 const ROSE_NEUTRAL: PaletteScale = { 50: "#f6f3f1", 100: "#ebe5e1", 200: "#ddd4ce", 300: "#c9bcb3", 400: "#ab9c92", 500: "#8a7b71", 600: "#6e615a", 700: "#554a45", 800: "#3a322e", 900: "#241f1c" };
-const FUCHSIA: PaletteScale = { 50: "#fdf4ff", 100: "#fae8ff", 200: "#f5d0fe", 300: "#f0abfc", 400: "#e879f9", 500: "#d946ef", 600: "#c026d3", 700: "#a21caf", 800: "#86198f", 900: "#701a75" };
+// `100` is bumped from Tailwind's stock #fae8ff: at that lightness it was
+// nearly indistinguishable from the light-mode page background (#f5f3f1 /
+// #ffffff), making talkset flowsheet rows (danger/soft) blend into the page.
+// Reuses the scale's own `200` stop rather than inventing a new color.
+const FUCHSIA: PaletteScale = { 50: "#fdf4ff", 100: "#f5d0fe", 200: "#f5d0fe", 300: "#f0abfc", 400: "#e879f9", 500: "#d946ef", 600: "#c026d3", 700: "#a21caf", 800: "#86198f", 900: "#701a75" };
 const INDIGO_DARK: PaletteScale = { 50: "#eef2ff", 100: "#e0e7ff", 200: "#c7d2fe", 300: "#a5b4fc", 400: "#818cf8", 500: "#6366f1", 600: "#4f46e5", 700: "#4338ca", 800: "#3730a3", 900: "#312e81" };
 
 // Muted, sophisticated format hues that sit calmly next to rose.

--- a/src/components/experiences/modern/flowsheet/Entries/DraggableEntryWrapper.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/DraggableEntryWrapper.tsx
@@ -52,13 +52,6 @@ export default function DraggableEntryWrapper({
         : effectiveVariant === "plain"
           ? "rgba(255, 255, 255, 0.015)"
           : theme.palette.background.backdrop;
-  // An always-opaque surface tone for the row-actions legibility gradient:
-  // plain rows' near-transparent wash can't mask the status chips, so they
-  // mask against the hover fill tone instead (see tableStyles).
-  const rowBackdrop =
-    effectiveVariant === "plain" || effectiveVariant === "outlined"
-      ? theme.palette.background.level1
-      : rowBg;
 
   return (
     <Reorder.Item
@@ -74,7 +67,6 @@ export default function DraggableEntryWrapper({
         // The row color is painted by the cells (via --row-bg) so they can
         // carry rounded corners; a tr background would bleed square.
         ["--row-bg" as string]: rowBg,
-        ["--row-backdrop" as string]: rowBackdrop,
         ["--row-accent" as string]:
           theme.palette[color ?? "neutral"].solidBg,
         background: "transparent",

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
@@ -231,6 +231,12 @@ const SongEntry = memo(function SongEntry({
             borderRadius: "sm",
             pl: 3,
             pr: 0.5,
+            // At narrower breakpoints this bar's content can overflow its
+            // status column and sit visually on top of the label field's
+            // edit button. The bar itself shouldn't intercept clicks meant
+            // for whatever is underneath — only its actual controls should.
+            pointerEvents: "none",
+            "& > *": { pointerEvents: "auto" },
           }}
         >
           <SongEntryControls entry={entry} queue={queue} editable={editable} />

--- a/src/components/experiences/modern/flowsheet/Entries/tableStyles.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/tableStyles.tsx
@@ -38,10 +38,19 @@ export const FLOWSHEET_TABLE_SX: SxProps = {
   // The current play lifts off the log for depth and keeps its
   // controls available without hover.
   "& tbody tr.row-playing > td": {
-    boxShadow: "0 6px 12px -4px rgba(0, 0, 0, 0.35)",
-    // Keep only the downward shadow: side bleed draws seams between
-    // the row's cells.
-    clipPath: "inset(0 0 -12px 0)",
+    // The now-playing row's fill is painted per cell (so its ends can round),
+    // so at fractional column widths a hairline of the page shows through the
+    // seams between cells and reads as a stray outline around the row. The two
+    // zero-blur horizontal shadows extend each cell's fill 1px left/right to
+    // bridge those seams; they carry no vertical offset, so they never bleed
+    // into the 4px gaps between rows (no stray lines there). They come first so
+    // they paint over the drop shadow's 1px of side bleed. The drop shadow
+    // supplies the lift; the clip keeps it to the bottom edge (unclipped top
+    // bleed would itself re-draw seams), with -1px left/right insets so the
+    // seam bridge is not clipped away.
+    boxShadow:
+      "1px 0 0 var(--row-bg), -1px 0 0 var(--row-bg), 0 6px 12px -4px rgba(0, 0, 0, 0.35)",
+    clipPath: "inset(0 -1px -12px -1px)",
   },
   "& tbody tr.row-playing .row-actions > *": { opacity: 1 },
   "& tbody tr > td:first-of-type": {
@@ -52,17 +61,9 @@ export const FLOWSHEET_TABLE_SX: SxProps = {
     borderTopRightRadius: "8px",
     borderBottomRightRadius: "8px",
   },
-  // Legibility backdrop between the action icons and the status chips they
-  // overlay. Applied whenever the actions are visible at rest — a persisted
-  // control (activated request/segue), the always-revealed playing row —
-  // not just on hover; hover/focus reveal below adds it for the rest.
-  // `--row-backdrop` (set by DraggableEntryWrapper) is an opaque surface
-  // color even for near-transparent plain rows, so the mask actually masks.
-  "& tbody tr .row-actions:has(.row-actions-persist), & tbody tr.row-playing .row-actions":
-    {
-      background:
-        "linear-gradient(to right, transparent, var(--row-backdrop) 18px)",
-    },
+  // The action bar carries no background of its own — it's a fully transparent
+  // overlay, so the row shows straight through behind the controls (its fill,
+  // hover lift, and playing color) with no patch that could read as a seam.
   // Controls stay quieter than the music identity: revealed on row
   // hover/focus on pointer devices, always visible on touch. A control
   // marked row-actions-persist (e.g. an activated request phone) stays
@@ -76,18 +77,6 @@ export const FLOWSHEET_TABLE_SX: SxProps = {
       {
         opacity: 1,
       },
-    "& tbody tr:hover .row-actions, & tbody tr:focus-within .row-actions": {
-      background:
-        "linear-gradient(to right, transparent, var(--row-backdrop) 18px)",
-    },
-  },
-  // Touch devices skip the reveal entirely, so the actions (always visible)
-  // always carry the backdrop.
-  "@media (hover: none)": {
-    "& tbody tr .row-actions": {
-      background:
-        "linear-gradient(to right, transparent, var(--row-backdrop) 18px)",
-    },
   },
 };
 


### PR DESCRIPTION
Small, self-contained fixes for four flowsheet UI bugs reported against the current modern experience. All scoped to the flowsheet entries table plus one theme-token tweak.

## Bugs fixed

1. **Now-playing row outline at some widths.** The now-playing row paints its background per-cell (so its ends can round); at fractional column widths the seams between cells leaked a hairline of the page, reading as a stray outline around the row. Bridged with two zero-blur *horizontal* shadows (no vertical offset → nothing bleeds into the 4px gaps between rows, so no stray lines), with the clip widened 1px left/right so the bridge isn't clipped away.

2. **Action-bar background lighter than / mismatched with the row.** The `row-actions` overlay behind the segue / request / info controls painted an opaque surface tone (`--row-backdrop`) that read lighter than the row at rest and didn't track the hover lift. The mask is now removed entirely — the bar is a **fully transparent overlay**, so the row (its fill, hover lift, and playing color) shows straight through behind the controls in every state. Removes the now-dead `--row-backdrop` plumbing.

3. **Action-bar overlapping the label edit button (md/xl) blocked clicks.** The absolutely-positioned bar can overflow its status column onto the adjacent label field's edit button. The bar container is now `pointer-events: none` with its actual controls re-enabled (`& > * { pointer-events: auto }`), so it never intercepts clicks meant for what's underneath.

4. **"The Stacks" light theme — talkset entries blended into the background.** Talkset rows resolve to `danger`/`soft` → `FUCHSIA[100]` (`#fae8ff`), which is nearly indistinguishable from the light-mode page background (`#f5f3f1` / `#ffffff`). Bumped that one stop to the scale's own `#f5d0fe` so talkset entries read distinctly. (Also slightly increases saturation of any other `danger`+`soft` UI in Stacks *light* only — a plausible improvement, not a regression.)

## Files
- `src/components/experiences/modern/flowsheet/Entries/tableStyles.tsx` — seam bridge (1) + transparent bar overlay (2)
- `src/components/experiences/modern/flowsheet/Entries/DraggableEntryWrapper.tsx` — remove dead `--row-backdrop` (2)
- `src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx` — click-through (3)
- `lib/features/experiences/modern/themes/definitions.ts` — talkset contrast (4)

## Verification
- `tsc --noEmit` clean
- `vitest run` on flowsheet + modern-experience suites: 509/509 passing
- Verified visually in the running app across rest / hover / now-playing states and viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)