### PR TITLE
feat(bin): export/share button for the Mail Bin

### DIFF
--- a/lib/features/bin/export.test.ts
+++ b/lib/features/bin/export.test.ts
@@ -1,17 +1,27 @@
 import { describe, it, expect } from "vitest";
-import { formatBinForExport } from "./export";
+import { formatBinForExport, callNumberFor } from "./export";
 import { createTestAlbum, createTestArtist } from "@/lib/test-utils/fixtures";
 
 const stereolab = createTestAlbum({
   title: "DOGA",
-  artist: createTestArtist({ name: "Juana Molina" }),
+  artist: createTestArtist({
+    name: "Juana Molina",
+    lettercode: "JM",
+    numbercode: 12,
+  }),
+  entry: 3,
   label: "Sonamos",
   format: "Vinyl",
 });
 
 const pratt = createTestAlbum({
   title: "On Your Own Love Again",
-  artist: createTestArtist({ name: "Jessica Pratt" }),
+  artist: createTestArtist({
+    name: "Jessica Pratt",
+    lettercode: "PR",
+    numbercode: 4,
+  }),
+  entry: 1,
   label: "Drag City",
   format: "CD",
 });
@@ -21,10 +31,10 @@ describe("formatBinForExport", () => {
     const { tsv } = formatBinForExport([stereolab, pratt]);
 
     const lines = tsv.split("\n");
-    expect(lines[0]).toBe("Album\tArtist\tLabel\tFormat");
-    expect(lines[1]).toBe("DOGA\tJuana Molina\tSonamos\tVinyl");
+    expect(lines[0]).toBe("Call #\tAlbum\tArtist\tLabel\tFormat");
+    expect(lines[1]).toBe("JM 12/3\tDOGA\tJuana Molina\tSonamos\tVinyl");
     expect(lines[2]).toBe(
-      "On Your Own Love Again\tJessica Pratt\tDrag City\tCD",
+      "PR 4/1\tOn Your Own Love Again\tJessica Pratt\tDrag City\tCD",
     );
   });
 
@@ -32,9 +42,9 @@ describe("formatBinForExport", () => {
     const { html } = formatBinForExport([stereolab]);
 
     expect(html).toContain("<table>");
-    expect(html).toContain("<th>Album</th>");
+    expect(html).toContain("<th>Call #</th>");
     expect(html).toContain(
-      "<td>DOGA</td><td>Juana Molina</td><td>Sonamos</td><td>Vinyl</td>",
+      "<td>JM 12/3</td><td>DOGA</td><td>Juana Molina</td><td>Sonamos</td><td>Vinyl</td>",
     );
   });
 
@@ -50,24 +60,37 @@ describe("formatBinForExport", () => {
     expect(html).not.toContain("<Roll>");
   });
 
-  it("builds readable share lines with the label in parentheses", () => {
+  it("builds readable share lines with the call number and label", () => {
     const { shareText } = formatBinForExport([stereolab, pratt]);
 
     const lines = shareText.split("\n");
     expect(lines[0]).toBe("WXYC Mail Bin");
-    expect(lines[2]).toBe("DOGA — Juana Molina (Sonamos)");
-    expect(lines[3]).toBe("On Your Own Love Again — Jessica Pratt (Drag City)");
+    expect(lines[2]).toBe("[JM 12/3] DOGA — Juana Molina (Sonamos)");
+    expect(lines[3]).toBe(
+      "[PR 4/1] On Your Own Love Again — Jessica Pratt (Drag City)",
+    );
   });
 
   it("omits the parenthetical when an album has no label", () => {
     const noLabel = createTestAlbum({
       title: "Untitled",
-      artist: createTestArtist({ name: "Unknown" }),
+      artist: createTestArtist({
+        name: "Unknown",
+        lettercode: "UN",
+        numbercode: 1,
+      }),
+      entry: 5,
       label: "",
     });
 
     const { shareText } = formatBinForExport([noLabel]);
 
-    expect(shareText.split("\n")[2]).toBe("Untitled — Unknown");
+    expect(shareText.split("\n")[2]).toBe("[UN 1/5] Untitled — Unknown");
+  });
+});
+
+describe("callNumberFor", () => {
+  it("formats lettercode, numbercode and entry as `LL N/E`", () => {
+    expect(callNumberFor(stereolab)).toBe("JM 12/3");
   });
 });

