### PR TITLE
ci(preview): retry smoke + fold checks so Cloudflare propagation lag stops failing the job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,7 +401,23 @@ jobs:
           PROBE_URL="${DEPLOY_URL%/}/"
           echo "Probing ${PROBE_URL}"
 
-          HTTP_CODE=$(curl -sS -o /dev/null -w '%{http_code}\n' --max-time 30 "$PROBE_URL" || echo "000")
+          # A Direct-Upload deployment is not instantly live: the new
+          # *.pages.dev hostname can take a minute-plus to propagate at the
+          # edge, during which curl sees DNS/connect failures (000), 5xx, or
+          # stale-routing 4xx. Poll for up to ~3 minutes before treating the
+          # status as real — historically almost every failure of this step
+          # was propagation lag, not a broken build.
+          MAX_ATTEMPTS=12
+          HTTP_CODE="000"
+          for ATTEMPT in $(seq 1 "$MAX_ATTEMPTS"); do
+            HTTP_CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "$PROBE_URL" || echo "000")
+            case "$HTTP_CODE" in
+              2*|3*|401|403) break ;;
+            esac
+            echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: HTTP ${HTTP_CODE} — waiting for the deployment to propagate."
+            if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then sleep 15; fi
+          done
+
           echo "Preview ${PROBE_URL} returned HTTP ${HTTP_CODE}"
           echo "http_code=${HTTP_CODE}" >> "$GITHUB_OUTPUT"
 
@@ -439,14 +455,29 @@ jobs:
           # the only automated guard against the fold regressing (unit tests and
           # Playwright E2E both run on Node/undici, which never folds). sign-out
           # emits the deletions unconditionally, so this creates no session/user.
-          HDRS=$(curl -sS -D - -o /dev/null --max-time 30 -X POST \
-            -H 'content-type: application/json' \
-            -H 'origin: https://dj.wxyc.org' \
-            "${BASE}/auth/sign-out" || true)
-          STATUS=$(printf '%s' "$HDRS" | head -1 | tr -d '\r')
-          COUNT=$(printf '%s' "$HDRS" | grep -ic '^set-cookie:')
-          echo "sign-out at ${BASE}: ${STATUS}; ${COUNT} Set-Cookie header(s)"
+          # Retry a few times: the smoke step already waited for the
+          # deployment to go live, but a POST through a cold edge node can
+          # still transiently fail or return an error page with no cookies.
+          # `|| true` on the grep is load-bearing — grep -c exits 1 on zero
+          # matches, and without it `bash -e` kills the step before COUNT is
+          # logged or written to $GITHUB_OUTPUT (the empty-count PR comments).
+          MAX_ATTEMPTS=5
+          COUNT=0
+          STATUS=""
+          for ATTEMPT in $(seq 1 "$MAX_ATTEMPTS"); do
+            HDRS=$(curl -sS -D - -o /dev/null --max-time 30 -X POST \
+              -H 'content-type: application/json' \
+              -H 'origin: https://dj.wxyc.org' \
+              "${BASE}/auth/sign-out" || true)
+            STATUS=$(printf '%s' "$HDRS" | head -1 | tr -d '\r')
+            COUNT=$(printf '%s' "$HDRS" | grep -ic '^set-cookie:' || true)
+            echo "Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: sign-out at ${BASE}: ${STATUS:-<no response>}; ${COUNT} Set-Cookie header(s)"
+            if [ "$COUNT" -ge 2 ]; then break; fi
+            if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then sleep 10; fi
+          done
+
           echo "setcookie_count=${COUNT}" >> "$GITHUB_OUTPUT"
+          echo "signout_status=${STATUS:-no response}" >> "$GITHUB_OUTPUT"
           if [ "$COUNT" -lt 2 ]; then
             echo "::error::/auth/sign-out returned ${COUNT} Set-Cookie header(s), expected 3 — multiple Set-Cookie headers are being folded into one (opennextjs-cloudflare#501). See app/auth/[...path]/route.ts."
             exit 1
