### PR TITLE
Add rotation_id submit-time telemetry (Closes #759)

### DIFF
--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -17,6 +17,7 @@ import {
   compareEntriesNewestFirst,
   primaryShowId,
 } from "@/lib/features/flowsheet/infinite-cache";
+import { safeCapture } from "@/lib/posthog";
 import { useFlowsheetPollingInterval } from "./useSSEConnection";
 import { partitionFlowsheetEntries } from "@/lib/features/flowsheet/partition";
 import {
@@ -605,6 +606,10 @@ export const useFlowsheetSubmit = () => {
     }
   }, [selectedResult, selectedEntry, flowSheetRawQuery]);
 
+  // Reference equality only — ids can collide across the bin/catalog/rotation/lml sources.
+  const isRotationPick =
+    selectedEntry !== null && rotationResults.includes(selectedEntry);
+
   const handleSubmit = useCallback(
     async (e: FormEvent) => {
       e.preventDefault();
@@ -619,6 +624,13 @@ export const useFlowsheetSubmit = () => {
         addToQueue(selectedResultData);
         dispatch(flowsheetSlice.actions.resetSearch());
         return;
+      }
+      if (isRotationPick && selectedEntry) {
+        safeCapture("flowsheet_submit_rotation_link", {
+          rotation_id_present: selectedEntry.rotation_id != null,
+          rotation_id: selectedEntry.rotation_id ?? null,
+          album_id_present: selectedEntry.id != null,
+        });
       }
       try {
         await addToFlowsheet(convertQueryToSubmission(selectedResultData));
@@ -644,6 +656,8 @@ export const useFlowsheetSubmit = () => {
       addToQueue,
       selectedResultData,
       dispatch,
+      isRotationPick,
+      selectedEntry,
     ]
   );
 

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -46,7 +46,7 @@ const mockUseCatalogFlowsheetSearch = vi.fn(() => ({
   searchResults: [] as ReturnType<typeof createTestAlbum>[],
 }));
 const mockUseRotationFlowsheetSearch = vi.fn(() => ({
-  searchResults: [],
+  searchResults: [] as ReturnType<typeof createTestAlbum>[],
   loading: false,
 }));
 
@@ -166,6 +166,11 @@ vi.mock("sonner", () => ({
     success: vi.fn(),
     error: (...args: unknown[]) => mockToastError(...args),
   },
+}));
+
+const safeCaptureMock = vi.fn();
+vi.mock("@/lib/posthog", () => ({
+  safeCapture: (...args: unknown[]) => safeCaptureMock(...args),
 }));
 
 const createWrapper = () =>
@@ -1845,6 +1850,176 @@ describe("flowsheetHooks", () => {
       // selectedEntry should be the album from search results
       expect(result.current.selectedEntry).toBeDefined();
       expect(result.current.selectedEntry?.id).toBe(999);
+    });
+
+    describe("flowsheet_submit_rotation_link telemetry", () => {
+      const rotationWrapper = (rotationOverrides: { rotation_id?: number } = {}) => {
+        const rotationAlbum = createTestAlbum({
+          id: 111,
+          title: "DOGA",
+          label: "Sonamos",
+          artist: createTestArtist({ name: "Juana Molina" }),
+          ...rotationOverrides,
+        });
+        mockUseRotationFlowsheetSearch.mockReturnValue({
+          searchResults: [rotationAlbum],
+          loading: false,
+        });
+        return createHookWrapper(
+          { flowsheet: flowsheetSlice, liveUpdates: liveUpdatesSlice },
+          {
+            flowsheet: {
+              ...flowsheetSlice.getInitialState(),
+              search: {
+                ...flowsheetSlice.getInitialState().search,
+                selectedResult: 1,
+                query: {
+                  song: "la paradoja",
+                  artist: "",
+                  album: "",
+                  label: "",
+                  request: false,
+                },
+              },
+            },
+          }
+        );
+      };
+
+      it("fires with rotation_id_present:true when the rotation-picked entry has rotation_id set", async () => {
+        const wrapper = rotationWrapper({ rotation_id: 222 });
+        const { result } = renderHook(() => useFlowsheetSubmit(), { wrapper });
+
+        await act(async () => {
+          await result.current.handleSubmit({
+            preventDefault: vi.fn(),
+          } as unknown as FormEvent);
+        });
+
+        expect(safeCaptureMock).toHaveBeenCalledWith(
+          "flowsheet_submit_rotation_link",
+          {
+            rotation_id_present: true,
+            rotation_id: 222,
+            album_id_present: true,
+          }
+        );
+      });
+
+      it("fires with rotation_id_present:false when the rotation-picked entry has no rotation_id", async () => {
+        const wrapper = rotationWrapper();
+        const { result } = renderHook(() => useFlowsheetSubmit(), { wrapper });
+
+        await act(async () => {
+          await result.current.handleSubmit({
+            preventDefault: vi.fn(),
+          } as unknown as FormEvent);
+        });
+
+        expect(safeCaptureMock).toHaveBeenCalledWith(
+          "flowsheet_submit_rotation_link",
+          {
+            rotation_id_present: false,
+            rotation_id: null,
+            album_id_present: true,
+          }
+        );
+      });
+
+      it("does not fire for a non-rotation (catalog) pick", async () => {
+        const catalogAlbum = createTestAlbum({
+          id: 333,
+          title: "On Your Own Love Again",
+          artist: createTestArtist({ name: "Jessica Pratt" }),
+        });
+        mockUseCatalogFlowsheetSearch.mockReturnValue({
+          searchResults: [catalogAlbum],
+        });
+
+        const wrapper = createHookWrapper(
+          { flowsheet: flowsheetSlice, liveUpdates: liveUpdatesSlice },
+          {
+            flowsheet: {
+              ...flowsheetSlice.getInitialState(),
+              search: {
+                ...flowsheetSlice.getInitialState().search,
+                selectedResult: 1,
+                query: {
+                  song: "la paradoja",
+                  artist: "",
+                  album: "",
+                  label: "",
+                  request: false,
+                },
+              },
+            },
+          }
+        );
+
+        const { result } = renderHook(() => useFlowsheetSubmit(), { wrapper });
+
+        await act(async () => {
+          await result.current.handleSubmit({
+            preventDefault: vi.fn(),
+          } as unknown as FormEvent);
+        });
+
+        expect(mockAddToFlowsheet).toHaveBeenCalled();
+        expect(safeCaptureMock).not.toHaveBeenCalled();
+      });
+
+      it("does not fire for a freeform (typed, no selection) submit", async () => {
+        const wrapper = createHookWrapper(
+          { flowsheet: flowsheetSlice, liveUpdates: liveUpdatesSlice },
+          {
+            flowsheet: {
+              ...flowsheetSlice.getInitialState(),
+              search: {
+                ...flowsheetSlice.getInitialState().search,
+                selectedResult: 0,
+                query: {
+                  song: "la paradoja",
+                  artist: "Juana Molina",
+                  album: "DOGA",
+                  label: "Sonamos",
+                  request: false,
+                },
+              },
+            },
+          }
+        );
+
+        const { result } = renderHook(() => useFlowsheetSubmit(), { wrapper });
+
+        await act(async () => {
+          await result.current.handleSubmit({
+            preventDefault: vi.fn(),
+          } as unknown as FormEvent);
+        });
+
+        expect(mockAddToFlowsheet).toHaveBeenCalled();
+        expect(safeCaptureMock).not.toHaveBeenCalled();
+      });
+
+      it("does not fire when addToQueue (Ctrl+Enter) is used instead of a direct flowsheet submit", async () => {
+        const wrapper = rotationWrapper({ rotation_id: 222 });
+        const { result } = renderHook(() => useFlowsheetSubmit(), { wrapper });
+
+        act(() => {
+          document.dispatchEvent(
+            new KeyboardEvent("keydown", { key: "Control" })
+          );
+        });
+
+        await act(async () => {
+          await result.current.handleSubmit({
+            preventDefault: vi.fn(),
+          } as unknown as FormEvent);
+        });
+
+        expect(mockAddToFlowsheet).not.toHaveBeenCalled();
+        expect(safeCaptureMock).not.toHaveBeenCalled();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #759. Instruments the flowsheet submit path so a picker-side rotation_id regression is visible from telemetry instead of requiring a manual prod-DB query.

## Seam chosen

`useFlowsheetSubmit` in `src/hooks/flowsheetHooks.ts`, not `api.ts`'s `addToFlowsheet` `onQueryStarted`, and not `FlowsheetSearchbar.tsx` (owned by parked PR #830).

`selectedEntry` (the picker's chosen result, a uniformly-typed `AlbumEntry` across the bin/rotation/catalog/lml result sources) is only available at this hook layer, before `convertQueryToSubmission` reshapes it onto the wire. By the time the mutation arg reaches `api.ts`, a picker-side `rotation_id` drop is already indistinguishable from a legitimately freeform entry — the wire shape has lost the "picker intent" signal. `useFlowsheetSubmit` is the last point where both are still available together.

Origin discriminator: `selectedEntry !== null && rotationResults.includes(selectedEntry)` — reference-identity membership in the rotation search results array (ids can collide across sources, so identity is used instead of an id comparison).

## Event schema

`flowsheet_submit_rotation_link`, fired via `safeCapture` (`lib/posthog.ts`) synchronously at mutation dispatch, only for rotation-picker-originated submissions:

```ts
{
  rotation_id_present: boolean, // selectedEntry.rotation_id != null
  rotation_id: number | null,
  album_id_present: boolean,    // selectedEntry.id != null
}
```

Catalog/bin/lml picks, freeform typed entries, and the Ctrl+Enter queue path (which defers to a later, separate submission and never hits this dispatch point) emit nothing.

## Detecting a future regression

Filter PostHog events where `event = flowsheet_submit_rotation_link` and `rotation_id_present = false`. A nonzero rate turns the investigation from "compare prod DB row counts across days" into "filter events by an attribute."

## Adjacency note

PR #911 (`fix/860-idempotent-swap`) is concurrently open and touches `lib/features/flowsheet/infinite-cache.ts` + its test file. This PR only touches `src/hooks/flowsheetHooks.ts` and `tests/unit/hooks/flowsheetHooks.test.tsx` — no file overlap.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint` (0 errors, no new warnings)
- [x] `npm run test:run` (3678 passed, including 5 new cases covering rotation-id-present, rotation-id-absent, non-rotation pick, freeform submit, and the queue path)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)