### PR TITLE
feat(playlist-search): migrate to builder.infiniteQuery

### DIFF
--- a/lib/features/playlist-search/api.ts
+++ b/lib/features/playlist-search/api.ts
@@ -5,50 +5,50 @@ import type {
   PlaylistSearchResponse,
 } from "@wxyc/shared";
 
-// Local extensions until @wxyc/shared adds cursor pagination to api.yaml.
-// Backend-Service /flowsheet/search accepts cursor and returns nextCursor;
-// see docs/playlist-search/README.md step 3 in that repo. page is optional
-// here because cursor mode does not use it (and the backend defaults page
-// to 0 when missing); offset-mode callers can still supply it.
-export type PlaylistSearchParamsWithCursor = Omit<
-  PlaylistSearchParams,
-  "page"
-> & {
-  page?: number;
-  cursor?: string;
-};
-
+// Backend-Service /flowsheet/search accepts an opaque cursor and returns
+// nextCursor; @wxyc/shared's api.yaml has not yet added cursor pagination.
 export type PlaylistSearchResponseWithCursor = PlaylistSearchResponse & {
   nextCursor?: string;
 };
+
+// Search key for the infinite query — everything except pagination. `page` and
+// the cursor are supplied per-page from pageParam.
+export type PlaylistSearchInfiniteArg = Omit<PlaylistSearchParams, "page">;
+
+// null pageParam = first page; a string pageParam is the opaque nextCursor.
+type PlaylistSearchPageParam = string | null;
 
 export const playlistSearchApi = createApi({
   reducerPath: "playlistSearchApi",
   baseQuery: backendBaseQuery("flowsheet"),
   endpoints: (builder) => ({
-    searchPlaylists: builder.query<
+    searchPlaylists: builder.infiniteQuery<
       PlaylistSearchResponseWithCursor,
-      PlaylistSearchParamsWithCursor
+      PlaylistSearchInfiniteArg,
+      PlaylistSearchPageParam
     >({
-      query: ({
-        q,
-        page = 0,
-        limit = 50,
-        sort = "date",
-        order = "desc",
-        cursor,
-      }) => ({
-        url: "/search",
-        // Only forward cursor when defined — sending cursor=undefined would
-        // serialize as the literal string "undefined".
-        params:
-          cursor !== undefined
-            ? { q, page, limit, sort, order, cursor }
-            : { q, page, limit, sort, order },
-      }),
+      infiniteQueryOptions: {
+        initialPageParam: null,
+        getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      },
+      query({ pageParam, queryArg }) {
+        const { q, limit = 50, sort = "date", order = "desc" } = queryArg;
+        return {
+          url: "/search",
+          // Only forward cursor for non-first pages — sending cursor=null
+          // would serialize as the literal string "null".
+          params:
+            pageParam !== null
+              ? { q, page: 0, limit, sort, order, cursor: pageParam }
+              : { q, page: 0, limit, sort, order },
+        };
+      },
+      transformResponse: (
+        response: PlaylistSearchResponseWithCursor | null,
+      ): PlaylistSearchResponseWithCursor =>
+        response ?? { results: [], total: 0, page: 0, totalPages: 0 },
     }),
   }),
 });
 
-export const { useSearchPlaylistsQuery, useLazySearchPlaylistsQuery } =
-  playlistSearchApi;
+export const { useSearchPlaylistsInfiniteQuery } = playlistSearchApi;

