### PR TITLE
refactor(auth): typed authFetch gateway + roster provisionUser mutation

### DIFF
--- a/lib/features/admin/api.ts
+++ b/lib/features/admin/api.ts
@@ -1,5 +1,6 @@
 import { createApi, fakeBaseQuery } from "@reduxjs/toolkit/query/react";
-import { authClient } from "@/lib/features/authentication/client";
+import { authClient, authFetch } from "@/lib/features/authentication/client";
+import { authErrorMessage } from "@/lib/features/authentication/auth-fetch";
 import { resolveOrganizationIdAdmin } from "@/lib/features/authentication/organization-utils";
 import { throwIfBetterAuthError } from "@/src/utilities/throwIfBetterAuthError";
 import { adminSlice } from "./frontend";
@@ -8,6 +9,30 @@ import { Account, ROSTER_PAGE_SIZE } from "./types";
 
 type RosterArgs = { search: string; page: number };
 type RosterResult = { accounts: Account[]; total: number };
+
+type ProvisionUserArgs = {
+  email: string;
+  username: string;
+  name: string;
+  organizationSlug: string;
+  role: string;
+  realName?: string;
+  djName?: string;
+};
+
+type ProvisionUserResult = {
+  emailSent?: boolean;
+  emailError?: string;
+};
+
+/** Normalize a rejected provisionUser mutation into a user-facing message. */
+export function provisionErrorMessage(error: unknown): string {
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string" && message) return message;
+  }
+  return "Failed to create account";
+}
 
 export const adminApi = createApi({
   reducerPath: "adminApi",
@@ -81,7 +106,22 @@ export const adminApi = createApi({
       },
       providesTags: ["Roster"],
     }),
+    provisionUser: builder.mutation<ProvisionUserResult, ProvisionUserArgs>({
+      queryFn: async (args) => {
+        const { ok, status, data } = await authFetch<
+          ProvisionUserResult & { message?: string; error?: string }
+        >("/admin/provision-user", { method: "POST", json: args });
+
+        if (!ok) {
+          return {
+            error: { message: authErrorMessage(data, `Failed to create user (${status})`) },
+          };
+        }
+
+        return { data: { emailSent: data?.emailSent, emailError: data?.emailError } };
+      },
+    }),
   }),
 });
 
-export const { useGetRosterQuery } = adminApi;
+export const { useGetRosterQuery, useProvisionUserMutation } = adminApi;

--- a/lib/features/admin/api.ts
+++ b/lib/features/admin/api.ts
@@ -108,17 +108,25 @@ export const adminApi = createApi({
     }),
     provisionUser: builder.mutation<ProvisionUserResult, ProvisionUserArgs>({
       queryFn: async (args) => {
-        const { ok, status, data } = await authFetch<
-          ProvisionUserResult & { message?: string; error?: string }
-        >("/admin/provision-user", { method: "POST", json: args });
+        try {
+          const { ok, status, data } = await authFetch<
+            ProvisionUserResult & { message?: string; error?: string }
+          >("/admin/provision-user", { method: "POST", json: args });
 
-        if (!ok) {
+          if (!ok) {
+            return {
+              error: { message: authErrorMessage(data, `Failed to create user (${status})`) },
+            };
+          }
+
+          return { data: { emailSent: data?.emailSent, emailError: data?.emailError } };
+        } catch (err) {
           return {
-            error: { message: authErrorMessage(data, `Failed to create user (${status})`) },
+            error: {
+              message: err instanceof Error ? err.message : "Failed to create user",
+            },
           };
         }
-
-        return { data: { emailSent: data?.emailSent, emailError: data?.emailError } };
       },
     }),
   }),

