### PR TITLE
Telemetry: defer posthog-js, add instrumentation.ts, report Web Vitals

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -2,7 +2,7 @@ import type { Instrumentation } from "next";
 import { safeCaptureException } from "@/lib/posthog";
 
 /**
- * Single server-observability entry point (#960).
+ * Single server-observability entry point.
  *
  * No server-side PostHog node client is warranted yet: telemetry is an
  * optional adapter (CLAUDE.md) and PostHog is browser-only here, so `register`
@@ -26,7 +26,7 @@ export function register(): void {}
  *     this handler never needs to demote them.
  *
  * `safeCaptureException` no-ops server-side (posthog-js is loaded via a
- * browser-only dynamic import, #972) — the fail-open contract holds; the tags
+ * browser-only dynamic import) — the fail-open contract holds; the tags
  * below are carried on the event for wherever a server sink is later attached.
  */
 export const onRequestError: Instrumentation.onRequestError = (

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,43 @@
+import type { Instrumentation } from "next";
+import { safeCaptureException } from "@/lib/posthog";
+
+/**
+ * Single server-observability entry point (#960).
+ *
+ * No server-side PostHog node client is warranted yet: telemetry is an
+ * optional adapter (CLAUDE.md) and PostHog is browser-only here, so `register`
+ * is an intentional no-op. Add server setup here if a node client is ever
+ * introduced.
+ */
+export function register(): void {}
+
+/**
+ * Forwards server-side errors (Server Components, Route Handlers, Server
+ * Actions) to the existing fail-open `safeCaptureException` wrapper — no new
+ * PostHog integration path.
+ *
+ * Alerting bucket, for future call sites deciding where an error belongs:
+ *   - Backend-Service-origin failures (the one hard external dependency per
+ *     CLAUDE.md; e.g. surfaced from lib/features/backend.ts's fetchBaseQuery
+ *     wrapper) are alerting-worthy — anything reaching `onRequestError` is a
+ *     real server failure in this bucket.
+ *   - Optional-adapter failures (PostHog et al.) stay informational: they
+ *     fail open at their `safeCapture*` wrapper and never propagate here, so
+ *     this handler never needs to demote them.
+ *
+ * `safeCaptureException` no-ops server-side (posthog-js is loaded via a
+ * browser-only dynamic import, #972) — the fail-open contract holds; the tags
+ * below are carried on the event for wherever a server sink is later attached.
+ */
+export const onRequestError: Instrumentation.onRequestError = (
+  err,
+  request,
+  context
+) => {
+  safeCaptureException(err, {
+    path: request.path,
+    routerKind: context.routerKind,
+    routeType: context.routeType,
+    routePath: context.routePath,
+  });
+};

--- a/lib/posthog.ts
+++ b/lib/posthog.ts
@@ -7,20 +7,58 @@ import type { PostHog } from "posthog-js";
  * or render path.
  *
  * `posthog-js` is loaded via a dynamic `import()` inside `initTelemetry` (#972)
- * rather than a top-level static import, so the ~heavy client library ships in
- * its own deferred chunk instead of the root layout's shared bundle that every
- * route parses before hydration. Until that import resolves — SSR, tests, a
- * missing key, or the window between hydration and chunk load — `client` is
- * null and every capture no-ops (events fired in that window are dropped, not
- * queued; the pre-load window is short and these are best-effort signals).
+ * rather than a top-level static import, so the client library ships in its own
+ * deferred chunk instead of the root layout's shared bundle that every route
+ * parses before hydration.
  */
 let client: PostHog | null = null;
+// Non-null once a load starts (in-flight OR settled): also the StrictMode
+// re-entry guard. `loadFailed` records a settled *rejection* so wrappers stop
+// buffering (the buffer would otherwise grow with no flush to drain it).
 let loading: Promise<void> | null = null;
+let loadFailed = false;
+
+// Captures fired before the chunk resolves would otherwise be lost — this is
+// the whole cold-session window: the first $pageview, TTFB/FCP web-vitals, and
+// INP/CLS that only emit on pagehide (bounce visits). Buffer them in order and
+// flush once `client` resolves. Bounded so a pathological pre-load burst can't
+// grow unboundedly; on overflow the NEWEST event is dropped, preserving the
+// earliest, highest-value events (first pageview). Client-only: the buffer is
+// touched solely while `loading` is set, and `loading` is only ever set after
+// the `typeof window === "undefined"` bail, so SSR never enqueues.
+type BufferedCapture =
+  | { readonly method: "capture"; readonly args: readonly [string, Record<string, unknown>?] }
+  | { readonly method: "captureException"; readonly args: readonly [Error, Record<string, unknown>?] };
+const MAX_BUFFERED = 20;
+let buffer: BufferedCapture[] = [];
+
+function bufferCapture(item: BufferedCapture): void {
+  // No load in flight (SSR, missing key) or a failed load: no-op so nothing
+  // accumulates without a flush to drain it.
+  if (loading === null || loadFailed) return;
+  if (buffer.length >= MAX_BUFFERED) return;
+  buffer.push(item);
+}
+
+function flushBuffer(ph: PostHog): void {
+  const pending = buffer;
+  buffer = [];
+  for (const item of pending) {
+    try {
+      if (item.method === "capture") ph.capture(...item.args);
+      else ph.captureException(...item.args);
+    } catch {
+      // optional-service contract: swallow
+    }
+  }
+}
 
 export function initTelemetry(): void {
   if (typeof window === "undefined") return;
-  // Guard against re-entry (React StrictMode double-invokes effects): a single
-  // in-flight or settled import is cached in `loading`.
+  // A single in-flight or settled import is cached in `loading`; a rejected
+  // load is not retried (a broken `-assets` chunk host stays broken for the
+  // session, and TelemetryProvider mounts once so there is no natural retrigger
+  // anyway). Telemetry is best-effort; failing dark beats hammering the host.
   if (loading) return;
 
   const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
@@ -40,9 +78,14 @@ export function initTelemetry(): void {
         });
       }
       client = posthog;
+      flushBuffer(posthog);
     })
     .catch(() => {
-      // optional-service contract: a failed chunk load must not surface
+      // optional-service contract: a failed chunk load must not surface. Mark
+      // failed and drop the buffer so it can't accrete for a session that will
+      // never flush.
+      loadFailed = true;
+      buffer = [];
     });
 }
 
