### PR TITLE
feat(security): httpOnly app_state cookie + security headers with Report-Only CSP (#631)

### DIFF
--- a/lib/__tests__/csp-violation-reporter.test.ts
+++ b/lib/__tests__/csp-violation-reporter.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { safeCapture } from "@/lib/posthog";
+import {
+  handleSecurityPolicyViolation,
+  resetCspViolationReporterForTests,
+} from "@/lib/csp-violation-reporter";
+
+vi.mock("@/lib/posthog", () => ({
+  safeCapture: vi.fn(),
+}));
+
+function violation(overrides: Partial<{
+  violatedDirective: string;
+  blockedURI: string;
+  documentURI: string;
+  disposition: string;
+}> = {}) {
+  return {
+    violatedDirective: "connect-src",
+    blockedURI: "https://evil.example.com/collect?token=secret123",
+    documentURI: "https://dj.wxyc.org/dashboard/flowsheet?session=abc",
+    disposition: "report",
+    ...overrides,
+  } as SecurityPolicyViolationEvent;
+}
+
+describe("handleSecurityPolicyViolation", () => {
+  beforeEach(() => {
+    vi.mocked(safeCapture).mockClear();
+    resetCspViolationReporterForTests();
+  });
+
+  it("captures a csp_violation event with trimmed payload", () => {
+    handleSecurityPolicyViolation(violation());
+
+    expect(safeCapture).toHaveBeenCalledTimes(1);
+    expect(safeCapture).toHaveBeenCalledWith("csp_violation", {
+      violatedDirective: "connect-src",
+      // Origin only — the full URL's path/query (potential tokens) must not
+      // ship to telemetry.
+      blockedURI: "https://evil.example.com",
+      // Path only — no query string.
+      documentURI: "/dashboard/flowsheet",
+      disposition: "report",
+    });
+  });
+
+  it("passes non-URL blockedURI keywords through unchanged", () => {
+    handleSecurityPolicyViolation(
+      violation({ violatedDirective: "script-src", blockedURI: "inline" })
+    );
+
+    expect(safeCapture).toHaveBeenCalledWith(
+      "csp_violation",
+      expect.objectContaining({ blockedURI: "inline" })
+    );
+  });
+
+  it("dedupes repeat violations of the same (directive, origin) pair", () => {
+    handleSecurityPolicyViolation(violation());
+    handleSecurityPolicyViolation(
+      violation({ blockedURI: "https://evil.example.com/other-path" })
+    );
+
+    expect(safeCapture).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports the same origin under a different directive", () => {
+    handleSecurityPolicyViolation(violation());
+    handleSecurityPolicyViolation(violation({ violatedDirective: "img-src" }));
+
+    expect(safeCapture).toHaveBeenCalledTimes(2);
+  });
+
+  it("caps reports per session so distinct origins cannot flood telemetry", () => {
+    for (let i = 0; i < 60; i++) {
+      handleSecurityPolicyViolation(
+        violation({ blockedURI: `https://origin-${i}.example.com/x` })
+      );
+    }
+
+    expect(safeCapture).toHaveBeenCalledTimes(50);
+  });
+});

--- a/lib/__tests__/features/session.test.ts
+++ b/lib/__tests__/features/session.test.ts
@@ -75,6 +75,12 @@ describe("session", () => {
       expect(sessionOptions.cookieOptions.path).toBe("/");
       expect(sessionOptions.cookieOptions.sameSite).toBe("lax");
     });
+
+    it("marks the app_state cookie httpOnly so it is not script-readable (#631)", async () => {
+      const { sessionOptions } = await import("@/lib/features/session");
+
+      expect(sessionOptions.cookieOptions.httpOnly).toBe(true);
+    });
   });
 
   describe("createServerSideProps", () => {

--- a/lib/__tests__/next.config.test.ts
+++ b/lib/__tests__/next.config.test.ts
@@ -11,6 +11,14 @@ async function loadConfig() {
   return mod.default;
 }
 
+async function loadModule() {
+  vi.resetModules();
+  return import("../../next.config.mjs");
+}
+
+// The builders accept process.env; tests pass minimal partials.
+const env = (e: Partial<NodeJS.ProcessEnv> = {}) => e as NodeJS.ProcessEnv;
+
 type Rewrite = { source?: string };
 type RewritesResult =
   | Rewrite[]
@@ -108,6 +116,81 @@ describe("next.config", () => {
       const dashboard = redirects.find((r) => r.source === "/dashboard");
 
       expect(dashboard?.destination).toBe("/dashboard/flowsheet");
+    });
+  });
+
+  describe("security headers (#631)", () => {
+    it("applies the security header set to all paths", async () => {
+      const config = (await loadConfig()) as {
+        headers?: () => Promise<
+          Array<{ source: string; headers: Array<{ key: string }> }>
+        >;
+      };
+      const rules = config.headers ? await config.headers() : [];
+      expect(rules).toHaveLength(1);
+      expect(rules[0].source).toBe("/:path*");
+
+      const keys = rules[0].headers.map((h) => h.key);
+      expect(keys).toContain("Content-Security-Policy-Report-Only");
+      expect(keys).toContain("X-Content-Type-Options");
+      expect(keys).toContain("X-Frame-Options");
+      expect(keys).toContain("Referrer-Policy");
+    });
+
+    it("ships the CSP as Report-Only, not enforcing, for the first rollout", async () => {
+      const { buildSecurityHeaders } = await loadModule();
+      const keys = buildSecurityHeaders(env()).map((h) => h.key);
+      expect(keys).toContain("Content-Security-Policy-Report-Only");
+      expect(keys).not.toContain("Content-Security-Policy");
+    });
+
+    it("sets the static header values", async () => {
+      const { buildSecurityHeaders } = await loadModule();
+      const byKey = Object.fromEntries(
+        buildSecurityHeaders(env()).map((h) => [h.key, h.value]),
+      );
+      expect(byKey["X-Content-Type-Options"]).toBe("nosniff");
+      expect(byKey["X-Frame-Options"]).toBe("DENY");
+      expect(byKey["Referrer-Policy"]).toBe("strict-origin-when-cross-origin");
+    });
+
+    it("gates HSTS to production builds only", async () => {
+      const { buildSecurityHeaders } = await loadModule();
+      const has = (e: NodeJS.ProcessEnv) =>
+        buildSecurityHeaders(e).some(
+          (h) => h.key === "Strict-Transport-Security",
+        );
+      expect(has(env({ NODE_ENV: "production" }))).toBe(true);
+      expect(has(env({ NODE_ENV: "development" }))).toBe(false);
+      expect(has(env())).toBe(false);
+    });
+
+    it("derives connect-src origins from the backend and telemetry env vars", async () => {
+      const { buildContentSecurityPolicy } = await loadModule();
+      const csp = buildContentSecurityPolicy(
+        env({
+          NEXT_PUBLIC_BACKEND_URL: "https://api.wxyc.org",
+          NEXT_PUBLIC_ORCHESTRATOR_URL: "https://orchestrator.wxyc.org",
+          NEXT_PUBLIC_POSTHOG_HOST: "https://us.i.posthog.com",
+        }),
+      );
+      const connectSrc = csp
+        .split(";")
+        .map((d) => d.trim())
+        .find((d) => d.startsWith("connect-src"));
+      expect(connectSrc).toContain("'self'");
+      expect(connectSrc).toContain("https://api.wxyc.org");
+      expect(connectSrc).toContain("https://orchestrator.wxyc.org");
+      expect(connectSrc).toContain("https://us.i.posthog.com");
+      expect(connectSrc).toContain("https://us-assets.i.posthog.com");
+    });
+
+    it("declares the live audio stream and broad image origins", async () => {
+      const { buildContentSecurityPolicy } = await loadModule();
+      const csp = buildContentSecurityPolicy(env());
+      expect(csp).toContain("media-src 'self' https://audio-mp3.ibiblio.org");
+      expect(csp).toContain("img-src 'self' https: data: blob:");
+      expect(csp).toContain("frame-ancestors 'none'");
     });
   });
 });