--- a/lib/features/playlist-search/frontend.ts
+++ b/lib/features/playlist-search/frontend.ts
@@ -29,10 +29,6 @@ export type PlaylistSearchState = {
   rows: SearchRow[];
   sortBy: SortField;
   sortOrder: SortOrder;
-  // Cursor for the next page to fetch. null = first page (start from the
-  // most recent entries). The hook reads nextCursor from the previous
-  // response and dispatches advanceCursor(nextCursor) on infinite-scroll.
-  cursor: string | null;
 };
 
 const createInitialRow = (): SearchRow => ({
@@ -47,7 +43,6 @@ const initialState: PlaylistSearchState = {
   rows: [createInitialRow()],
   sortBy: "date",
   sortOrder: "desc",
-  cursor: null,
 };
 
 export const playlistSearchSlice = createAppSlice({
@@ -63,7 +58,6 @@ export const playlistSearchSlice = createAppSlice({
     removeRow: (state, action: PayloadAction<string>) => {
       if (state.rows.length > 1) {
         state.rows = state.rows.filter((r) => r.id !== action.payload);
-        state.cursor = null;
       }
     },
     updateRow: (
@@ -73,7 +67,6 @@ export const playlistSearchSlice = createAppSlice({
       const row = state.rows.find((r) => r.id === action.payload.id);
       if (row) {
         Object.assign(row, action.payload.updates);
-        state.cursor = null;
       }
     },
     setSort: (state, action: PayloadAction<SortField>) => {
@@ -83,13 +76,6 @@ export const playlistSearchSlice = createAppSlice({
         state.sortBy = action.payload;
         state.sortOrder = "desc";
       }
-      state.cursor = null;
-    },
-    advanceCursor: (state, action: PayloadAction<string>) => {
-      state.cursor = action.payload;
-    },
-    resetCursor: (state) => {
-      state.cursor = null;
     },
     reset: () => initialState,
   },
@@ -97,6 +83,5 @@ export const playlistSearchSlice = createAppSlice({
     getRows: (state) => state.rows,
     getSortBy: (state) => state.sortBy,
     getSortOrder: (state) => state.sortOrder,
-    getCursor: (state) => state.cursor,
   },
 });

--- a/src/hooks/playlistSearchHooks.ts
+++ b/src/hooks/playlistSearchHooks.ts
@@ -1,17 +1,13 @@
 "use client";
 
-import { useLazySearchPlaylistsQuery } from "@/lib/features/playlist-search/api";
+import { useSearchPlaylistsInfiniteQuery } from "@/lib/features/playlist-search/api";
 import {
   playlistSearchSlice,
   SearchRow,
 } from "@/lib/features/playlist-search/frontend";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
-import { useCallback, useEffect, useRef, useState, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import type { PlaylistSearchResult } from "@wxyc/shared";
-import type { PlaylistSearchParams } from "@wxyc/shared/dtos";
-
-type SortField = PlaylistSearchParams["sort"];
-type SortOrder = PlaylistSearchParams["order"];
 
 const MIN_QUERY_LENGTH = 2;
 const LIMIT = 50;
@@ -68,109 +64,48 @@ export function usePlaylistSearch() {
   const rows = useAppSelector(playlistSearchSlice.selectors.getRows);
   const sortBy = useAppSelector(playlistSearchSlice.selectors.getSortBy);
   const sortOrder = useAppSelector(playlistSearchSlice.selectors.getSortOrder);
-  const cursor = useAppSelector(playlistSearchSlice.selectors.getCursor);
 
   const effectiveQuery = useMemo(() => buildQuery(rows), [rows]);
 
-  // null sentinel = "never fired" — distinguishes initial mount from a
-  // user-cleared empty query so the on-mount empty-q request still goes out.
-  const lastFiredQueryRef = useRef<string | null>(null);
-  const lastFiredParamsRef = useRef<{
-    cursor: string | null;
-    sortBy: SortField;
-    sortOrder: SortOrder;
-  }>({
-    cursor: null,
-    sortBy: "date",
-    sortOrder: "desc",
-  });
+  // A single-character partial isn't worth a request; an empty query is the
+  // "show recent tracks" default and must fire.
+  const isPartialQuery =
+    effectiveQuery.length > 0 && effectiveQuery.length < MIN_QUERY_LENGTH;
 
-  // State, not a ref, so the data-arrival effect actually re-renders the
-  // consumer — a ref-based version (#540) mutated after render without
-  // projecting into the DOM, so the page showed "Found N results" over an
-  // empty table.
-  const [accumulatedResults, setAccumulatedResults] = useState<
-    PlaylistSearchResult[]
-  >([]);
-  const lastQueryForAccumulationRef = useRef<string>("");
+  // The search key. Changing it re-keys the RTK cache entry, restarting
+  // pagination from initialPageParam — replace-on-new-query. fetchNextPage
+  // appends further pages within the current key. A key change mid-flight is
+  // picked up by RTK's own refetch, so no manual defer-until-settle is needed.
+  const queryArg = useMemo(
+    () => ({ q: effectiveQuery, limit: LIMIT, sort: sortBy, order: sortOrder }),
+    [effectiveQuery, sortBy, sortOrder],
+  );
 
-  const [trigger, { data, isFetching, isError, originalArgs }] =
-    useLazySearchPlaylistsQuery();
+  // refetchOnMountOrArgChange preserves the old lazy trigger()'s always-fetch
+  // semantics: the archive gains entries continuously, so re-entering the page
+  // (or revisiting a prior sort within RTK's cache-retention window) must fetch
+  // fresh page 1 rather than serve a stale cached entry. It does not affect
+  // in-session appends — fetchNextPage keeps the same arg, so no refetch fires.
+  const { data, isFetching, isError, hasNextPage, fetchNextPage } =
+    useSearchPlaylistsInfiniteQuery(queryArg, {
+      skip: isPartialQuery,
+      refetchOnMountOrArgChange: true,
+    });
 
-  // The cursor that actually PRODUCED `data` (from originalArgs), not the
-  // live `cursor` selector — typing resets the slice cursor to null one
-  // render before the new fetch lands, so the live cursor can't be trusted
-  // to describe the in-hand `data`. Basing replace-vs-append on this
-  // fingerprint keeps a just-blanked accumulator from being repopulated with
-  // the prior query's rows (#604).
-  const producingCursor = originalArgs?.cursor ?? null;
-
-  // ORDERING INVARIANT: this effect must stay declared BEFORE the accumulate
-  // effect below — when a new query's first page lands, both run in the same
-  // commit, and reset-then-populate is what keeps the fresh page from being
-  // blanked (populate-then-reset would wipe it).
-  useEffect(() => {
-    const currentParams = `${effectiveQuery}-${sortBy}-${sortOrder}`;
-    if (currentParams !== lastQueryForAccumulationRef.current) {
-      setAccumulatedResults([]);
-      lastQueryForAccumulationRef.current = currentParams;
-    }
-  }, [effectiveQuery, sortBy, sortOrder]);
-
-  // A null producingCursor means "first page" (replace); otherwise append,
-  // deduped by id (paginating). Keyed on producingCursor, never the live
-  // `cursor` — a live-cursor flip on a new query previously re-fired this
-  // against the prior query's `data`, replacing the blanked accumulator with
-  // stale rows (#604).
-  useEffect(() => {
-    if (data?.results) {
-      if (producingCursor === null) {
-        setAccumulatedResults(data.results);
-      } else {
-        setAccumulatedResults((prev) => {
-          const existingIds = new Set(prev.map((r) => r.id));
-          const newResults = data.results.filter((r) => !existingIds.has(r.id));
-          return [...prev, ...newResults];
-        });
+  const results = useMemo<PlaylistSearchResult[]>(() => {
+    if (!data?.pages?.length) return [];
+    const seen = new Set<number>();
+    const flat: PlaylistSearchResult[] = [];
+    for (const page of data.pages) {
+      for (const row of page.results) {
+        if (!seen.has(row.id)) {
+          seen.add(row.id);
+          flat.push(row);
+        }
       }
     }
-  }, [data, producingCursor]);
-
-  // Fires search on query/params change, and IS the mid-flight change
-  // protection (#623): a change made while a request is in flight hits the
-  // isFetching no-op branch below, then the settle (isFetching -> false)
-  // re-runs this effect against the live tuple. Comparing the FULL tuple
-  // (query AND cursor/sortBy/sortOrder), not just the query string, is what
-  // fires that deferred request — a query-only comparison would silently
-  // drop a mid-flight sort/cursor change. No separate drain queue is needed:
-  // the live selectors at settle time are exactly the params last requested.
-  useEffect(() => {
-    // Debounce single-character partials; empty query is the "show recent
-    // tracks" default and fires immediately.
-    const isPartialQuery =
-      effectiveQuery.length > 0 && effectiveQuery.length < MIN_QUERY_LENGTH;
-    if (isPartialQuery) return;
-
-    // Defer while a request is in flight; the settle re-run picks it up.
-    if (isFetching) return;
-
-    const paramsChanged =
-      cursor !== lastFiredParamsRef.current.cursor ||
-      sortBy !== lastFiredParamsRef.current.sortBy ||
-      sortOrder !== lastFiredParamsRef.current.sortOrder;
-
-    if (effectiveQuery !== lastFiredQueryRef.current || paramsChanged) {
-      lastFiredQueryRef.current = effectiveQuery;
-      lastFiredParamsRef.current = { cursor, sortBy, sortOrder };
-      trigger({
-        q: effectiveQuery,
-        limit: LIMIT,
-        sort: sortBy,
-        order: sortOrder,
-        cursor: cursor ?? undefined,
-      });
-    }
-  }, [effectiveQuery, cursor, sortBy, sortOrder, isFetching, trigger]);
+    return flat;
+  }, [data?.pages]);
 
   const addRow = useCallback(
     () => dispatch(playlistSearchSlice.actions.addRow()),
@@ -194,46 +129,22 @@ export function usePlaylistSearch() {
     [dispatch],
   );
 
-  // No-op when nextCursor is unavailable (last page or response not yet arrived).
+  // No-op when there is no next page (last page or response not yet arrived).
   const loadNextPage = useCallback(() => {
-    if (data?.nextCursor) {
-      dispatch(playlistSearchSlice.actions.advanceCursor(data.nextCursor));
-    }
-  }, [dispatch, data?.nextCursor]);
-
-  const reset = useCallback(() => {
-    setAccumulatedResults([]);
-    lastQueryForAccumulationRef.current = "";
-    dispatch(playlistSearchSlice.actions.reset());
-  }, [dispatch]);
-
-  const hasMore = data?.nextCursor !== undefined;
-
-  // Same tuple-vs-last-fired comparison the fire effect uses, so the two
-  // can't disagree about whether a change is waiting for the settle re-fire.
-  const isPartialQuery =
-    effectiveQuery.length > 0 && effectiveQuery.length < MIN_QUERY_LENGTH;
-  const hasPendingQuery =
-    isFetching &&
-    !isPartialQuery &&
-    (effectiveQuery !== lastFiredQueryRef.current ||
-      cursor !== lastFiredParamsRef.current.cursor ||
-      sortBy !== lastFiredParamsRef.current.sortBy ||
-      sortOrder !== lastFiredParamsRef.current.sortOrder);
+    if (hasNextPage) void fetchNextPage();
+  }, [hasNextPage, fetchNextPage]);
 
   return {
     rows,
     sortBy,
     sortOrder,
-    cursor,
     effectiveQuery,
 
-    results: accumulatedResults,
-    total: data?.total ?? 0,
-    hasMore,
+    results,
+    total: data?.pages?.[0]?.total ?? 0,
+    hasMore: hasNextPage ?? false,
 
     isLoading: isFetching,
-    hasPendingQuery,
     isError,
 
     addRow,
@@ -241,6 +152,5 @@ export function usePlaylistSearch() {
     updateRow,
     handleSort,
     loadNextPage,
-    reset,
   };
 }

--- a/tests/integration/components/classic/playlists/PreviousSetsContainer.test.tsx
+++ b/tests/integration/components/classic/playlists/PreviousSetsContainer.test.tsx
@@ -3,19 +3,22 @@ import { screen, waitFor } from "@testing-library/react";
 import { renderWithProviders } from "@/tests/helpers/render";
 import type { PlaylistSearchResult } from "@wxyc/shared/dtos";
 
-const mockTrigger = vi.fn();
+const mockFetchNextPage = vi.fn();
 const mockQueryState = {
   data: undefined as
     | {
-        results: PlaylistSearchResult[];
-        total: number;
-        page: number;
-        totalPages: number;
-        nextCursor?: string;
+        pages: Array<{
+          results: PlaylistSearchResult[];
+          total: number;
+          page: number;
+          totalPages: number;
+          nextCursor?: string;
+        }>;
       }
     | undefined,
   isFetching: false,
   isError: false,
+  hasNextPage: false,
 };
 
 vi.mock("@/lib/features/playlist-search/api", async () => {
@@ -24,9 +27,12 @@ vi.mock("@/lib/features/playlist-search/api", async () => {
   >("@/lib/features/playlist-search/api");
   return {
     ...actual,
-    useLazySearchPlaylistsQuery: () =>
-      [mockTrigger, mockQueryState] as unknown as ReturnType<
-        typeof actual.useLazySearchPlaylistsQuery
+    useSearchPlaylistsInfiniteQuery: () =>
+      ({
+        ...mockQueryState,
+        fetchNextPage: mockFetchNextPage,
+      }) as unknown as ReturnType<
+        typeof actual.useSearchPlaylistsInfiniteQuery
       >,
   };
 });
@@ -35,10 +41,11 @@ vi.mock("@/lib/features/playlist-search/api", async () => {
 import PreviousSetsContainer from "@/src/components/experiences/classic/playlists/PreviousSetsContainer";
 
 beforeEach(() => {
-  mockTrigger.mockReset();
+  mockFetchNextPage.mockReset();
   mockQueryState.data = undefined;
   mockQueryState.isFetching = false;
   mockQueryState.isError = false;
+  mockQueryState.hasNextPage = false;
 });
 
 describe("Classic Previous Sets PreviousSetsContainer", () => {
@@ -63,40 +70,36 @@ describe("Classic Previous Sets PreviousSetsContainer", () => {
     const { user, rerender } = renderWithProviders(<PreviousSetsContainer />);
     const input = screen.getByPlaceholderText(/type to search/i);
     await user.type(input, "Juana");
-    // Land the response AFTER typing so the data effect ([data, cursor])
-    // fires its accumulator update — the reset effect (which clears on
-    // effectiveQuery change) doesn't fire again on this render.
+    // Land the response after typing, then rerender to project the fulfilled
+    // page into the DOM.
     mockQueryState.data = {
-      results: [
+      pages: [
         {
-          id: 1,
-          play_date: "2024-06-15T14:30:00.000Z",
-          artist_name: "Juana Molina",
-          track_title: "la paradoja",
-          album_title: "DOGA",
-          record_label: "Sonamos",
-          dj_name: "Test DJ",
-          show_id: 100,
+          results: [
+            {
+              id: 1,
+              play_date: "2024-06-15T14:30:00.000Z",
+              artist_name: "Juana Molina",
+              track_title: "la paradoja",
+              album_title: "DOGA",
+              record_label: "Sonamos",
+              dj_name: "Test DJ",
+              show_id: 100,
+            },
+          ],
+          total: 1,
+          page: 0,
+          totalPages: 1,
         },
       ],
-      total: 1,
-      page: 0,
-      totalPages: 1,
     };
-    // Single rerender simulates the one re-render that RTK Query would
-    // trigger in production when its cache state flips from pending to
-    // fulfilled. Issue #540: the bug shipped because accumulated results
-    // lived in a useRef — the data effect mutated it after render but no
-    // additional render happened to project the new array into the DOM.
     rerender(<PreviousSetsContainer />);
     await waitFor(() => {
       expect(screen.getByText("Juana Molina")).toBeDefined();
     });
   });
 
-  // Regression test for #540: when the hook returns total > 0 with results
-  // populated, the result table must render on the same render where the
-  // count copy appears — no extra re-render required.
+  // The count copy and the populated rows must appear on the same render.
   it("renders the result table when the hook returns { total: 5, results: [...5 rows...] }", async () => {
     const { user, rerender } = renderWithProviders(<PreviousSetsContainer />);
     await user.type(
@@ -104,67 +107,70 @@ describe("Classic Previous Sets PreviousSetsContainer", () => {
       "stereolab"
     );
     mockQueryState.data = {
-      results: [
+      pages: [
         {
-          id: 10,
-          play_date: "2024-06-15T14:30:00.000Z",
-          artist_name: "Stereolab",
-          track_title: "Brakhage",
-          album_title: "Dots and Loops",
-          record_label: "Duophonic",
-          dj_name: "Test DJ",
-          show_id: 200,
-        },
-        {
-          id: 11,
-          play_date: "2024-06-15T14:35:00.000Z",
-          artist_name: "Stereolab",
-          track_title: "Miss Modular",
-          album_title: "Dots and Loops",
-          record_label: "Duophonic",
-          dj_name: "Test DJ",
-          show_id: 200,
-        },
-        {
-          id: 12,
-          play_date: "2024-06-15T14:40:00.000Z",
-          artist_name: "Stereolab",
-          track_title: "The Flower Called Nowhere",
-          album_title: "Dots and Loops",
-          record_label: "Duophonic",
-          dj_name: "Test DJ",
-          show_id: 200,
-        },
-        {
-          id: 13,
-          play_date: "2024-06-15T14:45:00.000Z",
-          artist_name: "Stereolab",
-          track_title: "Diagonals",
-          album_title: "Dots and Loops",
-          record_label: "Duophonic",
-          dj_name: "Test DJ",
-          show_id: 200,
-        },
-        {
-          id: 14,
-          play_date: "2024-06-15T14:50:00.000Z",
-          artist_name: "Stereolab",
-          track_title: "Prisoner of Mars",
-          album_title: "Dots and Loops",
-          record_label: "Duophonic",
-          dj_name: "Test DJ",
-          show_id: 200,
+          results: [
+            {
+              id: 10,
+              play_date: "2024-06-15T14:30:00.000Z",
+              artist_name: "Stereolab",
+              track_title: "Brakhage",
+              album_title: "Dots and Loops",
+              record_label: "Duophonic",
+              dj_name: "Test DJ",
+              show_id: 200,
+            },
+            {
+              id: 11,
+              play_date: "2024-06-15T14:35:00.000Z",
+              artist_name: "Stereolab",
+              track_title: "Miss Modular",
+              album_title: "Dots and Loops",
+              record_label: "Duophonic",
+              dj_name: "Test DJ",
+              show_id: 200,
+            },
+            {
+              id: 12,
+              play_date: "2024-06-15T14:40:00.000Z",
+              artist_name: "Stereolab",
+              track_title: "The Flower Called Nowhere",
+              album_title: "Dots and Loops",
+              record_label: "Duophonic",
+              dj_name: "Test DJ",
+              show_id: 200,
+            },
+            {
+              id: 13,
+              play_date: "2024-06-15T14:45:00.000Z",
+              artist_name: "Stereolab",
+              track_title: "Diagonals",
+              album_title: "Dots and Loops",
+              record_label: "Duophonic",
+              dj_name: "Test DJ",
+              show_id: 200,
+            },
+            {
+              id: 14,
+              play_date: "2024-06-15T14:50:00.000Z",
+              artist_name: "Stereolab",
+              track_title: "Prisoner of Mars",
+              album_title: "Dots and Loops",
+              record_label: "Duophonic",
+              dj_name: "Test DJ",
+              show_id: 200,
+            },
+          ],
+          total: 5,
+          page: 0,
+          totalPages: 1,
         },
       ],
-      total: 5,
-      page: 0,
-      totalPages: 1,
     };
     rerender(<PreviousSetsContainer />);
 
     await waitFor(() => {
-      // The count copy is the smoking gun in #540 — it appears even when
-      // the table doesn't.
+      // The count copy must not appear without the rows beneath it.
       expect(screen.getByText(/found 5 results/i)).toBeDefined();
     });
     // The actual fix: the table renders, with all five rows.

--- a/tests/integration/hooks/playlistSearchRekey.test.tsx
+++ b/tests/integration/hooks/playlistSearchRekey.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { Provider } from "react-redux";
+import { http, HttpResponse, delay } from "msw";
+import { createTestStore, server, TEST_BACKEND_URL } from "@/tests/helpers";
+import { playlistSearchSlice } from "@/lib/features/playlist-search/frontend";
+import { usePlaylistSearch } from "@/src/hooks/playlistSearchHooks";
+
+// The base query's prepareHeaders fetches a JWT; no auth server runs here.
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue(null),
+  clearTokenCache: vi.fn(),
+  authBaseURL: "http://localhost:3001/auth",
+  authClient: {},
+}));
+
+function makeRow(id: number, sort: string) {
+  return {
+    id,
+    play_date: "2024-06-15T14:30:00.000Z",
+    artist_name: `artist-${sort}`,
+    track_title: `title-${sort}`,
+    album_title: "album",
+    record_label: "label",
+    dj_name: "dj",
+    show_id: 1,
+  };
+}
+
+describe("usePlaylistSearch — mid-flight param change (real store + RTK)", () => {
+  it("re-keys on a mid-flight sort change so final results reflect the new params with no stale-page leak", async () => {
+    // sort=date is slow (its fetch is still in flight when the sort changes);
+    // sort=artist responds immediately. Each sort returns a distinct id so a
+    // leak from the stale in-flight entry into the subscribed one is detectable.
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/flowsheet/search`, async ({ request }) => {
+        const sort = new URL(request.url).searchParams.get("sort");
+        if (sort === "artist") {
+          return HttpResponse.json({
+            results: [makeRow(2, "artist")],
+            total: 1,
+            page: 0,
+            totalPages: 1,
+          });
+        }
+        await delay(60);
+        return HttpResponse.json({
+          results: [makeRow(1, "date")],
+          total: 1,
+          page: 0,
+          totalPages: 1,
+        });
+      }),
+    );
+
+    const store = createTestStore();
+    const rowId = store.getState().playlistSearch.rows[0].id;
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(Provider, { store, children });
+
+    const { result } = renderHook(() => usePlaylistSearch(), { wrapper });
+
+    // Type a query — its sort=date fetch is slow and goes in flight.
+    act(() => {
+      store.dispatch(
+        playlistSearchSlice.actions.updateRow({
+          id: rowId,
+          updates: { value: "abc" },
+        }),
+      );
+    });
+
+    // While that fetch is in flight, change the sort. RTK re-keys the
+    // subscription to {q:abc, sort:artist} and fetches the new entry.
+    act(() => {
+      store.dispatch(playlistSearchSlice.actions.setSort("artist"));
+    });
+
+    // Final results reflect the new sort, not the slow in-flight date fetch.
+    await waitFor(() =>
+      expect(result.current.results.map((r) => r.id)).toEqual([2]),
+    );
+
+    // Let the slow date response land; it populates its now-unsubscribed cache
+    // entry and must never leak into the subscribed artist entry.
+    await delay(150);
+    expect(result.current.results.map((r) => r.id)).toEqual([2]);
+  });
+});

--- a/tests/unit/hooks/playlistSearchHooks.test.ts
+++ b/tests/unit/hooks/playlistSearchHooks.test.ts
@@ -5,19 +5,23 @@ import { Provider } from "react-redux";
 import { makeStore, AppStore } from "@/lib/store";
 import { playlistSearchSlice } from "@/lib/features/playlist-search/frontend";
 
-const mockTrigger = vi.fn();
-const mockQueryState = {
-  data: undefined as
-    | { results: { id: number }[]; total: number; nextCursor?: string }
-    | undefined,
+const mockFetchNextPage = vi.fn();
+
+type MockPage = { results: { id: number }[]; total: number; nextCursor?: string };
+type MockQueryArg = { q?: string; limit?: number; sort?: string; order?: string };
+
+let lastQueryArg: MockQueryArg | undefined;
+let lastSkip = false;
+let lastRefetchOnMountOrArgChange: boolean | undefined;
+
+// Mutable canned result for the infinite query. `data.pages` is the RTK page
+// array the hook flattens; hasNextPage is RTK's projection of nextCursor via
+// getNextPageParam.
+const mockInfiniteState = {
+  data: undefined as { pages: MockPage[] } | undefined,
   isFetching: false,
   isError: false,
-  // originalArgs mirrors RTK's lazy-query result: the request args that
-  // produced the current `data`. The accumulator keys replace-vs-append on
-  // originalArgs.cursor, so tests that assert accumulation must set it.
-  originalArgs: undefined as
-    | { q: string; cursor?: string; sort: string; order: string }
-    | undefined,
+  hasNextPage: false,
 };
 
 vi.mock("@/lib/features/playlist-search/api", async () => {
@@ -26,10 +30,24 @@ vi.mock("@/lib/features/playlist-search/api", async () => {
   >("@/lib/features/playlist-search/api");
   return {
     ...actual,
-    useLazySearchPlaylistsQuery: () =>
-      [mockTrigger, mockQueryState] as unknown as ReturnType<
-        typeof actual.useLazySearchPlaylistsQuery
-      >,
+    useSearchPlaylistsInfiniteQuery: (
+      queryArg: MockQueryArg,
+      options?: { skip?: boolean; refetchOnMountOrArgChange?: boolean },
+    ) => {
+      lastQueryArg = queryArg;
+      lastSkip = options?.skip ?? false;
+      lastRefetchOnMountOrArgChange = options?.refetchOnMountOrArgChange;
+      if (options?.skip) {
+        return {
+          data: undefined,
+          isFetching: false,
+          isError: false,
+          hasNextPage: false,
+          fetchNextPage: mockFetchNextPage,
+        };
+      }
+      return { ...mockInfiniteState, fetchNextPage: mockFetchNextPage };
+    },
   };
 });
 
@@ -45,11 +63,14 @@ function createWrapper(store?: AppStore) {
 }
 
 beforeEach(() => {
-  mockTrigger.mockReset();
-  mockQueryState.data = undefined;
-  mockQueryState.isFetching = false;
-  mockQueryState.isError = false;
-  mockQueryState.originalArgs = undefined;
+  mockFetchNextPage.mockReset();
+  lastQueryArg = undefined;
+  lastSkip = false;
+  lastRefetchOnMountOrArgChange = undefined;
+  mockInfiniteState.data = undefined;
+  mockInfiniteState.isFetching = false;
+  mockInfiniteState.isError = false;
+  mockInfiniteState.hasNextPage = false;
 });
 
 describe("usePlaylistSearch", () => {
@@ -59,10 +80,21 @@ describe("usePlaylistSearch", () => {
 
       renderHook(() => usePlaylistSearch(), { wrapper });
 
-      await waitFor(() => expect(mockTrigger).toHaveBeenCalled());
-      expect(mockTrigger).toHaveBeenCalledWith(
-        expect.objectContaining({ q: "", cursor: undefined }),
-      );
+      await waitFor(() => expect(lastQueryArg).toBeDefined());
+      expect(lastQueryArg).toEqual(expect.objectContaining({ q: "" }));
+      expect(lastSkip).toBe(false);
+      // The cursor is RTK's pageParam, not part of the search key; the first
+      // page starts from initialPageParam.
+      expect(lastQueryArg).not.toHaveProperty("cursor");
+    });
+
+    it("forces a fresh fetch on mount rather than serving a stale cached page", async () => {
+      const { wrapper } = createWrapper();
+
+      renderHook(() => usePlaylistSearch(), { wrapper });
+
+      await waitFor(() => expect(lastQueryArg).toBeDefined());
+      expect(lastRefetchOnMountOrArgChange).toBe(true);
     });
 
     it("re-fires the empty query when the user clears all rows back to default", async () => {
@@ -71,10 +103,8 @@ describe("usePlaylistSearch", () => {
 
       renderHook(() => usePlaylistSearch(), { wrapper });
 
-      // Initial empty fire
-      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(lastQueryArg?.q).toBe(""));
 
-      // User types something
       act(() => {
         store.dispatch(
           playlistSearchSlice.actions.updateRow({
@@ -83,13 +113,8 @@ describe("usePlaylistSearch", () => {
           }),
         );
       });
-      await waitFor(() =>
-        expect(mockTrigger).toHaveBeenCalledWith(
-          expect.objectContaining({ q: "autechre" }),
-        ),
-      );
+      await waitFor(() => expect(lastQueryArg?.q).toBe("autechre"));
 
-      // User clears it
       act(() => {
         store.dispatch(
           playlistSearchSlice.actions.updateRow({
@@ -98,10 +123,7 @@ describe("usePlaylistSearch", () => {
           }),
         );
       });
-      await waitFor(() => {
-        const lastCall = mockTrigger.mock.calls.at(-1);
-        expect(lastCall?.[0]).toEqual(expect.objectContaining({ q: "" }));
-      });
+      await waitFor(() => expect(lastQueryArg?.q).toBe(""));
     });
   });
 
@@ -112,8 +134,7 @@ describe("usePlaylistSearch", () => {
 
       renderHook(() => usePlaylistSearch(), { wrapper });
 
-      // Wait for the initial empty fire so we can isolate the next behavior
-      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(lastSkip).toBe(false));
 
       act(() => {
         store.dispatch(
@@ -124,9 +145,9 @@ describe("usePlaylistSearch", () => {
         );
       });
 
-      // Give effects a tick to settle, then assert no new call
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(mockTrigger).toHaveBeenCalledTimes(1);
+      // A single-char partial skips the query — no request goes out.
+      await waitFor(() => expect(lastQueryArg?.q).toBe("a"));
+      expect(lastSkip).toBe(true);
     });
 
     it("fires once the user types a second character", async () => {
@@ -135,7 +156,7 @@ describe("usePlaylistSearch", () => {
 
       renderHook(() => usePlaylistSearch(), { wrapper });
 
-      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(lastSkip).toBe(false));
 
       act(() => {
         store.dispatch(
@@ -146,22 +167,26 @@ describe("usePlaylistSearch", () => {
         );
       });
 
-      await waitFor(() =>
-        expect(mockTrigger).toHaveBeenCalledWith(
-          expect.objectContaining({ q: "au" }),
-        ),
-      );
+      await waitFor(() => {
+        expect(lastQueryArg?.q).toBe("au");
+        expect(lastSkip).toBe(false);
+      });
     });
   });
 
   describe("cursor pagination", () => {
     it("hasMore is true when the response includes a nextCursor", async () => {
       const { wrapper } = createWrapper();
-      mockQueryState.data = {
-        results: [],
-        total: 1000,
-        nextCursor: "2024-06-15T14:30:00.000Z_42",
+      mockInfiniteState.data = {
+        pages: [
+          {
+            results: [],
+            total: 1000,
+            nextCursor: "2024-06-15T14:30:00.000Z_42",
+          },
+        ],
       };
+      mockInfiniteState.hasNextPage = true;
 
       const { result } = renderHook(() => usePlaylistSearch(), { wrapper });
 
@@ -170,76 +195,80 @@ describe("usePlaylistSearch", () => {
 
     it("hasMore is false when the response has no nextCursor", async () => {
       const { wrapper } = createWrapper();
-      mockQueryState.data = { results: [], total: 5 };
+      mockInfiniteState.data = { pages: [{ results: [], total: 5 }] };
+      mockInfiniteState.hasNextPage = false;
 
       const { result } = renderHook(() => usePlaylistSearch(), { wrapper });
 
       await waitFor(() => expect(result.current.hasMore).toBe(false));
     });
 
-    it("loadNextPage advances the cursor to nextCursor and re-fires", async () => {
-      const { store, wrapper } = createWrapper();
-      mockQueryState.data = {
-        results: [{ id: 1 }],
-        total: 1000,
-        nextCursor: "2024-06-15T14:30:00.000Z_42",
+    it("loadNextPage fetches the next page — RTK advances the cursor internally", async () => {
+      const { wrapper } = createWrapper();
+      mockInfiniteState.data = {
+        pages: [
+          {
+            results: [{ id: 1 }],
+            total: 1000,
+            nextCursor: "2024-06-15T14:30:00.000Z_42",
+          },
+        ],
       };
+      mockInfiniteState.hasNextPage = true;
 
       const { result } = renderHook(() => usePlaylistSearch(), { wrapper });
 
-      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(result.current.hasMore).toBe(true));
 
       act(() => {
         result.current.loadNextPage();
       });
 
-      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(2));
-      expect(mockTrigger.mock.calls[1][0]).toEqual(
-        expect.objectContaining({ cursor: "2024-06-15T14:30:00.000Z_42" }),
-      );
-      expect(store.getState().playlistSearch.cursor).toBe(
-        "2024-06-15T14:30:00.000Z_42",
-      );
+      expect(mockFetchNextPage).toHaveBeenCalledTimes(1);
     });
 
     it("loadNextPage is a no-op when no nextCursor is available", async () => {
       const { wrapper } = createWrapper();
-      mockQueryState.data = { results: [{ id: 1 }], total: 1 };
+      mockInfiniteState.data = { pages: [{ results: [{ id: 1 }], total: 1 }] };
+      mockInfiniteState.hasNextPage = false;
 
       const { result } = renderHook(() => usePlaylistSearch(), { wrapper });
 
-      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(result.current.results).toHaveLength(1));
 
       act(() => {
         result.current.loadNextPage();
       });
 
-      // Wait long enough for any spurious effect to fire
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(mockTrigger).toHaveBeenCalledTimes(1);
+      expect(mockFetchNextPage).not.toHaveBeenCalled();
     });
 
-    it("editing a row resets the cursor and refetches from the start", async () => {
+    it("editing a row re-keys the query so pagination restarts from the first page", async () => {
       const { store, wrapper } = createWrapper();
       const rowId = store.getState().playlistSearch.rows[0].id;
+      mockInfiniteState.data = {
+        pages: [
+          {
+            results: [{ id: 1 }],
+            total: 1000,
+            nextCursor: "2024-06-15T14:30:00.000Z_42",
+          },
+        ],
+      };
+      mockInfiniteState.hasNextPage = true;
 
-      // Simulate having paged once already
+      const { result } = renderHook(() => usePlaylistSearch(), { wrapper });
+
+      await waitFor(() => expect(result.current.hasMore).toBe(true));
+
       act(() => {
-        store.dispatch(
-          playlistSearchSlice.actions.advanceCursor(
-            "2024-06-15T14:30:00.000Z_42",
-          ),
-        );
+        result.current.loadNextPage();
       });
+      expect(mockFetchNextPage).toHaveBeenCalled();
 
-      renderHook(() => usePlaylistSearch(), { wrapper });
-
-      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
-      expect(mockTrigger.mock.calls[0][0]).toEqual(
-        expect.objectContaining({ cursor: "2024-06-15T14:30:00.000Z_42" }),
-      );
-
-      // User edits the search → cursor resets
+      // Editing the query changes the search key; RTK serves a fresh cache
+      // entry whose pagination starts from initialPageParam (no cursor in the
+      // arg).
       act(() => {
         store.dispatch(
           playlistSearchSlice.actions.updateRow({
@@ -249,34 +278,19 @@ describe("usePlaylistSearch", () => {
         );
       });
 
-      await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(2));
-      expect(mockTrigger.mock.calls[1][0]).toEqual(
-        expect.objectContaining({ q: "autechre", cursor: undefined }),
-      );
-      expect(store.getState().playlistSearch.cursor).toBeNull();
+      await waitFor(() => expect(lastQueryArg?.q).toBe("autechre"));
+      expect(lastQueryArg).not.toHaveProperty("cursor");
     });
   });
 
-  // Race-simulation coverage for the async-search hardening (#604, #623).
   describe("async-race hardening", () => {
-    describe("#604 — stale accumulator on cursor reset", () => {
-      it("does not resurrect the prior query's rows when typing resets the cursor", async () => {
+    describe("stale results on query change", () => {
+      it("does not resurrect the prior query's rows when the query changes", async () => {
         const { store, wrapper } = createWrapper();
         const rowId = store.getState().playlistSearch.rows[0].id;
 
-        // Paginated state of an OLD query: cursor advanced, and data +
-        // originalArgs describe a page produced with a non-null cursor.
-        act(() => {
-          store.dispatch(
-            playlistSearchSlice.actions.advanceCursor("c1"),
-          );
-        });
-        mockQueryState.data = { results: [{ id: 111 }, { id: 222 }], total: 2 };
-        mockQueryState.originalArgs = {
-          q: "old",
-          cursor: "c1",
-          sort: "date",
-          order: "desc",
+        mockInfiniteState.data = {
+          pages: [{ results: [{ id: 111 }, { id: 222 }], total: 2 }],
         };
 
         const { result, rerender } = renderHook(() => usePlaylistSearch(), {
@@ -286,9 +300,9 @@ describe("usePlaylistSearch", () => {
           expect(result.current.results.map((r) => r.id)).toEqual([111, 222]),
         );
 
-        // Type a NEW query. updateRow resets the slice cursor to null, but
-        // data + originalArgs still hold the OLD query until the new fetch
-        // lands. The just-typed query must not flash the old rows.
+        // Typing a new query re-keys the cache entry; the fresh entry has no
+        // pages yet. Results derive only from the current entry, so the old
+        // rows cannot flash back.
         act(() => {
           store.dispatch(
             playlistSearchSlice.actions.updateRow({
@@ -297,29 +311,24 @@ describe("usePlaylistSearch", () => {
             }),
           );
         });
+        mockInfiniteState.data = undefined;
         rerender();
 
         await waitFor(() => expect(result.current.results).toEqual([]));
-        // Stays cleared across subsequent renders (no delayed stale flash).
         rerender();
         expect(result.current.results).toEqual([]);
       });
 
-      it("still appends the next page for the same query", async () => {
+      it("appends and dedupes the next page for the same query", async () => {
         const { wrapper } = createWrapper();
 
-        // Page 1 of the current query — produced with no cursor (first page).
-        mockQueryState.data = {
-          results: [{ id: 1 }, { id: 2 }],
-          total: 4,
-          nextCursor: "c1",
+        mockInfiniteState.data = {
+          pages: [
+            { results: [{ id: 1 }, { id: 2 }], total: 4, nextCursor: "c1" },
+          ],
         };
-        mockQueryState.originalArgs = {
-          q: "",
-          cursor: undefined,
-          sort: "date",
-          order: "desc",
-        };
+        mockInfiniteState.hasNextPage = true;
+
         const { result, rerender } = renderHook(() => usePlaylistSearch(), {
           wrapper,
         });
@@ -327,18 +336,19 @@ describe("usePlaylistSearch", () => {
           expect(result.current.results.map((r) => r.id)).toEqual([1, 2]),
         );
 
-        // Load the next page: cursor advances, then page 2 arrives produced
-        // with the c1 cursor. Overlapping id 2 is deduped.
         act(() => {
           result.current.loadNextPage();
         });
-        mockQueryState.data = { results: [{ id: 2 }, { id: 3 }], total: 4 };
-        mockQueryState.originalArgs = {
-          q: "",
-          cursor: "c1",
-          sort: "date",
-          order: "desc",
+        expect(mockFetchNextPage).toHaveBeenCalled();
+
+        // Page 2 arrives as a second RTK page; the overlapping id 2 is deduped.
+        mockInfiniteState.data = {
+          pages: [
+            { results: [{ id: 1 }, { id: 2 }], total: 4, nextCursor: "c1" },
+            { results: [{ id: 2 }, { id: 3 }], total: 4 },
+          ],
         };
+        mockInfiniteState.hasNextPage = false;
         rerender();
 
         await waitFor(() =>
@@ -347,22 +357,19 @@ describe("usePlaylistSearch", () => {
       });
     });
 
-    // #623 — regression guard on the fire effect's full-tuple paramsChanged
-    // comparison. That comparison (query string AND cursor/sortBy/sortOrder,
-    // re-run when isFetching flips false) is what carries a mid-flight
-    // sort/cursor change into a deferred re-fire; a query-string-only
-    // comparison would drop it. This pins the existing guard rather than
-    // reproducing a live failure.
-    describe("#623 — sort change while a fetch is in flight", () => {
-      it("re-fires with the new sort once the in-flight fetch settles", async () => {
+    // The end-to-end no-stale-leak guarantee is proven against a real store in
+    // tests/integration/hooks/playlistSearchRekey.test.tsx. This unit case pins
+    // the hook-level mechanism it relies on: the query key is never gated on
+    // fetch state, so a sort change made while a fetch is in flight always
+    // reaches the key (it cannot be dropped at the hook boundary).
+    describe("sort change while a fetch is in flight", () => {
+      it("updates the query key even while a fetch is in flight", async () => {
         const { store, wrapper } = createWrapper();
         const rowId = store.getState().playlistSearch.rows[0].id;
         const { rerender } = renderHook(() => usePlaylistSearch(), { wrapper });
 
-        // Initial empty-query mount fire.
-        await waitFor(() => expect(mockTrigger).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(lastQueryArg?.q).toBe(""));
 
-        // Type a query and let it fire.
         act(() => {
           store.dispatch(
             playlistSearchSlice.actions.updateRow({
@@ -372,40 +379,28 @@ describe("usePlaylistSearch", () => {
           );
         });
         await waitFor(() =>
-          expect(mockTrigger).toHaveBeenLastCalledWith(
+          expect(lastQueryArg).toEqual(
             expect.objectContaining({ q: "abc", sort: "date" }),
           ),
         );
-        const callsAfterAbc = mockTrigger.mock.calls.length;
 
-        // That abc/date fetch is now slow and in flight.
+        // Mark the abc/date fetch in flight, then change the sort. The key must
+        // still advance to sort:artist — the hook does not read isFetching.
         act(() => {
-          mockQueryState.isFetching = true;
+          mockInfiniteState.isFetching = true;
         });
         rerender();
 
-        // User clicks the sort header — query text unchanged, only the sort
-        // moves. Nothing new should fire while the request is in flight; the
-        // change is picked up by the settle re-run of the fire effect.
         act(() => {
           store.dispatch(playlistSearchSlice.actions.setSort("artist"));
         });
         rerender();
-        expect(mockTrigger.mock.calls.length).toBe(callsAfterAbc);
 
-        // The in-flight fetch settles.
-        act(() => {
-          mockQueryState.isFetching = false;
-        });
-        rerender();
-
-        // Exactly one re-fire, carrying the new sort.
         await waitFor(() =>
-          expect(mockTrigger).toHaveBeenLastCalledWith(
+          expect(lastQueryArg).toEqual(
             expect.objectContaining({ q: "abc", sort: "artist" }),
           ),
         );
-        expect(mockTrigger.mock.calls.length).toBe(callsAfterAbc + 1);
       });
     });
   });


### PR DESCRIPTION
Closes #883

## Summary

Playlist search hand-rolled pagination through a chained-effect accumulator. This migrates it to RTK Query's `builder.infiniteQuery`, mirroring the proven local pattern in `lib/features/catalog/`, and **deletes the effect chain**.

## Before / After architecture

**Before** — `src/hooks/playlistSearchHooks.ts` ran three coupled `useEffect`s plus an `accumulatedResults` `useState`:
- a reset effect that cleared the accumulator on `effectiveQuery`/sort change,
- an accumulate effect keyed on a `producingCursor` fingerprint (`originalArgs.cursor`) to decide replace-vs-append and dedupe by id,
- a fire effect that compared the full `(query, cursor, sortBy, sortOrder)` tuple against `lastFiredParamsRef`, deferred while `isFetching`, and re-fired on settle.

The pagination cursor lived in the Redux slice (`advanceCursor` / `resetCursor` / `getCursor`), and a lazy query (`useLazySearchPlaylistsQuery`) was triggered manually.

**After** — `searchPlaylists` is a `builder.infiniteQuery`:
- **Search key** (RTK cache key) = `{ q, limit, sort, order }`. **pageParam** = the opaque cursor (`null` = first page). `getNextPageParam` maps `nextCursor -> hasNextPage`.
- The hook derives `results` from `data.pages` (flatten + dedupe by id) in a `useMemo` — no accumulator state, **no effects**.
- The cursor is now RTK's `pageParam`, so it was removed from the slice (**one authoritative owner per value**).
- `loadNextPage` -> `fetchNextPage`; `hasMore` -> `hasNextPage`; single-char partials use `skip`.

## Preserved-behavior checklist

- [x] **Replace-vs-append (#604)** — a new query changes the search key, so RTK serves a fresh cache entry that restarts from `initialPageParam` (replace); `fetchNextPage` appends within the current key. There is no longer any accumulator that can be repopulated with a prior query's rows — the failure mode #604 hardened against is now structurally impossible.
- [x] **Mid-flight deferral (#623)** — a param change (e.g. sort) made while a fetch is in flight re-keys the query; RTK refetches the new key and the subscription reflects the new params, rather than dropping the change. The hand-rolled defer-until-settle machinery is gone, replaced by RTK's own request lifecycle. Timing differs (old: deferred, fired once on settle; new: fires the new key immediately, stale in-flight response lands in the now-unsubscribed old entry) — same final results, one extra concurrent request, not user-visible. Now covered end-to-end by a store-level MSW test (see below).
- [x] **Empty-query default listing** — an empty query (`q: ""`) is a real, non-skipped cache key, so the "show recent tracks" request fires on mount.
- [x] **Single-char partial debounce** — `skip: true` while `0 < len < 2`.
- [x] **Fresh-on-mount / on-arg-revisit (cache-freshness parity)** — see below.

## Cache-freshness parity (review F1 — replaces the earlier "no component behavior changed" claim)

The old hook used `useLazySearchPlaylistsQuery` + `trigger({...})` with the default `preferCacheValue=false`, i.e. it **forced a network refetch on every mount and param fire**. A plain auto infinite-query would instead serve RTK's cached entry for up to 60s, so re-entering Previous Sets (or revisiting a prior sort) within that window would show cached, possibly-stale rows on a live-updating archive.

To restore the old always-fresh semantics, the hook passes **`refetchOnMountOrArgChange: true`**. Re-entering the page or revisiting a previously-fetched arg now fetches a fresh page 1. This does **not** affect in-session pagination appends — `fetchNextPage` keeps the same arg, so no refetch fires.

Residual difference (minor, arguably nicer UX): on remount within the retention window, RTK restores the previously-cached pages and refreshes them, rather than hard-resetting to a single page as the old component-local `useState` accumulator did. Data is fresh either way; only the restored-scroll-depth differs.

Pinned by a unit assertion (`refetchOnMountOrArgChange: true` is passed on mount).

## Test-count ledger

| File | Before | After | Notes |
|------|-------:|------:|-------|
| `tests/unit/hooks/playlistSearchHooks.test.ts` (spec) | 12 | 13 | Remocked to the infinite-query hook; +1 fresh-on-mount assertion |
| `tests/integration/hooks/playlistSearchRekey.test.tsx` (new) | 0 | 1 | Store-level MSW proof of the #623 no-stale-leak guarantee |
| `tests/integration/.../PreviousSetsContainer.test.tsx` | 6 | 6 | Remocked; `data.results` wrapped as `data.pages[0]` |
| **Full suite** | — | 3689 | all green |

The spec's mock switched from `useLazySearchPlaylistsQuery` (`[trigger, state]`) to `useSearchPlaylistsInfiniteQuery(queryArg, { skip, refetchOnMountOrArgChange })` returning `{ data: { pages }, hasNextPage, fetchNextPage, ... }` — the same mocking plumbing `tests/unit/hooks/useCatalogQueryResults.test.tsx` uses.

### Strengthened #623 coverage (review F2)

The prior unit #623 test set `mockInfiniteState.isFetching = true` to represent "in flight," but the hook never reads `isFetching` for `queryArg`/`skip`, so that assertion reduced to "the queryArg memo recomputes on sort change." It is now:
- **Kept and reframed honestly** as a hook-level mechanism test: *the query key advances even while a fetch is in flight (the hook does not gate the key on `isFetching`)* — the property the end-to-end guarantee relies on.
- **Backed by a real store-level test** (`playlistSearchRekey.test.tsx`): with a controllable MSW baseQuery where `sort=date` is slow (in flight) and `sort=artist` is immediate and returns a distinct id, a mid-flight sort change re-keys the subscription so the **final rendered results reflect the new params (`[id:2]`) with no stale-page leak** — the slow date response lands in its now-unsubscribed cache entry and never surfaces.

### Assertions structurally impossible under infiniteQuery (documented, with behavioral equivalent)

These probed the old *implementation* (slice cursor + manual trigger), not user-visible behavior. Each was replaced by the equivalent guarantee; **no behavior lost coverage**:

1. **`store.getState().playlistSearch.cursor` / `advanceCursor`** — cursor is now RTK's `pageParam`. Replaced by: `loadNextPage` invokes `fetchNextPage`, and editing the query re-keys the arg so pagination restarts from `initialPageParam` (`queryArg` carries no `cursor`).
2. **`mockTrigger.toHaveBeenCalledWith({ q, cursor })`** — no manual trigger. Replaced by asserting the infinite hook is called with the expected `queryArg` and `skip: false`.
3. **#623 "nothing fires while in flight; exactly one deferred re-fire on settle"** — counted the deleted defer machinery. Replaced by the store-level no-stale-leak test above.

### Residual test gap (review F3, unchanged)

The unit #604 "no resurrection" test simulates re-keying by manually clearing the mock's `data` after the edit, because the mock returns one global state regardless of `queryArg` — it does not exercise RTK's per-cache-key isolation directly. The new store-level rekey test exercises real per-key isolation for the sort case; the query-string case remains unit-mocked. Inherent to mocking RTK at the hook layer.

## Consumer updates

Component behavior is unchanged except the cache-freshness parity noted above. `PlaylistSearchContainer`, classic `PreviousSetsContainer`, `Results`, `ResultsContainer`, `SearchBar`, `SearchForm`, `SortBySelect` consume the same return keys (`results`, `total`, `hasMore`, `isLoading`, `isError`, `loadNextPage`, `sortBy`, `sortOrder`, `handleSort`, `effectiveQuery`, `rows`, `addRow`, `removeRow`, `updateRow`). Unused return values (`cursor`, `hasPendingQuery`, `reset`) were dropped — no consumer read them.

## Known dead code (review F3/F4 — flagged, left for a future cleanup)

`lib/features/playlist-search/frontend.ts` still defines `reset: () => initialState`. With the cursor machinery and the hook's `reset` callback removed, nothing dispatches it (`resetApplication` never referenced this slice). It was already only reachable via the now-deleted hook `reset`. Left in place as out-of-scope for this migration; noted for a follow-up deletion.

## Verification

`npx tsc --noEmit` · `npm run lint` (0 errors, no new warnings) · `npm run test:run --maxWorkers=2` (3689 pass, 272 files) · `npm run build` — all green, before and after rebasing onto latest `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)