### PR TITLE
refactor(layout): S17 — server-render document shell, providers inside body

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -42,29 +42,30 @@ interface Props {
 
 export default async function RootLayout({ children }: Props) {
   const serverSideProps = await createServerSideProps();
+  const { experience, themeId } = serverSideProps.application;
 
   return (
-    <StoreProvider>
-      <TelemetryProvider>
-        <ThemeRegistry
-          options={{ key: "joy" }}
-          experience={serverSideProps.application.experience}
-          themeId={serverSideProps.application.themeId}
-        >
-          <html lang="en" data-experience={serverSideProps.application.experience}>
-            <body>
+    <html lang="en" data-experience={experience}>
+      <body>
+        <StoreProvider>
+          <TelemetryProvider>
+            <ThemeRegistry
+              options={{ key: "joy" }}
+              experience={experience}
+              themeId={themeId}
+            >
               <Toaster closeButton richColors />
               <PageTitleUpdater />
               <div id="root" style={{ height: "100%", overflow: "hidden" }}>
                 <main>
                   {children}
-                  <AppbarWrapper experience={serverSideProps.application.experience} />
+                  <AppbarWrapper experience={experience} />
                 </main>
               </div>
-            </body>
-          </html>
-        </ThemeRegistry>
-      </TelemetryProvider>
-    </StoreProvider>
+            </ThemeRegistry>
+          </TelemetryProvider>
+        </StoreProvider>
+      </body>
+    </html>
   );
 }

--- a/docs/plans/devx-refactor/17-root-layout-boundary.md
+++ b/docs/plans/devx-refactor/17-root-layout-boundary.md
@@ -1,6 +1,22 @@
 # S17 — root-layout-boundary
 
-Status: pending · Risk: risky (Opus) · PR: —
+Status: reviewed, PR pending · Risk: risky (Opus) · PR: —
+
+### Independent review (fresh-context, Opus): no blocking issues
+
+All checks CONFIRMED-SAFE with evidence: emotion cache has no insertionPoint/prepend
+assumption and `useServerInsertedHTML` is position-independent; the Suspense wraps
+only TelemetryPageView (NOT children — ThemeRegistry still flushes SSR styles);
+`data-joy-color-scheme` was never SSR'd in either structure (no InitColorSchemeScript
+exists; Joy sets documentElement imperatively — identical timing pre/post); classic's
+compound `html[data-experience][data-joy-color-scheme]` selectors (Jackson's flag)
+receive both attributes unchanged; hydration parity (no provider renders a DOM
+wrapper); route table byte-identical (20 routes); scope clean.
+
+**NEEDS-GATE-CHECK (Jackson, at merge or M4):** load classic dark login — confirm
+`.signon-table`/`.title` paint dark without a light flash — and classic dark
+flowsheet, compared against main. Pixel timing is the one thing static analysis
+cannot prove.
 Added 2026-07-15 from charter §8 / `<nextjs_rules>` (REFACTOR_CHARTER.md).
 
 ## Task
@@ -51,3 +67,74 @@ Baseline commands (tsc / full vitest / build with route-table diff) + layout and
 theme test suites. Runtime: this slice lands immediately before a visual gate —
 Jackson smoke-tests theme switching across all four themes, both experiences, login →
 dashboard, and checks the console for hydration warnings.
+
+## Result
+
+Restructured (not a no-change). `<html>`/`<body>` are now emitted by the `RootLayout`
+server component, with `StoreProvider → TelemetryProvider → ThemeRegistry` moved
+inside `<body>`; the `useSearchParams` pageview consumer is isolated behind a
+`Suspense fallback={null}` boundary inside `TelemetryProvider`.
+
+### Investigation — why the providers wrapped `<html>`
+
+The nesting was the common-but-suboptimal App Router pattern, not a technical
+requirement. Inspecting the theme internals (read-only, excluded scope):
+
+- `ThemeRegistry` uses emotion `CacheProvider` + `useServerInsertedHTML` (the
+  emotion-js#2928 SSR pattern) and Joy `CssVarsProvider`. `useServerInsertedHTML`
+  collects `<style>` tags during the server render pass and Next hoists them into
+  `<head>` regardless of where the hook sits in the tree — it does not need to wrap
+  `<html>`.
+- Joy `CssVarsProvider` emits its `:root` vars as injected CSS (into `<head>`) and
+  manipulates `document.documentElement`'s color-scheme attribute imperatively at
+  runtime; neither renders the `<html>` element.
+- The `data-experience` attribute on `<html>` is set directly by the server
+  component from `serverSideProps` — no provider attaches it.
+- `StoreProvider` (Redux) and `TelemetryProvider` (posthog init + pageview + CSP
+  reporter) have no document-shell dependency.
+
+So none of the providers attach anything to `<html>`; the canonical structure
+(server shell, providers inside `<body>`) is safe and is what the MUI/emotion
+official examples use.
+
+### What changed
+
+- `app/layout.tsx`: server component now renders `<html data-experience>`/`<body>`
+  directly; providers nest inside `<body>`. Destructured `experience`/`themeId` from
+  `serverSideProps.application` (readability in a touched file; no behavior change).
+- `src/components/shared/TelemetryProvider.tsx`: wrapped `<TelemetryPageView />` in
+  `<Suspense fallback={null}>`, matching the existing `app/login/layout.tsx`
+  convention for `useSearchParams` consumers.
+
+### Route-table diff
+
+`next build` route classification byte-identical pre/post (20 routes; all `ƒ`
+dynamic except `○ /icon.ico`). The root layout already opts every route into dynamic
+rendering via `cookies()` in `createServerSideProps`, so the `Suspense` boundary
+changed nothing in the table — it hardens against any future static route. Diff of
+the captured route lists: identical.
+
+### Invariant verification
+
+- Theme/experience selection unchanged: `data-experience` still on `<html>` from the
+  same `serverSideProps`; theme vars still injected during SSR via
+  `useServerInsertedHTML`; `#611` reload-only repaint semantics untouched (ThemeRegistry
+  internals not modified). No change to when/how CSS vars are applied → no
+  flash-of-wrong-theme regression.
+- Redux store, pageview timing/payload (`safeCapturePageview` on the same
+  `[pathname, searchParams]` effect), font/global CSS, `<body>` attributes, and
+  `global-error` all unchanged.
+
+### Verification performed
+
+- `npx tsc --noEmit`: clean (pre and post).
+- `npm run build`: passes; route table identical (diff empty).
+- `npm run test:run`: 269 files / 3,670 tests passed — ledger preserved exactly.
+- Focused `ThemedLayout` + `Theme/*` suites: 6 files / 33 tests passed.
+- No tests added (structure change has no new unit-testable surface; the hydration
+  and visual check is the Jackson M4 gate).
+
+### Deviations
+
+None. Excluded scope (ThemeRegistry / StoreProvider internals, theme preference
+hooks, per-route layouts, experiences registry) untouched.

--- a/src/components/shared/TelemetryProvider.tsx
+++ b/src/components/shared/TelemetryProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { initTelemetry, safeCapturePageview } from "@/lib/posthog";
 import { installCspViolationReporter } from "@/lib/csp-violation-reporter";
@@ -36,7 +36,11 @@ export function TelemetryProvider({ children }: Props) {
 
   return (
     <>
-      <TelemetryPageView />
+      {/* useSearchParams must sit under a Suspense boundary so it never forces
+          ancestor routes into dynamic rendering. */}
+      <Suspense fallback={null}>
+        <TelemetryPageView />
+      </Suspense>
       {children}
     </>
   );


### PR DESCRIPTION
Slice S17 of the DevX refactor campaign (charter §8). Two source files.

## What

- `app/layout.tsx`: the server component now renders `<html data-experience>`/`<body>` directly; `StoreProvider → TelemetryProvider → ThemeRegistry` moved inside `<body>` (the canonical App Router structure). Investigation confirmed nothing required the old providers-above-html nesting: emotion's `useServerInsertedHTML` hoists SSR styles to `<head>` regardless of tree position, and Joy sets `data-joy-color-scheme` imperatively on `documentElement`.
- `TelemetryProvider.tsx`: the sole root-graph `useSearchParams` consumer (pageview) is now behind `<Suspense fallback={null}>` (matches the app/login/layout.tsx convention).

## Verified (implementer + independent review, no blocking findings)

- **Classic-mode compound selectors** (`html[data-experience="classic"][data-joy-color-scheme="dark"]` across classic CSS) — both attributes land on `<html>` unchanged with identical timing; neither was provider-position-dependent
- Route table byte-identical (20 routes); hydration parity (no provider renders a DOM wrapper); pageview timing/payload unchanged; Suspense wraps only the pageview component, so ThemeRegistry's SSR style flush is unaffected
- tsc clean; 269 files / 3,670 tests; build passes

## 👀 Merge-time visual check (the one thing statics can't prove)

Load **classic dark login** (`.signon-table`/`.title` should paint dark with no light flash) and **classic dark flowsheet**, compared to main. Modern themes per usual smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)