### PR TITLE
feat(metadata): conditional-GET revalidation in metadataApi baseQuery

### DIFF
--- a/lib/features/metadata/api.ts
+++ b/lib/features/metadata/api.ts
@@ -1,5 +1,6 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import { backendBaseQuery } from "../backend";
+import { withConditionalGet } from "./conditionalGet";
 import {
   AlbumMetadata,
   AlbumMetadataQueryParams,
@@ -9,7 +10,7 @@ import {
 
 export const metadataApi = createApi({
   reducerPath: "metadataApi",
-  baseQuery: backendBaseQuery("proxy"),
+  baseQuery: withConditionalGet(backendBaseQuery("proxy")),
   endpoints: (builder) => ({
     getAlbumMetadata: builder.query<AlbumMetadata, AlbumMetadataQueryParams>({
       query: ({ artistName, releaseTitle, trackTitle }) => ({

--- a/lib/features/metadata/conditionalGet.ts
+++ b/lib/features/metadata/conditionalGet.ts
@@ -1,0 +1,95 @@
+import type {
+  BaseQueryApi,
+  BaseQueryFn,
+  FetchArgs,
+  FetchBaseQueryError,
+  FetchBaseQueryMeta,
+} from "@reduxjs/toolkit/query";
+
+type ProxyBaseQuery = BaseQueryFn<
+  string | FetchArgs,
+  unknown,
+  FetchBaseQueryError,
+  Record<string, unknown>,
+  FetchBaseQueryMeta
+>;
+
+type Validators = {
+  etag?: string;
+  lastModified?: string;
+  // The prior response body, kept beside its validators so a 304 can restore
+  // the cache entry without a re-decode, and so both evict together — sending
+  // If-None-Match while lacking a body to return on 304 would strand the entry.
+  body: unknown;
+};
+
+const isEmpty = (value: string | null | undefined): boolean =>
+  value === null || value === undefined || value.trim().length === 0;
+
+/**
+ * Wrap a `fetchBaseQuery`-derived base query with HTTP conditional-GET
+ * revalidation. On a repeat fetch of the same RTK Query cache key it forwards
+ * the prior response's `ETag` / `Last-Modified` as `If-None-Match` /
+ * `If-Modified-Since`; a `304 Not Modified` then restores the cached body
+ * without re-parsing.
+ *
+ * The validator store is a plain module-level map keyed by `queryCacheKey`, not
+ * part of the Redux cache entry — no `redux-persist` or entry-shape coupling.
+ * It never gates cache validity: absent headers degrade to an ordinary fetch,
+ * so endpoints outside the Backend conditional-GET contract are unaffected.
+ */
+export const withConditionalGet = (baseQuery: ProxyBaseQuery): ProxyBaseQuery => {
+  const store = new Map<string, Validators>();
+
+  return async (args, api: BaseQueryApi, extraOptions) => {
+    const cacheKey = api.queryCacheKey;
+    const cached = cacheKey !== undefined ? store.get(cacheKey) : undefined;
+
+    const requestArgs =
+      cached === undefined ? args : withConditionalHeaders(args, cached);
+
+    const result = await baseQuery(requestArgs, api, extraOptions);
+
+    const status = result.meta?.response?.status;
+
+    if (status === 304 && cached !== undefined) {
+      return { data: cached.body, meta: result.meta };
+    }
+
+    if (cacheKey !== undefined && result.data !== undefined && status === 200) {
+      const headers = result.meta?.response?.headers;
+      const etag = headers?.get("etag") ?? undefined;
+      const lastModified = headers?.get("last-modified") ?? undefined;
+      if (!isEmpty(etag) || !isEmpty(lastModified)) {
+        store.set(cacheKey, { etag, lastModified, body: result.data });
+      } else {
+        // Resource stopped advertising validators — drop any stale entry so a
+        // later fetch doesn't send a conditional header the server won't honor.
+        store.delete(cacheKey);
+      }
+    }
+
+    return result;
+  };
+};
+
+/**
+ * `If-None-Match` takes precedence over `If-Modified-Since` when both are
+ * available (RFC 9111 §4.3.2), so only one is sent.
+ */
+const withConditionalHeaders = (
+  args: string | FetchArgs,
+  validators: Validators
+): FetchArgs => {
+  const base: FetchArgs = typeof args === "string" ? { url: args } : { ...args };
+  const headers = new Headers(base.headers as HeadersInit | undefined);
+
+  if (!isEmpty(validators.etag)) {
+    headers.set("If-None-Match", validators.etag as string);
+  } else if (!isEmpty(validators.lastModified)) {
+    headers.set("If-Modified-Since", validators.lastModified as string);
+  }
+
+  base.headers = headers;
+  return base;
+};

--- a/tests/unit/lib/features/metadata/api.test.ts
+++ b/tests/unit/lib/features/metadata/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { http, HttpResponse } from "msw";
+import type { ArtistMetadata } from "@/lib/features/metadata/types";
 import { metadataApi } from "@/lib/features/metadata/api";
 import {
   createTestStore,
@@ -7,6 +8,16 @@ import {
   server,
   TEST_BACKEND_URL,
 } from "@/tests/helpers";
+
+const ARTIST_ENDPOINT = `${TEST_BACKEND_URL}/proxy/metadata/artist`;
+
+const artistMetadata = (discogsArtistId: number): ArtistMetadata => ({
+  discogsArtistId,
+  bio: null,
+  bioTokens: null,
+  wikipediaUrl: null,
+  imageUrl: null,
+});
 
 describe("metadataApi", () => {
   describeApi(metadataApi, {
@@ -92,6 +103,170 @@ describe("metadataApi", () => {
 
       expect(result.source).toBeNull();
       expect(result.tracks).toEqual([]);
+    });
+  });
+
+  // The validator store keyed by RTK Query cache key is a module singleton
+  // shared across this file's runs, so every case uses a distinct artistId to
+  // avoid cross-test bleed.
+  describe("conditional GET revalidation", () => {
+    const fetchArtist = (artistId: number, forceRefetch = false) =>
+      createTestStore()
+        .dispatch(
+          metadataApi.endpoints.getArtistMetadata.initiate(
+            { artistId },
+            { forceRefetch }
+          )
+        )
+        .unwrap();
+
+    it("sends no conditional headers on the first fetch", async () => {
+      const artistId = 5001;
+      const seen: (string | null)[] = [];
+      server.use(
+        http.get(ARTIST_ENDPOINT, ({ request }) => {
+          seen.push(request.headers.get("if-none-match"));
+          seen.push(request.headers.get("if-modified-since"));
+          return HttpResponse.json(artistMetadata(artistId), {
+            headers: { ETag: '"rev-1"' },
+          });
+        })
+      );
+
+      await fetchArtist(artistId);
+
+      expect(seen).toEqual([null, null]);
+    });
+
+    it("forwards the prior ETag as If-None-Match on a repeat fetch", async () => {
+      const artistId = 5002;
+      const conditional: (string | null)[] = [];
+      server.use(
+        http.get(ARTIST_ENDPOINT, ({ request }) => {
+          conditional.push(request.headers.get("if-none-match"));
+          return HttpResponse.json(artistMetadata(artistId), {
+            headers: { ETag: '"rev-1"' },
+          });
+        })
+      );
+
+      await fetchArtist(artistId);
+      await fetchArtist(artistId, true);
+
+      expect(conditional).toEqual([null, '"rev-1"']);
+    });
+
+    it("forwards Last-Modified as If-Modified-Since when no ETag is present", async () => {
+      const artistId = 5003;
+      const lastModified = "Wed, 03 Jun 2026 10:00:00 GMT";
+      const seen: { inm: string | null; ims: string | null }[] = [];
+      server.use(
+        http.get(ARTIST_ENDPOINT, ({ request }) => {
+          seen.push({
+            inm: request.headers.get("if-none-match"),
+            ims: request.headers.get("if-modified-since"),
+          });
+          return HttpResponse.json(artistMetadata(artistId), {
+            headers: { "Last-Modified": lastModified },
+          });
+        })
+      );
+
+      await fetchArtist(artistId);
+      await fetchArtist(artistId, true);
+
+      expect(seen[1]).toEqual({ inm: null, ims: lastModified });
+    });
+
+    it("prefers If-None-Match over If-Modified-Since when both are known", async () => {
+      const artistId = 5004;
+      const seen: { inm: string | null; ims: string | null }[] = [];
+      server.use(
+        http.get(ARTIST_ENDPOINT, ({ request }) => {
+          seen.push({
+            inm: request.headers.get("if-none-match"),
+            ims: request.headers.get("if-modified-since"),
+          });
+          return HttpResponse.json(artistMetadata(artistId), {
+            headers: {
+              ETag: '"rev-1"',
+              "Last-Modified": "Wed, 03 Jun 2026 10:00:00 GMT",
+            },
+          });
+        })
+      );
+
+      await fetchArtist(artistId);
+      await fetchArtist(artistId, true);
+
+      expect(seen[1]).toEqual({ inm: '"rev-1"', ims: null });
+    });
+
+    it("preserves the cached body on a 304 without re-decoding", async () => {
+      const artistId = 5005;
+      let calls = 0;
+      server.use(
+        http.get(ARTIST_ENDPOINT, ({ request }) => {
+          calls += 1;
+          if (request.headers.get("if-none-match") === '"rev-1"') {
+            return new HttpResponse(null, {
+              status: 304,
+              headers: { ETag: '"rev-1"' },
+            });
+          }
+          return HttpResponse.json(artistMetadata(artistId), {
+            headers: { ETag: '"rev-1"' },
+          });
+        })
+      );
+
+      const first = await fetchArtist(artistId);
+      const second = await fetchArtist(artistId, true);
+
+      expect(calls).toBe(2);
+      expect(second).toEqual(first);
+      expect(second).toEqual(artistMetadata(artistId));
+    });
+
+    it("replaces the cache entry and adopts the new validator on a 200", async () => {
+      const artistId = 5006;
+      const conditional: (string | null)[] = [];
+      server.use(
+        http.get(ARTIST_ENDPOINT, ({ request }) => {
+          const inm = request.headers.get("if-none-match");
+          conditional.push(inm);
+          const rev = inm ? "rev-2" : "rev-1";
+          return HttpResponse.json(
+            { ...artistMetadata(artistId), discogsArtistId: inm ? 99 : artistId },
+            { headers: { ETag: `"${rev}"` } }
+          );
+        })
+      );
+
+      await fetchArtist(artistId);
+      const replaced = await fetchArtist(artistId, true);
+      await fetchArtist(artistId, true);
+
+      expect(replaced.discogsArtistId).toBe(99);
+      // Third fetch must carry the ETag from the 200 replacement, not the first.
+      expect(conditional).toEqual([null, '"rev-1"', '"rev-2"']);
+    });
+
+    it("degrades to an unconditional fetch when the server emits no validators", async () => {
+      const artistId = 5007;
+      const conditional: (string | null)[] = [];
+      server.use(
+        http.get(ARTIST_ENDPOINT, ({ request }) => {
+          conditional.push(request.headers.get("if-none-match"));
+          return HttpResponse.json(artistMetadata(artistId));
+        })
+      );
+
+      const first = await fetchArtist(artistId);
+      const second = await fetchArtist(artistId, true);
+
+      expect(conditional).toEqual([null, null]);
+      expect(second).toEqual(first);
     });
   });
 });


### PR DESCRIPTION
Closes #582

## What

Wraps `metadataApi`'s base query with an HTTP conditional-GET enhancer (`withConditionalGet`). On a repeat fetch of the same RTK Query cache key, it forwards the prior response's `ETag` / `Last-Modified` as `If-None-Match` / `If-Modified-Since`; a `304 Not Modified` restores the cached body without re-decoding, and a `200` replaces body + validators.

Backend Epic F (BS#880, conditional-GET / staleness contract) landed 2026-06-03, so the `/proxy/metadata/*` endpoints now emit DB-derived `ETag` / `Last-Modified`.

## Design

- **New enhancer** `lib/features/metadata/conditionalGet.ts`, applied only in `lib/features/metadata/api.ts` (`withConditionalGet(backendBaseQuery("proxy"))`). It sits *outside* `backendBaseQuery`, so the existing JWT / `X-Request-Id` / non-JSON soft-fail behavior is untouched.
- **Where validators live:** a plain module-level `Map<queryCacheKey, { etag?, lastModified?, body }>`. The prior body is stored *beside* its validators so both evict together — sending `If-None-Match` while lacking a body to return on 304 would strand the entry. `queryCacheKey` comes off `BaseQueryApi` (RTK 2.12). This deliberately keeps validators **out of the Redux cache-entry shape**, so there is no `redux-persist` interaction to coordinate.
- **Persistence check:** grepped the repo — there is **no** `redux-persist` / `persistReducer` / `persistStore` anywhere. The entry-shape concern from the issue is moot; the side-map avoids it entirely.
- **304 handling:** detected via `meta.response.status === 304` (fetchBaseQuery surfaces 304 as a status error since it's not 2xx). The enhancer returns `{ data: cachedBody, meta }`, so RTK keeps the entry current and `transformResponse` re-parses nothing.
- **Precedence:** `If-None-Match` is sent in preference to `If-Modified-Since` when both validators are known (RFC 9111 §4.3.2), matching the issue.
- **No regression path:** a `200` with neither header deletes any stale validator entry, so a resource that stops advertising validators reverts to unconditional fetches. `5xx` / network errors leave the store untouched and pass through unchanged.

## Server contract verified

Backend Epic F (BS#880) closed 2026-06-03 and emits `ETag` (and/or `Last-Modified`) on the metadata proxy endpoints, returning `304` when a client sends a matching `If-None-Match`. The enhancer treats validators strictly as an optimization — it never gates cache validity on them.

## Catalog scope decision

Left `lib/features/catalog/api.ts` out of scope. `catalogApi` uses the `library` domain (`/library/*`), not the `/proxy/*` metadata endpoints Epic F covers; the issue's "possibly extend" note is conditional on Epic F covering `/proxy/library/search` shapes, which it doesn't for the catalog proxy. `lmlApi` also uses the `proxy` domain and could be a future adopter of the same enhancer. Both are follow-ups, not touched here.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warning backlog unchanged; no new warnings from these files)
- `npm run test:run -- --maxWorkers=2` — 3683 passed (270 files), including 7 new conditional-GET specs: no headers on first fetch, `If-None-Match` on repeat, `If-Modified-Since` fallback, `If-None-Match` precedence, 304 body-preservation without re-decode, 200 replacement + new-validator adoption, and missing-header degradation
- `npm run build` — compiled successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)