### PR TITLE
refactor(bin): S12 — replace toast-on-error effect with callback catch

### DIFF
--- a/docs/plans/devx-refactor/00-campaign.md
+++ b/docs/plans/devx-refactor/00-campaign.md
@@ -49,7 +49,7 @@ and test count exactly (minus explicitly deleted duplicates, which must be named
 | 09 | auth-session-ownership | single session/org-role owner; stable useRegistry identities | risky | pending |
 | 10 | flowsheet-search-results-single-source | shared merge/cap pipeline for search + submit | risky | pending |
 | 11 | rightbar-and-experience-read-consolidation | vestigial slice state; one experience read path | moderate | pending |
-| 12 | bin-hooks-cleanup | toast-on-error effect → callback catch | simple | pending |
+| 12 | bin-hooks-cleanup | toast-on-error effect → callback catch | simple | done, no PR |
 | 13 | admin-roster-server-state | RTKQ queryFn over authClient; delete roster-events bus | risky | pending |
 | 14 | comment-reduction-pass | top-density files untouched by earlier slices | simple | pending |
 | 15 | playlist-search-infinite-migration | moved to issue #883 (Jackson, 2026-07-15) | — | out of campaign |

--- a/docs/plans/devx-refactor/12-bin-hooks-cleanup.md
+++ b/docs/plans/devx-refactor/12-bin-hooks-cleanup.md
@@ -1,6 +1,6 @@
 # S12 — bin-hooks-cleanup
 
-Status: pending · Risk: simple (Sonnet) · PR: —
+Status: done · Risk: simple (Sonnet) · PR: —
 
 ## Task
 
@@ -32,3 +32,95 @@ assertions.
 ## Verification
 
 Baseline commands + bin vitest suites. Jackson checks bin error toasts at gate M4.
+
+## Result
+
+**Work removed (charter §7.9):** one `useEffect` in `useBinMutation` (`src/hooks/binHooks.ts`),
+subscribed to the whole RTK Query mutation `result` object just to toast on
+`result.isError`. That's one effect and one whole-object dependency subscription
+eliminated — the toast now raises directly in the `action` callback's
+`.unwrap().catch()`, synchronous with the mutation call that triggered it, with no
+extra render/commit cycle for the effect to observe the error flag and no
+broad-object dependency (`result`) forcing the callback to re-diff on every mutation
+state change (loading flips, etc.), not just on failure.
+
+**Callback design:** `useBinMutation`'s `action` now calls
+`mutate({ dj_id, album_id }).unwrap().catch(() => toast.error(errorMessage))`
+instead of firing the mutation and leaving error handling to a separate effect.
+`errorMessage` moved into the `useCallback` dependency array (previously only an
+effect dependency); it's a static string literal per call site (`useAddToBin` /
+`useDeleteFromBin`), so this doesn't destabilize the callback identity.
+
+**Non-null-assertion findings (charter §12, S19 lint inventory, 2 in this file):**
+both were the `optional-chain-then-non-null` pattern (`info?.id!`), which is *not*
+behavior-neutral to convert into `info!.id` — `?.` short-circuits to `undefined`
+without throwing when `info` is null, while `info!.id` is a plain property access
+that throws at runtime if `info` actually is null. Fixed each with the minimal
+behavior-preserving form instead:
+- `useBin`'s query args: `info?.id!` → `info?.id ?? ""`. The value is only ever
+  read by RTK Query when `skip` is false, and `skip: !info || loading` already
+  guarantees `info` is truthy whenever that happens — so the `""` fallback is
+  never actually sent; it only replaces what was silently `undefined` while the
+  query is skipped.
+- `useBinMutation`'s `action` callback: `info?.id!` → `info.id`. The callback
+  already returns early on `!info` before this line, so TypeScript narrows `info`
+  to non-null here without any assertion — this line is provably identical at
+  runtime to the old `info?.id!` (both reduce to `info.id` once `info` is known
+  truthy).
+
+Both `npm run lint` findings for `@typescript-eslint/no-non-null-asserted-optional-chain`
+in `binHooks.ts` are gone (226 warnings vs. the 228 baseline recorded in S19; 0
+errors, matching baseline). The unrelated `info.id!` in `useClearBin` (no `?.`
+involved, so not flagged by this rule) was left untouched — out of scope.
+
+**Preserved behavior:** identical toast copy on failure ("Failed to add album to
+bin", "Failed to remove album from bin"); `useClearBin`'s partial-failure toast
+(named-albums summary, 3-item truncation with "and N more") is untouched — it
+already handled its own errors via `Promise.allSettled` + `.unwrap()`, not through
+the deleted effect.
+
+**Test adjustments (original pass):** none required at the time — `tests/unit/hooks/binHooks.test.tsx`
+only exercised `useClearBin`, which wasn't touched; no test in the repo asserted
+the `useAddToBin`/`useDeleteFromBin` toast-on-error path directly (grepped for
+`useAddToBin`/`useDeleteFromBin` call sites across `tests/` and `src/`), so there
+were no effect-mechanics assertions to adjust.
+
+**Comment reduction (charter §6):** no removals — the file's pre-existing
+comments (the `useClearBin` doc block, the aggregate-pending-state rationale, the
+failed-titles-summary rationale) each explain a non-obvious reason and were kept.
+One comment added, explaining the `?? ""` fallback's non-obviousness (why not an
+assertion).
+
+### Independent review finding (blocking) and follow-up
+
+The fresh-context review of this slice's diff passed all correctness checks but
+raised one blocking finding: the add/delete toast-on-error path rewired out of
+the effect had **no test coverage anywhere** in the repo, and charter §5.4
+prioritizes failure-handling coverage. The review classified the underlying
+change itself — eliminating the duplicate toast risk the old whole-object effect
+carried (an effect re-running on unrelated `result` field changes, e.g. loading
+flips, was a latent double-toast surface) — as a strict improvement, pending
+Jackson's sign-off via PR.
+
+Addressed by extending `tests/unit/hooks/binHooks.test.tsx` with two new
+`describe` blocks, `useAddToBin` and `useDeleteFromBin`, four cases total:
+
+- add succeeds → `addTrigger` called with `{ dj_id, album_id }`, no toast;
+- add fails → exactly one `toast.error("Failed to add album to bin")`;
+- delete succeeds → `deleteTrigger` called with `{ dj_id, album_id }`, no toast;
+- delete fails → exactly one `toast.error("Failed to remove album from bin")`.
+
+The `useAddToBinMutation` mock changed from a bare `vi.fn()` to a trigger
+returning `{ unwrap: () => ... }` (mirroring the pre-existing `deleteTrigger`
+pattern), gated by a new `addFailIds` set, since the production callback now
+calls `.unwrap()` on the mutate result. A `flushMicrotasks` helper (two
+`await Promise.resolve()`) drains the `.unwrap().catch()` chain, which the
+`action` callback fires but does not return/await. No existing test was
+weakened or altered — all 5 original `useClearBin` cases are unchanged.
+
+**Counts:** 269 files / 3,674 tests, all passing (3,670 campaign-ledger baseline
++ 4 new bin-hooks toast-on-error cases). `npx tsc --noEmit` clean. `npm run lint`:
+0 errors / 226 warnings (unchanged from the first pass; down 2 from the 228 S19
+baseline). `npm run build` succeeds (verified in the first pass; no production
+source changed in this follow-up, test-file-only diff). Focused
+`tests/unit/hooks/binHooks.test.tsx`: 9/9 passing (5 original + 4 new).

