### PR TITLE
fix(leftbar): swap Flowsheet icon from Podcasts to CellTower

### DIFF
--- a/src/components/experiences/modern/Leftbar/FlowsheetLink.tsx
+++ b/src/components/experiences/modern/Leftbar/FlowsheetLink.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useShowControl } from "@/src/hooks/flowsheetHooks";
-import { Podcasts } from "@mui/icons-material";
+import { CellTower } from "@mui/icons-material";
 import { Badge } from "@mui/joy";
 import LeftbarLink from "./LeftbarLink";
 
@@ -20,7 +20,7 @@ export default function FlowsheetLink() {
       }}
     >
       <LeftbarLink path="/dashboard/flowsheet" title={`Flowsheet${live ? "      🔴 [ON AIR]" : ""}`}>
-        <Podcasts />
+        <CellTower />
       </LeftbarLink>
     </Badge>
   );

--- a/tests/integration/components/modern/Leftbar/FlowsheetLink.test.tsx
+++ b/tests/integration/components/modern/Leftbar/FlowsheetLink.test.tsx
@@ -25,7 +25,7 @@ vi.mock("next/link", () => ({
 
 // Mock MUI icons
 vi.mock("@mui/icons-material", () => ({
-  Podcasts: () => <span data-testid="podcasts-icon" />,
+  CellTower: () => <span data-testid="celltower-icon" />,
 }));
 
 describe("FlowsheetLink", () => {
@@ -40,10 +40,10 @@ describe("FlowsheetLink", () => {
     expect(link).toHaveAttribute("href", "/dashboard/flowsheet");
   });
 
-  it("should render podcasts icon", () => {
+  it("should render celltower icon", () => {
     render(<FlowsheetLink />);
 
-    expect(screen.getByTestId("podcasts-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("celltower-icon")).toBeInTheDocument();
   });
 
   it("should show 'Flowsheet' title when not live", () => {


### PR DESCRIPTION
## Summary
- Swaps the Flowsheet leftbar icon from `Podcasts` to `CellTower`, following the same pattern as the previous icon swap (#c01dbc8d, Stream → Podcasts).

## Test plan
- [x] `npx vitest run tests/integration/components/modern/Leftbar/FlowsheetLink.test.tsx` — 7 passed
- [x] `npx eslint` on both changed files — clean