### PR TITLE
refactor(flowsheet): S10 — single-source search-results pipeline for view + submit

### DIFF
--- a/docs/plans/devx-refactor/10-flowsheet-search-results-single-source.md
+++ b/docs/plans/devx-refactor/10-flowsheet-search-results-single-source.md
@@ -1,6 +1,18 @@
 # S10 — flowsheet-search-results-single-source
 
-Status: pending · Risk: risky (Opus) · PR: —
+Status: reviewed, PR pending · Risk: risky (Opus) · PR: —
+
+### Independent review (fresh-context, Opus): APPROVE, no blocking findings
+
+The critical byte-parity check confirmed the two pre-change pipeline copies were
+logically identical (cosmetic identifier differences only) — no consumer's behavior
+changed; the slice eliminates the divergence RISK, not live divergence. Return
+shapes identical for both hooks (all 19 fields); subscription semantics unchanged
+(neither copy ever used conditional skip); agreement tests verified against the
+real MAX_VISIBLE_RESULTS=50 and assert through both public hooks only; all flagged
+comment rationale survives. Advisory applied: §7.9 wording tightened below — the
+removal is the second maintained copy and its drift risk; runtime dual-mount cost
+is unchanged (both hooks still subscribe when mounted; RTKQ dedupes the network).
 
 ## Task
 
@@ -38,3 +50,75 @@ resolve identically for the same query; all flowsheet tests pass.
 Baseline commands + flowsheet hook/component vitest suites; CI e2e `flowsheet/` suite.
 Comment reduction in `flowsheetHooks.ts` (93 lines — keep perf rationale, drop step
 narration) happens here.
