### PR TITLE
feat: server-render initial data for /live and /playlists (Closes #977 / #978)

### DIFF
--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -1,6 +1,10 @@
 import WXYCPage from "@/src/Layout/WXYCPage";
 import SSESubscription from "@/src/components/shared/SSESubscription";
 import NowPlaying from "@/src/widgets/NowPlaying";
+import {
+  fetchNowPlayingSeed,
+  fetchWhoIsLiveSeed,
+} from "@/lib/features/flowsheet/server";
 import { Box, Card } from "@mui/joy";
 import { Metadata } from "next";
 import { getPageTitle } from "@/lib/utils/page-title";
@@ -9,7 +13,12 @@ export const metadata: Metadata = {
   title: getPageTitle("Listen Live"),
 };
 
-export default function LivePage() {
+export default async function LivePage() {
+  const [initialEntry, initialOnAirData] = await Promise.all([
+    fetchNowPlayingSeed(),
+    fetchWhoIsLiveSeed(),
+  ]);
+
   return (
     <WXYCPage>
       <SSESubscription surface="live" />
@@ -28,7 +37,11 @@ export default function LivePage() {
           alignItems: "center",
         }}
       >
-        <NowPlaying mini={false} />
+        <NowPlaying
+          mini={false}
+          initialEntry={initialEntry}
+          initialOnAirData={initialOnAirData}
+        />
       </Box>
     </WXYCPage>
   );

--- a/app/playlists/page.tsx
+++ b/app/playlists/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 };
 
 export default async function PlaylistsPage() {
-  const { results, total } = await fetchRecentPlaylistsSeed();
+  const { results } = await fetchRecentPlaylistsSeed();
 
   return (
     <WXYCPage>
@@ -22,7 +22,7 @@ export default async function PlaylistsPage() {
           py: 2,
         }}
       >
-        <PlaylistSearchContainer initialResults={results} initialTotal={total} />
+        <PlaylistSearchContainer initialResults={results} />
       </Box>
     </WXYCPage>
   );

--- a/app/playlists/page.tsx
+++ b/app/playlists/page.tsx
@@ -1,5 +1,6 @@
 import WXYCPage from "@/src/Layout/WXYCPage";
 import { PlaylistSearchContainer } from "@/src/components/experiences/modern/playlist-search";
+import { fetchRecentPlaylistsSeed } from "@/lib/features/playlist-search/server";
 import { Box } from "@mui/joy";
 import { Metadata } from "next";
 import { getPageTitle } from "@/lib/utils/page-title";
@@ -8,7 +9,9 @@ export const metadata: Metadata = {
   title: getPageTitle("Playlist Archive"),
 };
 
-export default function PlaylistsPage() {
+export default async function PlaylistsPage() {
+  const { results, total } = await fetchRecentPlaylistsSeed();
+
   return (
     <WXYCPage>
       <Box
@@ -19,7 +22,7 @@ export default function PlaylistsPage() {
           py: 2,
         }}
       >
-        <PlaylistSearchContainer />
+        <PlaylistSearchContainer initialResults={results} initialTotal={total} />
       </Box>
     </WXYCPage>
   );

--- a/lib/features/flowsheet/server.ts
+++ b/lib/features/flowsheet/server.ts
@@ -1,0 +1,39 @@
+import "server-only";
+
+import { fetchBackendSeed } from "../server-fetch";
+import { convertDJsOnAir, convertV2Entry } from "./conversions";
+import {
+  FlowsheetEntry,
+  FlowsheetV2EntryJSON,
+  OnAirDJData,
+  OnAirDJResponse,
+} from "./types";
+
+/**
+ * Current now-playing entry for seeding the public NowPlaying widget.
+ * `undefined` means the seed is unavailable (backend slow/down at request
+ * time) — the widget keeps its client-fetched loading behavior. `null` means
+ * the fetch succeeded and nothing is playing.
+ */
+export async function fetchNowPlayingSeed(): Promise<
+  FlowsheetEntry | null | undefined
+> {
+  const raw = await fetchBackendSeed<FlowsheetV2EntryJSON | null>(
+    "/flowsheet/latest",
+  );
+  if (raw === undefined) return undefined;
+  return raw ? convertV2Entry(raw) : null;
+}
+
+/**
+ * Who-is-on-air summary for seeding the public NowPlaying widget. `undefined`
+ * means the seed is unavailable and the widget keeps its client-fetched
+ * loading behavior.
+ */
+export async function fetchWhoIsLiveSeed(): Promise<OnAirDJData | undefined> {
+  const raw = await fetchBackendSeed<OnAirDJResponse[] | null>(
+    "/flowsheet/djs-on-air",
+  );
+  if (raw === undefined) return undefined;
+  return convertDJsOnAir(raw ?? undefined);
+}

--- a/lib/features/playlist-search/server.ts
+++ b/lib/features/playlist-search/server.ts
@@ -6,7 +6,6 @@ import type { PlaylistSearchResponseWithCursor } from "./api";
 
 export type RecentPlaylistsSeed = {
   results: PlaylistSearchResult[];
-  total: number;
 };
 
 // The empty-query "recent playlists" listing is canonical, request-time-knowable
@@ -27,6 +26,5 @@ export async function fetchRecentPlaylistsSeed(): Promise<RecentPlaylistsSeed> {
   );
   return {
     results: raw?.results ?? [],
-    total: raw?.total ?? 0,
   };
 }

--- a/lib/features/playlist-search/server.ts
+++ b/lib/features/playlist-search/server.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import type { PlaylistSearchResult } from "@wxyc/shared";
+import { fetchBackendSeed } from "../server-fetch";
+import type { PlaylistSearchResponseWithCursor } from "./api";
+
+export type RecentPlaylistsSeed = {
+  results: PlaylistSearchResult[];
+  total: number;
+};
+
+// The empty-query "recent playlists" listing is canonical, request-time-knowable
+// data requiring no auth — the same first page the client's infinite query
+// requests (sort date/desc, limit 50). Server-rendering it puts populated rows
+// in the initial HTML; the client query takes over once it mounts. On failure
+// this returns an empty seed and the client query fills the table.
+export async function fetchRecentPlaylistsSeed(): Promise<RecentPlaylistsSeed> {
+  const params = new URLSearchParams({
+    q: "",
+    page: "0",
+    limit: "50",
+    sort: "date",
+    order: "desc",
+  });
+  const raw = await fetchBackendSeed<PlaylistSearchResponseWithCursor | null>(
+    `/flowsheet/search?${params.toString()}`,
+  );
+  return {
+    results: raw?.results ?? [],
+    total: raw?.total ?? 0,
+  };
+}

--- a/lib/features/server-fetch.ts
+++ b/lib/features/server-fetch.ts
@@ -1,0 +1,33 @@
+import "server-only";
+
+// Request-time seed fetches for public Server Components must fail open: a slow
+// or unreachable backend renders the page's normal loading state, never an
+// error page. The short timeout keeps a hung backend from stalling the route.
+const SEED_FETCH_TIMEOUT_MS = 2000;
+
+/**
+ * Unauthenticated GET against Backend-Service for server-rendered initial data.
+ * Returns `undefined` on any failure (network error, timeout, non-2xx, or an
+ * empty/non-JSON body) so callers can fall back to their client-fetched state.
+ */
+export async function fetchBackendSeed<T>(
+  path: string,
+): Promise<T | undefined> {
+  const base = process.env.NEXT_PUBLIC_BACKEND_URL;
+  if (!base) return undefined;
+
+  try {
+    const response = await fetch(`${base}${path}`, {
+      signal: AbortSignal.timeout(SEED_FETCH_TIMEOUT_MS),
+      cache: "no-store",
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) return undefined;
+
+    const body = await response.text();
+    if (!body) return undefined;
+    return JSON.parse(body) as T;
+  } catch {
+    return undefined;
+  }
+}

--- a/lib/features/server-fetch.ts
+++ b/lib/features/server-fetch.ts
@@ -3,7 +3,9 @@ import "server-only";
 // Request-time seed fetches for public Server Components must fail open: a slow
 // or unreachable backend renders the page's normal loading state, never an
 // error page. The short timeout keeps a hung backend from stalling the route.
-const SEED_FETCH_TIMEOUT_MS = 2000;
+// Seed fetches run before the first byte of the document: this bound is
+// the worst-case TTFB penalty a degraded backend can add to a public page.
+const SEED_FETCH_TIMEOUT_MS = 800;
 
 /**
  * Unauthenticated GET against Backend-Service for server-rendered initial data.

--- a/src/components/experiences/modern/playlist-search/PlaylistSearchContainer.tsx
+++ b/src/components/experiences/modern/playlist-search/PlaylistSearchContainer.tsx
@@ -1,12 +1,26 @@
 "use client";
 
-import { usePlaylistSearch } from "@/src/hooks/playlistSearchHooks";
+import {
+  MIN_QUERY_LENGTH,
+  usePlaylistSearch,
+} from "@/src/hooks/playlistSearchHooks";
+import type { PlaylistSearchResult } from "@wxyc/shared";
 import { Box, Typography } from "@mui/joy";
 import PlaylistResultsTable from "./PlaylistResultsTable";
 import PlaylistInfiniteScroll from "./PlaylistInfiniteScroll";
 import SearchBar from "@/src/components/experiences/modern/previous-sets/Search/SearchBar";
 
-export default function PlaylistSearchContainer() {
+export interface PlaylistSearchContainerProps {
+  // Server-rendered "recent playlists" listing for the empty default query.
+  // The client infinite query takes over once it resolves.
+  initialResults?: PlaylistSearchResult[];
+  initialTotal?: number;
+}
+
+export default function PlaylistSearchContainer({
+  initialResults = [],
+  initialTotal = 0,
+}: PlaylistSearchContainerProps) {
   const {
     sortBy,
     sortOrder,
@@ -20,6 +34,19 @@ export default function PlaylistSearchContainer() {
     effectiveQuery,
   } = usePlaylistSearch();
 
+  // The empty query is the canonical "recent playlists" default. Its results
+  // are shown just like a real query's — the earlier gate discarded a fetch the
+  // hook already fired. A single-character partial still shows nothing (the
+  // hook skips it). Until the client query resolves, the server seed backs the
+  // default view so the initial HTML carries populated rows.
+  const isDefaultQuery = effectiveQuery.length === 0;
+  const isRealQuery = effectiveQuery.length >= MIN_QUERY_LENGTH;
+  const showResults = isDefaultQuery || isRealQuery;
+
+  const usingSeed = isDefaultQuery && results.length === 0;
+  const displayResults = usingSeed ? initialResults : results;
+  const displayTotal = usingSeed ? initialTotal : total;
+
   return (
     <Box sx={{ width: "100%", px: 2 }}>
       <Typography level="h2" sx={{ mb: 2 }}>
@@ -32,30 +59,32 @@ export default function PlaylistSearchContainer() {
 
       <SearchBar />
 
-      {effectiveQuery.length >= 2 && (
+      {showResults && (
         <Box sx={{ mt: 2 }}>
-          <Typography level="body-sm" sx={{ mb: 1, color: "text.secondary" }}>
-            {isLoading
-              ? "Searching..."
-              : total > 0
-              ? `Found ${total.toLocaleString()} results`
-              : "No results found"}
-          </Typography>
+          {isRealQuery && (
+            <Typography level="body-sm" sx={{ mb: 1, color: "text.secondary" }}>
+              {isLoading
+                ? "Searching..."
+                : displayTotal > 0
+                ? `Found ${displayTotal.toLocaleString()} results`
+                : "No results found"}
+            </Typography>
+          )}
 
-          {isError && (
+          {isError && isRealQuery && (
             <Typography level="body-sm" color="danger" sx={{ mb: 2 }}>
               An error occurred while searching. Please try again.
             </Typography>
           )}
 
-          {results.length > 0 && (
+          {displayResults.length > 0 && (
             <PlaylistInfiniteScroll
               hasMore={hasMore}
               isLoading={isLoading}
               onLoadMore={loadNextPage}
             >
               <PlaylistResultsTable
-                results={results}
+                results={displayResults}
                 sortBy={sortBy}
                 sortOrder={sortOrder}
                 onSort={handleSort}

--- a/src/components/experiences/modern/playlist-search/PlaylistSearchContainer.tsx
+++ b/src/components/experiences/modern/playlist-search/PlaylistSearchContainer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import {
   MIN_QUERY_LENGTH,
   usePlaylistSearch,
@@ -14,12 +15,10 @@ export interface PlaylistSearchContainerProps {
   // Server-rendered "recent playlists" listing for the empty default query.
   // The client infinite query takes over once it resolves.
   initialResults?: PlaylistSearchResult[];
-  initialTotal?: number;
 }
 
 export default function PlaylistSearchContainer({
   initialResults = [],
-  initialTotal = 0,
 }: PlaylistSearchContainerProps) {
   const {
     sortBy,
@@ -43,9 +42,18 @@ export default function PlaylistSearchContainer({
   const isRealQuery = effectiveQuery.length >= MIN_QUERY_LENGTH;
   const showResults = isDefaultQuery || isRealQuery;
 
-  const usingSeed = isDefaultQuery && results.length === 0;
+  // The seed retires permanently once the client query produces an answer:
+  // sort/argument changes re-key the RTK cache (results drop to [] mid-flight),
+  // and resurfacing the seed there would flash rows in the original server
+  // order over the user's chosen sort.
+  const seedRetired = useRef(false);
+  if (results.length > 0 || isError) {
+    seedRetired.current = true;
+  }
+
+  const usingSeed =
+    isDefaultQuery && results.length === 0 && !seedRetired.current;
   const displayResults = usingSeed ? initialResults : results;
-  const displayTotal = usingSeed ? initialTotal : total;
 
   return (
     <Box sx={{ width: "100%", px: 2 }}>
@@ -65,8 +73,8 @@ export default function PlaylistSearchContainer({
             <Typography level="body-sm" sx={{ mb: 1, color: "text.secondary" }}>
               {isLoading
                 ? "Searching..."
-                : displayTotal > 0
-                ? `Found ${displayTotal.toLocaleString()} results`
+                : total > 0
+                ? `Found ${total.toLocaleString()} results`
                 : "No results found"}
             </Typography>
           )}

--- a/src/hooks/playlistSearchHooks.ts
+++ b/src/hooks/playlistSearchHooks.ts
@@ -9,7 +9,7 @@ import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { useCallback, useMemo } from "react";
 import type { PlaylistSearchResult } from "@wxyc/shared";
 
-const MIN_QUERY_LENGTH = 2;
+export const MIN_QUERY_LENGTH = 2;
 const LIMIT = 50;
 
 /** Field-specific prefixes for backend query parsing. */

--- a/src/widgets/NowPlaying/index.tsx
+++ b/src/widgets/NowPlaying/index.tsx
@@ -4,6 +4,10 @@ import {
   useGetNowPlayingQuery,
   useWhoIsLiveQuery,
 } from "@/lib/features/flowsheet/api";
+import {
+  FlowsheetEntry,
+  OnAirDJData,
+} from "@/lib/features/flowsheet/types";
 import { useEffect, useRef, useState } from "react";
 import { useFlowsheetPollingInterval } from "@/src/hooks/useSSEConnection";
 import NowPlayingMain from "./Main";
@@ -11,6 +15,11 @@ import NowPlayingMini from "./Mini";
 
 export type NowPlayingWidgetProps = {
   mini: boolean;
+  // Server-rendered seeds for the public /live page so first paint shows the
+  // on-air DJ and now-playing track instead of a spinner. Omitted elsewhere
+  // (e.g. the Rightbar), where the widget keeps its client-fetched behavior.
+  initialEntry?: FlowsheetEntry | null;
+  initialOnAirData?: OnAirDJData;
 };
 
 const AUDIO_SRC = "https://audio-mp3.ibiblio.org/wxyc.mp3";
@@ -31,7 +40,11 @@ type NowPlayingAudioGraph = {
 };
 const audioGraphCache = new WeakMap<HTMLMediaElement, NowPlayingAudioGraph>();
 
-export default function NowPlaying({ mini = false }: NowPlayingWidgetProps) {
+export default function NowPlaying({
+  mini = false,
+  initialEntry,
+  initialOnAirData,
+}: NowPlayingWidgetProps) {
   const audioRef = useRef<HTMLAudioElement>(null);
 
   // AudioContext / AnalyserNode live in state (not refs) so the children
@@ -44,25 +57,33 @@ export default function NowPlaying({ mini = false }: NowPlayingWidgetProps) {
   const [isPlaying, setIsPlaying] = useState(false);
 
   const {
-    data: djsOnAirData,
-    isLoading: djLoading,
+    data: whoIsLiveData,
+    isLoading: whoIsLiveLoading,
     isError: djError,
   } = useWhoIsLiveQuery();
 
-  const onAirDJ = djsOnAirData?.onAir;
+  // The client query owns this value once it resolves; before then fall back to
+  // the server seed so the public page renders the on-air state on first paint.
+  const onAirData = whoIsLiveData ?? initialOnAirData;
+  const onAirDJ = onAirData?.onAir;
   const live = onAirDJ !== undefined && onAirDJ !== "Off Air" && !djError;
+  // Show today's spinner only while the query is loading AND no seed is present;
+  // with a seed there is already content to render.
+  const djLoading = whoIsLiveLoading && onAirData === undefined;
 
   const nowPlayingPollingInterval = useFlowsheetPollingInterval();
 
-  const {
-    data: latestEntry,
-    isLoading: latestEntryLoading,
-    isError: latestEntryError,
-  } = useGetNowPlayingQuery(undefined, {
+  const { data: nowPlayingData } = useGetNowPlayingQuery(undefined, {
     pollingInterval: nowPlayingPollingInterval,
     // Don't keep hitting the backend on a hidden/blurred tab. (#634)
     skipPollingIfUnfocused: true,
   });
+
+  // `data` is undefined only until the first client fetch resolves; once it
+  // does (even to null = nothing playing) it owns the value. Seed from the
+  // server-provided entry until then.
+  const latestEntry =
+    nowPlayingData !== undefined ? nowPlayingData : initialEntry;
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -172,7 +193,7 @@ export default function NowPlaying({ mini = false }: NowPlayingWidgetProps) {
         <NowPlayingMini
           entry={latestEntry ?? undefined}
           live={live}
-          onAirDJs={djsOnAirData?.djs}
+          onAirDJs={onAirData?.djs}
           audioRef={audioRef}
           isPlaying={isPlaying}
           onTogglePlay={onTogglePlay}

--- a/tests/integration/components/experiences/modern/playlist-search/PlaylistSearchContainer.test.tsx
+++ b/tests/integration/components/experiences/modern/playlist-search/PlaylistSearchContainer.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders as render } from "@/tests/helpers";
+import type { PlaylistSearchResult } from "@wxyc/shared";
+import { PlaylistSearchContainer } from "@/src/components/experiences/modern/playlist-search";
+
+const mockUsePlaylistSearch = vi.fn();
+
+vi.mock("@/src/hooks/playlistSearchHooks", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/src/hooks/playlistSearchHooks")>();
+  return {
+    ...actual,
+    usePlaylistSearch: () => mockUsePlaylistSearch(),
+  };
+});
+
+vi.mock(
+  "@/src/components/experiences/modern/previous-sets/Search/SearchBar",
+  () => ({ default: () => <div data-testid="search-bar" /> }),
+);
+
+vi.mock(
+  "@/src/components/experiences/modern/playlist-search/PlaylistResultsTable",
+  () => ({
+    default: ({ results }: { results: PlaylistSearchResult[] }) => (
+      <div
+        data-testid="results-table"
+        data-row-ids={results.map((r) => r.id).join(",")}
+      />
+    ),
+  }),
+);
+
+vi.mock(
+  "@/src/components/experiences/modern/playlist-search/PlaylistInfiniteScroll",
+  () => ({
+    default: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="infinite-scroll">{children}</div>
+    ),
+  }),
+);
+
+function makeResult(id: number): PlaylistSearchResult {
+  return {
+    id,
+    play_date: "2024-11-01T00:00:00Z",
+    artist_name: "Jessica Pratt",
+    track_title: "Back, Baby",
+    album_title: "On Your Own Love Again",
+    record_label: "Drag City",
+    dj_name: "DJ Test",
+    show_id: 1,
+  };
+}
+
+const baseHookReturn = {
+  sortBy: "date" as const,
+  sortOrder: "desc" as const,
+  handleSort: vi.fn(),
+  results: [] as PlaylistSearchResult[],
+  total: 0,
+  hasMore: false,
+  isLoading: false,
+  isError: false,
+  loadNextPage: vi.fn(),
+  effectiveQuery: "",
+};
+
+describe("PlaylistSearchContainer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUsePlaylistSearch.mockReturnValue({ ...baseHookReturn });
+  });
+
+  it("renders the server seed for the empty default query before the client resolves", () => {
+    mockUsePlaylistSearch.mockReturnValue({
+      ...baseHookReturn,
+      effectiveQuery: "",
+      results: [],
+    });
+    render(
+      <PlaylistSearchContainer
+        initialResults={[makeResult(11), makeResult(12)]}
+        initialTotal={2}
+      />,
+    );
+    expect(screen.getByTestId("results-table")).toHaveAttribute(
+      "data-row-ids",
+      "11,12",
+    );
+  });
+
+  it("lets resolved client results take over from the seed for the default query", () => {
+    mockUsePlaylistSearch.mockReturnValue({
+      ...baseHookReturn,
+      effectiveQuery: "",
+      results: [makeResult(50)],
+    });
+    render(
+      <PlaylistSearchContainer initialResults={[makeResult(11)]} initialTotal={1} />,
+    );
+    expect(screen.getByTestId("results-table")).toHaveAttribute(
+      "data-row-ids",
+      "50",
+    );
+  });
+
+  it("renders client results and a count for a real query", () => {
+    mockUsePlaylistSearch.mockReturnValue({
+      ...baseHookReturn,
+      effectiveQuery: "stereolab",
+      results: [makeResult(1), makeResult(2)],
+      total: 2,
+    });
+    render(<PlaylistSearchContainer />);
+    expect(screen.getByTestId("results-table")).toHaveAttribute(
+      "data-row-ids",
+      "1,2",
+    );
+    expect(screen.getByText("Found 2 results")).toBeInTheDocument();
+  });
+
+  it("shows nothing for a single-character partial query", () => {
+    mockUsePlaylistSearch.mockReturnValue({
+      ...baseHookReturn,
+      effectiveQuery: "a",
+      results: [],
+    });
+    render(
+      <PlaylistSearchContainer initialResults={[makeResult(11)]} initialTotal={1} />,
+    );
+    expect(screen.queryByTestId("results-table")).not.toBeInTheDocument();
+  });
+
+  it("does not render the seed table when the seed is empty", () => {
+    mockUsePlaylistSearch.mockReturnValue({
+      ...baseHookReturn,
+      effectiveQuery: "",
+      results: [],
+    });
+    render(<PlaylistSearchContainer initialResults={[]} initialTotal={0} />);
+    expect(screen.queryByTestId("results-table")).not.toBeInTheDocument();
+  });
+});

--- a/tests/integration/components/experiences/modern/playlist-search/PlaylistSearchContainer.test.tsx
+++ b/tests/integration/components/experiences/modern/playlist-search/PlaylistSearchContainer.test.tsx
@@ -82,7 +82,6 @@ describe("PlaylistSearchContainer", () => {
     render(
       <PlaylistSearchContainer
         initialResults={[makeResult(11), makeResult(12)]}
-        initialTotal={2}
       />,
     );
     expect(screen.getByTestId("results-table")).toHaveAttribute(
@@ -98,7 +97,7 @@ describe("PlaylistSearchContainer", () => {
       results: [makeResult(50)],
     });
     render(
-      <PlaylistSearchContainer initialResults={[makeResult(11)]} initialTotal={1} />,
+      <PlaylistSearchContainer initialResults={[makeResult(11)]} />,
     );
     expect(screen.getByTestId("results-table")).toHaveAttribute(
       "data-row-ids",
@@ -128,7 +127,7 @@ describe("PlaylistSearchContainer", () => {
       results: [],
     });
     render(
-      <PlaylistSearchContainer initialResults={[makeResult(11)]} initialTotal={1} />,
+      <PlaylistSearchContainer initialResults={[makeResult(11)]} />,
     );
     expect(screen.queryByTestId("results-table")).not.toBeInTheDocument();
   });
@@ -139,7 +138,7 @@ describe("PlaylistSearchContainer", () => {
       effectiveQuery: "",
       results: [],
     });
-    render(<PlaylistSearchContainer initialResults={[]} initialTotal={0} />);
+    render(<PlaylistSearchContainer initialResults={[]} />);
     expect(screen.queryByTestId("results-table")).not.toBeInTheDocument();
   });
 });

