### PR TITLE
fix(flowsheet): harden submit, go-live, and queue paths (cluster-02 PR b)

### DIFF
--- a/lib/__tests__/features/flowsheet/constants.test.ts
+++ b/lib/__tests__/features/flowsheet/constants.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import {
-  FLOWSHEET_OPTIMISTIC_DJ_PLACEHOLDER,
   FLOWSHEET_PAGE_SIZE,
   OFF_AIR_LABEL,
 } from "@/lib/features/flowsheet/constants";
@@ -9,6 +8,5 @@ describe("flowsheet constants", () => {
   it("exports stable pagination and copy constants", () => {
     expect(FLOWSHEET_PAGE_SIZE).toBe(20);
     expect(OFF_AIR_LABEL).toBe("Off Air");
-    expect(FLOWSHEET_OPTIMISTIC_DJ_PLACEHOLDER).toBeTruthy();
   });
 });

--- a/lib/__tests__/features/flowsheet/flowsheet.test.ts
+++ b/lib/__tests__/features/flowsheet/flowsheet.test.ts
@@ -83,6 +83,46 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.search.selectedResult).toBe(3);
     });
 
+    it("resetSearch clears every optional FlowsheetQuery field (#645)", () => {
+      // Seed a query where every optional field is populated (rotation
+      // metadata, segue, track_position) — the fields the default literal
+      // previously omitted — then reset and assert they all read undefined.
+      const stateWithAllFields: FlowsheetFrontendState = {
+        ...harness().initialState,
+        search: {
+          ...harness().initialState.search,
+          query: {
+            song: "la paradoja",
+            artist: "Juana Molina",
+            album: "DOGA",
+            label: "Sonamos",
+            request: true,
+            segue: true,
+            album_id: 42,
+            rotation_bin: "H",
+            rotation_id: 7,
+            track_position: "A1",
+          },
+        },
+      };
+
+      const result = harness().reduce(
+        actions.resetSearch(),
+        stateWithAllFields
+      );
+
+      expect(result.search.query.song).toBe("");
+      expect(result.search.query.artist).toBe("");
+      expect(result.search.query.album).toBe("");
+      expect(result.search.query.label).toBe("");
+      expect(result.search.query.request).toBe(false);
+      expect(result.search.query.segue).toBeUndefined();
+      expect(result.search.query.album_id).toBeUndefined();
+      expect(result.search.query.rotation_bin).toBeUndefined();
+      expect(result.search.query.rotation_id).toBeUndefined();
+      expect(result.search.query.track_position).toBeUndefined();
+    });
+
     // Arrow-key navigation between search results moves to a different
     // album_id (each result is a distinct release). track_position picked on
     // the previous result would orphan onto the new release if not cleared.
@@ -457,6 +497,51 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       mockedSaveQueue.mockClear();
       harness().reduce(actions.reorderQueue([]));
       expect(mockedSaveQueue).toHaveBeenCalled();
+    });
+
+    it("lifts queueIdCounter above any reordered id ≥ the current counter (#646)", () => {
+      const stateWithQueue: FlowsheetFrontendState = {
+        ...harness().initialState,
+        queue: [createTestFlowsheetEntry({ id: 0, play_order: 0 })],
+        queueIdCounter: 1,
+      };
+
+      // A future caller reorders in an entry whose id (9) exceeds the counter;
+      // without the recompute a later addToQueue would reuse id 1..9 and
+      // collide.
+      const reordered = [
+        createTestFlowsheetEntry({ id: 9, play_order: 0, track_title: "New" }),
+        createTestFlowsheetEntry({ id: 0, play_order: 1, track_title: "Old" }),
+      ];
+      const result = harness().reduce(
+        actions.reorderQueue(reordered),
+        stateWithQueue
+      );
+
+      expect(result.queueIdCounter).toBe(10);
+      // Invariant: counter is strictly greater than every id in the queue.
+      for (const entry of result.queue) {
+        expect(result.queueIdCounter).toBeGreaterThan(entry.id);
+      }
+    });
+
+    it("never lowers queueIdCounter on a same-id reorder (#646)", () => {
+      const entries = [
+        createTestFlowsheetEntry({ id: 0, play_order: 0 }),
+        createTestFlowsheetEntry({ id: 1, play_order: 1 }),
+      ];
+      const stateWithQueue: FlowsheetFrontendState = {
+        ...harness().initialState,
+        queue: entries,
+        queueIdCounter: 5,
+      };
+
+      const result = harness().reduce(
+        actions.reorderQueue([entries[1], entries[0]]),
+        stateWithQueue
+      );
+
+      expect(result.queueIdCounter).toBe(5);
     });
   });
 

--- a/lib/__tests__/features/flowsheet/joinShow.optimistic.test.ts
+++ b/lib/__tests__/features/flowsheet/joinShow.optimistic.test.ts
@@ -44,15 +44,20 @@ function selectWhoIsLiveCache(store: ReturnType<typeof createTestStore>) {
     .data;
 }
 