--- a/lib/csp-violation-reporter.ts
+++ b/lib/csp-violation-reporter.ts
@@ -1,0 +1,74 @@
+import { safeCapture } from "./posthog";
+
+/**
+ * Forwards Content-Security-Policy violations to PostHog so the Report-Only
+ * rollout (#631) gathers real-user signal instead of relying on individual
+ * DevTools consoles. Installed once per page from PostHogProvider.
+ */
+
+// Dedupe per (violatedDirective, blockedURI-origin) per page session so a hot
+// violation (e.g. one blocked origin hit on every render) can't flood
+// telemetry; the cap bounds the pathological many-distinct-origins case.
+const reportedKeys = new Set<string>();
+const MAX_REPORTS_PER_SESSION = 50;
+
+/**
+ * Reduce blockedURI to its origin: full URLs can carry query tokens or other
+ * sensitive path segments that must not ship to telemetry. Non-URL keywords
+ * the browser reports ("inline", "eval", "data", "") pass through unchanged.
+ */
+function blockedURIOrigin(blockedURI: string): string {
+  try {
+    return new URL(blockedURI).origin;
+  } catch {
+    return blockedURI;
+  }
+}
+
+/** Reduce documentURI to its path for the same query-token reason. */
+function documentURIPath(documentURI: string): string {
+  try {
+    return new URL(documentURI).pathname;
+  } catch {
+    return documentURI;
+  }
+}
+
+type CspViolation = Pick<
+  SecurityPolicyViolationEvent,
+  "violatedDirective" | "blockedURI" | "documentURI" | "disposition"
+>;
+
+export function handleSecurityPolicyViolation(event: CspViolation): void {
+  const blockedOrigin = blockedURIOrigin(event.blockedURI);
+  const key = `${event.violatedDirective}|${blockedOrigin}`;
+
+  if (reportedKeys.has(key) || reportedKeys.size >= MAX_REPORTS_PER_SESSION) {
+    return;
+  }
+  reportedKeys.add(key);
+
+  safeCapture("csp_violation", {
+    violatedDirective: event.violatedDirective,
+    blockedURI: blockedOrigin,
+    documentURI: documentURIPath(event.documentURI),
+    disposition: event.disposition,
+  });
+}
+
+let installed = false;
+
+export function installCspViolationReporter(): void {
+  if (typeof document === "undefined" || installed) return;
+  installed = true;
+  document.addEventListener(
+    "securitypolicyviolation",
+    handleSecurityPolicyViolation
+  );
+}
+
+/** Test-only escape hatch: clears the dedupe set and installed flag. */
+export function resetCspViolationReporterForTests(): void {
+  reportedKeys.clear();
+  installed = false;
+}