--- a/tests/integration/components/widgets/NowPlaying/index.test.tsx
+++ b/tests/integration/components/widgets/NowPlaying/index.test.tsx
@@ -558,6 +558,86 @@ describe("NowPlaying", () => {
     });
   });
 
+  describe("server-seeded initial data", () => {
+    const seededEntry: FlowsheetSongEntry = {
+      id: 99,
+      play_order: 5,
+      show_id: 3,
+      track_title: "Seeded Track",
+      artist_name: "Seeded Artist",
+      album_title: "Seeded Album",
+      record_label: "Seeded Label",
+      request_flag: false,
+      segue: false,
+    };
+
+    const seededOnAir: OnAirDJData = {
+      onAir: "DJ Seed",
+      djs: [{ id: "7", dj_name: "DJ Seed" }],
+    };
+
+    it("renders the seeded entry before the client query resolves", () => {
+      render(<NowPlaying mini={false} initialEntry={seededEntry} />);
+      const main = screen.getByTestId("now-playing-main");
+      expect(main).toHaveAttribute("data-has-entry", "true");
+      expect(main).toHaveAttribute("data-entry-id", "99");
+    });
+
+    it("lets a resolved client entry take over from the seed", () => {
+      mockUseGetNowPlayingQuery.mockReturnValue({
+        data: mockSongEntry,
+        isLoading: false,
+        isError: false,
+      });
+      render(<NowPlaying mini={false} initialEntry={seededEntry} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-entry-id",
+        "1"
+      );
+    });
+
+    it("does not resurrect the seed once the client query resolves to nothing playing", () => {
+      // null is the resolved "nothing playing" value and must own the slot; the
+      // seed only fills the undefined pre-resolution gap.
+      mockUseGetNowPlayingQuery.mockReturnValue({
+        data: null,
+        isLoading: false,
+        isError: false,
+      });
+      render(<NowPlaying mini={false} initialEntry={seededEntry} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-has-entry",
+        "false"
+      );
+    });
+
+    it("seeds the on-air DJ with no spinner on first paint", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+      });
+      render(<NowPlaying mini={false} initialOnAirData={seededOnAir} />);
+      const main = screen.getByTestId("now-playing-main");
+      expect(main).toHaveAttribute("data-live", "true");
+      expect(main).toHaveAttribute("data-on-air-dj", "DJ Seed");
+      expect(main).toHaveAttribute("data-loading", "false");
+    });
+
+    it("keeps the loading spinner when no seed exists and the query is loading", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+      });
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-loading",
+        "true"
+      );
+    });
+  });
+
   describe("mini vs main switching", () => {
     it("should pass different props to mini vs main", () => {
       mockUseWhoIsLiveQuery.mockReturnValue({

--- a/tests/unit/lib/features/flowsheet/server.test.ts
+++ b/tests/unit/lib/features/flowsheet/server.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  fetchNowPlayingSeed,
+  fetchWhoIsLiveSeed,
+} from "@/lib/features/flowsheet/server";
+import type {
+  FlowsheetSongEntry,
+  FlowsheetV2EntryJSON,
+  OnAirDJResponse,
+} from "@/lib/features/flowsheet/types";
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+const BACKEND_URL = "http://backend.test";
+
+describe("flowsheet server seeds", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_BACKEND_URL = BACKEND_URL;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("fetchNowPlayingSeed", () => {
+    const rawTrack: FlowsheetV2EntryJSON = {
+      id: 42,
+      play_order: 7,
+      show_id: 3,
+      add_time: "2024-11-01T00:00:00.000Z",
+      entry_type: "track",
+      track_title: "Back, Baby",
+      artist_name: "Jessica Pratt",
+      album_title: "On Your Own Love Again",
+      record_label: "Drag City",
+      request_flag: false,
+      segue: false,
+    };
+
+    it("converts a fetched track entry", async () => {
+      vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(rawTrack)));
+      const entry = (await fetchNowPlayingSeed()) as FlowsheetSongEntry;
+      expect(entry).not.toBeNull();
+      expect(entry.id).toBe(42);
+      expect(entry.track_title).toBe("Back, Baby");
+      expect(entry.artist_name).toBe("Jessica Pratt");
+    });
+
+    it("returns null when the backend reports nothing playing", async () => {
+      vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(null)));
+      expect(await fetchNowPlayingSeed()).toBeNull();
+    });
+
+    it("fails open to undefined on a non-2xx response", async () => {
+      vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(rawTrack, false)));
+      expect(await fetchNowPlayingSeed()).toBeUndefined();
+    });
+
+    it("fails open to undefined when the fetch rejects", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          throw new Error("network down");
+        }),
+      );
+      expect(await fetchNowPlayingSeed()).toBeUndefined();
+    });
+
+    it("fails open to undefined when the backend url is unset", async () => {
+      delete process.env.NEXT_PUBLIC_BACKEND_URL;
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      expect(await fetchNowPlayingSeed()).toBeUndefined();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fetchWhoIsLiveSeed", () => {
+    const rawOnAir: OnAirDJResponse[] = [{ id: "1", dj_name: "DJ Seed" }];
+
+    it("summarizes the on-air DJs", async () => {
+      vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(rawOnAir)));
+      const data = await fetchWhoIsLiveSeed();
+      expect(data).toEqual({ djs: rawOnAir, onAir: "DJ Seed" });
+    });
+
+    it("returns the off-air shape for an empty on-air list", async () => {
+      vi.stubGlobal("fetch", vi.fn(async () => jsonResponse([])));
+      const data = await fetchWhoIsLiveSeed();
+      expect(data?.djs).toEqual([]);
+      expect(data?.onAir).toBe("Off Air");
+    });
+
+    it("fails open to undefined when the fetch rejects", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          throw new Error("timeout");
+        }),
+      );
+      expect(await fetchWhoIsLiveSeed()).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/lib/features/playlist-search/server.test.ts
+++ b/tests/unit/lib/features/playlist-search/server.test.ts
@@ -34,7 +34,7 @@ describe("fetchRecentPlaylistsSeed", () => {
     vi.unstubAllGlobals();
   });
 
