### PR TITLE
fix(catalog): data-integrity — LML field pass-through, soft-fail guards, add-mutation cache tags, synthetic-id collisions (cluster 05)

### DIFF
--- a/lib/__tests__/features/catalog/conversions.test.ts
+++ b/lib/__tests__/features/catalog/conversions.test.ts
@@ -304,6 +304,72 @@ describe("catalog conversions", () => {
       });
     });
 
+    // dj-site#626: two failure modes for synthesizeAlbumId.
+    //   (a) all-null rows hashed "|||||" to one id → React key collapse.
+    //   (b) two rows with an identical populated snapshot but different
+    //       rotation_id hashed equal (rotation-picker variant).
+    describe("synthetic id collisions (dj-site#626)", () => {
+      // Every snapshot field null AND no rotation_id — nothing to hash.
+      const allNullRow = {
+        add_date: undefined,
+        album_title: null,
+        artist_name: null,
+        code_letters: null,
+        code_number: null,
+        code_artist_number: null,
+        format_name: null,
+        genre_name: null,
+        label: null,
+        rotation_id: null,
+        rotation_bin: undefined,
+        plays: undefined,
+        id: null,
+      } as unknown as AlbumSearchResultJSON;
+
+      it("(a) gives two all-null rows DISTINCT ids", () => {
+        const first = convertToAlbumEntry(allNullRow);
+        const second = convertToAlbumEntry({
+          ...allNullRow,
+        } as AlbumSearchResultJSON);
+        expect(first.id).not.toBe(second.id);
+      });
+
+      it("(a) keeps all-null synthetic ids negative (can't collide with real ids)", () => {
+        const result = convertToAlbumEntry(allNullRow);
+        expect(result.id).toBeLessThan(0);
+      });
+
+      it("(b) gives identical populated snapshots with DIFFERENT rotation_id distinct ids", () => {
+        const a = convertToAlbumEntry({
+          ...unlinkedRowBase,
+          rotation_id: 5001,
+          id: null as unknown as number,
+        } as AlbumSearchResultJSON);
+        const b = convertToAlbumEntry({
+          ...unlinkedRowBase,
+          rotation_id: 5002,
+          id: null as unknown as number,
+        } as AlbumSearchResultJSON);
+        expect(a.id).not.toBe(b.id);
+      });
+
+      it("(b) keeps determinism where it matters: same snapshot + same rotation_id → same id", () => {
+        // Two distinct object references, equivalent payloads — the cross-call
+        // stability React keys depend on for populated rows.
+        const a = convertToAlbumEntry({
+          ...unlinkedRowBase,
+          rotation_id: 5001,
+          id: null as unknown as number,
+        } as AlbumSearchResultJSON);
+        const b = convertToAlbumEntry({
+          ...unlinkedRowBase,
+          rotation_id: 5001,
+          id: null as unknown as number,
+        } as AlbumSearchResultJSON);
+        expect(a.id).toBe(b.id);
+      });
+    });
+
     // These tests exercise the actual `BinLibraryDetails` branch (no `id`,
     // no `rotation_*`, no `add_date`, no `plays`). They pin the
     // `isSearchResult` gating audit promised in the commit body: removing

