### PR TITLE
fix(api): guard app_state mutations against CSRF and malformed cookies

### DIFF
--- a/app/api/experiences/__tests__/switch.test.ts
+++ b/app/api/experiences/__tests__/switch.test.ts
@@ -119,6 +119,18 @@ describe("POST /api/experiences/switch", () => {
     expect(JSON.parse(store.get("app_state")!.value).experience).toBe("modern");
   });
 
+  it("rejects a cross-origin POST via the Referer fallback with 403", async () => {
+    const { POST } = await import("@/app/api/experiences/switch/route");
+    const response = await POST(
+      makeRequest(
+        { experience: "classic" },
+        { host: SITE_HOST, referer: "https://evil.example/attack" }
+      )
+    );
+
+    expect((response as any).status).toBe(403);
+  });
+
   it("rejects a POST with no Origin or Referer with 403 (fail closed)", async () => {
     const { POST } = await import("@/app/api/experiences/switch/route");
     const response = await POST(

--- a/app/api/experiences/__tests__/switch.test.ts
+++ b/app/api/experiences/__tests__/switch.test.ts
@@ -39,16 +39,17 @@ vi.mock("next/server", () => {
   };
 });
 
-// The guard requires an authenticated session; mock it so tests control that.
 vi.mock("@/lib/features/authentication/server-utils", () => ({
   getServerSession: vi.fn(async () => ({ user: { id: "test-user" } })),
 }));
 
 const SITE_HOST = "dj.wxyc.org";
 
-// Build a request-like object exposing the headers the guard reads. Defaults to
-// a same-origin, authenticated request; override to exercise the guard.
+// Build a request-like object exposing the headers the guard reads and the
+// JSON body the switch handler parses. Defaults to a same-origin, authenticated
+// request switching to the classic experience.
 function makeRequest(
+  body: unknown = { experience: "classic" },
   headers: Record<string, string> = {
     host: SITE_HOST,
     origin: `https://${SITE_HOST}`,
@@ -58,6 +59,7 @@ function makeRequest(
     headers: {
       get: (name: string) => headers[name.toLowerCase()] ?? null,
     },
+    json: async () => body,
   };
 }
 
@@ -68,7 +70,7 @@ async function getServerSessionMock() {
   return vi.mocked(getServerSession);
 }
 
-describe("POST /api/view/rightbar (Bug 5)", () => {
+describe("POST /api/experiences/switch", () => {
   beforeEach(async () => {
     const { cookies } = await import("next/headers");
     const store = await cookies();
@@ -78,40 +80,23 @@ describe("POST /api/view/rightbar (Bug 5)", () => {
     } as any);
   });
 
-  it("should return the NEW state after toggling, not the old state", async () => {
-    const { POST } = await import("@/app/api/view/rightbar/route");
-
-    const response = await POST(makeRequest());
-    const body = (response as any).body;
-
-    expect(body.rightBarMini).toBe(!defaultApplicationState.rightBarMini);
-  });
-
-  it("should toggle rightBarMini from the current cookie state", async () => {
+  it("switches the experience on a same-origin authenticated POST", async () => {
+    const { POST } = await import("@/app/api/experiences/switch/route");
     const { cookies } = await import("next/headers");
     const store = await cookies();
-    store.set({
-      name: "app_state",
-      value: JSON.stringify({ ...defaultApplicationState, rightBarMini: false }),
-    });
 
-    const { POST } = await import("@/app/api/view/rightbar/route");
+    const response = await POST(makeRequest({ experience: "classic" }));
 
-    const response = await POST(makeRequest());
-    const body = (response as any).body;
-
-    expect(body.rightBarMini).toBe(true);
+    expect((response as any).status).toBe(200);
+    expect((response as any).body.experience).toBe("classic");
+    expect(JSON.parse(store.get("app_state")!.value).experience).toBe("classic");
   });
-});
 
-describe("POST /api/view/rightbar origin/auth guard (#599)", () => {
-  beforeEach(async () => {
-    const { cookies } = await import("next/headers");
-    const store = await cookies();
-    (store as any)._reset();
-    (await getServerSessionMock()).mockResolvedValue({
-      user: { id: "test-user" },
-    } as any);
+  it("rejects an invalid experience with 400", async () => {
+    const { POST } = await import("@/app/api/experiences/switch/route");
+    const response = await POST(makeRequest({ experience: "space-age" }));
+
+    expect((response as any).status).toBe(400);
   });
 
   it("rejects a cross-origin POST with 403 and does not mutate the cookie", async () => {
@@ -119,53 +104,37 @@ describe("POST /api/view/rightbar origin/auth guard (#599)", () => {
     const store = await cookies();
     store.set({
       name: "app_state",
-      value: JSON.stringify({ ...defaultApplicationState, rightBarMini: false }),
+      value: JSON.stringify({ ...defaultApplicationState, experience: "modern" }),
     });
 
-    const { POST } = await import("@/app/api/view/rightbar/route");
+    const { POST } = await import("@/app/api/experiences/switch/route");
     const response = await POST(
-      makeRequest({ host: SITE_HOST, origin: "https://evil.example" })
+      makeRequest(
+        { experience: "classic" },
+        { host: SITE_HOST, origin: "https://evil.example" }
+      )
     );
 
     expect((response as any).status).toBe(403);
-    // Cookie is untouched: the stored value still parses to the original state.
-    expect(JSON.parse(store.get("app_state")!.value).rightBarMini).toBe(false);
+    expect(JSON.parse(store.get("app_state")!.value).experience).toBe("modern");
   });
 
   it("rejects a POST with no Origin or Referer with 403 (fail closed)", async () => {
-    const { POST } = await import("@/app/api/view/rightbar/route");
-    const response = await POST(makeRequest({ host: SITE_HOST }));
-
-    expect((response as any).status).toBe(403);
-  });
-
-  it("allows a same-origin POST via the Referer header when Origin is absent", async () => {
-    const { POST } = await import("@/app/api/view/rightbar/route");
+    const { POST } = await import("@/app/api/experiences/switch/route");
     const response = await POST(
-      makeRequest({ host: SITE_HOST, referer: `https://${SITE_HOST}/dashboard` })
+      makeRequest({ experience: "classic" }, { host: SITE_HOST })
     );
 
-    expect((response as any).status).toBe(200);
+    expect((response as any).status).toBe(403);
   });
 
   it("rejects an unauthenticated same-origin POST with 403", async () => {
     (await getServerSessionMock()).mockResolvedValue(null);
 
-    const { POST } = await import("@/app/api/view/rightbar/route");
+    const { POST } = await import("@/app/api/experiences/switch/route");
     const response = await POST(makeRequest());
 
     expect((response as any).status).toBe(403);
-  });
-});
-
-describe("POST /api/view/rightbar malformed cookie (#600)", () => {
-  beforeEach(async () => {
-    const { cookies } = await import("next/headers");
-    const store = await cookies();
-    (store as any)._reset();
-    (await getServerSessionMock()).mockResolvedValue({
-      user: { id: "test-user" },
-    } as any);
   });
 
   it("returns success with defaults, not 500, when app_state is malformed", async () => {
@@ -173,13 +142,10 @@ describe("POST /api/view/rightbar malformed cookie (#600)", () => {
     const store = await cookies();
     store.set({ name: "app_state", value: "{not valid json" });
 
-    const { POST } = await import("@/app/api/view/rightbar/route");
-    const response = await POST(makeRequest());
+    const { POST } = await import("@/app/api/experiences/switch/route");
+    const response = await POST(makeRequest({ experience: "classic" }));
 
     expect((response as any).status).toBe(200);
-    // Falls back to defaults, then toggles rightBarMini off its default.
-    expect((response as any).body.rightBarMini).toBe(
-      !defaultApplicationState.rightBarMini
-    );
+    expect((response as any).body.experience).toBe("classic");
   });
 });

--- a/app/api/experiences/switch/route.ts
+++ b/app/api/experiences/switch/route.ts
@@ -1,15 +1,21 @@
 import { defaultApplicationState } from "@/lib/features/application/types";
 import { isExperienceId } from "@/lib/features/experiences/types";
 import { sessionOptions } from "@/lib/features/session";
+import { guardAppStateMutation } from "@/lib/features/session-guards";
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
+  const guardResponse = await guardAppStateMutation(request);
+  if (guardResponse) {
+    return guardResponse;
+  }
+
   const cookieStore = await cookies();
   const body = await request.json();
-  
+
   const requestedExperience = body.experience;
-  
+
   // Validate the experience
   if (!isExperienceId(requestedExperience)) {
     return NextResponse.json(
@@ -20,9 +26,14 @@ export async function POST(request: NextRequest) {
 
   // Get current state
   const data = cookieStore.get("app_state")?.value;
-  const currentState = data
-    ? { ...defaultApplicationState, ...JSON.parse(data) }
-    : defaultApplicationState;
+  let currentState = defaultApplicationState;
+  if (data) {
+    try {
+      currentState = { ...defaultApplicationState, ...JSON.parse(data) };
+    } catch (error) {
+      console.error("Failed to parse app_state", error);
+    }
+  }
   
   // Update with new experience
   const newState = {

--- a/app/api/view/__tests__/rightbar.test.ts
+++ b/app/api/view/__tests__/rightbar.test.ts
@@ -148,6 +148,95 @@ describe("POST /api/view/rightbar origin/auth guard (#599)", () => {
     expect((response as any).status).toBe(200);
   });
 
+  it("rejects a cross-origin POST via the Referer fallback with 403", async () => {
+    const { POST } = await import("@/app/api/view/rightbar/route");
+    const response = await POST(
+      makeRequest({ host: SITE_HOST, referer: "https://evil.example/attack" })
+    );
+
+    expect((response as any).status).toBe(403);
+  });
+
+  it("prefers x-forwarded-host over host when a proxy sets it", async () => {
+    const { POST } = await import("@/app/api/view/rightbar/route");
+    const response = await POST(
+      makeRequest({
+        "x-forwarded-host": SITE_HOST,
+        host: "internal-render-host:8788",
+        origin: `https://${SITE_HOST}`,
+      })
+    );
+
+    expect((response as any).status).toBe(200);
+  });
+
+  it("still rejects a cross-origin POST when x-forwarded-host is set", async () => {
+    const { POST } = await import("@/app/api/view/rightbar/route");
+    const response = await POST(
+      makeRequest({
+        "x-forwarded-host": SITE_HOST,
+        host: "internal-render-host:8788",
+        origin: "https://evil.example",
+      })
+    );
+
+    expect((response as any).status).toBe(403);
+  });
+
+  it("uses the first value of a comma-separated x-forwarded-host list", async () => {
+    const { POST } = await import("@/app/api/view/rightbar/route");
+    const response = await POST(
+      makeRequest({
+        "x-forwarded-host": `${SITE_HOST}, inner-proxy.internal`,
+        host: "internal-render-host:8788",
+        origin: `https://${SITE_HOST}`,
+      })
+    );
+
+    expect((response as any).status).toBe(200);
+  });
+
+  it("matches host header ports against the Origin's port", async () => {
+    const { POST } = await import("@/app/api/view/rightbar/route");
+    const response = await POST(
+      makeRequest({ host: "localhost:3000", origin: "http://localhost:3000" })
+    );
+
+    expect((response as any).status).toBe(200);
+  });
+
+  it("rejects an Origin on a different port of the same hostname with 403", async () => {
+    // The port is part of the origin boundary; a hostname-only comparison
+    // would wrongly admit any other service on the same machine.
+    const { POST } = await import("@/app/api/view/rightbar/route");
+    const response = await POST(
+      makeRequest({ host: "localhost:3000", origin: "http://localhost:8080" })
+    );
+
+    expect((response as any).status).toBe(403);
+  });
+
+  it("rejects a literal 'Origin: null' (sandboxed iframe) with 403, not 500", async () => {
+    const { POST } = await import("@/app/api/view/rightbar/route");
+    const response = await POST(
+      makeRequest({ host: SITE_HOST, origin: "null" })
+    );
+
+    expect((response as any).status).toBe(403);
+  });
+
+  it("compares hosts case-insensitively", async () => {
+    const { POST } = await import("@/app/api/view/rightbar/route");
+    const response = await POST(
+      makeRequest({
+        "x-forwarded-host": SITE_HOST.toUpperCase(),
+        origin: `https://${SITE_HOST}`,
+      })
+    );
+
+    expect((response as any).status).toBe(200);
+  });
+
   it("rejects an unauthenticated same-origin POST with 403", async () => {
     (await getServerSessionMock()).mockResolvedValue(null);
 

--- a/app/api/view/rightbar/route.ts
+++ b/app/api/view/rightbar/route.ts
@@ -1,15 +1,26 @@
 import { defaultApplicationState } from "@/lib/features/application/types";
 import { sessionOptions } from "@/lib/features/session";
+import { guardAppStateMutation } from "@/lib/features/session-guards";
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
+  const guardResponse = await guardAppStateMutation(request);
+  if (guardResponse) {
+    return guardResponse;
+  }
+
   const cookieStore = await cookies();
 
   const data = cookieStore.get("app_state")?.value;
-  const appState = data
-    ? { ...defaultApplicationState, ...JSON.parse(data) }
-    : defaultApplicationState;
+  let appState = defaultApplicationState;
+  if (data) {
+    try {
+      appState = { ...defaultApplicationState, ...JSON.parse(data) };
+    } catch (error) {
+      console.error("Failed to parse app_state", error);
+    }
+  }
   const newState = {
     ...appState,
     rightBarMini: !appState.rightBarMini,

--- a/lib/features/session-guards.ts
+++ b/lib/features/session-guards.ts
@@ -1,0 +1,61 @@
+import "server-only";
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "./authentication/server-utils";
+
+// The host we were served on, as reported by the edge/proxy. Cloudflare Pages
+// (and local dev) set `host`; a fronting proxy may instead set
+// `x-forwarded-host`. Deriving the expected origin from the request itself keeps
+// the check correct across production, localhost, and per-commit preview deploys
+// without hardcoding a host.
+function servedHost(request: NextRequest): string | null {
+  return request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+}
+
+function hostOf(headerValue: string | null): string | null {
+  if (!headerValue) return null;
+  try {
+    return new URL(headerValue).host;
+  } catch {
+    return null;
+  }
+}
+
+function forbidden(): NextResponse {
+  return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+}
+
+/**
+ * Guard for POST routes that mutate the `app_state` cookie
+ * (`/api/experiences/switch`, `/api/view/rightbar`).
+ *
+ * The session cookie is `sameSite: "lax"` (see `sessionOptions`), which lets a
+ * third-party page drive a top-level cross-origin POST, so we reject any request
+ * whose Origin/Referer host isn't the host we were served on. A request missing
+ * BOTH Origin and Referer is rejected too (fail closed): a legitimate
+ * same-origin fetch from the app always carries at least a Referer. We also
+ * require an authenticated session — neither route has a logged-out caller
+ * (see the PR notes), so this adds a defense-in-depth layer without breaking a
+ * legitimate flow.
+ *
+ * Returns a 403 `NextResponse` to return as-is, or `null` when the request may
+ * proceed.
+ */
+export async function guardAppStateMutation(
+  request: NextRequest
+): Promise<NextResponse | null> {
+  const expectedHost = servedHost(request);
+  const requestHost =
+    hostOf(request.headers.get("origin")) ??
+    hostOf(request.headers.get("referer"));
+
+  if (!expectedHost || !requestHost || requestHost !== expectedHost) {
+    return forbidden();
+  }
+
+  const session = await getServerSession();
+  if (!session) {
+    return forbidden();
+  }
+
+  return null;
+}

--- a/lib/features/session-guards.ts
+++ b/lib/features/session-guards.ts
@@ -8,13 +8,25 @@ import { getServerSession } from "./authentication/server-utils";
 // the check correct across production, localhost, and per-commit preview deploys
 // without hardcoding a host.
 function servedHost(request: NextRequest): string | null {
-  return request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  // Trusting x-forwarded-host assumes the edge (Cloudflare) overwrites any
+  // inbound value; a direct request spoofing it carries no victim session
+  // cookie, and the session requirement below backstops it.
+  const forwarded = request.headers.get("x-forwarded-host");
+  if (forwarded) {
+    // Multi-proxy chains may append a comma-separated list; the first entry is
+    // the client-facing host.
+    return forwarded.split(",")[0].trim().toLowerCase();
+  }
+  return request.headers.get("host")?.toLowerCase() ?? null;
 }
 
 function hostOf(headerValue: string | null): string | null {
   if (!headerValue) return null;
   try {
-    return new URL(headerValue).host;
+    // `host` includes any explicit port — the port is part of the origin
+    // boundary, so a hostname-only comparison would wrongly admit a different
+    // port on the same machine.
+    return new URL(headerValue).host.toLowerCase();
   } catch {
     return null;
   }


### PR DESCRIPTION
## What

- **#599 (P1, security)** — `/api/experiences/switch` and `/api/view/rightbar` mutated the `app_state` cookie with zero validation (session cookie is `sameSite: lax`, which permits cross-origin top-level POSTs). Both POST handlers now run a shared `guardAppStateMutation()` (`lib/features/session-guards.ts`) before any cookie work: Origin (Referer fallback) host must match the served host — derived from `x-forwarded-host` (first value, case-normalized) falling back to `host` — else 403; requests missing both headers fail closed; then an authenticated session is required.
- **#600** — the same two handlers wrapped their bare `JSON.parse(app_state)` in try/catch falling back to `defaultApplicationState`, mirroring the sibling `preferences/route.ts` pattern. Malformed cookie → 200 with defaults, not 500.

## Decisions

- **Session required, not just origin-checked:** verified no logged-out caller exists — the rightbar toggle mounts only inside the `requireAuth`-gated dashboard, and login-page theme switching goes through `/api/experiences/preferences` (untouched). Notably, `/api/experiences/switch` has **zero frontend callers** at all (everything routes through preferences) — hardened anyway; deletion is a separate conversation.
- **Port stays in the comparison** — it's part of the origin boundary (hostname-only matching would accept cross-port CSRF in dev).
- **`x-forwarded-host` trust assumption documented** at the call site: the edge overwrites inbound values; a direct spoofed request carries no victim cookie; the session check backstops.

## Red-team review (high effort, security-focused)

No live bypass found — suffix/subdomain tricks, Referer path-injection, `Origin: null`, auth-service-down, and guard-ordering were each attacked and held (fail-closed throughout). Review-driven hardening applied in the second commit: case normalization, comma-list `x-forwarded-host` handling, and the full attack-matrix test coverage (port mismatch, `Origin: null`, Referer-reject on both routes, x-f-h precedence).

## Testing

Typecheck clean; full suite green (3,565 tests). The two route test files carry a 22-test guard matrix.

Closes #599
Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)