### PR TITLE
Harden admin RBAC: fail-closed authority + middleware gating

### DIFF
--- a/lib/features/authentication/server-utils.ts
+++ b/lib/features/authentication/server-utils.ts
@@ -71,8 +71,10 @@ export async function requireAuth(): Promise<BetterAuthSession> {
 }
 
 /**
- * Extracts the user's authorization level, preferring the APP_ORGANIZATION
- * role query and falling back to role data embedded in the session.
+ * Extracts the user's authorization level. When an organization is configured,
+ * authority is scoped to it: an unresolved org role (not a member, or a
+ * transient failure) fails closed to NO, and the session base role is never
+ * trusted. The base role is used only when no organization is configured.
  */
 async function getUserAuthority(session: BetterAuthSession, cookieHeader?: string): Promise<Authorization> {
   const organizationId = getAppOrganizationId();
@@ -88,23 +90,20 @@ async function getUserAuthority(session: BetterAuthSession, cookieHeader?: strin
       if (orgRole !== undefined) {
         return roleToAuthorization(orgRole);
       }
-      // Not a member: fall through to session-based fallback (resolves to NO access).
     } catch (error) {
-      console.warn("Failed to fetch organization role, falling back to session data:", error);
+      console.warn("Failed to fetch organization role; failing closed to NO authority:", error);
     }
+
+    return Authorization.NO;
   }
 
-  // Organization role takes precedence over base user role; also check
-  // metadata/custom fields some flows stash the role in.
   const organizationRole = (session.user as any).organization?.role;
   const userRole = (session.user as any).role;
   const metadataRole = (session.user as any).metadata?.role;
   const customRole = (session.user as any).customRole;
   const roleToMap = organizationRole || metadataRole || customRole || userRole;
 
