### PR TITLE
chore(deps): ignore @mui/icons-material major bumps (blocked by Joy UI)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    ignore:
+      # icons-material majors track @mui/material majors, and Material is
+      # pinned to 6.x until Joy UI ships against the v7+/v9 core (or we
+      # migrate off Joy). See #878; doomed bump attempt: #824.
+      - dependency-name: "@mui/icons-material"
+        update-types: ["version-update:semver-major"]
     groups:
       better-auth:
         patterns:


### PR DESCRIPTION
Stops Dependabot from re-proposing the @mui/icons-material major bump that can never pass CI: icons-material majors peer-depend on the matching `@mui/material` major, and we are pinned to Material 6.x while the UI is built on Joy UI (`@mui/joy@5.0.0-beta.52`, v5-era core). See #824 (closed after tonight's migration attempt) and #878 (tracking the deliberate unblock paths).

Minors/patches on the 6.x line still flow through the existing `production-dependencies` group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)