### PR TITLE
Card Catalog: keep search spinner mounted so its animation survives per-keystroke refetches

### DIFF
--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -24,6 +24,20 @@ import TableHeader from "./TableHeader";
 // CSS-hidden), so a page of N results never mounts 2N component trees.
 const MOBILE_QUERY = "(max-width: 599.95px)";
 
+// Toggled via sx opacity/visibility rather than conditional rendering: the
+// element must stay mounted across a refetch or its CSS animation restarts.
+const loadingOverlaySx = (loading: boolean) => ({
+  position: "absolute" as const,
+  inset: 0,
+  display: "flex",
+  justifyContent: "center",
+  pt: "3rem",
+  opacity: loading ? 1 : 0,
+  visibility: loading ? "visible" : ("hidden" as const),
+  transition: "opacity 120ms",
+  pointerEvents: "none" as const,
+});
+
 export default function Results({
   color,
 }: {
@@ -73,24 +87,30 @@ export default function Results({
   if (isMobile) {
     return (
       <ResultsContainer>
-        <Box
-          sx={{ display: "flex", flexDirection: "column", gap: 1, p: 1 }}
-        >
-          {loading ? (
-            <Box sx={{ display: "flex", justifyContent: "center", pt: "3rem" }}>
-              <CircularProgress color="primary" size="md" />
-            </Box>
-          ) : (
-            releaseList?.map((album) => (
+        <Box sx={{ position: "relative" }}>
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 1,
+              p: 1,
+              opacity: loading ? 0.35 : 1,
+              transition: "opacity 120ms",
+            }}
+          >
+            {releaseList.map((album) => (
               <CatalogMobileResult
                 album={album}
                 live={live}
                 addToQueue={addToQueue}
                 key={`mobile-result-${album.id}`}
               />
-            ))
-          )}
-          {!loading && loadMoreButton}
+            ))}
+            {!loading && loadMoreButton}
+          </Box>
+          <Box data-testid="catalog-loading-overlay" sx={loadingOverlaySx(loading)}>
+            <CircularProgress color="primary" size="md" />
+          </Box>
         </Box>
       </ResultsContainer>
     );
@@ -98,185 +118,176 @@ export default function Results({
 
   return (
     <ResultsContainer>
-      <Table
-        aria-labelledby="tableTitle"
-        stickyHeader
-        hoverRow
-        sx={{
-          // Album/Artist have a floor here; below this the container's
-          // overflow:auto becomes a horizontal scroll rather than crushing.
-          // Lower below xl since Artist collapses into the Album column.
-          minWidth: { xs: 760, xl: 900 },
-          // The Artist gets its own column only at and above xl; below xl it
-          // collapses (the artist stacks under the album title in the Album
-          // column instead) to fit narrower laptops.
-          "& .col-artist": {
-            display: { xs: "none", xl: "table-cell" },
-          },
-          "--TableCell-headBackground": (theme) =>
-            theme.vars.palette.background.level1,
-          "--Table-headerUnderlineThickness": "1px",
-          "--TableRow-hoverBackground": (theme) =>
-            theme.vars.palette.background.level1,
-          // Media-list rows: taller than a data grid, everything vertically
-          // centered on the artwork.
-          "& tbody tr > td": {
-            height: "68px",
-            verticalAlign: "middle",
-          },
-          // Selected rows read as intentional: subtle fill + left accent rail.
-          "& tbody tr.row-selected > td": {
-            bgcolor: (theme) => theme.vars.palette.background.level1,
-          },
-          "& tbody tr.row-selected > td:first-of-type": {
-            boxShadow: (theme) =>
-              `inset 2px 0 0 ${theme.vars.palette.primary[500]}`,
-          },
-          // The actions live in a zero-width cell pinned (sticky) to the
-          // scroll container's right edge, so they stay at the visible edge
-          // no matter the horizontal scroll — no reserved column, no dead
-          // space, and no need to scroll right to reach them.
-          "& tbody tr > td.actions-cell": {
-            position: "sticky",
-            right: 0,
-            zIndex: 3,
-            width: 0,
-            minWidth: 0,
-            maxWidth: 0,
-            padding: 0,
-            overflow: "visible",
-            background: "transparent",
-          },
-          // Actions are revealed on row hover/focus on pointer devices;
-          // always visible on touch. The hover-bg backdrop keeps them
-          // legible over the stats they cover.
-          "& tbody tr .row-actions": {
-            background:
-              "linear-gradient(to right, transparent, var(--TableRow-hoverBackground) 18px)",
-          },
-          "@media (hover: hover)": {
-            "& tbody tr .row-actions": {
-              opacity: 0,
-              pointerEvents: "none",
-              transition: "opacity 120ms",
+      <Box sx={{ position: "relative" }}>
+        <Table
+          aria-labelledby="tableTitle"
+          stickyHeader
+          hoverRow
+          sx={{
+            // Album/Artist have a floor here; below this the container's
+            // overflow:auto becomes a horizontal scroll rather than crushing.
+            // Lower below xl since Artist collapses into the Album column.
+            minWidth: { xs: 760, xl: 900 },
+            opacity: loading ? 0.35 : 1,
+            transition: "opacity 120ms",
+            // The Artist gets its own column only at and above xl; below xl it
+            // collapses (the artist stacks under the album title in the Album
+            // column instead) to fit narrower laptops.
+            "& .col-artist": {
+              display: { xs: "none", xl: "table-cell" },
             },
-            "& tbody tr:hover .row-actions, & tbody tr:focus-within .row-actions":
-              {
-                opacity: 1,
-                pointerEvents: "auto",
+            "--TableCell-headBackground": (theme) =>
+              theme.vars.palette.background.level1,
+            "--Table-headerUnderlineThickness": "1px",
+            "--TableRow-hoverBackground": (theme) =>
+              theme.vars.palette.background.level1,
+            // Media-list rows: taller than a data grid, everything vertically
+            // centered on the artwork.
+            "& tbody tr > td": {
+              height: "68px",
+              verticalAlign: "middle",
+            },
+            // Selected rows read as intentional: subtle fill + left accent rail.
+            "& tbody tr.row-selected > td": {
+              bgcolor: (theme) => theme.vars.palette.background.level1,
+            },
+            "& tbody tr.row-selected > td:first-of-type": {
+              boxShadow: (theme) =>
+                `inset 2px 0 0 ${theme.vars.palette.primary[500]}`,
+            },
+            // The actions live in a zero-width cell pinned (sticky) to the
+            // scroll container's right edge, so they stay at the visible edge
+            // no matter the horizontal scroll — no reserved column, no dead
+            // space, and no need to scroll right to reach them.
+            "& tbody tr > td.actions-cell": {
+              position: "sticky",
+              right: 0,
+              zIndex: 3,
+              width: 0,
+              minWidth: 0,
+              maxWidth: 0,
+              padding: 0,
+              overflow: "visible",
+              background: "transparent",
+            },
+            // Actions are revealed on row hover/focus on pointer devices;
+            // always visible on touch. The hover-bg backdrop keeps them
+            // legible over the stats they cover.
+            "& tbody tr .row-actions": {
+              background:
+                "linear-gradient(to right, transparent, var(--TableRow-hoverBackground) 18px)",
+            },
+            "@media (hover: hover)": {
+              "& tbody tr .row-actions": {
+                opacity: 0,
+                pointerEvents: "none",
+                transition: "opacity 120ms",
               },
-          },
-        }}
-      >
-        <thead>
-          <tr>
-            <th scope="col" style={{ width: 48, textAlign: "center", padding: 12 }}>
-              <Checkbox
-                indeterminate={
-                  selected.length > 0 && selected.length !== releaseList?.length
-                }
-                checked={
-                  releaseList != null &&
-                  releaseList.length > 0 &&
-                  selected.length === releaseList.length
-                }
-                onChange={(event: ChangeEvent<HTMLInputElement>) => {
-                  setSelection(
-                    event.target.checked
-                      ? releaseList?.map((row) => row.id) ?? []
-                      : []
-                  );
-                }}
-                color={
-                  selected.length > 0 || selected.length === releaseList?.length
-                    ? "primary"
-                    : undefined
-                }
-                sx={{ verticalAlign: "text-bottom" }}
-              />
-            </th>
-            <th scope="col" style={{ width: 64, padding: 12 }}></th>
-            {/* Album and Artist carry no width: with table-layout fixed they
-                split the leftover space, so they grow to fill wide screens
-                while the metadata columns stay compact on the right. */}
-            <th scope="col" aria-sort={ariaSort("album")} style={{ padding: 12 }}>
-              <TableHeader textValue="Album" />
-              {/* Below xl the Artist sort lives here, since the artist is
-                  stacked into this column. */}
-              <Box component="span" sx={{ display: { xs: "inline", xl: "none" } }}>
-                <span style={{ margin: "0 6px", opacity: 0.4 }}>/</span>
-                <TableHeader textValue="Artist" />
-              </Box>
-            </th>
-            <th
-              className="col-artist"
-              scope="col"
-              aria-sort={ariaSort("artist")}
-              style={{ padding: 12 }}
-            >
-              <TableHeader textValue="Artist" />
-            </th>
-            <th scope="col" style={{ width: 140, padding: 12 }}>
-              <TableHeader textValue="Tags" />
-            </th>
-            <th scope="col" style={{ width: 100, padding: 12 }}>
-              <TableHeader textValue="Call #" />
-            </th>
-            <th scope="col" aria-sort={ariaSort("plays")} style={{ width: 60, padding: 12 }}>
-              <TableHeader textValue="Plays" />
-            </th>
-            <th scope="col" style={{ width: 160, padding: 12 }}>
-              <TableHeader textValue="Label" />
-            </th>
-            {/* Zero-width column hosting the sticky hover-actions overlay. */}
-            <th aria-hidden style={{ width: 0, padding: 0 }}></th>
-          </tr>
-        </thead>
-        <tbody>
-          {loading ? (
-            <tr style={{ background: "transparent" }}>
-              <td
-                colSpan={9}
-                style={{
-                  textAlign: "center",
-                  paddingTop: "3rem",
-                  background: "transparent",
-                }}
+              "& tbody tr:hover .row-actions, & tbody tr:focus-within .row-actions":
+                {
+                  opacity: 1,
+                  pointerEvents: "auto",
+                },
+            },
+          }}
+        >
+          <thead>
+            <tr>
+              <th scope="col" style={{ width: 48, textAlign: "center", padding: 12 }}>
+                <Checkbox
+                  indeterminate={
+                    selected.length > 0 && selected.length !== releaseList.length
+                  }
+                  checked={
+                    releaseList.length > 0 &&
+                    selected.length === releaseList.length
+                  }
+                  onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                    setSelection(
+                      event.target.checked
+                        ? releaseList.map((row) => row.id)
+                        : []
+                    );
+                  }}
+                  color={
+                    selected.length > 0 || selected.length === releaseList.length
+                      ? "primary"
+                      : undefined
+                  }
+                  sx={{ verticalAlign: "text-bottom" }}
+                />
+              </th>
+              <th scope="col" style={{ width: 64, padding: 12 }}></th>
+              {/* Album and Artist carry no width: with table-layout fixed they
+                  split the leftover space, so they grow to fill wide screens
+                  while the metadata columns stay compact on the right. */}
+              <th scope="col" aria-sort={ariaSort("album")} style={{ padding: 12 }}>
+                <TableHeader textValue="Album" />
+                {/* Below xl the Artist sort lives here, since the artist is
+                    stacked into this column. */}
+                <Box component="span" sx={{ display: { xs: "inline", xl: "none" } }}>
+                  <span style={{ margin: "0 6px", opacity: 0.4 }}>/</span>
+                  <TableHeader textValue="Artist" />
+                </Box>
+              </th>
+              <th
+                className="col-artist"
+                scope="col"
+                aria-sort={ariaSort("artist")}
+                style={{ padding: 12 }}
               >
-                <CircularProgress color="primary" size="md" />
-              </td>
+                <TableHeader textValue="Artist" />
+              </th>
+              <th scope="col" style={{ width: 140, padding: 12 }}>
+                <TableHeader textValue="Tags" />
+              </th>
+              <th scope="col" style={{ width: 100, padding: 12 }}>
+                <TableHeader textValue="Call #" />
+              </th>
+              <th scope="col" aria-sort={ariaSort("plays")} style={{ width: 60, padding: 12 }}>
+                <TableHeader textValue="Plays" />
+              </th>
+              <th scope="col" style={{ width: 160, padding: 12 }}>
+                <TableHeader textValue="Label" />
+              </th>
+              {/* Zero-width column hosting the sticky hover-actions overlay. */}
+              <th aria-hidden style={{ width: 0, padding: 0 }}></th>
             </tr>
-          ) : (
-            releaseList?.map((album) => (
+          </thead>
+          <tbody>
+            {releaseList.map((album) => (
               <CatalogResult
                 album={album}
                 live={live}
                 addToQueue={addToQueue}
                 key={`result-${album.id}`}
               />
-            ))
-          )}
+            ))}
 
-          {!loading && hasMore && (
-            <tr>
-              <td colSpan={9} style={{ textAlign: "center" }}>
-                <Button
-                  variant="solid"
-                  color="primary"
-                  size="lg"
-                  loading={isFetchingMore}
-                  sx={{
-                    marginRight: "1rem",
-                  }}
-                  onClick={loadNextPage}
-                >
-                  Load more
-                </Button>
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </Table>
+            {!loading && hasMore && (
+              <tr>
+                <td colSpan={9} style={{ textAlign: "center" }}>
+                  <Button
+                    variant="solid"
+                    color="primary"
+                    size="lg"
+                    loading={isFetchingMore}
+                    sx={{
+                      marginRight: "1rem",
+                    }}
+                    onClick={loadNextPage}
+                  >
+                    Load more
+                  </Button>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </Table>
+        <Box data-testid="catalog-loading-overlay" sx={loadingOverlaySx(loading)}>
+          <CircularProgress color="primary" size="md" />
+        </Box>
+      </Box>
     </ResultsContainer>
   );
 }

--- a/tests/integration/components/modern/catalog/Results/Results.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/Results.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { createTestAlbum, createTestArtist } from "@/tests/helpers";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => "/dashboard/catalog",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useShowControl: () => ({ live: false }),
+  useQueue: () => ({ addToQueue: vi.fn() }),
+}));
+
+vi.mock(
+  "@/src/components/experiences/modern/catalog/Results/ResultsContainer",
+  () => ({
+    default: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+  }),
+);
+
+vi.mock("@/src/components/experiences/modern/catalog/Results/Result", () => ({
+  default: ({ album }: { album: { id: number; title: string } }) => (
+    <tr data-testid={`result-${album.id}`}>
+      <td>{album.title}</td>
+    </tr>
+  ),
+}));
+
+vi.mock(
+  "@/src/components/experiences/modern/catalog/Results/MobileResult",
+  () => ({
+    default: ({ album }: { album: { id: number; title: string } }) => (
+      <div data-testid={`mobile-result-${album.id}`}>{album.title}</div>
+    ),
+  }),
+);
+
+const mockUseCatalogQueryResults = vi.hoisted(() => vi.fn());
+const mockUseCatalogQuerySearch = vi.hoisted(() => vi.fn());
+const mockUseMediaQuery = vi.hoisted(() => vi.fn());
+
+vi.mock("@/src/hooks/catalogHooks", () => ({
+  useCatalogQueryResults: () => mockUseCatalogQueryResults(),
+  useCatalogQuerySearch: () => mockUseCatalogQuerySearch(),
+}));
+
+vi.mock("@/src/hooks/useMediaQuery", () => ({
+  useMediaQuery: () => mockUseMediaQuery(),
+}));
+
+import Results from "@/src/components/experiences/modern/catalog/Results/Results";
+
+const albums = [
+  createTestAlbum({
+    id: 1,
+    title: "DOGA",
+    artist: createTestArtist({ name: "Juana Molina" }),
+  }),
+  createTestAlbum({
+    id: 2,
+    title: "Cover Story",
+    artist: createTestArtist({ name: "Stereolab" }),
+  }),
+];
+
+function mockQueryResults(overrides: {
+  results?: typeof albums;
+  isLoadingInitial?: boolean;
+  isFetchingMore?: boolean;
+  hasNextPage?: boolean;
+}) {
+  mockUseCatalogQueryResults.mockReturnValue({
+    results: overrides.results ?? [],
+    total: (overrides.results ?? []).length,
+    isLoadingInitial: overrides.isLoadingInitial ?? false,
+    isFetchingMore: overrides.isFetchingMore ?? false,
+    hasNextPage: overrides.hasNextPage ?? false,
+    fetchNextPage: vi.fn(),
+    isError: false,
+  });
+}
+
+describe("Results loading overlay", () => {
+  beforeEach(() => {
+    mockUseCatalogQuerySearch.mockReturnValue({
+      selected: [],
+      setSelection: vi.fn(),
+      sortBy: "album",
+      sortOrder: "asc",
+      hasActiveQuery: true,
+    });
+    mockUseMediaQuery.mockReturnValue(false);
+  });
+
+  it("keeps the same spinner DOM node mounted across a keystroke-driven refetch cycle", () => {
+    mockQueryResults({ results: [], isLoadingInitial: true });
+    const { rerender } = renderWithProviders(<Results color={undefined} />);
+    const spinner = screen.getByRole("progressbar", { hidden: true });
+
+    mockQueryResults({ results: albums, isLoadingInitial: false });
+    rerender(<Results color={undefined} />);
+    expect(screen.getByRole("progressbar", { hidden: true })).toBe(spinner);
+
+    mockQueryResults({ results: [], isLoadingInitial: true });
+    rerender(<Results color={undefined} />);
+    expect(screen.getByRole("progressbar", { hidden: true })).toBe(spinner);
+
+    mockQueryResults({ results: albums, isLoadingInitial: false });
+    rerender(<Results color={undefined} />);
+    expect(screen.getByRole("progressbar", { hidden: true })).toBe(spinner);
+  });
+
+  it("hides the overlay once results land and shows it while loading", () => {
+    mockQueryResults({ results: [], isLoadingInitial: true });
+    const { rerender } = renderWithProviders(<Results color={undefined} />);
+    expect(getComputedStyle(screen.getByTestId("catalog-loading-overlay")).visibility).toBe(
+      "visible",
+    );
+
+    mockQueryResults({ results: albums, isLoadingInitial: false });
+    rerender(<Results color={undefined} />);
+    expect(getComputedStyle(screen.getByTestId("catalog-loading-overlay")).visibility).toBe(
+      "hidden",
+    );
+  });
+
+  it("renders the fetched rows once loading completes", () => {
+    mockQueryResults({ results: albums, isLoadingInitial: false });
+    renderWithProviders(<Results color={undefined} />);
+
+    expect(screen.getByText("DOGA")).toBeDefined();
+    expect(screen.getByText("Cover Story")).toBeDefined();
+  });
+
+  it("keeps the same spinner DOM node mounted across a refetch cycle on mobile", () => {
+    mockUseMediaQuery.mockReturnValue(true);
+    mockQueryResults({ results: [], isLoadingInitial: true });
+    const { rerender } = renderWithProviders(<Results color={undefined} />);
+    const spinner = screen.getByRole("progressbar", { hidden: true });
+
+    mockQueryResults({ results: albums, isLoadingInitial: false });
+    rerender(<Results color={undefined} />);
+    expect(screen.getByRole("progressbar", { hidden: true })).toBe(spinner);
+
+    mockQueryResults({ results: [], isLoadingInitial: true });
+    rerender(<Results color={undefined} />);
+    expect(screen.getByRole("progressbar", { hidden: true })).toBe(spinner);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #585

- The Card Catalog `<CircularProgress>` in `Results.tsx` (both the
  desktop table and mobile stacked-card layouts) was conditionally
  rendered on `isLoadingInitial`, so it unmounted/remounted on
  effectively every keystroke past the 2-char minimum, restarting its
  CSS animation.
- Root cause has drifted slightly from the issue's description: the
  `pendingQueryRef` + drain-effect throttling in `catalogHooks.ts` the
  issue cites no longer exists — the md-split refactor moved
  `useCatalogQueryResults` onto RTK Query's native infinite-query API
  (`useSearchLibraryQueryInfiniteQuery`, returning
  `hasNextPage`/`isLoadingInitial`/`isFetchingMore`/`fetchNextPage`).
  The underlying problem is the same shape and arguably more
  pronounced: each keystroke produces a distinct query-arg cache
  entry, so `isLoadingInitial` genuinely flips
  `false -> true -> false` on nearly every character.
- Per design-owner direction, the fix keeps the spinner (rather than
  the issue's suggested status-line replacement): `<CircularProgress>`
  now renders unconditionally, inside an always-mounted
  absolute-positioned overlay in both the desktop table and mobile
  stacked-card layouts, with visibility/opacity toggled via `sx`
  instead of conditional JSX rendering. The element is never removed
  from the tree, so its CSS animation can't restart no matter how
  often the underlying loading boolean flips.
- Confirmed via grep that no e2e spec asserts on the spinner.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint` (0 errors; pre-existing warning count unchanged)
- [x] `npm run test:run` (271 files / 3684 tests passed) — added
      `tests/integration/components/modern/catalog/Results/Results.test.tsx`
      asserting the spinner DOM node's identity is stable across a
      keystroke-driven refetch cycle (desktop and mobile), that the
      overlay's visibility toggles correctly, and that fetched rows
      render once loading completes
- [x] `npm run build`
- [ ] visual: type in catalog query builder, spinner should not
      snap/restart — Jackson to confirm at merge check (no dev server
      was run for this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)