### PR TITLE
fix: keep GoLive aria-label stable through hydration

### DIFF
--- a/src/components/experiences/modern/flowsheet/GoLive.tsx
+++ b/src/components/experiences/modern/flowsheet/GoLive.tsx
@@ -19,11 +19,25 @@ import {
   Stack,
   Tooltip,
 } from "@mui/joy";
+import { useEffect, useState } from "react";
 
 export default function GoLive() {
   const { live, autoplay, setAutoPlay, loading, goLive, leave } =
     useShowControl();
   const isSaving = useFlowsheetSaving();
+
+  // Must match the server's markup until this flips true post-mount, or the
+  // aria-label React hydrates onto the ButtonGroup won't match server HTML.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  const goLiveLabel =
+    mounted && !loading
+      ? live
+        ? "Click to leave"
+        : "Click to go live"
+      : "Loading...";
 
   return (
     <Stack direction="row" spacing={1} alignItems="center">
@@ -53,7 +67,7 @@ export default function GoLive() {
         </Tooltip>
       ) : null}
       <Tooltip
-        title={loading ? "Loading..." : live ? "Click to leave" : "Click to go live"}
+        title={goLiveLabel}
         placement="top"
         size="sm"
         variant="outlined"

--- a/tests/integration/components/modern/flowsheet/GoLive.test.tsx
+++ b/tests/integration/components/modern/flowsheet/GoLive.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { hydrateRoot } from "react-dom/client";
 import GoLive from "@/src/components/experiences/modern/flowsheet/GoLive";
 
 // Mock flowsheet hooks
@@ -144,6 +146,65 @@ describe("GoLive", () => {
     expect(buttons[1]).toBeDisabled();
   });
 
+  describe("hydration safety", () => {
+    it("keeps the go-live aria-label consistent between the server render and the client's first hydration pass, then updates once mounted", async () => {
+      const { useShowControl } = await import("@/src/hooks/flowsheetHooks");
+      // clearAllMocks() clears call history, not a prior mockReturnValue.
+      vi.mocked(useShowControl).mockReturnValue({
+        live: false,
+        autoplay: false,
+        setAutoPlay: mockSetAutoPlay,
+        loading: false,
+        goLive: mockGoLive,
+        leave: mockLeave,
+        currentShow: -1,
+      });
+      vi.mocked(useShowControl).mockImplementationOnce(() => ({
+        live: false,
+        autoplay: false,
+        setAutoPlay: mockSetAutoPlay,
+        loading: true,
+        goLive: mockGoLive,
+        leave: mockLeave,
+        currentShow: -1,
+      }));
+
+      const serverHtml = renderToString(<GoLive />);
+      expect(serverHtml).toContain('aria-label="Loading..."');
+
+      const container = document.createElement("div");
+      container.innerHTML = serverHtml;
+      document.body.appendChild(container);
+
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      let root!: ReturnType<typeof hydrateRoot>;
+      act(() => {
+        root = hydrateRoot(container, <GoLive />);
+      });
+
+      // React's mismatch dump includes unchanged attributes as surrounding
+      // context, so match a `+`/`-` diff line, not any mention of the name.
+      const ariaLabelMismatchLogged = errorSpy.mock.calls.some((call) =>
+        call.some(
+          (arg) => typeof arg === "string" && /^[+-]\s*aria-label=/m.test(arg)
+        )
+      );
+      expect(ariaLabelMismatchLogged).toBe(false);
+      errorSpy.mockRestore();
+
+      const buttonGroup = container.querySelector('[role="group"]');
+      await waitFor(() => {
+        expect(buttonGroup).toHaveAttribute("aria-label", "Click to go live");
+      });
+
+      act(() => {
+        root.unmount();
+      });
+      document.body.removeChild(container);
+    });
+  });
+
   it("should show saving indicator when isSaving", async () => {
     const { useShowControl } = await import("@/src/hooks/flowsheetHooks");
     vi.mocked(useShowControl).mockReturnValue({
@@ -155,7 +216,9 @@ describe("GoLive", () => {
       leave: mockLeave,
       currentShow: 1,
     });
-    mockUseFlowsheetSaving.mockReturnValueOnce(true);
+    // Not `mockReturnValueOnce`: GoLive re-renders once more after mount,
+    // calling this hook again — a "once" value wouldn't cover that render.
+    mockUseFlowsheetSaving.mockReturnValue(true);
 
     render(<GoLive />);
     expect(screen.getByRole("progressbar")).toBeInTheDocument();


### PR DESCRIPTION
## Root cause

`src/components/experiences/modern/flowsheet/GoLive.tsx:56` derived the go-live Tooltip title (which `ButtonGroup` mirrors into `aria-label`) from `loading`, sourced from `useShowControl` → `useRegistry` → `useAuthentication`. The SSR pass renders with `loading: true` (session not yet resolved), but the client's first render can already have `loading: false` (better-auth's session resolves before hydration completes), so React has to patch the `aria-label` during hydration — the mismatch reported in #895.

The sibling "Autoplay is On/Off" label (line ~31) was checked for the same class of divergence: `autoplay` comes from a plain Redux slice with a static `false` initial state and no localStorage/cookie rehydration, so it's identical on server and client — not affected, left unchanged.

## Fix

Gate the go-live label behind a `mounted` flag (`useState(false)` + `useEffect` → `true`), following the existing mount-gate pattern already used in `WelcomeQuotes` (`src/components/experiences/modern/login/Quotes/Welcome.tsx`). The label reads `"Loading..."` — matching whatever the server emitted — until mounted, then settles to the real `loading`/`live`-derived value.

## Tests

Added a regression test in `tests/integration/components/modern/flowsheet/GoLive.test.tsx` that renders with `react-dom/server`'s `renderToString`, hydrates the resulting HTML with `react-dom/client`'s `hydrateRoot`, and asserts no `aria-label` hydration-mismatch is logged by React — then confirms the label updates to the real state once mounted. Verified this test fails against the pre-fix component and passes after the fix.

Also fixed an existing test ("should show saving indicator when isSaving") that relied on `mockReturnValueOnce` for a hook GoLive now calls twice (initial render + the one extra re-render the mount-gate causes) — switched to `mockReturnValue`.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warning backlog untouched)
- `npm run test:run` — 3674/3674 passed
- `npm run build` — succeeds

Note: visual/hydration-console check on the flowsheet dashboard — Jackson to confirm at merge check (no dev servers were run as part of this change).

Closes #895

🤖 Generated with [Claude Code](https://claude.com/claude-code)