### PR TITLE
fix(rightbar,appbar): full-height rightbar + right-justified footer

### DIFF
--- a/src/components/experiences/modern/Rightbar/Bin/BinContent.test.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/BinContent.test.tsx
@@ -76,6 +76,8 @@ vi.mock("@mui/joy", () => ({
       data-testid="card"
       data-variant={variant}
       data-overflow-y={sx?.overflowY}
+      data-flex={sx?.flex}
+      data-min-height={sx?.minHeight}
       style={{ height: sx?.height }}
     >
       {children}
@@ -86,6 +88,8 @@ vi.mock("@mui/joy", () => ({
     <div
       data-testid="skeleton"
       data-variant={variant}
+      data-flex={sx?.flex}
+      data-min-height={sx?.minHeight}
       style={{ height: sx?.height }}
     />
   ),
@@ -214,20 +218,13 @@ describe("BinContent", () => {
     );
   });
 
-  it("should use a fixed box height that scrolls on overflow (auto)", () => {
+  it("should fill the leftover column height and scroll on overflow (auto)", () => {
     render(<BinContent />);
 
     const card = screen.getByTestId("card");
-    expect(card).toHaveStyle({ height: "335px" });
+    expect(card).toHaveAttribute("data-flex", "1");
+    expect(card).toHaveAttribute("data-min-height", "0");
     expect(card).toHaveAttribute("data-overflow-y", "auto");
-  });
-
-  it("should use the taller fixed height when the rightbar is expanded", () => {
-    mockUseGetRightbarQuery.mockReturnValue({ data: true });
-
-    render(<BinContent />);
-
-    expect(screen.getByTestId("card")).toHaveStyle({ height: "500px" });
   });
 
   it("should render empty message when bin is empty", () => {
@@ -333,7 +330,7 @@ describe("BinContent", () => {
     expect(screen.queryByTestId("clear-bin-button")).not.toBeInTheDocument();
   });
 
-  it("should render skeleton with a fixed height when loading", () => {
+  it("should render skeleton that fills the leftover column height when loading", () => {
     mockUseBin.mockReturnValue({
       bin: undefined,
       loading: true,
@@ -344,7 +341,8 @@ describe("BinContent", () => {
     render(<BinContent />);
 
     const skeleton = screen.getByTestId("skeleton");
-    expect(skeleton).toHaveStyle({ height: "335px" });
+    expect(skeleton).toHaveAttribute("data-flex", "1");
+    expect(skeleton).toHaveAttribute("data-min-height", "0");
   });
 
   it("should render single entry without divider", () => {

--- a/src/components/experiences/modern/Rightbar/Bin/BinContent.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/BinContent.tsx
@@ -7,7 +7,6 @@ import { useMemo } from "react";
 import RightBarContentContainer from "../RightBarContentContainer";
 import BinEntry from "./BinEntry";
 import ClearBinButton from "./ClearBinButton";
-import { useGetRightbarQuery } from "@/lib/features/application/api";
 import {
   useFlowsheet,
   useQueue,
@@ -16,7 +15,6 @@ import {
 import type { BinEntryActionDeps } from "./useBinEntryActions";
 
 export default function BinContent() {
-  const { data: max } = useGetRightbarQuery();
   const { bin, isError, loading } = useBin();
   // Hoist the live subscription once for all rows (shared, like the catalog).
   const { live } = useShowControl();
@@ -31,21 +29,19 @@ export default function BinContent() {
     [addToQueue, addToFlowsheet, deleteFromBin],
   );
 
-  // Fixed-size box: reserves a consistent blank area and scrolls internally
-  // once its content exceeds it, rather than growing the rightbar downward.
-  const height = max ? 500 : 335;
-
   if (loading) {
     return (
       <RightBarContentContainer
         label="Mail Bin"
         startDecorator={<Inbox sx={{ mt: 0.3, mr: 1 }} />}
+        fill
       >
         <Skeleton
           variant="rectangular"
           sx={{
             width: { xs: "100%", sm: 300, lg: 400 },
-            height: height,
+            flex: 1,
+            minHeight: 0,
             borderRadius:
               "max((8px - 1px) - 1rem, min(1rem / 2, (8px - 1px) / 2))",
           }}
@@ -61,13 +57,18 @@ export default function BinContent() {
       label="Mail Bin"
       startDecorator={<Inbox sx={{ mt: 0.3, mr: 1 }} />}
       endDecorator={hasEntries ? <ClearBinButton count={bin.length} /> : undefined}
+      fill
     >
+      {/* Fills the leftover column height (see RightBarContentContainer#fill)
+          and scrolls internally, so a tall bin no longer pushes the rightbar
+          past the viewport. */}
       <Card
         variant="outlined"
         sx={{
           overflowY: "auto",
           width: { xs: "100%", sm: 300, lg: 400 },
-          height: height,
+          flex: 1,
+          minHeight: 0,
         }}
       >
         {!hasEntries ? (

--- a/src/components/experiences/modern/Rightbar/RightBarContentContainer.tsx
+++ b/src/components/experiences/modern/Rightbar/RightBarContentContainer.tsx
@@ -5,22 +5,41 @@ export default function RightBarContentContainer({
   endDecorator,
   label,
   children,
+  fill = false,
 }: {
   startDecorator: React.ReactNode;
   endDecorator?: React.ReactNode;
   label: string;
   children: React.ReactNode;
+  /**
+   * When true the container claims the leftover column height and turns into a
+   * flex column (with min-height:0 propagated) so a scrollable child — the Mail
+   * Bin card — can fill the remaining space and scroll internally instead of
+   * growing the whole rightbar past the viewport.
+   */
+  fill?: boolean;
 }) {
   return (
     <Box
       sx={{
         p: 2,
         pb: 3,
+        ...(fill && {
+          flex: 1,
+          minHeight: 0,
+          display: "flex",
+          flexDirection: "column",
+        }),
       }}
     >
       <List
         sx={{
           flexGrow: 1,
+          ...(fill && {
+            minHeight: 0,
+            display: "flex",
+            flexDirection: "column",
+          }),
         }}
       >
         <ListSubheader

--- a/src/components/experiences/modern/Rightbar/RightbarContainer.tsx
+++ b/src/components/experiences/modern/Rightbar/RightbarContainer.tsx
@@ -27,11 +27,13 @@ export default function RightbarContainer({
         flexShrink: 0,
         display: "flex",
         flexDirection: "column",
-        // Pin the trailing spacer to the bottom of the sidebar when the
-        // content is shorter than the viewport…
-        justifyContent: "space-between",
-        // …and let the column scroll when its content (Now Playing + a tall
-        // Mail Bin) exceeds it, instead of clipping the overflow off-screen.
+        // The Mail Bin flex-grows to absorb the leftover column height and
+        // scrolls internally (see BinContent), so the default content fills the
+        // viewport exactly — the trailing footer spacer stays pinned to the
+        // bottom without needing justify-content. overflowY stays `auto` as a
+        // fallback: the alternate panels (settings, album detail) render here
+        // too and can legitimately exceed the viewport, and a genuinely short
+        // screen should scroll rather than clip.
         overflowY: "auto",
         minHeight: 0,
         gap: 1,

--- a/src/components/shared/Theme/Appbar.tsx
+++ b/src/components/shared/Theme/Appbar.tsx
@@ -30,6 +30,12 @@ export default function Appbar() {
         bottom: 5,
         right: 5,
         zIndex: 10000,
+        // Right-justify the whole footer: a long version string used to widen
+        // the box and shove the button row leftward. Anchoring both the text
+        // and the button group to the right edge keeps them lined up.
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-end",
       }}
     >
       <Typography level="body-xs" variant="plain" sx={{ textAlign: "right" }}>
@@ -46,8 +52,11 @@ export default function Appbar() {
             General Feedback
           </LinkButton>
         )}
-        <ThemePicker />
+        {/* Classic-mode switcher sits left of the color-theme picker. The
+            picker is intentionally absent from AppbarClassic, so it is
+            unavailable once classic mode is enabled. */}
         <ThemeSwitcher />
+        <ThemePicker />
         <ColorSchemeToggle />
       </ButtonGroup>
     </Box>

--- a/src/components/shared/Theme/AppbarClassic.tsx
+++ b/src/components/shared/Theme/AppbarClassic.tsx
@@ -28,6 +28,11 @@ export default function AppbarClassic() {
         bottom: 5,
         right: 5,
         zIndex: 10000,
+        // Right-justify the whole footer so a long version string can't shove
+        // the button row leftward (matches the modern Appbar).
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-end",
       }}
     >
       <Typography level="body-xs" variant="plain" sx={{ textAlign: "right" }}>


### PR DESCRIPTION
## Summary

Three viewport bugs in the modern dashboard chrome:

1. **Rightbar always fills the viewport, no outer scroll.** The Mail Bin used a fixed pixel height (`500`/`335`), so on shorter screens Now Playing + a tall bin overflowed and scrolled the entire rightbar. The bin now flex-grows to absorb the leftover column height and scrolls *internally*, so the default content sums to exactly the viewport height. `overflowY: auto` is kept on the container as a fallback for the alternate panels (settings / album-detail) and genuinely tiny screens.

2. **Fixed footer is right-justified.** A long `NEXT_PUBLIC_VERSION` string widened the footer box and shoved the button row leftward. The footer (`Appbar` + `AppbarClassic`) now anchors both the version text and the button group to the right edge (`alignItems: flex-end`).

3. **Footer control order + theme-picker gating.** The classic-mode switcher now sits left of the color-theme picker. The color-theme picker is already absent from `AppbarClassic`, so it remains unavailable once classic mode is enabled (added a comment noting the invariant).

## Changes

- `Bin/BinContent.tsx` — bin `Card` + loading skeleton switch from fixed height to `flex: 1; minHeight: 0`; removed the now-unused `useGetRightbarQuery`/`max` height logic.
- `RightBarContentContainer.tsx` — new `fill` prop turns the container + `List` into a `minHeight:0` flex column so the internal scroll propagates to the card. Only the Mail Bin opts in.
- `RightbarContainer.tsx` — dropped `justifyContent: space-between` (flex-grow now pins the footer spacer); kept `overflowY: auto` as a fallback.
- `Appbar.tsx` / `AppbarClassic.tsx` — right-justify the footer; swap switcher/picker order.

## Testing

- `vitest run` over `Rightbar/` + `Theme/`: **141 passing**. `BinContent.test.tsx` updated to assert the fill/scroll behavior (`data-flex="1"`, `minHeight:0`, `overflow-y:auto`) instead of fixed pixel heights.
- `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)