### PR TITLE
fix(search): stale-response and debounce-window races in playlist-search and LML hooks (cluster 04)

### DIFF
--- a/src/hooks/lml/useLmlLibrarySearch.test.ts
+++ b/src/hooks/lml/useLmlLibrarySearch.test.ts
@@ -305,6 +305,77 @@ describe("useLmlLibrarySearch", () => {
     });
   });
 
+  describe("stale-results guard on backspace below MIN_QUERY_LENGTH (#625)", () => {
+    it("clears rendered results within one render when the live query drops below the threshold", async () => {
+      server.use(
+        http.get(PROXY_SEARCH_URL, () =>
+          HttpResponse.json({
+            results: [
+              createTestLmlLibraryItem({
+                id: 7,
+                title: "DOGA",
+                artist: "Juana Molina",
+              }),
+            ],
+            total: 1,
+            query: "Juana Molina",
+          } satisfies LmlLibrarySearchResponse)
+        )
+      );
+
+      const { result, rerender } = renderHook(
+        ({ artist, album }) => useLmlLibrarySearch({ artist, album }),
+        { initialProps: { artist: "Juana", album: "" }, wrapper: withStore() }
+      );
+
+      // Let the debounce fire and the results land.
+      await vi.advanceTimersByTimeAsync(400);
+      await waitFor(() => expect(result.current.results.length).toBe(1));
+
+      // Backspace to below MIN_QUERY_LENGTH (len 2). `debounced` still holds
+      // "Juana" (and its warm cache entry) for the 350ms debounce window, so
+      // `skip` stays false — but the rendered results must clear immediately,
+      // without advancing any timers.
+      rerender({ artist: "Ju", album: "" });
+
+      expect(result.current.results).toEqual([]);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("keeps showing results while the query stays valid mid-typing", async () => {
+      server.use(
+        http.get(PROXY_SEARCH_URL, () =>
+          HttpResponse.json({
+            results: [
+              createTestLmlLibraryItem({
+                id: 8,
+                title: "DOGA",
+                artist: "Juana Molina",
+              }),
+            ],
+            total: 1,
+            query: "Juana Molina",
+          } satisfies LmlLibrarySearchResponse)
+        )
+      );
+
+      const { result, rerender } = renderHook(
+        ({ artist, album }) => useLmlLibrarySearch({ artist, album }),
+        { initialProps: { artist: "Juana", album: "" }, wrapper: withStore() }
+      );
+
+      await vi.advanceTimersByTimeAsync(400);
+      await waitFor(() => expect(result.current.results.length).toBe(1));
+
+      // Extend the query (still >= MIN_QUERY_LENGTH). The guard keys on
+      // hasValidQuery, which is still true, so results must not be blanked
+      // while the debounce catches up.
+      rerender({ artist: "Juana M", album: "" });
+
+      expect(result.current.results.length).toBe(1);
+    });
+  });
+
   it("isLoading is true while debounce is pending for a valid query", async () => {
     server.use(
       http.get(PROXY_SEARCH_URL, () =>

--- a/src/hooks/lml/useLmlLibrarySearch.ts
+++ b/src/hooks/lml/useLmlLibrarySearch.ts
@@ -72,7 +72,13 @@ export function useLmlLibrarySearch({
   );
 
   return {
-    results: skip ? [] : data ?? [],
+    // Gate results on hasValidQuery, which is derived from the LIVE args, not
+    // just `skip` (derived from the debounced args). Backspacing below
+    // MIN_QUERY_LENGTH flips hasValidQuery false immediately, but `debounced`
+    // still holds the prior valid args (and the cache entry stays warm) for the
+    // 350ms until the debounce timer fires — without this guard the stale rows
+    // would keep rendering during that window (#625).
+    results: hasValidQuery && !skip ? data ?? [] : [],
     isLoading: hasValidQuery && (pendingDebounce || isFetching),
   };
 }

--- a/src/hooks/playlistSearchHooks.test.ts
+++ b/src/hooks/playlistSearchHooks.test.ts
@@ -347,6 +347,12 @@ describe("usePlaylistSearch", () => {
       });
     });
 
+    // #623 — regression guard on the fire effect's full-tuple paramsChanged
+    // comparison. That comparison (query string AND cursor/sortBy/sortOrder,
+    // re-run when isFetching flips false) is what carries a mid-flight
+    // sort/cursor change into a deferred re-fire; a query-string-only
+    // comparison would drop it. This pins the existing guard rather than
+    // reproducing a live failure.
     describe("#623 — sort change while a fetch is in flight", () => {
       it("re-fires with the new sort once the in-flight fetch settles", async () => {
         const { store, wrapper } = createWrapper();
@@ -380,7 +386,7 @@ describe("usePlaylistSearch", () => {
 
         // User clicks the sort header — query text unchanged, only the sort
         // moves. Nothing new should fire while the request is in flight; the
-        // full params tuple is queued instead.
+        // change is picked up by the settle re-run of the fire effect.
         act(() => {
           store.dispatch(playlistSearchSlice.actions.setSort("artist"));
         });

--- a/src/hooks/playlistSearchHooks.test.ts
+++ b/src/hooks/playlistSearchHooks.test.ts
@@ -257,7 +257,7 @@ describe("usePlaylistSearch", () => {
     });
   });
 
-  // Race-simulation coverage for the async-search hardening.
+  // Race-simulation coverage for the async-search hardening (#604, #623).
   describe("async-race hardening", () => {
     describe("#604 — stale accumulator on cursor reset", () => {
       it("does not resurrect the prior query's rows when typing resets the cursor", async () => {
@@ -344,6 +344,62 @@ describe("usePlaylistSearch", () => {
         await waitFor(() =>
           expect(result.current.results.map((r) => r.id)).toEqual([1, 2, 3]),
         );
+      });
+    });
+
+    describe("#623 — sort change while a fetch is in flight", () => {
+      it("re-fires with the new sort once the in-flight fetch settles", async () => {
+        const { store, wrapper } = createWrapper();
+        const rowId = store.getState().playlistSearch.rows[0].id;
+        const { rerender } = renderHook(() => usePlaylistSearch(), { wrapper });
+
+        // Initial empty-query mount fire.
+        await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+
+        // Type a query and let it fire.
+        act(() => {
+          store.dispatch(
+            playlistSearchSlice.actions.updateRow({
+              id: rowId,
+              updates: { value: "abc" },
+            }),
+          );
+        });
+        await waitFor(() =>
+          expect(mockTrigger).toHaveBeenLastCalledWith(
+            expect.objectContaining({ q: "abc", sort: "date" }),
+          ),
+        );
+        const callsAfterAbc = mockTrigger.mock.calls.length;
+
+        // That abc/date fetch is now slow and in flight.
+        act(() => {
+          mockQueryState.isFetching = true;
+        });
+        rerender();
+
+        // User clicks the sort header — query text unchanged, only the sort
+        // moves. Nothing new should fire while the request is in flight; the
+        // full params tuple is queued instead.
+        act(() => {
+          store.dispatch(playlistSearchSlice.actions.setSort("artist"));
+        });
+        rerender();
+        expect(mockTrigger.mock.calls.length).toBe(callsAfterAbc);
+
+        // The in-flight fetch settles.
+        act(() => {
+          mockQueryState.isFetching = false;
+        });
+        rerender();
+
+        // Exactly one re-fire, carrying the new sort.
+        await waitFor(() =>
+          expect(mockTrigger).toHaveBeenLastCalledWith(
+            expect.objectContaining({ q: "abc", sort: "artist" }),
+          ),
+        );
+        expect(mockTrigger.mock.calls.length).toBe(callsAfterAbc + 1);
       });
     });
   });

--- a/src/hooks/playlistSearchHooks.test.ts
+++ b/src/hooks/playlistSearchHooks.test.ts
@@ -12,6 +12,12 @@ const mockQueryState = {
     | undefined,
   isFetching: false,
   isError: false,
+  // originalArgs mirrors RTK's lazy-query result: the request args that
+  // produced the current `data`. The accumulator keys replace-vs-append on
+  // originalArgs.cursor, so tests that assert accumulation must set it.
+  originalArgs: undefined as
+    | { q: string; cursor?: string; sort: string; order: string }
+    | undefined,
 };
 
 vi.mock("@/lib/features/playlist-search/api", async () => {
@@ -43,6 +49,7 @@ beforeEach(() => {
   mockQueryState.data = undefined;
   mockQueryState.isFetching = false;
   mockQueryState.isError = false;
+  mockQueryState.originalArgs = undefined;
 });
 
 describe("usePlaylistSearch", () => {
@@ -247,6 +254,97 @@ describe("usePlaylistSearch", () => {
         expect.objectContaining({ q: "autechre", cursor: undefined }),
       );
       expect(store.getState().playlistSearch.cursor).toBeNull();
+    });
+  });
+
+  // Race-simulation coverage for the async-search hardening.
+  describe("async-race hardening", () => {
+    describe("#604 — stale accumulator on cursor reset", () => {
+      it("does not resurrect the prior query's rows when typing resets the cursor", async () => {
+        const { store, wrapper } = createWrapper();
+        const rowId = store.getState().playlistSearch.rows[0].id;
+
+        // Paginated state of an OLD query: cursor advanced, and data +
+        // originalArgs describe a page produced with a non-null cursor.
+        act(() => {
+          store.dispatch(
+            playlistSearchSlice.actions.advanceCursor("c1"),
+          );
+        });
+        mockQueryState.data = { results: [{ id: 111 }, { id: 222 }], total: 2 };
+        mockQueryState.originalArgs = {
+          q: "old",
+          cursor: "c1",
+          sort: "date",
+          order: "desc",
+        };
+
+        const { result, rerender } = renderHook(() => usePlaylistSearch(), {
+          wrapper,
+        });
+        await waitFor(() =>
+          expect(result.current.results.map((r) => r.id)).toEqual([111, 222]),
+        );
+
+        // Type a NEW query. updateRow resets the slice cursor to null, but
+        // data + originalArgs still hold the OLD query until the new fetch
+        // lands. The just-typed query must not flash the old rows.
+        act(() => {
+          store.dispatch(
+            playlistSearchSlice.actions.updateRow({
+              id: rowId,
+              updates: { value: "new" },
+            }),
+          );
+        });
+        rerender();
+
+        await waitFor(() => expect(result.current.results).toEqual([]));
+        // Stays cleared across subsequent renders (no delayed stale flash).
+        rerender();
+        expect(result.current.results).toEqual([]);
+      });
+
+      it("still appends the next page for the same query", async () => {
+        const { wrapper } = createWrapper();
+
+        // Page 1 of the current query — produced with no cursor (first page).
+        mockQueryState.data = {
+          results: [{ id: 1 }, { id: 2 }],
+          total: 4,
+          nextCursor: "c1",
+        };
+        mockQueryState.originalArgs = {
+          q: "",
+          cursor: undefined,
+          sort: "date",
+          order: "desc",
+        };
+        const { result, rerender } = renderHook(() => usePlaylistSearch(), {
+          wrapper,
+        });
+        await waitFor(() =>
+          expect(result.current.results.map((r) => r.id)).toEqual([1, 2]),
+        );
+
+        // Load the next page: cursor advances, then page 2 arrives produced
+        // with the c1 cursor. Overlapping id 2 is deduped.
+        act(() => {
+          result.current.loadNextPage();
+        });
+        mockQueryState.data = { results: [{ id: 2 }, { id: 3 }], total: 4 };
+        mockQueryState.originalArgs = {
+          q: "",
+          cursor: "c1",
+          sort: "date",
+          order: "desc",
+        };
+        rerender();
+
+        await waitFor(() =>
+          expect(result.current.results.map((r) => r.id)).toEqual([1, 2, 3]),
+        );
+      });
     });
   });
 });

--- a/src/hooks/playlistSearchHooks.ts
+++ b/src/hooks/playlistSearchHooks.ts
@@ -97,8 +97,16 @@ export function usePlaylistSearch() {
   >([]);
   const lastQueryForAccumulationRef = useRef<string>("");
 
-  const [trigger, { data, isFetching, isError }] =
+  const [trigger, { data, isFetching, isError, originalArgs }] =
     useLazySearchPlaylistsQuery();
+
+  // The cursor that actually PRODUCED `data`, read from the request's
+  // originalArgs — not the live `cursor` selector. Typing resets the slice
+  // cursor to null (frontend.ts updateRow/setSort) one render before the new
+  // fetch lands, so the live cursor no longer describes the in-hand `data`.
+  // Basing replace-vs-append on this fingerprint keeps a just-blanked
+  // accumulator from being repopulated with the prior query's rows (#604).
+  const producingCursor = originalArgs?.cursor ?? null;
 
   // Reset accumulated results when query or sort changes
   useEffect(() => {
@@ -109,12 +117,15 @@ export function usePlaylistSearch() {
     }
   }, [effectiveQuery, sortBy, sortOrder]);
 
-  // Accumulate results when new data arrives. cursor === null means "first
-  // page" so we replace; otherwise we append (deduping by id) since the
-  // user is paginating.
+  // Accumulate results when new data arrives. A null producing cursor means
+  // "first page" so we replace; otherwise we append (deduping by id) since the
+  // user is paginating. Keyed on `producingCursor` (the cursor that produced
+  // `data`), never the live `cursor` — a live-cursor flip on a new query
+  // re-fired this effect against the previous query's `data` and replaced the
+  // blanked accumulator with stale rows (#604).
   useEffect(() => {
     if (data?.results) {
-      if (cursor === null) {
+      if (producingCursor === null) {
         setAccumulatedResults(data.results);
       } else {
         setAccumulatedResults((prev) => {
@@ -124,7 +135,7 @@ export function usePlaylistSearch() {
         });
       }
     }
-  }, [data, cursor]);
+  }, [data, producingCursor]);
 
   // Fire search when query changes (response-based throttling)
   useEffect(() => {

--- a/src/hooks/playlistSearchHooks.ts
+++ b/src/hooks/playlistSearchHooks.ts
@@ -8,6 +8,22 @@ import {
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useCallback, useEffect, useRef, useState, useMemo } from "react";
 import type { PlaylistSearchResult } from "@wxyc/shared";
+import type { PlaylistSearchParams } from "@wxyc/shared/dtos";
+
+type SortField = PlaylistSearchParams["sort"];
+type SortOrder = PlaylistSearchParams["order"];
+
+/**
+ * The full parameter tuple a search fires with. Queued whole (q + cursor +
+ * sort + order) so a sort/cursor change during an in-flight fetch whose query
+ * text is unchanged is not silently dropped by a query-string-only gate (#623).
+ */
+type SearchParams = {
+  q: string;
+  cursor: string | null;
+  sortBy: SortField;
+  sortOrder: SortOrder;
+};
 
 const MIN_QUERY_LENGTH = 2;
 const LIMIT = 50;
@@ -72,15 +88,17 @@ export function usePlaylistSearch() {
 
   const effectiveQuery = useMemo(() => buildQuery(rows), [rows]);
 
-  // Track pending query to fire after current request completes
-  const pendingQueryRef = useRef<string | null>(null);
+  // Params tuple queued to fire after the current request completes. Holds the
+  // WHOLE tuple (not just the query string) so an in-flight fetch cannot swallow
+  // a concurrent sort/cursor change that leaves the query text untouched (#623).
+  const pendingParamsRef = useRef<SearchParams | null>(null);
   // null sentinel = "never fired" — distinguishes initial mount from a
   // user-cleared empty query so the on-mount empty-q request still goes out.
   const lastFiredQueryRef = useRef<string | null>(null);
   const lastFiredParamsRef = useRef<{
     cursor: string | null;
-    sortBy: string;
-    sortOrder: string;
+    sortBy: SortField;
+    sortOrder: SortOrder;
   }>({
     cursor: null,
     sortBy: "date",
@@ -145,7 +163,7 @@ export function usePlaylistSearch() {
     const isPartialQuery =
       effectiveQuery.length > 0 && effectiveQuery.length < MIN_QUERY_LENGTH;
     if (isPartialQuery) {
-      pendingQueryRef.current = null;
+      pendingParamsRef.current = null;
       return;
     }
 
@@ -155,13 +173,15 @@ export function usePlaylistSearch() {
       sortOrder !== lastFiredParamsRef.current.sortOrder;
 
     if (isFetching) {
-      // Request in flight - queue this query for later
-      pendingQueryRef.current = effectiveQuery;
+      // Request in flight - queue the FULL params tuple for later. Storing the
+      // whole tuple (not just effectiveQuery) is what lets the drain effect
+      // notice a sort/cursor change made while the query text stayed the same.
+      pendingParamsRef.current = { q: effectiveQuery, cursor, sortBy, sortOrder };
     } else if (effectiveQuery !== lastFiredQueryRef.current || paramsChanged) {
       // No request in flight and query/params changed - fire immediately
       lastFiredQueryRef.current = effectiveQuery;
       lastFiredParamsRef.current = { cursor, sortBy, sortOrder };
-      pendingQueryRef.current = null;
+      pendingParamsRef.current = null;
       trigger({
         q: effectiveQuery,
         limit: LIMIT,
@@ -172,26 +192,37 @@ export function usePlaylistSearch() {
     }
   }, [effectiveQuery, cursor, sortBy, sortOrder, isFetching, trigger]);
 
-  // When request completes, check if there's a pending query
+  // When the in-flight request completes, drain any queued params. The gate
+  // compares the ENTIRE pending tuple against the last-fired tuple — a
+  // query-string-only comparison here would drop a queued sort/cursor change
+  // whose query text matches what already fired (#623). Fires with the QUEUED
+  // params (captured when the change happened), not the live selector values.
   useEffect(() => {
-    if (
-      !isFetching &&
-      pendingQueryRef.current &&
-      pendingQueryRef.current !== lastFiredQueryRef.current
-    ) {
-      const pending = pendingQueryRef.current;
-      lastFiredQueryRef.current = pending;
-      lastFiredParamsRef.current = { cursor, sortBy, sortOrder };
-      pendingQueryRef.current = null;
-      trigger({
-        q: pending,
-        limit: LIMIT,
-        sort: sortBy,
-        order: sortOrder,
-        cursor: cursor ?? undefined,
-      });
+    const pending = pendingParamsRef.current;
+    if (!isFetching && pending) {
+      const changed =
+        pending.q !== lastFiredQueryRef.current ||
+        pending.cursor !== lastFiredParamsRef.current.cursor ||
+        pending.sortBy !== lastFiredParamsRef.current.sortBy ||
+        pending.sortOrder !== lastFiredParamsRef.current.sortOrder;
+      pendingParamsRef.current = null;
+      if (changed) {
+        lastFiredQueryRef.current = pending.q;
+        lastFiredParamsRef.current = {
+          cursor: pending.cursor,
+          sortBy: pending.sortBy,
+          sortOrder: pending.sortOrder,
+        };
+        trigger({
+          q: pending.q,
+          limit: LIMIT,
+          sort: pending.sortBy,
+          order: pending.sortOrder,
+          cursor: pending.cursor ?? undefined,
+        });
+      }
     }
-  }, [isFetching, cursor, sortBy, sortOrder, trigger]);
+  }, [isFetching, trigger]);
 
   // Actions
   const addRow = useCallback(
@@ -248,7 +279,7 @@ export function usePlaylistSearch() {
 
     // Loading states
     isLoading: isFetching,
-    hasPendingQuery: pendingQueryRef.current !== null,
+    hasPendingQuery: pendingParamsRef.current !== null,
     isError,
 
     // Actions

--- a/src/hooks/playlistSearchHooks.ts
+++ b/src/hooks/playlistSearchHooks.ts
@@ -13,18 +13,6 @@ import type { PlaylistSearchParams } from "@wxyc/shared/dtos";
 type SortField = PlaylistSearchParams["sort"];
 type SortOrder = PlaylistSearchParams["order"];
 
-/**
- * The full parameter tuple a search fires with. Queued whole (q + cursor +
- * sort + order) so a sort/cursor change during an in-flight fetch whose query
- * text is unchanged is not silently dropped by a query-string-only gate (#623).
- */
-type SearchParams = {
-  q: string;
-  cursor: string | null;
-  sortBy: SortField;
-  sortOrder: SortOrder;
-};
-
 const MIN_QUERY_LENGTH = 2;
 const LIMIT = 50;
 
@@ -88,10 +76,6 @@ export function usePlaylistSearch() {
 
   const effectiveQuery = useMemo(() => buildQuery(rows), [rows]);
 
-  // Params tuple queued to fire after the current request completes. Holds the
-  // WHOLE tuple (not just the query string) so an in-flight fetch cannot swallow
-  // a concurrent sort/cursor change that leaves the query text untouched (#623).
-  const pendingParamsRef = useRef<SearchParams | null>(null);
   // null sentinel = "never fired" — distinguishes initial mount from a
   // user-cleared empty query so the on-mount empty-q request still goes out.
   const lastFiredQueryRef = useRef<string | null>(null);
@@ -126,7 +110,11 @@ export function usePlaylistSearch() {
   // accumulator from being repopulated with the prior query's rows (#604).
   const producingCursor = originalArgs?.cursor ?? null;
 
-  // Reset accumulated results when query or sort changes
+  // Reset accumulated results when query or sort changes.
+  // ORDERING INVARIANT: this effect must stay declared BEFORE the accumulate
+  // effect below — when the new query's first page lands, both run in the same
+  // commit and reset-then-populate is what keeps the fresh page from being
+  // blanked (populate-then-reset would wipe it).
   useEffect(() => {
     const currentParams = `${effectiveQuery}-${sortBy}-${sortOrder}`;
     if (currentParams !== lastQueryForAccumulationRef.current) {
@@ -155,33 +143,37 @@ export function usePlaylistSearch() {
     }
   }, [data, producingCursor]);
 
-  // Fire search when query changes (response-based throttling)
+  // Fire search when query or params change (response-based throttling).
+  //
+  // This single effect is ALSO the mid-flight change protection (#623): a
+  // sort/cursor/query change made while a request is in flight takes the
+  // isFetching branch (no-op), and when the request settles, isFetching
+  // flipping false re-runs this effect against the live tuple. The full-tuple
+  // comparison — query string AND cursor/sortBy/sortOrder — is what fires the
+  // deferred request; if it compared the query string alone, a mid-flight
+  // sort/cursor change with unchanged query text would be silently dropped.
+  // There is no separate drain queue: the live selectors at settle time are
+  // exactly the params the user last requested.
   useEffect(() => {
     // Empty query is the "show recent tracks" default. Single-character
     // partials still get debounced — wait for at least MIN_QUERY_LENGTH
     // chars before issuing a substring match.
     const isPartialQuery =
       effectiveQuery.length > 0 && effectiveQuery.length < MIN_QUERY_LENGTH;
-    if (isPartialQuery) {
-      pendingParamsRef.current = null;
-      return;
-    }
+    if (isPartialQuery) return;
+
+    // Request in flight — defer. The settle re-run (isFetching dep) picks the
+    // change up.
+    if (isFetching) return;
 
     const paramsChanged =
       cursor !== lastFiredParamsRef.current.cursor ||
       sortBy !== lastFiredParamsRef.current.sortBy ||
       sortOrder !== lastFiredParamsRef.current.sortOrder;
 
-    if (isFetching) {
-      // Request in flight - queue the FULL params tuple for later. Storing the
-      // whole tuple (not just effectiveQuery) is what lets the drain effect
-      // notice a sort/cursor change made while the query text stayed the same.
-      pendingParamsRef.current = { q: effectiveQuery, cursor, sortBy, sortOrder };
-    } else if (effectiveQuery !== lastFiredQueryRef.current || paramsChanged) {
-      // No request in flight and query/params changed - fire immediately
+    if (effectiveQuery !== lastFiredQueryRef.current || paramsChanged) {
       lastFiredQueryRef.current = effectiveQuery;
       lastFiredParamsRef.current = { cursor, sortBy, sortOrder };
-      pendingParamsRef.current = null;
       trigger({
         q: effectiveQuery,
         limit: LIMIT,
@@ -191,38 +183,6 @@ export function usePlaylistSearch() {
       });
     }
   }, [effectiveQuery, cursor, sortBy, sortOrder, isFetching, trigger]);
-
-  // When the in-flight request completes, drain any queued params. The gate
-  // compares the ENTIRE pending tuple against the last-fired tuple — a
-  // query-string-only comparison here would drop a queued sort/cursor change
-  // whose query text matches what already fired (#623). Fires with the QUEUED
-  // params (captured when the change happened), not the live selector values.
-  useEffect(() => {
-    const pending = pendingParamsRef.current;
-    if (!isFetching && pending) {
-      const changed =
-        pending.q !== lastFiredQueryRef.current ||
-        pending.cursor !== lastFiredParamsRef.current.cursor ||
-        pending.sortBy !== lastFiredParamsRef.current.sortBy ||
-        pending.sortOrder !== lastFiredParamsRef.current.sortOrder;
-      pendingParamsRef.current = null;
-      if (changed) {
-        lastFiredQueryRef.current = pending.q;
-        lastFiredParamsRef.current = {
-          cursor: pending.cursor,
-          sortBy: pending.sortBy,
-          sortOrder: pending.sortOrder,
-        };
-        trigger({
-          q: pending.q,
-          limit: LIMIT,
-          sort: pending.sortBy,
-          order: pending.sortOrder,
-          cursor: pending.cursor ?? undefined,
-        });
-      }
-    }
-  }, [isFetching, trigger]);
 
   // Actions
   const addRow = useCallback(
@@ -264,6 +224,19 @@ export function usePlaylistSearch() {
 
   const hasMore = data?.nextCursor !== undefined;
 
+  // True when a change arrived while a request was in flight and is waiting
+  // for the settle re-fire: same tuple-vs-last-fired comparison the fire
+  // effect uses, so the two can't disagree.
+  const isPartialQuery =
+    effectiveQuery.length > 0 && effectiveQuery.length < MIN_QUERY_LENGTH;
+  const hasPendingQuery =
+    isFetching &&
+    !isPartialQuery &&
+    (effectiveQuery !== lastFiredQueryRef.current ||
+      cursor !== lastFiredParamsRef.current.cursor ||
+      sortBy !== lastFiredParamsRef.current.sortBy ||
+      sortOrder !== lastFiredParamsRef.current.sortOrder);
+
   return {
     // State
     rows,
@@ -279,7 +252,7 @@ export function usePlaylistSearch() {
 
     // Loading states
     isLoading: isFetching,
-    hasPendingQuery: pendingParamsRef.current !== null,
+    hasPendingQuery,
     isError,
 
     // Actions


### PR DESCRIPTION
## Dependencies / adjacencies (docs/plans/bug-triage-2026-07/PR-DEPENDENCIES.md)

No file overlap with any open PR (#868 touched `lml-conversions`/`types`; this touches only `useLmlLibrarySearch.ts` + `playlistSearchHooks.ts`).

## What

- **#604 (P1)** — typing during an in-flight paginated fetch no longer flashes the previous query's rows: the accumulator's replace-vs-append decision now keys on the cursor that *produced* the data (`originalArgs`), not the live cursor selector that typing resets. Fail-before verified (stale rows reappeared on unfixed code).
- **#623 — honest resolution: the described drop was already prevented.** Investigation (confirmed independently in review) showed the fire effect's full-tuple comparison plus its settle re-run already handles sort/cursor changes mid-flight; the string-only drain the issue flagged was *dormant, unreachable* machinery. Rather than shipping an elaborate queue with no reachable path, the drain is **removed** (−40 lines), the real mechanism is documented at the fire effect, `hasPendingQuery` derives from the same comparison so flag and effect can't disagree, and the load-bearing reset-before-accumulate effect ordering is pinned with a constraint comment. The regression test guards the actual mechanism and says so.
- **#625** — backspacing below the minimum query length clears LML results within one render (gated on live args, matching `isLoading`), instead of showing stale rows for the 350ms debounce window. Fail-before verified.

## Red-team review (high effort)

#604's fingerprint verified sound (the cross-query cursor-null blind spot is unreachable via RTK's per-arg cache entries); #625 clean (the valid→valid growth direction is pre-existing intended stale-while-revalidate, untouched). The review *proved* #623's queue was inert — the simplification commit is that finding applied.

## Testing

Typecheck clean; 3,550 tests green (5 new race-simulation tests; two verified fail-before, one an honest green-before regression guard on the pre-existing mechanism).

Closes #604
Closes #623
Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)