--- a/lib/features/authentication/auth-fetch.ts
+++ b/lib/features/authentication/auth-fetch.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared request plumbing for the WXYC auth service (better-auth). Base-URL
+ * resolution differs between browser and server, so the environment-specific
+ * variants (`authFetch` in client.ts, `serverAuthFetch` in server-client.ts)
+ * inject the base URL here. This module stays free of any client- or
+ * server-only import so both variants can share it without dragging React or
+ * the `server-only` tripwire across the boundary.
+ */
+
+export type AuthFetchInit = RequestInit & {
+  /** Serialized to a JSON body with a matching Content-Type header when set. */
+  json?: unknown;
+};
+
+export type AuthResult<T> = {
+  ok: boolean;
+  status: number;
+  /** Parsed JSON body, or null when the body was absent or not JSON. */
+  data: T | null;
+};
+
+export async function authFetchWithBase<T>(
+  baseURL: string,
+  path: string,
+  init: AuthFetchInit = {},
+): Promise<AuthResult<T>> {
+  const { json, headers, body, ...rest } = init;
+  const finalHeaders = new Headers(headers);
+  let finalBody = body;
+  if (json !== undefined) {
+    finalHeaders.set("Content-Type", "application/json");
+    finalBody = JSON.stringify(json);
+  }
+
+  const response = await fetch(`${baseURL}${path}`, {
+    ...rest,
+    headers: finalHeaders,
+    body: finalBody,
+  });
+
+  let data: T | null = null;
+  try {
+    data = (await response.json()) as T;
+  } catch {
+    // A non-JSON or empty body is a valid outcome for several auth endpoints;
+    // callers decide what a null body means for their case.
+    data = null;
+  }
+
+  return { ok: response.ok, status: response.status, data };
+}
+
+/**
+ * Extract a user-facing message from an auth-service error body, preferring the
+ * `error` field over `message`, falling back to a caller-supplied default.
+ */
+export function authErrorMessage(data: unknown, fallback: string): string {
+  if (data && typeof data === "object") {
+    const payload = data as { error?: unknown; message?: unknown };
+    if (typeof payload.error === "string" && payload.error) return payload.error;
+    if (typeof payload.message === "string" && payload.message) return payload.message;
+  }
+  return fallback;
+}

--- a/lib/features/authentication/client.ts
+++ b/lib/features/authentication/client.ts
@@ -3,6 +3,7 @@
 import { createAuthClient } from "better-auth/react"
 import { adminClient, emailOTPClient, usernameClient, jwtClient, organizationClient } from "better-auth/client/plugins"
 import { isValidEmail } from "@wxyc/shared/validation"