--- a/lib/features/session.ts
+++ b/lib/features/session.ts
@@ -14,6 +14,10 @@ export const sessionOptions = {
     path: "/",
     sameSite: "lax" as const,
     secure: process.env.NODE_ENV === "production",
+    // app_state carries UI preference state only; the client reads it through
+    // the /api/view GET route (see src/hooks/themePreferenceHooks.ts), never
+    // document.cookie, so it never needs to be script-readable.
+    httpOnly: true,
   },
 };
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,128 @@ const distDir = process.env.NEXT_DIST_DIR_SUFFIX
   ? `.next-${process.env.NEXT_DIST_DIR_SUFFIX}`
   : ".next";
 
+// --- Security headers (#631) -------------------------------------------------
+// The CSP ships as Content-Security-Policy-Report-Only for the first rollout:
+// on Cloudflare Pages / OpenNext a too-tight policy can break the site
+// invisibly, so this observes violations (browser console) without enforcing.
+// Every directive below traces to an observed load in the codebase:
+//
+//   script-src   'unsafe-inline' — Next.js App Router injects inline hydration/
+//                bootstrap scripts and has no nonce pipeline here. PostHog
+//                (lib/posthog.ts) lazy-loads its recorder/exception-autocapture
+//                bundles from the region "-assets" host.
+//   style-src    'unsafe-inline' — MUI Joy UI / Emotion inject runtime <style>
+//                tags and inline style attributes; next/font emits inline
+//                @font-face. All self-hosted; no external stylesheet origins.
+//   img-src      https: — album artwork (album.artwork_url, useAlbumArtwork)
+//                is resolved by the backend /metadata proxy and points at
+//                third-party image hosts not enumerable at build time; data:/
+//                blob: cover inline SVG and canvas.
+//   font-src     'self' data: — next/font self-hosts under /_next/static; no
+//                fonts.googleapis/gstatic requests exist. data: is defensive.
+//   media-src    audio-mp3.ibiblio.org — the live stream AUDIO_SRC in
+//                src/widgets/NowPlaying/index.tsx.
+//   connect-src  backend origin — RTK Query (lib/features/backend.ts) and the
+//                SSE EventSource (lib/features/flowsheet/live-updates-listener.ts)
+//                hit NEXT_PUBLIC_BACKEND_URL directly; PostHog host + assets for
+//                telemetry; orchestrator origin when NEXT_PUBLIC_ORCHESTRATOR_URL
+//                is set (lib/features/autoDJ/api.ts). Auth is same-origin: the
+//                client resolves a cross-origin NEXT_PUBLIC_BETTER_AUTH_URL to
+//                the local /auth proxy (lib/features/authentication/client.ts),
+//                so 'self' covers it.
+//   frame-ancestors 'none' — nothing embeds dj-site in an iframe (grep found no
+//                self-framing); mirrors X-Frame-Options: DENY.
+//
+// NEXT_PUBLIC_* values are inlined at build time, so the derived origins below
+// resolve to the environment being built (prod vs preview vs local).
+function originOf(url) {
+  if (!url) return null;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+// PostHog cloud serves the recorder / exception-autocapture assets from the
+// region "-assets" host (us.i -> us-assets.i). Self-hosted deployments serve
+// them from the same host, so a non-matching origin is returned unchanged.
+function posthogAssetsOrigin(origin) {
+  if (!origin) return null;
+  return origin.replace(
+    /^https:\/\/([a-z0-9-]+)\.i\.posthog\.com$/,
+    "https://$1-assets.i.posthog.com"
+  );
+}
+
+const AUDIO_STREAM_ORIGIN = "https://audio-mp3.ibiblio.org";
+
+export function buildContentSecurityPolicy(env = process.env) {
+  const backendOrigin = originOf(env.NEXT_PUBLIC_BACKEND_URL);
+  const orchestratorOrigin = originOf(env.NEXT_PUBLIC_ORCHESTRATOR_URL);
+  const posthogOrigin = originOf(
+    env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com"
+  );
+  const posthogAssets = posthogAssetsOrigin(posthogOrigin);
+
+  const dedupe = (values) => [...new Set(values.filter(Boolean))];
+
+  const scriptSrc = dedupe([
+    "'self'",
+    "'unsafe-inline'",
+    posthogOrigin,
+    posthogAssets,
+  ]);
+  const connectSrc = dedupe([
+    "'self'",
+    backendOrigin,
+    orchestratorOrigin,
+    posthogOrigin,
+    posthogAssets,
+  ]);
+
+  const directives = [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    `script-src ${scriptSrc.join(" ")}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' https: data: blob:",
+    "font-src 'self' data:",
+    `media-src 'self' ${AUDIO_STREAM_ORIGIN}`,
+    `connect-src ${connectSrc.join(" ")}`,
+    "worker-src 'self' blob:",
+    "manifest-src 'self'",
+  ];
+
+  return directives.join("; ");
+}
+
+export function buildSecurityHeaders(env = process.env) {
+  const headers = [
+    {
+      key: "Content-Security-Policy-Report-Only",
+      value: buildContentSecurityPolicy(env),
+    },
+    { key: "X-Content-Type-Options", value: "nosniff" },
+    { key: "X-Frame-Options", value: "DENY" },
+    { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  ];
+
+  // HSTS only in production builds: a max-age on a local/http origin would pin
+  // the browser to https for a domain that may not serve it.
+  if (env.NODE_ENV === "production") {
+    headers.push({
+      key: "Strict-Transport-Security",
+      value: "max-age=63072000; includeSubDomains; preload",
+    });
+  }
+
+  return headers;
+}
+
 const nextConfig = {
   reactStrictMode: false,
   productionBrowserSourceMaps: true,
@@ -22,6 +144,14 @@ const nextConfig = {
   outputFileTracingRoot: import.meta.dirname,
   // Required for OpenNext Cloudflare
   output: "standalone",
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: buildSecurityHeaders(),
+      },
+    ];
+  },
   async redirects() {
     return [
       {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -60,6 +60,9 @@ function originOf(url) {
 // PostHog cloud serves the recorder / exception-autocapture assets from the
 // region "-assets" host (us.i -> us-assets.i). Self-hosted deployments serve
 // them from the same host, so a non-matching origin is returned unchanged.
+// Only the ^https://<region>.i.posthog.com$ shape is rewritten: a custom or
+// proxied NEXT_PUBLIC_POSTHOG_HOST that still lazy-loads from a "-assets"
+// host will need that origin added here manually.
 function posthogAssetsOrigin(origin) {
   if (!origin) return null;
   return origin.replace(
@@ -124,8 +127,13 @@ export function buildSecurityHeaders(env = process.env) {
     { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
   ];
 
-  // HSTS only in production builds: a max-age on a local/http origin would pin
-  // the browser to https for a domain that may not serve it.
+  // NODE_ENV === "production" does NOT mean "production deploys only": `next
+  // build` sets it for EVERY build, previews included, so HSTS ships on
+  // *.wxyc-dj.pages.dev too (harmless — pages.dev is already HSTS-preloaded).
+  // The gate's only real effect is excluding `next dev`, where a max-age on a
+  // local http origin would pin the browser to https it doesn't serve.
+  // Cutover caveat: preload + includeSubDomains + 2y max-age is sticky on the
+  // eventual custom domain — be deliberate before flipping DNS to this app.
   if (env.NODE_ENV === "production") {
     headers.push({
       key: "Strict-Transport-Security",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -43,8 +43,14 @@ const distDir = process.env.NEXT_DIST_DIR_SUFFIX
 //                client resolves a cross-origin NEXT_PUBLIC_BETTER_AUTH_URL to
 //                the local /auth proxy (lib/features/authentication/client.ts),
 //                so 'self' covers it.
-//   frame-ancestors 'none' — nothing embeds dj-site in an iframe (grep found no
-//                self-framing); mirrors X-Frame-Options: DENY.
+//   frame-ancestors 'none' — nothing embeds dj-site in an iframe today (grep
+//                found no self-framing; confirmed by the maintainer 2026-07-15);
+//                mirrors X-Frame-Options: DENY. KNOWN FUTURE CAVEAT: serving
+//                the player from wxyc.org in an iframe is a long-term goal —
+//                when that project lands, relax this to
+//                `frame-ancestors 'self' https://wxyc.org` (and scope the
+//                X-Frame-Options change to the embedded route) rather than
+//                dropping framing protection wholesale.
 //
 // NEXT_PUBLIC_* values are inlined at build time, so the derived origins below
 // resolve to the environment being built (prod vs preview vs local).

--- a/src/components/shared/PostHogProvider.tsx
+++ b/src/components/shared/PostHogProvider.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { initPostHog, posthog } from "@/lib/posthog";
+import { installCspViolationReporter } from "@/lib/csp-violation-reporter";
 import type { ReactNode } from "react";
 
 function PostHogPageView() {
@@ -30,6 +31,9 @@ interface Props {
 export function PostHogProvider({ children }: Props) {
   useEffect(() => {
     initPostHog();
+    // Report-Only CSP violations (#631) fire securitypolicyviolation events
+    // client-side; forward them to PostHog so the rollout gathers signal.
+    installCspViolationReporter();
   }, []);
 
   return (


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until the preview-deploy checklist below is verified by the maintainer

## Dependencies / adjacencies

- `next.config.mjs`: adds a `headers()` block — adjacent to the cluster-09 PR's `redirects()` edit in the same file; trivially mergeable either order.
- No other file overlap with open PRs.

## What

- **`httpOnly: true` on the `app_state` cookie** — audited: zero `document.cookie` readers anywhere (the client reads exclusively via `GET /api/view`); all three cookie writers spread the shared options, so the attribute propagates consistently. E2E unaffected (Playwright reads via `context.cookies()`).
- **`headers()` in `next.config.mjs`** via unit-tested builders: `Content-Security-Policy-Report-Only` (NOT enforcing — every directive traced to observed usage, evidence in the config comments: PostHog script/connect, Emotion/next-font inline styles, backend + orchestrator + SSE connect-src, the ibiblio stream for media-src, broad https: img-src for backend-proxied artwork), plus nosniff, `X-Frame-Options: DENY`/`frame-ancestors 'none'`, Referrer-Policy, and HSTS (comment documents honestly that the NODE_ENV gate only excludes `next dev` — previews get HSTS too, harmless on pages.dev — and the preload/includeSubDomains cutover stickiness caveat).
- **CSP violation telemetry** (review-driven): a `securitypolicyviolation` listener forwards trimmed, deduped, session-capped reports to PostHog via `safeCapture` — without this, the Report-Only window would gather no real-user signal at all.

## Preview-deploy checklist (the actual verification)

1. `curl -sI` the preview URL for `/`, `/login`, and a `/dashboard/*` route: confirm `content-security-policy-report-only`, `x-content-type-options`, `x-frame-options`, `referrer-policy` are present on each HTML response. **This is the load-bearing check** — OpenNext-on-Cloudflare may serve some responses from the asset store, bypassing `headers()`; if headers are missing on any document response, the fix is a `public/_headers` file (deliberately not pre-added to avoid double-application).
2. `curl -sI` a `/_next/static/...` asset — note whether headers apply there (acceptable either way; record it).
3. Exercise the app on the preview (flowsheet, audio stream, album artwork, SSE connect, PostHog init) with DevTools open: **zero CSP violations**, and confirm any that do appear arrive as `csp_violation` events in PostHog.
4. Confirm `connect-src` in the served header contains the real backend origin and `media-src` has `audio-mp3.ibiblio.org`.
5. DevTools → cookies: `app_state` carries `HttpOnly`; theme switching still round-trips.
6. Stakeholder check before ever flipping to enforcing: nothing on wxyc.org embeds dj-site in an iframe (XFO DENY would break it).

## Red-team review (high effort)

No enforcing-path regressions (Report-Only by design). Findings addressed: violation observability (fixed with telemetry), HSTS comment accuracy (fixed), PostHog assets-origin brittleness (documented). The delivery question — whether `headers()` reaches asset-store responses — is exactly what checklist item 1 answers.

## Testing

Typecheck clean; 3,557 tests green (13 new: header/CSP builder shape ×6, cookie ×1, violation reporter ×5, +1).

Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)