### PR TITLE
fix(flowsheet): harden the optimistic-cache layer (cluster-02 PR a)

### DIFF
--- a/lib/__tests__/features/flowsheet/conversions.test.ts
+++ b/lib/__tests__/features/flowsheet/conversions.test.ts
@@ -502,11 +502,13 @@ describe("flowsheet conversions", () => {
         expect(result.message).toBe("Custom station message");
       });
 
-      it("should handle null show_id", () => {
+      it("maps null show_id to the -1 no-show sentinel (never a real show id)", () => {
         const entry = createTestV2TrackEntry({ show_id: null });
         const result = convertV2Entry(entry);
 
-        expect(result.show_id).toBe(0);
+        // 0 is a plausible real show id; -1 matches primaryShowId's sentinel
+        // so orphaned entries can never partition into an actual show (#629).
+        expect(result.show_id).toBe(-1);
       });
 
       it("should throw for unknown entry type", () => {

--- a/lib/__tests__/features/flowsheet/deferred-refetch.test.ts
+++ b/lib/__tests__/features/flowsheet/deferred-refetch.test.ts
@@ -103,7 +103,12 @@ describe("scheduleDeferredFlowsheetRefetch — #476 deferred metadata refetch", 
     await vi.runAllTimersAsync();
 
     expect(initiateSpy).toHaveBeenCalledTimes(1);
-    expect(initiateSpy).toHaveBeenCalledWith(undefined, { forceRefetch: true });
+    // subscribe: false — a leaked default subscription per addEntry pinned
+    // the getNowPlaying cache entry forever (#628).
+    expect(initiateSpy).toHaveBeenCalledWith(undefined, {
+      forceRefetch: true,
+      subscribe: false,
+    });
   });
 
   it("patches the infinite-query cache when the now-playing result matches the entry id", async () => {

--- a/lib/__tests__/features/flowsheet/infinite-cache.test.ts
+++ b/lib/__tests__/features/flowsheet/infinite-cache.test.ts
@@ -3,6 +3,11 @@ import type {
   FlowsheetSongEntry,
   FlowsheetSubmissionParams,
 } from "@/lib/features/flowsheet/types";
+
+const safeCaptureMock = vi.fn();
+vi.mock("@/lib/posthog", () => ({
+  safeCapture: (...args: unknown[]) => safeCaptureMock(...args),
+}));
 import {
   buildOptimisticEntry,
   compareEntriesNewestFirst,
@@ -147,8 +152,8 @@ describe("infinite-cache", () => {
     expect(draft.pages[0].map((e) => e.id)).toEqual([51, 50, 49]);
   });
 
-  it("replaceEntryIdAllPages inserts when temp entry is not found, warning for #860 instrumentation", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("replaceEntryIdAllPages inserts when temp entry is not found, capturing the #860 telemetry event", () => {
+    safeCaptureMock.mockClear();
     const draft = {
       pages: [[song(50, 10, 1), song(49, 9, 1)]],
       pageParams: [0],
@@ -156,10 +161,36 @@ describe("infinite-cache", () => {
     const server = song(51, 11, 1);
     replaceEntryIdAllPages(draft, -999, server);
     expect(draft.pages[0].map((e) => e.id)).toEqual([51, 50, 49]);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("dj-site#860")
+    expect(safeCaptureMock).toHaveBeenCalledWith(
+      "flowsheet_optimistic_replace_miss",
+      { tempId: -999, serverEntryId: 51 }
     );
-    warnSpy.mockRestore();
+  });
+
+  it("replaceEntryIdAllPages does not emit telemetry on a normal swap", () => {
+    safeCaptureMock.mockClear();
+    const temp = song(-5, 11, 1);
+    const draft = {
+      pages: [[temp, song(50, 10, 1)]],
+      pageParams: [0],
+    };
+    replaceEntryIdAllPages(draft, -5, song(51, 11, 1));
+    expect(safeCaptureMock).not.toHaveBeenCalled();
+  });
+
+  it("primaryShowId skips orphaned entries so one null-show row can't read as 'nobody live' (#629)", () => {
+    const orphan = song(90, 12, -1);
+    const draft = { pages: [[orphan, song(89, 11, 5)], [song(88, 10, 5)]], pageParams: [0, 1] };
+    expect(primaryShowId(draft)).toBe(5);
+  });
+
+  it("movePlayOrder refuses to renumber orphaned (show_id -1) entries as one block", () => {
+    const draft = {
+      pages: [[song(9, 3, -1), song(8, 2, -1), song(7, 1, -1)]],
+      pageParams: [0],
+    };
+    movePlayOrder(draft, 9, 1);
+    expect(draft.pages[0].map((e) => e.play_order)).toEqual([3, 2, 1]);
   });
 
   it("nextOptimisticTempId never collides across rapid same-millisecond calls (#620)", () => {

--- a/lib/__tests__/features/flowsheet/infinite-cache.test.ts
+++ b/lib/__tests__/features/flowsheet/infinite-cache.test.ts
@@ -1,11 +1,15 @@
-import { describe, it, expect } from "vitest";
-import type { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
+import { describe, it, expect, vi } from "vitest";
+import type {
+  FlowsheetSongEntry,
+  FlowsheetSubmissionParams,
+} from "@/lib/features/flowsheet/types";
 import {
   buildOptimisticEntry,
   compareEntriesNewestFirst,
   insertEntrySortedFirstPage,
   maxPlayOrder,
   movePlayOrder,
+  nextOptimisticTempId,
   primaryShowId,
   removeEntryById,
   replaceEntryIdAllPages,
@@ -143,7 +147,8 @@ describe("infinite-cache", () => {
     expect(draft.pages[0].map((e) => e.id)).toEqual([51, 50, 49]);
   });
 
-  it("replaceEntryIdAllPages inserts when temp entry is not found", () => {
+  it("replaceEntryIdAllPages inserts when temp entry is not found, warning for #860 instrumentation", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const draft = {
       pages: [[song(50, 10, 1), song(49, 9, 1)]],
       pageParams: [0],
@@ -151,6 +156,35 @@ describe("infinite-cache", () => {
     const server = song(51, 11, 1);
     replaceEntryIdAllPages(draft, -999, server);
     expect(draft.pages[0].map((e) => e.id)).toEqual([51, 50, 49]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("dj-site#860")
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("nextOptimisticTempId never collides across rapid same-millisecond calls (#620)", () => {
+    const ids = new Set<number>();
+    for (let i = 0; i < 1000; i++) ids.add(nextOptimisticTempId());
+    expect(ids.size).toBe(1000);
+    for (const id of ids) expect(id).toBeLessThan(0);
+  });
+
+  it("later temp ids sort newer under compareEntriesNewestFirst (#620)", () => {
+    const older = nextOptimisticTempId();
+    const newer = nextOptimisticTempId();
+    expect(compareEntriesNewestFirst(song(newer, 2, 1), song(older, 1, 1))).toBeLessThan(0);
+  });
+
+  it("removeEntryById removes a duplicated id from every page (#643)", () => {
+    const dupA = song(7, 5, 1);
+    const dupB = song(7, 5, 1);
+    const draft = {
+      pages: [[song(9, 9, 1), dupA], [dupB, song(3, 3, 1)]],
+      pageParams: [0, 1],
+    };
+    removeEntryById(draft, 7);
+    expect(draft.pages[0].map((e) => e.id)).toEqual([9]);
+    expect(draft.pages[1].map((e) => e.id)).toEqual([3]);
   });
 
   it("movePlayOrder moving down renumbers the crossed block up by one", () => {
@@ -264,6 +298,48 @@ describe("infinite-cache", () => {
       draft
     );
     expect("segue" in entry && entry.segue).toBe(true);
+  });
+
+  it("buildOptimisticEntry takes the freeform branch when album_id key is present but undefined (#607)", () => {
+    // usePlayNow's pre-gate payloads carried `album_id: undefined` for
+    // freeform queue entries; key-presence alone must not select the blank
+    // catalog branch.
+    const draft = { pages: [[song(1, 10, 7)]], pageParams: [0] };
+    const { entry } = buildOptimisticEntry(
+      {
+        track_title: "On Your Own Love Again",
+        artist_name: "Jessica Pratt",
+        album_title: "On Your Own Love Again",
+        request_flag: false,
+        album_id: undefined,
+      } as FlowsheetSubmissionParams,
+      draft
+    );
+    expect("artist_name" in entry && entry.artist_name).toBe("Jessica Pratt");
+  });
+
+  it("buildOptimisticEntry takes the freeform branch for synthesized negative album_id (#607)", () => {
+    const draft = { pages: [[song(1, 10, 7)]], pageParams: [0] };
+    const { entry } = buildOptimisticEntry(
+      {
+        track_title: "la paradoja",
+        artist_name: "Juana Molina",
+        album_title: "DOGA",
+        request_flag: false,
+        album_id: -42,
+      } as FlowsheetSubmissionParams,
+      draft
+    );
+    expect("artist_name" in entry && entry.artist_name).toBe("Juana Molina");
+  });
+
+  it("buildOptimisticEntry uses the -1 no-show sentinel on an empty cache (#629)", () => {
+    const draft = { pages: [], pageParams: [] };
+    const { entry } = buildOptimisticEntry(
+      { track_title: "X", artist_name: "Y", album_title: "Z", request_flag: false },
+      draft
+    );
+    expect(entry.show_id).toBe(-1);
   });
 
   it("buildOptimisticEntry leaves `segue` undefined when not provided", () => {

--- a/lib/__tests__/features/flowsheet/infinite-cache.test.ts
+++ b/lib/__tests__/features/flowsheet/infinite-cache.test.ts
@@ -184,6 +184,14 @@ describe("infinite-cache", () => {
     expect(primaryShowId(draft)).toBe(5);
   });
 
+  it("primaryShowId returns a negative optimistic show-marker id (only -1 is the orphan sentinel)", () => {
+    // The #619 goLive fix pushes a show-start marker whose show_id is a fresh
+    // negative tempId; it must win over the prior show's entries.
+    const marker = song(-40, 13, -40);
+    const draft = { pages: [[marker, song(89, 12, 5)]], pageParams: [0] };
+    expect(primaryShowId(draft)).toBe(-40);
+  });
+
   it("movePlayOrder refuses to renumber orphaned (show_id -1) entries as one block", () => {
     const draft = {
       pages: [[song(9, 3, -1), song(8, 2, -1), song(7, 1, -1)]],

--- a/lib/features/bin/conversions.ts
+++ b/lib/features/bin/conversions.ts
@@ -1,4 +1,5 @@
 import { AlbumEntry } from "../catalog/types";
+import { hasLinkedAlbumId } from "../flowsheet/linkage";
 import { FlowsheetQuery, FlowsheetSubmissionParams } from "../flowsheet/types";
 
 export function convertBinToFlowsheet(
@@ -14,8 +15,7 @@ export function convertBinToFlowsheet(
   // rotation_id stays on the wire (BS#1308 / @wxyc/shared 1.9.0 added it to
   // FlowsheetCreateSongFreeform), so the iOS rotation-artwork resolver can
   // still find unlinked-rotation bin plays by rotation_id alone.
-  const hasLinkedAlbum =
-    typeof binEntry.id === "number" && binEntry.id > 0;
+  const hasLinkedAlbum = hasLinkedAlbumId(binEntry.id);
 
   if (hasLinkedAlbum) {
     return {

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -1,5 +1,6 @@
 import { Rotation } from "../rotation/types";
 import { OFF_AIR_LABEL } from "./constants";
+import { hasLinkedAlbumId } from "./linkage";
 import {
   FlowsheetEntry,
   FlowsheetQuery,
@@ -35,8 +36,7 @@ export function convertQueryToSubmission(
   // caller that lands a non-positive `album_id` falls back to the freeform
   // variant — at the cost of the rotation linkage, until BS-side schema work
   // lands. Matches the Classic-side shape from PR #699. (dj-site#701)
-  const hasLinkedAlbum =
-    typeof query.album_id === "number" && query.album_id > 0;
+  const hasLinkedAlbum = hasLinkedAlbumId(query.album_id);
   return {
     track_title: query.song,
     artist_name: query.artist,

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -101,7 +101,9 @@ export function convertV2Entry(entry: FlowsheetV2EntryJSON): FlowsheetEntry {
   const base = {
     id: entry.id,
     play_order: entry.play_order,
-    show_id: entry.show_id ?? 0,
+    // -1 mirrors primaryShowId's no-show sentinel; 0 collides with a real
+    // show id and would mis-partition orphaned entries into it (#629).
+    show_id: entry.show_id ?? -1,
   };
 
   switch (entry.entry_type) {

--- a/lib/features/flowsheet/deferred-refetch.ts
+++ b/lib/features/flowsheet/deferred-refetch.ts
@@ -30,9 +30,13 @@ export function scheduleDeferredFlowsheetRefetch(
   setTimeout(() => {
     void (async () => {
       try {
+        // subscribe: false — this is a one-shot refetch; the default
+        // subscription is never released and accretes a permanent ref count
+        // on the getNowPlaying cache entry per addEntry (#628).
         const result = await dispatch(
           flowsheetApi.endpoints.getNowPlaying.initiate(undefined, {
             forceRefetch: true,
+            subscribe: false,
           })
         ).unwrap();
         if (!result || result.id !== entryId) return;

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -2,6 +2,7 @@ import { createAppSlice } from "@/lib/createAppSlice";
 import { PayloadAction } from "@reduxjs/toolkit";
 import { FlowsheetFrontendState, FlowsheetQuery, FlowsheetSearchProperty, FlowsheetSongEntry } from "./types";
 import { Rotation } from "../rotation/types";
+import { hasLinkedAlbumId } from "./linkage";
 import { clearQueueFromStorage, loadQueueFromStorage, saveQueueToStorage } from "./queue-storage";
 
 // Drop the catalog-anchored trio (album_id, rotation_id, rotation) from a
@@ -19,7 +20,7 @@ function withSanitizedAlbumLinkage<
     rotation?: Rotation;
   }
 >(entry: T): T {
-  if (typeof entry.album_id === "number" && entry.album_id > 0) {
+  if (hasLinkedAlbumId(entry.album_id)) {
     return entry;
   }
   return {

--- a/lib/features/flowsheet/infinite-cache.ts
+++ b/lib/features/flowsheet/infinite-cache.ts
@@ -29,8 +29,14 @@ export function primaryShowId(draft: Pick<InfiniteEntriesDraft, "pages">): numbe
   return -1;
 }
 
+// Monotonic counter, not Date.now()+random: two submissions in the same
+// millisecond had a real collision chance, and a collision makes
+// replaceEntryIdAllPages silently drop one of the rows (#620).
+// More-negative = newer, which compareEntriesNewestFirst relies on.
+let optimisticTempIdCounter = 0;
+
 export function nextOptimisticTempId(): number {
-  return -(Date.now() * 1000 + Math.floor(Math.random() * 1000));
+  return -++optimisticTempIdCounter;
 }
 
 export function buildOptimisticEntry(
@@ -39,9 +45,9 @@ export function buildOptimisticEntry(
 ): { entry: FlowsheetEntry; tempId: number } {
   const tempId = nextOptimisticTempId();
   const play_order = maxPlayOrder(draft) + 1;
-  const sid = primaryShowId(draft);
-  // Fallback until POST response replaces row (empty cache / unknown show).
-  const show_id = sid >= 0 ? sid : 0;
+  // -1 is the shared unknown-show sentinel (primaryShowId, convertV2Entry);
+  // 0 collides with a real show id (#629). Server response replaces the row.
+  const show_id = primaryShowId(draft);
 
   if ("message" in arg) {
     const entry: FlowsheetMessageEntry = {
@@ -53,7 +59,10 @@ export function buildOptimisticEntry(
     return { entry, tempId };
   }
 
-  if ("album_id" in arg) {
+  // Key presence isn't enough: callers can pass `album_id: undefined` (or a
+  // synthesized negative id for library-unlinked rows), which must render
+  // the freeform variant, not a blank catalog row (#607).
+  if ("album_id" in arg && typeof arg.album_id === "number" && arg.album_id > 0) {
     const entry: FlowsheetSongEntry = {
       id: tempId,
       play_order,
@@ -71,13 +80,15 @@ export function buildOptimisticEntry(
     return { entry, tempId };
   }
 
+  // Freeform submissions — and linked-shape args whose album_id wasn't a
+  // usable positive id — render whatever typed fields they carry.
   const entry: FlowsheetSongEntry = {
     id: tempId,
     play_order,
     show_id,
     track_title: arg.track_title,
-    artist_name: arg.artist_name,
-    album_title: arg.album_title,
+    artist_name: "artist_name" in arg ? arg.artist_name : "",
+    album_title: "album_title" in arg ? arg.album_title : "",
     record_label: arg.record_label ?? "",
     request_flag: arg.request_flag,
     segue: arg.segue,
@@ -96,7 +107,7 @@ export function compareEntriesNewestFirst(a: FlowsheetEntry, b: FlowsheetEntry):
   const aTemp = a.id < 0;
   const bTemp = b.id < 0;
   if (aTemp !== bTemp) return aTemp ? -1 : 1;
-  if (aTemp) return a.id - b.id; // more negative = newer (larger Date.now())
+  if (aTemp) return a.id - b.id; // more negative = newer (later counter value)
   return b.id - a.id;
 }
 
@@ -120,11 +131,12 @@ export function insertEntrySortedFirstPage(
 }
 
 export function removeEntryById(draft: InfiniteEntriesDraft, id: number): void {
+  // No early return: ids must not survive on any page (the "AllPages" caller
+  // below depends on it), even if a bug elsewhere duplicated one (#643).
   for (const page of draft.pages) {
     const index = page.findIndex((item) => item.id === id);
     if (index !== -1) {
       page.splice(index, 1);
-      return;
     }
   }
 }
@@ -149,6 +161,18 @@ export function replaceEntryIdAllPages(
   tempId: number,
   serverEntry: FlowsheetEntry
 ): void {
+  if (
+    process.env.NODE_ENV !== "production" &&
+    !draft.pages.some((page) => page.some((e) => e.id === tempId))
+  ) {
+    // Instrumentation for #860 (entries transiently vanishing after re-sync):
+    // a missed swap means the optimistic row was already gone when the server
+    // response landed. The insert below still runs, so the server entry is
+    // never lost — but the miss itself is the signal worth capturing.
+    console.warn(
+      `[flowsheet] replaceEntryIdAllPages: tempId ${tempId} not in cache (dj-site#860)`
+    );
+  }
   removeEntryById(draft, tempId);
   insertEntrySortedFirstPage(draft, serverEntry);
 }

--- a/lib/features/flowsheet/infinite-cache.ts
+++ b/lib/features/flowsheet/infinite-cache.ts
@@ -1,3 +1,5 @@
+import { safeCapture } from "@/lib/posthog";
+import { hasLinkedAlbumId } from "./linkage";
 import type {
   FlowsheetEntry,
   FlowsheetMessageEntry,
@@ -21,19 +23,29 @@ export function maxPlayOrder(draft: Pick<InfiniteEntriesDraft, "pages">): number
   return m;
 }
 
-/** First non-empty `show_id` in page order, or `-1` if none. */
+/**
+ * Newest entry's `show_id`, skipping orphaned entries (show_id -1, from
+ * convertV2Entry's null mapping), or `-1` if none. The skip matters:
+ * partitionFlowsheetEntries treats currentShow -1 as "nobody is live", so a
+ * single orphaned newest row must not masquerade as that sentinel and flip
+ * the whole live show into "previous".
+ */
 export function primaryShowId(draft: Pick<InfiniteEntriesDraft, "pages">): number {
   for (const page of draft.pages) {
-    if (page.length > 0) return page[0].show_id;
+    for (const e of page) {
+      if (e.show_id >= 0) return e.show_id;
+    }
   }
   return -1;
 }
 
 // Monotonic counter, not Date.now()+random: two submissions in the same
 // millisecond had a real collision chance, and a collision makes
-// replaceEntryIdAllPages silently drop one of the rows (#620).
-// More-negative = newer, which compareEntriesNewestFirst relies on.
-let optimisticTempIdCounter = 0;
+// replaceEntryIdAllPages silently drop one of the rows (#620). Seeded from
+// the clock so a Fast-Refresh module re-eval can't reissue an id still held
+// by an in-flight optimistic row. More-negative = newer, which
+// compareEntriesNewestFirst relies on.
+let optimisticTempIdCounter = Date.now();
 
 export function nextOptimisticTempId(): number {
   return -++optimisticTempIdCounter;
@@ -62,7 +74,7 @@ export function buildOptimisticEntry(
   // Key presence isn't enough: callers can pass `album_id: undefined` (or a
   // synthesized negative id for library-unlinked rows), which must render
   // the freeform variant, not a blank catalog row (#607).
-  if ("album_id" in arg && typeof arg.album_id === "number" && arg.album_id > 0) {
+  if ("album_id" in arg && hasLinkedAlbumId(arg.album_id)) {
     const entry: FlowsheetSongEntry = {
       id: tempId,
       play_order,
@@ -161,17 +173,22 @@ export function replaceEntryIdAllPages(
   tempId: number,
   serverEntry: FlowsheetEntry
 ): void {
-  if (
-    process.env.NODE_ENV !== "production" &&
-    !draft.pages.some((page) => page.some((e) => e.id === tempId))
-  ) {
+  if (!draft.pages.some((page) => page.some((e) => e.id === tempId))) {
     // Instrumentation for #860 (entries transiently vanishing after re-sync):
     // a missed swap means the optimistic row was already gone when the server
     // response landed. The insert below still runs, so the server entry is
-    // never lost — but the miss itself is the signal worth capturing.
-    console.warn(
-      `[flowsheet] replaceEntryIdAllPages: tempId ${tempId} not in cache (dj-site#860)`
-    );
+    // never lost. Known benign source of the same signal: a DJ deleting
+    // their just-submitted row before its POST resolves — correlate ids when
+    // analyzing, don't treat every event as a #860 repro.
+    safeCapture("flowsheet_optimistic_replace_miss", {
+      tempId,
+      serverEntryId: serverEntry.id,
+    });
+    if (process.env.NODE_ENV === "development") {
+      console.warn(
+        `[flowsheet] replaceEntryIdAllPages: tempId ${tempId} not in cache (dj-site#860)`
+      );
+    }
   }
   removeEntryById(draft, tempId);
   insertEntrySortedFirstPage(draft, serverEntry);
@@ -195,6 +212,9 @@ export function movePlayOrder(
     }
   }
   if (!moved) return;
+  // Orphaned entries (show_id -1) don't form a real per-show block — two
+  // unrelated orphans would renumber each other's play_order.
+  if (moved.show_id < 0) return;
   const oldPosition = moved.play_order;
   if (oldPosition === newPosition) return;
   const showId = moved.show_id;

--- a/lib/features/flowsheet/infinite-cache.ts
+++ b/lib/features/flowsheet/infinite-cache.ts
@@ -24,16 +24,19 @@ export function maxPlayOrder(draft: Pick<InfiniteEntriesDraft, "pages">): number
 }
 
 /**
- * Newest entry's `show_id`, skipping orphaned entries (show_id -1, from
- * convertV2Entry's null mapping), or `-1` if none. The skip matters:
+ * Newest entry's `show_id`, skipping orphaned entries (show_id exactly -1,
+ * from convertV2Entry's null mapping), or `-1` if none. The skip matters:
  * partitionFlowsheetEntries treats currentShow -1 as "nobody is live", so a
  * single orphaned newest row must not masquerade as that sentinel and flip
- * the whole live show into "previous".
+ * the whole live show into "previous". Other negative show_ids are NOT
+ * skipped — the #619 fix pushes an optimistic show-start marker whose
+ * show_id is a fresh negative tempId, and it must win here so the prior
+ * show's tail stops partitioning as current during the goLive window.
  */
 export function primaryShowId(draft: Pick<InfiniteEntriesDraft, "pages">): number {
   for (const page of draft.pages) {
     for (const e of page) {
-      if (e.show_id >= 0) return e.show_id;
+      if (e.show_id !== -1) return e.show_id;
     }
   }
   return -1;
@@ -212,9 +215,11 @@ export function movePlayOrder(
     }
   }
   if (!moved) return;
-  // Orphaned entries (show_id -1) don't form a real per-show block — two
-  // unrelated orphans would renumber each other's play_order.
-  if (moved.show_id < 0) return;
+  // Orphaned entries (show_id exactly -1) don't form a real per-show block —
+  // two unrelated orphans would renumber each other's play_order. Other
+  // negative show_ids are coherent optimistic show blocks (#619 marker) and
+  // may renumber normally.
+  if (moved.show_id === -1) return;
   const oldPosition = moved.play_order;
   if (oldPosition === newPosition) return;
   const showId = moved.show_id;

--- a/lib/features/flowsheet/linkage.ts
+++ b/lib/features/flowsheet/linkage.ts
@@ -1,0 +1,11 @@
+/**
+ * True when `album_id` is a real library link: a positive DB id.
+ * `undefined` means freeform; negative ids are synthesized client-side for
+ * library-unlinked rows (`synthesizeAlbumId` in catalog/conversions), and
+ * BS's album lookup throws on them (#701). Callers gate the linked-album
+ * submission shape on this — previously five files re-derived the check
+ * locally (#607/#608/#701/#702 lineage).
+ */
+export function hasLinkedAlbumId(albumId: unknown): albumId is number {
+  return typeof albumId === "number" && albumId > 0;
+}

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.test.ts
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
+import { usePlayNow } from "./usePlayNow";
+
+const addToFlowsheetMock = vi.fn((_params: Record<string, unknown>) => ({
+  unwrap: () => Promise.resolve(),
+}));
+
+vi.mock("@/lib/features/flowsheet/api", () => ({
+  useAddToFlowsheetMutation: () => [addToFlowsheetMock],
+}));
+
+vi.mock("@/src/hooks/authenticationHooks", () => ({
+  useRegistry: () => ({ loading: false, info: { id: 1 } }),
+}));
+
+vi.mock("@/lib/hooks", () => ({
+  useAppDispatch: () => vi.fn(),
+}));
+
+const queueEntry = (overrides: Partial<FlowsheetSongEntry>): FlowsheetSongEntry => ({
+  id: 3,
+  play_order: 3,
+  show_id: 7,
+  track_title: "la paradoja",
+  artist_name: "Juana Molina",
+  album_title: "DOGA",
+  record_label: "Sonamos",
+  request_flag: false,
+  ...overrides,
+});
+
+describe("usePlayNow submission payload (#607/#701 gate)", () => {
+  beforeEach(() => {
+    addToFlowsheetMock.mockClear();
+  });
+
+  it("omits album_id/rotation keys for a freeform queue entry (album_id undefined)", () => {
+    const { result } = renderHook(() => usePlayNow(queueEntry({})));
+    result.current();
+
+    const payload = addToFlowsheetMock.mock.calls[0][0];
+    expect("album_id" in payload).toBe(false);
+    expect("rotation_id" in payload).toBe(false);
+    expect("rotation_bin" in payload).toBe(false);
+    expect(payload.artist_name).toBe("Juana Molina");
+  });
+
+  it("omits the linkage keys for a synthesized negative album_id (BS throws on those)", () => {
+    const { result } = renderHook(() =>
+      usePlayNow(queueEntry({ album_id: -42, rotation_id: 9 }))
+    );
+    result.current();
+
+    const payload = addToFlowsheetMock.mock.calls[0][0];
+    expect("album_id" in payload).toBe(false);
+    expect("rotation_id" in payload).toBe(false);
+  });
+
+  it("carries the linkage keys for a real positive album_id", () => {
+    const { result } = renderHook(() =>
+      usePlayNow(queueEntry({ album_id: 42, rotation_id: 9, rotation: "H" }))
+    );
+    result.current();
+
+    const payload = addToFlowsheetMock.mock.calls[0][0];
+    expect(payload.album_id).toBe(42);
+    expect(payload.rotation_id).toBe(9);
+    expect(payload.rotation_bin).toBe("H");
+  });
+});

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.test.ts
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.test.ts
@@ -36,18 +36,17 @@ describe("usePlayNow submission payload (#607/#701 gate)", () => {
     addToFlowsheetMock.mockClear();
   });
 
-  it("omits album_id/rotation keys for a freeform queue entry (album_id undefined)", () => {
+  it("omits album_id/rotation_bin for a freeform queue entry (album_id undefined)", () => {
     const { result } = renderHook(() => usePlayNow(queueEntry({})));
     result.current();
 
     const payload = addToFlowsheetMock.mock.calls[0][0];
     expect("album_id" in payload).toBe(false);
-    expect("rotation_id" in payload).toBe(false);
     expect("rotation_bin" in payload).toBe(false);
     expect(payload.artist_name).toBe("Juana Molina");
   });
 
-  it("omits the linkage keys for a synthesized negative album_id (BS throws on those)", () => {
+  it("drops a synthesized negative album_id but keeps rotation_id (freeform wire carries it, BS#1308)", () => {
     const { result } = renderHook(() =>
       usePlayNow(queueEntry({ album_id: -42, rotation_id: 9 }))
     );
@@ -55,7 +54,7 @@ describe("usePlayNow submission payload (#607/#701 gate)", () => {
 
     const payload = addToFlowsheetMock.mock.calls[0][0];
     expect("album_id" in payload).toBe(false);
-    expect("rotation_id" in payload).toBe(false);
+    expect(payload.rotation_id).toBe(9);
   });
 
   it("carries the linkage keys for a real positive album_id", () => {

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.ts
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.ts
@@ -2,6 +2,7 @@
 
 import { useAddToFlowsheetMutation } from "@/lib/features/flowsheet/api";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { hasLinkedAlbumId } from "@/lib/features/flowsheet/linkage";
 import {
   FlowsheetSongEntry,
   FlowsheetSubmissionParams,
@@ -24,12 +25,12 @@ export function usePlayNow(entry: FlowsheetSongEntry) {
     if (!userData || userData.id === undefined || userloading) {
       return;
     }
-    // Same gate as convertQueryToSubmission (#701): queue entries can carry
-    // `album_id: undefined` (freeform) or a synthesized negative id
-    // (library-unlinked bin rows, which BS throws on). Only a real positive
-    // album_id may carry the rotation linkage keys (#607).
-    const hasLinkedAlbum =
-      typeof entry.album_id === "number" && entry.album_id > 0;
+    // Queue entries can carry `album_id: undefined` (freeform) or a
+    // synthesized negative id (library-unlinked bin rows, which BS throws
+    // on — #701). Only a real positive album_id may go on the wire (#607).
+    // rotation_id stays either way: the freeform variant carries it since
+    // BS#1308 so unlinked rotation plays keep their linkage (mirrors
+    // convertBinToFlowsheet).
     addToFlowsheet({
       track_title: entry.track_title,
       artist_name: entry.artist_name,
@@ -37,9 +38,9 @@ export function usePlayNow(entry: FlowsheetSongEntry) {
       record_label: entry.record_label,
       request_flag: entry.request_flag,
       segue: entry.segue,
-      ...(hasLinkedAlbum && {
+      rotation_id: entry.rotation_id,
+      ...(hasLinkedAlbumId(entry.album_id) && {
         album_id: entry.album_id,
-        rotation_id: entry.rotation_id,
         rotation_bin: entry.rotation,
       }),
     } as FlowsheetSubmissionParams)

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.ts
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.ts
@@ -24,6 +24,12 @@ export function usePlayNow(entry: FlowsheetSongEntry) {
     if (!userData || userData.id === undefined || userloading) {
       return;
     }
+    // Same gate as convertQueryToSubmission (#701): queue entries can carry
+    // `album_id: undefined` (freeform) or a synthesized negative id
+    // (library-unlinked bin rows, which BS throws on). Only a real positive
+    // album_id may carry the rotation linkage keys (#607).
+    const hasLinkedAlbum =
+      typeof entry.album_id === "number" && entry.album_id > 0;
     addToFlowsheet({
       track_title: entry.track_title,
       artist_name: entry.artist_name,
@@ -31,9 +37,11 @@ export function usePlayNow(entry: FlowsheetSongEntry) {
       record_label: entry.record_label,
       request_flag: entry.request_flag,
       segue: entry.segue,
-      rotation_id: entry.rotation_id,
-      album_id: entry.album_id,
-      rotation_bin: entry.rotation,
+      ...(hasLinkedAlbum && {
+        album_id: entry.album_id,
+        rotation_id: entry.rotation_id,
+        rotation_bin: entry.rotation,
+      }),
     } as FlowsheetSubmissionParams)
       .unwrap()
       .then(() => {


### PR DESCRIPTION
## What

Five cache-layer fixes from the 2026-07 bug triage (`docs/plans/bug-triage-2026-07/02-…`), plus red-team follow-ups:

- **#620** — `nextOptimisticTempId` is a clock-seeded monotonic counter: same-millisecond submissions could collide under `Date.now()*1000+random`, silently dropping a row in `replaceEntryIdAllPages`; the clock seed also survives Fast-Refresh module re-evaluation.
- **#607** — `buildOptimisticEntry` gates its catalog branch on a real positive `album_id` instead of key presence (freeform queue entries rendered blank), and `usePlayNow` applies the same gate — which also stops "Play Now" 500s on bin-sourced entries carrying synthesized negative ids (#701 class). `rotation_id` stays on the freeform wire per BS#1308.
- **#629** — nullable `show_id` maps to the `-1` sentinel, never `0` (a real show 0 would adopt orphaned entries). Red-team follow-up: `primaryShowId` skips orphans so one null-show row can't read as partition's "nobody live" sentinel and blank the live show, and `movePlayOrder` refuses to renumber orphans as one show block.
- **#643** — `removeEntryById` removes from every page, matching what `replaceEntryIdAllPages`' name promises.
- **#628** — the deferred metadata refetch passes `subscribe: false`; the leaked default subscription pinned the `getNowPlaying` cache entry per addEntry.
- **#860 instrumentation** — `safeCapture("flowsheet_optimistic_replace_miss")` (production-visible, matching `live-updates-listener`'s telemetry pattern) + dev-mode warn, with the known-benign delete-before-POST-resolves race documented at the call site.
- **Reuse** — the five per-file re-derivations of the album-linkage gate collapse into one exported `hasLinkedAlbumId()` (`lib/features/flowsheet/linkage.ts`).

## Red-team review (high effort, 5 angles + verify)

Four CONFIRMED correctness findings were fixed in the second commit (orphan-sentinel collision with the partition control flow being the significant one — the first commit's `-1` mapping would have blanked a live show on one orphaned row). One accepted residual: the replace-miss telemetry also fires on a benign delete-during-inflight-POST race — documented at the call site with correlating ids rather than suppressed.

## Testing

3,557 unit tests + typecheck green. New coverage: tempId uniqueness + ordering, freeform/negative/undefined `album_id` branches, `-1` sentinel conversion, orphan-skip in `primaryShowId`, orphan guard in `movePlayOrder`, all-pages removal, `subscribe: false` assertion, telemetry on missed swaps (and none on normal swaps), `usePlayNow` payload shapes.

Closes #607
Closes #620
Closes #628
Closes #629
Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)