### PR TITLE
fix(theme): SSR data-joy-color-scheme to kill first-paint flash (#894)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from "react";
+import InitColorSchemeScript from "@mui/joy/InitColorSchemeScript";
 import { StoreProvider } from "@/src/StoreProvider";
 import { TelemetryProvider } from "@/src/components/shared/TelemetryProvider";
 
@@ -47,6 +48,12 @@ export default async function RootLayout({ children }: Props) {
   return (
     <html lang="en" data-experience={experience}>
       <body>
+        {/*
+          Must remain the first child of <body> so its inline script stamps
+          data-joy-color-scheme before hydration. Reads the same storage keys
+          CssVarsProvider (and useThemePreferenceSync via setMode) persist to.
+        */}
+        <InitColorSchemeScript />
         <StoreProvider>
           <TelemetryProvider>
             <ThemeRegistry

--- a/tests/integration/app/InitColorSchemeScript.test.tsx
+++ b/tests/integration/app/InitColorSchemeScript.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import InitColorSchemeScript from "@mui/joy/InitColorSchemeScript";
+
+describe("InitColorSchemeScript SSR contract", () => {
+  const markup = renderToStaticMarkup(<InitColorSchemeScript />);
+
+  it("emits a synchronous inline script (runs before hydration)", () => {
+    expect(markup).toContain("<script");
+    expect(markup).toContain("localStorage.getItem");
+  });
+
+  it("stamps the data-joy-color-scheme attribute classic CSS keys on", () => {
+    expect(markup).toContain("data-joy-color-scheme");
+    expect(markup).toContain("setAttribute");
+  });
+
+  it("reads the same storage keys CssVarsProvider persists to", () => {
+    expect(markup).toContain("joy-mode");
+    expect(markup).toContain("joy-color-scheme");
+  });
+});


### PR DESCRIPTION
Closes #894

## Root cause
No `InitColorSchemeScript`/`getInitColorSchemeScript` existed anywhere in the repo, so `data-joy-color-scheme` was only ever applied imperatively by Joy's `CssVarsProvider` on `document.documentElement` *after* hydration. Classic CSS keys on compound selectors like `html[data-experience="classic"][data-joy-color-scheme="dark"]` (`src/styles/classic/{wxyc,login,flowsheet}.css`), which can't match until that attribute lands client-side — producing a visible first-paint flash, worst in classic dark mode.

## Approach
Render `<InitColorSchemeScript />` (from `@mui/joy/InitColorSchemeScript`) as the **first child of `<body>`** in `app/layout.tsx` (per MUI's Next.js App Router guidance). It emits a synchronous inline `<script>` that reads `localStorage` and stamps `data-joy-color-scheme` on `document.documentElement` *before* hydration/first paint. `data-experience` is already SSR'd on `<html>`, so with the color-scheme attribute now stamped pre-hydration, the compound classic selectors match on the first paint.

The provider structure (charter §8 root-layout boundary) is untouched — this only adds one server-rendered script node at the top of `<body>`.

## Storage-key agreement (the #611 theme-sync constraint)
Verified in `node_modules`: Joy's `CssVarsProvider` is created via `createCssVarsProvider` using the **same** `defaultConfig` imported from `@mui/joy/InitColorSchemeScript` (`@mui/joy/styles/CssVarsProvider.js`):

- `attribute: 'data-joy-color-scheme'`
- `modeStorageKey: 'joy-mode'`
- `colorSchemeStorageKey: 'joy-color-scheme'`
- `defaultColorScheme: { light: 'light', dark: 'dark' }`

The app renders `<CssVarsProvider theme={theme}>` with **no** storage-key/attribute/defaultMode overrides (`src/styles/ThemeRegistry.tsx`), so `<InitColorSchemeScript />` (which passes that same `defaultConfig`) reads exactly the keys the provider writes — one source of truth, cannot drift. `useThemePreferenceSync` (`src/hooks/themePreferenceHooks.ts`) sets the color mode via Joy's `setMode()`, which persists to `joy-mode`; the init script reads `joy-mode`. Agreement confirmed end-to-end.

## Verification
Local gates (all green):
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warnings only; none in changed files)
- `npm run test:run` — 3676/3676 tests pass. One *unhandled* jsdom teardown error surfaced from an unrelated file (`RotationEntryFields.refetch.test.tsx`, a cross-file `requestAnimationFrame`/`_location` race); that file passes in isolation and is untouched by this change.
- `npm run build` — succeeds

Added `tests/integration/app/InitColorSchemeScript.test.tsx`: a contract test that SSR-renders the script and pins that it stays keyed on `data-joy-color-scheme` / `joy-mode` / `joy-color-scheme` — so a future Joy upgrade that renamed those defaults (silently re-introducing the flash) fails CI.

### Visually verified
Built and served the app (`next start`, port 3021) and inspected the SSR'd `/login` HTML:
- `<html lang="en" data-experience="modern">` — experience attribute SSR'd on `<html>`.
- The inline init script is emitted at the very top of `<body>` (only a hidden Suspense marker precedes it), reads `joy-mode`, and calls `setAttribute('data-joy-color-scheme', …)` on `document.documentElement` — i.e. before hydration.
- Executed the extracted inline script against a mock DOM: `joy-mode=dark → data-joy-color-scheme=dark`, `light → light`, no-storage → `light` (matches Joy's default), and a custom per-mode scheme (`joy-color-scheme-dark=deadstock`) is respected.

### Deferred to merge check
- **Classic dark mode (the canary) live in a browser** requires an authenticated session against a running Backend-Service, which isn't available in this environment — please confirm on the preview deploy: set `localStorage['joy-mode']='dark'`, switch to classic, hard-reload, and confirm no light flash before the dark classic styling.
- A transient first-paint flash isn't capturable in a single post-load screenshot; the SSR evidence above (attribute stamped pre-hydration) is the load-bearing proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)