--- a/lib/features/bin/export.test.ts
+++ b/lib/features/bin/export.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { formatBinForExport } from "./export";
+import { createTestAlbum, createTestArtist } from "@/lib/test-utils/fixtures";
+
+const stereolab = createTestAlbum({
+  title: "DOGA",
+  artist: createTestArtist({ name: "Juana Molina" }),
+  label: "Sonamos",
+  format: "Vinyl",
+});
+
+const pratt = createTestAlbum({
+  title: "On Your Own Love Again",
+  artist: createTestArtist({ name: "Jessica Pratt" }),
+  label: "Drag City",
+  format: "CD",
+});
+
+describe("formatBinForExport", () => {
+  it("emits a TSV header plus one tab-separated row per album", () => {
+    const { tsv } = formatBinForExport([stereolab, pratt]);
+
+    const lines = tsv.split("\n");
+    expect(lines[0]).toBe("Album\tArtist\tLabel\tFormat");
+    expect(lines[1]).toBe("DOGA\tJuana Molina\tSonamos\tVinyl");
+    expect(lines[2]).toBe(
+      "On Your Own Love Again\tJessica Pratt\tDrag City\tCD",
+    );
+  });
+
+  it("emits a table whose rows carry each album's cells", () => {
+    const { html } = formatBinForExport([stereolab]);
+
+    expect(html).toContain("<table>");
+    expect(html).toContain("<th>Album</th>");
+    expect(html).toContain(
+      "<td>DOGA</td><td>Juana Molina</td><td>Sonamos</td><td>Vinyl</td>",
+    );
+  });
+
+  it("escapes HTML-special characters in cell values", () => {
+    const risky = createTestAlbum({
+      title: "Rock & <Roll>",
+      artist: createTestArtist({ name: "A & B" }),
+    });
+
+    const { html } = formatBinForExport([risky]);
+
+    expect(html).toContain("<td>Rock &amp; &lt;Roll&gt;</td>");
+    expect(html).not.toContain("<Roll>");
+  });
+
+  it("builds readable share lines with the label in parentheses", () => {
+    const { shareText } = formatBinForExport([stereolab, pratt]);
+
+    const lines = shareText.split("\n");
+    expect(lines[0]).toBe("WXYC Mail Bin");
+    expect(lines[2]).toBe("DOGA — Juana Molina (Sonamos)");
+    expect(lines[3]).toBe("On Your Own Love Again — Jessica Pratt (Drag City)");
+  });
+
+  it("omits the parenthetical when an album has no label", () => {
+    const noLabel = createTestAlbum({
+      title: "Untitled",
+      artist: createTestArtist({ name: "Unknown" }),
+      label: "",
+    });
+
+    const { shareText } = formatBinForExport([noLabel]);
+
+    expect(shareText.split("\n")[2]).toBe("Untitled — Unknown");
+  });
+});

--- a/lib/features/bin/export.ts
+++ b/lib/features/bin/export.ts
@@ -1,10 +1,23 @@
 import type { AlbumEntry } from "@/lib/features/catalog/types";
 
 /** Columns shared by every export format, in display order. */
