### PR TITLE
fix: keep GoLive disabled/loading props stable through hydration

### DIFF
--- a/src/components/experiences/modern/flowsheet/GoLive.tsx
+++ b/src/components/experiences/modern/flowsheet/GoLive.tsx
@@ -27,17 +27,22 @@ export default function GoLive() {
   const isSaving = useFlowsheetSaving();
 
   // Must match the server's markup until this flips true post-mount, or the
-  // aria-label React hydrates onto the ButtonGroup won't match server HTML.
+  // aria-label/disabled/loading props React hydrates onto these elements
+  // won't match server HTML.
   const [mounted, setMounted] = useState(false);
   useEffect(() => {
     setMounted(true);
   }, []);
-  const goLiveLabel =
-    mounted && !loading
-      ? live
-        ? "Click to leave"
-        : "Click to go live"
-      : "Loading...";
+  // SSR always renders as if the session were still unresolved (mounted is
+  // false server-side too), so the client's first pass must hold `loading`
+  // true regardless of the real value or React sees a disabled/Mui-loading
+  // class diff during hydration.
+  const effectiveLoading = mounted ? loading : true;
+  const goLiveLabel = effectiveLoading
+    ? "Loading..."
+    : live
+      ? "Click to leave"
+      : "Click to go live";
 
   return (
     <Stack direction="row" spacing={1} alignItems="center">
@@ -76,7 +81,7 @@ export default function GoLive() {
           <IconButton
             variant="outlined"
             onClick={() => (live ? leave() : goLive())}
-            disabled={loading}
+            disabled={effectiveLoading}
             data-testid="flowsheet-go-live-button"
           >
             {live ? <PortableWifiOff /> : <WifiTethering />}
@@ -85,8 +90,8 @@ export default function GoLive() {
             variant={live ? "solid" : "outlined"}
             color={live ? "primary" : "neutral"}
             onClick={() => (live ? leave() : goLive())}
-            disabled={loading}
-            loading={loading}
+            disabled={effectiveLoading}
+            loading={effectiveLoading}
             data-testid="flowsheet-live-status"
             sx={{ transition: "all 0.25s ease" }}
           >

--- a/tests/integration/components/modern/flowsheet/GoLive.test.tsx
+++ b/tests/integration/components/modern/flowsheet/GoLive.test.tsx
@@ -171,6 +171,12 @@ describe("GoLive", () => {
 
       const serverHtml = renderToString(<GoLive />);
       expect(serverHtml).toContain('aria-label="Loading..."');
+      // Joy renders `disabled` as a `Mui-disabled` class, not a native
+      // `disabled` attribute, so that's what a divergent `loading` prop
+      // would show up as in the server markup.
+      expect(serverHtml).toMatch(
+        /data-testid="flowsheet-go-live-button"[^>]*class="[^"]*\bMui-disabled\b/
+      );
 
       const container = document.createElement("div");
       container.innerHTML = serverHtml;
@@ -191,11 +197,23 @@ describe("GoLive", () => {
         )
       );
       expect(ariaLabelMismatchLogged).toBe(false);
+      // disabled/loading render as class="…Mui-disabled…" / "…Mui-loading…",
+      // so a diverging `loading` prop shows up as a `className` diff line.
+      const classNameMismatchLogged = errorSpy.mock.calls.some((call) =>
+        call.some(
+          (arg) => typeof arg === "string" && /^[+-]\s*className=/m.test(arg)
+        )
+      );
+      expect(classNameMismatchLogged).toBe(false);
       errorSpy.mockRestore();
 
+      const goLiveButton = container.querySelector(
+        '[data-testid="flowsheet-go-live-button"]'
+      );
       const buttonGroup = container.querySelector('[role="group"]');
       await waitFor(() => {
         expect(buttonGroup).toHaveAttribute("aria-label", "Click to go live");
+        expect(goLiveButton?.className).not.toMatch(/\bMui-disabled\b/);
       });
 
       act(() => {


### PR DESCRIPTION
## Root cause

`src/components/experiences/modern/flowsheet/GoLive.tsx` derived the go-live buttons' `disabled`/`loading` props directly from `loading` (via `useShowControl` → `useRegistry` → `useAuthentication`). The SSR pass renders with `loading: true` (session not yet resolved server-side), but the client's first render can already have `loading: false` (better-auth's session resolves before hydration completes), so React has to patch the `Mui-disabled`/`MuiButton-loading` classes during hydration — the mismatch reported in #920, found while fixing the sibling aria-label issue (#895, PR #919).

## Fix

Hoists the `mounted` gate #919 already added for the Tooltip label so it also covers the `disabled`/`loading` props, deriving both from a single `effectiveLoading` value that holds `true` until mounted (matching whatever SSR always renders, since SSR never runs effects either), then settles to the real `loading` value post-mount. `goLiveLabel` is rewritten in terms of the same `effectiveLoading` value instead of duplicating the `mounted && !loading` check.

## Tests

Extended the existing `renderToString` + `hydrateRoot` regression test in `tests/integration/components/modern/flowsheet/GoLive.test.tsx` to also assert no `className` hydration-mismatch is logged (Joy renders `disabled` as a `Mui-disabled` class, not a native `disabled` attribute, so that's what a divergent `loading` prop shows up as), and that the go-live button's `Mui-disabled` class clears once mounted. Verified this addition fails against pre-fix code (`expect(classNameMismatchLogged).toBe(false)` → received `true`) and passes after the fix.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warning backlog untouched)
- `npm run test:run` — 3758/3758 passed
- `npm run build` — succeeds

Closes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)