### PR TITLE
fix(auth): client-state hygiene — theme sync races, stale fetches, cache keying, login error routing

### DIFF
--- a/app/login/@modern/LoginSlotSwitcher.test.tsx
+++ b/app/login/@modern/LoginSlotSwitcher.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import { applicationSlice } from "@/lib/features/application/frontend";
+import { renderWithProviders } from "@/lib/test-utils";
 import LoginSlotSwitcher from "./LoginSlotSwitcher";
 
 const mockSearchParamsGet = vi.fn();
@@ -52,5 +53,63 @@ describe("LoginSlotSwitcher", () => {
     renderSwitcher(true, null);
 
     expect(screen.getByText("Incomplete onboarding")).toBeInTheDocument();
+  });
+});
+
+describe("LoginSlotSwitcher error-code routing (#617)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderWithError(errorCode: string | null) {
+    mockSearchParamsGet.mockImplementation((key: string) =>
+      key === "error" ? errorCode : null
+    );
+
+    return renderWithProviders(
+      <LoginSlotSwitcher
+        isIncomplete={false}
+        normal={<div>Normal login</div>}
+        newuser={<div>Incomplete onboarding</div>}
+        reset={<div>Password reset</div>}
+      />
+    );
+  }
+
+  it("routes the reset-flow error code (INVALID_TOKEN) to the reset slot", () => {
+    renderWithError("INVALID_TOKEN");
+
+    expect(screen.getByText("Password reset")).toBeInTheDocument();
+    expect(screen.queryByText("Normal login")).not.toBeInTheDocument();
+  });
+
+  // Codes emitted by app/auth/verify-email/route.ts — none is a reset error and
+  // each must land on the normal login form, never the password-reset slot.
+  it("keeps ?error=missing-verification-token on the normal login form with a visible error", () => {
+    renderWithError("missing-verification-token");
+
+    expect(screen.getByText("Normal login")).toBeInTheDocument();
+    expect(screen.queryByText("Password reset")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/something went wrong with that link/i)
+    ).toBeInTheDocument();
+  });
+
+  it("keeps ?error=verification-failed on the normal login form with its specific alert", () => {
+    renderWithError("verification-failed");
+
+    expect(screen.getByText("Normal login")).toBeInTheDocument();
+    expect(screen.queryByText("Password reset")).not.toBeInTheDocument();
+    expect(screen.getByText(/email verification failed/i)).toBeInTheDocument();
+  });
+
+  it("routes an unknown error code to the normal login form with a generic error", () => {
+    renderWithError("some-unexpected-code");
+
+    expect(screen.getByText("Normal login")).toBeInTheDocument();
+    expect(screen.queryByText("Password reset")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/something went wrong with that link/i)
+    ).toBeInTheDocument();
   });
 });

--- a/app/login/@modern/LoginSlotSwitcher.tsx
+++ b/app/login/@modern/LoginSlotSwitcher.tsx
@@ -6,6 +6,17 @@ import { useSearchParams } from "next/navigation";
 import { ReactNode, useEffect } from "react";
 import { Alert } from "@mui/joy";
 
