### PR TITLE
ci: full-history checkout so vitest --changed resolves a merge-base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,12 +103,22 @@ jobs:
       matrix:
         shard: [1/3, 2/3, 3/3]
     steps:
+      # fetch-depth: 0 (full history) so `vitest run --changed origin/main`
+      # below always resolves a merge-base between the PR head and origin/main.
+      # A shallow checkout (default depth 1) + `git fetch origin main --depth=1`
+      # leaves no shared history, so `git merge-base` fails and vitest's
+      # --changed degrades unpredictably — in some cases selecting zero tests
+      # and silently letting a source change through the merge gate (#642).
+      # Full history is cheap here: the repo's object store is ~22MB (~1.1k
+      # commits), a couple seconds of clone time, versus dropping --changed and
+      # running the full ~258-file unit suite on every PR. The old depth-1
+      # fetch step is intentionally removed: fetch-depth: 0 already brings the
+      # origin/main remote-tracking ref, and a subsequent --depth=1 fetch would
+      # re-shallow the clone and reintroduce the same merge-base failure.
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Fetch base branch for change detection
-        if: github.event_name == 'pull_request'
-        run: git fetch origin main --depth=1
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Dependencies

None — single workflow-file hunk, no overlap with any open PR. (Branch pushed via SSH by the maintainer; tokens lack workflow scope.)

## What

#642: the unit-test job ran `vitest run --changed origin/main` on a depth-1 checkout plus a depth-1 base fetch — no shared merge-base, so change detection degraded unpredictably (potentially selecting zero tests and waving a source change through the merge gate). Now `fetch-depth: 0` on that job's checkout, with the old depth-1 fetch step removed — deliberately, since a `--depth=1` fetch on a full clone would re-shallow it and reintroduce the exact failure.

Measured trade-off (documented in the workflow comment): full history is ~22MB / ~1.1k commits ≈ seconds of clone time, vs. losing `--changed` and running all ~258 test files on every PR.

## #579 (same cluster, deliberately no commit)

Investigation found the tubafrenzy mirror stub **already on main** (#567/`aebd96fc` — postdating the logs #579 cites) and all dj-site provisioning specs already UUID-suffixed. The residual dup-key source is Backend-Service's `seed_db.sql` upserting `ON CONFLICT (id)` rather than `(username)`. Full forensics on the issue; it stays open for two-consecutive-clean-runs observation per its own acceptance criteria.

Closes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)