### PR TITLE
refactor(telemetry): S2 — complete the application-owned PostHog contract

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { posthog } from "@/lib/posthog";
+import { safeCaptureException } from "@/lib/posthog";
 
 export default function GlobalError({
   error,
@@ -11,7 +11,7 @@ export default function GlobalError({
   reset: () => void;
 }) {
   useEffect(() => {
-    posthog.captureException(error);
+    safeCaptureException(error);
   }, [error]);
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react";
 import { StoreProvider } from "@/src/StoreProvider";
-import { PostHogProvider } from "@/src/components/shared/PostHogProvider";
+import { TelemetryProvider } from "@/src/components/shared/TelemetryProvider";
 
 import "@/src/styles/globals.css";
 import { createServerSideProps } from "@/lib/features/session";
@@ -45,7 +45,7 @@ export default async function RootLayout({ children }: Props) {
 
   return (
     <StoreProvider>
-      <PostHogProvider>
+      <TelemetryProvider>
         <ThemeRegistry
           options={{ key: "joy" }}
           experience={serverSideProps.application.experience}
@@ -64,7 +64,7 @@ export default async function RootLayout({ children }: Props) {
             </body>
           </html>
         </ThemeRegistry>
-      </PostHogProvider>
+      </TelemetryProvider>
     </StoreProvider>
   );
 }

--- a/docs/plans/devx-refactor/00-campaign.md
+++ b/docs/plans/devx-refactor/00-campaign.md
@@ -10,6 +10,11 @@ green.
 - Integration branch `refactor/devx-root` hosts the merged campaign for local
   verification; it never becomes a PR. Slice branches fork from it; PRs target `main`,
   sequentially (one open at a time; a second only if directories are fully disjoint).
+- The repo allows rebase merges only, and branches carrying devx-root's integration
+  merge commits cannot rebase-merge. Before any slice PR opens (or after drift), the
+  branch is rebuilt as a single clean commit atop `origin/main`:
+  `git reset --hard origin/main && git cherry-pick <slice-commit> && git push
+  --force-with-lease`.
 - Agents verify with `npx tsc --noEmit`, `npm run test:run`, `npm run build`, and CI
   only — never a dev server or screenshots. Jackson verifies visually at milestone
   gates on `refactor/devx-root`.

--- a/docs/plans/devx-refactor/02-telemetry-contract.md
+++ b/docs/plans/devx-refactor/02-telemetry-contract.md
@@ -1,6 +1,6 @@
 # S2 — telemetry-contract
 
-Status: pending · Risk: risky (Opus) · PR: —
+Status: reviewed, PR pending · Risk: risky (Opus) · PR: —
 
 ## Task
 
@@ -44,3 +44,89 @@ no raw `posthog` export remains; all baseline tests pass.
 Baseline commands + `vitest run lib/__tests__/posthog.test.ts lib/__tests__/store.test.ts
 lib/__tests__/csp-violation-reporter.test.ts` (paths shift if run after S5). Runtime
 pageview confirmation deferred to Jackson's M1 gate.
+
+## Result
+
+### Inspected
+- `lib/posthog.ts` (raw `posthog` re-export + `initPostHog`/`safeCapture`/`safeCaptureException`).
+- All consumers of the raw export (grep-verified): `lib/features/backend.ts`,
+  `app/global-error.tsx`, `src/components/shared/PostHogProvider.tsx`
+  (pageview + PHProvider `client`).
+- `posthog-js/react` / `usePostHog` consumers: zero besides the PHProvider wrapper
+  itself — confirmed removable.
+- Existing safe-contract consumers left untouched: `lib/store.ts`,
+  `lib/csp-violation-reporter.ts`, `lib/features/flowsheet/{live-updates-listener,infinite-cache}.ts`,
+  `app/login/LoginBounceTelemetry.tsx`, `src/hooks/authenticationHooks.ts`.
+- Test callers of the raw export: `lib/__tests__/features/backend.test.ts` (mocked
+  `posthog.captureException`) and `lib/__tests__/features/flowsheet/live-updates-listener.test.ts`
+  (spied on `posthog.capture`/`captureException`).
+
+### Changed
+- `lib/posthog.ts` — removed the raw `posthog` re-export; renamed `initPostHog` →
+  `initTelemetry`; added `safeCapturePageview(url)` (emits `$pageview` with `$current_url`);
+  kept `safeCapture`/`safeCaptureException`; `posthog-js` import stays inside the adapter.
+  Comment essays condensed to one contract note.
+- `lib/features/backend.ts` — imports `safeCaptureException`; dropped the now-redundant
+  local `try/catch` (the adapter owns the never-throw guarantee); trimmed two narration
+  comments in `prepareHeaders`. Soft-fail contract JSDoc preserved.
+- `app/global-error.tsx` — raw `posthog.captureException` → `safeCaptureException`.
+- `src/components/shared/PostHogProvider.tsx` → renamed to `TelemetryProvider.tsx`
+  (`git mv`; only importer was `app/layout.tsx`). Dropped `posthog-js/react` PHProvider
+  wrapper (children now render under a fragment); init + pageview (via `safeCapturePageview`)
+  + CSP-reporter install semantics unchanged. Internal `PostHogPageView` → `TelemetryPageView`.
+- `app/layout.tsx` — import + tags updated to `TelemetryProvider`.
+- `lib/csp-violation-reporter.ts` — one-word doc-comment reference updated
+  (`from PostHogProvider` → `from TelemetryProvider`); no code change.
+- Tests: `lib/__tests__/posthog.test.ts` renamed `initPostHog`→`initTelemetry` and added
+  contract coverage (forward args, non-Error wrap, never-throw-on-SDK-throw, pageview
+  shape) for all four exports (+7 tests). `backend.test.ts` mock switched to
+  `{ safeCaptureException }`; its "defensive throw" case re-pointed to the contract
+  boundary (soft-fail still returns `{data:null}` and routes through `safeCaptureException`)
+  since the never-throw guarantee now lives in and is tested by the adapter.
+  `live-updates-listener.test.ts` switched from spying on the raw export to mocking the
+  `safeCapture`/`safeCaptureException` contract (same asserted call args).
+
+### Verified
+- `npx tsc --noEmit`: clean.
+- `npm run test:run`: 269 files / 3670 tests passing (269/3663 baseline + 7 new adapter
+  contract tests; no tests lost). Known pre-existing jsdom `_location` noise unchanged.
+- `npm run build`: succeeds.
+- Focused: `posthog.test.ts`, `store.test.ts`, `csp-violation-reporter.test.ts`,
+  `backend.test.ts`, `live-updates-listener.test.ts` — 5 files / 70 tests pass.
+- Acceptance grep `grep -rn "posthog-js" app src lib --include="*.ts*"` hits only
+  `lib/posthog.ts` and `lib/__tests__/posthog.test.ts` (the adapter's own test mocks the
+  SDK — allowed per spec). No raw `posthog` export remains; zero `PHProvider`/`usePostHog`.
+
+### Invariants (all hold)
+- Telemetry never throws into app code — every capture wrapped in the adapter; init
+  no-ops without `NEXT_PUBLIC_POSTHOG_KEY` (and on server / when already loaded).
+- Pageview unchanged — `safeCapturePageview` emits `$pageview` with `$current_url`.
+- RTK error-middleware semantics untouched — `lib/store.ts` not modified.
+- CSP reporter installed exactly once — `installCspViolationReporter`'s `installed` flag
+  and its single call site (the provider effect) are unchanged.
+
+### Deviations
+- Provider **renamed** to `TelemetryProvider` (spec allowed it "if churn stays small";
+  the only importer was `app/layout.tsx`). This entailed the one-word comment update in
+  `lib/csp-violation-reporter.ts` to keep the reference accurate.
+- Two test files outside the primary edit set were updated because they referenced the
+  removed raw `posthog` export (`backend.test.ts`, `live-updates-listener.test.ts`) —
+  necessary consequence of the contract change, not opportunistic cleanup; no assertions
+  weakened.
+- All four named exports have live consumers, so none were dropped.
+
+### Independent review (fresh-context, Opus)
+
+All eight areas CONFIRMED-SAFE; no blocking issues, no code changes required. Notable
+verifications: the adapter's try boundary covers argument wrapping and every SDK path
+(so dropping backend.ts's local try/catch adds no new throw exposure — the same
+property reads already ran unguarded in pre-existing code); `global-error.tsx` calling
+the adapter outside the provider tree is strictly safer than the old unguarded raw
+call; pageview/init are byte-parity; zero `posthog-js/react` context consumers existed.
+
+Two standing advisories (accepted design, no action):
+1. The never-throw guarantee's owner is now the adapter, not call sites — callers must
+   keep passing trivially-safe arguments (true for both current call sites).
+2. The backend boundary's throwing-capture case is proven transitively (adapter
+   never-throws test against the real implementation + backend routes-through-adapter
+   test) rather than in a single end-to-end test.

--- a/lib/__tests__/features/backend.test.ts
+++ b/lib/__tests__/features/backend.test.ts
@@ -12,7 +12,7 @@ const { mockCaptureException } = vi.hoisted(() => ({
   mockCaptureException: vi.fn(),
 }));
 vi.mock("@/lib/posthog", () => ({
-  posthog: { captureException: mockCaptureException },
+  safeCaptureException: mockCaptureException,
 }));
 
 // We need to mock fetchBaseQuery from Redux Toolkit. The mock returns a function
@@ -351,10 +351,11 @@ describe("backend", () => {
         expect(result).toBe(success);
       });
 
-      it("does not throw if PostHog capture fails (defensive)", async () => {
-        mockCaptureException.mockImplementationOnce(() => {
-          throw new Error("posthog not initialized");
-        });
+      // The soft-fail path routes telemetry through the safeCaptureException
+      // contract, which owns the never-throw guarantee (covered in
+      // posthog.test.ts). backend must never wrap a query in a raw capture that
+      // could surface a telemetry outage as a query error.
+      it("routes the soft-fail through safeCaptureException and stays quiet", async () => {
         mockInnerBaseQuery.mockResolvedValueOnce({
           error: {
             status: "PARSING_ERROR",
@@ -369,6 +370,7 @@ describe("backend", () => {
         await expect(
           baseQuery({ url: "/42/tracks" }, fakeApi, fakeExtra)
         ).resolves.toEqual(expect.objectContaining({ data: null }));
+        expect(mockCaptureException).toHaveBeenCalledTimes(1);
       });
 
       // Mutations must keep surfacing the error loudly. Soft-handling a POST

--- a/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
+++ b/lib/__tests__/features/flowsheet/live-updates-listener.test.ts
@@ -13,14 +13,17 @@ import {
   liveUpdatesSlice,
 } from "@/lib/features/flowsheet/live-updates-slice";
 import type { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
-import { posthog } from "@/lib/posthog";
 import { makeStore } from "@/lib/store";
 import { server, TEST_BACKEND_URL } from "@/lib/test-utils";
 
-const captureSpy = vi.spyOn(posthog, "capture").mockImplementation(() => undefined as never);
-const captureExceptionSpy = vi
-  .spyOn(posthog, "captureException")
-  .mockImplementation(() => undefined as never);
+const { captureSpy, captureExceptionSpy } = vi.hoisted(() => ({
+  captureSpy: vi.fn(),
+  captureExceptionSpy: vi.fn(),
+}));
+vi.mock("@/lib/posthog", () => ({
+  safeCapture: captureSpy,
+  safeCaptureException: captureExceptionSpy,
+}));
 
 type MockES = {
   url: string;

--- a/lib/__tests__/posthog.test.ts
+++ b/lib/__tests__/posthog.test.ts
@@ -12,7 +12,7 @@ vi.mock("posthog-js", () => {
   };
 });
 
-describe("initPostHog", () => {
+describe("initTelemetry", () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
@@ -29,8 +29,8 @@ describe("initPostHog", () => {
     process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test123";
     process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://custom.posthog.com";
 
-    const { initPostHog } = await import("@/lib/posthog");
-    initPostHog();
+    const { initTelemetry } = await import("@/lib/posthog");
+    initTelemetry();
 
     expect(posthog.init).toHaveBeenCalledWith("phc_test123", {
       api_host: "https://custom.posthog.com",
@@ -44,8 +44,8 @@ describe("initPostHog", () => {
     process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test123";
     delete process.env.NEXT_PUBLIC_POSTHOG_HOST;
 
-    const { initPostHog } = await import("@/lib/posthog");
-    initPostHog();
+    const { initTelemetry } = await import("@/lib/posthog");
+    initTelemetry();
 
     expect(posthog.init).toHaveBeenCalledWith(
       "phc_test123",
@@ -58,8 +58,8 @@ describe("initPostHog", () => {
   it("no-ops when NEXT_PUBLIC_POSTHOG_KEY is unset", async () => {
     delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
 
-    const { initPostHog } = await import("@/lib/posthog");
-    initPostHog();
+    const { initTelemetry } = await import("@/lib/posthog");
+    initTelemetry();
 
     expect(posthog.init).not.toHaveBeenCalled();
   });
@@ -70,8 +70,8 @@ describe("initPostHog", () => {
     const windowSpy = vi.spyOn(globalThis, "window", "get");
     windowSpy.mockReturnValue(undefined as any);
 
-    const { initPostHog } = await import("@/lib/posthog");
-    initPostHog();
+    const { initTelemetry } = await import("@/lib/posthog");
+    initTelemetry();
 
     expect(posthog.init).not.toHaveBeenCalled();
     windowSpy.mockRestore();
@@ -81,9 +81,81 @@ describe("initPostHog", () => {
     process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test123";
     (posthog as any).__loaded = true;
 
-    const { initPostHog } = await import("@/lib/posthog");
-    initPostHog();
+    const { initTelemetry } = await import("@/lib/posthog");
+    initTelemetry();
 
     expect(posthog.init).not.toHaveBeenCalled();
+  });
+});
+
+describe("safe capture contract", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.mocked(posthog.capture).mockReset();
+    vi.mocked(posthog.captureException).mockReset();
+  });
+
+  it("safeCapture forwards event and props to posthog.capture", async () => {
+    const { safeCapture } = await import("@/lib/posthog");
+    safeCapture("csp_violation", { blockedURI: "https://evil.example.com" });
+
+    expect(posthog.capture).toHaveBeenCalledWith("csp_violation", {
+      blockedURI: "https://evil.example.com",
+    });
+  });
+
+  it("safeCapture never throws when the SDK throws", async () => {
+    vi.mocked(posthog.capture).mockImplementationOnce(() => {
+      throw new Error("posthog not initialized");
+    });
+
+    const { safeCapture } = await import("@/lib/posthog");
+    expect(() => safeCapture("some_event")).not.toThrow();
+  });
+
+  it("safeCaptureException forwards an Error unchanged", async () => {
+    const err = new Error("boom");
+    const { safeCaptureException } = await import("@/lib/posthog");
+    safeCaptureException(err, { domain: "flowsheet" });
+
+    expect(posthog.captureException).toHaveBeenCalledWith(err, {
+      domain: "flowsheet",
+    });
+  });
+
+  it("safeCaptureException wraps a non-Error value in an Error", async () => {
+    const { safeCaptureException } = await import("@/lib/posthog");
+    safeCaptureException("just a string");
+
+    const captured = vi.mocked(posthog.captureException).mock.calls[0][0];
+    expect(captured).toBeInstanceOf(Error);
+    expect((captured as Error).message).toBe("just a string");
+  });
+
+  it("safeCaptureException never throws when the SDK throws", async () => {
+    vi.mocked(posthog.captureException).mockImplementationOnce(() => {
+      throw new Error("posthog not initialized");
+    });
+
+    const { safeCaptureException } = await import("@/lib/posthog");
+    expect(() => safeCaptureException(new Error("boom"))).not.toThrow();
+  });
+
+  it("safeCapturePageview emits $pageview with $current_url", async () => {
+    const { safeCapturePageview } = await import("@/lib/posthog");
+    safeCapturePageview("https://wxyc.org/dashboard");
+
+    expect(posthog.capture).toHaveBeenCalledWith("$pageview", {
+      $current_url: "https://wxyc.org/dashboard",
+    });
+  });
+
+  it("safeCapturePageview never throws when the SDK throws", async () => {
+    vi.mocked(posthog.capture).mockImplementationOnce(() => {
+      throw new Error("posthog not initialized");
+    });
+
+    const { safeCapturePageview } = await import("@/lib/posthog");
+    expect(() => safeCapturePageview("https://wxyc.org/live")).not.toThrow();
   });
 });

--- a/lib/csp-violation-reporter.ts
+++ b/lib/csp-violation-reporter.ts
@@ -3,7 +3,7 @@ import { safeCapture } from "./posthog";
 /**
  * Forwards Content-Security-Policy violations to PostHog so the Report-Only
  * rollout (#631) gathers real-user signal instead of relying on individual
- * DevTools consoles. Installed once per page from PostHogProvider.
+ * DevTools consoles. Installed once per page from TelemetryProvider.
  */
 
 // Dedupe per (violatedDirective, blockedURI-origin) per page session so a hot

--- a/lib/features/backend.ts
+++ b/lib/features/backend.ts
@@ -7,7 +7,7 @@ import type {
 } from "@reduxjs/toolkit/query";
 import { fetchBaseQuery } from "@reduxjs/toolkit/query";
 import { getJWTToken } from "./authentication/client";
-import { posthog } from "../posthog";
+import { safeCaptureException } from "../posthog";
 
 type BackendBaseQuery = BaseQueryFn<
   string | FetchArgs,
@@ -24,11 +24,8 @@ const innerBaseQuery = (domain: string): BackendBaseQuery =>
       headers.set("Content-Type", "application/json");
       headers.set("X-Request-Id", crypto.randomUUID());
 
-      // Get JWT token from better-auth /token endpoint
       const token = await getJWTToken();
-
       if (token) {
-        // Use Bearer format for better-auth JWT tokens
         headers.set("Authorization", `Bearer ${token}`);
       }
       return headers;
@@ -76,16 +73,12 @@ const logNonJsonResponse = (
     params,
   });
   // PostHog is the project's wired error sink (see lib/store.ts).
-  try {
-    posthog.captureException(new Error(message), {
-      domain,
-      url,
-      params,
-      originalStatus: error.originalStatus,
-    });
-  } catch {
-    // posthog may not be initialized (tests, SSR) — never let logging crash a query.
-  }
+  safeCaptureException(new Error(message), {
+    domain,
+    url,
+    params,
+    originalStatus: error.originalStatus,
+  });
 };
 
 /**

--- a/lib/posthog.ts
+++ b/lib/posthog.ts
@@ -1,6 +1,6 @@
 import posthog from "posthog-js";
 
-export function initPostHog() {
+export function initTelemetry(): void {
   if (typeof window === "undefined") return;
   if (posthog.__loaded) return;
 
@@ -19,9 +19,10 @@ export function initPostHog() {
 }
 
 /**
- * Capture an exception without ever throwing back to the caller. PostHog may
- * be uninitialized (tests, SSR) — the dispatch / request path must not crash
- * because telemetry is unavailable.
+ * Telemetry is optional (CLAUDE.md optional-service rule): PostHog may be
+ * uninitialized (tests, SSR, missing key). Every capture is wrapped so an
+ * unavailable SDK fails open and never throws back into the dispatch, request,
+ * or render path.
  */
 export function safeCaptureException(
   err: unknown,
@@ -33,11 +34,10 @@ export function safeCaptureException(
       context
     );
   } catch {
-    // intentionally swallowed — see jsdoc
+    // optional-service contract: swallow
   }
 }
 
-/** Capture a PostHog event without throwing on uninitialized telemetry. */
 export function safeCapture(
   event: string,
   props?: Record<string, unknown>
@@ -45,8 +45,10 @@ export function safeCapture(
   try {
     posthog.capture(event, props);
   } catch {
-    // intentionally swallowed — see safeCaptureException
+    // optional-service contract: swallow
   }
 }
 
-export { posthog };
+export function safeCapturePageview(url: string): void {
+  safeCapture("$pageview", { $current_url: url });
+}

--- a/src/components/shared/TelemetryProvider.tsx
+++ b/src/components/shared/TelemetryProvider.tsx
@@ -2,23 +2,21 @@
 
 import { useEffect } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
-import { PostHogProvider as PHProvider } from "posthog-js/react";
-import { initPostHog, posthog } from "@/lib/posthog";
+import { initTelemetry, safeCapturePageview } from "@/lib/posthog";
 import { installCspViolationReporter } from "@/lib/csp-violation-reporter";
 import type { ReactNode } from "react";
 
-function PostHogPageView() {
+function TelemetryPageView() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    if (pathname && posthog) {
-      let url = window.origin + pathname;
-      if (searchParams.toString()) {
-        url += "?" + searchParams.toString();
-      }
-      posthog.capture("$pageview", { $current_url: url });
+    if (!pathname) return;
+    let url = window.origin + pathname;
+    if (searchParams.toString()) {
+      url += "?" + searchParams.toString();
     }
+    safeCapturePageview(url);
   }, [pathname, searchParams]);
 
   return null;
@@ -28,18 +26,18 @@ interface Props {
   readonly children: ReactNode;
 }
 
-export function PostHogProvider({ children }: Props) {
+export function TelemetryProvider({ children }: Props) {
   useEffect(() => {
-    initPostHog();
+    initTelemetry();
     // Report-Only CSP violations (#631) fire securitypolicyviolation events
     // client-side; forward them to PostHog so the rollout gathers signal.
     installCspViolationReporter();
   }, []);
 
   return (
-    <PHProvider client={posthog}>
-      <PostHogPageView />
+    <>
+      <TelemetryPageView />
       {children}
-    </PHProvider>
+    </>
   );
 }


### PR DESCRIPTION
Slice S2 of the DevX refactor campaign (docket: `docs/plans/devx-refactor/`). Behavior-preserving; nothing newly captured, nothing stopped.

## What

- `lib/posthog.ts` is now the complete telemetry adapter: raw `posthog` re-export removed; surface is `initTelemetry`, `safeCapture`, `safeCaptureException`, `safeCapturePageview` (all four have live consumers). `posthog-js` imports exist only inside the adapter — satisfies the CLAUDE.md optional-service rule for telemetry.
- `lib/features/backend.ts` + `app/global-error.tsx`: raw SDK calls → `safeCaptureException`. backend.ts's local try/catch dropped — the never-throw guarantee is owned by the adapter (verified end-to-end in review; global-error is now strictly safer than before, which called the raw SDK unguarded).
- `PostHogProvider.tsx` → `TelemetryProvider.tsx`: dropped the `posthog-js/react` PHProvider wrapper (zero context consumers, grep-verified); init + pageview + CSP-reporter semantics byte-parity.
- Campaign doc: codified the pre-PR branch-rebuild rule (rebase-only repo).

## Invariants verified (implementer + independent fresh-context review, 8/8 areas CONFIRMED-SAFE)

- Telemetry never throws into app code; init no-ops without `NEXT_PUBLIC_POSTHOG_KEY`
- Pageview unchanged: `$pageview` with `$current_url`, same firing conditions
- RTK error-middleware toast semantics untouched (`lib/store.ts` unmodified)
- CSP reporter installed exactly once

## Verification

- tsc clean, build succeeds
- Tests: 269 files / 3,663 → **269 / 3,670** (+7 adapter contract tests, none lost), all passing
- Full trail + review record: `docs/plans/devx-refactor/02-telemetry-contract.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)