### PR TITLE
fix(flowsheet): make optimistic→server cache swap idempotent (Part of #860)

### DIFF
--- a/lib/features/flowsheet/infinite-cache.ts
+++ b/lib/features/flowsheet/infinite-cache.ts
@@ -145,15 +145,23 @@ export function insertEntrySortedFirstPage(
   }
 }
 
-export function removeEntryById(draft: InfiniteEntriesDraft, id: number): void {
-  // No early return: ids must not survive on any page (the "AllPages" caller
-  // below depends on it), even if a bug elsewhere duplicated one (#643).
+/**
+ * Remove every row carrying `id` from every page. All copies must go, including
+ * duplicates on a single page, because the swap below relies on the id surviving
+ * on no page. Iterate back-to-front so a splice can't shift an unchecked row
+ * past the cursor.
+ */
+export function removeEntryById(draft: InfiniteEntriesDraft, id: number): boolean {
+  let removed = false;
   for (const page of draft.pages) {
-    const index = page.findIndex((item) => item.id === id);
-    if (index !== -1) {
-      page.splice(index, 1);
+    for (let i = page.length - 1; i >= 0; i--) {
+      if (page[i].id === id) {
+        page.splice(i, 1);
+        removed = true;
+      }
     }
   }
+  return removed;
 }
 
 export function patchEntryById(
@@ -170,19 +178,23 @@ export function patchEntryById(
   }
 }
 
-/** Replace the entry with `tempId` everywhere it appears with `serverEntry`. */
+/**
+ * Replace the optimistic `tempId` row with `serverEntry`. A refetch may have
+ * already placed the real row in the cache before this runs, so `serverEntry.id`
+ * is removed before inserting to keep it present exactly once.
+ */
 export function replaceEntryIdAllPages(
   draft: InfiniteEntriesDraft,
   tempId: number,
   serverEntry: FlowsheetEntry
 ): void {
-  if (!draft.pages.some((page) => page.some((e) => e.id === tempId))) {
-    // Instrumentation for #860 (entries transiently vanishing after re-sync):
-    // a missed swap means the optimistic row was already gone when the server
-    // response landed. The insert below still runs, so the server entry is
-    // never lost. Known benign source of the same signal: a DJ deleting
-    // their just-submitted row before its POST resolves — correlate ids when
-    // analyzing, don't treat every event as a #860 repro.
+  const tempRemoved = removeEntryById(draft, tempId);
+  const serverRowAlreadyPresent = removeEntryById(draft, serverEntry.id);
+  insertEntrySortedFirstPage(draft, serverEntry);
+
+  // A miss only when neither row was present: an already-present server row is a
+  // benign refetch-race, not a lost optimistic entry.
+  if (!tempRemoved && !serverRowAlreadyPresent) {
     safeCapture("flowsheet_optimistic_replace_miss", {
       tempId,
       serverEntryId: serverEntry.id,
@@ -193,8 +205,6 @@ export function replaceEntryIdAllPages(
       );
     }
   }
-  removeEntryById(draft, tempId);
-  insertEntrySortedFirstPage(draft, serverEntry);
 }
 
 /**

--- a/tests/unit/lib/features/flowsheet/infinite-cache.test.ts
+++ b/tests/unit/lib/features/flowsheet/infinite-cache.test.ts
@@ -178,6 +178,44 @@ describe("infinite-cache", () => {
     expect(safeCaptureMock).not.toHaveBeenCalled();
   });
 
+  it("replaceEntryIdAllPages leaves the server id exactly once when the refetch already landed it (#860)", () => {
+    safeCaptureMock.mockClear();
+    const draft = {
+      pages: [[song(51, 11, 1), song(50, 10, 1), song(49, 9, 1)]],
+      pageParams: [0],
+    };
+    replaceEntryIdAllPages(draft, -5, song(51, 11, 1));
+    const ids = draft.pages.flat().map((e) => e.id);
+    expect(ids.filter((id) => id === 51)).toHaveLength(1);
+    expect(ids).toEqual([51, 50, 49]);
+  });
+
+  it("replaceEntryIdAllPages does not emit telemetry when the server row already landed (benign refetch-race, #860)", () => {
+    safeCaptureMock.mockClear();
+    const draft = {
+      pages: [[song(51, 11, 1), song(50, 10, 1)]],
+      pageParams: [0],
+    };
+    replaceEntryIdAllPages(draft, -5, song(51, 11, 1));
+    expect(safeCaptureMock).not.toHaveBeenCalled();
+  });
+
+  it("removeEntryById removes every copy of a same-page duplicate id (#860)", () => {
+    const draft = {
+      pages: [[song(9, 9, 1), song(7, 5, 1), song(7, 5, 1), song(3, 3, 1)]],
+      pageParams: [0],
+    };
+    const removed = removeEntryById(draft, 7);
+    expect(removed).toBe(true);
+    expect(draft.pages[0].map((e) => e.id)).toEqual([9, 3]);
+  });
+
+  it("removeEntryById reports whether it removed anything", () => {
+    const draft = { pages: [[song(9, 9, 1)]], pageParams: [0] };
+    expect(removeEntryById(draft, 999)).toBe(false);
+    expect(removeEntryById(draft, 9)).toBe(true);
+  });
+
   it("primaryShowId skips orphaned entries so one null-show row can't read as 'nobody live' (#629)", () => {
     const orphan = song(90, 12, -1);
     const draft = { pages: [[orphan, song(89, 11, 5)], [song(88, 10, 5)]], pageParams: [0, 1] };


### PR DESCRIPTION
## Part of #860

A max-effort review of the instrumented optimistic→server swap (post-#861) found a concrete cache-integrity defect in the same function the `flowsheet_optimistic_replace_miss` telemetry watches. This lands the correctness fix; **#860 stays open** for telemetry observation.

### The defect
`replaceEntryIdAllPages` removed only `tempId`, then unconditionally inserted `serverEntry` (and `insertEntrySortedFirstPage` does not dedupe). When an SSE/poll refetch (`invalidateTags(["Flowsheet"])`) lands the real row before the POST resolves — reachable because `addToFlowsheet` invalidates only `["NowPlaying"]`, never `getInfiniteEntries` — the cache ended up holding `serverEntry.id` twice. The render map dedupes by id (last-write-wins), so it read as transient duplication "fixed by hard refresh." `removeEntryById` compounded it by splicing only the first match per page, breaking its own "ids must not survive on any page" invariant on a same-page duplicate.

### The fix
1. **Idempotent swap** — `replaceEntryIdAllPages` now removes `serverEntry.id` as well as `tempId` before inserting, so the id appears exactly once.
2. **Full removal** — `removeEntryById` removes every match per page (back-to-front splice) and returns whether it removed anything.
3. **Telemetry precision** — `flowsheet_optimistic_replace_miss` fires only on a genuine loss (neither `tempId` nor `serverEntry.id` present). The benign refetch-race that the dedupe silently repairs no longer inflates the metric. The separate `pages.some(...)` pre-scan is dropped in favor of the `removeEntryById` return value.

### Acceptance criteria → tests (`tests/unit/lib/features/flowsheet/infinite-cache.test.ts`)
| Criterion | Test |
|---|---|
| (a) cache already contains `serverEntry.id` → id appears exactly once after swap | `replaceEntryIdAllPages leaves the server id exactly once when the refetch already landed it (#860)` |
| (b) same-page duplicate → `removeEntryById` removes both | `removeEntryById removes every copy of a same-page duplicate id (#860)` (+ `removeEntryById reports whether it removed anything`) |
| (c) telemetry only on genuine loss | `...does not emit telemetry when the server row already landed (benign refetch-race, #860)` (benign path) + existing `...capturing the #860 telemetry event` (genuine-loss path, still green) |
| (d) no behavior change to the common path; existing cases stay green unmodified | full `infinite-cache.test.ts` (36 tests) + suite (3677) pass unmodified |

### Scope note (low-severity, no change made)
The issue also flagged `convertV2Entry` mapping `show_id` with `?? -1`, worrying a wire `show_id: 0` could re-open the #629 collision. Checked and **left unchanged**: the wire contract (`@wxyc/shared` `FlowsheetV2Base.show_id: number | null`) represents a no-show row as `null`, so `?? -1` sentinels exactly the no-show case, and `0` is a legitimate real show id that must survive. Not a bug; noting here as the requested follow-up observation.

### Verification
`npx tsc --noEmit` · `npm run lint` (0 errors) · `npm run test:run` (3677 passed) · `npm run build` — all green. Untouched: SSE listener, `deferred-refetch.ts`, `FlowsheetSearchbar.tsx`.

Issue #860 stays open pending correlation of live `flowsheet_optimistic_replace_miss` telemetry against this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)