### PR TITLE
chore(bundle): per-route JS baseline + @mui/joy optimizePackageImports

### DIFF
--- a/docs/plans/nextjs-modernization/bundle-baseline.md
+++ b/docs/plans/nextjs-modernization/bundle-baseline.md
@@ -42,6 +42,11 @@ This runs `next build --experimental-analyze` and prints the per-route table via
 the tables below (and the commit/date header) when re-measuring after a
 bundle-weight PR lands.
 
+`--experimental-analyze` is Turbopack-only: `next build` errors if a webpack
+build (`--webpack`, or a `webpack` key in next.config) is ever introduced, and
+the script exits non-zero if the analyzer stops emitting `analyze.data` —
+neither can silently produce an empty table.
+
 ## Before — commit `c01dbc8d`
 
 | Route | Client JS (raw) | Client JS (gzip) |

--- a/docs/plans/nextjs-modernization/bundle-baseline.md
+++ b/docs/plans/nextjs-modernization/bundle-baseline.md
@@ -1,0 +1,55 @@
+# Bundle baseline — Next.js modernization pass
+
+Baseline of per-route client JS for the routes called out across the Next.js
+modernization pass, so later PRs in the campaign (and reviewers) can diff a
+change against a known "before".
+
+- **Taken from:** commit `c01dbc8d` (branch point `origin/main`)
+- **Date:** 2026-07-17
+- **Next.js:** 16.2.10 (Turbopack, the default `next build` bundler)
+
+## What the numbers are
+
+Each row is the total **client** JS (`.next/static/**/*.js`) reachable from a
+route, in raw (uncompressed) and gzip bytes. Server/SSR chunks are excluded.
+
+This is a superset of strict "First Load JS": it counts every client chunk in
+the route's module graph, including lazily-imported ones that a strict
+first-load figure would omit. It is used here because it is derived identically
+for every measurement, so **before/after deltas are valid** even though the
+absolute number runs higher than the historical Next route-table column.
+
+### Why not `next build`'s route table
+
+Next 16 no longer prints the Size / First Load JS columns in the `next build`
+route table — neither the default Turbopack build nor `next build --webpack`
+emits per-route sizes. `@next/bundle-analyzer` only instruments the webpack
+builder (a no-op under the Turbopack production build) and would add a
+dependency subtree. So the numbers here come from Next's own built-in analyzer,
+`next build --experimental-analyze`, which writes per-route module/size data to
+`.next/diagnostics/analyze/`; `scripts/analyze-bundle.mjs` sums the client
+chunks from it. No new dependency.
+
+## How to regenerate
+
+```
+npm run analyze
+```
+
+This runs `next build --experimental-analyze` and prints the per-route table via
+`scripts/analyze-bundle.mjs`. It is intentionally separate from `build` /
+`build:opennext`, so normal CI/dev builds never carry the analyzer cost. Update
+the tables below (and the commit/date header) when re-measuring after a
+bundle-weight PR lands.
+
+## Before — commit `c01dbc8d`
+
+| Route | Client JS (raw) | Client JS (gzip) |
+| --- | --- | --- |
+| `/` | 1679.3 kB | 650.9 kB |
+| `/login` | 1785.9 kB | 696.9 kB |
+| `/live` | 1686.6 kB | 654.2 kB |
+| `/playlists` | 1684.1 kB | 652.8 kB |
+| `/dashboard/flowsheet` | 2187.6 kB | 884.8 kB |
+| `/dashboard/catalog` | 1847.2 kB | 728.9 kB |
+| `/dashboard/admin/roster` | 1808.8 kB | 710.6 kB |

--- a/docs/plans/nextjs-modernization/bundle-baseline.md
+++ b/docs/plans/nextjs-modernization/bundle-baseline.md
@@ -53,3 +53,24 @@ bundle-weight PR lands.
 | `/dashboard/flowsheet` | 2187.6 kB | 884.8 kB |
 | `/dashboard/catalog` | 1847.2 kB | 728.9 kB |
 | `/dashboard/admin/roster` | 1808.8 kB | 710.6 kB |