--- a/src/hooks/binHooks.ts
+++ b/src/hooks/binHooks.ts
@@ -3,7 +3,7 @@ import {
   useDeleteFromBinMutation,
   useGetBinQuery,
 } from "@/lib/features/bin/api";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useRegistry } from "./authenticationHooks";
 import { useAppSelector } from "@/lib/hooks";
@@ -15,9 +15,11 @@ import { filterBySearchTerms } from "@/src/utilities/filterBySearchTerms";
 export const useBin = () => {
   const { loading, info } = useRegistry();
 
+  // dj_id is unused by the query while skipped; "" avoids asserting through
+  // the null case the skip condition already covers.
   const { data, isLoading, isSuccess, isError } = useGetBinQuery(
     {
-      dj_id: info?.id!,
+      dj_id: info?.id ?? "",
     },
     {
       skip: !info || loading,
@@ -42,16 +44,12 @@ function useBinMutation(
   const action = useCallback(
     (album_id: number) => {
       if (loading || !info) return;
-      mutate({ dj_id: info?.id!, album_id });
+      mutate({ dj_id: info.id, album_id })
+        .unwrap()
+        .catch(() => toast.error(errorMessage));
     },
-    [info, loading, mutate]
+    [info, loading, mutate, errorMessage]
   );
-
-  useEffect(() => {
-    if (result.isError) {
-      toast.error(errorMessage);
-    }
-  }, [result, errorMessage]);
 
   return { action, loading: result.isLoading || loading };
 }

--- a/tests/unit/hooks/binHooks.test.tsx
+++ b/tests/unit/hooks/binHooks.test.tsx
@@ -16,6 +16,15 @@ const deleteTrigger = vi.fn((arg: { dj_id: string; album_id: number }) => ({
       : Promise.resolve(),
 }));
 
+// Same shape for useAddToBin's mutation trigger; unwrap rejects for ids in `addFailIds`.
+const addFailIds = new Set<number>();
+const addTrigger = vi.fn((arg: { dj_id: string; album_id: number }) => ({
+  unwrap: () =>
+    addFailIds.has(arg.album_id)
+      ? Promise.reject(new Error("add failed"))
+      : Promise.resolve(),
+}));
+
 vi.mock("@/src/hooks/authenticationHooks", () => ({
   useRegistry: () => mockUseRegistry(),
 }));
@@ -23,14 +32,21 @@ vi.mock("@/src/hooks/authenticationHooks", () => ({
 vi.mock("@/lib/features/bin/api", () => ({
   useGetBinQuery: (...args: unknown[]) => mockUseGetBinQuery(...args),
   useDeleteFromBinMutation: () => [deleteTrigger, { isLoading: false }],
-  useAddToBinMutation: () => [vi.fn(), { isLoading: false }],
+  useAddToBinMutation: () => [addTrigger, { isLoading: false }],
 }));
 
 vi.mock("sonner", () => ({
   toast: { error: (...a: unknown[]) => toastError(...a) },
 }));
 
-import { useClearBin } from "@/src/hooks/binHooks";
+import { useClearBin, useAddToBin, useDeleteFromBin } from "@/src/hooks/binHooks";
+
+// Flushes the microtask queue past the mutate().unwrap().catch() chain in
+// useBinMutation's action callback, which isn't awaited by the caller.
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 const entry = (id: number) => ({ id, title: `Album ${id}` }) as AlbumEntry;
 
@@ -115,5 +131,71 @@ describe("useClearBin", () => {
     });
 
     expect(deleteTrigger).not.toHaveBeenCalled();
+  });
+});
+
+describe("useAddToBin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addFailIds.clear();
+    mockUseRegistry.mockReturnValue({ loading: false, info: { id: "dj1" } });
+  });
+
+  it("does not toast when the add mutation succeeds", async () => {
+    const { result } = renderHook(() => useAddToBin());
+
+    await act(async () => {
+      result.current.addToBin(1);
+      await flushMicrotasks();
+    });
+
+    expect(addTrigger).toHaveBeenCalledWith({ dj_id: "dj1", album_id: 1 });
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("toasts once with the add-failure message when the add mutation fails", async () => {
+    addFailIds.add(1);
+    const { result } = renderHook(() => useAddToBin());
+
+    await act(async () => {
+      result.current.addToBin(1);
+      await flushMicrotasks();
+    });
+
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastError).toHaveBeenCalledWith("Failed to add album to bin");
+  });
+});
+
+describe("useDeleteFromBin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    failIds.clear();
+    mockUseRegistry.mockReturnValue({ loading: false, info: { id: "dj1" } });
+  });
+
+  it("does not toast when the delete mutation succeeds", async () => {
+    const { result } = renderHook(() => useDeleteFromBin());
+
+    await act(async () => {
+      result.current.deleteFromBin(1);
+      await flushMicrotasks();
+    });
+
+    expect(deleteTrigger).toHaveBeenCalledWith({ dj_id: "dj1", album_id: 1 });
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("toasts once with the remove-failure message when the delete mutation fails", async () => {
+    failIds.add(1);
+    const { result } = renderHook(() => useDeleteFromBin());
+
+    await act(async () => {
+      result.current.deleteFromBin(1);
+      await flushMicrotasks();
+    });
+
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(toastError).toHaveBeenCalledWith("Failed to remove album from bin");
   });
 });


