### PR TITLE
Convert enumerable local static images to next/image

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -158,6 +158,16 @@ const nextConfig = {
   outputFileTracingRoot: import.meta.dirname,
   // Required for OpenNext Cloudflare
   output: "standalone",
+  images: {
+    // wrangler.jsonc declares no `images` (Cloudflare Images) binding.
+    // OpenNext's /_next/image handler (@opennextjs/cloudflare compile-images)
+    // checks `env.IMAGES` and, when it's undefined, returns the original
+    // bytes unresized/unconverted — so the default optimizer would add a
+    // Worker round-trip for no benefit. `unoptimized: true` skips that hop;
+    // next/image still buys explicit width/height (CLS) and native
+    // lazy-loading. Revisit if a Cloudflare Images binding is ever added.
+    unoptimized: true,
+  },
   async headers() {
     return [
       {

--- a/src/components/experiences/classic/catalog/SearchForm.tsx
+++ b/src/components/experiences/classic/catalog/SearchForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { FormEvent, useEffect, useRef } from "react";
 
@@ -52,9 +53,14 @@ export default function SearchForm() {
               <tr>
                 <td align="center" valign="top">
                   <span className="title">Search the&nbsp;&nbsp;</span>
-                  <img
+                  {/* unoptimized: see next.config.mjs images.unoptimized comment */}
+                  <Image
                     src="/img/wxyc-logo-classic.gif"
                     alt="WXYC logo"
+                    width={148}
+                    height={35}
+                    unoptimized
+                    priority
                     style={{ border: 0 }}
                   />
                   <span className="title">&nbsp;&nbsp;Library:</span>

--- a/src/components/experiences/classic/login/Layout/Header.tsx
+++ b/src/components/experiences/classic/login/Layout/Header.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 export default function Header() {
   return (
     <table cellPadding="10">
@@ -8,9 +10,14 @@ export default function Header() {
             valign="top"
             style={{ display: "flex", justifyContent: "center" }}
           >
-            <img
-              src={`/img/wxyc-logo-classic.gif`}
+            {/* unoptimized: see next.config.mjs images.unoptimized comment */}
+            <Image
+              src="/img/wxyc-logo-classic.gif"
               alt="WXYC logo"
+              width={148}
+              height={35}
+              unoptimized
+              priority
               style={{ border: 0 }}
             />
           </td>

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumErrorCard.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumErrorCard.tsx
@@ -11,6 +11,7 @@ import {
   Stack,
   Typography,
 } from "@mui/joy";
+import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
@@ -27,7 +28,8 @@ export default function AlbumErrorCard() {
     >
       <CardOverflow>
         <AspectRatio ratio="4">
-          <img src="/img/wxyc_dark.jpg" />
+          {/* unoptimized: see next.config.mjs images.unoptimized comment */}
+          <Image src="/img/wxyc_dark.jpg" alt="" fill unoptimized priority />
         </AspectRatio>
         <ModalClose variant="solid" />;
       </CardOverflow>

--- a/src/widgets/NowPlaying/AlbumArtAndIcons.tsx
+++ b/src/widgets/NowPlaying/AlbumArtAndIcons.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/features/flowsheet/types";
 import { Headphones, Logout, Mic, Timer } from "@mui/icons-material";
 import { AspectRatio, Box } from "@mui/joy";
+import Image from "next/image";
 import { ENTRY_TONES } from "@/lib/features/experiences/modern/tokens/roles";
 
 const DEFAULT_ARTWORK_URL = "/img/cassette.png";
@@ -26,32 +27,29 @@ export default function AlbumArtAndIcons({
   entry: FlowsheetEntry | undefined;
 }) {
   if (!entry) {
-    return (
-      <ImageWrapper>
-        <img
-          src={DEFAULT_ARTWORK_URL}
-          srcSet={DEFAULT_ARTWORK_URL}
-          loading="lazy"
-          alt=""
-          style={{ width: "100%", objectPosition: "center" }}
-        />
-      </ImageWrapper>
-    );
+    return <DefaultArtwork />;
   }
 
   if (isFlowsheetSongEntry(entry)) {
-    const artworkUrl = entry.artwork_url ?? DEFAULT_ARTWORK_URL;
-    return (
-      <ImageWrapper>
-        <img
-          src={artworkUrl}
-          srcSet={artworkUrl}
-          loading="lazy"
-          alt=""
-          style={{ width: "100%", objectPosition: "center" }}
-        />
-      </ImageWrapper>
-    );
+    // entry.artwork_url, when present, is resolved from a third-party host at
+    // runtime (see the img-src CSP comment in next.config.mjs) — next/image
+    // needs a build-time-known remote pattern, so only the local
+    // DEFAULT_ARTWORK_URL fallback below converts; a live artwork_url keeps
+    // the plain <img>.
+    if (entry.artwork_url) {
+      return (
+        <ImageWrapper>
+          <img
+            src={entry.artwork_url}
+            srcSet={entry.artwork_url}
+            loading="lazy"
+            alt=""
+            style={{ width: "100%", objectPosition: "center" }}
+          />
+        </ImageWrapper>
+      );
+    }
+    return <DefaultArtwork />;
   }
 
   if (isFlowsheetBreakpointEntry(entry)) {
@@ -86,17 +84,19 @@ export default function AlbumArtAndIcons({
     );
   }
 
-  return (
-    <ImageWrapper>
-      <img
-        src={DEFAULT_ARTWORK_URL}
-        srcSet={DEFAULT_ARTWORK_URL}
-        loading="lazy"
-        alt=""
-      />
-    </ImageWrapper>
-  );
+  return <DefaultArtwork />;
 }
+
+// AspectRatio clones its first child with `data-first-child`, which its own
+// styles target for the fill/cover sizing (see @mui/joy AspectRatio.js) —
+// `Image fill` becomes that first child directly, no extra wrapper needed.
+// unoptimized: see next.config.mjs images.unoptimized comment; `sizes` is
+// moot alongside it (the optimizer's width negotiation never runs).
+const DefaultArtwork = () => (
+  <ImageWrapper>
+    <Image src={DEFAULT_ARTWORK_URL} alt="" fill unoptimized />
+  </ImageWrapper>
+);
 
 const BoxWrapper = ({
   children


### PR DESCRIPTION
## Summary

Closes #965.

Replaces the local-static-asset `<img>` tags in four files with `next/image`'s `Image` component, using explicit `width`/`height` or `fill` matched to each layout:

- `src/widgets/NowPlaying/AlbumArtAndIcons.tsx` — the three `DEFAULT_ARTWORK_URL` (`/img/cassette.png`) fallback branches now share one `DefaultArtwork` helper using `Image ... fill`. The song-entry branch was split in two: a live `entry.artwork_url` (third-party host, resolved at runtime) keeps the plain `<img>`, and only the local-fallback path converts — `next/image` needs a build-time-known remote pattern, which a third-party artwork host isn't (see the `img-src` CSP comment in `next.config.mjs`).
- `src/components/experiences/modern/Rightbar/panels/album/AlbumErrorCard.tsx` — `/img/wxyc_dark.jpg` now uses `Image ... fill` inside the existing `AspectRatio`.
- `src/components/experiences/classic/login/Layout/Header.tsx` — the `wxyc-logo-classic.gif` logo now uses `Image` with explicit `width={148} height={35}` (the gif's intrinsic size).
- `src/components/experiences/classic/catalog/SearchForm.tsx` — same logo, same explicit dimensions.

**Deployment note (Cloudflare Pages via OpenNext):** `wrangler.jsonc` declares no `images` (Cloudflare Images) binding. OpenNext's `/_next/image` handler (`@opennextjs/cloudflare`'s `compile-images.js`) checks `env.IMAGES` and, when undefined, returns the original bytes unresized rather than erroring — but that's a pointless Worker round-trip with zero optimization benefit. Rather than silently relying on an endpoint that does nothing, `next.config.mjs` now sets `images.unoptimized: true` (repo-wide, documented in place) and each converted `Image` also passes `unoptimized` explicitly so behavior is identical and deterministic in tests (which don't read `next.config.mjs`), dev, and the CF Pages build. `next/image` still buys explicit width/height (layout stability) and native lazy-loading (`loading="lazy"` by default; `priority` used for the two above-the-fold logos, matching their prior eager-load behavior).

`AspectRatio` from `@mui/joy` already special-cases `next/image`'s `fill` layout — its source comment says as much (`// use nested selector for integrating with nextjs image \`fill\` layout`) — so the `fill` conversions in `AlbumArtAndIcons` / `AlbumErrorCard` are a drop-in for the existing `object-fit: cover` sizing, no wrapper changes needed.

Untouched, as scoped by the issue: the third-party album-artwork `<img>` tags in `SongEntry.tsx` / `MobileSongEntry.tsx`, and everything under `flowsheet/Search/**`.

## What to check

- **Now Playing widget** (mini/full player) — with no current flowsheet entry, or a talkset/breakpoint/show-block entry: cassette placeholder art renders at the same 100×100 square, same rounded corners/shadow, same crop.
- **Now Playing widget** — a song entry *without* `artwork_url` (or a `metadataApi` fetch failure): same cassette placeholder as above.
- **Now Playing widget** — a song entry *with* `artwork_url`: real album art renders unchanged (still the plain `<img>` path).
- **Rightbar album panel error state** — trigger an album-load failure: the "Ack!" error card shows the WXYC dark-mode graphic at the same 4:1 aspect ratio, same crop/position.
- **Classic login page** (`/login`, classic experience) — WXYC logo header renders at its normal size, same position.
- **Classic catalog search page** — the inline WXYC logo between "Search the" and "Library:" renders at its normal size, same position.

## Verification gate

- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors (pre-existing warnings only, none in touched files)
- `npx vitest run` — 275 files / 3765 tests passed
- `npm run build` — clean
- `npm run build:opennext` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)