-  it("requests the empty-query first page and returns its rows and total", async () => {
+  it("requests the empty-query first page and returns its rows", async () => {
     const fetchMock = vi.fn(async () =>
       jsonResponse({
         results: [makeResult(1), makeResult(2)],
@@ -47,7 +47,6 @@ describe("fetchRecentPlaylistsSeed", () => {
 
     const seed = await fetchRecentPlaylistsSeed();
     expect(seed.results).toHaveLength(2);
-    expect(seed.total).toBe(2);
 
     const requestedUrl = String(
       (fetchMock.mock.calls[0] as unknown as unknown[])[0],
@@ -62,7 +61,7 @@ describe("fetchRecentPlaylistsSeed", () => {
   it("fails open to an empty seed on a non-2xx response", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(null, false)));
     const seed = await fetchRecentPlaylistsSeed();
-    expect(seed).toEqual({ results: [], total: 0 });
+    expect(seed).toEqual({ results: [] });
   });
 
   it("fails open to an empty seed when the fetch rejects", async () => {
@@ -73,6 +72,6 @@ describe("fetchRecentPlaylistsSeed", () => {
       }),
     );
     const seed = await fetchRecentPlaylistsSeed();
-    expect(seed).toEqual({ results: [], total: 0 });
+    expect(seed).toEqual({ results: [] });
   });
 });

--- a/tests/unit/lib/features/playlist-search/server.test.ts
+++ b/tests/unit/lib/features/playlist-search/server.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { fetchRecentPlaylistsSeed } from "@/lib/features/playlist-search/server";
+import type { PlaylistSearchResult } from "@wxyc/shared";
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+function makeResult(id: number): PlaylistSearchResult {
+  return {
+    id,
+    play_date: "2024-11-01T00:00:00Z",
+    artist_name: "Stereolab",
+    track_title: "Miss Modular",
+    album_title: "Dots and Loops",
+    record_label: "Duophonic",
+    dj_name: "DJ Test",
+    show_id: 1,
+  };
+}
+
+describe("fetchRecentPlaylistsSeed", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_BACKEND_URL = "http://backend.test";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests the empty-query first page and returns its rows and total", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        results: [makeResult(1), makeResult(2)],
+        total: 2,
+        page: 0,
+        totalPages: 1,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const seed = await fetchRecentPlaylistsSeed();
+    expect(seed.results).toHaveLength(2);
+    expect(seed.total).toBe(2);
+
+    const requestedUrl = String(
+      (fetchMock.mock.calls[0] as unknown as unknown[])[0],
+    );
+    expect(requestedUrl).toContain("/flowsheet/search?");
+    expect(requestedUrl).toContain("q=");
+    expect(requestedUrl).toContain("sort=date");
+    expect(requestedUrl).toContain("order=desc");
+    expect(requestedUrl).toContain("limit=50");
+  });
+
+  it("fails open to an empty seed on a non-2xx response", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(null, false)));
+    const seed = await fetchRecentPlaylistsSeed();
+    expect(seed).toEqual({ results: [], total: 0 });
+  });
+
+  it("fails open to an empty seed when the fetch rejects", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    const seed = await fetchRecentPlaylistsSeed();
+    expect(seed).toEqual({ results: [], total: 0 });
+  });
+});