+
+## Result
+
+### Design
+
+Both `useFlowsheetSearch` and `useFlowsheetSubmit` previously carried their own copy
+of the entire 4-source pipeline — the four source subscriptions (bin / rotation /
+catalog / lml), the byte-similar `lmlResults` dedupe memo, the `allSearchResults`
+cap/concat memo, and the `selectedResult → selectedEntry` resolution. Those two copies
+were the #657 divergence hazard: the row the view highlights and the entry submit
+carries were resolved by independent code that could drift.
+
+Introduced one private hook, `useFlowsheetSearchResults()`, that owns the pipeline end
+to end and returns `{ searchQuery, selectedResult, binResults, catalogResults,
+rotationResults, lmlResults (deduped), selectedEntry }`. `useFlowsheetSearch` consumes
+it for `selectedEntry` + `getDisplayValue`; `useFlowsheetSubmit` consumes it for the
+result arrays + `selectedResultData`. No component API changed — every consumer keeps
+its exact return shape (verified: `FlowsheetSearchbar`, `FlowsheetSearchInput`,
+`NewEntryPreview`, `FlowsheetBackendResult`, `RotationModeToggle`, `TalksetButton`,
+`BreakpointButton`, `RotationEntryFields`). No wrapper-hook fragmentation (charter
+§7.2): one real shared implementation, not renamed forwarders.
+
+### Work removed (§7.9)
+
+What is removed is the second MAINTAINED COPY of the pipeline — a second `lmlResults`
+dedupe memo, `allSearchResults` cap/concat memo, `selectedEntry` resolution, and set
+of four source-hook subscription SITES in source code — and with it the #657 drift
+risk. This is a maintainability/correctness-risk removal, not a runtime-work
+removal: both consumer hooks still mount and subscribe (RTKQ dedupes the network),
+so per-render cost is unchanged. The cap ordering
+(bin → rotation → catalog → lml) and `MAX_VISIBLE_RESULTS` coupling with
+`FlowsheetSearchResults` offsets and the searchbar nav bound are unchanged. (Honest
+scope note: `useFlowsheetSubmit`'s per-row execution via `FlowsheetBackendResult` is
+untouched — out of scope — so the dual-mount render cost in the searchbar itself is
+unchanged; the removal is the second maintained copy of the derivation and its
+divergence risk, not the per-mount memo count.)
+
+### Invariant evidence
+
+- **#657 (view/submit agree):** structurally guaranteed — both hooks resolve
+  `selectedEntry` from the single `useFlowsheetSearchResults` concat, so divergence is
+  no longer expressible. New test block `search view / submit agreement for the same
+  query (#657)` in `tests/unit/hooks/flowsheetHooks.test.tsx` renders
+  `useFlowsheetSearch` + `useFlowsheetSubmit` against one store and asserts they resolve
+  the same album id/title (incl. `getDisplayValue("album")` === `selectedResultData.album`)
+  at a mid-list index, at the last visible capped row (index 50 → the 50th painted
+  album, id 2049), and past the cap (index 51 → both fall back to manual entry, never an
+  unseen album).
+- **Dedupe order / cap coupling:** preserved verbatim in the shared memo; existing
+  `visible-index → submission mapping under the render cap (#657)` tests still pass
+  unweakened.
+- **Excluded scope untouched:** no changes to `lib/features/flowsheet/*`, search UI
+  components, or queue logic.
+
+### Comment reduction
+
+`flowsheetHooks.ts` comment lines 93 → 83. Dropped step narration (per-branch
+"User is creating…", "Deduplicate LML results…", "Get the display value…", "Combine
+both keyboard listeners…", "Flatten all pages…"); the two duplicated #657 blocks
+collapse into one concise invariant doc on `useFlowsheetSearchResults`. Kept: the
+Ctrl+Enter ref-race rationale, the HTML5-validation-bypass guard note, `NO_MUTATION_STATE`
+/ per-row narrowing rationale, and all #644 queue-clear commentary.
+
+### Verification
+
+- `npx tsc --noEmit`: clean.
+- `npm run lint`: 0 errors (pre-existing warnings only; none in touched files).
+- `npm run test:run`: 269 files / 3679 tests pass (ledger 3676 + 3 new agreement tests).
+- Focused: `flowsheetHooks.test.tsx` 92 pass; flowsheet component integration suite
+  (32 files / 450 tests) pass.
+- `npm run build`: succeeds.
+- Not locally verified: CI e2e `flowsheet/` suite (runs on the PR).

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -165,6 +165,66 @@ export const useShowControl = () => {
 export const useFlowsheetSaving = (): boolean =>
   useAppSelector(selectFlowsheetMutationPending);
 
+/**
+ * The one flowsheet search pipeline — four ordered sources
+ * (bin → rotation → catalog → lml), LML dedupe against the first three, and the
+ * MAX_VISIBLE_RESULTS-capped concat that FlowsheetSearchResults' offsets and
+ * FlowsheetSearchbar's arrow-key bound share. Search view (useFlowsheetSearch)
+ * and submit (useFlowsheetSubmit) resolve their selected entry from this single
+ * implementation, so the highlighted row and the submitted entry can never
+ * resolve to different albums — the divergence two hand-kept copies allowed. (#657)
+ */
+const useFlowsheetSearchResults = () => {
+  const searchQuery = useAppSelector(flowsheetSlice.selectors.getSearchQuery);
+  const selectedResult = useAppSelector(
+    flowsheetSlice.selectors.getSelectedResult
+  );
+
+  const { searchResults: binResults } = useBinResults();
+  const { searchResults: catalogResults } = useCatalogFlowsheetSearch();
+  const { searchResults: rotationResults } = useRotationFlowsheetSearch();
+  const { results: rawLmlResults } = useLmlLibrarySearch({
+    artist: searchQuery.artist,
+    album: searchQuery.album,
+  });
+
+  const lmlResults = useMemo(() => {
+    const seen = new Set<number>();
+    for (const r of binResults) seen.add(r.id);
+    for (const r of rotationResults) seen.add(r.id);
+    for (const r of catalogResults) seen.add(r.id);
+    return rawLmlResults.filter((r) => !seen.has(r.id));
+  }, [binResults, rotationResults, catalogResults, rawLmlResults]);
+
+  const allSearchResults = useMemo(
+    () => [
+      ...binResults.slice(0, MAX_VISIBLE_RESULTS),
+      ...rotationResults.slice(0, MAX_VISIBLE_RESULTS),
+      ...catalogResults.slice(0, MAX_VISIBLE_RESULTS),
+      ...lmlResults.slice(0, MAX_VISIBLE_RESULTS),
+    ],
+    [binResults, rotationResults, catalogResults, lmlResults]
+  );
+
+  const selectedEntry = useMemo(
+    () =>
+      selectedResult === 0
+        ? null
+        : allSearchResults[selectedResult - 1] ?? null,
+    [selectedResult, allSearchResults]
+  );
+
+  return {
+    searchQuery,
+    selectedResult,
+    binResults,
+    catalogResults,
+    rotationResults,
+    lmlResults,
+    selectedEntry,
+  };
+};
+
 export const useFlowsheetSearch = () => {
   const { live, loading } = useShowControl();
   const isSaving = useFlowsheetSaving();
@@ -175,67 +235,37 @@ export const useFlowsheetSearch = () => {
     dispatch(flowsheetSlice.actions.setSearchOpen(open));
   };
   const resetSearch = () => dispatch(flowsheetSlice.actions.resetSearch());
-  const searchQuery = useAppSelector(flowsheetSlice.selectors.getSearchQuery);
-  const selectedIndex = useAppSelector(flowsheetSlice.selectors.getSelectedResult);
   const setSearchProperty = (name: FlowsheetSearchProperty, value: string) => {
     dispatch(flowsheetSlice.actions.setSearchProperty({ name, value }));
   };
 
-  // Get the selected entry from search results
-  const { searchResults: binResults } = useBinResults();
-  const { searchResults: catalogResults } = useCatalogFlowsheetSearch();
-  const { searchResults: rotationResults } = useRotationFlowsheetSearch();
-  const { results: rawLmlResults } = useLmlLibrarySearch({
-    artist: searchQuery.artist,
-    album: searchQuery.album,
-  });
+  const {
+    searchQuery,
+    selectedResult: selectedIndex,
+    selectedEntry,
+  } = useFlowsheetSearchResults();
 
-  // Deduplicate LML results against the other three sources
-  const lmlResults = useMemo(() => {
-    const seen = new Set<number>();
-    for (const r of binResults) seen.add(r.id);
-    for (const r of rotationResults) seen.add(r.id);
-    for (const r of catalogResults) seen.add(r.id);
-    return rawLmlResults.filter((r) => !seen.has(r.id));
-  }, [binResults, rotationResults, catalogResults, rawLmlResults]);
-
-  // Each section is capped to MAX_VISIBLE_RESULTS in the results dropdown, so
-  // the selectedResult index space maps into the capped concatenation — same
-  // order and same cap as FlowsheetSearchResults' offsets, keeping the
-  // highlighted row and the resolved entry in lockstep. (#657)
-  const allSearchResults = useMemo(() => [
-    ...binResults.slice(0, MAX_VISIBLE_RESULTS),
-    ...rotationResults.slice(0, MAX_VISIBLE_RESULTS),
-    ...catalogResults.slice(0, MAX_VISIBLE_RESULTS),
-    ...lmlResults.slice(0, MAX_VISIBLE_RESULTS),
-  ], [binResults, rotationResults, catalogResults, lmlResults]);
-
-  const selectedEntry = useMemo(() => {
-    if (selectedIndex === 0) return null;
-    return allSearchResults[selectedIndex - 1] ?? null;
-  }, [selectedIndex, allSearchResults]);
-
-  // Get the display value for a field - either from selected result or raw query
-  const getDisplayValue = useCallback((name: FlowsheetSearchProperty): string => {
-    if (selectedIndex === 0 || !selectedEntry) {
-      // Show raw query values when creating new
-      return searchQuery[name] as string;
-    }
-    
-    // Show selected result values when a result is selected
-    switch (name) {
-      case "song":
-        return searchQuery.song as string; // Always show user input for song
-      case "artist":
-        return selectedEntry.artist?.name || searchQuery.artist as string;
-      case "album":
-        return selectedEntry.title || searchQuery.album as string;
-      case "label":
-        return selectedEntry.label || searchQuery.label as string;
-      default:
+  const getDisplayValue = useCallback(
+    (name: FlowsheetSearchProperty): string => {
+      if (selectedIndex === 0 || !selectedEntry) {
         return searchQuery[name] as string;
-    }
-  }, [selectedIndex, selectedEntry, searchQuery]);
+      }
+      switch (name) {
+        case "song":
+          // Song always reflects the DJ's own input, even under a selection.
+          return searchQuery.song as string;
+        case "artist":
+          return selectedEntry.artist?.name || (searchQuery.artist as string);
+        case "album":
+          return selectedEntry.title || (searchQuery.album as string);
+        case "label":
+          return selectedEntry.label || (searchQuery.label as string);
+        default:
+          return searchQuery[name] as string;
+      }
+    },
+    [selectedIndex, selectedEntry, searchQuery]
+  );
 
   return {
     live,
@@ -269,7 +299,6 @@ export const useFlowsheet = () => {
     pollingInterval: flowsheetPollingInterval,
   });
 
-  // Flatten all pages into a single deduplicated, sorted array
   const allEntries = useMemo(() => {
     if (!infiniteData?.pages) return [];
     const map = new Map<number, FlowsheetEntry>();
@@ -541,53 +570,18 @@ export const useFlowsheetSubmit = () => {
     }
   }, []);
 
-  const { searchResults: binResults } = useBinResults();
-  const { searchResults: catalogResults } = useCatalogFlowsheetSearch();
-  const { searchResults: rotationResults } = useRotationFlowsheetSearch();
+  const {
+    searchQuery: flowSheetRawQuery,
+    selectedResult,
+    binResults,
+    catalogResults,
+    rotationResults,
+    lmlResults,
+    selectedEntry,
+  } = useFlowsheetSearchResults();
 
-  const selectedResult = useAppSelector(
-    flowsheetSlice.selectors.getSelectedResult
-  );
-
-  const flowSheetRawQuery = useAppSelector(
-    flowsheetSlice.selectors.getSearchQuery
-  );
-
-  const { results: rawLmlResults } = useLmlLibrarySearch({
-    artist: flowSheetRawQuery.artist,
-    album: flowSheetRawQuery.album,
-  });
-
-  // Deduplicate LML results against the other three sources
-  const lmlResults = useMemo(() => {
-    const seen = new Set<number>();
-    for (const r of binResults) seen.add(r.id);
-    for (const r of rotationResults) seen.add(r.id);
-    for (const r of catalogResults) seen.add(r.id);
-    return rawLmlResults.filter((r) => !seen.has(r.id));
-  }, [binResults, rotationResults, catalogResults, rawLmlResults]);
-
-  // Memoized collection of all VISIBLE search results. Must mirror the capped
-  // index space (FlowsheetSearchResults offsets + FlowsheetSearchbar nav
-  // bound): submitting through the full lists would map a visible index onto a
-  // different, unseen album whenever an earlier section is truncated. (#657)
-  const allSearchResults = useMemo(() => [
-    ...binResults.slice(0, MAX_VISIBLE_RESULTS),
-    ...rotationResults.slice(0, MAX_VISIBLE_RESULTS),
-    ...catalogResults.slice(0, MAX_VISIBLE_RESULTS),
-    ...lmlResults.slice(0, MAX_VISIBLE_RESULTS),
-  ], [binResults, rotationResults, catalogResults, lmlResults]);
-
-  // Memoized selected entry (null if creating new)
-  const selectedEntry = useMemo(() => {
-    if (selectedResult === 0) return null;
-    return allSearchResults[selectedResult - 1] ?? null;
-  }, [selectedResult, allSearchResults]);
-
-  // Memoized calculation of the selected result data
   const selectedResultData = useMemo<FlowsheetQuery>(() => {
     if (selectedResult == 0 || !selectedEntry) {
-      // User is creating a new entry manually (or in rotation mode)
       return {
         song: flowSheetRawQuery.song as string,
         artist: flowSheetRawQuery.artist as string,
@@ -600,8 +594,7 @@ export const useFlowsheetSubmit = () => {
         request: flowSheetRawQuery.request,
       };
     } else {
-      // User has selected a result from the search
-      // Use result values if available, otherwise fall back to user edits
+      // Selected result fields win; each falls back to the DJ's typed value.
       return {
         song: flowSheetRawQuery.song as string,
         artist: selectedEntry.artist?.name || flowSheetRawQuery.artist as string,
@@ -658,7 +651,6 @@ export const useFlowsheetSubmit = () => {
     ]
   );
 
-  // Combine both keyboard listeners into one effect
   useEffect(() => {
     document.addEventListener("keydown", handleKeyDown);
     document.addEventListener("keyup", handleKeyUp);

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -1847,4 +1847,82 @@ describe("flowsheetHooks", () => {
       expect(result.current.selectedEntry?.id).toBe(999);
     });
   });
+
+  // The search view (useFlowsheetSearch) and the submit path (useFlowsheetSubmit)
+  // now resolve the selected result through one shared pipeline
+  // (useFlowsheetSearchResults). This proves the #657 invariant structurally:
+  // for the same query and selectedResult, the album the view highlights and the
+  // album the submission carries are always the same one — including at the
+  // MAX_VISIBLE_RESULTS cap boundary where a divergent second copy could drift.
+  describe("search view / submit agreement for the same query (#657)", () => {
+    const manyAlbums = Array.from({ length: 500 }, (_, i) =>
+      createTestAlbum({
+        id: 2000 + i,
+        title: `Agree Album ${i}`,
+        artist: createTestArtist({ name: "Juana Molina" }),
+      })
+    );
+
+    const wrapperWithSelected = (selectedResult: number) =>
+      createHookWrapper(
+        { flowsheet: flowsheetSlice, liveUpdates: liveUpdatesSlice },
+        {
+          flowsheet: {
+            ...flowsheetSlice.getInitialState(),
+            search: {
+              ...flowsheetSlice.getInitialState().search,
+              selectedResult,
+              query: {
+                ...flowsheetSlice.getInitialState().search.query,
+                song: "la paradoja",
+              },
+            },
+          },
+        }
+      );
+
+    const renderBoth = (selectedResult: number) =>
+      renderHook(
+        () => ({ search: useFlowsheetSearch(), submit: useFlowsheetSubmit() }),
+        { wrapper: wrapperWithSelected(selectedResult) }
+      );
+
+    it("resolves the highlighted view row and the submitted entry to the same album", () => {
+      mockUseCatalogFlowsheetSearch.mockReturnValue({ searchResults: manyAlbums });
+
+      const { result } = renderBoth(10);
+
+      const viewEntry = result.current.search.selectedEntry;
+      const submitEntry = result.current.submit.selectedEntry;
+
+      expect(viewEntry).not.toBeNull();
+      expect(viewEntry?.id).toBe(submitEntry?.id);
+      expect(result.current.submit.selectedResultData.album_id).toBe(viewEntry?.id);
+      expect(result.current.submit.selectedResultData.album).toBe(viewEntry?.title);
+      // What the view input paints must equal what the submission carries.
+      expect(result.current.search.getDisplayValue("album")).toBe(
+        result.current.submit.selectedResultData.album
+      );
+    });
+
+    it("agrees at the last visible capped row (index 50 → the 50th painted album)", () => {
+      mockUseCatalogFlowsheetSearch.mockReturnValue({ searchResults: manyAlbums });
+
+      const { result } = renderBoth(50);
+
+      expect(result.current.search.selectedEntry?.id).toBe(2049);
+      expect(result.current.submit.selectedEntry?.id).toBe(2049);
+      expect(result.current.submit.selectedResultData.album_id).toBe(2049);
+    });
+
+    it("agrees on manual entry past the visible cap — never an unseen album (index 51)", () => {
+      mockUseCatalogFlowsheetSearch.mockReturnValue({ searchResults: manyAlbums });
+
+      const { result } = renderBoth(51);
+
+      expect(result.current.search.selectedEntry).toBeNull();
+      expect(result.current.submit.selectedEntry).toBeNull();
+      expect(result.current.submit.selectedResultData.album_id).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
Slice S10 of the DevX refactor campaign. One production file; three files total.

## What

`useFlowsheetSearch` and `useFlowsheetSubmit` each carried a full copy of the 4-source (bin → rotation → catalog → lml) merge/dedupe/cap pipeline — the exact duplication that produces #657-class bugs (highlighted row and submitted entry resolving to different albums). Both now consume one private `useFlowsheetSearchResults()`; **divergence is no longer expressible in the code**.

Framing per review: this is a **maintainability/correctness-risk removal, not a runtime optimization** — the review confirmed the two copies were still logically identical (the slice removed the drift risk before it became a bug), both hooks keep their exact 11- and 8-field return shapes, and runtime subscription behavior is unchanged (RTKQ dedupes the network).

## Verification

- +3 agreement tests asserting through both public hooks against one store, at the boundary indices of the real `MAX_VISIBLE_RESULTS=50` (mid-list, last visible row, past-cap → both fall back to manual entry, never an unseen album)
- tsc clean; lint 0 errors; **269 files / 3,679 tests** pass; build passes; flowsheet integration suite 450/450
- Independent fresh-context review: **APPROVE, no blocking findings** (pipeline byte-parity verified against both pre-change copies line by line)
- Known noise: the full-suite run can exit nonzero from the pre-existing jsdom `_location` teardown flake (all tests pass; unrelated file; predates the campaign)
- Comments 93 → 83, all issue-numbered rationale kept
- **CI e2e `flowsheet/` suite is the runtime gate** — worth watching before merge
- Trail: `docs/plans/devx-refactor/10-flowsheet-search-results-single-source.md`

## 🎯 Gate M3 after merge

Auth/login/role-gating smoke (S9 landed) + flowsheet search from all four sources: for each of bin/rotation/catalog/LML, the highlighted row must match what submits — including at the bottom of a long result list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)