### PR TITLE
chore: deployment/docs residue cleanup (upload, cf-typegen, README, middleware note)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,11 @@ Production and PR previews are built in GitHub Actions and pushed to the `wxyc-d
 
 Deploy-helper scripts live in `scripts/deploy/`, each with a bats suite in `scripts/__tests__/deploy/`; run `npm run test:scripts`. See [`docs/ci-cd.md`](docs/ci-cd.md) and the cutover procedure in [`docs/deploy-cutover-runbook.md`](docs/deploy-cutover-runbook.md).
 
-## API Integration
-The revised catalog leverages services defined in `api-service.js`, which utilizes the popular Axios library to communicate with an AWS API Gateway. This integration allows seamless communication between the front-end application and the API endpoints, enabling data retrieval and manipulation.
-
 ## Technologies Used
-- React: The front-end framework used for building the revised WXYC Card Catalog.
+- Next.js (App Router): React framework for the revised WXYC Card Catalog.
 - MUI Joy UI: A library of pre-built UI components for React that allows fast and beautiful feature development.
-- Github Pages: For hosting the frontend and automating publication.
-- Axios: A JavaScript library used for making HTTP requests to the AWS API Gateway.
+- Redux Toolkit / RTK Query: Owns server state, talking directly to [Backend-Service](https://github.com/WXYC/Backend-Service) (see [Local Development Prerequisites](#local-development-prerequisites) below).
+- Cloudflare Pages (via OpenNext/wrangler): Hosting and deployment — see [Deployment](#deployment) above.
 
 ## Local Development Prerequisites
 

--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -10,6 +10,11 @@ export default {
     },
   },
   edgeExternals: ["node:crypto"],
+  // middleware.ts stays on the deprecated Edge-runtime convention rather than
+  // migrating to proxy.ts: proxy.ts is Node.js-runtime-only (no `runtime`
+  // override), and @opennextjs/cloudflare 1.20.1's build.js hard-fails
+  // (process.exit(1)) the moment it detects Node.js middleware. Revisit once
+  // the adapter supports Node.js middleware/proxy. See dj-site#967.
   middleware: {
     external: true,
     override: {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "start": "next start",
     "preview": "npm run build:opennext && opennextjs-cloudflare preview",
     "deploy": "npm run build:opennext && wrangler pages deploy .open-next/assets",
-    "upload": "npm run build:opennext && opennextjs-cloudflare upload",
-    "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",


### PR DESCRIPTION
## Summary

Four small cleanup items from the Next.js modernization pass, bundled into one PR since each is trivially small:

- Removed the `upload` npm script — it invokes `opennextjs-cloudflare upload` (`wrangler versions upload`), a Cloudflare Workers Gradual Deployments command incompatible with this repo's Cloudflare Pages Direct Upload deploy model (`wrangler.jsonc` has no Workers `main` entrypoint). No docs presented it as a supported route, so no doc changes were needed. `npm run deploy` remains the documented local deploy path.
- Removed the `cf-typegen` npm script — dead tooling. Fresh greps confirm: no `cloudflare-env.d.ts` exists anywhere, zero `CloudflareEnv` references outside `node_modules`, and `wrangler.jsonc` declares zero Cloudflare bindings.
- Fixed README.md's stale "API Integration" and "Technologies Used" sections (referenced a nonexistent `api-service.js`, Axios, AWS API Gateway, and "Github Pages" — directly contradicting the accurate "Deployment" section a few lines above). Replaced with the real stack (Next.js App Router, RTK Query → Backend-Service, Cloudflare Pages via OpenNext/wrangler) and pointers back to the existing Deployment section instead of duplicating it.
- Added a constraint comment next to the `middleware` override block in `open-next.config.ts` documenting why `middleware.ts` hasn't been migrated to `proxy.ts`: `@opennextjs/cloudflare` 1.20.1's `build.js` hard-fails (`process.exit(1)`) on Node.js middleware, and `proxy.ts` is Node-runtime-only with no way to opt back into Edge. No functional change.

Closes #964
Closes #969
Closes #971
Closes #967

## What to check

- `package.json` no longer has `upload` or `cf-typegen` scripts, and is valid JSON.
- `npm run deploy` is still present and unchanged as the documented local deploy path.
- README's "Technologies Used" section reads consistently with "Deployment" right above it, with no more `api-service.js` / Axios / AWS API Gateway / "Github Pages" mentions anywhere in README.md or docs/.
- The new comment in `open-next.config.ts` is non-functional — `git diff` shows only comment lines added.
- Full gate green: `npx tsc --noEmit`, `npm run lint` (0 errors), `npx vitest run` (275 files / 3765 tests passed), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)