### PR DESCRIPTION
Part of #977 — do NOT close on merge: production `/flowsheet/search` currently 500s for every query (WXYC/Backend-Service#1681), so the seeded table cannot be verified live; close #977 manually after the endpoint is restored and the seeded rows are confirmed in `/playlists` view-source
Closes #978

Server-renders request-time-knowable initial data for two public routes so they no longer paint a spinner (or an empty table) for content that needs no session. Both routes fail open: a slow or unreachable backend renders exactly today's loading state, never an error page.

## What changed

**Shared foundation** — `lib/features/server-fetch.ts`: `fetchBackendSeed()`, an unauthenticated GET against `NEXT_PUBLIC_BACKEND_URL` that returns `undefined` on any failure (network error, `AbortSignal.timeout` of 2s, non-2xx, empty/non-JSON body). No RTK Query SSR/hydration machinery.

**#978 — `/live` NowPlaying seed**
- `app/live/page.tsx` (Server Component) fetches `/flowsheet/latest` and `/flowsheet/djs-on-air` and passes converted results to `NowPlaying` as `initialEntry` / `initialOnAirData` (plain serializable JSON — no functions/instances).
- `NowPlaying` seeds its first render from those props; the RTK Query result owns the value once it resolves (even to `null` = nothing playing), so a resolved "nothing playing" is not overwritten by a stale seed. Polling (`useFlowsheetPollingInterval`) and the `AudioContext` graph are untouched.
- Fail-open: when the seed is absent the widget keeps today's spinner/OFF AIR behavior exactly.

