### PR TITLE
fix(admin): clearable profile fields, safe modification resets, roster state preservation (cluster 08)

### DIFF
--- a/src/components/experiences/modern/admin/roster/RosterTable.test.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
-import { renderWithProviders } from "@/lib/test-utils";
+import { MOCK_USERS, renderWithProviders } from "@/lib/test-utils";
 import { makeStore } from "@/lib/store";
 import { adminSlice } from "@/lib/features/admin/frontend";
 import { Authorization } from "@/lib/features/admin/types";
@@ -28,8 +28,8 @@ vi.mock("sonner", () => ({
 }));
 
 const adminUser = {
-  username: "sm-admin",
-  email: "sm@wxyc.org",
+  username: MOCK_USERS.stationManager.username,
+  email: MOCK_USERS.stationManager.email,
   authority: Authorization.SM,
 } as User;
 
@@ -51,7 +51,7 @@ describe("RosterTable", () => {
   it("preserves the search filter and page after a successful add", async () => {
     const store = makeStore();
     // Order matters: setSearchString resets page to 0, so page is set after.
-    store.dispatch(adminSlice.actions.setSearchString("smith"));
+    store.dispatch(adminSlice.actions.setSearchString("Test DJ"));
     store.dispatch(adminSlice.actions.setPage(2));
     store.dispatch(adminSlice.actions.setAdding(true));
 
@@ -60,9 +60,18 @@ describe("RosterTable", () => {
       { store }
     );
 
-    await user.type(screen.getByPlaceholderText("Name"), "Sam Smith");
-    await user.type(screen.getByPlaceholderText("Username"), "ssmith");
-    await user.type(screen.getByPlaceholderText("Email"), "ssmith@wxyc.org");
+    await user.type(
+      screen.getByPlaceholderText("Name"),
+      MOCK_USERS.dj1.realName
+    );
+    await user.type(
+      screen.getByPlaceholderText("Username"),
+      MOCK_USERS.dj1.username
+    );
+    await user.type(
+      screen.getByPlaceholderText("Email"),
+      MOCK_USERS.dj1.email
+    );
 
     await user.click(screen.getByRole("button", { name: /Save/i }));
 
@@ -72,7 +81,9 @@ describe("RosterTable", () => {
     );
 
     // …but the search + page context is untouched.
-    expect(adminSlice.selectors.getSearchString(store.getState())).toBe("smith");
+    expect(adminSlice.selectors.getSearchString(store.getState())).toBe(
+      "Test DJ"
+    );
     expect(adminSlice.selectors.getPage(store.getState())).toBe(2);
   });
 });

--- a/src/components/experiences/modern/admin/roster/RosterTable.test.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithProviders } from "@/lib/test-utils";
+import { makeStore } from "@/lib/store";
+import { adminSlice } from "@/lib/features/admin/frontend";
+import { Authorization } from "@/lib/features/admin/types";
+import type { User } from "@/lib/features/authentication/types";
+import RosterTable from "./RosterTable";
+
+const mockRefetch = vi.fn();
+vi.mock("@/src/hooks/adminHooks", () => ({
+  useAccountListResults: () => ({
+    data: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: mockRefetch,
+  }),
+}));
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authBaseURL: "http://auth.test",
+  authClient: {},
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}));
+
+const adminUser = {
+  username: "sm-admin",
+  email: "sm@wxyc.org",
+  authority: Authorization.SM,
+} as User;
+
+describe("RosterTable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ emailSent: true }),
+      }))
+    );
+  });
+
+  // #638: a successful add must not reset the whole admin slice — the DJ's
+  // active search filter and page position have to survive.
+  it("preserves the search filter and page after a successful add", async () => {
+    const store = makeStore();
+    // Order matters: setSearchString resets page to 0, so page is set after.
+    store.dispatch(adminSlice.actions.setSearchString("smith"));
+    store.dispatch(adminSlice.actions.setPage(2));
+    store.dispatch(adminSlice.actions.setAdding(true));
+
+    const { user } = renderWithProviders(
+      <RosterTable user={adminUser} organizationSlug="wxyc" />,
+      { store }
+    );
+
+    await user.type(screen.getByPlaceholderText("Name"), "Sam Smith");
+    await user.type(screen.getByPlaceholderText("Username"), "ssmith");
+    await user.type(screen.getByPlaceholderText("Email"), "ssmith@wxyc.org");
+
+    await user.click(screen.getByRole("button", { name: /Save/i }));
+
+    // The add form closes on success…
+    await waitFor(() =>
+      expect(adminSlice.selectors.getAdding(store.getState())).toBe(false)
+    );
+
+    // …but the search + page context is untouched.
+    expect(adminSlice.selectors.getSearchString(store.getState())).toBe("smith");
+    expect(adminSlice.selectors.getPage(store.getState())).toBe(2);
+  });
+});

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -114,8 +114,9 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
           toast.success(`Account created for ${newAccount.username} — setup email sent to ${newAccount.email}`);
         }
 
