### PR TITLE
fix(e2e): hydration-safe password-form switch in auth setup

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -26,9 +26,13 @@ async function performLogin(
     name: "Sign in with password instead",
   });
   await passwordLink.waitFor({ state: "visible", timeout: 15000 });
-  await passwordLink.click();
-
-  await page.waitForSelector('input[name="username"]');
+  // The switch is a client onClick: a click that lands before hydration
+  // attaches the handler is a silent no-op. Retry the click until the
+  // password form actually appears.
+  await expect(async () => {
+    await passwordLink.click();
+    await page.waitForSelector('input[name="username"]', { timeout: 1500 });
+  }).toPass({ timeout: 15000 });
   await page.fill('input[name="username"]', username);
   await page.fill('input[name="password"]', password);
 


### PR DESCRIPTION
**Fixes the intermittent auth.setup failure** seen on #905 (shard 4, called a flake at the time — incorrectly) and now on main post-S11 (shard 2, music-director setup).

## Root cause

The password-login switch is a client `onClick` in `EmailOTPForm`. Playwright clicks on *visibility*, but a click before React hydration attaches the handler is a silent no-op — the setup then waits 10s for a form that never switches. A latent race in the test since it was written; S11's removal of the appbar's `getActiveExperience` fetch shifted the login page's load waterfall enough to make it fire regularly in CI. Product code is not implicated (humans and most shards never hit it; failures occur exactly and only at the un-attached-handler window).

## Fix

Standard hydration-safe pattern: `expect(async () => { click; waitForSelector(1.5s) }).toPass(15s)` — the click itself retries until it takes effect.

Verified locally: the switch now succeeds on every setup; remaining local failures are the known dev-DB seed-user gap, at the submit stage.

## Process note

The #905 shard-4 failure was re-run to green without root-cause — that's how this reached main. Going forward: no rerun-to-green on campaign PRs without an identified cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)