### PR TITLE
docs: engineering ruleset (CLAUDE.md) + refactor census prompt and slice template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,32 +1,159 @@
-# dj-site
+# DJ Site Engineering and Refactoring Rules
 
-DJ flowsheet and card catalog frontend for WXYC 89.3 FM. React-based revision of the original WXYC flowsheet and card catalog at `dj.wxyc.org`.
+## Mission
 
-## Topic guides
+Make `dj-site` the simplest accurate expression of its required behavior.
 
-CLAUDE.md is a router for the always-loaded reference card. Topic depth lives in `docs/`:
+Optimize in this order:
 
-- **[`docs/architecture.md`](docs/architecture.md)** — Tech stack (Next.js 16 / React 18 / MUI Joy UI / Redux Toolkit / better-auth), project structure (app router + parallel routes, `src/components/experiences/{classic,modern}`, `lib/features/*` feature layout), code conventions (path alias, typed hooks, experience registry, onboarding completeness flag, admin org resolution)
-- **[`docs/development.md`](docs/development.md)** — Local-dev prerequisites (Backend-Service running), npm script table (`dev`, `build`, `build:opennext`, `test`, `test:e2e`, …), local test credentials
-- **[`docs/env-vars.md`](docs/env-vars.md)** — Full env-var reference (`NEXT_PUBLIC_*`, `AUTH_REWRITE_URL`) + feature-flag catalog (`NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED`)
-- **[`docs/testing.md`](docs/testing.md)** — Vitest setup, `lib/test-utils/` factory functions, test constants (`TEST_ENTITY_IDS`, `TEST_SEARCH_STRINGS`), time utilities, the slice / API / component / conversion harnesses, MSW patterns, test organization, conventions
-- **[`docs/ci-cd.md`](docs/ci-cd.md)** — `.github/workflows/ci.yml` shape, E2E workflow (Docker Compose Backend-Service + Playwright), E2E-only deps (`pg` for Tier 1 SSE), second dj-site instance for the `AUTH_REWRITE_URL` Tier 2 test, Cloudflare Pages deploy via OpenNext / Wrangler, CI pin maintenance (workflow `permissions:` floors, `@gha/v1` reusable refs, `actionlint`)
-- **[`docs/test-fixtures.md`](docs/test-fixtures.md)** — Example WXYC catalog data (Juana Molina, Stereolab, Cat Power, Jessica Pratt, Chuquimamani-Condori, Duke Ellington & John Coltrane) for factory overrides
+1. Correct user-facing behavior.
+2. Data integrity and security.
+3. Reliability of the primary `Backend-Service` path.
+4. Failure isolation for every optional external service.
+5. Clear ownership and dependency direction.
+6. Removal of unnecessary runtime work.
+7. Readability and low cognitive overhead.
+8. Deletion of obsolete code and redundant comments.
 
-Read the relevant topic doc before doing work in that area.
+Do not optimize for minimum line count at the expense of clarity.
 
-## Always-loaded rules
+## Architectural Standard
 