+        // setAdding(false) already clears the add-form data; a full slice
+        // reset would also wipe the admin's search + page context (#638).
         dispatch(adminSlice.actions.setAdding(false));
-        dispatch(adminSlice.actions.reset());
 
         // Refresh account list
         await refetch();

--- a/src/components/experiences/modern/settings/SettingsInput.test.tsx
+++ b/src/components/experiences/modern/settings/SettingsInput.test.tsx
@@ -110,4 +110,50 @@ describe("SettingsInput", () => {
     const input = screen.getByRole("textbox");
     expect(input).toHaveAttribute("name", "djName");
   });
+
+  // #609: clearing a previously-set field must register as a modification so
+  // the save flow can propagate the clear (before the fix, an empty value was
+  // treated as unmodified and silently dropped).
+  it("marks the field modified when a set value is cleared", () => {
+    const { Wrapper, store } = createWrapper();
+    render(
+      <Wrapper>
+        <SettingsInput name="pronouns" backendValue="they/them" />
+      </Wrapper>
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "" } });
+
+    expect(store.getState().authentication.modifications.pronouns).toBe(true);
+  });
+
+  it("marks the field unmodified when restored to the backend value", () => {
+    const { Wrapper, store } = createWrapper();
+    render(
+      <Wrapper>
+        <SettingsInput name="pronouns" backendValue="they/them" />
+      </Wrapper>
+    );
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.change(input, { target: { value: "they/them" } });
+
+    expect(store.getState().authentication.modifications.pronouns).toBe(false);
+  });
+
+  it("does not mark an unset field modified when typed then cleared", () => {
+    const { Wrapper, store } = createWrapper();
+    render(
+      <Wrapper>
+        <SettingsInput name="pronouns" />
+      </Wrapper>
+    );
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "she/her" } });
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(store.getState().authentication.modifications.pronouns).toBe(false);
+  });
 });