@@ -463,12 +494,13 @@ jobs:
           DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
           HTTP_CODE: ${{ steps.smoke.outputs.http_code }}
           SETCOOKIE_COUNT: ${{ steps.setcookie.outputs.setcookie_count }}
+          SIGNOUT_STATUS: ${{ steps.setcookie.outputs.signout_status }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           if [ "$DEPLOY_OUTCOME" != "success" ]; then
             BODY="Preview smoke check failed: the CI preview build/deploy for commit ${HEAD_SHA} did not complete (build error or \`wrangler pages deploy\` failure). See the workflow run for details: ${RUN_URL}. Merging is blocked until the preview builds and boots cleanly."
           elif printf '%s' "$HTTP_CODE" | grep -qE '^(2|3|401|403)'; then
-            BODY="Preview fold check failed: \`POST /auth/sign-out\` at ${DEPLOY_URL} returned \`${SETCOOKIE_COUNT}\` Set-Cookie header(s), expected 3. Multiple Set-Cookie headers are being folded into one (opennextjs-cloudflare#501) — the regression \`app/auth/[...path]/route.ts\` fixes. See the workflow run: ${RUN_URL}."
+            BODY="Preview fold check failed: \`POST /auth/sign-out\` at ${DEPLOY_URL} returned \`${SETCOOKIE_COUNT:-no}\` Set-Cookie header(s) (status: \`${SIGNOUT_STATUS:-unknown}\`), expected 3. Multiple Set-Cookie headers are being folded into one (opennextjs-cloudflare#501) — the regression \`app/auth/[...path]/route.ts\` fixes. See the workflow run: ${RUN_URL}."
           else
             BODY="Preview smoke check failed: ${DEPLOY_URL}/ returned HTTP \`${HTTP_CODE}\`. A 5xx response usually means the Cloudflare worker failed at boot — see the workflow run: ${RUN_URL}. Merging is blocked until the preview URL returns a non-5xx response."
           fi


### PR DESCRIPTION
## Problem

The `Preview URL smoke check` job almost always needs a manual re-run: it probes the fresh `*.pages.dev` deployment exactly once, immediately after `wrangler pages deploy` returns, but Direct-Upload deployments routinely take a minute-plus to actually go live at the Cloudflare edge. During that window the probe sees `000`/`404`/`5xx` and fails the required check even though the build is fine.

Separately, when the **Set-Cookie fold regression check** failed transiently (e.g. PR #861), the failure comment reported an empty count — ``returned ` ` Set-Cookie header(s)`` — because `grep -ic` exits `1` on zero matches and, under the step's `bash -e` shell, that killed the step **before** the count was echoed or written to `$GITHUB_OUTPUT`. A transient network blip was therefore indistinguishable from a real fold regression.

## Changes (`.github/workflows/ci.yml`, preview job only)

- **Smoke-test preview URL**: poll for up to ~3 minutes (12 × 15 s) until a healthy status (`2xx/3xx/401/403`) appears, before treating the final status as real. Failure semantics are unchanged — a genuine 5xx/4xx still blocks after the window.
- **Set-Cookie fold check**: `|| true` on the `grep -c` pipeline (the actual bug), plus up to 5 attempts 10 s apart for cold edge nodes, and a new `signout_status` output so failures show the HTTP status line of the sign-out response.
- **Failure comment**: includes the sign-out status, and falls back to `no`/`unknown` instead of rendering empty backticks when outputs are missing.

## Verification

Extracted the three edited `run:` blocks verbatim (with `set -e`, matching the Actions shell) and ran them locally:

- against the live PR #861 preview → smoke passes on attempt 1, fold check finds 3 `Set-Cookie` headers, `http_code=200`, `setcookie_count=3`, `signout_status=HTTP/2 200` all written to `$GITHUB_OUTPUT`;
- against a nonexistent `*.pages.dev` subdomain (with attempts/sleeps shrunk) → both steps retry, then exit 1 with the proper `::error::` annotations, and `setcookie_count=0` (not empty) plus `signout_status=HTTP/2 404` are written.

`bash -n` and a YAML parse pass on the workflow. (No local `actionlint` available; script blocks were validated as above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)