-- **TypeScript strict mode.** `@/` alias resolves to project root. Typed Redux hooks (`useAppDispatch` / `useAppSelector` / `useAppStore`) from `@/lib/hooks` — never bare `useDispatch` / `useSelector`.
-- **Two experiences.** UI lives under `src/components/experiences/{classic,modern}`. Classic-theme views are prefixed `CLASSIC_`. Experience routing uses the registry pattern in `lib/features/experiences/registry.ts`.
-- **No formatter / linter config.** Follow existing code style.
-- **Dashboard home fallback.** The post-auth landing page is `NEXT_PUBLIC_DASHBOARD_HOME_PAGE`; its single-source-of-truth fallback is `DEFAULT_DASHBOARD_HOME_PAGE` in `lib/features/application/constants.ts`. Reference that constant everywhere the env var is read — `next.config.mjs` (can't import TS) and `.env.example` duplicate the literal and MUST match it.
-- **Test fixtures use real WXYC catalog data**, not mainstream acts. Defaults: `createTestArtist({ name: "Stereolab", … })`, `createTestAlbum({ title: "DOGA", artist: createTestArtist({ name: "Juana Molina", … }), label: "Sonamos", … })`, `createTestFlowsheetQuery({ artist: "Jessica Pratt", album: "On Your Own Love Again", … })`. Full preference list in `docs/test-fixtures.md`.
-- **Always render through `renderWithProviders`** for component tests (never bare RTL `render`); use the slice / API / component / conversion harnesses from `@/lib/test-utils` instead of ad-hoc test scaffolds.
-- **Branches.** Push to `main` triggers CI; on success the `deploy-production` job in `ci.yml` builds (`build:opennext`) and Direct-Uploads to the `wxyc-dj` Cloudflare Pages project via `wrangler pages deploy` (`scripts/deploy/deploy-cf-pages.sh`). PRs get a per-commit preview deploy from the `preview` job. No `prod` branch; no Cloudflare GitHub App Git build (removed in #810 — its pinned wrangler 3.x boot-500'd OpenNext ≥ 1.19).
+`Backend-Service` is the only external service that may be treated as a core runtime dependency.
 
-## Related Repos
+Every other external service—including PostHog, metadata lookup, telemetry, artwork, enrichment, recommendations, and feature flags—must:
 
-- **Backend-Service** (`github.com/WXYC/Backend-Service`): API server (port 8080) + auth service (port 8082). Provides all REST endpoints consumed by RTK Query APIs
-- **wxyc-shared** (`@wxyc/shared`): Shared DTOs, auth client, validation. Published to GitHub Packages. Used for type definitions and auth integration
-- **tubafrenzy**: Legacy Java flowsheet. The current database schema originates from here
+- be accessed through an application-owned contract;
+- have a service-specific adapter;
+- contain provider-specific types within that adapter;
+- fail open;
+- avoid blocking primary rendering or unrelated workflows;
+- provide a no-op, unavailable, or fallback implementation where appropriate.
+
+Feature modules may depend on integration contracts. They must not import optional third-party SDKs directly.
+
+## Simplicity
+
+Prefer:
+
+- direct code over speculative abstraction;
+- one authoritative owner for each value;
+- one primary implementation;
+- feature-specific modules over generic utility collections;
+- ordinary TypeScript and recognizable Next.js patterns;
+- deletion over indefinite deprecation;
+- framework capabilities over custom infrastructure.
+
+Introduce an abstraction only when it represents a real domain concept, enforces a necessary boundary, isolates a volatile dependency, removes substantial verified duplication, or enables otherwise impractical testing.
+
+Potential future reuse is not sufficient.
+
+A valid result is that no change should be made.
+
+## Tests
+
+Production source directories must not contain colocated tests or `__tests__` directories.
+
+Place tests under the top-level `tests/` hierarchy, organized by purpose and semantic feature:
+
+- `tests/unit`
+- `tests/integration`
+- `tests/contract`
+- `tests/e2e`
+- `tests/fixtures`
+- `tests/helpers`
+- `tests/fakes`
+
+Do not weaken tests to accommodate a refactor.
+
+## Comments
+
+Actively reduce comments in every touched file.
+
+Remove comments that:
+
+- restate code;
+- narrate control flow;
+- explain ordinary syntax;
+- repeat names or types;
+- announce obvious sections;
+- describe implementation history;
+- contain agent narration;
+- preserve commented-out code;
+- act as changelog entries;
+- contain vague TODOs;
+- compensate for unclear naming.
+
+Preserve only concise comments that explain a non-obvious reason, external constraint, compatibility requirement, security property, race condition, subtle invariant, or intentional exception.
+
+## Hooks and State
+
+Keep hooks grouped with their semantic feature.
+
+Audit every hook for:
+
+- mirrored server or prop state;
+- values that should be derived during render;
+- unnecessary effects;
+- effect chains;
+- unstable query arguments;
+- duplicate RTK Query subscriptions;
+- unnecessary polling or refetching;
+- broad cache invalidation;
+- broad Redux selection;
+- selectors that allocate on every call;
+- unnecessary memoization;
+- repeated parsing or normalization;
+- event-listener or timer leaks;
+- optional work delaying primary data;
+- multiple unrelated responsibilities.
+
+Use:
+
+- RTK Query for `Backend-Service` server state;
+- Redux for genuinely shared client-owned state;
+- local state for temporary local interaction state;
+- URL state when navigation or shareability requires it.
+
+Use effects only to synchronize with systems outside React.
+
+Do not claim a performance improvement without identifying the work removed or providing relevant evidence.
+
+## Next.js Boundaries
+
+Use Server Components by default when client interactivity is not required.
+
+Do not expand `"use client"` boundaries for convenience.
+
+Keep route and layout files focused on composition and framework concerns.
+
+Do not import server-only modules into client dependency graphs.
+
+Do not place the complete application beneath a failure-prone optional provider.
+
+## Change Discipline
+
+Work on one coherent architectural slice at a time.
+
+For each slice:
+
+1. Inspect the target and all callers.
+2. Establish observable behavior.
+3. Identify state and dependency ownership.
+4. Locate relevant tests.
+5. State invariants.
+6. Propose the smallest coherent design.
+7. Implement only that slice.
+8. Move affected tests into `tests/`.
+9. Reduce comments in touched files.
+10. Remove superseded code.
+11. Run focused and broader relevant tests.
+12. Run type checking, linting, and the production build.
+13. Verify runtime behavior where static checks are insufficient.
+14. Review the diff for unrelated changes.
+15. Request a fresh-context architectural review.
+16. Address supported findings and rerun verification.
+
+Do not combine unrelated cleanup with the active slice.
+
+Report what was inspected, changed, statically verified, tested, runtime verified, inferred, and not verified.

--- a/README.md
+++ b/README.md
@@ -1,216 +1,34 @@
-# WXYC Card Catalog, Revised
+# DJ Site Claude Refactoring Kit
 
-[See the site in action here!](https://dj.wxyc.org)
+Copy the contents of this archive into the root of the `dj-site` repository.
 
+The resulting structure should be:
 
-## Description
-The WXYC Card Catalog, Revised is a React-based revision of the original WXYC card catalog and flowsheet. This repository showcases an improved version of the existing catalog and flowsheet, while maintaining the classic theme and preserving the original look. Notably, the revised version is optimized for performance, resulting in faster loading times.
-
-## Features
-- Retains the classic theme: The revised version of the WXYC Card Catalog doesn't modify the old look in any way. Users will still experience the familiar aesthetics they are accustomed to.
-- Classic theme views: All views within the application that utilize the classic theme are prepended with `CLASSIC_`. This helps users distinguish between the classic and updated versions of the application.
-- New theme: With updated components and views, a faster and more seamless workflow between the flowsheet and card catalog is possible.
-- Mail Bin: a digital mail bin is available on every account, so DJs can add to the flowsheet directly from their bin without having to type during their sets.
-
-## Deployment
-Production and PR previews are built in GitHub Actions and pushed to the `wxyc-dj` Cloudflare Pages project via **Direct Upload** (`wrangler pages deploy`, using the repo's wrangler 4.x). This replaced the Cloudflare Pages Git-build integration, whose pinned wrangler 3.x miscompiled `@opennextjs/cloudflare >= 1.19` into a boot-500 ([WXYC/dj-site#810](https://github.com/WXYC/dj-site/issues/810)).
-
-- **Production** — the `deploy-production` job in `.github/workflows/ci.yml` runs on pushes to `main`, gated on the rest of CI passing. It builds with `npm run build:opennext` and deploys via `scripts/deploy/deploy-cf-pages.sh` (`--branch main`) in its own `cancel-in-progress: false` concurrency group so a queued push can't cancel a mid-flight upload.
-- **PR previews** — the single `preview` job in `ci.yml` builds and Direct-Uploads a per-PR preview deployment, then probes its URL and blocks merge on a 5xx (the required "Preview URL smoke check"). Fork PRs soft-skip (no repo secrets); same-repo PRs missing config hard-fail (see #740).
-- **Build-time env** — `NEXT_PUBLIC_*` values are inlined at build time and live as repo variables (production: `NEXT_PUBLIC_*`; preview: `PREVIEW_NEXT_PUBLIC_*`). `scripts/deploy/check-build-env.sh` hard-fails a deploy if a required build var is empty or points at localhost. See [`docs/env-vars.md`](docs/env-vars.md).
-- **Monitoring** — `.github/workflows/cloudflare-deploy-status.yml` polls the CF API hourly and probes `dj.wxyc.org` for runtime health.
-
-Deploy-helper scripts live in `scripts/deploy/`, each with a bats suite in `scripts/__tests__/deploy/`; run `npm run test:scripts`. See [`docs/ci-cd.md`](docs/ci-cd.md) and the cutover procedure in [`docs/deploy-cutover-runbook.md`](docs/deploy-cutover-runbook.md).
-
-## API Integration
-The revised catalog leverages services defined in `api-service.js`, which utilizes the popular Axios library to communicate with an AWS API Gateway. This integration allows seamless communication between the front-end application and the API endpoints, enabling data retrieval and manipulation.
-
-## Technologies Used
-- React: The front-end framework used for building the revised WXYC Card Catalog.
-- MUI Joy UI: A library of pre-built UI components for React that allows fast and beautiful feature development.
-- Github Pages: For hosting the frontend and automating publication.
-- Axios: A JavaScript library used for making HTTP requests to the AWS API Gateway.
-
-## Local Development Prerequisites
-
-The frontend requires the WXYC Backend-Service to be running locally for full functionality. Without the backend:
-- Authentication will not work
-- API calls (flowsheet, library, etc.) will fail
-- Most features will be unavailable
-
-**Option 1: Manual Setup**
-1. Clone and start [Backend-Service](https://github.com/WXYC/Backend-Service) following its Quick Start guide
-2. Ensure both backend (:8080) and auth (:8082) services are running
-3. Continue with frontend setup below
-
-**Option 2: Automated Setup**
-Use the setup script from [wxyc-shared](https://github.com/WXYC/wxyc-shared) to automatically configure the entire stack.
-
-## Installation and Setup
-1. Clone the repository: `git clone https://github.com/WXYC/dj-site.git`
-2. Navigate to the project directory: `cd dj-site`
-3. Install dependencies: `npm install`
-4. Create `.env.local` with required environment variables (see below)
-5. Run the application: `npm run dev`
-6. Access the application locally: Open your web browser and visit `http://localhost:3000`
-
-## Environment Variables
-
-Create a `.env.local` file in the project root with the following variables:
-
-```bash
-# Backend API URL (required)
-NEXT_PUBLIC_BACKEND_URL=http://localhost:8080
-
-# Better Auth service URL (required for authentication) — browser-facing
-NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:8082/auth
-
-# Optional: server-side override for the /auth/:path* rewrite destination. Set
-# this when the auth service is reachable from the host at NEXT_PUBLIC_BETTER_AUTH_URL
-# but not from inside the dj-site server process (e.g. docker compose, where
-# localhost inside the container is the container itself). Falls back to
-# NEXT_PUBLIC_BETTER_AUTH_URL when unset, so production (Cloudflare Pages) needs
-# no change.
-# AUTH_REWRITE_URL=http://auth:8082/auth
-
-# Default page after login. When unset, all entry points fall back to
-# DEFAULT_DASHBOARD_HOME_PAGE in lib/features/application/constants.ts.
-NEXT_PUBLIC_DASHBOARD_HOME_PAGE=/dashboard/catalog
-
-# UI Experience settings
-NEXT_PUBLIC_DEFAULT_EXPERIENCE=modern
-NEXT_PUBLIC_ENABLED_EXPERIENCES=modern,classic
-NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING=true
+```text
+dj-site/
+  CLAUDE.md
+  .claude/
+    rules/
+      integrations.md
+      hooks.md
+      tests.md
+      nextjs-boundaries.md
+    skills/
+      refactor-slice/
+        SKILL.md
+  docs/
+    architecture/
+      FABLE_REFACTOR_CENSUS_PROMPT.md
+      REFACTOR_SLICE_TEMPLATE.md
 ```
 
-### Environment Variable Reference
+## Suggested Use
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `NEXT_PUBLIC_BACKEND_URL` | Yes | Backend API base URL |
-| `NEXT_PUBLIC_BETTER_AUTH_URL` | Yes | Auth service URL (must end with `/auth`); used by the browser and as the fallback rewrite target |
-| `AUTH_REWRITE_URL` | No | Server-only override for the `/auth/:path*` rewrite destination; defaults to `NEXT_PUBLIC_BETTER_AUTH_URL`. Set in containerized deploys where the browser URL isn't reachable from the dj-site server |
-| `NEXT_PUBLIC_DASHBOARD_HOME_PAGE` | No | Redirect path after login |
-| `NEXT_PUBLIC_DEFAULT_EXPERIENCE` | No | Default UI theme (`modern` or `classic`) |
-| `NEXT_PUBLIC_ENABLED_EXPERIENCES` | No | Comma-separated list of available themes |
-| `NEXT_PUBLIC_ALLOW_EXPERIENCE_SWITCHING` | No | Enable theme switching in UI |
+1. Commit these files before beginning the refactoring campaign.
+2. Start a new Fable session.
+3. Paste the prompt from `docs/architecture/FABLE_REFACTOR_CENSUS_PROMPT.md`.
+4. Review and save the resulting census.
+5. Use `docs/architecture/REFACTOR_SLICE_TEMPLATE.md` for one bounded slice at a time.
+6. Tell Claude or Fable to use the `refactor-slice` skill for each implementation task.
 
-## Authentication Flow
-
-The application uses [Better Auth](https://www.better-auth.com/) for authentication, running as a separate service within Backend-Service.
-
-**How it works:**
-1. User submits credentials on the login page
-2. Frontend sends request to Better Auth service (`NEXT_PUBLIC_BETTER_AUTH_URL`)
-3. Better Auth validates credentials against the PostgreSQL database
-4. On success, Better Auth returns a JWT token stored in an HTTP-only cookie
-5. Subsequent API requests include the token automatically
-6. Backend validates tokens via JWKS endpoint
-
-**Test credentials** (local development):
-- Username: `test_member`, `test_dj1`, `test_dj2`, `test_music_director`, or `test_station_manager`
-- Password: `testpassword123`
-
-## Testing
-
-The project uses [Vitest](https://vitest.dev/) for testing with React Testing Library and MSW for API mocking.
-
-### Running Tests
-
-```bash
-# Run tests in watch mode
-npm test
-
-# Run tests once
-npm run test:run
-
-# Run tests with UI
-npm run test:ui
-
-# Run tests with coverage
-npm run test:coverage
-```
-
-### Test Structure
-
-- `lib/__tests__/` - Feature tests (Redux slices, RTK Query APIs)
-- `**/*.test.tsx` - Component tests (co-located with components)
-- `lib/test-utils/` - Shared test utilities
-
-### Writing Tests
-
-#### Redux Slice Tests
-
-```typescript
-import { describe, it, expect } from "vitest";
-import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
-
-describe("flowsheetSlice", () => {
-  it("should set autoplay", () => {
-    const nextState = flowsheetSlice.reducer(
-      initialState,
-      flowsheetSlice.actions.setAutoplay(true)
-    );
-    expect(nextState.autoplay).toBe(true);
-  });
-});
-```
-
-#### RTK Query Tests with MSW
-
-```typescript
-import { describe, it, expect } from "vitest";
-import { http, HttpResponse } from "msw";
-import { server, TEST_BACKEND_URL } from "@/lib/test-utils";
-
-describe("catalogApi", () => {
-  it("should fetch albums", async () => {
-    server.use(
-      http.get(`${TEST_BACKEND_URL}/library/`, () => {
-        return HttpResponse.json([{ id: 1, title: "Test Album" }]);
-      })
-    );
-    // ... test implementation
-  });
-});
-```
-
-#### Component Tests
-
-```typescript
-import { describe, it, expect } from "vitest";
-import { screen } from "@testing-library/react";
-import { renderWithProviders } from "@/lib/test-utils";
-import MyComponent from "./MyComponent";
-
-describe("MyComponent", () => {
-  it("should render", () => {
-    renderWithProviders(<MyComponent />);
-    expect(screen.getByText("Hello")).toBeInTheDocument();
-  });
-});
-```
-
-### Test Utilities
-
-Import test utilities from `@/lib/test-utils`:
-
-- `renderWithProviders` - Render with Redux and MUI providers
-- `createTestAlbum`, `createTestArtist`, etc. - Factory functions for test data
-- `server` - MSW server instance for API mocking
-- `TEST_BACKEND_URL` - Backend URL constant for MSW handlers
-
-## Contributing
-Contributions to the WXYC Card Catalog, Revised are welcome! If you would like to contribute, please follow these steps:
-1. Create a new branch: `git checkout -b my-feature-branch`
-2. Make your changes and commit them: `git commit -m "Add some feature"`
-3. Test your build: `npm run build`
-4. Push to the branch: `git push origin my-feature-branch`
-5. Submit a pull request detailing your changes.
-6. When your pull request is approved, Github Actions will auto-deploy your changes to the site. Be sure to give 5-10 minutes after the build completes for the changes to propagate.
-
-## License
-The WXYC Card Catalog, Revised is released under the [MIT License](LICENSE). Feel free to use, modify, and distribute the code as per the terms of this license.
-
-## Acknowledgments
-We would like to express our gratitude to the contributors and maintainers of the original WXYC Card Catalog for their valuable work, which served as the foundation for this revised version. In particular, Tim Ross/Tubafrenzy, who developed the original flowsheet site and maintained the database for years during decades when it was much more difficult to maintain and develop a site like this one.
+Adjust the `paths` frontmatter in `.claude/rules/` if the repository uses directories other than `src/` or `app/`.

--- a/docs/architecture/FABLE_REFACTOR_CENSUS_PROMPT.md
+++ b/docs/architecture/FABLE_REFACTOR_CENSUS_PROMPT.md
@@ -1,0 +1,68 @@
+# Fable Read-Only Refactoring Census Prompt
+
+Paste the prompt below into a new Fable session before beginning broad implementation.
+
+```xml
+<task>
+Perform a read-only architectural census of the dj-site repository.
+
+Do not modify files.
+
+Map the repository as it actually exists, with special attention to:
+
+1. all Backend-Service access paths;
+2. every other external service and SDK;
+3. direct PostHog imports and calls;
+4. library metadata lookup paths;
+5. telemetry and error-reporting integrations;
+6. how optional service failures currently propagate;
+7. Redux and RTK Query ownership;
+8. duplicated or overlapping server state;
+9. every custom hook bundle;
+10. unnecessary effects, duplicate queries, broad selectors, or mirrored state;
+11. all test locations and test-runner assumptions;
+12. comments that appear narrational, generated, historical, decorative, or redundant;
+13. server and client component boundaries;
+14. duplicate, legacy, or superseded implementations.
+
+For each external integration, identify:
+
+- direct consumers;
+- third-party imports;
+- application-owned types, if any;
+- current failure behavior;
+- whether primary rendering waits for it;
+- whether a no-op or fallback exists;
+- the smallest appropriate application-owned contract.
+
+For each major hook bundle, identify:
+
+- semantic purpose;
+- inputs and outputs;
+- state owners;
+- effects;
+- query subscriptions;
+- mutations;
+- Redux selectors;
+- external service calls;
+- likely unnecessary work.
+
+For the test suite, propose a top-level tests structure that preserves semantic discoverability without colocating tests beside production code.
+
+Do not recommend a generic architecture without repository evidence.
+
+Identify the strongest existing local implementation pattern for each concern and recommend whether it should become the repository standard.
+
+Produce:
+
+1. a concise current-state architecture map;
+2. a dependency and integration inventory;
+3. a hook-performance audit;
+4. a test-migration map;
+5. a comment-reduction audit;
+6. the highest-risk behavior-preservation areas;
+7. an ordered refactoring campaign composed of small, independently verifiable slices.
+
+Do not implement any slice yet.
+</task>
+```

--- a/docs/architecture/REFACTOR_SLICE_TEMPLATE.md
+++ b/docs/architecture/REFACTOR_SLICE_TEMPLATE.md
@@ -1,0 +1,55 @@
+# Refactor Slice Prompt Template
+
+Use this after the architectural census, one bounded slice at a time.
+
+```xml
+<task>
+Refactor the following coherent dj-site slice:
+
+[TARGET FEATURE, INTEGRATION, HOOK BUNDLE, OR DIRECTORY]
+</task>
+
+<current_problem>
+[REPOSITORY-EVIDENCED PROBLEM]
+</current_problem>
+
+<desired_outcome>
+[CONCRETE ARCHITECTURAL AND USER-FACING OUTCOME]
+</desired_outcome>
+
+<preserved_behavior>
+[BEHAVIORAL INVARIANTS]
+</preserved_behavior>
+
+<excluded_scope>
+[FILES, FEATURES, OR CONTRACTS THAT MUST NOT CHANGE]
+</excluded_scope>
+
+<special_requirements>
+- Move affected tests into the top-level tests hierarchy.
+- Audit and remove useless or wordy comments in every touched file.
+- Preserve only comments that contain irreducible rationale or constraints.
+- Keep hooks grouped with their semantic feature.
+- Remove unnecessary effects, state mirroring, subscriptions, query work, and rerenders.
+- Route optional external services through application-owned contracts and dedicated adapters.
+- Ensure optional service failure cannot impair unrelated frontend behavior.
+- Do not introduce speculative abstraction.
+</special_requirements>
+
+<acceptance_criteria>
+[EXECUTABLE AND ARCHITECTURAL COMPLETION CONDITIONS]
+</acceptance_criteria>
+
+<verification>
+Run focused tests, relevant integration or contract tests, type checking, linting, the production build, and runtime verification where static checks are insufficient.
+
+Search the repository after implementation to confirm:
+
+- no affected test remains colocated;
+- no prohibited direct third-party imports remain;
+- no superseded implementation remains reachable;
+- no unnecessary comments remain in touched files.
+
+Delegate an independent review and address supported findings before completion.
+</verification>
+```


### PR DESCRIPTION
Docs-only. Lands the new CLAUDE.md engineering/refactoring ruleset, the README update, and `docs/architecture/{FABLE_REFACTOR_CENSUS_PROMPT,REFACTOR_SLICE_TEMPLATE}.md` — the files that govern the DevX refactor campaign (#882). These were living only in a worktree's working tree; the merged docket references the slice template, so main needs them. Files are committed verbatim as authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)