+// Error codes that belong to the password-reset flow. better-auth's
+// reset-password link redirects to its redirectTo (/login, set in
+// useResetPassword.handleRequestReset) with ?error=INVALID_TOKEN when the token
+// is expired/invalid — the same code documented for the onboarding link in
+// app/onboarding/@modern/page.tsx. Only these route to the reset slot; every
+// other ?error= is NOT a reset error and must render the normal login form with
+// the error surfaced — notably verify-email's `missing-verification-token` and
+// `verification-failed` (app/auth/verify-email/route.ts) and server-utils'
+// `email-not-verified`, none of which previously routed anywhere sensible (#617).
+const RESET_ERROR_CODES: readonly string[] = ["INVALID_TOKEN"];
+
 export default function LoginSlotSwitcher({
   normal,
   newuser,
@@ -27,11 +38,20 @@ export default function LoginSlotSwitcher({
   const isVerified = searchParams?.get("verified") === "true";
 
   const hasResetToken = !!searchParams?.get("token");
-  const hasResetError =
+  // Allowlist, not denylist: only known reset error codes fall into the reset
+  // flow. An unknown ?error= (e.g. a broken verification link) must not drop
+  // the user into a password-reset form with no reset token (#617).
+  const hasResetError = !!errorParam && RESET_ERROR_CODES.includes(errorParam);
+  const hasResetParams = hasResetToken || hasResetError;
+
+  // An error code that is neither a reset error nor one of the specifically
+  // handled verify-email states: surface it on the normal login form instead of
+  // silently swallowing it (#617).
+  const hasUnrecognizedError =
     !!errorParam &&
+    !hasResetError &&
     !isEmailNotVerified &&
     !isVerificationFailed;
-  const hasResetParams = hasResetToken || hasResetError;
 
   useEffect(() => {
     if (hasResetParams) {
@@ -67,6 +87,12 @@ export default function LoginSlotSwitcher({
         <Alert color="danger" sx={{ mb: 2 }}>
           Email verification failed — the link may have expired. Please contact
           an administrator for a new invitation.
+        </Alert>
+      )}
+      {hasUnrecognizedError && (
+        <Alert color="danger" sx={{ mb: 2 }}>
+          Something went wrong with that link. Please sign in below, or contact
+          an administrator if the problem persists.
         </Alert>
       )}
       {normal}

--- a/e2e/tests/auth/password-reset.spec.ts
+++ b/e2e/tests/auth/password-reset.spec.ts
@@ -97,8 +97,9 @@ test.describe("Password Reset - Complete Flow", () => {
   });
 
   test("should show error message for invalid/expired token", async ({ page }) => {
-    // Navigate with an error parameter
-    await loginPage.gotoWithError("invalid_token");
+    // INVALID_TOKEN is the code better-auth actually redirects with for a bad
+    // or expired reset link; LoginSlotSwitcher allowlists it into the reset slot
+    await loginPage.gotoWithError("INVALID_TOKEN");
 
     // Should show error alert (use MUI Alert selector to avoid matching Next.js route announcer)
     const alertMessage = page.locator('[role="alert"].MuiAlert-root');
@@ -243,12 +244,22 @@ test.describe("Password Reset - Error Handling", () => {
   });
 
   test("should display helpful error message for expired link", async ({ page }) => {
-    await loginPage.gotoWithError("expired");
+    // better-auth reports an expired link with the same INVALID_TOKEN code
+    await loginPage.gotoWithError("INVALID_TOKEN");
 
     // Use MUI Alert selector to avoid matching Next.js route announcer
     const alertMessage = page.locator('[role="alert"].MuiAlert-root');
     await expect(alertMessage).toBeVisible();
     await expect(alertMessage).toContainText(/invalid|expired/i);
+  });
+
+  test("should keep an unrecognized error code on the login form with a generic alert", async ({ page }) => {
+    // Not a reset-flow code: must NOT open the password-reset slot (#617)
+    await loginPage.gotoWithError("some-unexpected-code");
+
+    const alertMessage = page.locator('[role="alert"].MuiAlert-root');
+    await expect(alertMessage).toContainText(/something went wrong with that link/i);
+    await loginPage.expectLoginFormVisible();
   });
 });
 

--- a/lib/__tests__/features/authentication/organization-utils.test.ts
+++ b/lib/__tests__/features/authentication/organization-utils.test.ts
@@ -38,6 +38,7 @@ import {
   getUserRoleInOrganizationClient,
   organizationRoleFromJwtToken,
   resolveOrganizationIdAdmin,
+  resetOrganizationIdCache,
   _resetOrgCacheForTesting,
 } from "@/lib/features/authentication/organization-utils";
 import {
@@ -162,6 +163,42 @@ describe("organization-utils", () => {
 
       expect(result).toBeNull();
       expect(receivedSlug).toBeNull();
+    });
+
+    it("caches distinct slugs independently (no cross-slug leakage) — #616", async () => {
+      const wxyc = await resolveOrganizationIdAdmin("wxyc");
+      const kvrx = await resolveOrganizationIdAdmin("kvrx");
+
+      expect(wxyc).toBe("org-for-wxyc");
+      expect(kvrx).toBe("org-for-kvrx");
+
+      // A repeat lookup of the first slug must return ITS cached id, not the
+      // most-recently-resolved slug's — the pre-#616 single-value cache failed
+      // this.
+      expect(await resolveOrganizationIdAdmin("wxyc")).toBe("org-for-wxyc");
+    });
+
+    it("resetOrganizationIdCache clears entries so a later resolve re-fetches — #616", async () => {
+      let calls = 0;
+      server.use(
+        http.get(
+          "https://api.wxyc.org/auth/admin/resolve-organization",
+          ({ request }) => {
+            calls++;
+            const slug = new URL(request.url).searchParams.get("slug");
+            return HttpResponse.json({ id: `org-for-${slug}` });
+          }
+        )
+      );
+
+      await resolveOrganizationIdAdmin("wxyc");
+      await resolveOrganizationIdAdmin("wxyc"); // served from cache
+      expect(calls).toBe(1);
+
+      resetOrganizationIdCache();
+
+      await resolveOrganizationIdAdmin("wxyc"); // cache cleared → refetch
+      expect(calls).toBe(2);
     });
   });
 

--- a/lib/features/authentication/organization-utils.ts
+++ b/lib/features/authentication/organization-utils.ts
@@ -4,11 +4,13 @@ import { getAppOrganizationId, getAppOrganizationIdClient } from "./organization
 import { BetterAuthJwtPayload, WXYCRole } from "./types";
 
 /**
- * Module-level cache for the organization ID resolved via the admin endpoint.
- * The slug-to-ID mapping is stable (WXYC has a single org) so no TTL is needed.
- * Resets on page reload.
+ * Module-level cache of organization IDs resolved via the admin endpoint,
+ * keyed by slug so distinct slugs never collide (multi-org / staging-vs-prod /
+ * admin-impersonation). Slug-to-ID mappings are stable so no TTL is needed;
+ * the cache resets on page reload and, on logout, via resetOrganizationIdCache
+ * so a departing user's resolved UUID can't leak into the next session (#616).
  */
-let cachedAdminOrgId: string | null = null;
+const cachedAdminOrgIds = new Map<string, string>();
 
 /**
  * Resolve the configured organization slug to its UUID via the admin endpoint.
@@ -20,10 +22,11 @@ let cachedAdminOrgId: string | null = null;
  * @returns The organization UUID, or null if the slug is not configured or resolution fails.
  */
 export async function resolveOrganizationIdAdmin(slugOverride?: string): Promise<string | null> {
-  if (cachedAdminOrgId) return cachedAdminOrgId;
-
   const slug = slugOverride || process.env.NEXT_PUBLIC_APP_ORGANIZATION;
   if (!slug) return null;
+
+  const cached = cachedAdminOrgIds.get(slug);
+  if (cached) return cached;
 
   try {
     const response = await fetch(
@@ -33,8 +36,9 @@ export async function resolveOrganizationIdAdmin(slugOverride?: string): Promise
 
     if (!response.ok) return null;
     const data = await response.json();
-    cachedAdminOrgId = data.id;
-    return cachedAdminOrgId;
+    if (!data.id) return null;
+    cachedAdminOrgIds.set(slug, data.id);
+    return data.id;
   } catch {
     return null;
   }
@@ -241,7 +245,14 @@ export function normalizeRole(role: string): string {
   return role;
 }
 
-/** @internal — test-only cache reset */
-export function _resetOrgCacheForTesting() {
-  cachedAdminOrgId = null;
+/**
+ * Clear the admin org-id cache. Wired into the logout flow (resetApplication)
+ * so a departing user's resolved organization UUID can't leak into the next
+ * session on the same browser (#616).
+ */
+export function resetOrganizationIdCache() {
+  cachedAdminOrgIds.clear();
 }
+
+/** @internal — test-only alias of {@link resetOrganizationIdCache}. */
+export const _resetOrgCacheForTesting = resetOrganizationIdCache;

--- a/src/hooks/applicationHooks.test.ts
+++ b/src/hooks/applicationHooks.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { makeStore } from "@/lib/store";
+import { applicationSlice } from "@/lib/features/application/frontend";
+import { adminSlice } from "@/lib/features/admin/frontend";
+import {
+  resolveOrganizationIdAdmin,
+  resetOrganizationIdCache,
+} from "@/lib/features/authentication/organization-utils";
+import { resetApplication } from "./applicationHooks";
+
+describe("resetApplication (logout state hygiene) — #639/#616", () => {
+  beforeEach(() => {
+    resetOrganizationIdCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resets application (panel/sidebar/auth-stage) and admin (search/page) slice state", () => {
+    const store = makeStore();
+
+    // Seed previous-session UI + admin state.
+    store.dispatch(applicationSlice.actions.setRightbarMini(true));
+    store.dispatch(applicationSlice.actions.setAuthStage("reset"));
+    store.dispatch(adminSlice.actions.setSearchString("bromberg"));
+    store.dispatch(adminSlice.actions.setPage(3));
+
+    expect(applicationSlice.selectors.getRightbarMini(store.getState())).toBe(true);
+    expect(adminSlice.selectors.getSearchString(store.getState())).toBe("bromberg");
+    expect(adminSlice.selectors.getPage(store.getState())).toBe(3);
+
+    resetApplication(store.dispatch);
+
+    // Nothing from the previous session survives.
+    expect(applicationSlice.selectors.getRightbarMini(store.getState())).toBe(false);
+    expect(applicationSlice.selectors.getAuthStage(store.getState())).toBe("otp-email");
+    expect(adminSlice.selectors.getSearchString(store.getState())).toBe("");
+    expect(adminSlice.selectors.getPage(store.getState())).toBe(0);
+  });
+
+  it("clears the admin org-id cache so it can't leak into the next session", async () => {
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        calls++;
+        return { ok: true, json: async () => ({ id: "org-123" }) } as unknown as Response;
+      })
+    );
+
+    await resolveOrganizationIdAdmin("wxyc");
+    await resolveOrganizationIdAdmin("wxyc"); // served from cache — no new fetch
+    expect(calls).toBe(1);
+
+    // A logout (dispatch is irrelevant to the cache clear) must drop the entry.
+    resetApplication(vi.fn() as never);
+
+    await resolveOrganizationIdAdmin("wxyc"); // cache cleared → refetch
+    expect(calls).toBe(2);
+  });
+});

--- a/src/hooks/applicationHooks.ts
+++ b/src/hooks/applicationHooks.ts
@@ -1,4 +1,7 @@
+import { adminSlice } from "@/lib/features/admin/frontend";
+import { applicationSlice } from "@/lib/features/application/frontend";
 import { authenticationSlice } from "@/lib/features/authentication/frontend";
+import { resetOrganizationIdCache } from "@/lib/features/authentication/organization-utils";
 import { binApi } from "@/lib/features/bin/api";
 import { catalogApi } from "@/lib/features/catalog/api";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
@@ -89,4 +92,12 @@ export function resetApplication(dispatch: ReturnType<typeof useAppDispatch>) {
   dispatch(catalogSlice.actions.reset());
   dispatch(binApi.util.resetApiState());
   dispatch(authenticationSlice.actions.reset());
+  // Wipe UI + admin state so a previous user's open panel, sidebar, roster
+  // search string, and page index don't survive into the next session on the
+  // same browser (#639).
+  dispatch(applicationSlice.actions.reset());
+  dispatch(adminSlice.actions.reset());
+  // Clear the module-level admin org-id cache so a departing user's resolved
+  // org UUID can't leak into the next session either (#616).
+  resetOrganizationIdCache();
 }

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -528,6 +528,10 @@ export const useAuthentication = () => {
         });
     } else if (!session) {
       setAuthData({ message: "Not Authenticated" });
+      // If the session ended while a role fetch was in flight, that fetch's
+      // finally is now cancelled-gated and can no longer reset the flag —
+      // settle it here or `authenticating` sticks true forever (#612).
+      setIsLoadingRole(false);
     }
     return () => {
       cancelled = true;

--- a/src/hooks/authenticationHooks.ts
+++ b/src/hooks/authenticationHooks.ts
@@ -504,25 +504,34 @@ export const useAuthentication = () => {
   );
   const [isLoadingRole, setIsLoadingRole] = useState(false);
 
-  // Fetch organization role when session is available
+  // Fetch organization role when session is available.
   useEffect(() => {
+    // Guard against a stale session's role fetch resolving after a newer one:
+    // on a session transition (logout→login, refresh, OTP) the older promise
+    // could otherwise clobber authData with the previous session's role, and
+    // resolve after unmount ("setState on unmounted component") — #612.
+    let cancelled = false;
     if (session && !isPending) {
       setIsLoadingRole(true);
       betterAuthSessionToAuthenticationDataAsync(session as any)
         .then((data) => {
-          setAuthData(data);
+          if (!cancelled) setAuthData(data);
         })
         .catch((error) => {
+          if (cancelled) return;
           console.error("Failed to fetch organization role, using session data:", error);
           // Fall back to synchronous version on error
           setAuthData(betterAuthSessionToAuthenticationData(session as any));
         })
         .finally(() => {
-          setIsLoadingRole(false);
+          if (!cancelled) setIsLoadingRole(false);
         });
     } else if (!session) {
       setAuthData({ message: "Not Authenticated" });
     }
+    return () => {
+      cancelled = true;
+    };
   }, [session, isPending]);
 
   return {

--- a/src/hooks/themePreferenceHooks.test.tsx
+++ b/src/hooks/themePreferenceHooks.test.tsx
@@ -32,6 +32,12 @@ vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 import { useThemePreferenceSync } from "./themePreferenceHooks";
 
+// vitest.setup.ts replaces window.localStorage with a vi.fn() mock (setItem is
+// a no-op), so tests seed the store by stubbing getItem's return value.
+function setLocalPreference(value: string | null) {
+  vi.mocked(window.localStorage.getItem).mockReturnValue(value);
+}
+
 const mockSetMode = vi.fn();
 const mockSetThemeId = vi.fn();
 
@@ -56,7 +62,7 @@ const mockReload = vi.fn();
 describe("useThemePreferenceSync (#611)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.clear();
+    setLocalPreference(null);
     delete document.documentElement.dataset.experience;
     setColorScheme("light");
     setModernTheme("stacks");
@@ -147,5 +153,72 @@ describe("useThemePreferenceSync (#611)", () => {
     expect(mockSetMode).not.toHaveBeenCalled();
 
     vi.unstubAllGlobals();
+  });
+
+  it("applies a late-arriving account appSkin after the first sync, serialized and exactly once", async () => {
+    // First sync resolves from local state; the better-auth session (and its
+    // authoritative appSkin) arrives only afterwards — the follow-up sync must
+    // still apply it rather than dropping it behind the synced guard.
+    setLocalPreference("modern-stacks-light");
+    mockUseSession.mockReturnValue({ data: { user: { id: "u1" } } });
+
+    let resolveFirstPersist!: () => void;
+    mockSetPreference
+      .mockReturnValueOnce({
+        unwrap: () =>
+          new Promise<void>((r) => {
+            resolveFirstPersist = () => r(undefined);
+          }),
+      })
+      .mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
+
+    const { rerender } = renderHook(() => useThemePreferenceSync());
+    await flush();
+    expect(mockSetPreference).toHaveBeenCalledTimes(1);
+    expect(mockSetPreference).toHaveBeenCalledWith({
+      preference: "modern-stacks-light",
+    });
+
+    // The account appSkin resolves while sync #1's persist is still in flight.
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "u1", appSkin: "modern-bluenote-dark" } },
+    });
+    rerender();
+    await flush();
+
+    // Serialized: the re-sync is queued, never concurrent with sync #1.
+    expect(mockSetPreference).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirstPersist();
+    });
+    await flush();
+
+    // The account preference applied exactly once.
+    expect(mockSetPreference).toHaveBeenCalledTimes(2);
+    expect(mockSetPreference).toHaveBeenLastCalledWith({
+      preference: "modern-bluenote-dark",
+    });
+    expect(mockSetMode).toHaveBeenCalledWith("dark");
+    expect(mockSetThemeId).toHaveBeenCalledWith("bluenote");
+  });
+
+  it("skips the re-sync when the late account appSkin matches what was already applied", async () => {
+    setLocalPreference("modern-stacks-light");
+    mockUseSession.mockReturnValue({ data: { user: { id: "u1" } } });
+
+    const { rerender } = renderHook(() => useThemePreferenceSync());
+    await flush();
+    expect(mockSetPreference).toHaveBeenCalledTimes(1);
+
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "u1", appSkin: "modern-stacks-light" } },
+    });
+    rerender();
+    await flush();
+
+    // Already reconciled — no second persist and no reload churn.
+    expect(mockSetPreference).toHaveBeenCalledTimes(1);
+    expect(mockReload).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/themePreferenceHooks.test.tsx
+++ b/src/hooks/themePreferenceHooks.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const mockUseSession = vi.fn();
+const mockUpdateUser = vi.fn();
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: {
+    useSession: (...a: unknown[]) => mockUseSession(...a),
+    updateUser: (...a: unknown[]) => mockUpdateUser(...a),
+  },
+}));
+
+// Partial-mock Joy so the theme registry's own Joy imports stay real; only the
+// color-scheme hook is swapped for one we drive.
+const mockUseColorScheme = vi.fn();
+vi.mock("@mui/joy/styles", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mui/joy/styles")>();
+  return { ...actual, useColorScheme: () => mockUseColorScheme() };
+});
+
+const mockUseModernTheme = vi.fn();
+vi.mock("@/src/styles/ModernThemeContext", () => ({
+  useModernTheme: () => mockUseModernTheme(),
+}));
+
+const mockSetPreference = vi.fn();
+vi.mock("@/lib/features/experiences/api", () => ({
+  useSetExperiencePreferenceMutation: () => [mockSetPreference],
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { useThemePreferenceSync } from "./themePreferenceHooks";
+
+const mockSetMode = vi.fn();
+const mockSetThemeId = vi.fn();
+
+function setColorScheme(mode: string | undefined) {
+  mockUseColorScheme.mockReturnValue({ mode, setMode: mockSetMode });
+}
+function setModernTheme(themeId = "stacks") {
+  mockUseModernTheme.mockReturnValue({ themeId, setThemeId: mockSetThemeId });
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+const realLocation = window.location;
+const mockReload = vi.fn();
+
+describe("useThemePreferenceSync (#611)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    delete document.documentElement.dataset.experience;
+    setColorScheme("light");
+    setModernTheme("stacks");
+    mockSetPreference.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...realLocation, reload: mockReload },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: realLocation,
+    });
+  });
+
+  it("does not start a second sync (double persist) when the session's appSkin arrives mid-fetch", async () => {
+    // No appSkin and no localStorage forces the fetchAppState path, opening a
+    // window in which the session's appSkin can arrive and re-fire the effect.
+    mockUseSession.mockReturnValue({ data: { user: { id: "u1" } } });
+    let resolveFetch!: (v: unknown) => void;
+    const fetchP = new Promise((r) => { resolveFetch = r; });
+    vi.stubGlobal("fetch", vi.fn(() => fetchP));
+
+    const { rerender } = renderHook(() => useThemePreferenceSync());
+
+    // Session resolves with an appSkin mid-fetch — the effect re-fires.
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "u1", appSkin: "modern-stacks-light" } },
+    });
+    rerender();
+
+    await act(async () => {
+      resolveFetch({
+        ok: true,
+        json: async () => ({ experience: "modern", colorMode: "light", themeId: "stacks" }),
+      });
+      await Promise.resolve();
+    });
+    await flush();
+
+    // The synchronous guard means the mid-fetch re-fire cannot spawn a second
+    // concurrent sync, so persistPreference runs at most once.
+    expect(mockSetPreference.mock.calls.length).toBeLessThanOrEqual(1);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not reload on a first load where <html> lacks data-experience (modern default)", async () => {
+    mockUseSession.mockReturnValue({
+      data: { user: { id: "u1", appSkin: "modern-stacks-light" } },
+    });
+
+    renderHook(() => useThemePreferenceSync());
+    await flush();
+
+    // An absent data-experience attribute means SSR painted the default modern
+    // experience, which agrees with the resolved modern preference — no reload.
+    expect(mockReload).not.toHaveBeenCalled();
+  });
+
+  it("lets a mid-sync color-mode toggle win over the resolved preference", async () => {
+    mockUseSession.mockReturnValue({ data: { user: { id: "u1" } } });
+    let resolveFetch!: (v: unknown) => void;
+    const fetchP = new Promise((r) => { resolveFetch = r; });
+    vi.stubGlobal("fetch", vi.fn(() => fetchP));
+
+    const { rerender } = renderHook(() => useThemePreferenceSync());
+
+    // User toggles the color mode while the app_state fetch is still in flight.
+    setColorScheme("dark");
+    rerender();
+
+    await act(async () => {
+      // app_state resolves to "dark". The stale closure captured mode="light"
+      // at sync start, so the pre-fix `if (mode !== parsed.colorMode)` guard
+      // ("light" !== "dark") would fire setMode and stomp the live toggle.
+      resolveFetch({
+        ok: true,
+        json: async () => ({ experience: "modern", colorMode: "dark", themeId: "stacks" }),
+      });
+      await Promise.resolve();
+    });
+    await flush();
+
+    // The sync must defer to the user's live toggle and not drive setMode itself.
+    expect(mockSetMode).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/hooks/themePreferenceHooks.ts
+++ b/src/hooks/themePreferenceHooks.ts
@@ -102,14 +102,13 @@ export function useThemePreferenceSync() {
   const { mode, setMode } = useColorScheme();
   const { themeId: paintedThemeId, setThemeId } = useModernTheme();
   const { persistPreference } = useThemePreferenceActions();
-  const hasSyncedRef = useRef(false);
   // Live mirror of the color mode: reads after an await must observe a user's
   // mid-sync toggle, not the value captured when the effect first ran (#611).
   const modeRef = useRef(mode);
   modeRef.current = mode;
   // Set only when the component actually unmounts (empty-dep cleanup), so a
-  // mere dep change — e.g. the session's appSkin arriving — does not abort the
-  // one sync the synchronous guard below already committed to (#611).
+  // mere dep change — e.g. the session's appSkin arriving — does not abort a
+  // sync the synchronous guard below already committed to (#611).
   const unmountedRef = useRef(false);
   useEffect(() => {
     unmountedRef.current = false;
@@ -118,20 +117,43 @@ export function useThemePreferenceSync() {
     };
   }, []);
 
+  // Track WHAT was synced, not just that a sync ran: on cold loads the
+  // better-auth session resolves asynchronously, so the account's
+  // authoritative appSkin often arrives AFTER the first sync completed from
+  // local state — it must still apply (#611 follow-up). Each claimed sync
+  // records the session appSkin it saw; a later effect run re-syncs only when
+  // that value changed (undefined → value counts as a change). Syncs are
+  // chained onto one promise so a re-sync can never run concurrently with an
+  // in-flight sync, and a re-sync resolving to the canonical preference an
+  // earlier sync already applied is a no-op.
+  const hasSyncedRef = useRef(false);
+  const lastClaimedAppSkinRef = useRef<unknown>(undefined);
+  const lastAppliedCanonicalRef = useRef<AppSkinPreference | null>(null);
+  const syncChainRef = useRef<Promise<void>>(Promise.resolve());
+
+  const sessionAppSkin = (session?.user as any)?.appSkin;
+
   useEffect(() => {
-    if (hasSyncedRef.current || !mode) return;
+    if (!mode) return;
+    if (
+      hasSyncedRef.current &&
+      lastClaimedAppSkinRef.current === sessionAppSkin
+    ) {
+      return;
+    }
 
     // Claim the sync synchronously. A dep change (most commonly the session's
     // appSkin resolving mid-fetch) re-fires this effect; without claiming the
     // guard up front a second sync() would race the first and call
     // setMode/setThemeId/persistPreference out of order (#611).
     hasSyncedRef.current = true;
+    lastClaimedAppSkinRef.current = sessionAppSkin;
     const modeAtSyncStart = mode;
 
     const sync = async () => {
       // Resolve a preference from the first available source, in priority order.
       let parsed: ParsedAppSkin | null =
-        parseAppSkinPreference((session?.user as any)?.appSkin) ??
+        parseAppSkinPreference(sessionAppSkin) ??
         parseAppSkinPreference(readLocalPreference());
 
       if (!parsed) {
@@ -141,6 +163,13 @@ export function useThemePreferenceSync() {
       }
 
       if (!parsed) {
+        return;
+      }
+
+      // Already reconciled: a re-sync (late-arriving account appSkin) that
+      // resolves to what an earlier sync applied has nothing to do — and must
+      // not re-persist or trigger another reload check.
+      if (parsed.canonical === lastAppliedCanonicalRef.current) {
         return;
       }
 
@@ -156,6 +185,8 @@ export function useThemePreferenceSync() {
       if (parsed.experience === "modern") {
         setThemeId(parsed.themeId);
       }
+
+      lastAppliedCanonicalRef.current = parsed.canonical;
 
       // Self-heal: persist the canonical form everywhere, and push it to the
       // backend user record only when the stored value drifted (legacy 2-part
@@ -193,8 +224,13 @@ export function useThemePreferenceSync() {
       }
     };
 
-    sync();
-  }, [mode, persistPreference, (session?.user as any)?.appSkin, setMode, setThemeId, paintedThemeId]);
+    // Serialize: queue behind any in-flight sync so two syncs never interleave.
+    // Catch so one failed sync can't wedge the chain (or surface as an
+    // unhandled rejection) and block every later re-sync.
+    syncChainRef.current = syncChainRef.current.then(sync).catch((error) => {
+      console.error("Theme preference sync failed:", error);
+    });
+  }, [mode, persistPreference, sessionAppSkin, setMode, setThemeId, paintedThemeId]);
 }
 
 export function buildPreference(

--- a/src/hooks/themePreferenceHooks.ts
+++ b/src/hooks/themePreferenceHooks.ts
@@ -103,9 +103,30 @@ export function useThemePreferenceSync() {
   const { themeId: paintedThemeId, setThemeId } = useModernTheme();
   const { persistPreference } = useThemePreferenceActions();
   const hasSyncedRef = useRef(false);
+  // Live mirror of the color mode: reads after an await must observe a user's
+  // mid-sync toggle, not the value captured when the effect first ran (#611).
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
+  // Set only when the component actually unmounts (empty-dep cleanup), so a
+  // mere dep change — e.g. the session's appSkin arriving — does not abort the
+  // one sync the synchronous guard below already committed to (#611).
+  const unmountedRef = useRef(false);
+  useEffect(() => {
+    unmountedRef.current = false;
+    return () => {
+      unmountedRef.current = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (hasSyncedRef.current || !mode) return;
+
+    // Claim the sync synchronously. A dep change (most commonly the session's
+    // appSkin resolving mid-fetch) re-fires this effect; without claiming the
+    // guard up front a second sync() would race the first and call
+    // setMode/setThemeId/persistPreference out of order (#611).
+    hasSyncedRef.current = true;
+    const modeAtSyncStart = mode;
 
     const sync = async () => {
       // Resolve a preference from the first available source, in priority order.
@@ -115,15 +136,20 @@ export function useThemePreferenceSync() {
 
       if (!parsed) {
         const appState = await fetchAppState();
+        if (unmountedRef.current) return;
         parsed = parseAppSkinPreference(getPreferenceFromAppState(appState));
       }
 
       if (!parsed) {
-        hasSyncedRef.current = true;
         return;
       }
 
-      if (mode !== parsed.colorMode) {
+      // Respect a mid-sync theme toggle: if the user changed the color mode
+      // while we were resolving the preference, their choice wins — reading the
+      // live value (not the closure-captured `mode`) keeps us from reverting it
+      // to the server-resolved mode (#611).
+      const userToggledMode = modeRef.current !== modeAtSyncStart;
+      if (!userToggledMode && modeRef.current !== parsed.colorMode) {
         setMode(parsed.colorMode);
       }
 
@@ -137,6 +163,7 @@ export function useThemePreferenceSync() {
       const persisted = await persistPreference(parsed.canonical, {
         updateUser: parsed.needsRewrite,
       });
+      if (unmountedRef.current) return;
 
       // Joy's CssVarsProvider can't regenerate its injected :root vars at
       // runtime (see ThemePicker), so if SSR painted a different experience
@@ -145,15 +172,21 @@ export function useThemePreferenceSync() {
       // won't re-mount the provider. Reload only once the cookie actually
       // persisted; otherwise the next SSR would paint the same stale theme
       // and this sync would loop.
+      //
+      // The RHS defaults to `false` when <html data-experience> is absent: an
+      // unset attribute means SSR painted the default (modern) experience, so a
+      // reload is warranted only when the resolved preference is classic-shaped
+      // and thus disagrees with that default. Comparing against a bare
+      // `undefined` made this `boolean !== undefined` — always true — and fired
+      // a reload on every first load before the attribute was set (#611).
       const experienceMismatch =
         typeof window !== "undefined" &&
         parsed.canonical.startsWith("classic") !==
-          document.documentElement.dataset.experience?.startsWith("classic");
+          (document.documentElement.dataset.experience?.startsWith("classic") ??
+            false);
       // Both ids are registry-resolved, so this comparison is loop-safe.
       const themeMismatch =
         parsed.experience === "modern" && parsed.themeId !== paintedThemeId;
-
-      hasSyncedRef.current = true;
 
       if (persisted && (experienceMismatch || themeMismatch)) {
         window.location.reload();

--- a/src/hooks/useAuthentication.test.tsx
+++ b/src/hooks/useAuthentication.test.tsx
@@ -75,6 +75,36 @@ describe("useAuthentication async role fetch (#612)", () => {
     expect(result.current.data).toEqual(dataB);
   });
 
+  it("settles authenticating=false when the session ends mid-fetch, and still discards the stale result", async () => {
+    const sessionA = { user: { id: "A" } };
+    let resolveA!: (v: unknown) => void;
+    const pA = new Promise<unknown>((r) => { resolveA = r; });
+    mockAsync.mockReturnValueOnce(pA);
+
+    mockUseSession.mockReturnValue({ data: sessionA, isPending: false, error: null });
+    const { result, rerender } = renderHook(() => useAuthentication());
+    expect(result.current.authenticating).toBe(true);
+
+    // Logout/expiry while A's role fetch is still in flight.
+    mockUseSession.mockReturnValue({ data: null, isPending: false, error: null });
+    rerender();
+
+    // The cancelled fetch's finally can no longer reset isLoadingRole, so the
+    // no-session branch must — otherwise `authenticating` sticks true forever.
+    expect(result.current.authenticating).toBe(false);
+    expect(result.current.data).toEqual({ message: "Not Authenticated" });
+
+    // A's fetch resolving late must not clobber the signed-out state.
+    await act(async () => {
+      resolveA({ message: "Authenticated", user: { id: "A", role: "dj" } });
+      await pA;
+      await Promise.resolve();
+    });
+
+    expect(result.current.data).toEqual({ message: "Not Authenticated" });
+    expect(result.current.authenticating).toBe(false);
+  });
+
   it("applies the role fetch result for a stable session", async () => {
     const session = { user: { id: "A" } };
     const data = { message: "Authenticated", user: { id: "A", role: "dj" } };

--- a/src/hooks/useAuthentication.test.tsx
+++ b/src/hooks/useAuthentication.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// useAuthentication only reads authClient.useSession and the session→auth-data
+// converters; mock those so we can drive a session transition and control when
+// each role fetch resolves. The other client exports are referenced at module
+// import time by sibling hooks (not by useAuthentication) — stub them so the
+// module loads.
+const mockUseSession = vi.fn();
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: (...a: unknown[]) => mockUseSession(...a) },
+  authBaseURL: "https://api.wxyc.org/auth",
+  clearTokenCache: vi.fn(),
+  completeOnboarding: vi.fn(),
+  lookupEmailByIdentifier: vi.fn(),
+}));
+
+const mockAsync = vi.fn();
+const mockSync = vi.fn();
+vi.mock("@/lib/features/authentication/utilities", () => ({
+  betterAuthSessionToAuthenticationDataAsync: (...a: unknown[]) => mockAsync(...a),
+  betterAuthSessionToAuthenticationData: (...a: unknown[]) => mockSync(...a),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("./applicationHooks", () => ({ resetApplication: vi.fn() }));
+vi.mock("@/lib/posthog", () => ({ safeCapture: vi.fn() }));
+
+import { useAuthentication } from "./authenticationHooks";
+
+describe("useAuthentication async role fetch (#612)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSync.mockReturnValue({ message: "Not Authenticated" });
+  });
+
+  it("discards a stale session's role fetch when the session changes mid-flight", async () => {
+    const sessionA = { user: { id: "A" } };
+    const sessionB = { user: { id: "B" } };
+    const dataA = { message: "Authenticated", user: { id: "A", role: "stationManager" } };
+    const dataB = { message: "Authenticated", user: { id: "B", role: "dj" } };
+
+    let resolveA!: (v: unknown) => void;
+    let resolveB!: (v: unknown) => void;
+    const pA = new Promise<unknown>((r) => { resolveA = r; });
+    const pB = new Promise<unknown>((r) => { resolveB = r; });
+    mockAsync.mockReturnValueOnce(pA).mockReturnValueOnce(pB);
+
+    mockUseSession.mockReturnValue({ data: sessionA, isPending: false, error: null });
+    const { result, rerender } = renderHook(() => useAuthentication());
+
+    // Session transitions A -> B before A's role fetch has resolved.
+    mockUseSession.mockReturnValue({ data: sessionB, isPending: false, error: null });
+    rerender();
+
+    // The NEWER fetch (B) resolves first...
+    await act(async () => {
+      resolveB(dataB);
+      await pB;
+      await Promise.resolve();
+    });
+    // ...then the STALE fetch (A) resolves late. Without the cancellation guard
+    // it would clobber authData with the previous session's role.
+    await act(async () => {
+      resolveA(dataA);
+      await pA;
+      await Promise.resolve();
+    });
+
+    expect(result.current.data).toEqual(dataB);
+  });
+
+  it("applies the role fetch result for a stable session", async () => {
+    const session = { user: { id: "A" } };
+    const data = { message: "Authenticated", user: { id: "A", role: "dj" } };
+    mockAsync.mockResolvedValue(data);
+    mockUseSession.mockReturnValue({ data: session, isPending: false, error: null });
+
+    const { result } = renderHook(() => useAuthentication());
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.data).toEqual(data);
+  });
+});


### PR DESCRIPTION
## What

Five triaged auth client-state fixes (`docs/plans/bug-triage-2026-07/07-…`):

- **#611 (P1)** — `useThemePreferenceSync`'s three defects: concurrent syncs on dep changes (synchronous claim + promise-chain serialization), the always-true `boolean !== undefined` refresh comparison that fired `router.refresh()` on every first load where `data-experience` was absent (`?? false`, with the reasoning encoded: the server always stamps the attribute, so absence is dev-only), and the stale closure-captured `mode` reverting a user's mid-sync toggle (live ref + toggle-wins guard). Review follow-up: the sync guard now tracks *what* was synced, so an account `appSkin` arriving after the first sync (the common cold-load ordering) still applies — exactly once, serialized, no reload churn.
- **#612** — `useAuthentication`'s role fetch is cancellation-guarded, so a stale session's result can't clobber a newer session's state. Review follow-up: the no-session path resets `isLoadingRole`, closing a logout-mid-fetch path that left `authenticating` stuck true.
- **#616** — the org-id cache is a slug-keyed `Map` with an exported `resetOrganizationIdCache()` (test alias preserved), cleared on logout.
- **#639** — `resetApplication` now also resets `applicationSlice`, `adminSlice`, and the org-id cache — no more cross-session panel/search/pagination leakage on shared machines.
- **#617** — `LoginSlotSwitcher` routes by allowlist (`INVALID_TOKEN`, verified as exactly what better-auth emits for both invalid and expired reset tokens) instead of a denylist; unknown `?error=` codes (e.g. verify-email's `missing-verification-token`) render the normal login form with a visible error instead of dead-ending in the reset slot. Cross-checked: no verification/invite flow targets a `/login` callbackURL, so no code collision.

## Merge notes

Same file as PR #862 (`organization-utils.ts`) but non-overlapping hunks — verified clean merge either order.

## Red-team review (high effort)

Two findings fixed in the follow-up commit (stuck `isLoadingRole`; dropped late appSkin). StrictMode ref semantics, the `?? false` SSR assumption, import cycles, dep-array identity, and the allowlist completeness were each attacked and held with quoted evidence.

## Testing

Typecheck clean; 3,561 tests green. New suites for theme-sync races (double-persist, absent attribute, toggle-wins, late-appSkin serialization ×2), stale-session discard + logout-mid-fetch, cache keying/reset, slice resets on logout, and all four login error-code routes.

Closes #611
Closes #612
Closes #616
Closes #617
Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)