--- a/lib/__tests__/features/catalog/invalidation.test.ts
+++ b/lib/__tests__/features/catalog/invalidation.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server, TEST_BACKEND_URL, createTestStore } from "@/lib/test-utils";
+import { catalogApi } from "@/lib/features/catalog/api";
+
+// Mock the authentication client so the base query's token fetch resolves.
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+// dj-site#624: addAlbum / addArtist had no invalidatesTags nor cache patching,
+// so a newly created row didn't appear in cached search results until a manual
+// refresh. These tests pin that the add mutations now invalidate the list tags
+// and force the subscribed list queries to refetch.
+
+describe("catalog add-mutation cache invalidation (#624)", () => {
+  it("addAlbum invalidates CatalogList so the catalog search refetches", async () => {
+    let searchCalls = 0;
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/library/`, () => {
+        searchCalls += 1;
+        return HttpResponse.json([]);
+      }),
+      http.post(`${TEST_BACKEND_URL}/library/`, () =>
+        HttpResponse.json({ id: 4242 }),
+      ),
+    );
+
+    const store = createTestStore();
+    // Keep the subscription alive so invalidation triggers a refetch.
+    const sub = store.dispatch(
+      catalogApi.endpoints.searchCatalog.initiate({
+        artist_name: "Juana Molina",
+        album_title: undefined,
+        n: undefined,
+      }),
+    );
+    await sub;
+    expect(searchCalls).toBe(1);
+
+    await store.dispatch(
+      catalogApi.endpoints.addAlbum.initiate({
+        album_title: "DOGA",
+        label: "Sonamos",
+        genre_id: 1,
+        format_id: 1,
+        artist_name: "Juana Molina",
+      }),
+    );
+
+    await vi.waitFor(() => expect(searchCalls).toBe(2));
+    sub.unsubscribe();
+  });
+
+  it("addArtist invalidates both ArtistSearch and CatalogList", async () => {
+    let artistSearchCalls = 0;
+    let catalogCalls = 0;
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/library/artists/search`, () => {
+        artistSearchCalls += 1;
+        return HttpResponse.json({ artists: [] });
+      }),
+      http.get(`${TEST_BACKEND_URL}/library/`, () => {
+        catalogCalls += 1;
+        return HttpResponse.json([]);
+      }),
+      http.post(`${TEST_BACKEND_URL}/library/artists`, () =>
+        HttpResponse.json({ id: 7001 }),
+      ),
+    );
+
+    const store = createTestStore();
+    const artistSub = store.dispatch(
+      catalogApi.endpoints.searchArtistsInGenre.initiate({
+        genre_id: 1,
+        q: "Stereolab",
+      }),
+    );
+    const catalogSub = store.dispatch(
+      catalogApi.endpoints.searchCatalog.initiate({
+        artist_name: "Stereolab",
+        album_title: undefined,
+        n: undefined,
+      }),
+    );
+    await Promise.all([artistSub, catalogSub]);
+    expect(artistSearchCalls).toBe(1);
+    expect(catalogCalls).toBe(1);
+
+    await store.dispatch(
+      catalogApi.endpoints.addArtist.initiate({
+        artist_name: "Stereolab",
+        code_letters: "ST",
+        genre_id: 1,
+        code_number: 1,
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(artistSearchCalls).toBe(2);
+      expect(catalogCalls).toBe(2);
+    });
+    artistSub.unsubscribe();
+    catalogSub.unsubscribe();
+  });
+});