+
+## After — `experimental.optimizePackageImports: ["@mui/joy"]` (#962)
+
+| Route | Client JS (raw) | Δ raw | Client JS (gzip) | Δ gzip |
+| --- | --- | --- | --- | --- |
+| `/` | 1679.3 kB | 0.0 kB | 650.9 kB | 0.0 kB |
+| `/login` | 1785.9 kB | 0.0 kB | 696.9 kB | 0.0 kB |
+| `/live` | 1686.6 kB | 0.0 kB | 654.2 kB | 0.0 kB |
+| `/playlists` | 1684.1 kB | 0.0 kB | 652.8 kB | 0.0 kB |
+| `/dashboard/flowsheet` | 2187.6 kB | 0.0 kB | 884.8 kB | 0.0 kB |
+| `/dashboard/catalog` | 1847.2 kB | 0.0 kB | 728.9 kB | 0.0 kB |
+| `/dashboard/admin/roster` | 1808.8 kB | 0.0 kB | 710.6 kB | 0.0 kB |
+
+Output is byte-for-byte identical (same chunk sizes and same chunk counts on
+every route). Turbopack already tree-shakes the `@mui/joy` barrel natively —
+per-route sizes vary with actual usage, which only happens if the barrel is
+being pruned — so `optimizePackageImports`, historically a webpack/SWC
+barrel-rewrite optimization, has no measurable effect on the production
+Turbopack build here. The config entry is still correct and worth keeping: it
+satisfies the optimization for the webpack builder and matches Next's own
+default handling of `@mui/material`/`@mui/icons-material`.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -154,6 +154,12 @@ const nextConfig = {
   reactStrictMode: false,
   productionBrowserSourceMaps: true,
   distDir,
+  experimental: {
+    // @mui/material and @mui/icons-material are in Next's default
+    // optimizePackageImports list; @mui/joy (this app's primary UI kit) is not,
+    // so it must be listed explicitly.
+    optimizePackageImports: ["@mui/joy"],
+  },
   // Explicitly set workspace root to silence lockfile warning
   outputFileTracingRoot: import.meta.dirname,
   // Required for OpenNext Cloudflare

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "build": "next build",
     "build:opennext": "opennextjs-cloudflare build && node scripts/post-build.js",
+    "analyze": "next build --experimental-analyze && node scripts/analyze-bundle.mjs",
     "start": "next start",
     "preview": "npm run build:opennext && opennextjs-cloudflare preview",
     "deploy": "npm run build:opennext && wrangler pages deploy .open-next/assets",

--- a/scripts/analyze-bundle.mjs
+++ b/scripts/analyze-bundle.mjs
@@ -44,7 +44,9 @@ function clientJsBytes(file) {
   let raw = 0;
   let gz = 0;
   for (const [index, sums] of perOutput) {
-    const name = data.output_files[index].filename;
+    const outputFile = data.output_files[index];
+    if (!outputFile) continue;
+    const name = outputFile.filename;
     if (name.includes("/static/") && name.endsWith(".js")) {
       raw += sums.raw;
       gz += sums.gz;
@@ -64,6 +66,15 @@ const kb = (n) => `${(n / 1024).toFixed(1)} kB`;
 const rows = findRouteDataFiles(ANALYZE_DIR)
   .map((file) => ({ route: routeOf(file), ...clientJsBytes(file) }))
   .sort((a, b) => a.route.localeCompare(b.route));
+
+// Fail loudly if a future Next stops emitting analyze.data — an empty table
+// diffed against the baseline would read as a 100% bundle win.
+if (rows.length === 0) {
+  console.error(
+    `Analyzer directory ${ANALYZE_DIR} exists but contains no analyze.data files.`
+  );
+  process.exit(1);
+}
 
 const width = Math.max(...rows.map((r) => r.route.length), "Route".length);
 console.log(`${"Route".padEnd(width)}  ${"Client JS".padStart(12)}  ${"gzip".padStart(12)}`);

--- a/scripts/analyze-bundle.mjs
+++ b/scripts/analyze-bundle.mjs
@@ -1,0 +1,72 @@
+// Summarizes per-route client JS from a `next build --experimental-analyze`
+// run. Next 16's route table no longer prints First Load JS (the Size columns
+// were dropped for both the Turbopack and webpack builders), so the committed
+// bundle baseline (docs/plans/nextjs-modernization/bundle-baseline.md) is
+// derived from the built-in analyzer's per-route data instead. Run via
+// `npm run analyze`.
+//
+// Per route this sums the client output chunks only (`.next/static/**.js`);
+// server/SSR chunks in the same graph are excluded. The total is every client
+// chunk reachable from the route (a superset of strict first-load, since lazy
+// chunks are included), which is stable enough to diff before/after a change
+// as long as the same method is used on both sides.
+import fs from "node:fs";
+import path from "node:path";
+
+const ANALYZE_DIR = path.join(".next", "diagnostics", "analyze", "data");
+
+function findRouteDataFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...findRouteDataFiles(full));
+    else if (entry.name === "analyze.data") out.push(full);
+  }
+  return out;
+}
+
+function routeOf(file) {
+  const rel = path.relative(ANALYZE_DIR, path.dirname(file));
+  return rel === "" ? "/" : `/${rel}`;
+}
+
+function clientJsBytes(file) {
+  const buf = fs.readFileSync(file);
+  const len = buf.readUInt32BE(0);
+  const data = JSON.parse(buf.subarray(4, 4 + len).toString("utf8"));
+  const perOutput = new Map();
+  for (const part of data.chunk_parts) {
+    const cur = perOutput.get(part.output_file_index) || { raw: 0, gz: 0 };
+    cur.raw += part.size;
+    cur.gz += part.compressed_size;
+    perOutput.set(part.output_file_index, cur);
+  }
+  let raw = 0;
+  let gz = 0;
+  for (const [index, sums] of perOutput) {
+    const name = data.output_files[index].filename;
+    if (name.includes("/static/") && name.endsWith(".js")) {
+      raw += sums.raw;
+      gz += sums.gz;
+    }
+  }
+  return { raw, gz };
+}
+
+if (!fs.existsSync(ANALYZE_DIR)) {
+  console.error(
+    `No analyzer output at ${ANALYZE_DIR}. Run \`next build --experimental-analyze\` first (or \`npm run analyze\`).`
+  );
+  process.exit(1);
+}
+
+const kb = (n) => `${(n / 1024).toFixed(1)} kB`;
+const rows = findRouteDataFiles(ANALYZE_DIR)
+  .map((file) => ({ route: routeOf(file), ...clientJsBytes(file) }))
+  .sort((a, b) => a.route.localeCompare(b.route));
+
+const width = Math.max(...rows.map((r) => r.route.length), "Route".length);
+console.log(`${"Route".padEnd(width)}  ${"Client JS".padStart(12)}  ${"gzip".padStart(12)}`);
+for (const row of rows) {
+  console.log(`${row.route.padEnd(width)}  ${kb(row.raw).padStart(12)}  ${kb(row.gz).padStart(12)}`);
+}


### PR DESCRIPTION
Closes #973
Closes #962

Establishes the measurable client-JS baseline the modernization pass's bundle-weight issues will diff against, then adds `@mui/joy` to `optimizePackageImports`.

## #973 — bundle baseline
- Adds `npm run analyze` = `next build --experimental-analyze` (Next's **built-in** analyzer, Turbopack) + `scripts/analyze-bundle.mjs`, which sums per-route client (`.next/static/**/*.js`) chunk bytes. **No new dependency / no lockfile churn.** Kept out of `build` / `build:opennext`.
- Commits `docs/plans/nextjs-modernization/bundle-baseline.md` with the per-route table (date + commit `c01dbc8d`) and regeneration instructions.

Heads-up: **Next 16 no longer prints the Size / First Load JS columns** in the `next build` route table (neither Turbopack nor `--webpack`), so the issue's "use next build's route table" path is no longer possible. The doc records total client JS reachable per route (raw + gzip) — a superset proxy for First Load JS, but derived identically every run, so before/after deltas are valid.

## #962 — optimizePackageImports: ["@mui/joy"]
`@mui/joy` (this app's primary UI kit) is absent from Next's default optimize list (which already covers `@mui/material` / `@mui/icons-material`). Declared explicitly; no import-site changes.

### Before / after (client JS, raw / gzip)
| Route | Before | After | Δ |
| --- | --- | --- | --- |
| `/` | 1679.3 / 650.9 kB | 1679.3 / 650.9 kB | 0 |
| `/login` | 1785.9 / 696.9 kB | 1785.9 / 696.9 kB | 0 |
| `/live` | 1686.6 / 654.2 kB | 1686.6 / 654.2 kB | 0 |
| `/playlists` | 1684.1 / 652.8 kB | 1684.1 / 652.8 kB | 0 |
| `/dashboard/flowsheet` | 2187.6 / 884.8 kB | 2187.6 / 884.8 kB | 0 |
| `/dashboard/catalog` | 1847.2 / 728.9 kB | 1847.2 / 728.9 kB | 0 |
| `/dashboard/admin/roster` | 1808.8 / 710.6 kB | 1808.8 / 710.6 kB | 0 |

Output is byte-for-byte identical. **Turbopack already tree-shakes the `@mui/joy` barrel natively** (per-route sizes vary with usage, so pruning is happening) — `optimizePackageImports` is a webpack-era SWC transform and has no measurable effect on the production Turbopack build. The entry is still correct: it satisfies the optimization for the webpack builder and mirrors Next's own default handling of the other MUI packages.

## Gates
`tsc --noEmit` ✅ · `lint` ✅ (0 errors) · `vitest run` ✅ (275 files / 3765 tests) · `next build` ✅ · `build:opennext` ✅ — all green post-rebase onto current `main`.

## What to check
- `next.config.mjs` diff is a single additive `experimental.optimizePackageImports` block — no other config changed.
- `npm run analyze` runs locally and prints the per-route table.
- Sanity: app still boots and Joy components render (no measured bundle change expected under Turbopack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)