-  const authority = roleToAuthorization(roleToMap);
-
-  return authority;
+  return roleToAuthorization(roleToMap);
 }
 
 /** Non-redirecting permission check. */

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getSessionCookie } from "better-auth/cookies";
+
+// dj-site is a better-auth client with no auth secret at the edge, so the
+// session cookie can be checked for presence but not verified or decoded. Role
+// authorization stays in the admin Server Component's requireRole; adding a
+// Backend-Service round-trip per request here is not acceptable.
+export function middleware(request: NextRequest) {
+  const sessionCookie = getSessionCookie(request);
+
+  if (!sessionCookie) {
+    return NextResponse.redirect(new URL("/login?bounced=no-session", request.url), 307);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/dashboard/admin/:path*"],
+};

--- a/tests/unit/lib/features/authentication/server-utils.test.ts
+++ b/tests/unit/lib/features/authentication/server-utils.test.ts
@@ -248,15 +248,76 @@ describe("server-utils", () => {
       expect(result).toBe(true);
     });
 
-    it("should fall back to session role when organization lookup fails", async () => {
+    it("should fail closed (NO authority) when org resolution throws in an org-scoped deployment", async () => {
       mockGetAppOrganizationId.mockReturnValue("wxyc-org-id");
       mockGetUserRoleInOrganization.mockRejectedValue(new Error("Org lookup failed"));
 
       const session = createTestSessionWithOrgRole("dj");
       const result = await checkRole(session, Authorization.DJ);
 
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
+
+    it("should fail closed (NO authority) when org resolution returns undefined (not a member)", async () => {
+      mockGetAppOrganizationId.mockReturnValue("wxyc-org-id");
+      mockGetUserRoleInOrganization.mockResolvedValue(undefined);
+
+      const session = createTestSessionWithOrgRole("stationManager");
+      const result = await checkRole(session, Authorization.DJ);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getUserAuthority fail-closed matrix", () => {
+    // getUserAuthority is private; exercised here via getUserFromSession, which
+    // returns the computed authority.
+    const baseRoles = ["admin", "owner", "stationManager", "musicDirector", "dj", "member", "user"];
+
+    beforeEach(() => {
+      mockGetAppOrganizationId.mockReturnValue("wxyc-org-id");
+    });
+
+    it.each(baseRoles)(
+      "org resolution FAILURE (throws) with base role %s => NO authority",
+      async (role) => {
+        mockGetUserRoleInOrganization.mockRejectedValue(new Error("transient"));
+        const session = createTestBetterAuthSession({
+          user: { id: "u", email: "u@wxyc.org", name: "u", emailVerified: true, role },
+        });
+        const result = await getUserFromSession(session);
+        expect(result.authority).toBe(Authorization.NO);
+      }
+    );
+
+    it.each(baseRoles)(
+      "org resolution UNDEFINED (not a member) with base role %s => NO authority",
+      async (role) => {
+        mockGetUserRoleInOrganization.mockResolvedValue(undefined);
+        const session = createTestBetterAuthSession({
+          user: { id: "u", email: "u@wxyc.org", name: "u", emailVerified: true, role },
+        });
+        const result = await getUserFromSession(session);
+        expect(result.authority).toBe(Authorization.NO);
+      }
+    );
+
+    it.each([
+      ["stationManager", Authorization.SM],
+      ["musicDirector", Authorization.MD],
+      ["dj", Authorization.DJ],
+      ["member", Authorization.NO],
+    ] as const)(
+      "successful org resolution of %s is unchanged => %s",
+      async (orgRole, expected) => {
+        mockGetUserRoleInOrganization.mockResolvedValue(orgRole);
+        const session = createTestBetterAuthSession({
+          user: { id: "u", email: "u@wxyc.org", name: "u", emailVerified: true, role: "admin" },
+        });
+        const result = await getUserFromSession(session);
+        expect(result.authority).toBe(expected);
+      }
+    );
   });
 
   describe("requireRole", () => {

--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { middleware, config } from "@/middleware";
+
+function requestWithCookie(pathname: string, cookie?: string): NextRequest {
+  const headers = new Headers();
+  if (cookie) headers.set("cookie", cookie);
+  return new NextRequest(new URL(`http://localhost${pathname}`), { headers });
+}
+
+describe("middleware (admin RBAC edge gate, #909)", () => {
+  it("scopes the matcher tightly to /dashboard/admin", () => {
+    expect(config.matcher).toEqual(["/dashboard/admin/:path*"]);
+  });
+
+  it("denies an unauthenticated admin request with an atomic 307 to login", () => {
+    const res = middleware(requestWithCookie("/dashboard/admin/roster"));
+    expect(res.status).toBe(307);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("/login");
+    expect(location).toContain("bounced=no-session");
+  });
+
+  it("passes an authenticated request through (role check stays server-side)", () => {
+    const res = middleware(
+      requestWithCookie("/dashboard/admin/roster", "better-auth.session_token=abc.def")
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("location")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #909

Two defense-in-depth improvements to the admin access path. No active vulnerability today — the Server Component guard is already fail-closed for ordinary members and Backend-Service authorizes every admin API call independently. These close a latent fail-open class and make the unauthenticated admin deny atomic.

## 1. Fail-closed authority (`lib/features/authentication/server-utils.ts`)

`getUserAuthority` previously fell through to the session-embedded base role when the org-role query returned `undefined` or threw. Because `roleToAuthorization` maps better-auth base `admin`/`owner` → `SM`, a system-admin who is **not** an org-SM could be granted SM authority during a transient Backend-Service hiccup.

Now, when an organization is configured, authority is scoped to it: an unresolved org role fails closed to `NO` and the base role is never consulted. The base-role path survives only for deployments with no configured organization (its sole signal).

### Behavior (org-scoped deployment)

| better-auth base role | org resolution outcome | authority |
|---|---|---|
| admin / owner | throws (transient failure) | **NO** |
| admin / owner | undefined (not a member) | **NO** |
| stationManager / musicDirector / dj / member / user | throws / undefined | **NO** |
| any | resolves → stationManager | SM (unchanged) |
| any | resolves → musicDirector | MD (unchanged) |
| any | resolves → dj | DJ (unchanged) |
| any | resolves → member | NO (unchanged) |

Successful resolution is unchanged; only the failure/undefined fallback changed. Unit tests cover the full base-role × outcome matrix plus the unchanged success cases.

## 2. Middleware gating (`middleware.ts`)

New middleware gates `/dashboard/admin/*` at the edge. An unauthenticated admin request is denied as an atomic **307** to `/login` before any admin-URL response is produced — replacing the previous path where the deny fired only in the roster Server Component after several sequential Backend-Service round-trips, by which point Next 16 had begun streaming the dashboard shell (200 at the admin URL + shell flash + post-hydration client redirect).

**Matcher scope + latency:** the matcher is `/dashboard/admin/:path*` — only admin URLs pay the cost. The check is `getSessionCookie` presence only. dj-site is a better-auth *client* with no auth secret at the edge, so the signed session/cookie-cache cannot be verified or decoded there, and the authoritative role (the org-membership role) is deliberately **not** fetched — a Backend-Service round-trip on every admin navigation is the wrong trade-off. The Server Component's fail-closed `requireRole(SM)` remains the authoritative **second** layer; middleware adds a layer, it does not replace the server-side check.

## #908 workaround verdict

The middleware makes the **unauthenticated** admin deny atomic. The **authenticated-insufficient-role** deny (member/DJ/MD) — the class #908's hydration-tolerant `waitForURL` poll works around — still resolves in the Server Component, because the authoritative role is not edge-readable in a client-only deployment (no auth secret; org role lives in Backend-Service membership, not a verifiable cookie). The #908 poll therefore **stays**; the e2e RBAC spec is unchanged (its unauthenticated-admin case already waits for `**/login**`, which the new 307 satisfies).

## Verification

`npx tsc --noEmit` · `npm run lint` (0 errors) · `npm run test:run` (3695 pass, incl. new fail-closed matrix + middleware tests) · `npm run build` (middleware registered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)