-async function seedStore() {
+async function seedStore(
+  onAirDJs: { id: string | null; dj_name: string }[] = []
+) {
   server.use(
     http.get(`${TEST_BACKEND_URL}/flowsheet/`, () =>
       HttpResponse.json(priorEntries)
     ),
     http.get(`${TEST_BACKEND_URL}/flowsheet/djs-on-air`, () =>
-      HttpResponse.json([])
+      HttpResponse.json(onAirDJs)
     ),
-    http.post(`${TEST_BACKEND_URL}/flowsheet/join`, () => HttpResponse.json({}))
+    http.post(`${TEST_BACKEND_URL}/flowsheet/join`, () =>
+      HttpResponse.json({})
+    ),
+    http.post(`${TEST_BACKEND_URL}/flowsheet/end`, () => HttpResponse.json({}))
   );
 
   const store = createTestStore();
@@ -131,5 +136,71 @@ describe("joinShow optimistic patch", () => {
     expect(live.djs.some((d) => d.dj_name === "Live")).toBe(false);
 
     await promise;
+  });
+
+  it("keeps the previous banner when a DJ with no display name joins solo (#621)", async () => {
+    const store = await seedStore();
+
+    const promise = store.dispatch(
+      flowsheetApi.endpoints.joinShow.initiate({ dj_id: "test-user-1" })
+    );
+
+    const live = selectWhoIsLiveCache(store)!;
+    // The DJ still flips live (the id lands in djs)...
+    expect(live.djs.some((d) => d.id === "test-user-1")).toBe(true);
+    // ...but the banner never blanks and never reads "Live"; it stays the
+    // previous value ("Off Air") until the refetch supplies a real name.
+    expect(live.onAir).toBe("Off Air");
+    expect(live.onAir).not.toBe("");
+    expect(live.onAir).not.toContain("Live");
+
+    await promise;
+  });
+
+  it("formats the banner without a trailing comma when a no-name DJ joins alongside another DJ (#621)", async () => {
+    const store = await seedStore([{ id: "1", dj_name: "Marz" }]);
+
+    const promise = store.dispatch(
+      flowsheetApi.endpoints.joinShow.initiate({ dj_id: "test-user-1" })
+    );
+
+    const live = selectWhoIsLiveCache(store)!;
+    expect(live.djs).toHaveLength(2);
+    // Only named DJs render; no "Marz, " trailing comma, no "Live".
+    expect(live.onAir).toBe("Marz");
+
+    await promise;
+  });
+
+  it("leaveShow removes the optimistic show-start marker when leaving before join's refetch (#619)", async () => {
+    const store = await seedStore();
+
+    const joinPromise = store.dispatch(
+      flowsheetApi.endpoints.joinShow.initiate({
+        dj_id: "test-user-1",
+        dj_name: "Test DJ",
+      })
+    );
+
+    // Marker present during the pre-refetch window.
+    expect(
+      selectEntriesCache(store)!
+        .pages.flat()
+        .some((e) => e.show_id < 0)
+    ).toBe(true);
+
+    const leavePromise = store.dispatch(
+      flowsheetApi.endpoints.leaveShow.initiate({ dj_id: "test-user-1" })
+    );
+
+    // leaveShow's optimistic patch drops the orphaned marker immediately...
+    const cache = selectEntriesCache(store)!;
+    expect(cache.pages.flat().some((e) => e.show_id < 0)).toBe(false);
+    // ...while the real prior-show entries survive.
+    expect(cache.pages.flat().map((e) => e.id)).toEqual(
+      expect.arrayContaining([5001, 5002])
+    );
+
+    await Promise.all([joinPromise, leavePromise]);
   });
 });

