### PR TITLE
fix(leftbar): swap Flowsheet icon from Stream to Podcasts

### DIFF
--- a/src/components/experiences/modern/Leftbar/FlowsheetLink.tsx
+++ b/src/components/experiences/modern/Leftbar/FlowsheetLink.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useShowControl } from "@/src/hooks/flowsheetHooks";
-import { Stream } from "@mui/icons-material";
+import { Podcasts } from "@mui/icons-material";
 import { Badge } from "@mui/joy";
 import LeftbarLink from "./LeftbarLink";
 
@@ -20,7 +20,7 @@ export default function FlowsheetLink() {
       }}
     >
       <LeftbarLink path="/dashboard/flowsheet" title={`Flowsheet${live ? "      🔴 [ON AIR]" : ""}`}>
-        <Stream />
+        <Podcasts />
       </LeftbarLink>
     </Badge>
   );

--- a/tests/integration/components/modern/Leftbar/FlowsheetLink.test.tsx
+++ b/tests/integration/components/modern/Leftbar/FlowsheetLink.test.tsx
@@ -25,7 +25,7 @@ vi.mock("next/link", () => ({
 
 // Mock MUI icons
 vi.mock("@mui/icons-material", () => ({
-  Stream: () => <span data-testid="stream-icon" />,
+  Podcasts: () => <span data-testid="podcasts-icon" />,
 }));
 
 describe("FlowsheetLink", () => {
@@ -40,10 +40,10 @@ describe("FlowsheetLink", () => {
     expect(link).toHaveAttribute("href", "/dashboard/flowsheet");
   });
 
-  it("should render stream icon", () => {
+  it("should render podcasts icon", () => {
     render(<FlowsheetLink />);
 
-    expect(screen.getByTestId("stream-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("podcasts-icon")).toBeInTheDocument();
   });
 
   it("should show 'Flowsheet' title when not live", () => {


### PR DESCRIPTION
## Summary

Replaces the leftbar Flowsheet link icon (`Stream`) with the `Podcasts` icon from `@mui/icons-material`, per maintainer request.

- `FlowsheetLink.tsx`: `Stream` → `Podcasts` (import + render)
- `FlowsheetLink.test.tsx`: icon mock and testid updated to match

## Testing

- `FlowsheetLink.test.tsx`: 7/7 passing
- `npm run lint`: 0 errors; no warnings on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)