### PR DESCRIPTION
Slice S12 of the DevX refactor campaign (charter §7.4 effect discipline). One production file.

## What

- `src/hooks/binHooks.ts`: the `useBinMutation` toast-on-error `useEffect` (keyed on the whole mutation `result` object) is gone; failures now toast via `.unwrap().catch()` in the action callback. Work removed (charter §7.9): one effect + one whole-object dependency subscription.
- Both S19-flagged `info?.id!` assertions fixed with control-flow-verified substitutions (NOT naive `info!.id`, which would have changed crash semantics) — the two lint warnings disappear (228 → 226).
- +4 tests covering the exact rewired path (review-mandated): failed add/delete → exactly one toast with the same message; success → no toast.

## ⚠️ One deliberate divergence for your sign-off

The old effect could fire **duplicate toasts** (re-renders while error state persisted; StrictMode double-invoke). The new design toasts exactly once per failed call. The independent review classified this as a strict improvement — merging this PR signs off on it.

## Verification

- Ledger: 269 files / **3,674** tests (+4 new, none lost), all passing; tsc clean; lint 0 errors; build passes
- Independent fresh-context review: PASS — behavioral-equivalence enumeration, both assertion fixes verified against control flow (incl. RTK Query skip/cache-key semantics), callback identity stable; its one blocking finding (missing coverage) addressed with the 4 tests
- Trail: `docs/plans/devx-refactor/12-bin-hooks-cleanup.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)