--- a/lib/__tests__/features/flowsheet/joinShow.optimistic.test.ts
+++ b/lib/__tests__/features/flowsheet/joinShow.optimistic.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+
+import { flowsheetApi } from "@/lib/features/flowsheet/api";
+import {
+  compareEntriesNewestFirst,
+  primaryShowId,
+} from "@/lib/features/flowsheet/infinite-cache";
+import { partitionFlowsheetEntries } from "@/lib/features/flowsheet/partition";
+import type { FlowsheetEntry } from "@/lib/features/flowsheet/types";
+import {
+  createTestStore,
+  createTestV2TrackEntry,
+  server,
+  TEST_BACKEND_URL,
+  TEST_ENTITY_IDS,
+} from "@/lib/test-utils";
+
+// Mock the auth client so the base query's prepareHeaders doesn't try to fetch
+// a JWT (no auth server running). Mirrors addToFlowsheet.wiring.test.ts.
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue(null),
+  clearTokenCache: vi.fn(),
+  authBaseURL: "http://localhost:3001/auth",
+  authClient: {},
+}));
+
+const PAST_SHOW = TEST_ENTITY_IDS.SHOW.PAST_SHOW;
+
+/** Prior show's tail — two tracks that predate the DJ going live. */
+const priorEntries = [
+  createTestV2TrackEntry({ id: 5001, show_id: PAST_SHOW, play_order: 1 }),
+  createTestV2TrackEntry({ id: 5002, show_id: PAST_SHOW, play_order: 2 }),
+];
+
+function selectEntriesCache(store: ReturnType<typeof createTestStore>) {
+  return flowsheetApi.endpoints.getInfiniteEntries.select(undefined)(
+    store.getState()
+  ).data;
+}
+
+function selectWhoIsLiveCache(store: ReturnType<typeof createTestStore>) {
+  return flowsheetApi.endpoints.whoIsLive.select(undefined)(store.getState())
+    .data;
+}
+
+async function seedStore() {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/flowsheet/`, () =>
+      HttpResponse.json(priorEntries)
+    ),
+    http.get(`${TEST_BACKEND_URL}/flowsheet/djs-on-air`, () =>
+      HttpResponse.json([])
+    ),
+    http.post(`${TEST_BACKEND_URL}/flowsheet/join`, () => HttpResponse.json({}))
+  );
+
+  const store = createTestStore();
+  // Prime both caches so the optimistic patches have data to work with.
+  await store
+    .dispatch(flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined))
+    .unwrap();
+  await store
+    .dispatch(flowsheetApi.endpoints.whoIsLive.initiate(undefined))
+    .unwrap();
+  return store;
+}
+
+describe("joinShow optimistic patch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("moves the previous show's entries out of the current-show pane immediately after goLive (#619)", async () => {
+    const store = await seedStore();
+
+    // Sanity: before joining, the newest entry is the prior show, so a naive
+    // currentShow would partition the prior show's tail as current.
+    expect(primaryShowId(selectEntriesCache(store)!)).toBe(PAST_SHOW);
+
+    // Dispatch without awaiting: the optimistic patch runs synchronously in
+    // onQueryStarted, so we inspect the cache during the pre-refetch window.
+    const promise = store.dispatch(
+      flowsheetApi.endpoints.joinShow.initiate({
+        dj_id: "test-user-1",
+        dj_name: "Test DJ",
+      })
+    );
+
+    const cache = selectEntriesCache(store)!;
+    const currentShow = primaryShowId(cache);
+    // currentShow no longer resolves to the previous show.
+    expect(currentShow).not.toBe(PAST_SHOW);
+
+    const allEntries = cache.pages
+      .flat()
+      .slice()
+      .sort(compareEntriesNewestFirst) as FlowsheetEntry[];
+    const { current, previous } = partitionFlowsheetEntries(
+      allEntries,
+      currentShow,
+      true
+    );
+
+    // No prior-show entry leaks into the current-show pane.
+    expect(current.some((e) => e.show_id === PAST_SHOW)).toBe(false);
+    // The prior tail is preserved under previous shows.
+    expect(previous.filter((e) => e.id === 5001 || e.id === 5002)).toHaveLength(
+      2
+    );
+    // The only current-show entry is the optimistic show-start marker.
+    expect(current).toHaveLength(1);
+    expect(current[0]).toMatchObject({ isStart: true, dj_name: "Test DJ" });
+
+    await promise;
+  });
+
+  it("seeds the optimistic banner with the real dj_name, never the 'Live' placeholder (#621)", async () => {
+    const store = await seedStore();
+
+    const promise = store.dispatch(
+      flowsheetApi.endpoints.joinShow.initiate({
+        dj_id: "test-user-1",
+        dj_name: "Test DJ",
+      })
+    );
+
+    const live = selectWhoIsLiveCache(store)!;
+    expect(live.onAir).toBe("Test DJ");
+    expect(live.onAir).not.toContain("Live");
+    expect(live.djs.some((d) => d.dj_name === "Live")).toBe(false);
+
+    await promise;
+  });
+});

--- a/lib/__tests__/features/flowsheet/soft-fail.test.ts
+++ b/lib/__tests__/features/flowsheet/soft-fail.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+
+import { flowsheetApi } from "@/lib/features/flowsheet/api";
+import { OFF_AIR_LABEL } from "@/lib/features/flowsheet/constants";
+import { createTestStore, server, TEST_BACKEND_URL } from "@/lib/test-utils";
+
+// Mock the auth client so the base query's prepareHeaders doesn't try to fetch
+// a JWT (no auth server running). Mirrors addToFlowsheet.wiring.test.ts.
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue(null),
+  clearTokenCache: vi.fn(),
+  authBaseURL: "http://localhost:3001/auth",
+  authClient: {},
+}));
+
+// backendBaseQuery soft-fails non-JSON GETs (gateway interstitials, HTML
+// error pages) to `{data: null}` (#606). These transforms must map that to
+// a safe empty shape instead of crashing in a converter.
+describe("flowsheet transformResponse soft-fail guards (#606)", () => {
+  it("getInfiniteEntries resolves to an empty page on a non-JSON body", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/flowsheet/`, () =>
+        HttpResponse.text("<html>Bad Gateway</html>")
+      )
+    );
+    const store = createTestStore();
+    const result = await store.dispatch(
+      flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined, {
+        subscribe: false,
+      })
+    );
+    expect(result.status).toBe("fulfilled");
+    expect(result.data?.pages[0]).toEqual([]);
+  });
+
+  it("whoIsLive resolves to the off-air shape on a non-JSON body", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/flowsheet/djs-on-air`, () =>
+        HttpResponse.text("<html>Bad Gateway</html>")
+      )
+    );
+    const store = createTestStore();
+    const result = await store.dispatch(
+      flowsheetApi.endpoints.whoIsLive.initiate(undefined, {
+        subscribe: false,
+      })
+    );
+    expect(result.status).toBe("fulfilled");
+    expect(result.data).toEqual({ djs: [], onAir: OFF_AIR_LABEL });
+  });
+});

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -24,6 +24,7 @@ import {
   FlowsheetEntry,
   FlowsheetShowBlockEntry,
   FlowsheetSubmissionParams,
+  isFlowsheetStartShowEntry,
   FlowsheetSwitchParams,
   FlowsheetUpdateParams,
   FlowsheetV2EntryJSON,
@@ -120,7 +121,10 @@ export const flowsheetApi = createApi({
       invalidatesTags: ["NowPlaying", "WhoIsLive"],
       async onQueryStarted(arg, { dispatch, queryFulfilled }) {
         // Seed the banner with the real dj_name so the public /live page never
-        // renders the "Live" placeholder during the refetch window. (#621)
+        // renders a "Live" placeholder during the refetch window. A joiner
+        // with no display name must not blank the banner or leave a trailing
+        // comma: format only the named DJs, and when none exist keep the
+        // previous banner until the refetch lands. (#621)
         const patchLive = dispatch(
           flowsheetApi.util.updateQueryData(
             "whoIsLive",
@@ -132,7 +136,10 @@ export const flowsheetApi = createApi({
                   id: arg.dj_id,
                   dj_name: arg.dj_name ?? "",
                 });
-                draft.onAir = formatOnAirSummary(draft.djs);
+                const named = draft.djs.filter((d) => d.dj_name);
+                if (named.length) {
+                  draft.onAir = formatOnAirSummary(named);
+                }
               }
             }
           )
@@ -190,12 +197,32 @@ export const flowsheetApi = createApi({
             }
           )
         );
+        // Leaving before joinShow's refetch lands would orphan the optimistic
+        // show-start marker (negative show_id) as a stray row — drop any such
+        // markers here. (#619)
+        const patchEntries = dispatch(
+          flowsheetApi.util.updateQueryData(
+            "getInfiniteEntries",
+            undefined,
+            (draft) => {
+              for (const page of draft.pages) {
+                for (let i = page.length - 1; i >= 0; i--) {
+                  const entry = page[i];
+                  if (entry.show_id < 0 && isFlowsheetStartShowEntry(entry)) {
+                    page.splice(i, 1);
+                  }
+                }
+              }
+            }
+          )
+        );
         try {
           await queryFulfilled;
           dispatch(flowsheetApi.util.invalidateTags(["Flowsheet"]));
         } catch (err) {
           flowsheetMutationCatch("leaveShow", err);
           patchLive.undo();
+          patchEntries.undo();
         }
       },
     }),

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -1,10 +1,7 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import { DJRequestParams } from "../authentication/types";
 import { backendBaseQuery } from "../backend";
-import {
-  FLOWSHEET_OPTIMISTIC_DJ_PLACEHOLDER,
-  FLOWSHEET_PAGE_SIZE,
-} from "./constants";
+import { FLOWSHEET_PAGE_SIZE } from "./constants";
 import { scheduleDeferredFlowsheetRefetch } from "./deferred-refetch";
 import {
   convertDJsOnAir,
@@ -16,13 +13,16 @@ import {
 import {
   buildOptimisticEntry,
   insertEntrySortedFirstPage,
+  maxPlayOrder,
   movePlayOrder,
+  nextOptimisticTempId,
   patchEntryById,
   removeEntryById,
   replaceEntryIdAllPages,
 } from "./infinite-cache";
 import {
   FlowsheetEntry,
+  FlowsheetShowBlockEntry,
   FlowsheetSubmissionParams,
   FlowsheetSwitchParams,
   FlowsheetUpdateParams,
@@ -107,15 +107,20 @@ export const flowsheetApi = createApi({
     }),
     joinShow: builder.mutation<
       void,
-      DJRequestParams & { dj_name_override?: string }
+      DJRequestParams & { dj_name?: string; dj_name_override?: string }
     >({
-      query: (params) => ({
+      // `dj_name` is a client-only display hint for the optimistic patches
+      // below; keep it off the wire (the backend derives the on-air name from
+      // dj_id / dj_name_override).
+      query: ({ dj_name: _dj_name, ...params }) => ({
         url: "/join",
         method: "POST",
         body: params,
       }),
       invalidatesTags: ["NowPlaying", "WhoIsLive"],
       async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+        // Seed the banner with the real dj_name so the public /live page never
+        // renders the "Live" placeholder during the refetch window. (#621)
         const patchLive = dispatch(
           flowsheetApi.util.updateQueryData(
             "whoIsLive",
@@ -125,10 +130,34 @@ export const flowsheetApi = createApi({
               if (!draft.djs.some((d) => d.id === arg.dj_id)) {
                 draft.djs.push({
                   id: arg.dj_id,
-                  dj_name: FLOWSHEET_OPTIMISTIC_DJ_PLACEHOLDER,
+                  dj_name: arg.dj_name ?? "",
                 });
                 draft.onAir = formatOnAirSummary(draft.djs);
               }
+            }
+          )
+        );
+        // Push an optimistic show-start marker with a fresh (negative) show_id
+        // so `currentShow` (the newest entry's show_id) no longer resolves to
+        // the previous show. Without this, the prior show's tail partitions as
+        // the current show and stays editable until the refetch lands. (#619)
+        const patchEntries = dispatch(
+          flowsheetApi.util.updateQueryData(
+            "getInfiniteEntries",
+            undefined,
+            (draft) => {
+              if (!draft.pages.length) return;
+              const tempId = nextOptimisticTempId();
+              const marker: FlowsheetShowBlockEntry = {
+                id: tempId,
+                play_order: maxPlayOrder(draft) + 1,
+                show_id: tempId,
+                dj_name: arg.dj_name ?? "",
+                isStart: true,
+                day: "",
+                time: "",
+              };
+              insertEntrySortedFirstPage(draft, marker);
             }
           )
         );
@@ -138,6 +167,7 @@ export const flowsheetApi = createApi({
         } catch (err) {
           flowsheetMutationCatch("joinShow", err);
           patchLive.undo();
+          patchEntries.undo();
         }
       },
     }),

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -71,9 +71,11 @@ export const flowsheetApi = createApi({
           url: `/?page=${pageParam}&limit=${FLOWSHEET_PAGE_SIZE}`,
         };
       },
+      // `backendBaseQuery` soft-fails non-JSON GETs to `{data: null}` (#606);
+      // guard so a gateway interstitial can't crash the transform.
       transformResponse: (
-        response: FlowsheetV2PaginatedResponseJSON | FlowsheetV2EntryJSON[]
-      ) => convertV2FlowsheetResponse(extractFlowsheetEntries(response)),
+        response: FlowsheetV2PaginatedResponseJSON | FlowsheetV2EntryJSON[] | null
+      ) => (response ? convertV2FlowsheetResponse(extractFlowsheetEntries(response)) : []),
       providesTags: ["Flowsheet"],
     }),
     switchEntries: builder.mutation<undefined, FlowsheetSwitchParams>({
@@ -230,8 +232,10 @@ export const flowsheetApi = createApi({
       query: () => ({
         url: "/djs-on-air",
       }),
-      transformResponse: (response: OnAirDJResponse[]): OnAirDJData =>
-        convertDJsOnAir(response),
+      // convertDJsOnAir already maps a missing list to the off-air shape;
+      // widen for the #606 null soft-fail so it takes that path.
+      transformResponse: (response: OnAirDJResponse[] | null): OnAirDJData =>
+        convertDJsOnAir(response ?? undefined),
       providesTags: ["WhoIsLive"],
     }),
     addToFlowsheet: builder.mutation<FlowsheetEntry, FlowsheetSubmissionParams>(

--- a/lib/features/flowsheet/constants.ts
+++ b/lib/features/flowsheet/constants.ts
@@ -1,9 +1,6 @@
 /** Page size for flowsheet list / infinite query (must match backend pagination). */
 export const FLOWSHEET_PAGE_SIZE = 20;
 
-/** Shown as `dj_name` until WhoIsLive refetches after join. */
-export const FLOWSHEET_OPTIMISTIC_DJ_PLACEHOLDER = "Live";
-
 /** Empty / off-air summary label (keep in sync with API copy). */
 export const OFF_AIR_LABEL = "Off Air";
 

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -35,12 +35,20 @@ export const defaultFlowsheetFrontendState: FlowsheetFrontendState = {
   rotationMode: false,
   search: {
     open: false,
+    // Enumerate every FlowsheetQuery field (explicit `undefined` for the
+    // optionals) so resetSearch clears them all — even a future path that
+    // mutates search.query in place instead of reassigning it. (#645)
     query: {
       song: "",
       artist: "",
       album: "",
       label: "",
       request: false,
+      segue: undefined,
+      album_id: undefined,
+      rotation_bin: undefined,
+      rotation_id: undefined,
+      track_position: undefined,
     },
     selectedResult: 0,
     confirmedArtist: "",
@@ -176,6 +184,14 @@ export const flowsheetSlice = createAppSlice({
     },
     reorderQueue: (state, action: PayloadAction<FlowsheetSongEntry[]>) => {
       state.queue = action.payload;
+      // Keep the counter strictly ahead of every id in the queue so a future
+      // caller that passes entries with ids beyond the current counter can't
+      // make a later addToQueue collide. (#646)
+      const maxId = action.payload.reduce(
+        (max, entry) => Math.max(max, entry.id),
+        -1
+      );
+      state.queueIdCounter = Math.max(state.queueIdCounter, maxId + 1);
       saveQueueToStorage(state.queue);
     },
     setSelectedResult: (state, action: PayloadAction<number>) => {

--- a/src/hooks/flowsheetHooks.test.tsx
+++ b/src/hooks/flowsheetHooks.test.tsx
@@ -304,6 +304,29 @@ describe("flowsheetHooks", () => {
       });
     });
 
+    it("falls back to real_name for the optimistic dj_name when the DJ has no handle (#621)", () => {
+      mockUseRegistry.mockReturnValue({
+        loading: false,
+        info: {
+          ...mockUserInfo,
+          dj_name: undefined,
+        } as unknown as typeof mockUserInfo,
+      });
+
+      const { result } = renderHook(() => useShowControl(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.goLive();
+      });
+
+      expect(mockGoLiveFunction).toHaveBeenCalledWith({
+        dj_id: "test-user-1",
+        dj_name: "Test User",
+      });
+    });
+
     it("should omit dj_name_override when goLive is called without one", () => {
       const { result } = renderHook(() => useShowControl(), {
         wrapper: createWrapper(),
@@ -938,7 +961,7 @@ describe("flowsheetHooks", () => {
       expect(result.current.queue.length).toBe(1);
     });
 
-    it("clears the queue once WhoIsLive settles and confirms the DJ is off-air (#644)", () => {
+    it("clears the queue after two consecutive settled off-air reads (#644)", () => {
       const { result, rerender } = renderHook(() => useQueue(), {
         wrapper: createWrapper(),
       });
@@ -954,8 +977,28 @@ describe("flowsheetHooks", () => {
       });
       expect(result.current.queue.length).toBe(1);
 
-      // Settled (isFetching false) AND off-air (empty djs): the DJ actually
-      // ended the show, so the queue clears.
+      // First settled off-air read: could be stale (see the post-join test
+      // below), so no clear yet.
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: { djs: [], onAir: "" },
+        isLoading: false,
+        isSuccess: true,
+        isFetching: false,
+      } as ReturnType<typeof mockUseWhoIsLiveQuery>);
+      rerender();
+      expect(result.current.queue.length).toBe(1);
+
+      // Next poll cycle: refetch...
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: { djs: [], onAir: "" },
+        isLoading: false,
+        isSuccess: true,
+        isFetching: true,
+      } as ReturnType<typeof mockUseWhoIsLiveQuery>);
+      rerender();
+      expect(result.current.queue.length).toBe(1);
+
+      // ...settles off-air again: the DJ genuinely ended the show, so clear.
       mockUseWhoIsLiveQuery.mockReturnValue({
         data: { djs: [], onAir: "" },
         isLoading: false,
@@ -964,6 +1007,95 @@ describe("flowsheetHooks", () => {
       } as ReturnType<typeof mockUseWhoIsLiveQuery>);
       rerender();
       expect(result.current.queue.length).toBe(0);
+    });
+
+    it("survives a settled-but-stale off-air read right after join (#644)", () => {
+      // join fulfilled → invalidate → the refetch can settle BEFORE the
+      // backend registers the DJ, yielding a settled empty-djs read. One such
+      // read must not wipe the queue.
+      const { result, rerender } = renderHook(() => useQueue(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.addToQueue({
+          song: "Test Song",
+          artist: "Test Artist",
+          album: "Test Album",
+          label: "Test Label",
+          request: false,
+        });
+      });
+      expect(result.current.queue.length).toBe(1);
+
+      // Invalidation refetch in flight.
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: mockLiveData,
+        isLoading: false,
+        isSuccess: true,
+        isFetching: true,
+      } as ReturnType<typeof mockUseWhoIsLiveQuery>);
+      rerender();
+
+      // Refetch settles with a stale empty roster: queue must survive.
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: { djs: [], onAir: "" },
+        isLoading: false,
+        isSuccess: true,
+        isFetching: false,
+      } as ReturnType<typeof mockUseWhoIsLiveQuery>);
+      rerender();
+      expect(result.current.queue.length).toBe(1);
+
+      // Next poll corrects the roster: still live, still intact.
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: mockLiveData,
+        isLoading: false,
+        isSuccess: true,
+        isFetching: true,
+      } as ReturnType<typeof mockUseWhoIsLiveQuery>);
+      rerender();
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: mockLiveData,
+        isLoading: false,
+        isSuccess: true,
+        isFetching: false,
+      } as ReturnType<typeof mockUseWhoIsLiveQuery>);
+      rerender();
+      expect(result.current.queue.length).toBe(1);
+    });
+
+    it("clears the queue on logout even though the WhoIsLive subscription is skipped (#644)", () => {
+      const { result, rerender } = renderHook(() => useQueue(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.addToQueue({
+          song: "Test Song",
+          artist: "Test Artist",
+          album: "Test Album",
+          label: "Test Label",
+          request: false,
+        });
+      });
+      expect(result.current.queue.length).toBe(1);
+
+      // Logout: useRegistry reports loading whenever unauthenticated, and the
+      // WhoIsLive query is skipped — the settled gate can never fire, so the
+      // signed-in → signed-out transition must clear directly.
+      mockUseRegistry.mockReturnValue({
+        loading: true,
+        info: null,
+      });
+      rerender();
+
+      expect(result.current.queue.length).toBe(0);
+      // clearQueue's reducer also drops the persisted copy
+      // (localStorage is the vi.fn stub from vitest.setup.ts).
+      expect(window.localStorage.removeItem).toHaveBeenCalledWith(
+        "wxyc_flowsheet_queue"
+      );
     });
 
     it("should handle removeFromQueue call when already live then user goes offline", () => {

--- a/src/hooks/flowsheetHooks.test.tsx
+++ b/src/hooks/flowsheetHooks.test.tsx
@@ -284,6 +284,7 @@ describe("flowsheetHooks", () => {
 
       expect(mockGoLiveFunction).toHaveBeenCalledWith({
         dj_id: "test-user-1",
+        dj_name: "Test DJ",
       });
     });
 
@@ -298,6 +299,7 @@ describe("flowsheetHooks", () => {
 
       expect(mockGoLiveFunction).toHaveBeenCalledWith({
         dj_id: "test-user-1",
+        dj_name: "Aubrey Hearst",
         dj_name_override: "Aubrey Hearst",
       });
     });
@@ -897,6 +899,73 @@ describe("flowsheetHooks", () => {
       expect(result.current.queue.length).toBe(0);
     });
 
+    it("does not clear the queue during a transient WhoIsLive refetch (#644)", () => {
+      // Add an entry while live and settled.
+      const { result, rerender } = renderHook(() => useQueue(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.addToQueue({
+          song: "Test Song",
+          artist: "Test Artist",
+          album: "Test Album",
+          label: "Test Label",
+          request: false,
+        });
+      });
+      expect(result.current.queue.length).toBe(1);
+
+      // Invalidate→refetch window: WhoIsLive momentarily reads off-air while
+      // isFetching is true. The old !loading gate would have cleared here.
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: { djs: [], onAir: "" },
+        isLoading: false,
+        isSuccess: true,
+        isFetching: true,
+      } as ReturnType<typeof mockUseWhoIsLiveQuery>);
+      rerender();
+      expect(result.current.queue.length).toBe(1);
+
+      // Refetch settles and confirms the DJ is still live: still no clear.
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: mockLiveData,
+        isLoading: false,
+        isSuccess: true,
+        isFetching: false,
+      } as ReturnType<typeof mockUseWhoIsLiveQuery>);
+      rerender();
+      expect(result.current.queue.length).toBe(1);
+    });
+
+    it("clears the queue once WhoIsLive settles and confirms the DJ is off-air (#644)", () => {
+      const { result, rerender } = renderHook(() => useQueue(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.addToQueue({
+          song: "Test Song",
+          artist: "Test Artist",
+          album: "Test Album",
+          label: "Test Label",
+          request: false,
+        });
+      });
+      expect(result.current.queue.length).toBe(1);
+
+      // Settled (isFetching false) AND off-air (empty djs): the DJ actually
+      // ended the show, so the queue clears.
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: { djs: [], onAir: "" },
+        isLoading: false,
+        isSuccess: true,
+        isFetching: false,
+      } as ReturnType<typeof mockUseWhoIsLiveQuery>);
+      rerender();
+      expect(result.current.queue.length).toBe(0);
+    });
+
     it("should handle removeFromQueue call when already live then user goes offline", () => {
       // First add an entry while live
       const { result, rerender } = renderHook(() => useQueue(), {
@@ -1348,6 +1417,70 @@ describe("flowsheetHooks", () => {
       });
 
       expect(result.current.selectedResultData.track_position).toBe("A1");
+    });
+
+    it("forwards the toggled request flag in the manual-entry branch (selectedResult == 0) (#602)", () => {
+      // A call-in request typed free-form: toggleRequest set query.request
+      // true, and the manual-entry branch of selectedResultData must forward
+      // it so convertQueryToSubmission emits request_flag: true.
+      const customWrapper = createHookWrapper(
+        { flowsheet: flowsheetSlice, liveUpdates: liveUpdatesSlice },
+        {
+          flowsheet: {
+            ...flowsheetSlice.getInitialState(),
+            search: {
+              ...flowsheetSlice.getInitialState().search,
+              selectedResult: 0,
+              query: {
+                song: "la paradoja",
+                artist: "Juana Molina",
+                album: "DOGA",
+                label: "Sonamos",
+                request: true,
+              },
+            },
+          },
+        }
+      );
+
+      const { result } = renderHook(() => useFlowsheetSubmit(), {
+        wrapper: customWrapper,
+      });
+
+      expect(result.current.selectedResultData.request).toBe(true);
+    });
+
+    it("forwards the toggled request flag in the selected-result branch (selectedResult > 0) (#602)", () => {
+      const mockAlbum = createTestAlbum({ id: 321, title: "DOGA" });
+      mockUseCatalogFlowsheetSearch.mockReturnValue({
+        searchResults: [mockAlbum],
+      });
+
+      const customWrapper = createHookWrapper(
+        { flowsheet: flowsheetSlice, liveUpdates: liveUpdatesSlice },
+        {
+          flowsheet: {
+            ...flowsheetSlice.getInitialState(),
+            search: {
+              ...flowsheetSlice.getInitialState().search,
+              selectedResult: 1,
+              query: {
+                song: "la paradoja",
+                artist: "Juana Molina",
+                album: "DOGA",
+                label: "Sonamos",
+                request: true,
+              },
+            },
+          },
+        }
+      );
+
+      const { result } = renderHook(() => useFlowsheetSubmit(), {
+        wrapper: customWrapper,
+      });
+
+      expect(result.current.selectedResultData.request).toBe(true);
     });
 
     it("should use fallback values from flowSheetRawQuery when selectedEntry has missing values", () => {

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -110,15 +110,17 @@ export const useShowControl = () => {
     // override; the backend treats empty/whitespace as absent, but the
     // hook keeps the wire-shape clean either way.
     // `dj_name` is a display-only hint for the optimistic WhoIsLive / feed
-    // patch (so the public banner reads the real name, never "Live"); it's
-    // stripped from the request body in the joinShow query. (#619, #621)
+    // patch (so the public banner reads a real name, never "Live"); it's
+    // stripped from the request body in the joinShow query. Fall through the
+    // identity fields useRegistry exposes — a DJ without a registered handle
+    // still has a real_name. (#619, #621)
     const payload: {
       dj_id: string;
       dj_name?: string;
       dj_name_override?: string;
     } = {
       dj_id: userData.id,
-      dj_name: djNameOverride ?? userData.dj_name,
+      dj_name: djNameOverride ?? userData.dj_name ?? userData.real_name,
     };
     if (djNameOverride !== undefined) {
       payload.dj_name_override = djNameOverride;
@@ -445,12 +447,37 @@ export const useQueue = () => {
     dispatch(flowsheetSlice.actions.loadQueue());
   }, [dispatch]); // Only run on mount
 
-  // Clear the queue only once WhoIsLive has settled and confirms the DJ is
-  // off-air — never during a transient refetch. (#644)
+  // True when the previous settled WhoIsLive read was also off-air. A single
+  // settled off-air read can be stale — right after joinShow fulfills, the
+  // invalidation refetch can land before the backend registers the DJ — so
+  // clearing requires two consecutive settled off-air reads. (#644)
+  const confirmedOffAir = useRef(false);
+  // Whether a signed-in user has been observed (drives the logout clear).
+  const hadUser = useRef(false);
+
+  // On logout the WhoIsLive subscription is skipped (and useRegistry reports
+  // loading whenever unauthenticated), so the settled gate below can never
+  // fire — clear directly on the signed-in → signed-out transition. (#644)
   useEffect(() => {
-    if (whoIsLiveSettled && !live && queue.length > 0) {
+    if (userData) {
+      hadUser.current = true;
+      return;
+    }
+    if (hadUser.current) {
+      hadUser.current = false;
+      confirmedOffAir.current = false;
       dispatch(flowsheetSlice.actions.clearQueue());
     }
+  }, [userData, dispatch]);
+
+  // Clear the queue only when WhoIsLive has settled off-air twice in a row —
+  // never during a transient refetch or a single stale post-join read. (#644)
+  useEffect(() => {
+    if (!whoIsLiveSettled) return;
+    if (!live && confirmedOffAir.current && queue.length > 0) {
+      dispatch(flowsheetSlice.actions.clearQueue());
+    }
+    confirmedOffAir.current = !live;
   }, [whoIsLiveSettled, live, queue.length, dispatch]);
 
   const addToQueue = useCallback(

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -109,8 +109,16 @@ export const useShowControl = () => {
     // Only include `dj_name_override` when the caller actually wants to
     // override; the backend treats empty/whitespace as absent, but the
     // hook keeps the wire-shape clean either way.
-    const payload: { dj_id: string; dj_name_override?: string } = {
+    // `dj_name` is a display-only hint for the optimistic WhoIsLive / feed
+    // patch (so the public banner reads the real name, never "Live"); it's
+    // stripped from the request body in the joinShow query. (#619, #621)
+    const payload: {
+      dj_id: string;
+      dj_name?: string;
+      dj_name_override?: string;
+    } = {
       dj_id: userData.id,
+      dj_name: djNameOverride ?? userData.dj_name,
     };
     if (djNameOverride !== undefined) {
       payload.dj_name_override = djNameOverride;
@@ -414,21 +422,36 @@ export const useFlowsheetPagination = () => {
 
 export const useQueue = () => {
   const { live, loading } = useShowControl();
+  const { loading: userloading, info: userData } = useRegistry();
   const dispatch = useAppDispatch();
 
   const queue = useAppSelector((state) => state.flowsheet.queue);
+
+  // A settled WhoIsLive read: a successful response that isn't mid-refetch.
+  // isLoading (behind useShowControl's `loading`) is true only on the first
+  // fetch, so it doesn't cover the invalidate→refetch gaps (e.g. an
+  // optimistic-miss during go-live) where WhoIsLive momentarily reads
+  // off-air; isFetching does. (#644)
+  const { whoIsLiveSettled } = useWhoIsLiveQuery(undefined, {
+    skip: !userData || userloading,
+    pollingInterval: 60000,
+    selectFromResult: ({ isSuccess, isFetching }) => ({
+      whoIsLiveSettled: isSuccess && !isFetching,
+    }),
+  });
 
   // Load queue from localStorage on mount
   useEffect(() => {
     dispatch(flowsheetSlice.actions.loadQueue());
   }, [dispatch]); // Only run on mount
 
-  // Clear queue when user goes offline or is not live after loading completes
+  // Clear the queue only once WhoIsLive has settled and confirms the DJ is
+  // off-air — never during a transient refetch. (#644)
   useEffect(() => {
-    if (!loading && !live && queue.length > 0) {
+    if (whoIsLiveSettled && !live && queue.length > 0) {
       dispatch(flowsheetSlice.actions.clearQueue());
     }
-  }, [live, loading, queue.length, dispatch]);
+  }, [whoIsLiveSettled, live, queue.length, dispatch]);
 
   const addToQueue = useCallback(
     (entry: FlowsheetQuery) => {
@@ -539,7 +562,7 @@ export const useFlowsheetSubmit = () => {
         rotation_id: flowSheetRawQuery.rotation_id,
         rotation_bin: flowSheetRawQuery.rotation_bin,
         track_position: flowSheetRawQuery.track_position,
-        request: false,
+        request: flowSheetRawQuery.request,
       };
     } else {
       // User has selected a result from the search
@@ -553,7 +576,7 @@ export const useFlowsheetSubmit = () => {
         rotation_bin: selectedEntry.rotation_bin ?? undefined,
         rotation_id: selectedEntry.rotation_id ?? undefined,
         track_position: flowSheetRawQuery.track_position,
-        request: false,
+        request: flowSheetRawQuery.request,
       };
     }
   }, [selectedResult, selectedEntry, flowSheetRawQuery]);


### PR DESCRIPTION
## ⚠️ Merge order: after #861

The #619 fix pushes an optimistic show-start marker whose `show_id` is a fresh negative tempId. #861's `buildOptimisticEntry`/`primaryShowId` changes complete those semantics (songs submitted during the go-live window inherit the marker's show block; only `-1` is the orphan sentinel). Standalone, this PR has one accepted transient: a song added in the sub-second go-live window briefly renders under "previous shows" — #861 closes it.

## What

Six triaged hooks/slice-layer fixes (`docs/plans/bug-triage-2026-07/02-…`, PR b of the cluster):

- **#602 (P1)** — the DJ's Request toggle now actually reaches the wire: both `selectedResultData` branches forward `flowSheetRawQuery.request` instead of hardcoding `false`. (Set direction only; the un-set direction is Backend-Service#1623.)
- **#619** — `joinShow` pushes an optimistic show-start marker into the entries cache, so the *prior* show's tail stops partitioning as the editable current show during the go-live window. Chose the marker approach after verifying the alternative is unimplementable: the whoIsLive wire (`OnAirStatusResponse`) carries no show id. `leaveShow` cleans the marker up if the DJ bails before the refetch.
- **#621** — the on-air banner shows the DJ's real name optimistically, never the literal "Live"; nameless DJs keep the previous banner rather than rendering blank or a trailing comma. The dead placeholder constant is removed.
- **#644** — the queue no longer wipes on transient WhoIsLive states: the clear now requires a *two-consecutive-settled-reads* off-air confirmation (one-poll debounce), survives the post-join stale-empty-refetch race, and an explicit signed-in→signed-out transition clears it on logout (the old incidental logout clear was a casualty of the stricter gate — caught in review).
- **#645** — the default search-query literal enumerates every `FlowsheetQuery` field, so `resetSearch` can't strand stale rotation/album linkage under future in-place mutation.
- **#646** — `reorderQueue` defensively recomputes `queueIdCounter`, closing the future-caller id-collision class.

## Red-team review (high effort, cross-PR semantics included)

Five findings fixed in the follow-up commit (logout clear regression, post-join stale-read race, nameless-DJ banner edges, orphaned marker on early leave, dead constant). Two accepted-as-known: the standalone go-live transient above, and a refetch-beats-server-show_start flicker that self-heals on the next poll/SSE.

## Testing

Typecheck clean; 3,560 tests green. New coverage: request-flag on both submit branches, go-live partition isolation (real store + MSW), banner name fallbacks and formatting, queue survival through transient/stale WhoIsLive windows + logout clear, resetSearch completeness, reorder counter invariants.

Closes #602
Closes #619
Closes #621
Closes #644
Closes #645
Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)