--- a/src/components/experiences/modern/settings/SettingsInput.tsx
+++ b/src/components/experiences/modern/settings/SettingsInput.tsx
@@ -26,8 +26,11 @@ export default function SettingsInput({
     setValue(newValue);
     dispatch(
       authenticationSlice.actions.modify({
+        // Any divergence from the backend value is a modification — including
+        // clearing a set field to "" — so the clear survives to the save
+        // payload instead of being dropped as unmodified (#609).
         key: name,
-        value: backendValue !== newValue && newValue !== "" ? true : false,
+        value: (backendValue ?? "") !== newValue,
       })
     );
   };

--- a/src/components/experiences/modern/settings/SettingsTextarea.tsx
+++ b/src/components/experiences/modern/settings/SettingsTextarea.tsx
@@ -26,8 +26,11 @@ export default function SettingsTextarea({
     setValue(newValue);
     dispatch(
       authenticationSlice.actions.modify({
+        // Any divergence from the backend value is a modification — including
+        // clearing a set field to "" — so the clear survives to the save
+        // payload instead of being dropped as unmodified (#609).
         key: name,
-        value: backendValue !== newValue && newValue !== "" ? true : false,
+        value: (backendValue ?? "") !== newValue,
       })
     );
   };

--- a/src/hooks/djHooks.test.ts
+++ b/src/hooks/djHooks.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { authenticationSlice } from "@/lib/features/authentication/frontend";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockUpdateUser = vi.fn();
+const mockGetSession = vi.fn();
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: {
+    updateUser: (...args: any[]) => mockUpdateUser(...args),
+    getSession: (...args: any[]) => mockGetSession(...args),
+  },
+}));
+
+vi.mock("@/src/utilities/throwIfBetterAuthError", () => ({
+  throwIfBetterAuthError: vi.fn(),
+}));
+
+// useDJAccount pulls the signed-in DJ from useRegistry; stub a resolved user so
+// handleSaveData proceeds to the updateUser call.
+vi.mock("./authenticationHooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./authenticationHooks")>();
+  return {
+    ...actual,
+    useRegistry: () => ({
+      info: { id: "u1", real_name: "Jessica Pratt", dj_name: "DJ Pratt" },
+      loading: false,
+    }),
+  };
+});
+
+function createTestStore() {
+  return configureStore({
+    reducer: { authentication: authenticationSlice.reducer },
+  });
+}
+
+type TestStore = ReturnType<typeof createTestStore>;
+
+function createWrapper(store: TestStore) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(Provider, { store, children });
+  };
+}
+
+// Build a real <form> so `new FormData(e.currentTarget)` reads named inputs the
+// way the browser would.
+function formEvent(fields: Record<string, string>) {
+  const form = document.createElement("form");
+  for (const [name, value] of Object.entries(fields)) {
+    const input = document.createElement("input");
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  }
+  return { preventDefault: vi.fn(), currentTarget: form } as any;
+}
+
+function modifications(store: TestStore) {
+  return authenticationSlice.selectors.getModifications({
+    authentication: store.getState().authentication,
+  } as any);
+}
+
+describe("useDJAccount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockUpdateUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+  });
+
+  describe("mount-time reset (#636)", () => {
+    it("preserves modifications set before the hook mounts", async () => {
+      const store = createTestStore();
+      store.dispatch(
+        authenticationSlice.actions.modify({ key: "pronouns", value: true })
+      );
+
+      const { useDJAccount } = await import("./djHooks");
+      renderHook(() => useDJAccount(), { wrapper: createWrapper(store) });
+
+      // The mount-time effect must NOT wipe the pre-existing edit.
+      expect(modifications(store)).toContain("pronouns");
+    });
+
+    it("resets modifications after a save completes", async () => {
+      const store = createTestStore();
+      store.dispatch(
+        authenticationSlice.actions.modify({ key: "bio", value: true })
+      );
+
+      // Hold the update open so the isUpdating true→false transition happens
+      // across two separate act() flushes — otherwise act coalesces the
+      // intermediate isUpdating:true render and the transition is never seen.
+      let resolveUpdate: (value: unknown) => void = () => {};
+      mockUpdateUser.mockReturnValue(
+        new Promise((resolve) => {
+          resolveUpdate = resolve;
+        })
+      );
+
+      const { useDJAccount } = await import("./djHooks");
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(store),
+      });
+
+      expect(modifications(store)).toContain("bio");
+
+      // Kick off the save; it parks on the pending updateUser with isUpdating=true.
+      let pending: Promise<void> | undefined;
+      await act(async () => {
+        pending = result.current.handleSaveData(formEvent({ bio: "New bio" }));
+      });
+
+      // Still mid-save — the reset must not have run yet.
+      expect(modifications(store)).toContain("bio");
+
+      await act(async () => {
+        resolveUpdate({ data: { user: { id: "u1" } } });
+        await pending;
+      });
+
+      // Post-save cleanup runs on the isUpdating true→false transition.
+      expect(modifications(store)).toEqual([]);
+    });
+  });
+});