@@ -51,10 +94,12 @@ export function safeCaptureException(
   context?: Record<string, unknown>
 ): void {
   try {
-    client?.captureException(
-      err instanceof Error ? err : new Error(String(err)),
-      context
-    );
+    const error = err instanceof Error ? err : new Error(String(err));
+    if (client) {
+      client.captureException(error, context);
+    } else {
+      bufferCapture({ method: "captureException", args: [error, context] });
+    }
   } catch {
     // optional-service contract: swallow
   }
@@ -65,7 +110,11 @@ export function safeCapture(
   props?: Record<string, unknown>
 ): void {
   try {
-    client?.capture(event, props);
+    if (client) {
+      client.capture(event, props);
+    } else {
+      bufferCapture({ method: "capture", args: [event, props] });
+    }
   } catch {
     // optional-service contract: swallow
   }

--- a/lib/posthog.ts
+++ b/lib/posthog.ts
@@ -6,7 +6,7 @@ import type { PostHog } from "posthog-js";
  * unavailable SDK fails open and never throws back into the dispatch, request,
  * or render path.
  *
- * `posthog-js` is loaded via a dynamic `import()` inside `initTelemetry` (#972)
+ * `posthog-js` is loaded via a dynamic `import()` inside `initTelemetry`
  * rather than a top-level static import, so the client library ships in its own
  * deferred chunk instead of the root layout's shared bundle that every route
  * parses before hydration.

--- a/lib/posthog.ts
+++ b/lib/posthog.ts
@@ -1,8 +1,27 @@
-import posthog from "posthog-js";
+import type { PostHog } from "posthog-js";
+
+/**
+ * Telemetry is optional (CLAUDE.md optional-service rule): PostHog may be
+ * uninitialized (tests, SSR, missing key). Every capture is wrapped so an
+ * unavailable SDK fails open and never throws back into the dispatch, request,
+ * or render path.
+ *
+ * `posthog-js` is loaded via a dynamic `import()` inside `initTelemetry` (#972)
+ * rather than a top-level static import, so the ~heavy client library ships in
+ * its own deferred chunk instead of the root layout's shared bundle that every
+ * route parses before hydration. Until that import resolves — SSR, tests, a
+ * missing key, or the window between hydration and chunk load — `client` is
+ * null and every capture no-ops (events fired in that window are dropped, not
+ * queued; the pre-load window is short and these are best-effort signals).
+ */
+let client: PostHog | null = null;
+let loading: Promise<void> | null = null;
 
 export function initTelemetry(): void {
   if (typeof window === "undefined") return;
-  if (posthog.__loaded) return;
+  // Guard against re-entry (React StrictMode double-invokes effects): a single
+  // in-flight or settled import is cached in `loading`.
+  if (loading) return;
 
   const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
   if (!key) return;
@@ -10,26 +29,29 @@ export function initTelemetry(): void {
   const host =
     process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com";
 
-  posthog.init(key, {
-    api_host: host,
-    capture_pageview: false,
-    capture_pageleave: true,
-    capture_exceptions: true,
-  });
+  loading = import("posthog-js")
+    .then(({ default: posthog }) => {
+      if (!posthog.__loaded) {
+        posthog.init(key, {
+          api_host: host,
+          capture_pageview: false,
+          capture_pageleave: true,
+          capture_exceptions: true,
+        });
+      }
+      client = posthog;
+    })
+    .catch(() => {
+      // optional-service contract: a failed chunk load must not surface
+    });
 }
 
-/**
- * Telemetry is optional (CLAUDE.md optional-service rule): PostHog may be
- * uninitialized (tests, SSR, missing key). Every capture is wrapped so an
- * unavailable SDK fails open and never throws back into the dispatch, request,
- * or render path.
- */
 export function safeCaptureException(
   err: unknown,
   context?: Record<string, unknown>
 ): void {
   try {
-    posthog.captureException(
+    client?.captureException(
       err instanceof Error ? err : new Error(String(err)),
       context
     );
@@ -43,7 +65,7 @@ export function safeCapture(
   props?: Record<string, unknown>
 ): void {
   try {
-    posthog.capture(event, props);
+    client?.capture(event, props);
   } catch {
     // optional-service contract: swallow
   }

--- a/lib/web-vitals-reporter.ts
+++ b/lib/web-vitals-reporter.ts
@@ -1,0 +1,27 @@
+import { safeCapture } from "./posthog";
+
+/**
+ * Forwards Core Web Vitals (LCP/CLS/INP/FCP/TTFB) to PostHog through the same
+ * fail-open `safeCapture` wrapper used for `$pageview` and `csp_violation`
+ * (#961), so it inherits the optional-service contract and needs no new
+ * adapter. Passed to `useReportWebVitals` from TelemetryProvider.
+ */
+
+/** Subset of next/web-vitals' `Metric` this reporter forwards. */
+export interface WebVitalMetric {
+  name: string;
+  value: number;
+  id: string;
+  rating: "good" | "needs-improvement" | "poor";
+}
+
+// Module-scope so the reference stays stable across renders: a changing
+// callback identity makes useReportWebVitals re-report already-seen metrics.
+export function reportWebVital(metric: WebVitalMetric): void {
+  safeCapture("web_vitals", {
+    name: metric.name,
+    value: metric.value,
+    id: metric.id,
+    rating: metric.rating,
+  });
+}

--- a/lib/web-vitals-reporter.ts
+++ b/lib/web-vitals-reporter.ts
@@ -3,7 +3,7 @@ import { safeCapture } from "./posthog";
 /**
  * Forwards Core Web Vitals (LCP/CLS/INP/FCP/TTFB) to PostHog through the same
  * fail-open `safeCapture` wrapper used for `$pageview` and `csp_violation`
- * (#961), so it inherits the optional-service contract and needs no new
+ * so it inherits the optional-service contract and needs no new
  * adapter. Passed to `useReportWebVitals` from TelemetryProvider.
  */
 

--- a/src/components/shared/TelemetryProvider.tsx
+++ b/src/components/shared/TelemetryProvider.tsx
@@ -2,8 +2,10 @@
 
 import { Suspense, useEffect } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
+import { useReportWebVitals } from "next/web-vitals";
 import { initTelemetry, safeCapturePageview } from "@/lib/posthog";
 import { installCspViolationReporter } from "@/lib/csp-violation-reporter";
+import { reportWebVital } from "@/lib/web-vitals-reporter";
 import type { ReactNode } from "react";
 
 function TelemetryPageView() {
@@ -33,6 +35,8 @@ export function TelemetryProvider({ children }: Props) {
     // client-side; forward them to PostHog so the rollout gathers signal.
     installCspViolationReporter();
   }, []);
+
+  useReportWebVitals(reportWebVital);
 
   return (
     <>

--- a/tests/unit/instrumentation.test.ts
+++ b/tests/unit/instrumentation.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { safeCaptureException } from "@/lib/posthog";
+import { onRequestError, register } from "@/instrumentation";
+
+vi.mock("@/lib/posthog", () => ({
+  safeCaptureException: vi.fn(),
+}));
+
+const request = {
+  path: "/dashboard/flowsheet",
+  method: "GET",
+  headers: {},
+} as const;
+
+const context = {
+  routerKind: "App Router",
+  routePath: "/dashboard/flowsheet",
+  routeType: "render",
+  revalidateReason: undefined,
+} as const;
+
+describe("instrumentation.onRequestError", () => {
+  beforeEach(() => {
+    vi.mocked(safeCaptureException).mockClear();
+  });
+
+  it("forwards the error to safeCaptureException tagged with request/router context", () => {
+    const err = new Error("server component blew up");
+    onRequestError(err, request, context);
+
+    expect(safeCaptureException).toHaveBeenCalledTimes(1);
+    expect(safeCaptureException).toHaveBeenCalledWith(err, {
+      path: "/dashboard/flowsheet",
+      routerKind: "App Router",
+      routeType: "render",
+      routePath: "/dashboard/flowsheet",
+    });
+  });
+
+  it("register is a no-op that does not throw", () => {
+    expect(() => register()).not.toThrow();
+  });
+});

--- a/tests/unit/lib/posthog.test.ts
+++ b/tests/unit/lib/posthog.test.ts
@@ -12,6 +12,24 @@ vi.mock("posthog-js", () => {
   };
 });
 
+// posthog-js is now loaded via a deferred dynamic import (#972), so
+// initTelemetry resolves the client on a microtask. Flush the queue before
+// asserting on init/capture, and re-import the module per test (vi.resetModules)
+// so the module-level `client`/`loading` singletons reset.
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+async function loadTelemetry() {
+  const mod = await import("@/lib/posthog");
+  return mod;
+}
+
+async function initAndWait() {
+  const mod = await loadTelemetry();
+  mod.initTelemetry();
+  await flush();
+  return mod;
+}
+
 describe("initTelemetry", () => {
   const originalEnv = { ...process.env };
 
@@ -19,6 +37,7 @@ describe("initTelemetry", () => {
     vi.resetModules();
     vi.mocked(posthog.init).mockClear();
     (posthog as any).__loaded = false;
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test123";
   });
 
   afterEach(() => {
@@ -26,11 +45,9 @@ describe("initTelemetry", () => {
   });
 
   it("calls posthog.init with correct config when NEXT_PUBLIC_POSTHOG_KEY is set", async () => {
-    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test123";
     process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://custom.posthog.com";
 
-    const { initTelemetry } = await import("@/lib/posthog");
-    initTelemetry();
+    await initAndWait();
 
     expect(posthog.init).toHaveBeenCalledWith("phc_test123", {
       api_host: "https://custom.posthog.com",
@@ -41,11 +58,9 @@ describe("initTelemetry", () => {
   });
 
   it("defaults posthog host to https://us.i.posthog.com", async () => {
-    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test123";
     delete process.env.NEXT_PUBLIC_POSTHOG_HOST;
 
-    const { initTelemetry } = await import("@/lib/posthog");
-    initTelemetry();
+    await initAndWait();
 
     expect(posthog.init).toHaveBeenCalledWith(
       "phc_test123",
@@ -58,45 +73,56 @@ describe("initTelemetry", () => {
   it("no-ops when NEXT_PUBLIC_POSTHOG_KEY is unset", async () => {
     delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
 
-    const { initTelemetry } = await import("@/lib/posthog");
-    initTelemetry();
+    await initAndWait();
 
     expect(posthog.init).not.toHaveBeenCalled();
   });
 
   it("no-ops on server (when window is undefined)", async () => {
-    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test123";
-
     const windowSpy = vi.spyOn(globalThis, "window", "get");
     windowSpy.mockReturnValue(undefined as any);
 
-    const { initTelemetry } = await import("@/lib/posthog");
-    initTelemetry();
+    await initAndWait();
 
     expect(posthog.init).not.toHaveBeenCalled();
     windowSpy.mockRestore();
   });
 
   it("skips re-init when posthog.__loaded is already true", async () => {
-    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test123";
     (posthog as any).__loaded = true;
 
-    const { initTelemetry } = await import("@/lib/posthog");
-    initTelemetry();
+    await initAndWait();
 
     expect(posthog.init).not.toHaveBeenCalled();
   });
 });
 
 describe("safe capture contract", () => {
+  const originalEnv = { ...process.env };
+
   beforeEach(() => {
     vi.resetModules();
     vi.mocked(posthog.capture).mockReset();
     vi.mocked(posthog.captureException).mockReset();
+    (posthog as any).__loaded = false;
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test123";
   });
 
-  it("safeCapture forwards event and props to posthog.capture", async () => {
-    const { safeCapture } = await import("@/lib/posthog");
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("no-ops safely before the dynamic import resolves", async () => {
+    const { safeCapture, safeCaptureException } = await loadTelemetry();
+
+    expect(() => safeCapture("early_event")).not.toThrow();
+    expect(() => safeCaptureException(new Error("early"))).not.toThrow();
+    expect(posthog.capture).not.toHaveBeenCalled();
+    expect(posthog.captureException).not.toHaveBeenCalled();
+  });
+
+  it("safeCapture forwards event and props to posthog.capture once loaded", async () => {
+    const { safeCapture } = await initAndWait();
     safeCapture("csp_violation", { blockedURI: "https://evil.example.com" });
 
     expect(posthog.capture).toHaveBeenCalledWith("csp_violation", {
@@ -105,17 +131,17 @@ describe("safe capture contract", () => {
   });
 
   it("safeCapture never throws when the SDK throws", async () => {
+    const { safeCapture } = await initAndWait();
     vi.mocked(posthog.capture).mockImplementationOnce(() => {
       throw new Error("posthog not initialized");
     });
 
-    const { safeCapture } = await import("@/lib/posthog");
     expect(() => safeCapture("some_event")).not.toThrow();
   });
 
-  it("safeCaptureException forwards an Error unchanged", async () => {
+  it("safeCaptureException forwards an Error unchanged once loaded", async () => {
     const err = new Error("boom");
-    const { safeCaptureException } = await import("@/lib/posthog");
+    const { safeCaptureException } = await initAndWait();
     safeCaptureException(err, { domain: "flowsheet" });
 
     expect(posthog.captureException).toHaveBeenCalledWith(err, {
@@ -124,7 +150,7 @@ describe("safe capture contract", () => {
   });
 
   it("safeCaptureException wraps a non-Error value in an Error", async () => {
-    const { safeCaptureException } = await import("@/lib/posthog");
+    const { safeCaptureException } = await initAndWait();
     safeCaptureException("just a string");
 
     const captured = vi.mocked(posthog.captureException).mock.calls[0][0];
@@ -133,16 +159,16 @@ describe("safe capture contract", () => {
   });
 
   it("safeCaptureException never throws when the SDK throws", async () => {
+    const { safeCaptureException } = await initAndWait();
     vi.mocked(posthog.captureException).mockImplementationOnce(() => {
       throw new Error("posthog not initialized");
     });
 
-    const { safeCaptureException } = await import("@/lib/posthog");
     expect(() => safeCaptureException(new Error("boom"))).not.toThrow();
   });
 
   it("safeCapturePageview emits $pageview with $current_url", async () => {
-    const { safeCapturePageview } = await import("@/lib/posthog");
+    const { safeCapturePageview } = await initAndWait();
     safeCapturePageview("https://wxyc.org/dashboard");
 
     expect(posthog.capture).toHaveBeenCalledWith("$pageview", {
@@ -151,11 +177,11 @@ describe("safe capture contract", () => {
   });
 
   it("safeCapturePageview never throws when the SDK throws", async () => {
+    const { safeCapturePageview } = await initAndWait();
     vi.mocked(posthog.capture).mockImplementationOnce(() => {
       throw new Error("posthog not initialized");
     });
 
-    const { safeCapturePageview } = await import("@/lib/posthog");
     expect(() => safeCapturePageview("https://wxyc.org/live")).not.toThrow();
   });
 });

--- a/tests/unit/lib/posthog.test.ts
+++ b/tests/unit/lib/posthog.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// posthog-js is now loaded via a deferred dynamic import (#972). Hoisted so the
+// posthog-js is now loaded via a deferred dynamic import. Hoisted so the
 // mock SDK is available for assertions; the rejection test overrides this with
 // vi.doMock to make the dynamic import fail.
 const control = vi.hoisted(() => ({
@@ -191,7 +191,7 @@ describe("safe capture contract", () => {
   });
 });
 
-describe("pre-load buffer (#972 review)", () => {
+describe("pre-load buffer", () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {

--- a/tests/unit/lib/posthog.test.ts
+++ b/tests/unit/lib/posthog.test.ts
@@ -1,26 +1,28 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import posthog from "posthog-js";
 
-vi.mock("posthog-js", () => {
-  return {
-    default: {
-      init: vi.fn(),
-      capture: vi.fn(),
-      captureException: vi.fn(),
-      __loaded: false,
-    },
-  };
-});
+// posthog-js is now loaded via a deferred dynamic import (#972). Hoisted so the
+// mock SDK is available for assertions; the rejection test overrides this with
+// vi.doMock to make the dynamic import fail.
+const control = vi.hoisted(() => ({
+  posthog: {
+    init: vi.fn(),
+    capture: vi.fn(),
+    captureException: vi.fn(),
+    __loaded: false,
+  },
+}));
 
-// posthog-js is now loaded via a deferred dynamic import (#972), so
-// initTelemetry resolves the client on a microtask. Flush the queue before
-// asserting on init/capture, and re-import the module per test (vi.resetModules)
-// so the module-level `client`/`loading` singletons reset.
+vi.mock("posthog-js", () => ({ default: control.posthog }));
+
+const posthog = control.posthog;
+
+// initTelemetry resolves the client on a microtask, so flush the queue before
+// asserting. Re-import per test (vi.resetModules) so the module-level
+// client/loading/buffer singletons reset.
 const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 async function loadTelemetry() {
-  const mod = await import("@/lib/posthog");
-  return mod;
+  return import("@/lib/posthog");
 }
 
 async function initAndWait() {
@@ -35,8 +37,10 @@ describe("initTelemetry", () => {
 
   beforeEach(() => {
     vi.resetModules();
-    vi.mocked(posthog.init).mockClear();
-    (posthog as any).__loaded = false;
+    posthog.init.mockClear();
+    posthog.capture.mockClear();
+    posthog.captureException.mockClear();
+    posthog.__loaded = false;
     process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test123";
   });
 
@@ -89,11 +93,20 @@ describe("initTelemetry", () => {
   });
 
   it("skips re-init when posthog.__loaded is already true", async () => {
-    (posthog as any).__loaded = true;
+    posthog.__loaded = true;
 
     await initAndWait();
 
     expect(posthog.init).not.toHaveBeenCalled();
+  });
+
+  it("imports posthog-js exactly once when initTelemetry is called twice (StrictMode)", async () => {
+    const mod = await loadTelemetry();
+    mod.initTelemetry();
+    mod.initTelemetry();
+    await flush();
+
+    expect(posthog.init).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -102,23 +115,15 @@ describe("safe capture contract", () => {
 
   beforeEach(() => {
     vi.resetModules();
-    vi.mocked(posthog.capture).mockReset();
-    vi.mocked(posthog.captureException).mockReset();
-    (posthog as any).__loaded = false;
+    posthog.capture.mockReset();
+    posthog.captureException.mockReset();
+    posthog.init.mockReset();
+    posthog.__loaded = false;
     process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test123";
   });
 
   afterEach(() => {
     process.env = { ...originalEnv };
-  });
-
-  it("no-ops safely before the dynamic import resolves", async () => {
-    const { safeCapture, safeCaptureException } = await loadTelemetry();
-
-    expect(() => safeCapture("early_event")).not.toThrow();
-    expect(() => safeCaptureException(new Error("early"))).not.toThrow();
-    expect(posthog.capture).not.toHaveBeenCalled();
-    expect(posthog.captureException).not.toHaveBeenCalled();
   });
 
   it("safeCapture forwards event and props to posthog.capture once loaded", async () => {
@@ -132,7 +137,7 @@ describe("safe capture contract", () => {
 
   it("safeCapture never throws when the SDK throws", async () => {
     const { safeCapture } = await initAndWait();
-    vi.mocked(posthog.capture).mockImplementationOnce(() => {
+    posthog.capture.mockImplementationOnce(() => {
       throw new Error("posthog not initialized");
     });
 
@@ -153,14 +158,14 @@ describe("safe capture contract", () => {
     const { safeCaptureException } = await initAndWait();
     safeCaptureException("just a string");
 
-    const captured = vi.mocked(posthog.captureException).mock.calls[0][0];
+    const captured = posthog.captureException.mock.calls[0][0];
     expect(captured).toBeInstanceOf(Error);
     expect((captured as Error).message).toBe("just a string");
   });
 
   it("safeCaptureException never throws when the SDK throws", async () => {
     const { safeCaptureException } = await initAndWait();
-    vi.mocked(posthog.captureException).mockImplementationOnce(() => {
+    posthog.captureException.mockImplementationOnce(() => {
       throw new Error("posthog not initialized");
     });
 
@@ -178,10 +183,92 @@ describe("safe capture contract", () => {
 
   it("safeCapturePageview never throws when the SDK throws", async () => {
     const { safeCapturePageview } = await initAndWait();
-    vi.mocked(posthog.capture).mockImplementationOnce(() => {
+    posthog.capture.mockImplementationOnce(() => {
       throw new Error("posthog not initialized");
     });
 
     expect(() => safeCapturePageview("https://wxyc.org/live")).not.toThrow();
+  });
+});
+
+describe("pre-load buffer (#972 review)", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    posthog.capture.mockReset();
+    posthog.captureException.mockReset();
+    posthog.init.mockReset();
+    posthog.__loaded = false;
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test123";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("flushes captures fired before load in order once the client resolves", async () => {
+    const mod = await loadTelemetry();
+    mod.initTelemetry(); // load is in-flight, client still null
+
+    mod.safeCapturePageview("https://wxyc.org/live");
+    mod.safeCapture("web_vitals", { name: "TTFB", value: 12 });
+    mod.safeCaptureException(new Error("early boom"));
+
+    // Nothing forwarded while the chunk is still loading.
+    expect(posthog.capture).not.toHaveBeenCalled();
+    expect(posthog.captureException).not.toHaveBeenCalled();
+
+    await flush();
+
+    expect(posthog.capture).toHaveBeenNthCalledWith(1, "$pageview", {
+      $current_url: "https://wxyc.org/live",
+    });
+    expect(posthog.capture).toHaveBeenNthCalledWith(2, "web_vitals", {
+      name: "TTFB",
+      value: 12,
+    });
+    expect(posthog.captureException.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(posthog.captureException.mock.calls[0][0].message).toBe(
+      "early boom"
+    );
+  });
+
+  it("no-ops (no buffering, no flush) when telemetry was never initialized", async () => {
+    const { safeCapture } = await loadTelemetry();
+    safeCapture("orphan_event");
+    await flush();
+
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it("all wrappers no-op and buffer clears when the dynamic import rejects", async () => {
+    // Force the posthog-js chunk import to fail for this test only.
+    vi.doMock("posthog-js", () => {
+      throw new Error("chunk load failed");
+    });
+    try {
+      const mod = await import("@/lib/posthog");
+      mod.initTelemetry();
+
+      // Buffer some events during the (doomed) load window.
+      mod.safeCapture("early_event");
+      mod.safeCaptureException(new Error("early"));
+      mod.safeCapturePageview("https://wxyc.org/live");
+
+      // Let the rejected import settle; must not raise an unhandled rejection.
+      await flush();
+
+      expect(posthog.capture).not.toHaveBeenCalled();
+      expect(posthog.captureException).not.toHaveBeenCalled();
+
+      // Post-failure captures also no-op (session stays dark, buffer cleared).
+      mod.safeCapture("later_event");
+      await flush();
+      expect(posthog.capture).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("posthog-js");
+      vi.resetModules();
+    }
   });
 });

--- a/tests/unit/lib/web-vitals-reporter.test.ts
+++ b/tests/unit/lib/web-vitals-reporter.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { safeCapture } from "@/lib/posthog";
+import {
+  reportWebVital,
+  type WebVitalMetric,
+} from "@/lib/web-vitals-reporter";
+
+vi.mock("@/lib/posthog", () => ({
+  safeCapture: vi.fn(),
+}));
+
+function metric(overrides: Partial<WebVitalMetric> = {}): WebVitalMetric {
+  return {
+    name: "LCP",
+    value: 1234.5,
+    id: "v3-1700000000000-1234567890123",
+    rating: "good",
+    ...overrides,
+  };
+}
+
+describe("reportWebVital", () => {
+  beforeEach(() => {
+    vi.mocked(safeCapture).mockClear();
+  });
+
+  it("captures a web_vitals event with the metric fields", () => {
+    reportWebVital(metric());
+
+    expect(safeCapture).toHaveBeenCalledTimes(1);
+    expect(safeCapture).toHaveBeenCalledWith("web_vitals", {
+      name: "LCP",
+      value: 1234.5,
+      id: "v3-1700000000000-1234567890123",
+      rating: "good",
+    });
+  });
+
+  it("forwards each metric name and rating unchanged", () => {
+    reportWebVital(metric({ name: "CLS", value: 0.02, rating: "needs-improvement" }));
+
+    expect(safeCapture).toHaveBeenCalledWith(
+      "web_vitals",
+      expect.objectContaining({ name: "CLS", value: 0.02, rating: "needs-improvement" })
+    );
+  });
+});


### PR DESCRIPTION
Observability + telemetry bundle-weight bundle. All three issues touch `lib/posthog.ts` / `TelemetryProvider`, so they ship together.

Closes #972
Closes #961
Closes #960

## What this does

- **#972 (perf):** `lib/posthog.ts` now loads `posthog-js` via a cached dynamic `import()` inside `initTelemetry()` instead of a top-level static import, moving the ~222 KB client library out of the root layout's shared client chunk and into its own deferred chunk. The `posthog-js` import is type-only at module scope (erased at build). `safeCapture` / `safeCaptureException` / `safeCapturePageview` keep their fail-open contract — they no-op safely (or buffer, see below) until the dynamic import resolves (SSR, tests, missing key, and the hydration→load window).
  - **Pre-load event handling:** events fired before the chunk resolves are held in a **bounded (20-item), in-order buffer** and flushed once the client resolves — this is the whole cold-session window (first `$pageview`, TTFB/FCP web-vitals, and INP/CLS that only fire on `pagehide` for bounce visits), which would otherwise be lost. On overflow the **newest** event is dropped, preserving the earliest/highest-value ones. The buffer is client-only (SSR never enqueues).
  - **Rejected import:** a failed chunk load marks telemetry failed and clears the buffer (so it can't accrete for a session that will never flush). **No retry** (documented inline): a broken `-assets` chunk host stays broken for the session and `TelemetryProvider` mounts once, so there's no natural retrigger — failing dark beats hammering the host.
- **#961 (observability):** `useReportWebVitals` (from `next/web-vitals`) is wired into `TelemetryProvider`, forwarding each metric through the existing `safeCapture("web_vitals", { name, value, id, rating })` — same fail-open path and naming convention as `$pageview` / `csp_violation`. Reporter logic lives in `lib/web-vitals-reporter.ts` (module-scope stable callback so metrics aren't re-reported) mirroring `lib/csp-violation-reporter.ts`.
- **#960 (observability):** new root `instrumentation.ts` exporting `register()` (intentional no-op — no server-side PostHog node client warranted yet) and `onRequestError()`, which forwards server errors to the existing fail-open `safeCaptureException` wrapper tagged with `path` / `routerKind` / `routeType` / `routePath`. A comment documents the Backend-Service-origin (alerting-worthy) vs optional-adapter (informational) bucket split. Per #972, `safeCaptureException` no-ops server-side (posthog-js is a browser-only dynamic import) — the fail-open contract holds; the tags ride the event for whenever a server sink is attached.
  - **Caveat:** whether OpenNext/Cloudflare's `workerd` runtime actually invokes Next's `onRequestError` is **unverified**. The adapter patches module loading so `register()` is wired, but the error-path invocation is not statically confirmable from here — treat `onRequestError` as forward-compatible plumbing (correct, fail-open, and ready if/when the runtime calls it) rather than a guaranteed-live server sink today.

## What to check

- **Chunk change (the point of #972).** After `npm run build`, `posthog-js` lives in on-demand chunk `.next/static/chunks/0eqxoazyb5ou5.js` (~222 KB). Verified it is (a) **absent from all 5 `rootMainFiles`** shared root chunks in `build-manifest.json`, and (b) **referenced 0 times** across every page/layout chunk list in `build-manifest.json` — it is fetched only via the dynamic-import glue, never eagerly with the root layout. Re-verified after the buffer change.
- **Fail-open + buffer contract** in `lib/posthog.ts`: captures before the import resolves buffer and flush in order; a rejected import no-ops all wrappers, clears the buffer, and raises no unhandled rejection; SSR/missing-key never buffer. Covered by `tests/unit/lib/posthog.test.ts`.
- **`onRequestError`** reuses `safeCaptureException` — no new PostHog integration path — with the bucket-distinction comment; forwarding covered by `tests/unit/instrumentation.test.ts`.
- **Web Vitals** shape/name matches existing conventions; unit test in `tests/unit/lib/web-vitals-reporter.test.ts`.

## Verification gate (all pass)

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors, no new warnings from touched files
- `npx vitest run` — 277 files / 3773 tests pass
- `npm run build` — success
- `npm run build:opennext` — success (only the pre-existing better-auth/zod `??` bundler warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)