**#977 — `/playlists` recent listing**
- `app/playlists/page.tsx` fetches the empty-query first page (`/flowsheet/search?q=&page=0&limit=50&sort=date&order=desc`) and seeds `PlaylistSearchContainer`.
- Reconciled the `effectiveQuery.length >= 2` gate: the empty default query now renders its rows (backed by the server seed until the client infinite query resolves) instead of firing a fetch the gate silently discarded. A single-character partial still renders nothing; search/sort keep the existing RTK Query path unchanged.

**Tests** (+415 lines, full suite green at 3811): NowPlaying seed/takeover/fail-open; container seed vs. client-results vs. partial-query gating; both server-seed fetchers incl. fail-open paths.

## Serializability

Every server→client prop is plain JSON: `FlowsheetEntry | null`, `OnAirDJData`, `PlaylistSearchResult[]`, numbers. No functions (incl. sx callbacks), class instances, or Response objects. `next build` does not catch such violations on these dynamic routes — the workerd gate below does.

## What to check

Local gate (all passed): `tsc --noEmit`, `lint` (0 errors, no new warnings), `vitest` (282 files / 3811 tests), `build`, `build:opennext`.

workerd gate (`wrangler pages dev` on the OpenNext bundle): `/`, `/live`, `/playlists`, `/login` all returned **200**. The local backend was not reachable from the workerd sandbox, so both routes rendered the **fail-open** state (200, `/live` = OFF AIR + spinner, `/playlists` = archive shell with no rows) — confirming no 500 from a non-serializable prop and that a down backend degrades to today's behavior.

Seeded-content-in-HTML is definitively assertable on the **preview deploy** (real backend reachable). Please verify via curl / view-source, e.g.:
- `curl <preview>/live | grep -iE 'LIVE|<dj name>|<current track title>'` — on-air DJ / now-playing track present in the initial HTML, no first-paint spinner.
- `curl <preview>/playlists | grep 'playlist search results'` — the results `<table>` and recent rows present in the initial HTML (visible with JS disabled).
- Typing a 2+ char query still searches; sort still works; a 1-char query shows nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)