### PR TITLE
fix(auth): clear cached bearer before EmailChangeModal password-reverify

### DIFF
--- a/src/components/experiences/modern/settings/EmailChangeModal.tsx
+++ b/src/components/experiences/modern/settings/EmailChangeModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { authClient } from "@/lib/features/authentication/client";
+import { authClient, clearTokenCache } from "@/lib/features/authentication/client";
 import { isValidEmail } from "@wxyc/shared/validation";
 import { Email, Key } from "@mui/icons-material";
 import {
@@ -70,7 +70,10 @@ export default function EmailChangeModal({
 
     try {
       // Better Auth's changeEmail requires the user to be authenticated;
-      // signing in here also verifies the password to prevent unauthorized changes
+      // signing in here also verifies the password to prevent unauthorized changes.
+      // signIn.email always issues a fresh session token, even for a same-identity
+      // reverify, so the cached bearer must be dropped before calling it.
+      clearTokenCache();
       const verifyResult = await authClient.signIn.email({
         email: currentEmail,
         password,

--- a/tests/integration/components/modern/settings/EmailChangeModal.test.tsx
+++ b/tests/integration/components/modern/settings/EmailChangeModal.test.tsx
@@ -6,6 +6,7 @@ import EmailChangeModal from "@/src/components/experiences/modern/settings/Email
 // Mock the auth client
 const mockChangeEmail = vi.fn();
 const mockSignInEmail = vi.fn();
+const mockClearTokenCache = vi.fn();
 
 vi.mock("@/lib/features/authentication/client", () => ({
   authClient: {
@@ -14,6 +15,7 @@ vi.mock("@/lib/features/authentication/client", () => ({
       email: (...args: unknown[]) => mockSignInEmail(...args),
     },
   },
+  clearTokenCache: (...args: unknown[]) => mockClearTokenCache(...args),
 }));
 
 // Mock sonner toast
@@ -187,6 +189,39 @@ describe("EmailChangeModal", () => {
       await waitFor(() => {
         expect(screen.getByText("Invalid credentials")).toBeInTheDocument();
       });
+    });
+
+    it("should clear the cached token before password-reverify sign-in", async () => {
+      const callOrder: string[] = [];
+      mockClearTokenCache.mockImplementation(() => {
+        callOrder.push("clearTokenCache");
+      });
+      mockSignInEmail.mockImplementation(async () => {
+        callOrder.push("signInEmail");
+        return { data: { user: {} } };
+      });
+
+      const { user } = renderWithProviders(
+        <EmailChangeModal {...defaultProps} />
+      );
+
+      const newEmailInput = screen.getByPlaceholderText("Enter your new email");
+      const passwordInput = screen.getByPlaceholderText("Confirm your password");
+
+      await user.type(newEmailInput, "new@example.com");
+      await user.type(passwordInput, "correctpassword");
+
+      const submitButton = screen.getByRole("button", {
+        name: "Send Verification Email",
+      });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockSignInEmail).toHaveBeenCalled();
+      });
+
+      expect(mockClearTokenCache).toHaveBeenCalledTimes(1);
+      expect(callOrder).toEqual(["clearTokenCache", "signInEmail"]);
     });
   });
 


### PR DESCRIPTION
Closes #679

## #679 — EmailChangeModal password-reverify may rotate session token without clearTokenCache

**Verdict: it rotates. Confirmed in the installed better-auth 1.6.23 source.**

- `node_modules/better-auth/dist/api/routes/sign-in.mjs` — the `signInEmail` handler unconditionally calls `ctx.context.internalAdapter.createSession(user.user.id, ...)` after password verification, with no branch that checks for or reuses an existing session for the same identity.
- `node_modules/better-auth/dist/db/internal-adapter.mjs` — `createSession` always assigns `token: generateId(32)`, a fresh random token on every call, then `setSessionCookie` overwrites the session cookie.

So `EmailChangeModal`'s password-reverify `signIn.email` call always mints a new session token, exactly like a normal login. Fix: added the same `clearTokenCache()` call used at the other `signIn.email`/`signIn.username`/`signIn.emailOtp`/`signOut` entry points, immediately before the reverify call in `EmailChangeModal.handleSubmit`.

Test: extended `tests/integration/components/modern/settings/EmailChangeModal.test.tsx` with a call-order assertion (`clearTokenCache` before `signInEmail`), matching the existing pattern for `useLogin`/`useOTPVerify` in `tests/unit/hooks/authenticationHooks.test.ts`.

A comment with this verdict has been posted on #679 directly.

## #678 — useNewUser inverse partial-failure window (not part of this PR's Closes)

Investigated and found **obsolete** — not included in this PR's code changes. Filed 2026-05-29 against the two-call `changePassword` → `updateUser({hasCompletedOnboarding:true})` sequence that #676 introduced in `useNewUser`. That entire code path no longer exists: commit `a993d7b5` ("feat(onboarding): complete setup via invite token", 2026-07-09) replaced it with a single atomic call to `completeOnboarding()` (`lib/features/authentication/client.ts`), which POSTs token + new password + profile fields together to `POST /auth/wxyc/complete-onboarding` in one request. That's exactly the issue's own "Option 2: atomic backend endpoint," already implemented — it supersedes the "Option 3: telemetry" first step the issue asked for, since the failure window it was meant to make visible can no longer occur client-side.

Confirmed no other call site reintroduced the split (`grep -rn "changePassword"` across `src/`, `lib/`, `app/` returns zero hits). A comment explaining this with the commit citation has been posted on #678; it's left open for the maintainer to close, per campaign convention.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors, 224 warnings (pre-existing baseline, unchanged by this diff)
- `npm run test:run -- --maxWorkers=2` — 269 files / 3674 tests passed
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
