### PR TITLE
test: cover ThemeRegistry SSR flush/theme selection and AppbarClassic

### DIFF
--- a/tests/integration/components/shared/Theme/AppbarClassic.test.tsx
+++ b/tests/integration/components/shared/Theme/AppbarClassic.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AppbarClassic from "@/src/components/shared/Theme/AppbarClassic";
+
+// Mock dependencies
+vi.mock("@/src/hooks/applicationHooks", () => ({
+  usePublicRoutes: vi.fn(() => false),
+}));
+
+vi.mock("next/dynamic", () => ({
+  default: () => () => null,
+}));
+
+vi.mock("@/src/components/shared/Theme/ThemeSwitcher", () => ({
+  default: () => <span data-testid="theme-switcher">Theme Switcher</span>,
+}));
+
+vi.mock("@/src/components/shared/General/LinkButton", () => ({
+  LinkButton: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href} data-testid="link-button">
+      {children}
+    </a>
+  ),
+}));
+
+describe("AppbarClassic", () => {
+  it("should render version text", () => {
+    render(<AppbarClassic experience="classic" />);
+    expect(screen.getByText(/WXYC DJ Site/)).toBeInTheDocument();
+  });
+
+  it("should render ThemeSwitcher", () => {
+    render(<AppbarClassic experience="classic" />);
+    expect(screen.getByTestId("theme-switcher")).toBeInTheDocument();
+  });
+
+  it("should not render a ThemePicker", () => {
+    // Unlike Appbar.tsx, AppbarClassic intentionally omits the color-theme
+    // picker: classic mode has no ThemePicker import at all.
+    render(<AppbarClassic experience="classic" />);
+    expect(screen.queryByTestId("theme-picker")).not.toBeInTheDocument();
+  });
+
+  it("should show Beta Tester Form and General Feedback links for authenticated users", () => {
+    render(<AppbarClassic experience="classic" />);
+    expect(screen.getByText("Beta Tester Form")).toBeInTheDocument();
+    expect(screen.getByText("General Feedback")).toBeInTheDocument();
+  });
+});
+
+describe("AppbarClassic when on public route", () => {
+  it("should show Log In link for public routes", async () => {
+    const { usePublicRoutes } = await import("@/src/hooks/applicationHooks");
+    vi.mocked(usePublicRoutes).mockReturnValue(true);
+
+    render(<AppbarClassic experience="classic" />);
+    expect(screen.getByText("Log In")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/styles/ThemeRegistry.test.tsx
+++ b/tests/unit/styles/ThemeRegistry.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+// buildModernTheme pulls in next/font via getModernTheme; server-safe id
+// validation lives in the registry module, but ThemeRegistry needs the built
+// theme object, so next/font must be stubbed like themes.test.ts does.
+vi.mock("next/font/google", () => ({
+  Kanit: () => ({ style: { fontFamily: "Kanit, sans-serif" } }),
+}));
+vi.mock("next/font/local", () => ({
+  default: () => ({ style: { fontFamily: "Minbus, sans-serif" } }),
+}));
+
+// useThemePreferenceSync's own races/session/mutation behavior is covered by
+// themePreferenceHooks.test.tsx; ThemeRegistry only owns wiring it in.
+vi.mock("@/src/hooks/themePreferenceHooks", () => ({
+  useThemePreferenceSync: vi.fn(),
+}));
+
+// jsdom never runs inside Next's streaming-SSR flush provider, so the real
+// hook would no-op (see server-inserted-html.shared-runtime.js: it reads
+// from a context that defaults to null off the server). Capturing the
+// callback ThemeRegistry passes in lets the test invoke the actual flush
+// closure it owns, instead of exercising Next's SSR plumbing.
+let capturedFlush: (() => ReactNode) | null = null;
+vi.mock("next/navigation", () => ({
+  useServerInsertedHTML: (callback: () => ReactNode) => {
+    capturedFlush = callback;
+  },
+}));
+
+// Spy on the theme CssVarsProvider receives without replacing its behavior,
+// so ThemedProvider's classic/modern selection logic renders for real.
+let capturedTheme: unknown = null;
+vi.mock("@mui/joy/styles", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mui/joy/styles")>();
+  return {
+    ...actual,
+    CssVarsProvider: (props: Parameters<typeof actual.CssVarsProvider>[0]) => {
+      capturedTheme = props.theme;
+      return <actual.CssVarsProvider {...props} />;
+    },
+  };
+});
+
+import ThemeRegistry from "@/src/styles/ThemeRegistry";
+import classicTheme from "@/lib/features/experiences/classic/theme";
+import { getModernTheme } from "@/lib/features/experiences/modern/themes";
+
+describe("ThemeRegistry theme selection", () => {
+  beforeEach(() => {
+    capturedTheme = null;
+  });
+
+  it("uses the classic theme for the classic experience", () => {
+    render(
+      <ThemeRegistry options={{ key: "joy" }} experience="classic" themeId="stacks">
+        <div>content</div>
+      </ThemeRegistry>
+    );
+
+    expect(capturedTheme).toBe(classicTheme);
+  });
+
+  it("uses the resolved modern theme for the modern experience", () => {
+    render(
+      <ThemeRegistry options={{ key: "joy" }} experience="modern" themeId="bluenote">
+        <div>content</div>
+      </ThemeRegistry>
+    );
+
+    expect(capturedTheme).toBe(getModernTheme("bluenote"));
+    expect(capturedTheme).not.toBe(classicTheme);
+  });
+
+  it("falls back to the default modern theme for an unrecognized themeId", () => {
+    render(
+      <ThemeRegistry options={{ key: "joy" }} experience="modern" themeId="not-a-real-theme">
+        <div>content</div>
+      </ThemeRegistry>
+    );
+
+    expect(capturedTheme).toBe(getModernTheme("stacks"));
+  });
+});
+
+describe("ThemeRegistry SSR emotion-cache flush", () => {
+  beforeEach(() => {
+    capturedFlush = null;
+  });
+
+  it("registers a flush callback with the SSR-inserted-HTML hook", () => {
+    render(
+      <ThemeRegistry options={{ key: "joy" }} experience="modern" themeId="stacks">
+        <div>content</div>
+      </ThemeRegistry>
+    );
+
+    expect(capturedFlush).not.toBeNull();
+  });
+
+  it("flushes a style tag carrying the emotion rules inserted during the mount render", () => {
+    render(
+      <ThemeRegistry options={{ key: "joy" }} experience="modern" themeId="stacks">
+        <div>content</div>
+      </ThemeRegistry>
+    );
+
+    // GlobalStyles/CssBaseline insert real emotion-serialized rules through
+    // the cache during the mount render, so the first flush must have
+    // something queued rather than returning null.
+    const styleElement = capturedFlush!() as React.ReactElement<{
+      "data-emotion": string;
+      dangerouslySetInnerHTML: { __html: string };
+    }> | null;
+
+    expect(styleElement).not.toBeNull();
+    expect(styleElement!.type).toBe("style");
+    expect(styleElement!.props["data-emotion"]).toEqual(
+      expect.stringMatching(/^joy /)
+    );
+    expect(
+      styleElement!.props.dangerouslySetInnerHTML.__html.length
+    ).toBeGreaterThan(0);
+  });
+
+  it("returns null on a second flush once nothing new has been inserted", () => {
+    render(
+      <ThemeRegistry options={{ key: "joy" }} experience="modern" themeId="stacks">
+        <div>content</div>
+      </ThemeRegistry>
+    );
+
+    // First flush drains whatever the mount render inserted.
+    capturedFlush!();
+    // A second flush with no intervening render has nothing queued.
+    const secondFlush = capturedFlush!();
+
+    expect(secondFlush).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #256.

## What this covers

The 2026-07-16 coverage audit found #256's other named surfaces already
substantively covered: ThemeSwitcher (6 tests), ColorSchemeToggle (5 tests),
Appbar (5 tests + AppbarWrapper 2 tests). This PR closes the two residual
gaps the audit identified.

**`src/styles/ThemeRegistry.tsx`** (`tests/unit/styles/ThemeRegistry.test.tsx`) — had zero direct or indirect coverage; `renderWithProviders` substitutes
a bare `CssVarsProvider`, bypassing the real component entirely. New tests
exercise the real component:
- **Theme selection** (`ThemedProvider`'s classic/modern branch): spies on
  the `theme` prop `CssVarsProvider` actually receives (via a `vi.mock` that
  wraps, not replaces, the real provider) and asserts classic experience
  resolves to `classicTheme`, modern resolves to `getModernTheme(themeId)`,
  and an unrecognized `themeId` falls back to the default.
- **SSR emotion-cache flush**: jsdom never runs inside Next's streaming-SSR
  flush context, so the real `useServerInsertedHTML` hook no-ops there (it
  reads a context that defaults to `null` off the server — see
  `server-inserted-html.shared-runtime.js`). The test can't exercise Next's
  actual SSR injection in jsdom, so it captures the flush callback
  `ThemeRegistry` passes in and invokes it directly, asserting on the real
  cache/flush closure's behavior: GlobalStyles/CssBaseline insert real
  emotion-serialized rules into the cache during the mount render, the first
  flush returns a `<style>` tag carrying them, and a second flush with
  nothing new inserted returns `null`. True SSR-boundary behavior (the
  server-side streaming injection itself) is out of jsdom's reach and isn't
  asserted — only what's testable client-side is.

`useThemePreferenceSync` (wired in via `ThemePreferenceSync`) is mocked out;
its own races/session/mutation behavior is already covered by
`themePreferenceHooks.test.tsx` — `ThemeRegistry` only owns wiring it in.

**`src/components/shared/Theme/AppbarClassic.tsx`** (`tests/integration/components/shared/Theme/AppbarClassic.test.tsx`) — had no dedicated test;
`AppbarWrapper.test.tsx` stubs it to a bare `<div>`. New test mirrors
`Appbar.test.tsx`'s structure/depth: version text, ThemeSwitcher render,
public-route Log In link vs. authenticated Beta Tester Form/General Feedback
links, and (unlike modern `Appbar`) the absence of a `ThemePicker`.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warning count unchanged)
- `npm run test:run -- --maxWorkers=2` — 275 files / 3766 tests passed
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)