### PR TITLE
fix(e2e): hydration-tolerant wait for RBAC deny redirect

### DIFF
--- a/e2e/pages/dashboard.page.ts
+++ b/e2e/pages/dashboard.page.ts
@@ -146,18 +146,20 @@ export class DashboardPage {
    * Users without proper permissions should be redirected away from admin pages
    */
   async expectRedirectedToDefaultDashboard(): Promise<void> {
-    // Wait for navigation to complete
-    await this.page.waitForLoadState("domcontentloaded");
-    // Give the app time to process the redirect
-    await this.page.waitForTimeout(1000);
-    const url = this.page.url();
-    // Should be redirected to dashboard, flowsheet, or catalog (NOT admin pages)
-    const isOnDashboard = url.includes("/dashboard");
-    const isNotOnAdminPage = !url.includes("/dashboard/admin");
-    const isNotOnLogin = !url.includes("/login");
-    // Accept any non-admin dashboard page as a valid redirect destination
-    const isValidRedirect = isOnDashboard && isNotOnAdminPage && isNotOnLogin;
-    expect(isValidRedirect, `Expected redirect to dashboard (not admin), got: ${url}`).toBe(true);
+    // The deny redirect can arrive as a streaming-SSR client redirect (the shell
+    // flushes at the admin URL first, the router soft-navigates after hydration),
+    // so poll for the final URL instead of sampling after a fixed delay.
+    await this.page.waitForURL(
+      (u) => {
+        const url = u.toString();
+        return (
+          url.includes("/dashboard") &&
+          !url.includes("/dashboard/admin") &&
+          !url.includes("/login")
+        );
+      },
+      { timeout: 15000 }
+    );
   }
 
   /**


### PR DESCRIPTION
Fixes the intermittent shard-4 failure on #907 (`role-access.spec.ts:109`, member not redirected from admin pages within the wait).

## Investigation summary (full trace by fresh-context agent)

- **Not a security regression.** The guard is server-side (`requireRole` in the roster page's Server Component) and **fail-closed** for members — the roster body is never rendered. Backend-Service authorizes every admin API call independently.
- The deny `redirect()` fires after Next 16 has begun streaming the dashboard shell, so it's delivered as a **post-hydration client redirect** (200 at the admin URL + RSC redirect), not a 307. The page object sampled the URL after a **fixed 1s wait** — a pre-existing race that campaign-added hydration weight (adminApi reducer, auth-hook restructure) widened. Guard code untouched by any campaign slice (git-log verified).
- Fix mirrors the existing `expectRedirectedToLogin` pattern: poll `waitForURL` (15s) for a non-admin dashboard URL.

## Related hardening (filed separately, not this PR)

- `getUserAuthority`'s session fallback maps base `admin`/`owner` → SM on transient org-resolution failure (fail-open for that narrow class); middleware-level admin gating would also make the deny an atomic 307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)