--- a/lib/__tests__/features/transformResponse-soft-fail.test.ts
+++ b/lib/__tests__/features/transformResponse-soft-fail.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server, TEST_BACKEND_URL, createTestStore } from "@/lib/test-utils";
+import { catalogApi } from "@/lib/features/catalog/api";
+import { rotationApi } from "@/lib/features/rotation/api";
+import { lmlApi } from "@/lib/features/lml/api";
+import { binApi } from "@/lib/features/bin/api";
+
+// Mock the authentication client so the base query's token fetch resolves.
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+// A non-JSON 200 (e.g. an HTML gateway/interstitial page) served with a JSON
+// content-type: fetchBaseQuery's json responseHandler throws, RTK surfaces
+// PARSING_ERROR, and backendBaseQuery soft-fails GETs to `{ data: null }`
+// (see WXYC/dj-site#519). The guarded transformResponse callbacks then receive
+// `null` and must return an empty/undefined value instead of throwing
+// `Cannot read properties of null (reading 'map')` (#606).
+const nonJsonBody = () =>
+  new HttpResponse("<!DOCTYPE html><html><body>Not Found</body></html>", {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("transformResponse soft-fail guards (#606)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("searchCatalog returns [] on a soft-failed (null) response", async () => {
+    server.use(http.get(`${TEST_BACKEND_URL}/library/`, () => nonJsonBody()));
+
+    const store = createTestStore();
+    const result = await store.dispatch(
+      catalogApi.endpoints.searchCatalog.initiate({
+        artist_name: "Juana Molina",
+        album_title: undefined,
+        n: undefined,
+      }),
+    );
+
+    expect(result.status).toBe("fulfilled");
+    expect(result.data).toEqual([]);
+  });
+
+  it("getInformation returns undefined on a soft-failed (null) response", async () => {
+    server.use(http.get(`${TEST_BACKEND_URL}/library/info`, () => nonJsonBody()));
+
+    const store = createTestStore();
+    const result = await store.dispatch(
+      catalogApi.endpoints.getInformation.initiate({ album_id: 1001 }),
+    );
+
+    expect(result.status).toBe("fulfilled");
+    expect(result.data).toBeUndefined();
+  });
+
+  it("getRotation returns [] on a soft-failed (null) response", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/library/rotation`, () => nonJsonBody()),
+    );
+
+    const store = createTestStore();
+    const result = await store.dispatch(
+      rotationApi.endpoints.getRotation.initiate(),
+    );
+
+    expect(result.status).toBe("fulfilled");
+    expect(result.data).toEqual([]);
+  });
+
+  it("lml searchLibrary returns [] on a soft-failed (null) response", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/proxy/library/search`, () => nonJsonBody()),
+    );
+
+    const store = createTestStore();
+    const result = await store.dispatch(
+      lmlApi.endpoints.searchLibrary.initiate({
+        artist: "Juana Molina",
+        title: "DOGA",
+      }),
+    );
+
+    expect(result.status).toBe("fulfilled");
+    expect(result.data).toEqual([]);
+  });
+
+  it("getBin returns [] on a soft-failed (null) response", async () => {
+    server.use(http.get(`${TEST_BACKEND_URL}/djs/bin/`, () => nonJsonBody()));
+
+    const store = createTestStore();
+    const result = await store.dispatch(
+      binApi.endpoints.getBin.initiate({ dj_id: "dj-5" }),
+    );
+
+    expect(result.status).toBe("fulfilled");
+    expect(result.data).toEqual([]);
+  });
+});

