### PR TITLE
fix(rotation): stale artist + compilation false-positive in picker (Closes #876, Closes #877)

### DIFF
--- a/lib/features/catalog/is-compilation-artist.ts
+++ b/lib/features/catalog/is-compilation-artist.ts
@@ -1,4 +1,6 @@
-// Keep in sync with apps/backend/services/requestLine/matching/compilation.ts.
+// Keep COMPILATION_KEYWORDS / isCompilationArtistName in sync with
+// apps/backend/services/requestLine/matching/compilation.ts. The stricter
+// isCompilationReleaseArtistName below is dj-site-only and has no backend twin.
 const COMPILATION_KEYWORDS = [
   "various",
   "soundtrack",
@@ -7,6 +9,13 @@ const COMPILATION_KEYWORDS = [
   "v.a.",
 ];
 
+/**
+ * Lenient substring compilation hint for the read-only search-hint consumers
+ * (useGhostText, catalogHooks, useLmlLibrarySearch), where a false positive
+ * only widens a search. Do NOT gate the rotation artist WRITE on this: the
+ * unbounded `.includes` also matches single artists whose name merely contains
+ * a keyword. Use isCompilationReleaseArtistName for the write gate.
+ */
 export function isCompilationArtistName(
   artist: string | null | undefined
 ): boolean {
@@ -18,22 +27,56 @@ export function isCompilationArtistName(
   return false;
 }
 
+// Whole-name compilation designations for the write gate: anchored to the
+// entire normalized name, not a substring or token scan, so a band name that
+// embeds a keyword as a real word does not qualify.
+const COMPILATION_ARTIST_PATTERNS: readonly RegExp[] = [
+  /^various(\s+artists?)?$/, //            "Various", "Various Artist(s)"
+  /^v\s*[/.]\s*a\.?$/, //                  "V/A", "V.A.", "V / A"
+  /^(original\s+)?(motion\s+picture\s+)?soundtrack$/, // "Soundtrack", "Original Soundtrack", "Original Motion Picture Soundtrack"
+  /^ost$/, //                             common soundtrack abbreviation
+  /^compilation$/,
+];
+
 /**
- * Release-level compilation/V-A predicate: `album_artist` populated (the
- * schema marks it "Credited album artist for compilations") or a V/A-shaped
- * artist name.
+ * Strict, whole-name compilation predicate for the rotation artist WRITE gate,
+ * decoupled from the lenient COMPILATION_KEYWORDS search-hint list.
  *
- * Consumers include the rotation picker's artist auto-fill gate (#763),
- * which uses a `true` here to decide that Discogs per-track credits are
- * performer names safe to WRITE to the flowsheet — a keyword added above
- * for a search-hint use case widens that write gate too. Note BS's
- * `GET /library/rotation` does not currently emit `album_artist`
- * (getRotationFromDB's SELECT omits it), so rotation rows are gated by
- * artist name alone until BS wires the column through.
+ * Name-only detection is lossy; residual gaps this does not cover:
+ *  - Localized or non-canonical V/A strings ("Verschiedene", "Diverse",
+ *    "Sampler") are not recognized and will not auto-fill.
+ *  - Compilations filed under a credited album artist (e.g. a DJ-mix under the
+ *    mixer's name) are only caught via `album_artist`, below.
+ *  - Splits filed under one band's name keep the release-level artist.
+ * The deterministic marker is `album_artist` on the rotation wire; BS's
+ * getRotationFromDB does not yet emit it, so this name heuristic is the interim
+ * gate. No backend twin: the backend matcher serves request-line parsing, which
+ * tolerates a different false-positive rate.
+ */
+export function isCompilationReleaseArtistName(
+  artist: string | null | undefined
+): boolean {
+  if (!artist) return false;
+  const normalized = artist.trim().toLowerCase().replace(/\s+/g, " ");
+  return COMPILATION_ARTIST_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+/**
+ * Release-level compilation/V-A predicate: true when `album_artist` is
+ * populated (schema: "Credited album artist for compilations") or the artist
+ * name is a compilation designation. The name check routes through the strict
+ * isCompilationReleaseArtistName, not the lenient search-hint list.
+ *
+ * BS's GET /library/rotation does not currently emit `album_artist`
+ * (getRotationFromDB omits the column), so rotation rows are gated on the name
+ * heuristic alone until that column is wired through.
  */
 export function isCompilationRelease(release: {
   album_artist?: string;
   artist?: { name?: string | null } | null;
 }): boolean {
-  return !!release.album_artist || isCompilationArtistName(release.artist?.name);
+  return (
+    !!release.album_artist ||
+    isCompilationReleaseArtistName(release.artist?.name)
+  );
 }

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -10,7 +10,7 @@ import {
   useGetRotationQuery,
   useGetRotationTracksQuery,
 } from "@/lib/features/rotation/api";
-import { useAppDispatch } from "@/lib/hooks";
+import { useAppDispatch, useAppStore } from "@/lib/hooks";
 import { useFlowsheetSearch } from "@/src/hooks/flowsheetHooks";
 import { Divider } from "@mui/joy";
 import { useCallback, useMemo, useState } from "react";
@@ -21,6 +21,7 @@ import TrackPickerDropdown from "./TrackPickerDropdown";
 
 export default function RotationEntryFields({ disabled }: { disabled: boolean }) {
   const dispatch = useAppDispatch();
+  const store = useAppStore();
   const { setSearchOpen } = useFlowsheetSearch();
 
   const [selectedBin, setSelectedBin] = useState<Rotation | null>(null);
@@ -107,10 +108,8 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
       dispatch(flowsheetSlice.actions.setSearchProperty({ name: "song", value: track.title ?? "" }));
       if (!trackCreditsAreDisambiguating) return;
       // `normalizeTrackArtists` strips the Discogs `(N)` disambig and dedupes
-      // — see its header for the LML cache duplication root cause. When
-      // credits are empty (Discogs has no per-track data, or every entry was
-      // malformed) leave the release-level artist in place. Join separator
-      // mirrors buildArtistCredit in apps/backend/controllers/proxy.controller.ts.
+      // — see its header for the LML cache duplication root cause. Join
+      // separator mirrors buildArtistCredit in apps/backend/controllers/proxy.controller.ts.
       const credits = normalizeTrackArtists(track.artists);
       if (credits.length > 0) {
         dispatch(
@@ -119,9 +118,25 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
             value: credits.join(", "),
           })
         );
+        return;
+      }
+      // No usable per-track credits: fall back to the release-level artist,
+      // dispatching only when it differs from the live value so re-selecting a
+      // release does not re-write it.
+      const releaseArtist = selectedRelease?.artist?.name ?? "";
+      const currentArtist = flowsheetSlice.selectors.getSearchQuery(
+        store.getState()
+      ).artist;
+      if (currentArtist !== releaseArtist) {
+        dispatch(
+          flowsheetSlice.actions.setSearchProperty({
+            name: "artist",
+            value: releaseArtist,
+          })
+        );
       }
     },
-    [dispatch, trackCreditsAreDisambiguating]
+    [dispatch, store, trackCreditsAreDisambiguating, selectedRelease]
   );
 
   const handleManualEntry = useCallback(() => {

--- a/tests/integration/components/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -428,6 +428,35 @@ describe("RotationEntryFields", () => {
       expect(artistValues(dispatchSpy)).toEqual(["Various Artists", "M.I.A."]);
     });
 
+    it("reverts to the release artist when switching from a credited to an uncredited track in one release", () => {
+      mockTracksData = [
+        {
+          position: "A1",
+          title: "Smoke Signal",
+          duration: null,
+          artists: ["Skull Mitten"],
+        },
+        {
+          position: "A2",
+          title: "Untitled Interlude",
+          duration: null,
+          artists: [],
+        },
+      ];
+
+      const { store } = renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
+      const dispatchSpy = vi.spyOn(store, "dispatch");
+      selectBinAndRelease(tobaccoAGoGo);
+      selectTrack(0);
+      selectTrack(1);
+
+      expect(artistValues(dispatchSpy)).toEqual([
+        "Various Artists",
+        "Skull Mitten",
+        "Various Artists",
+      ]);
+    });
+
     it("falls back to the release-level artist when every per-track credit is malformed", () => {
       // A partial-write LML cache row could surface [null, ""] as artists.
       // normalizeTrackArtists returns [] for that shape; the auto-fill must

--- a/tests/unit/lib/features/catalog/is-compilation-artist.test.ts
+++ b/tests/unit/lib/features/catalog/is-compilation-artist.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   isCompilationArtistName,
+  isCompilationReleaseArtistName,
   isCompilationRelease,
 } from "@/lib/features/catalog/is-compilation-artist";
 
@@ -41,7 +42,62 @@ describe("isCompilationArtistName", () => {
   });
 });
 
+describe("isCompilationReleaseArtistName", () => {
+  it.each([
+    "Various Artists",
+    "various artists",
+    "VARIOUS ARTISTS",
+    "Various Artist",
+    "Various",
+    "  Various   Artists  ", // extra/collapsed whitespace still matches
+    "V/A",
+    "v/a",
+    "V / A",
+    "V.A.",
+    "v.a.",
+    "Soundtrack",
+    "Original Soundtrack",
+    "Original Motion Picture Soundtrack",
+    "OST",
+    "Compilation",
+  ])("returns true for genuine compilation designation %s", (input) => {
+    expect(isCompilationReleaseArtistName(input)).toBe(true);
+  });
+
+  it.each([
+    "The Soundtrack of Our Lives",
+    "Various Production",
+    "Various Production, Inc.",
+    "Soundtrack of My Life",
+    "Death By Compilation",
+    "The Compilation Kids",
+    "Saint Etienne",
+    "Juana Molina",
+    "Stereolab",
+    "VA",
+  ])("returns false for keyword-substring single artist %s", (input) => {
+    expect(isCompilationReleaseArtistName(input)).toBe(false);
+  });
+
+  it.each([null, undefined, ""])(
+    "returns false for empty input %s",
+    (input) => {
+      expect(isCompilationReleaseArtistName(input)).toBe(false);
+    }
+  );
+});
+
 describe("isCompilationRelease", () => {
+  it.each([
+    "The Soundtrack of Our Lives",
+    "Various Production",
+  ])(
+    "returns false for keyword-substring single artist %s (no album_artist)",
+    (name) => {
+      expect(isCompilationRelease({ artist: { name } })).toBe(false);
+    }
+  );
+
   it("returns true when album_artist is populated, regardless of artist name", () => {
     expect(
       isCompilationRelease({


### PR DESCRIPTION
Closes #876, Closes #877 — two sibling rotation-picker bugs in the same code neighborhood.

## #877 — stale artist on a credited→uncredited track switch

**Root cause.** `handleSelectTrack` only dispatched an artist value when the picked track had ≥1 usable per-track credit (`if (credits.length > 0)`), with no `else`. On a compilation/V-A release, picking a credited track then an uncredited one within the same release never re-applied the release-level artist, so the *previous* track's performer stayed in the Redux `artist` field and mis-credited the second track.

**Fix.** In the empty-credits (compilation) branch, revert to the release-level artist (`selectedRelease?.artist?.name ?? ""`). The write is guarded by a live read of the current query value (`useAppStore().getState()`) so it only fires when the value actually drifted — the release-just-selected happy path adds no redundant dispatch/flicker, keeping the existing V/A empty-credits test at exactly `["Various Artists"]`. Added `store` and `selectedRelease` to the `useCallback` deps.

**Tests.** New integration test pins the credited-then-uncredited sequence within one release (artist reverts to `"Various Artists"`, not the prior performer). Existing V/A empty-credits and malformed-credits tests still pass.

## #876 — substring false positive re-opens #763

**Root cause.** `isCompilationArtistName` did an unbounded `.includes` over `COMPILATION_KEYWORDS`, so single artists whose name merely contains a keyword ("The Soundtrack of Our Lives", "Various Production") were misclassified as compilations. On the rotation write gate that let per-track contributor credits overwrite the real artist — the exact #763 corruption.

**Fix (interim heuristic).** Added a strict, whole-name-anchored `isCompilationReleaseArtistName` for the WRITE gate, decoupled from the lenient `COMPILATION_KEYWORDS` search-hint list. `isCompilationRelease` now routes its name check through the strict predicate; the `album_artist` branch is unchanged. The lenient `isCompilationArtistName` is untouched, so the four read-only search-hint consumers (`useGhostText`, `catalogHooks` ×2, `useLmlLibrarySearch`) keep their existing behavior. Residual name-heuristic gaps are documented in the helper header, in the style of its backend-twin note.

This is the **interim** fix: the deterministic marker is `album_artist` on the rotation wire, which BS's `getRotationFromDB` does not yet emit — that work is blocked on Backend-Service. Once the column is wired through, the name heuristic can be demoted to a fallback.

**Tests.** New unit tests pin the keyword-substring false-positive cases for both `isCompilationReleaseArtistName` and `isCompilationRelease`. The genuine V/A auto-fill (`tobaccoAGoGo` / "Various Artists") and the #763 normal-release case (`foxbaseAlpha` / "Saint Etienne") still pass.

## Verification
- `npx tsc --noEmit` ✅
- `npm run lint` ✅ (0 errors)
- `npm run test:run` ✅ (3705 passed)
- `npm run build` ✅

## Note on PR #830
This touches `flowsheet/Search/RotationEntryFields.tsx` — PR #830 (parked smart-entry redesign) must re-absorb this fix when rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)