### PR TITLE
fix(rotation): type addRotationEntry against the shared AddRotationRequest contract

### DIFF
--- a/lib/features/rotation/api.ts
+++ b/lib/features/rotation/api.ts
@@ -2,7 +2,8 @@ import { createApi } from "@reduxjs/toolkit/query/react";
 import { backendBaseQuery } from "../backend";
 import { convertToAlbumEntry } from "../catalog/conversions";
 import { AlbumEntry, AlbumSearchResultJSON } from "../catalog/types";
-import { KillRotationParams, RotationParams } from "./types";
+import type { AddRotationRequest } from "@wxyc/shared";
+import { KillRotationParams } from "./types";
 
 export const rotationApi = createApi({
   reducerPath: "rotationApi",
@@ -17,7 +18,10 @@ export const rotationApi = createApi({
         response.map(convertToAlbumEntry),
       providesTags: ["Rotation"],
     }),
-    addRotationEntry: builder.mutation<any, RotationParams>({
+    // Typed against the shared OpenAPI contract (album_id: number) — the old
+    // local RotationParams declared album_id: string, drifting from the wire
+    // and forcing casts on future callers (#627).
+    addRotationEntry: builder.mutation<any, AddRotationRequest>({
       query: (rotation) => ({
         url: "",
         method: "POST",

--- a/lib/features/rotation/types.ts
+++ b/lib/features/rotation/types.ts
@@ -11,11 +11,6 @@ export type RotationFrontendState = {
   orderDirection: "asc" | "desc";
 };
 
-export type RotationParams = {
-  album_id: string;
-  rotation_bin: Rotation;
-};
-
 export type KillRotationParams = {
   rotation_id: number;
   kill_date: Date | undefined;


### PR DESCRIPTION
## Dependencies (docs/plans/bug-triage-2026-07/PR-DEPENDENCIES.md)

Adjacent to PR #868 in `lib/features/rotation/api.ts` (868 guards `getRotation`'s transform; this changes `addRotationEntry`'s type) — different endpoints, non-overlapping hunks. Also relevant to open PR #800 (rotation bin selector), whose UI will be the first real caller of this mutation and now gets the correct `album_id: number` contract instead of the drifted `string`.

## What

#627: `RotationParams` declared `album_id: string`; the OpenAPI contract (`AddRotationRequest` in `@wxyc/shared`) declares `integer`. The mutation is now typed against the shared contract directly and the drifted local type is deleted. Zero existing call sites (verified), so no cast cleanup was needed — this closes the trap before #800 walks into it.

Typecheck + full suite green (3,556 tests).

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)