--- a/lib/features/bin/api.ts
+++ b/lib/features/bin/api.ts
@@ -14,8 +14,8 @@ export const binApi = createApi({
       query: ({ dj_id }) => ({
         url: `/?dj_id=${dj_id}`,
       }),
-      transformResponse: (response: BinLibraryDetails[]) =>
-        response.map(convertToAlbumEntry),
+      transformResponse: (response: BinLibraryDetails[] | null) =>
+        response ? response.map(convertToAlbumEntry) : [],
       providesTags: ["Bin"],
     }),
     deleteFromBin: builder.mutation<void, BinMutationQuery>({

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -119,7 +119,9 @@ export const catalogApi = createApi({
       // The POST response isn't a full AlbumEntry and the browse is a
       // paginated/sorted infinite query, so a new row can't be patched into the
       // cache coherently (its correct page may be unloaded). Invalidate the
-      // list instead so the panel refetches — dj-site#624.
+      // list instead so the panel refetches — dj-site#624. No UI dispatches
+      // this mutation yet; the tag is wired so the first adopter gets correct
+      // cache behavior instead of the stale-list bug #624 documented.
       invalidatesTags: [{ type: "CatalogList", id: "LIST" }],
     }),
     updateAlbum: builder.mutation<AlbumEntry, { albumId: number; body: UpdateAlbumRequestBody }>({
@@ -151,8 +153,10 @@ export const catalogApi = createApi({
         method: "POST",
         body,
       }),
-      // A new artist surfaces in the artist typeahead (searchArtistsInGenre) and
-      // can gate later album rows; refetch both rather than patch — dj-site#624.
+      // A new artist would surface in the artist typeahead (searchArtistsInGenre)
+      // and can gate later album rows; refetch both rather than patch —
+      // dj-site#624. Neither this mutation nor the typeahead has a UI consumer
+      // yet — tags are wired for the first adopter, not a live flow.
       invalidatesTags: [
         { type: "CatalogList", id: "LIST" },
         { type: "ArtistSearch", id: "LIST" },

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -66,8 +66,8 @@ export const catalogApi = createApi({
         url: "/",
         params: { artist_name, album_title, n, on_streaming },
       }),
-      transformResponse: (response: AlbumSearchResultJSON[]) =>
-        response.map(convertToAlbumEntry),
+      transformResponse: (response: AlbumSearchResultJSON[] | null) =>
+        response ? response.map(convertToAlbumEntry) : [],
     }),
     searchLibraryQuery: builder.query<LibraryQueryResult, LibraryQueryParams>({
       query: (params) => ({
@@ -159,13 +159,13 @@ export const catalogApi = createApi({
       ): SearchArtistsInGenreResponse =>
         response?.artists ? response : { artists: [] },
     }),
-    getInformation: builder.query<AlbumEntry, AlbumRequestParams>({
+    getInformation: builder.query<AlbumEntry | undefined, AlbumRequestParams>({
       query: ({ album_id }) => ({
         url: "/info",
         params: { album_id },
       }),
-      transformResponse: (response: AlbumSearchResultJSON) =>
-        convertToAlbumEntry(response),
+      transformResponse: (response: AlbumSearchResultJSON | null) =>
+        response ? convertToAlbumEntry(response) : undefined,
       providesTags: (result) =>
         result ? [{ type: "AlbumDetail", id: result.id }] : [],
     }),

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -59,7 +59,7 @@ function transformLibraryQueryResponse(
 export const catalogApi = createApi({
   reducerPath: "catalogApi",
   baseQuery: backendBaseQuery("library"),
-  tagTypes: ["Rotation", "AlbumDetail"],
+  tagTypes: ["Rotation", "AlbumDetail", "CatalogList", "ArtistSearch"],
   endpoints: (builder) => ({
     searchCatalog: builder.query<AlbumEntry[], SearchCatalogQueryParams>({
       query: ({ artist_name, album_title, n, on_streaming }) => ({
@@ -68,6 +68,11 @@ export const catalogApi = createApi({
       }),
       transformResponse: (response: AlbumSearchResultJSON[] | null) =>
         response ? response.map(convertToAlbumEntry) : [],
+      // A single LIST tag (not per-row AlbumDetail): updateAlbum/markMissing/
+      // markFound patch existing rows in place via patchCatalogSearchCaches, so
+      // this tag only needs to force a refetch when a brand-new row is added
+      // (addAlbum/addArtist) — see dj-site#624.
+      providesTags: [{ type: "CatalogList", id: "LIST" }],
     }),
     searchLibraryQuery: builder.query<LibraryQueryResult, LibraryQueryParams>({
       query: (params) => ({
@@ -76,6 +81,7 @@ export const catalogApi = createApi({
       }),
       transformResponse: (response: LibraryQueryResponseJSON | null) =>
         transformLibraryQueryResponse(response),
+      providesTags: [{ type: "CatalogList", id: "LIST" }],
     }),
     searchLibraryQueryInfinite: builder.infiniteQuery<
       LibraryQueryResult,
@@ -102,6 +108,7 @@ export const catalogApi = createApi({
       transformResponse: (
         response: LibraryQueryResponseJSON | null,
       ): LibraryQueryResult => transformLibraryQueryResponse(response),
+      providesTags: [{ type: "CatalogList", id: "LIST" }],
     }),
     addAlbum: builder.mutation<{ id: number } & Record<string, unknown>, AddAlbumRequestBody>({
       query: (body) => ({
@@ -109,6 +116,11 @@ export const catalogApi = createApi({
         method: "POST",
         body,
       }),
+      // The POST response isn't a full AlbumEntry and the browse is a
+      // paginated/sorted infinite query, so a new row can't be patched into the
+      // cache coherently (its correct page may be unloaded). Invalidate the
+      // list instead so the panel refetches — dj-site#624.
+      invalidatesTags: [{ type: "CatalogList", id: "LIST" }],
     }),
     updateAlbum: builder.mutation<AlbumEntry, { albumId: number; body: UpdateAlbumRequestBody }>({
       query: ({ albumId, body }) => ({
@@ -139,6 +151,12 @@ export const catalogApi = createApi({
         method: "POST",
         body,
       }),
+      // A new artist surfaces in the artist typeahead (searchArtistsInGenre) and
+      // can gate later album rows; refetch both rather than patch — dj-site#624.
+      invalidatesTags: [
+        { type: "CatalogList", id: "LIST" },
+        { type: "ArtistSearch", id: "LIST" },
+      ],
     }),
     peekArtistCode: builder.query<PeekArtistCodeResponse, PeekArtistCodeQuery>({
       query: ({ code_letters, genre_id }) => ({
@@ -158,6 +176,7 @@ export const catalogApi = createApi({
         response: SearchArtistsInGenreResponse | null,
       ): SearchArtistsInGenreResponse =>
         response?.artists ? response : { artists: [] },
+      providesTags: [{ type: "ArtistSearch", id: "LIST" }],
     }),
     getInformation: builder.query<AlbumEntry | undefined, AlbumRequestParams>({
       query: ({ album_id }) => ({

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -10,35 +10,48 @@ function isSearchResult(
 
 // Stable synthetic id for rows whose canonical id is null/missing. The BS
 // catalog proxy returns `id: null` for LML-only and unlinked-rotation rows
-// (see dj-site#564 + Backend-Service#689); without this, multiple such rows in
-// the same list collapse to a single React key. The hash is deterministic
-// across renders and negated so it can't collide with real positive album ids.
+// (see dj-site#564 + Backend-Service#689); without a synthetic id, multiple
+// such rows in one list collapse to a single React key.
 //
-// Known follow-ups (out of scope for #691). Hash inputs are
-// (artist|album|label|letters|artist_num|num):
+// The id is derived from the row snapshot so it stays stable across renders
+// (React keys depend on it) and is negated so it can't collide with real
+// positive album ids. Hash inputs are the six catalog fields
+// (artist|album|label|letters|artist_num|num) PLUS `rotation_id` when present:
+// two rows with an IDENTICAL populated snapshot but different rotation_ids (the
+// rotation-picker variant of dj-site#626) would otherwise hash equal and share
+// a key.
 //
-//   1. dj-site#626 — same hash for all-null fields (joined to "|||||"). The
-//      related-but-not-identical case of two rows with IDENTICAL populated
-//      snapshots but different rotation_ids producing the same React key is
-//      a sibling defect with the same root cause; see scope-expansion
-//      comment on #626 for the rotation-picker variant.
-//   2. dj-site#608 — synthetic id leaks to the wire from bin operations
-//      (`lib/features/bin/conversions.ts:8,19`, `flowsheet/connections.ts:10`
-//      per the issue's Evidence section). The rotation-picker path through
-//      `setRotationMetadata` → `convertQueryToSubmission` is a sibling
-//      surface with the same root cause and same fix shape; see scope-
-//      expansion comment on #608. Backend-Service treats negative album_id
-//      as a present FK (`flowsheet.controller.ts:255` `if (body.album_id !=
-//      null)`), then `getAlbumFromDB(-X)` returns undefined and the next
-//      line `albumInfo.record_label = ...` throws TypeError (controller line
-//      ~260) before BS's FK-validation layer can return 4xx. The unlinked-
-//      row e2e test in `__tests__/features/catalog/conversions.test.ts` pins
-//      the current observed wire shape so any fix in either layer must
-//      update the assertion deliberately.
+// Determinism yields only for a genuinely contentless row — every snapshot
+// field null/empty AND no rotation_id (the all-null "|||||" case in #626).
+// There is nothing to hash deterministically there, so such rows fall back to a
+// per-call counter that guarantees distinct keys for the several blank rows a
+// single response can carry. The trade-off: an all-null row draws a fresh id on
+// each conversion and so remounts across renders — acceptable because the row
+// carries no identity to preserve.
+//
+// Known follow-up (out of scope): dj-site#608 — synthetic id leaks to the wire
+// from bin operations (`lib/features/bin/conversions.ts:8,19`,
+// `flowsheet/connections.ts:10`). Backend-Service treats a negative album_id as
+// a present FK (`flowsheet.controller.ts:255` `if (body.album_id != null)`),
+// then `getAlbumFromDB(-X)` returns undefined and the next line
+// `albumInfo.record_label = ...` throws TypeError (~line 260) before BS's
+// FK-validation can 4xx. The unlinked-row e2e in
+// `__tests__/features/catalog/conversions.test.ts` pins the current wire shape,
+// so a fix in either layer must update the assertion deliberately.
+
+// Contentless rows can't be distinguished by content. Their counter is placed
+// one below the 32-bit hash range (the smallest hashed id is -(2**31 - 1)) so a
+// fallback id can never collide with a hashed id or a real positive id.
+const CONTENTLESS_ID_BASE = -(2 ** 31) - 1;
+let contentlessIdCounter = 0;
+function nextContentlessId(): number {
+  return CONTENTLESS_ID_BASE - contentlessIdCounter++;
+}
+
 function synthesizeAlbumId(
   response: AlbumSearchResultJSON | BinLibraryDetails
 ): number {
-  const key = [
+  const snapshot = [
     response.artist_name ?? "",
     response.album_title ?? "",
     response.label ?? "",
@@ -46,6 +59,16 @@ function synthesizeAlbumId(
     response.code_artist_number ?? "",
     response.code_number ?? "",
   ].join("|");
+  const rotationId =
+    "rotation_id" in response && response.rotation_id != null
+      ? String(response.rotation_id)
+      : "";
+
+  if (snapshot.replace(/\|/g, "") === "" && rotationId === "") {
+    return nextContentlessId();
+  }
+
+  const key = `${snapshot}|${rotationId}`;
   let hash = 5381;
   for (let i = 0; i < key.length; i++) {
     hash = ((hash << 5) + hash + key.charCodeAt(i)) | 0;

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -40,8 +40,10 @@ function isSearchResult(
 // so a fix in either layer must update the assertion deliberately.
 
 // Contentless rows can't be distinguished by content. Their counter is placed
-// one below the 32-bit hash range (the smallest hashed id is -(2**31 - 1)) so a
-// fallback id can never collide with a hashed id or a real positive id.
+// one below the 32-bit hash range: the hashed id is -(Math.abs(hash) || 1)
+// with hash coerced via `| 0`, and Math.abs(-2147483648) === 2147483648, so
+// the TRUE minimum hashed id is -(2**31) exactly. The base below must stay
+// strictly less than that — do not "simplify" it to -(2**31).
 const CONTENTLESS_ID_BASE = -(2 ** 31) - 1;
 let contentlessIdCounter = 0;
 function nextContentlessId(): number {

--- a/lib/features/lml/api.ts
+++ b/lib/features/lml/api.ts
@@ -33,8 +33,8 @@ export const lmlApi = createApi({
           limit,
         },
       }),
-      transformResponse: (response: LmlLibrarySearchResponse) =>
-        response.results.map(convertLmlItemToAlbumEntry),
+      transformResponse: (response: LmlLibrarySearchResponse | null) =>
+        response?.results ? response.results.map(convertLmlItemToAlbumEntry) : [],
     }),
   }),
 });

--- a/lib/features/rotation/api.ts
+++ b/lib/features/rotation/api.ts
@@ -13,8 +13,8 @@ export const rotationApi = createApi({
       query: () => ({
         url: "",
       }),
-      transformResponse: (response: AlbumSearchResultJSON[]) =>
-        response.map(convertToAlbumEntry),
+      transformResponse: (response: AlbumSearchResultJSON[] | null) =>
+        response ? response.map(convertToAlbumEntry) : [],
       providesTags: ["Rotation"],
     }),
     addRotationEntry: builder.mutation<any, RotationParams>({

--- a/src/hooks/lml/lml-conversions.test.ts
+++ b/src/hooks/lml/lml-conversions.test.ts
@@ -103,10 +103,55 @@ describe("convertLmlItemToAlbumEntry", () => {
     expect(result.artist.genre).toBe("Unknown");
   });
 
-  it("should always set label to empty string", () => {
+  it("should default a missing label to empty string", () => {
     const item = createTestLmlLibraryItem();
     const result = convertLmlItemToAlbumEntry(item);
     expect(result.label).toBe("");
+  });
+
+  it("should pass the record label through (dj-site#605)", () => {
+    const item = createTestLmlLibraryItem({ label: "Sonamos" });
+    const result = convertLmlItemToAlbumEntry(item);
+    expect(result.label).toBe("Sonamos");
+  });
+
+  it("should default a null label to empty string", () => {
+    const item = createTestLmlLibraryItem({ label: null });
+    const result = convertLmlItemToAlbumEntry(item);
+    expect(result.label).toBe("");
+  });
+
+  it("should pass on_streaming:false through so the EXCLUSIVE chip renders (dj-site#605)", () => {
+    // The catalog/flowsheet result rows render the WXYC EXCLUSIVE chip on
+    // `on_streaming === false` (see SearchResults.tsx / Capsule.tsx). Dropping
+    // the field silently hid the chip on LML-sourced results.
+    const item = createTestLmlLibraryItem({ on_streaming: false });
+    const result = convertLmlItemToAlbumEntry(item);
+    expect(result.on_streaming).toBe(false);
+  });
+
+  it("should pass on_streaming:true through", () => {
+    const item = createTestLmlLibraryItem({ on_streaming: true });
+    const result = convertLmlItemToAlbumEntry(item);
+    expect(result.on_streaming).toBe(true);
+  });
+
+  it.each([[null], [undefined]])(
+    "should leave on_streaming undefined (not false) when the field is %s",
+    (value) => {
+      // A nullish on_streaming must NOT collapse to `false` — that would render
+      // a spurious EXCLUSIVE chip on releases whose streaming status is unknown.
+      const item = createTestLmlLibraryItem({ on_streaming: value });
+      const result = convertLmlItemToAlbumEntry(item);
+      expect(result.on_streaming).toBeUndefined();
+    },
+  );
+
+  it("should pass matched_via track-match hints through (dj-site#605)", () => {
+    const matched_via = [{ source: "cta", title: "La Verdad" }];
+    const item = createTestLmlLibraryItem({ matched_via });
+    const result = convertLmlItemToAlbumEntry(item);
+    expect(result.matched_via).toEqual(matched_via);
   });
 
   it("should always set rotation_bin, rotation_id, plays, and add_date to undefined", () => {

--- a/src/hooks/lml/lml-conversions.ts
+++ b/src/hooks/lml/lml-conversions.ts
@@ -29,8 +29,11 @@ function normalizeGenre(genre: string | null): Genre {
 
 /**
  * Converts an LML library search result to the frontend `AlbumEntry` type.
- * LML does not carry label, rotation, or play count data — those fields are
- * left empty/undefined and filled in once the DJ selects the entry.
+ * LML does not carry rotation or play count data — those fields are left
+ * undefined and filled in once the DJ selects the entry. `label`,
+ * `on_streaming`, and `matched_via` DO ride on the response (dj-site#605); a
+ * missing/null `on_streaming` stays `undefined` so it is not mistaken for the
+ * `false` value that renders the WXYC EXCLUSIVE chip.
  */
 export function convertLmlItemToAlbumEntry(item: LmlLibraryItem): AlbumEntry {
   return {
@@ -46,7 +49,9 @@ export function convertLmlItemToAlbumEntry(item: LmlLibraryItem): AlbumEntry {
     entry: item.release_call_number ?? 0,
     format: normalizeFormat(item.format),
     alternate_artist: item.alternate_artist_name ?? "",
-    label: "",
+    label: item.label ?? "",
+    on_streaming: item.on_streaming ?? undefined,
+    matched_via: item.matched_via,
     rotation_bin: undefined,
     rotation_id: undefined,
     plays: undefined,

--- a/src/hooks/lml/types.ts
+++ b/src/hooks/lml/types.ts
@@ -1,3 +1,5 @@
+import type { TrackMatchHint } from "@/lib/features/catalog/types";
+
 export type LmlLibraryItem = {
   id: number;
   title: string | null;
@@ -9,6 +11,11 @@ export type LmlLibraryItem = {
   format: string | null;
   alternate_artist_name: string | null;
   library_url: string;
+  // Declared on `LibrarySearchItem` in wxyc-shared/api.yaml but not in its
+  // `required` set, so optional here (see dj-site#605).
+  label?: string | null;
+  on_streaming?: boolean | null;
+  matched_via?: TrackMatchHint[];
 };
 
 export type LmlLibrarySearchResponse = {


### PR DESCRIPTION
## Dependencies / adjacencies (see docs/plans/bug-triage-2026-07/PR-DEPENDENCIES.md)

- **No file overlap with any open PR** (verified in review: #861 touches `bin/conversions.ts`, this touches `bin/api.ts`; flowsheet PRs touch `flowsheet/conversions.ts`, this touches `catalog/conversions.ts`). Independent merge order.
- One cross-cluster export: this PR's transform audit found two unguarded flowsheet transforms — that fix went to **PR #865** (commit `23ea4bfd`), not here.

## What (one commit per issue + review follow-up)

- **#606 (P1, re-scoped on-issue)** — `backendBaseQuery` soft-fails non-JSON GETs to `{data: null}`; the four still-unguarded transforms now map that safely (`searchCatalog`/`getRotation`/`searchLibrary` → `[]`; `getInformation` → `undefined` with the return type widened — both consumers already null-guard). Full audit of every `transformResponse` in `lib/features/` included, which caught an unlisted fifth (`bin getBin`) plus the two flowsheet ones exported to #865. MSW-driven tests exercise the real PARSING_ERROR path per endpoint.
- **#605 (P1)** — LML-proxied results no longer silently lose `label`, `on_streaming`, and `matched_via`; `on_streaming: item.on_streaming ?? undefined` deliberately keeps null from masquerading as the `false` that renders the WXYC-EXCLUSIVE chip (chip logic tests `=== false`; verified load-bearing in review).
- **#624 (re-scoped on-issue)** — `addAlbum`/`addArtist` invalidate new `CatalogList`/`ArtistSearch` list tags. Chose invalidation over cache-patching: the POST responses lack sort keys and the browse is a paginated/sorted infinite query, so inserting a row coherently is unsound. **Honest caveat from review:** neither mutation has a UI consumer yet — this is first-adopter wiring, stated plainly at the call sites, not a live-path fix.
- **#626** — `synthesizeAlbumId` no longer collapses distinct rows: `rotation_id` joins the hash when present (fixes identical-snapshot collisions deterministically), and genuinely contentless rows get a counter id placed strictly below the true 32-bit hash floor (collision-proof by construction, with the floor math documented against a tempting future "simplification"). All PR #697 determinism tests still pass.

## Red-team review (high effort)

No correctness findings survived — consumer-by-consumer verification of the widened return type, chip semantics, tag completeness, id-stability into the flowsheet chokepoints, and the counter/hash floor. Two comment-accuracy findings fixed in the follow-up commit; one accepted observation: soft-failed rotation fetches now cache as empty-success (matches the existing #519/#637 error-affordance conventions; no consumer distinguishes the states today).

## Testing

Typecheck clean; 3,563 tests green. New: per-endpoint soft-fail suite, LML field pass-through, cache-invalidation behavior via MSW call-counting, four synthetic-id collision/stability cases.

Closes #605
Closes #606
Closes #624
Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)