+import { authErrorMessage, authFetchWithBase, type AuthFetchInit, type AuthResult } from "./auth-fetch"
 
 function getBaseURL(): string {
   // Client-side: prefer same-origin proxy to ensure session cookies are set
@@ -32,6 +33,18 @@ function getBaseURL(): string {
 const baseURL = getBaseURL();
 export { baseURL as authBaseURL };
 
+/**
+ * Typed gateway for browser-side auth-service requests. Resolves the path
+ * against the auth base URL and sends the session cookie by default (the
+ * same-origin proxy relies on it); a caller can override `credentials`.
+ */
+export function authFetch<T = unknown>(
+  path: string,
+  init: AuthFetchInit = {},
+): Promise<AuthResult<T>> {
+  return authFetchWithBase<T>(baseURL, path, { credentials: "include", ...init });
+}
+
 const baseConfig = {
     baseURL,
     fetchOptions: {
@@ -55,17 +68,15 @@ const TOKEN_CACHE_MS = 4 * 60 * 1000;
 
 async function fetchJWTToken(): Promise<string | null> {
   try {
-    const response = await fetch(`${baseURL}/token`, {
+    const { ok, data } = await authFetch<{ token?: string | null }>("/token", {
       method: "GET",
-      credentials: "include",
     });
 
-    if (!response.ok) {
+    if (!ok) {
       return null;
     }
 
-    const data = await response.json();
-    return data.token || null;
+    return data?.token || null;
   } catch (error) {
     console.error("Failed to get JWT token:", error);
     return null;
@@ -112,18 +123,18 @@ export async function lookupEmailByIdentifier(identifier: string): Promise<strin
     return identifier;
   }
 
-  const response = await fetch(`${baseURL}/wxyc/lookup-email`, {
+  // Unauthenticated public lookup: no session cookie is sent.
+  const { ok, data } = await authFetch<{ email?: string | null }>("/wxyc/lookup-email", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ identifier }),
+    credentials: "same-origin",
+    json: { identifier },
   });
 
-  if (!response.ok) {
+  if (!ok) {
     return null;
   }
 
-  const data = (await response.json()) as { email?: string | null };
-  return data.email ?? null;
+  return data?.email ?? null;
 }
 
 export type CompleteOnboardingRequest = {
@@ -151,26 +162,16 @@ type CompleteOnboardingErrorPayload = {
 export async function completeOnboarding(
   body: CompleteOnboardingRequest
 ): Promise<CompleteOnboardingResponse> {
-  const response = await fetch(`${baseURL}/wxyc/complete-onboarding`, {
+  const { ok, data } = await authFetch<
+    CompleteOnboardingResponse | CompleteOnboardingErrorPayload
+  >("/wxyc/complete-onboarding", {
     method: "POST",
-    credentials: "include",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
+    json: body,
   });
 
-  const payload = (await response.json().catch(() => null)) as
-    | CompleteOnboardingResponse
-    | CompleteOnboardingErrorPayload
-    | null;
-
-  if (!response.ok) {
-    const errorPayload = payload as CompleteOnboardingErrorPayload | null;
-    const message =
-      errorPayload?.error ||
-      errorPayload?.message ||
-      "Failed to complete onboarding";
-    throw new Error(message);
+  if (!ok) {
+    throw new Error(authErrorMessage(data, "Failed to complete onboarding"));
   }
 
-  return payload as CompleteOnboardingResponse;
+  return data as CompleteOnboardingResponse;
 }

--- a/lib/features/authentication/device-auth.ts
+++ b/lib/features/authentication/device-auth.ts
@@ -5,7 +5,7 @@ import {
   DeviceAuthTokenRequest,
   DeviceAuthTokenResponse,
 } from "@wxyc/shared/dtos";
-import { authBaseURL } from "./client";
+import { authFetch } from "./client";
 
 /**
  * The decision a single `/auth/device/token` poll resolves to.
@@ -86,18 +86,16 @@ export async function requestDeviceCode(
 ): Promise<DeviceAuthCodeResponse> {
   const body: DeviceAuthCodeRequest = { client_id: clientId };
 
-  const response = await fetch(`${authBaseURL}/device/code`, {
+  const { ok, status, data } = await authFetch<DeviceAuthCodeResponse>("/device/code", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
-    body: JSON.stringify(body),
+    json: body,
   });
 
-  if (!response.ok) {
-    throw new Error(`Failed to start device authorization (${response.status})`);
+  if (!ok) {
+    throw new Error(`Failed to start device authorization (${status})`);
   }
 
-  return (await response.json()) as DeviceAuthCodeResponse;
+  return data as DeviceAuthCodeResponse;
 }
 
 /** The fixed RFC 8628 device-flow grant type. */
@@ -122,19 +120,10 @@ export async function pollDeviceToken(
     client_id: clientId,
   };
 
-  const response = await fetch(`${authBaseURL}/device/token`, {
+  const { status, data } = await authFetch<unknown>("/device/token", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
-    body: JSON.stringify(body),
+    json: body,
   });
 
-  let parsed: unknown = null;
-  try {
-    parsed = await response.json();
-  } catch {
-    parsed = null;
-  }
-
-  return { status: response.status, body: parsed };
+  return { status, body: data };
 }

--- a/lib/features/authentication/organization-utils.server.ts
+++ b/lib/features/authentication/organization-utils.server.ts
@@ -21,7 +21,7 @@ async function fetchAuthJwtToken(cookieHeader?: string): Promise<string | null> 
 // Re-export client-safe functions for convenience
 export { getAppOrganizationId, getAppOrganizationIdClient } from "./organization-utils";
 
-async function resolveOrganizationId(
+export async function resolveOrganizationId(
   organizationSlugOrId: string,
   cookieHeader?: string
 ): Promise<string | undefined> {
@@ -52,6 +52,13 @@ async function resolveOrganizationId(
 
     if (data?.id) {
       return data.id;
+    }
+
+    if (data === null) {
+      // An ok response whose body didn't parse is a failure, not "no org by
+      // this slug" — falling through would hand the slug back as a UUID.
+      console.error("Unparseable organization resolution response:", { status });
+      return undefined;
     }
 
     // No organization found by slug: assume the input is already an ID.

--- a/lib/features/authentication/organization-utils.server.ts
+++ b/lib/features/authentication/organization-utils.server.ts
@@ -1,20 +1,18 @@
 import "server-only";
-import { serverAuthClient, getServerAuthBaseURL } from "./server-client";
+import { serverAuthClient, serverAuthFetch } from "./server-client";
 import { normalizeRole, organizationRoleFromJwtToken } from "./organization-utils";
 import { WXYCRole } from "./types";
 
 async function fetchAuthJwtToken(cookieHeader?: string): Promise<string | null> {
-  const baseURL = getServerAuthBaseURL();
   try {
-    const response = await fetch(`${baseURL}/token`, {
+    const { ok, data } = await serverAuthFetch<{ token?: unknown }>("/token", {
       method: "GET",
       headers: cookieHeader ? { cookie: cookieHeader } : {},
     });
-    if (!response.ok) {
+    if (!ok) {
       return null;
     }
-    const data = await response.json();
-    return typeof data.token === "string" ? data.token : null;
+    return typeof data?.token === "string" ? data.token : null;
   } catch {
     return null;
   }
@@ -28,37 +26,35 @@ async function resolveOrganizationId(
   cookieHeader?: string
 ): Promise<string | undefined> {
   try {
-    // The client SDK's findOrganizationBySlug returns 404, so we use the API directly
-    const baseURL = getServerAuthBaseURL();
-    const response = await fetch(`${baseURL}/organization/get-full-organization?organizationSlug=${encodeURIComponent(organizationSlugOrId)}`, {
-      method: 'GET',
-      headers: cookieHeader ? {
-        cookie: cookieHeader,
-      } : {},
-    });
-    
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let orgResult: any;
-    if (response.ok) {
-      const data = await response.json();
-      orgResult = { data, error: null };
-    } else {
-      const errorData = await response.json().catch(() => ({ message: response.statusText }));
-      orgResult = { data: null, error: { code: errorData.code, message: errorData.message || response.statusText, status: response.status, statusText: response.statusText } };
-    }
+    // The client SDK's findOrganizationBySlug returns 404, so call the API directly.
+    const { ok, status, data } = await serverAuthFetch<{
+      id?: string;
+      code?: string;
+      message?: string;
+    }>(
+      `/organization/get-full-organization?organizationSlug=${encodeURIComponent(organizationSlugOrId)}`,
+      {
+        method: "GET",
+        headers: cookieHeader ? { cookie: cookieHeader } : {},
+      }
+    );
 
-    if (orgResult.error) {
-      // Log the actual error to understand why slug lookup failed
-      console.error("Failed to resolve organization slug:", orgResult.error);
-      // If slug lookup fails, we should NOT use it as an ID - return undefined to fail gracefully
+    if (!ok) {
+      // A failed slug lookup must NOT be treated as an ID: returning the slug
+      // as a UUID silently downgrades the user to NO authority.
+      console.error("Failed to resolve organization slug:", {
+        code: data?.code,
+        message: data?.message,
+        status,
+      });
       return undefined;
     }
 
-    if (orgResult.data?.id) {
-      return orgResult.data.id;
+    if (data?.id) {
+      return data.id;
     }
 
-    // If no organization found by slug, assume it's already an ID
+    // No organization found by slug: assume the input is already an ID.
     return organizationSlugOrId;
   } catch (error) {
     console.error("Exception resolving organization ID from slug:", error);

--- a/lib/features/authentication/organization-utils.ts
+++ b/lib/features/authentication/organization-utils.ts
@@ -1,5 +1,5 @@
 import { jwtDecode } from "jwt-decode";
-import { authClient, authBaseURL, getJWTToken } from "./client";
+import { authClient, authFetch, getJWTToken } from "./client";
 import { getAppOrganizationId, getAppOrganizationIdClient } from "./organization-config";
 import { BetterAuthJwtPayload, WXYCRole } from "./types";
 
@@ -26,14 +26,13 @@ export async function resolveOrganizationIdAdmin(slugOverride?: string): Promise
   if (cached) return cached;
 
   try {
-    const response = await fetch(
-      `${authBaseURL}/admin/resolve-organization?slug=${encodeURIComponent(slug)}`,
-      { credentials: "include" }
+    const { ok, data } = await authFetch<{ id?: string }>(
+      `/admin/resolve-organization?slug=${encodeURIComponent(slug)}`,
+      { method: "GET" }
     );
 
-    if (!response.ok) return null;
-    const data = await response.json();
-    if (!data.id) return null;
+    if (!ok) return null;
+    if (!data?.id) return null;
     cachedAdminOrgIds.set(slug, data.id);
     return data.id;
   } catch {

--- a/lib/features/authentication/server-client.ts
+++ b/lib/features/authentication/server-client.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { createAuthClient } from "better-auth/client"
 import { adminClient, emailOTPClient, usernameClient, jwtClient, organizationClient } from "better-auth/client/plugins"
+import { authFetchWithBase, type AuthFetchInit, type AuthResult } from "./auth-fetch"
 
 // Server-side only - no React dependencies
 // This file can be safely imported in middleware, server components, and API routes
@@ -16,6 +17,19 @@ export function getServerAuthBaseURL(): string {
     process.env.NEXT_PUBLIC_BETTER_AUTH_URL ||
     "https://api.wxyc.org/auth"
   );
+}
+
+/**
+ * Typed gateway for server-side auth-service requests. Resolves the path
+ * against the server auth base URL (which honors the AUTH_REWRITE_URL
+ * override). Callers supply their own `cookie` header rather than relying on
+ * ambient credentials.
+ */
+export function serverAuthFetch<T = unknown>(
+  path: string,
+  init: AuthFetchInit = {},
+): Promise<AuthResult<T>> {
+  return authFetchWithBase<T>(getServerAuthBaseURL(), path, init);
 }
 
 const baseURL = getServerAuthBaseURL();

--- a/src/components/experiences/modern/admin/roster/ImportCSVModal.tsx
+++ b/src/components/experiences/modern/admin/roster/ImportCSVModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { authBaseURL } from "@/lib/features/authentication/client";
+import { provisionErrorMessage, useProvisionUserMutation } from "@/lib/features/admin/api";
 import { Authorization } from "@/lib/features/admin/types";
 import { authorizationToRole } from "@/lib/features/authentication/types";
 import { CheckCircle, Error as ErrorIcon, Upload } from "@mui/icons-material";
@@ -62,6 +62,7 @@ export default function ImportCSVModal({ open, onClose, onComplete, organization
   const [importProgress, setImportProgress] = useState(0);
   const [importResults, setImportResults] = useState<ImportResult[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [provisionUser] = useProvisionUserMutation();
 
   const validRowCount = rows.filter((_, i) => !errors.some((e) => e.row === i + 1)).length;
   const successCount = importResults.filter((r) => r.success).length;
@@ -105,48 +106,27 @@ export default function ImportCSVModal({ open, onClose, onComplete, organization
       const row = validRows[i];
 
       try {
-        const response = await fetch(`${authBaseURL}/admin/provision-user`, {
-          method: "POST",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            email: row.email,
-            username: row.username,
-            name: row.name,
-            organizationSlug,
-            role,
-            realName: row.name,
-            djName: row.djName,
-          }),
-        });
-
-        const provisionResult = (await response.json().catch(() => null)) as {
-          emailSent?: boolean;
-          emailError?: string;
-          message?: string;
-          error?: string;
-        } | null;
-
-        if (!response.ok) {
-          throw new Error(
-            provisionResult?.message ||
-              provisionResult?.error ||
-              `Failed (${response.status})`
-          );
-        }
+        const provisioned = await provisionUser({
+          email: row.email,
+          username: row.username,
+          name: row.name,
+          organizationSlug,
+          role,
+          realName: row.name,
+          djName: row.djName,
+        }).unwrap();
 
         results.push({
           row,
           success: true,
-          emailSent: provisionResult?.emailSent,
+          emailSent: provisioned.emailSent,
           error:
-            provisionResult?.emailSent === false
-              ? provisionResult.emailError || "Setup email failed to send"
+            provisioned.emailSent === false
+              ? provisioned.emailError || "Setup email failed to send"
               : undefined,
         });
       } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : "Failed to create account";
-        results.push({ row, success: false, error: errorMessage });
+        results.push({ row, success: false, error: provisionErrorMessage(err) });
       }
 
       setImportProgress(((i + 1) / validRows.length) * 100);
@@ -168,7 +148,7 @@ export default function ImportCSVModal({ open, onClose, onComplete, organization
     } else {
       toast.error(`Created ${successCount} of ${validRows.length} accounts — some failed`);
     }
-  }, [rows, errors, authorization]);
+  }, [rows, errors, authorization, organizationSlug, provisionUser]);
 
   const handleDone = () => {
     onComplete();

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { authBaseURL, authClient } from "@/lib/features/authentication/client";
 import { adminSlice } from "@/lib/features/admin/frontend";
+import { provisionErrorMessage, useProvisionUserMutation } from "@/lib/features/admin/api";
 import { Authorization, ROSTER_PAGE_SIZE } from "@/lib/features/admin/types";
 import { User, authorizationToRole } from "@/lib/features/authentication/types";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
@@ -33,6 +33,7 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
   const [importModalOpen, setImportModalOpen] = useState(false);
 
   const dispatch = useAppDispatch();
+  const [provisionUser] = useProvisionUserMutation();
   const isAdding = useAppSelector(adminSlice.selectors.getAdding);
   const page = useAppSelector(adminSlice.selectors.getPage);
   const totalAccounts = useAppSelector(adminSlice.selectors.getTotalAccounts);
@@ -77,40 +78,20 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
 
         const role = authorizationToRole(authorizationOfNewAccount);
 
-        const response = await fetch(`${authBaseURL}/admin/provision-user`, {
-          method: "POST",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            email: newAccount.email,
-            username: newAccount.username,
-            name: newAccount.realName || newAccount.username,
-            organizationSlug,
-            role,
-            realName: newAccount.realName || undefined,
-            djName: newAccount.djName || undefined,
-          }),
-        });
+        const provisioned = await provisionUser({
+          email: newAccount.email,
+          username: newAccount.username,
+          name: newAccount.realName || newAccount.username,
+          organizationSlug,
+          role,
+          realName: newAccount.realName || undefined,
+          djName: newAccount.djName || undefined,
+        }).unwrap();
 
-        const provisionResult = (await response.json().catch(() => null)) as {
-          emailSent?: boolean;
-          emailError?: string;
-          message?: string;
-          error?: string;
-        } | null;
-
-        if (!response.ok) {
-          throw new Error(
-            provisionResult?.message ||
-              provisionResult?.error ||
-              `Failed to create user (${response.status})`
-          );
-        }
-
-        if (provisionResult?.emailSent === false) {
+        if (provisioned.emailSent === false) {
           toast.warning(
             `Account created for ${newAccount.username}, but the setup email failed to send${
-              provisionResult.emailError ? `: ${provisionResult.emailError}` : ""
+              provisioned.emailError ? `: ${provisioned.emailError}` : ""
             }. Resend the invite from the roster.`
           );
         } else {
@@ -118,12 +99,12 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
         }
 
         // setAdding(false) already clears the add-form data; a full slice
-        // reset would also wipe the admin's search + page context (#638).
+        // reset would also wipe the admin's search + page context.
         dispatch(adminSlice.actions.setAdding(false));
 
         await refetch();
       } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : "Failed to create account";
+        const errorMessage = provisionErrorMessage(err);
         setCreateError(err instanceof Error ? err : new Error(errorMessage));
         if (errorMessage.trim().length > 0) {
           toast.error(errorMessage);
@@ -132,7 +113,7 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
         setIsCreating(false);
       }
     },
-    [authorizationOfNewAccount, canCreateUser, dispatch, refetch]
+    [authorizationOfNewAccount, canCreateUser, dispatch, organizationSlug, provisionUser, refetch]
   );
 
   return (

--- a/tests/integration/components/modern/admin/roster/ImportCSVModal.test.tsx
+++ b/tests/integration/components/modern/admin/roster/ImportCSVModal.test.tsx
@@ -3,9 +3,28 @@ import { screen, waitFor, within } from "@testing-library/react";
 import { renderWithProviders } from "@/tests/helpers/render";
 import ImportCSVModal from "@/src/components/experiences/modern/admin/roster/ImportCSVModal";
 
-// Mock the auth client
+// Mock the auth client. authFetch is the gateway the provisionUser mutation
+// calls; route it through the same global fetch these tests assert on, at the
+// URL the real gateway would build.
 vi.mock("@/lib/features/authentication/client", () => ({
   authBaseURL: "http://localhost:8082/auth",
+  authFetch: async (path: string, init: any = {}) => {
+    const { json, ...rest } = init;
+    const response = await fetch(`http://localhost:8082/auth${path}`, {
+      credentials: "include",
+      ...rest,
+      ...(json !== undefined
+        ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(json) }
+        : {}),
+    });
+    let data: unknown = null;
+    try {
+      data = await response.json();
+    } catch {
+      data = null;
+    }
+    return { ok: response.ok, status: response.status, data };
+  },
 }));
 
 // Mock sonner toast

--- a/tests/integration/components/modern/admin/roster/RosterTable.test.tsx
+++ b/tests/integration/components/modern/admin/roster/RosterTable.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/src/hooks/adminHooks", () => ({
 vi.mock("@/lib/features/authentication/client", () => ({
   authBaseURL: "http://auth.test",
   authClient: {},
+  authFetch: vi.fn(async () => ({ ok: true, status: 200, data: { emailSent: true } })),
 }));
 
 vi.mock("sonner", () => ({

--- a/tests/unit/lib/features/authentication/client.test.ts
+++ b/tests/unit/lib/features/authentication/client.test.ts
@@ -161,13 +161,11 @@ describe("authentication client", () => {
       consoleSpy.mockRestore();
     });
 
-    it("should return null on JSON parse error", async () => {
+    it("should return null when the token response body is not JSON", async () => {
       global.fetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.reject(new Error("Invalid JSON")),
       });
-
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       const { getJWTToken } = await import(
         "@/lib/features/authentication/client"
@@ -175,12 +173,6 @@ describe("authentication client", () => {
       const token = await getJWTToken();
 
       expect(token).toBeNull();
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Failed to get JWT token:",
-        expect.any(Error)
-      );
-
-      consoleSpy.mockRestore();
     });
 
     it("should return null on fetch timeout", async () => {

--- a/tests/unit/lib/features/authentication/organization-utils-server.test.ts
+++ b/tests/unit/lib/features/authentication/organization-utils-server.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { resolveOrganizationId } from "@/lib/features/authentication/organization-utils.server";
+
+const mockFetch = vi.fn();
+const realFetch = global.fetch;
+
+function fullOrgResponse(body: BodyInit, status = 200) {
+  mockFetch.mockImplementation((input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/organization/get-full-organization")) {
+      return Promise.resolve(
+        new Response(body, {
+          status,
+          headers: { "content-type": "application/json" },
+        })
+      );
+    }
+    return Promise.resolve(new Response("{}", { status: 200 }));
+  });
+}
+
+describe("resolveOrganizationId (server)", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_BETTER_AUTH_URL", "https://api.wxyc.org/auth");
+    global.fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    vi.unstubAllEnvs();
+  });
+
+  it("returns the resolved id from a valid body", async () => {
+    fullOrgResponse(JSON.stringify({ id: "org-uuid-1" }));
+    await expect(resolveOrganizationId("wxyc")).resolves.toBe("org-uuid-1");
+  });
+
+  it("passes the input through when a valid body has no id (input already an ID)", async () => {
+    fullOrgResponse(JSON.stringify({}));
+    await expect(resolveOrganizationId("org-uuid-2")).resolves.toBe(
+      "org-uuid-2"
+    );
+  });
+
+  it("fails closed to undefined when an ok response body does not parse", async () => {
+    fullOrgResponse("<html>gateway error</html>");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(resolveOrganizationId("wxyc")).resolves.toBeUndefined();
+    errorSpy.mockRestore();
+  });
+
+  it("fails closed to undefined on a non-ok response", async () => {
+    fullOrgResponse(JSON.stringify({ code: "NOT_FOUND" }), 404);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(resolveOrganizationId("wxyc")).resolves.toBeUndefined();
+    errorSpy.mockRestore();
+  });
+});

--- a/tests/unit/lib/features/authentication/organization-utils.test.ts
+++ b/tests/unit/lib/features/authentication/organization-utils.test.ts
@@ -4,6 +4,27 @@ import { server } from "@/tests/fakes/server";
 
 vi.mock("server-only", () => ({}));
 
+// A faithful stand-in for the shared authFetch plumbing that still routes
+// through the global fetch these tests stub / intercept, at the same URL the
+// real gateway would build.
+async function mockAuthFetch(path: string, init: any = {}) {
+  const { json, ...rest } = init;
+  const response = await fetch(`https://api.wxyc.org/auth${path}`, {
+    credentials: "include",
+    ...rest,
+    ...(json !== undefined
+      ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(json) }
+      : {}),
+  });
+  let data: unknown = null;
+  try {
+    data = await response.json();
+  } catch {
+    data = null;
+  }
+  return { ok: response.ok, status: response.status, data };
+}
+
 // Mock server auth client
 const mockListMembers = vi.fn();
 vi.mock("@/lib/features/authentication/server-client", () => ({
@@ -13,6 +34,7 @@ vi.mock("@/lib/features/authentication/server-client", () => ({
     },
   },
   getServerAuthBaseURL: () => "https://api.wxyc.org/auth",
+  serverAuthFetch: (path: string, init: any) => mockAuthFetch(path, init),
 }));
 
 // Mock auth client (client-side)
@@ -27,6 +49,7 @@ vi.mock("@/lib/features/authentication/client", () => ({
     },
   },
   authBaseURL: "https://api.wxyc.org/auth",
+  authFetch: (path: string, init: any) => mockAuthFetch(path, init),
   getJWTToken: () => mockGetJWTToken(),
 }));
 


### PR DESCRIPTION
Consolidates auth-service (better-auth, port 8082) access behind a typed gateway, the auth-side analog of `backendBaseQuery`.

Closes #952
Closes #953

## #952 — typed auth gateway
- New env-agnostic core `lib/features/authentication/auth-fetch.ts` (`authFetchWithBase`, `authErrorMessage`) with no client- or server-only import, shared by two variants:
  - `authFetch` (client, in `client.ts`) — defaults `credentials: "include"`.
  - `serverAuthFetch` (server, in `server-client.ts`) — cookie header supplied by caller; honors `AUTH_REWRITE_URL`.
- Migrated all raw fetch call sites onto it: token, lookup-email, complete-onboarding (`client.ts`), device code/token (`device-auth.ts`), admin resolve-organization (`organization-utils.ts`), server token + get-full-organization (`organization-utils.server.ts`).
- No behavior change; base-URL/credentials/header/JSON-parse/error-message logic now lives in one place.

## #953 — roster provisioning
- New `provisionUser` RTK Query mutation in `admin/api.ts` owns the `/admin/provision-user` request and its `emailSent`/`emailError`/`message`/`error` shape once.
- `RosterTable.tsx` and `ImportCSVModal.tsx` call the mutation instead of duplicating inline `fetch` + response parsing.

## What to check
- Client vs server base-URL split: `authFetch` never reads `AUTH_REWRITE_URL`; only `serverAuthFetch` does (grep confirms `AUTH_REWRITE_URL` appears only in `server-client.ts`).
- No raw `fetch()` to the auth service remains outside the gateway (fresh grep is clean).
- Deviations: the JWT-token fetch no longer logs a `console.error` when the body fails to parse (return value — `null` — unchanged; one unit test updated). `provisionUser` unifies the two components' error-message precedence to error-first and the fallback to `Failed to create user (N)`.

## Gates
- `npx tsc --noEmit` clean
- `npm run lint` 0 errors (no new warnings in touched files)
- `npx vitest run` 3790 passed / 279 files
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)