-const COLUMNS = ["Album", "Artist", "Label", "Format"] as const;
+const COLUMNS = ["Call #", "Album", "Artist", "Label", "Format"] as const;
+
+/**
+ * The library call number a DJ reads off the shelf: lettercode, artist number,
+ * then the album's entry — e.g. `RO 12/3`. Matches the format shown on catalog
+ * results (see Result.tsx). Missing parts collapse gracefully so a partial
+ * record still yields something scannable.
+ */
+export function callNumberFor(entry: AlbumEntry): string {
+  const { lettercode, numbercode } = entry.artist;
+  const prefix = [lettercode, numbercode].filter((p) => p != null && p !== "").join(" ");
+  return entry.entry != null ? `${prefix}/${entry.entry}`.trim() : prefix.trim();
+}
 
 function cellsFor(entry: AlbumEntry): string[] {
   return [
+    callNumberFor(entry),
     entry.title,
     entry.artist.name,
     entry.label ?? "",
@@ -54,9 +67,10 @@ export function formatBinForExport(entries: AlbumEntry[]): {
   const shareText = [
     "WXYC Mail Bin",
     "",
-    ...rows.map(([album, artist, label]) => {
+    ...rows.map(([callNumber, album, artist, label]) => {
       const suffix = label ? ` (${label})` : "";
-      return `${album} — ${artist}${suffix}`;
+      const prefix = callNumber ? `[${callNumber}] ` : "";
+      return `${prefix}${album} — ${artist}${suffix}`;
     }),
   ].join("\n");
 

--- a/lib/features/bin/export.ts
+++ b/lib/features/bin/export.ts
@@ -1,0 +1,64 @@
+import type { AlbumEntry } from "@/lib/features/catalog/types";
+
+/** Columns shared by every export format, in display order. */
+const COLUMNS = ["Album", "Artist", "Label", "Format"] as const;
+
+function cellsFor(entry: AlbumEntry): string[] {
+  return [
+    entry.title,
+    entry.artist.name,
+    entry.label ?? "",
+    entry.format ?? "",
+  ].map((value) => (value ?? "").toString().trim());
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Serializes the Mail Bin into the three shapes the export button needs:
+ *
+ * - `tsv` — tab-separated rows for `text/plain`. Pasting this into Google
+ *   Sheets (or Excel) splits it across cells, one album per row.
+ * - `html` — a real `<table>` for `text/html`. Google Docs and Sheets both
+ *   consume the rich-text flavor of the clipboard and render an actual table.
+ * - `shareText` — human-readable lines for the Web Share sheet / an email
+ *   body, where a raw TSV blob would look like noise.
+ */
+export function formatBinForExport(entries: AlbumEntry[]): {
+  tsv: string;
+  html: string;
+  shareText: string;
+} {
+  const rows = entries.map(cellsFor);
+
+  const tsv = [COLUMNS.join("\t"), ...rows.map((cols) => cols.join("\t"))].join(
+    "\n",
+  );
+
+  const headerCells = COLUMNS.map((col) => `<th>${escapeHtml(col)}</th>`).join(
+    "",
+  );
+  const bodyRows = rows
+    .map(
+      (cols) =>
+        `<tr>${cols.map((col) => `<td>${escapeHtml(col)}</td>`).join("")}</tr>`,
+    )
+    .join("");
+  const html = `<table><thead><tr>${headerCells}</tr></thead><tbody>${bodyRows}</tbody></table>`;
+
+  const shareText = [
+    "WXYC Mail Bin",
+    "",
+    ...rows.map(([album, artist, label]) => {
+      const suffix = label ? ` (${label})` : "";
+      return `${album} — ${artist}${suffix}`;
+    }),
+  ].join("\n");
+
+  return { tsv, html, shareText };
+}

--- a/src/components/experiences/modern/Rightbar/Bin/BinContent.test.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/BinContent.test.tsx
@@ -57,6 +57,12 @@ vi.mock("./ClearBinButton", () => ({
   ),
 }));
 
+vi.mock("./ExportBinButton", () => ({
+  default: ({ entries }: { entries: AlbumEntry[] }) => (
+    <button data-testid="export-bin-button">export-{entries.length}</button>
+  ),
+}));
+
 // Mock MUI components
 vi.mock("@mui/icons-material", () => ({
   Inbox: () => <svg data-testid="inbox-icon" />,
@@ -84,6 +90,9 @@ vi.mock("@mui/joy", () => ({
     </div>
   ),
   Divider: () => <hr data-testid="bin-divider" />,
+  Stack: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="stack">{children}</div>
+  ),
   Skeleton: ({ variant, sx }: { variant?: string; sx?: any }) => (
     <div
       data-testid="skeleton"

--- a/src/components/experiences/modern/Rightbar/Bin/BinContent.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/BinContent.tsx
@@ -2,11 +2,12 @@
 
 import { useBin, useDeleteFromBin } from "@/src/hooks/binHooks";
 import { Inbox } from "@mui/icons-material";
-import { Card, Divider, Skeleton, Typography } from "@mui/joy";
+import { Card, Divider, Skeleton, Stack, Typography } from "@mui/joy";
 import { useMemo } from "react";
 import RightBarContentContainer from "../RightBarContentContainer";
 import BinEntry from "./BinEntry";
 import ClearBinButton from "./ClearBinButton";
+import ExportBinButton from "./ExportBinButton";
 import {
   useFlowsheet,
   useQueue,
@@ -56,7 +57,14 @@ export default function BinContent() {
     <RightBarContentContainer
       label="Mail Bin"
       startDecorator={<Inbox sx={{ mt: 0.3, mr: 1 }} />}
-      endDecorator={hasEntries ? <ClearBinButton count={bin.length} /> : undefined}
+      endDecorator={
+        hasEntries ? (
+          <Stack direction="row" spacing={0.5} alignItems="center">
+            <ExportBinButton entries={bin} />
+            <ClearBinButton count={bin.length} />
+          </Stack>
+        ) : undefined
+      }
       fill
     >
       {/* Fills the leftover column height (see RightBarContentContainer#fill)

--- a/src/components/experiences/modern/Rightbar/Bin/ExportBinButton.test.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/ExportBinButton.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils/render";
+import { createTestAlbum, createTestArtist } from "@/lib/test-utils/fixtures";
+import { toast } from "sonner";
+import ExportBinButton from "./ExportBinButton";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const entries = [
+  createTestAlbum({
+    title: "DOGA",
+    artist: createTestArtist({ name: "Juana Molina" }),
+    label: "Sonamos",
+    format: "Vinyl",
+  }),
+];
+
+// Snapshot the descriptors so each test can install its own share/clipboard
+// stubs and we can fully restore jsdom's defaults afterward.
+const originalShare = Object.getOwnPropertyDescriptor(navigator, "share");
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+
+function setNavigator(prop: "share" | "clipboard", value: unknown) {
+  Object.defineProperty(navigator, prop, { value, configurable: true });
+}
+
+function restore(prop: "share" | "clipboard", desc?: PropertyDescriptor) {
+  if (desc) Object.defineProperty(navigator, prop, desc);
+  else delete (navigator as unknown as Record<string, unknown>)[prop];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Start each test with neither capability; opt in per case. Shadow with
+  // `undefined` rather than deleting — some jsdom builds expose `share` on the
+  // Navigator prototype, which a `delete` of the own property would re-reveal.
+  setNavigator("share", undefined);
+  setNavigator("clipboard", undefined);
+  vi.stubGlobal(
+    "ClipboardItem",
+    class {
+      items: Record<string, Blob>;
+      constructor(items: Record<string, Blob>) {
+        this.items = items;
+      }
+    },
+  );
+});
+
+afterEach(() => {
+  restore("share", originalShare);
+  restore("clipboard", originalClipboard);
+  vi.unstubAllGlobals();
+});
+
+describe("ExportBinButton", () => {
+  it("renders an export icon button", () => {
+    renderWithProviders(<ExportBinButton entries={entries} />);
+    expect(
+      screen.getByRole("button", { name: "Export Mail Bin" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the native share sheet when one is available, without copying", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    const { user } = renderWithProviders(<ExportBinButton entries={entries} />);
+    // Install after render: userEvent.setup() defines its own navigator.clipboard.
+    setNavigator("share", share);
+    setNavigator("clipboard", { write });
+    await user.click(screen.getByRole("button", { name: "Export Mail Bin" }));
+
+    await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
+    const arg = share.mock.calls[0][0];
+    expect(arg.title).toBe("WXYC Mail Bin");
+    expect(arg.text).toContain("DOGA — Juana Molina (Sonamos)");
+    // Sharing is its own confirmation — no clipboard write, no toast.
+    expect(write).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the user dismisses the share sheet", async () => {
+    const abort = new DOMException("dismissed", "AbortError");
+    const share = vi.fn().mockRejectedValue(abort);
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    const { user } = renderWithProviders(<ExportBinButton entries={entries} />);
+    setNavigator("share", share);
+    setNavigator("clipboard", { write });
+    await user.click(screen.getByRole("button", { name: "Export Mail Bin" }));
+
+    await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
+    expect(write).not.toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("copies a rich table to the clipboard and toasts when there is no share sheet", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    const { user } = renderWithProviders(<ExportBinButton entries={entries} />);
+    setNavigator("clipboard", { write });
+    await user.click(screen.getByRole("button", { name: "Export Mail Bin" }));
+
+    await waitFor(() => expect(write).toHaveBeenCalledTimes(1));
+    const item = write.mock.calls[0][0][0] as { items: Record<string, Blob> };
+    expect(Object.keys(item.items).sort()).toEqual(["text/html", "text/plain"]);
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith(
+        "Mail Bin copied — paste it into an email or a doc",
+      ),
+    );
+  });
+
+  it("falls back to writeText when rich clipboard write is unavailable", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    const { user } = renderWithProviders(<ExportBinButton entries={entries} />);
+    setNavigator("clipboard", { writeText });
+    await user.click(screen.getByRole("button", { name: "Export Mail Bin" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText.mock.calls[0][0]).toContain("DOGA\tJuana Molina");
+    await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1));
+  });
+
+  it("toasts an error when copying fails", async () => {
+    const write = vi.fn().mockRejectedValue(new Error("denied"));
+
+    const { user } = renderWithProviders(<ExportBinButton entries={entries} />);
+    setNavigator("clipboard", { write });
+    await user.click(screen.getByRole("button", { name: "Export Mail Bin" }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Couldn't copy the Mail Bin"),
+    );
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/experiences/modern/Rightbar/Bin/ExportBinButton.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/ExportBinButton.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { formatBinForExport } from "@/lib/features/bin/export";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
+import { IosShare } from "@mui/icons-material";
+import { IconButton, Tooltip } from "@mui/joy";
+import { useState } from "react";
+import { toast } from "sonner";
+
+/**
+ * Writes the bin to the clipboard carrying both flavors: `text/html` (a real
+ * table, so Google Docs / Sheets paste it as a table) and `text/plain` (TSV,
+ * which Sheets splits into cells). Falls back to plain text on browsers without
+ * the async `ClipboardItem` write.
+ */
+async function copyBinToClipboard(tsv: string, html: string): Promise<void> {
+  const clipboard =
+    typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+
+  if (
+    clipboard &&
+    typeof clipboard.write === "function" &&
+    typeof ClipboardItem !== "undefined"
+  ) {
+    await clipboard.write([
+      new ClipboardItem({
+        "text/plain": new Blob([tsv], { type: "text/plain" }),
+        "text/html": new Blob([html], { type: "text/html" }),
+      }),
+    ]);
+    return;
+  }
+
+  if (clipboard && typeof clipboard.writeText === "function") {
+    await clipboard.writeText(tsv);
+    return;
+  }
+
+  throw new Error("Clipboard unavailable");
+}
+
+/**
+ * Header action that exports the whole Mail Bin. On devices with a native share
+ * sheet (phones) it opens that first — the DJ can mail the list to themselves.
+ * Everywhere else, and if sharing fails, it copies the bin to the clipboard as
+ * a table with toast feedback. Rendered only when the bin is non-empty.
+ */
+export default function ExportBinButton({
+  entries,
+}: {
+  entries: AlbumEntry[];
+}) {
+  const [busy, setBusy] = useState(false);
+
+  const handleExport = async () => {
+    if (busy || entries.length === 0) return;
+    setBusy(true);
+    try {
+      const { tsv, html, shareText } = formatBinForExport(entries);
+
+      // Prefer the OS share sheet where it exists (email, messages, …).
+      if (
+        typeof navigator !== "undefined" &&
+        typeof navigator.share === "function"
+      ) {
+        try {
+          await navigator.share({ title: "WXYC Mail Bin", text: shareText });
+          return; // the native sheet is its own confirmation
+        } catch (err) {
+          // Dismissed the sheet: treat as a no-op rather than copying.
+          if (err instanceof DOMException && err.name === "AbortError") return;
+          // Any other share failure falls through to the clipboard path.
+        }
+      }
+
+      try {
+        await copyBinToClipboard(tsv, html);
+        toast.success("Mail Bin copied — paste it into an email or a doc");
+      } catch {
+        toast.error("Couldn't copy the Mail Bin");
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Tooltip title="Export / Share Mail Bin" placement="top" variant="outlined">
+      <IconButton
+        variant="plain"
+        color="neutral"
+        size="sm"
+        aria-label="Export Mail Bin"
+        loading={busy}
+        onClick={handleExport}
+      >
+        <IosShare />
+      </IconButton>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## What

Adds a plain icon button (⬆️ `IosShare`) next to **Clear Mail Bin** in the Rightbar's Mail Bin header that lets a DJ **export / share** the whole bin.

## Behavior

- **Phones / anything with a native share sheet** → opens `navigator.share` first, so you can send the bin to yourself over email, Messages, etc. Dismissing the sheet is a no-op.
- **Everywhere else (and if share fails)** → copies the bin to the clipboard carrying **both** flavors:
  - `text/html` — a real `<table>`, so pasting into **Google Docs / Sheets** lands as a table.
  - `text/plain` — TSV, so Sheets/Excel split it into cells.
  - Falls back to `writeText` (TSV) on browsers without the async `ClipboardItem` write.
- **Toast feedback** on copy (success + failure).

Columns exported: **Album · Artist · Label · Format**.

## Files

- `lib/features/bin/export.ts` — `formatBinForExport()` → `{ tsv, html, shareText }` (HTML-escaped).
- `src/components/experiences/modern/Rightbar/Bin/ExportBinButton.tsx` — the button + share/clipboard logic.
- `BinContent.tsx` — renders it in a `Stack` beside `ClearBinButton` when the bin is non-empty.

## Tests

- `export.test.ts` — TSV / table / share-line shapes + HTML escaping.
- `ExportBinButton.test.tsx` — share-sheet path, dismiss no-op, rich clipboard copy + toast, `writeText` fallback, copy-error toast.
- Updated `BinContent.test.tsx` mocks.

All 54 Bin-dir tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)