--- a/src/hooks/djHooks.test.ts
+++ b/src/hooks/djHooks.test.ts
@@ -4,6 +4,7 @@ import { createElement, type ReactNode } from "react";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import { authenticationSlice } from "@/lib/features/authentication/frontend";
+import type { ModifiableData } from "@/lib/features/authentication/types";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
@@ -77,6 +78,102 @@ describe("useDJAccount", () => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue({ data: { user: { id: "u1" } } });
     mockUpdateUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+  });
+
+  describe("clearing profile fields (#609)", () => {
+    const optionalFields: (keyof ModifiableData)[] = [
+      "pronouns",
+      "namePronunciation",
+      "showTimes",
+      "title",
+      "semesterHired",
+      "bio",
+      "location",
+    ];
+
+    it.each(optionalFields)(
+      "sends an empty string when the optional field %s is cleared",
+      async (field) => {
+        const store = createTestStore();
+        store.dispatch(
+          authenticationSlice.actions.modify({ key: field, value: true })
+        );
+
+        const { useDJAccount } = await import("./djHooks");
+        const { result } = renderHook(() => useDJAccount(), {
+          wrapper: createWrapper(store),
+        });
+
+        await act(async () => {
+          await result.current.handleSaveData(formEvent({ [field]: "" }));
+        });
+
+        expect(mockUpdateUser).toHaveBeenCalledWith({ [field]: "" });
+      }
+    );
+
+    it.each(["realName", "djName", "email"] as (keyof ModifiableData)[])(
+      "drops an empty submission for the required field %s",
+      async (field) => {
+        const store = createTestStore();
+        store.dispatch(
+          authenticationSlice.actions.modify({ key: field, value: true })
+        );
+
+        const { useDJAccount } = await import("./djHooks");
+        const { result } = renderHook(() => useDJAccount(), {
+          wrapper: createWrapper(store),
+        });
+
+        await act(async () => {
+          await result.current.handleSaveData(formEvent({ [field]: "" }));
+        });
+
+        // Nothing to send once the empty required field is dropped.
+        expect(mockUpdateUser).not.toHaveBeenCalled();
+      }
+    );
+
+    it("still sends a non-empty required field", async () => {
+      const store = createTestStore();
+      store.dispatch(
+        authenticationSlice.actions.modify({ key: "realName", value: true })
+      );
+
+      const { useDJAccount } = await import("./djHooks");
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(store),
+      });
+
+      await act(async () => {
+        await result.current.handleSaveData(
+          formEvent({ realName: "Juana Molina" })
+        );
+      });
+
+      expect(mockUpdateUser).toHaveBeenCalledWith({ realName: "Juana Molina" });
+    });
+
+    it("ignores fields that were never modified", async () => {
+      const store = createTestStore();
+      store.dispatch(
+        authenticationSlice.actions.modify({ key: "bio", value: true })
+      );
+
+      const { useDJAccount } = await import("./djHooks");
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(store),
+      });
+
+      await act(async () => {
+        await result.current.handleSaveData(
+          formEvent({ bio: "", location: "Chapel Hill, NC" })
+        );
+      });
+
+      // Only bio was modified; location must not leak into the payload.
+      expect(mockUpdateUser).toHaveBeenCalledWith({ bio: "" });
+    });
   });
 
   describe("mount-time reset (#636)", () => {

--- a/src/hooks/djHooks.test.ts
+++ b/src/hooks/djHooks.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 import { Provider } from "react-redux";
-import { configureStore } from "@reduxjs/toolkit";
+import { toast } from "sonner";
 import { authenticationSlice } from "@/lib/features/authentication/frontend";
 import type { ModifiableData } from "@/lib/features/authentication/types";
+import { createTestStore } from "@/lib/test-utils";
+import type { AppStore } from "@/lib/store";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
@@ -17,6 +19,7 @@ vi.mock("sonner", () => ({
 const mockUpdateUser = vi.fn();
 const mockGetSession = vi.fn();
 vi.mock("@/lib/features/authentication/client", () => ({
+  authBaseURL: "http://auth.test",
   authClient: {
     updateUser: (...args: any[]) => mockUpdateUser(...args),
     getSession: (...args: any[]) => mockGetSession(...args),
@@ -34,21 +37,13 @@ vi.mock("./authenticationHooks", async (importOriginal) => {
   return {
     ...actual,
     useRegistry: () => ({
-      info: { id: "u1", real_name: "Jessica Pratt", dj_name: "DJ Pratt" },
+      info: { id: "user-dj1", real_name: "Test DJ 1", dj_name: "Test dj1" },
       loading: false,
     }),
   };
 });
 
-function createTestStore() {
-  return configureStore({
-    reducer: { authentication: authenticationSlice.reducer },
-  });
-}
-
-type TestStore = ReturnType<typeof createTestStore>;
-
-function createWrapper(store: TestStore) {
+function createWrapper(store: AppStore) {
   return function Wrapper({ children }: { children: ReactNode }) {
     return createElement(Provider, { store, children });
   };
@@ -67,17 +62,15 @@ function formEvent(fields: Record<string, string>) {
   return { preventDefault: vi.fn(), currentTarget: form } as any;
 }
 
-function modifications(store: TestStore) {
-  return authenticationSlice.selectors.getModifications({
-    authentication: store.getState().authentication,
-  } as any);
+function modifications(store: AppStore) {
+  return authenticationSlice.selectors.getModifications(store.getState());
 }
 
 describe("useDJAccount", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetSession.mockResolvedValue({ data: { user: { id: "u1" } } });
-    mockUpdateUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockGetSession.mockResolvedValue({ data: { user: { id: "user-dj1" } } });
+    mockUpdateUser.mockResolvedValue({ data: { user: { id: "user-dj1" } } });
   });
 
   describe("clearing profile fields (#609)", () => {
@@ -113,7 +106,7 @@ describe("useDJAccount", () => {
     );
 
     it.each(["realName", "djName", "email"] as (keyof ModifiableData)[])(
-      "drops an empty submission for the required field %s",
+      "drops an empty submission for the required field %s and explains why",
       async (field) => {
         const store = createTestStore();
         store.dispatch(
@@ -129,8 +122,14 @@ describe("useDJAccount", () => {
           await result.current.handleSaveData(formEvent({ [field]: "" }));
         });
 
-        // Nothing to send once the empty required field is dropped.
+        // Nothing to send once the empty required field is dropped — but the
+        // drop must not be silent, and the modify flag must survive so Save
+        // stays enabled for the user to fix and resubmit.
         expect(mockUpdateUser).not.toHaveBeenCalled();
+        expect(toast.error).toHaveBeenCalledWith(
+          "Real name and DJ name can't be empty — keeping the previous value."
+        );
+        expect(modifications(store)).toContain(field);
       }
     );
 
@@ -174,9 +173,40 @@ describe("useDJAccount", () => {
       // Only bio was modified; location must not leak into the payload.
       expect(mockUpdateUser).toHaveBeenCalledWith({ bio: "" });
     });
+
+    it("saves the valid fields but keeps the flags when a required clear is dropped alongside them", async () => {
+      const store = createTestStore();
+      store.dispatch(
+        authenticationSlice.actions.modify({ key: "realName", value: true })
+      );
+      store.dispatch(
+        authenticationSlice.actions.modify({ key: "bio", value: true })
+      );
+
+      const { useDJAccount } = await import("./djHooks");
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(store),
+      });
+
+      await act(async () => {
+        await result.current.handleSaveData(
+          formEvent({ realName: "", bio: "Late-night freeform." })
+        );
+      });
+
+      // The clear was dropped but the bio still saves…
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        bio: "Late-night freeform.",
+      });
+      expect(toast.error).toHaveBeenCalledWith(
+        "Real name and DJ name can't be empty — keeping the previous value."
+      );
+      // …and no reset fires: the dropped field still needs fixing.
+      expect(modifications(store)).toContain("realName");
+    });
   });
 
-  describe("mount-time reset (#636)", () => {
+  describe("modification reset scoping (#636 + failed-save retry)", () => {
     it("preserves modifications set before the hook mounts", async () => {
       const store = createTestStore();
       store.dispatch(
@@ -186,24 +216,14 @@ describe("useDJAccount", () => {
       const { useDJAccount } = await import("./djHooks");
       renderHook(() => useDJAccount(), { wrapper: createWrapper(store) });
 
-      // The mount-time effect must NOT wipe the pre-existing edit.
+      // Mounting the hook must NOT wipe the pre-existing edit.
       expect(modifications(store)).toContain("pronouns");
     });
 
-    it("resets modifications after a save completes", async () => {
+    it("resets modifications after a successful save", async () => {
       const store = createTestStore();
       store.dispatch(
         authenticationSlice.actions.modify({ key: "bio", value: true })
-      );
-
-      // Hold the update open so the isUpdating true→false transition happens
-      // across two separate act() flushes — otherwise act coalesces the
-      // intermediate isUpdating:true render and the transition is never seen.
-      let resolveUpdate: (value: unknown) => void = () => {};
-      mockUpdateUser.mockReturnValue(
-        new Promise((resolve) => {
-          resolveUpdate = resolve;
-        })
       );
 
       const { useDJAccount } = await import("./djHooks");
@@ -213,22 +233,37 @@ describe("useDJAccount", () => {
 
       expect(modifications(store)).toContain("bio");
 
-      // Kick off the save; it parks on the pending updateUser with isUpdating=true.
-      let pending: Promise<void> | undefined;
       await act(async () => {
-        pending = result.current.handleSaveData(formEvent({ bio: "New bio" }));
+        await result.current.handleSaveData(formEvent({ bio: "New bio" }));
       });
 
-      // Still mid-save — the reset must not have run yet.
-      expect(modifications(store)).toContain("bio");
-
-      await act(async () => {
-        resolveUpdate({ data: { user: { id: "u1" } } });
-        await pending;
-      });
-
-      // Post-save cleanup runs on the isUpdating true→false transition.
       expect(modifications(store)).toEqual([]);
+      expect(toast.success).toHaveBeenCalled();
+    });
+
+    it("keeps modifications when the save fails, so Save stays enabled for a retry", async () => {
+      const store = createTestStore();
+      store.dispatch(
+        authenticationSlice.actions.modify({ key: "bio", value: true })
+      );
+      mockUpdateUser.mockRejectedValue(new Error("network down"));
+
+      const { useDJAccount } = await import("./djHooks");
+      const { result } = renderHook(() => useDJAccount(), {
+        wrapper: createWrapper(store),
+      });
+
+      await act(async () => {
+        await result.current.handleSaveData(formEvent({ bio: "New bio" }));
+      });
+
+      // The user's text still sits in the inputs; the flags must survive so
+      // isModified stays true and they can resubmit without re-touching.
+      expect(modifications(store)).toContain("bio");
+      expect(
+        authenticationSlice.selectors.isModified(store.getState())
+      ).toBe(true);
+      expect(toast.error).toHaveBeenCalledWith("network down");
     });
   });
 });

--- a/src/hooks/djHooks.ts
+++ b/src/hooks/djHooks.ts
@@ -5,7 +5,7 @@ import { AccountModification } from "@/lib/features/authentication/types";
 import { authClient } from "@/lib/features/authentication/client";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useRegistry } from "./authenticationHooks";
 import { throwIfBetterAuthError } from "@/src/utilities/throwIfBetterAuthError";
@@ -23,10 +23,15 @@ export function useDJAccount() {
   const [isUpdating, setIsUpdating] = useState(false);
   const [updateError, setUpdateError] = useState<Error | null>(null);
 
+  // Reset only on the isUpdating true→false transition (post-save cleanup).
+  // A mount-time reset would wipe modifications set by sibling fields that
+  // rendered earlier, producing an empty save payload (#636).
+  const wasUpdating = useRef(false);
   useEffect(() => {
-    if (!isUpdating) {
+    if (wasUpdating.current && !isUpdating) {
       dispatch(authenticationSlice.actions.resetModifications());
     }
+    wasUpdating.current = isUpdating;
   }, [isUpdating, dispatch]);
 
   const handleSaveData = useCallback(

--- a/src/hooks/djHooks.ts
+++ b/src/hooks/djHooks.ts
@@ -48,10 +48,22 @@ export function useDJAccount() {
 
         let data: AccountModification = {};
 
+        // realName / djName / email are required identity fields: an empty
+        // submission for these is dropped so the prior value is kept. Every
+        // other profile field is clearable — an empty string is a deliberate
+        // clear and must reach updateData (#609).
+        const nonClearableFields: (keyof AccountModification)[] = [
+          "realName",
+          "djName",
+          "email",
+        ];
+
         for (const [key, value] of formData.entries()) {
-          if (value !== "" && modifications.some((name) => name == key)) {
-            data[key as keyof AccountModification] = value as string;
-          }
+          const field = key as keyof AccountModification;
+          if (!modifications.some((name) => name == field)) continue;
+          const stringValue = value as string;
+          if (stringValue === "" && nonClearableFields.includes(field)) continue;
+          data[field] = stringValue;
         }
 
         if (Object.keys(data).length > 0) {

--- a/src/hooks/djHooks.ts
+++ b/src/hooks/djHooks.ts
@@ -5,7 +5,7 @@ import { AccountModification } from "@/lib/features/authentication/types";
 import { authClient } from "@/lib/features/authentication/client";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { useRegistry } from "./authenticationHooks";
 import { throwIfBetterAuthError } from "@/src/utilities/throwIfBetterAuthError";
@@ -23,16 +23,11 @@ export function useDJAccount() {
   const [isUpdating, setIsUpdating] = useState(false);
   const [updateError, setUpdateError] = useState<Error | null>(null);
 
-  // Reset only on the isUpdating true→false transition (post-save cleanup).
-  // A mount-time reset would wipe modifications set by sibling fields that
-  // rendered earlier, producing an empty save payload (#636).
-  const wasUpdating = useRef(false);
-  useEffect(() => {
-    if (wasUpdating.current && !isUpdating) {
-      dispatch(authenticationSlice.actions.resetModifications());
-    }
-    wasUpdating.current = isUpdating;
-  }, [isUpdating, dispatch]);
+  // No mount-time or transition-driven resetModifications here: a mount-time
+  // reset would wipe modifications set by sibling fields that rendered
+  // earlier (#636), and a reset keyed off isUpdating falling would also fire
+  // after a FAILED save, greying out Save while the user's text still sits in
+  // the inputs. The reset is dispatched inside handleSaveData, on success only.
 
   const handleSaveData = useCallback(
     async (e: React.FormEvent<HTMLFormElement>) => {
@@ -48,22 +43,37 @@ export function useDJAccount() {
 
         let data: AccountModification = {};
 
-        // realName / djName / email are required identity fields: an empty
-        // submission for these is dropped so the prior value is kept. Every
-        // other profile field is clearable — an empty string is a deliberate
-        // clear and must reach updateData (#609).
+        // realName / djName are required identity fields: an empty submission
+        // for these is dropped so the prior value is kept. email never reaches
+        // this loop (the settings email input is disabled and unnamed; changes
+        // go through EmailChangeModal) — listed defensively only. Every other
+        // profile field is clearable — an empty string is a deliberate clear
+        // and must reach updateData (#609).
         const nonClearableFields: (keyof AccountModification)[] = [
           "realName",
           "djName",
           "email",
         ];
+        const droppedClears: (keyof AccountModification)[] = [];
 
         for (const [key, value] of formData.entries()) {
           const field = key as keyof AccountModification;
           if (!modifications.some((name) => name == field)) continue;
           const stringValue = value as string;
-          if (stringValue === "" && nonClearableFields.includes(field)) continue;
+          if (stringValue === "" && nonClearableFields.includes(field)) {
+            droppedClears.push(field);
+            continue;
+          }
           data[field] = stringValue;
+        }
+
+        if (droppedClears.length > 0) {
+          // A silently kept previous value would look like a successful clear.
+          // Say so, and leave the modify flags alone so Save stays enabled for
+          // the user to fix and resubmit.
+          toast.error(
+            "Real name and DJ name can't be empty — keeping the previous value."
+          );
         }
 
         if (Object.keys(data).length > 0) {
@@ -97,7 +107,14 @@ export function useDJAccount() {
 
             throwIfBetterAuthError(result, "Failed to update user");
 
-            // Update successful
+            // Update successful. Reset the modify flags only now, on a
+            // confirmed save — never after a failure, which must keep Save
+            // enabled for a retry. When a required clear was dropped above,
+            // keep the flags too: those fields still need fixing and
+            // resubmitting.
+            if (droppedClears.length === 0) {
+              dispatch(authenticationSlice.actions.resetModifications());
+            }
             toast.success("User settings saved.");
             router.refresh();
           }
@@ -112,7 +129,7 @@ export function useDJAccount() {
         setIsUpdating(false);
       }
     },
-    [modifications]
+    [modifications, dispatch]
   );
 
   return {


### PR DESCRIPTION
## Dependencies / adjacencies (docs/plans/bug-triage-2026-07/PR-DEPENDENCIES.md)

- `RosterTable.tsx` hunk kept to a single dispatch-removal + comment so open PR #804's eventual rebase stays trivial. `AccountEditForm` untouched (PR #862 owns its flow).
- No other overlap with open PRs.

## What (one commit per issue + review follow-up)

- **#609 (P1)** — clearing optional profile fields (pronouns, bio, location, showTimes, title, semesterHired, namePronunciation) now actually saves. Two blocking layers fixed — the issue named one (`handleSaveData`'s `value !== ""` filter), but the settings inputs *also* dropped cleared fields from the modification set, so fixing only the hook wouldn't have worked: inputs now flag modification on any divergence from the backend value, and the hook lets empties through for clearable fields while a `nonClearableFields` guard (realName, djName; email defensively — it never reaches this path) keeps identity fields non-blankable.
- **#636** — the mount-time `resetModifications` that wiped sibling edits is gone. Review follow-up went further than the transition-ref fix: the reset now lives **only in the success path**, which also means a **failed save no longer wipes the retry state** (previously `finally` → transition → flags cleared → Save greyed while the user's text still sat in the inputs).
- **#638** — adding an account no longer nukes the admin's search/page context (the full slice reset is gone; the add-form state still clears via `setAdding(false)`'s reducer).
- **Review follow-up (UX honesty)** — clearing a required field then saving was a *silent no-op* (no request, no toast, Save greyed). Now it toasts "Real name and DJ name can't be empty — keeping the previous value," keeps the flag armed for fix-and-resubmit, and mixed submits still save the valid fields.

## Two items for the maintainer

1. **End-to-end `""` persistence** (one-minute check on the local stack): clear pronouns → Save → reload. The frontend now sends `""` correctly, but whether better-auth persists empty custom additionalFields (vs. ignoring them or wanting `null`) can't be verified from this repo. If empties are dropped server-side, #609 needs a BS-side follow-up.
2. Accepted #638 tradeoff: with an active search filter, a just-added DJ that doesn't match the filter stays hidden (previously the filter was wiped, making them visible). The success toast is the signal.

## Red-team review (high effort)

Verified clean: transition-ref mount logic, reopen-the-add-dialog staleness, clear propagation through both filter layers. Findings fixed: failed-save retry wipe, silent required-clear no-op, fixture conventions (MOCK_USERS instead of placeholder names, `createTestStore` harness).

## Testing

Typecheck clean; 3,565 tests green (18 new across djHooks/SettingsInput/RosterTable, including the failure-path and mixed-submit cases).

Closes #609
Closes #636
Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)