### PR TITLE
fix(rotation): only auto-fill per-track credits on compilation/V-A releases

### DIFF
--- a/lib/__tests__/features/catalog/is-compilation-artist.test.ts
+++ b/lib/__tests__/features/catalog/is-compilation-artist.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 
-import { isCompilationArtistName } from "@/lib/features/catalog/is-compilation-artist";
+import {
+  isCompilationArtistName,
+  isCompilationRelease,
+} from "@/lib/features/catalog/is-compilation-artist";
 
 describe("isCompilationArtistName", () => {
   it.each([
@@ -35,5 +38,36 @@ describe("isCompilationArtistName", () => {
 
   it.each([null, undefined, ""])("returns false for empty input %s", (input) => {
     expect(isCompilationArtistName(input)).toBe(false);
+  });
+});
+
+describe("isCompilationRelease", () => {
+  it("returns true when album_artist is populated, regardless of artist name", () => {
+    expect(
+      isCompilationRelease({
+        album_artist: "Kruder & Dorfmeister",
+        artist: { name: "Kruder & Dorfmeister" },
+      })
+    ).toBe(true);
+  });
+
+  it("returns true for a V/A-shaped artist name without album_artist", () => {
+    expect(isCompilationRelease({ artist: { name: "Various Artists" } })).toBe(
+      true
+    );
+  });
+
+  it("returns false for a normal release", () => {
+    expect(isCompilationRelease({ artist: { name: "Stereolab" } })).toBe(false);
+  });
+
+  it("returns false when artist is null and album_artist absent", () => {
+    expect(isCompilationRelease({ artist: null })).toBe(false);
+  });
+
+  it("returns false for an empty album_artist string", () => {
+    expect(
+      isCompilationRelease({ album_artist: "", artist: { name: "Cat Power" } })
+    ).toBe(false);
   });
 });

--- a/lib/features/catalog/is-compilation-artist.ts
+++ b/lib/features/catalog/is-compilation-artist.ts
@@ -17,3 +17,23 @@ export function isCompilationArtistName(
   }
   return false;
 }
+
+/**
+ * Release-level compilation/V-A predicate: `album_artist` populated (the
+ * schema marks it "Credited album artist for compilations") or a V/A-shaped
+ * artist name.
+ *
+ * Consumers include the rotation picker's artist auto-fill gate (#763),
+ * which uses a `true` here to decide that Discogs per-track credits are
+ * performer names safe to WRITE to the flowsheet — a keyword added above
+ * for a search-hint use case widens that write gate too. Note BS's
+ * `GET /library/rotation` does not currently emit `album_artist`
+ * (getRotationFromDB's SELECT omits it), so rotation rows are gated by
+ * artist name alone until BS wires the column through.
+ */
+export function isCompilationRelease(release: {
+  album_artist?: string;
+  artist?: { name?: string | null } | null;
+}): boolean {
+  return !!release.album_artist || isCompilationArtistName(release.artist?.name);
+}

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -101,11 +101,32 @@ const lightningBoltOoioo = createTestAlbum({
   rotation_bin: "H",
 });
 
-const selectBinAndRelease = () => {
+// Genuine V/A compilation — the shape where per-track Discogs credits ARE
+// the performing artist and the auto-fill must keep working (#518/#520).
+const tobaccoAGoGo = createTestAlbum({
+  id: 9,
+  title: "Tobacco A-Go-Go",
+  artist: createTestArtist({ name: "Various Artists" }),
+  rotation_id: 44,
+  rotation_bin: "H",
+});
+
+// The #763 report shape: normal release whose Discogs per-track credits are
+// contributor roles, not performers (rotation_id 21462 from Bb's repro).
+const foxbaseAlpha = createTestAlbum({
+  id: 10,
+  title: "Foxbase Alpha",
+  artist: createTestArtist({ name: "Saint Etienne" }),
+  label: "Heavenly",
+  rotation_id: 21462,
+  rotation_bin: "H",
+});
+
+const selectBinAndRelease = (release = lightningBoltOoioo) => {
   fireEvent.click(screen.getByRole("radio", { name: "H" }));
   fireEvent.focus(screen.getByTestId("rotation-release-combobox"));
   fireEvent.click(
-    screen.getByTestId(`rotation-release-option-${lightningBoltOoioo.id}`)
+    screen.getByTestId(`rotation-release-option-${release.id}`)
   );
 };
 
@@ -118,7 +139,7 @@ describe("RotationEntryFields", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSearchQuery = { artist: "", song: "", album: "", label: "" };
-    mockRotationData = [lightningBoltOoioo];
+    mockRotationData = [lightningBoltOoioo, tobaccoAGoGo, foxbaseAlpha];
     mockTracksData = undefined;
     mockTracksLoading = false;
   });
@@ -188,11 +209,12 @@ describe("RotationEntryFields", () => {
 
   describe("track-selection artist auto-fill", () => {
     // When a DJ picks a track from the dropdown, we override the artist that
-    // handleSelectRelease seeded iff the per-track Discogs credits (surfaced
-    // by BS#944) carry artist names. This covers V/A and split releases
-    // without any new UI. For normal releases BS falls back to
-    // [release.artist] so the value is identical to what handleSelectRelease
-    // already set; the override is functionally a no-op.
+    // handleSelectRelease seeded iff the release is credited as a
+    // compilation/V/A (album_artist populated, or a V/A-shaped artist name)
+    // AND the per-track Discogs credits (surfaced by BS#944) carry artist
+    // names. On normal releases Discogs per-track credits are contributor
+    // roles (producer, co-writer, sample) — trusting them corrupted the
+    // flowsheet write and the tubafrenzy mirror's rotation badging (#763).
     //
     // Test invariant: spy on `store.dispatch` *before* any clicks. react-redux's
     // useDispatch captures the dispatch reference at mount time, so spying
@@ -219,12 +241,13 @@ describe("RotationEntryFields", () => {
 
       const { store } = renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
       const dispatchSpy = vi.spyOn(store, "dispatch");
-      selectBinAndRelease();
+      selectBinAndRelease(tobaccoAGoGo);
       selectTrack(0);
 
-      // Release select dispatches artist=OOIOO; track select with empty
-      // credits must not dispatch any further artist value.
-      expect(artistValues(dispatchSpy)).toEqual(["OOIOO"]);
+      // Release select dispatches artist=Various Artists; track select with
+      // empty credits must not dispatch any further artist value even though
+      // the release qualifies for the override.
+      expect(artistValues(dispatchSpy)).toEqual(["Various Artists"]);
     });
 
     it("sets artist to track's single per-track credit on V/A releases", () => {
@@ -239,7 +262,7 @@ describe("RotationEntryFields", () => {
 
       const { store } = renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
       const dispatchSpy = vi.spyOn(store, "dispatch");
-      selectBinAndRelease();
+      selectBinAndRelease(tobaccoAGoGo);
       selectTrack(0);
 
       expect(dispatchSpy).toHaveBeenCalledWith(
@@ -262,7 +285,7 @@ describe("RotationEntryFields", () => {
 
       const { store } = renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
       const dispatchSpy = vi.spyOn(store, "dispatch");
-      selectBinAndRelease();
+      selectBinAndRelease(tobaccoAGoGo);
       selectTrack(0);
 
       expect(dispatchSpy).toHaveBeenCalledWith(
@@ -271,6 +294,91 @@ describe("RotationEntryFields", () => {
           value: "Skull Mitten, Various Drummers",
         })
       );
+    });
+
+    it("#763: does not overwrite the release artist with contributor credits on a normal release", () => {
+      // Bb's repro: "Glad" off Foxbase Alpha carries a Discogs contributor
+      // credit. Pre-fix, that name replaced "Saint Etienne" in the flowsheet
+      // write, and the tubafrenzy mirror then failed to badge the play as
+      // rotation on wxyc.info.
+      mockTracksData = [
+        {
+          position: "A2",
+          title: "Glad",
+          duration: null,
+          artists: ["Ian Catt"],
+        },
+      ];
+
+      const { store } = renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
+      const dispatchSpy = vi.spyOn(store, "dispatch");
+      selectBinAndRelease(foxbaseAlpha);
+      selectTrack(0);
+
+      expect(artistValues(dispatchSpy)).toEqual(["Saint Etienne"]);
+      // The track title itself must still auto-fill.
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        flowsheetSlice.actions.setSearchProperty({ name: "song", value: "Glad" })
+      );
+    });
+
+    it("overwrites via the album_artist compilation signal even when the artist name isn't V/A-shaped", () => {
+      // A compilation can be filed under a credited album artist (the
+      // api.yaml example: a DJ-Kicks filed under "Kruder & Dorfmeister").
+      // `album_artist` being populated is BS's deterministic compilation
+      // marker, so per-track credits are trustworthy here.
+      const djKicks = createTestAlbum({
+        id: 11,
+        title: "DJ-Kicks",
+        artist: createTestArtist({ name: "Kruder & Dorfmeister" }),
+        album_artist: "Kruder & Dorfmeister",
+        rotation_id: 45,
+        rotation_bin: "H",
+      });
+      mockRotationData = [djKicks];
+      mockTracksData = [
+        {
+          position: "A1",
+          title: "Donaueschingen",
+          duration: null,
+          artists: ["Rockers Hi-Fi"],
+        },
+      ];
+
+      const { store } = renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
+      const dispatchSpy = vi.spyOn(store, "dispatch");
+      selectBinAndRelease(djKicks);
+      selectTrack(0);
+
+      expect(artistValues(dispatchSpy)).toEqual([
+        "Kruder & Dorfmeister",
+        "Rockers Hi-Fi",
+      ]);
+    });
+
+    it("known gap: split releases filed under a band name keep the release artist", () => {
+      // Accepted limitation of the V/A-whitelist heuristic (#763 decision):
+      // a split whose release artist is one of the performers (not a V/A
+      // string) no longer gets per-track credit auto-fill. Restoring this
+      // requires the planned BS compilation/split hint on RotationTrack;
+      // until then the DJ edits the artist by hand for the other side's
+      // tracks — strictly better than silently writing contributor credits
+      // on every normal release.
+      mockTracksData = [
+        {
+          position: "B1",
+          title: "13 Monsters",
+          duration: null,
+          artists: ["Lightning Bolt"],
+        },
+      ];
+
+      const { store } = renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
+      const dispatchSpy = vi.spyOn(store, "dispatch");
+      selectBinAndRelease(lightningBoltOoioo);
+      selectTrack(0);
+
+      expect(artistValues(dispatchSpy)).toEqual(["OOIOO"]);
     });
 
     it("dedupes doubled per-track credits before writing to the artist field", () => {
@@ -290,10 +398,10 @@ describe("RotationEntryFields", () => {
 
       const { store } = renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
       const dispatchSpy = vi.spyOn(store, "dispatch");
-      selectBinAndRelease();
+      selectBinAndRelease(tobaccoAGoGo);
       selectTrack(0);
 
-      expect(artistValues(dispatchSpy)).toEqual(["OOIOO", "Warrior"]);
+      expect(artistValues(dispatchSpy)).toEqual(["Various Artists", "Warrior"]);
     });
 
     it("strips Discogs (N) disambig before writing to the artist field", () => {
@@ -311,10 +419,10 @@ describe("RotationEntryFields", () => {
 
       const { store } = renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
       const dispatchSpy = vi.spyOn(store, "dispatch");
-      selectBinAndRelease();
+      selectBinAndRelease(tobaccoAGoGo);
       selectTrack(0);
 
-      expect(artistValues(dispatchSpy)).toEqual(["OOIOO", "M.I.A."]);
+      expect(artistValues(dispatchSpy)).toEqual(["Various Artists", "M.I.A."]);
     });
 
     it("falls back to the release-level artist when every per-track credit is malformed", () => {
@@ -333,10 +441,10 @@ describe("RotationEntryFields", () => {
 
       const { store } = renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
       const dispatchSpy = vi.spyOn(store, "dispatch");
-      selectBinAndRelease();
+      selectBinAndRelease(tobaccoAGoGo);
       selectTrack(0);
 
-      expect(artistValues(dispatchSpy)).toEqual(["OOIOO"]);
+      expect(artistValues(dispatchSpy)).toEqual(["Various Artists"]);
     });
   });
 });

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -325,8 +325,11 @@ describe("RotationEntryFields", () => {
     it("overwrites via the album_artist compilation signal even when the artist name isn't V/A-shaped", () => {
       // A compilation can be filed under a credited album artist (the
       // api.yaml example: a DJ-Kicks filed under "Kruder & Dorfmeister").
-      // `album_artist` being populated is BS's deterministic compilation
-      // marker, so per-track credits are trustworthy here.
+      // NOTE: BS's GET /library/rotation does not currently emit
+      // album_artist (getRotationFromDB omits the column), so on today's
+      // rotation wire this arm is only reachable via catalog-sourced
+      // entries; this test pins the component contract for when BS wires
+      // it through.
       const djKicks = createTestAlbum({
         id: 11,
         title: "DJ-Kicks",

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { isCompilationArtistName } from "@/lib/features/catalog/is-compilation-artist";
+import { isCompilationRelease } from "@/lib/features/catalog/is-compilation-artist";
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { Rotation } from "@/lib/features/rotation/types";
@@ -94,14 +94,11 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
   // `projectInlineTracklist` forwards them raw. Only compilations and V/A
   // releases can trust them as the performing artist; on anything else the
   // auto-fill silently corrupted the flowsheet write (#763, the Saint
-  // Etienne / Foxbase Alpha report). Gate on the release being credited as
-  // a compilation: `album_artist` populated (deterministic BS signal) or a
-  // V/A-shaped artist name. Known gap until BS exposes a compilation/split
-  // hint on RotationTrack: splits filed under a band name keep the
-  // release-level artist.
+  // Etienne / Foxbase Alpha report). Known gap until BS exposes a
+  // compilation/split hint on RotationTrack: splits filed under a band
+  // name keep the release-level artist.
   const trackCreditsAreDisambiguating =
-    !!selectedRelease?.album_artist ||
-    isCompilationArtistName(selectedRelease?.artist?.name);
+    !!selectedRelease && isCompilationRelease(selectedRelease);
 
   const handleSelectTrack = useCallback(
     (track: RotationTrack) => {

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { isCompilationArtistName } from "@/lib/features/catalog/is-compilation-artist";
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { Rotation } from "@/lib/features/rotation/types";
@@ -88,21 +89,31 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
     [dispatch, setSearchOpen]
   );
 
+  // Discogs per-track `artists` carries contributor credits (producer,
+  // co-writer, sample) on normal releases, not just performers — BS's
+  // `projectInlineTracklist` forwards them raw. Only compilations and V/A
+  // releases can trust them as the performing artist; on anything else the
+  // auto-fill silently corrupted the flowsheet write (#763, the Saint
+  // Etienne / Foxbase Alpha report). Gate on the release being credited as
+  // a compilation: `album_artist` populated (deterministic BS signal) or a
+  // V/A-shaped artist name. Known gap until BS exposes a compilation/split
+  // hint on RotationTrack: splits filed under a band name keep the
+  // release-level artist.
+  const trackCreditsAreDisambiguating =
+    !!selectedRelease?.album_artist ||
+    isCompilationArtistName(selectedRelease?.artist?.name);
+
   const handleSelectTrack = useCallback(
     (track: RotationTrack) => {
       setSelectedTrack(track);
       setManualEntry(false);
       dispatch(flowsheetSlice.actions.setSearchProperty({ name: "song", value: track.title ?? "" }));
-      // Auto-fill artist from per-track Discogs credits (surfaced by BS#944)
-      // for V/A and split releases. For normal releases BS falls back to
-      // [release.artist] so this just re-sets the value already seeded by
-      // handleSelectRelease. `normalizeTrackArtists` strips the Discogs `(N)`
-      // disambig and dedupes — see its header for the LML cache duplication
-      // root cause. When credits are empty (Discogs has no per-track data, or
-      // every entry was malformed) leave the release-level artist in place;
-      // mis-credited cases fall through to manual-entry mode (the existing
-      // escape hatch). Join separator mirrors buildArtistCredit in
-      // apps/backend/controllers/proxy.controller.ts.
+      if (!trackCreditsAreDisambiguating) return;
+      // `normalizeTrackArtists` strips the Discogs `(N)` disambig and dedupes
+      // — see its header for the LML cache duplication root cause. When
+      // credits are empty (Discogs has no per-track data, or every entry was
+      // malformed) leave the release-level artist in place. Join separator
+      // mirrors buildArtistCredit in apps/backend/controllers/proxy.controller.ts.
       const credits = normalizeTrackArtists(track.artists);
       if (credits.length > 0) {
         dispatch(
@@ -113,7 +124,7 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
         );
       }
     },
-    [dispatch]
+    [dispatch, trackCreditsAreDisambiguating]
   );
 
   const handleManualEntry = useCallback(() => {


### PR DESCRIPTION
## Problem

Picking a track in the rotation picker unconditionally overwrote the release-level artist with Discogs per-track credits — which on normal releases are **contributor** roles (producer, co-writer, sample), not performers. The corrupted artist mirrors to tubafrenzy, whose (artist, album) classification then fails to badge the play as rotation on wxyc.info (#763, Bb's Saint Etienne / *Foxbase Alpha* repro, rotation_id 21462).

## Fix

Gate the overwrite on the release being credited as a compilation, via a new shared `isCompilationRelease()` (in `lib/features/catalog/is-compilation-artist.ts`, next to the existing whitelist it composes): `album_artist` populated, or a V/A-shaped artist name. Genuine V/A comps keep per-track auto-fill; normal releases keep the release artist.

**Known accepted gap** (per the triage decision, "whitelist now + BS signal later"): splits filed under a band name (e.g. the OOIOO / Lightning Bolt split) no longer auto-fill the other side's credits — pinned by an explicit test. Restoring that needs the BS `is_compilation_or_split` hint (follow-up ticket on Backend-Service).

## Red-team review (high effort, 6 angles + verify)

- Fixed in-branch: predicate extracted + shared-keyword-list coupling documented; corrected a comment that wrongly called `album_artist` a live signal on the rotation path (`getRotationFromDB`'s SELECT omits the column — verified in BS source).
- Known, deliberately out of scope: `TrackPickerDropdown` still *displays* contributor credits and matches search against them (the visual half of the report) — goes with the BS-signal follow-up; whitelist substring false-positives ("The Soundtrack of Our Lives") and false-negatives (bare "VA") are documented gaps of the helper, which stays synced with its backend twin.

## Testing

- 3,553 unit tests + typecheck green; new coverage: contributor-credit suppression (Foxbase Alpha shape), V/A comp auto-fill preserved, `album_artist` arm contract, split-gap pin, `isCompilationRelease` unit tests.

Closes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)