### PR TITLE
ci: add CodeQL scanning and a report-only npm audit step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,35 @@ jobs:
       - name: Run script tests
         run: npm run test:scripts
 
+  dependency-audit:
+    name: Dependency Audit
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.app_source == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Report-only: unresolved advisories on existing transitive deps (no
+      # fix available without a breaking major bump) would otherwise turn
+      # this red on every run regardless of what a PR actually changes.
+      # Findings are listed in the PR description; continue-on-error keeps
+      # them visible without blocking merges.
+      - name: npm audit (high severity, production deps)
+        run: npm audit --audit-level=high --omit=dev
+        continue-on-error: true
+
   # Production Direct-Upload deploy. Replaces the Cloudflare Pages Git-build
   # integration (whose pinned wrangler 3.x boot-500'd @opennextjs/cloudflare
   # >= 1.19 — WXYC/dj-site#810). Gated on full CI success. Own concurrency

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly baseline: catches new CodeQL query-pack advisories against
+    # unchanged code, independent of the push/PR-triggered scans above.
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+# Workflow-level floor; the analyze job restates contents:read (job-level
+# permissions replace, not add to, this block) alongside the write scope
+# github/codeql-action needs to upload results.
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      # Required so the action can read check-run/workflow-run metadata when
+      # triggered on a private repo; harmless no-op on a public one.
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          # No compilation step exists for this extraction mode -- CodeQL
+          # parses JS/TS sources directly rather than needing a build.
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
Closes #238.

## What lint already covers (S19)

`npm run lint` (ESLint flat config, `eslint-config-next` core-web-vitals + typescript) runs in `ci.yml`'s Type Check job. That's style/correctness static analysis over app source, not security-focused CodeQL-style data-flow analysis or dependency-vulnerability scanning — this PR adds the two residual pieces from #238.

## What's new

**`.github/workflows/codeql.yml`** — `github/codeql-action` for `javascript-typescript`, on push to `main`, PRs into `main`, and a weekly Monday cron (catches new query-pack advisories against unchanged code). `build-mode: none` since JS/TS extraction doesn't need a compile step. Permissions are job-scoped to `contents: read` + `security-events: write` (+ `actions: read`, harmless on a public repo, needed if this repo ever goes private) — matches the minimal-permissions floor pattern already in `ci.yml`.

**`ci.yml` → `dependency-audit` job** — `npm audit --audit-level=high --omit=dev`, gated by the same `changes`-job path filter as the other jobs. `continue-on-error: true`: this repo currently has unresolved advisories on transitive deps with no non-breaking fix, so a blocking step would be permanently red rather than a signal. Current findings (as of this PR, `npm audit --omit=dev`):

- **high**: `defu` <=6.1.4 — prototype pollution (GHSA-737v-mqg7-c878)
- **high**: `form-data` 4.0.0–4.0.5 — CRLF injection (GHSA-hmw2-7cc7-3qxx)
- **moderate**: `dompurify` <=3.4.10 — several XSS/pollution advisories
- **moderate**: `postcss` <8.5.10 — XSS via unescaped `</style>` (fix requires a breaking `next` downgrade)
- **moderate**: `yaml` 1.x/2.x — stack overflow via deeply nested collections

All are transitive (not direct `package.json` dependencies); `npm audit fix` resolves some, `npm audit fix --force` (breaking) is needed for the `postcss`/`next` one. Left for separate follow-up rather than folded into this CI-tooling PR. The step stays visible in every run's job list so this doesn't silently rot — flip `continue-on-error` off once the list is clear.

## Testing

- `python3 -c 'import yaml; yaml.safe_load(open(...))'` — both workflow files parse.
- No `actionlint` binary available in this environment; reviewed by hand against `ci.yml`'s existing conventions (action-version pinning style, job-level `permissions:`, `changes`-job path-filter gating, concurrency group naming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)