### PR TITLE
feat: scope the Redux store out of routes that don't need it

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,10 +1,16 @@
 import type { JSX } from "react";
 import { requireAuth } from "@/lib/features/authentication/server-utils";
 import ThemedLayout, { ThemedLayoutProps } from "@/src/ThemedLayout";
+import { StoreProvider } from "@/src/StoreProvider";
 
+// The full slice/API store is scoped to the authenticated dashboard, nested
+// inside the app-wide public store. Dashboard-only feature graphs (admin
+// roster, catalog, rotation, autoDJ, bin, metadata, LML) resolve here and stay
+// out of the public routes' client bundles.
 const Layout = async (props: ThemedLayoutProps): Promise<JSX.Element> => {
   await requireAuth();
-  return ThemedLayout(props);
+  const themed = await ThemedLayout(props);
+  return <StoreProvider>{themed}</StoreProvider>;
 };
 
 export default Layout;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react";
 import InitColorScheme from "@/src/styles/InitColorScheme";
-import { StoreProvider } from "@/src/StoreProvider";
+import { PublicStoreProvider } from "@/src/PublicStoreProvider";
 import { TelemetryProvider } from "@/src/components/shared/TelemetryProvider";
 
 import "@/src/styles/globals.css";
@@ -52,7 +52,7 @@ export default async function RootLayout({ children }: Props) {
     <html lang="en" data-experience={experience} suppressHydrationWarning>
       <body>
         <InitColorScheme />
-        <StoreProvider>
+        <PublicStoreProvider>
           <TelemetryProvider>
             <ThemeRegistry
               options={{ key: "joy" }}
@@ -69,7 +69,7 @@ export default async function RootLayout({ children }: Props) {
               </div>
             </ThemeRegistry>
           </TelemetryProvider>
-        </StoreProvider>
+        </PublicStoreProvider>
       </body>
     </html>
   );

--- a/docs/plans/nextjs-modernization/bundle-baseline.md
+++ b/docs/plans/nextjs-modernization/bundle-baseline.md
@@ -79,3 +79,50 @@ barrel-rewrite optimization, has no measurable effect on the production
 Turbopack build here. The config entry is still correct and worth keeping: it
 satisfies the optimization for the webpack builder and matches Next's own
 default handling of `@mui/material`/`@mui/icons-material`.
+
+## After store scoping
+
+The root layout previously mounted one combined 12-API store above every route.
+Public surfaces now mount a reduced store (`lib/store-public.ts`:
+authentication, application, experiences, flowsheet, playlist-search) and the
+authenticated dashboard nests the full store (`lib/store.ts`) inside it. The
+DJ-only feature graphs (admin roster, catalog, rotation, autoDJ, bin, metadata,
+LML) no longer enter the `/`, `/live`, or `/playlists` client graphs.
+
+| Route | Client JS (raw) | Δ raw | Client JS (gzip) | Δ gzip |
+| --- | --- | --- | --- | --- |
+| `/` | 1661.4 kB | −17.9 kB | 641.8 kB | −9.1 kB |
+| `/login` | 1772.4 kB | −13.5 kB | 691.2 kB | −5.7 kB |
+| `/live` | 1685.7 kB | −0.9 kB | 653.7 kB | −0.5 kB |
+| `/playlists` | 1667.6 kB | −16.5 kB | 644.3 kB | −8.5 kB |
+| `/dashboard/flowsheet` | 2214.0 kB | +26.4 kB | 897.3 kB | +12.5 kB |
+| `/dashboard/catalog` | 1888.4 kB | +41.2 kB | 749.1 kB | +20.2 kB |
+| `/dashboard/admin/roster` | 1834.3 kB | +25.5 kB | 722.7 kB | +12.1 kB |
+
+Deltas are vs the committed `c01dbc8d` "Before" table above (same
+`npm run analyze` method).
+
+What the numbers do and don't show:
+
+- The win on public routes is architectural first, bytes second. An analyzer
+  source-graph audit confirms `/`, `/live`, and `/playlists` no longer include
+  `lib/store.ts` or any of the admin/catalog/rotation/autoDJ/bin/metadata/LML
+  RTK slices or APIs. Their byte cost is small relative to the MUI-Joy-dominated
+  baseline, so removing them moves the analyzer total only modestly; on `/live`
+  the removed code overlaps shared chunks it still loads for the flowsheet
+  cluster it legitimately needs (live now-playing + SSE), so its byte total is
+  nearly flat even though the modules are gone.
+- `/live` and `/playlists` keep the public store, not zero Redux: `/live`'s
+  `NowPlaying` uses the flowsheet RTK Query hooks and its `SSESubscription`
+  drives the live-updates listener middleware; `/playlists` uses the
+  playlist-search API. The public store is the union those surfaces need.
+- `/login` still carries admin+bin+catalog because the shared logout helper
+  `resetApplication` resets every slice and so references them; it is out of the
+  public-route hot path targeted here and is security-sensitive (clears a prior
+  user's state), so it was left as-is.
+- Dashboard routes grow slightly. They now resolve two nested stores (the shell
+  reads the public store; dashboard content reads the full store). The slice
+  modules are shared between the two, so the net new code is the small
+  `store-public` / provider modules; the larger swing is Turbopack
+  re-attributing shared chunks across route graphs, not duplicated feature code.
+  Dashboard behavior is unchanged.

--- a/lib/rtk-query-error-logger.ts
+++ b/lib/rtk-query-error-logger.ts
@@ -1,0 +1,44 @@
+import type { Middleware } from "@reduxjs/toolkit";
+import { isRejectedWithValue } from "@reduxjs/toolkit";
+import { toast } from "sonner";
+import { safeCaptureException } from "./posthog";
+
+// Shared by every store variant so a rejected RTK Query surfaces the same
+// toast + telemetry regardless of which scoped store dispatched it. Lives in
+// its own module (not the full store's) so smaller stores can reuse it without
+// pulling the full slice graph into their bundle.
+export const rtkQueryErrorLogger: Middleware =
+  () => (next) => (action) => {
+    if (isRejectedWithValue(action)) {
+      const payload = action.payload as {
+        data?: { message?: string };
+        status?: string;
+        error?: string;
+      };
+
+      const endpointName = (action as any)?.meta?.arg?.endpointName;
+
+      safeCaptureException(
+        new Error(
+          payload?.data?.message || payload?.error || "RTK Query error"
+        ),
+        {
+          endpoint: endpointName,
+          status: payload?.status,
+        }
+      );
+
+      const serverMessage = payload?.data?.message;
+      if (serverMessage && serverMessage.trim().length > 0) {
+        toast.error(serverMessage);
+      } else if (payload?.status === "FETCH_ERROR") {
+        toast.error("Network error — please check your connection.");
+      } else if (payload?.status === "TIMEOUT_ERROR") {
+        toast.error("Request timed out — please try again.");
+      } else if (payload?.error && typeof payload.error === "string") {
+        toast.error(payload.error);
+      }
+    }
+
+    return next(action);
+  };

--- a/lib/store-public.ts
+++ b/lib/store-public.ts
@@ -1,0 +1,48 @@
+import { combineSlices, configureStore } from "@reduxjs/toolkit";
+import { rtkQueryErrorLogger } from "./rtk-query-error-logger";
+import { applicationSlice } from "./features/application/frontend";
+import { authenticationSlice } from "./features/authentication/frontend";
+import { experienceApi } from "./features/experiences/api";
+import { flowsheetApi } from "./features/flowsheet/api";
+import { flowsheetSlice } from "./features/flowsheet/frontend";
+import { liveUpdatesListenerMiddleware } from "./features/flowsheet/live-updates-listener";
+import { liveUpdatesSlice } from "./features/flowsheet/live-updates-slice";
+import { playlistSearchApi } from "./features/playlist-search/api";
+import { playlistSearchSlice } from "./features/playlist-search/frontend";
+
+// Store for routes rendered outside the authenticated dashboard: the home,
+// login, public live view, and playlist archive, plus the always-mounted shell
+// (theme controls persist a preference through experienceApi). It combines
+// only the slices those surfaces touch, so the DJ-facing feature graph
+// (admin roster, catalog, rotation, autoDJ, bin, metadata, LML) never enters a
+// public route's client bundle. The dashboard mounts its own superset store.
+//
+// Every reducer here is a strict subset of the full store's, so components
+// keep using the full-store-typed hooks; a public surface only ever reads
+// selectors present in both.
+const publicRootReducer = combineSlices(
+  authenticationSlice,
+  applicationSlice,
+  experienceApi,
+  flowsheetSlice,
+  flowsheetApi,
+  liveUpdatesSlice,
+  playlistSearchSlice,
+  playlistSearchApi
+);
+
+export const makePublicStore = () => {
+  return configureStore({
+    reducer: publicRootReducer,
+    middleware: (getDefaultMiddleware) => {
+      return getDefaultMiddleware()
+        .prepend(liveUpdatesListenerMiddleware.middleware)
+        .concat(rtkQueryErrorLogger)
+        .concat(experienceApi.middleware)
+        .concat(flowsheetApi.middleware)
+        .concat(playlistSearchApi.middleware);
+    },
+  });
+};
+
+export type PublicAppStore = ReturnType<typeof makePublicStore>;

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,16 +1,6 @@
-import type {
-  Action,
-  Middleware,
-  MiddlewareAPI,
-  ThunkAction,
-} from "@reduxjs/toolkit";
-import {
-  combineSlices,
-  configureStore,
-  isRejectedWithValue,
-} from "@reduxjs/toolkit";
-import { toast } from "sonner";
-import { safeCaptureException } from "./posthog";
+import type { Action, ThunkAction } from "@reduxjs/toolkit";
+import { combineSlices, configureStore } from "@reduxjs/toolkit";
+import { rtkQueryErrorLogger } from "./rtk-query-error-logger";
 import { adminApi } from "./features/admin/api";
 import { adminSlice } from "./features/admin/frontend";
 import { applicationApi } from "./features/application/api";
@@ -86,39 +76,3 @@ export type AppThunk<ThunkReturnType = void> = ThunkAction<
   unknown,
   Action
 >;
-
-export const rtkQueryErrorLogger: Middleware =
-  (api: MiddlewareAPI) => (next) => (action) => {
-    if (isRejectedWithValue(action)) {
-      const payload = action.payload as {
-        data?: { message?: string };
-        status?: string;
-        error?: string;
-      };
-
-      const endpointName = (action as any)?.meta?.arg?.endpointName;
-
-      safeCaptureException(
-        new Error(
-          payload?.data?.message || payload?.error || "RTK Query error"
-        ),
-        {
-          endpoint: endpointName,
-          status: payload?.status,
-        }
-      );
-
-      const serverMessage = payload?.data?.message;
-      if (serverMessage && serverMessage.trim().length > 0) {
-        toast.error(serverMessage);
-      } else if (payload?.status === "FETCH_ERROR") {
-        toast.error("Network error — please check your connection.");
-      } else if (payload?.status === "TIMEOUT_ERROR") {
-        toast.error("Request timed out — please try again.");
-      } else if (payload?.error && typeof payload.error === "string") {
-        toast.error(payload.error);
-      }
-    }
-
-    return next(action);
-  };

--- a/src/PublicStoreProvider.tsx
+++ b/src/PublicStoreProvider.tsx
@@ -1,0 +1,32 @@
+"use client";
+import type { PublicAppStore } from "@/lib/store-public";
+import { makePublicStore } from "@/lib/store-public";
+import { setupListeners } from "@reduxjs/toolkit/query";
+import type { ReactNode } from "react";
+import { useEffect, useRef } from "react";
+import { Provider } from "react-redux";
+
+interface Props {
+  readonly children: ReactNode;
+}
+
+// Wraps every route with the reduced public store. The authenticated dashboard
+// layout nests the full store inside this one, so its subtree resolves to the
+// superset while the shared shell (theme controls) keeps reading the public
+// store here.
+export const PublicStoreProvider = ({ children }: Props) => {
+  const storeRef = useRef<PublicAppStore | null>(null);
+
+  if (!storeRef.current) {
+    storeRef.current = makePublicStore();
+  }
+
+  useEffect(() => {
+    if (storeRef.current != null) {
+      const unsubscribe = setupListeners(storeRef.current.dispatch);
+      return unsubscribe;
+    }
+  }, []);
+
+  return <Provider store={storeRef.current}>{children}</Provider>;
+};

--- a/src/components/shared/Theme/Appbar.tsx
+++ b/src/components/shared/Theme/Appbar.tsx
@@ -2,7 +2,7 @@
 
 import { ColorSchemeToggleLoader } from "@/src/components/shared/Theme/ColorSchemeToggle";
 import { ExperienceId } from "@/lib/features/experiences/types";
-import { usePublicRoutes } from "@/src/hooks/applicationHooks";
+import { usePublicRoutes } from "@/src/hooks/usePublicRoutes";
 import { Box, ButtonGroup, Typography } from "@mui/joy";
 import dynamic from "next/dynamic";
 import { LinkButton } from "../General/LinkButton";

--- a/src/components/shared/Theme/AppbarClassic.tsx
+++ b/src/components/shared/Theme/AppbarClassic.tsx
@@ -2,7 +2,7 @@
 
 import { ColorSchemeToggleLoader } from "@/src/components/shared/Theme/ColorSchemeToggle";
 import { ExperienceId } from "@/lib/features/experiences/types";
-import { usePublicRoutes } from "@/src/hooks/applicationHooks";
+import { usePublicRoutes } from "@/src/hooks/usePublicRoutes";
 import { Box, ButtonGroup, Typography } from "@mui/joy";
 import dynamic from "next/dynamic";
 import { LinkButton } from "../General/LinkButton";

--- a/src/hooks/applicationHooks.ts
+++ b/src/hooks/applicationHooks.ts
@@ -8,8 +8,7 @@ import { catalogSlice } from "@/lib/features/catalog/frontend";
 import { flowsheetApi } from "@/lib/features/flowsheet/api";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { useAppDispatch } from "@/lib/hooks";
-import { usePathname } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 export function useWindowSize() {
   // Undefined initial width/height so the server and first client render
@@ -37,17 +36,6 @@ export function useWindowSize() {
   }, []);
   return windowSize;
 }
-
-export const usePublicRoutes = () => {
-  const publicRoutes = ["/live", "/login"];
-  const pathname = usePathname();
-
-  const isPublic = useMemo(() => {
-    return publicRoutes.includes(pathname) || pathname.length <= 1;
-  }, [pathname]);
-
-  return isPublic;
-};
 
 export const useShiftKey = () => {
   const [shiftKeyPressed, setShiftKeyPressed] = useState(false);

--- a/src/hooks/usePublicRoutes.ts
+++ b/src/hooks/usePublicRoutes.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useMemo } from "react";
+
+// Kept free of any Redux/feature imports: the always-mounted appbar reads this
+// on every route, so pulling a slice graph in here would land it in every
+// client bundle, including the public routes this scoping keeps lean.
+const PUBLIC_ROUTES = ["/live", "/login"];
+
+export const usePublicRoutes = (): boolean => {
+  const pathname = usePathname();
+
+  return useMemo(() => {
+    return PUBLIC_ROUTES.includes(pathname) || pathname.length <= 1;
+  }, [pathname]);
+};

--- a/tests/integration/components/shared/Theme/Appbar.test.tsx
+++ b/tests/integration/components/shared/Theme/Appbar.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import Appbar from "@/src/components/shared/Theme/Appbar";
 
 // Mock dependencies
-vi.mock("@/src/hooks/applicationHooks", () => ({
+vi.mock("@/src/hooks/usePublicRoutes", () => ({
   usePublicRoutes: vi.fn(() => false),
 }));
 
@@ -51,7 +51,7 @@ describe("Appbar", () => {
 
 describe("Appbar when on public route", () => {
   it("should show Log In link for public routes", async () => {
-    const { usePublicRoutes } = await import("@/src/hooks/applicationHooks");
+    const { usePublicRoutes } = await import("@/src/hooks/usePublicRoutes");
     vi.mocked(usePublicRoutes).mockReturnValue(true);
 
     render(<Appbar experience="modern" />);

--- a/tests/integration/components/shared/Theme/AppbarClassic.test.tsx
+++ b/tests/integration/components/shared/Theme/AppbarClassic.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import AppbarClassic from "@/src/components/shared/Theme/AppbarClassic";
 
 // Mock dependencies
-vi.mock("@/src/hooks/applicationHooks", () => ({
+vi.mock("@/src/hooks/usePublicRoutes", () => ({
   usePublicRoutes: vi.fn(() => false),
 }));
 
@@ -50,7 +50,7 @@ describe("AppbarClassic", () => {
 
 describe("AppbarClassic when on public route", () => {
   it("should show Log In link for public routes", async () => {
-    const { usePublicRoutes } = await import("@/src/hooks/applicationHooks");
+    const { usePublicRoutes } = await import("@/src/hooks/usePublicRoutes");
     vi.mocked(usePublicRoutes).mockReturnValue(true);
 
     render(<AppbarClassic experience="classic" />);

--- a/tests/unit/lib/store.test.ts
+++ b/tests/unit/lib/store.test.ts
@@ -7,7 +7,7 @@ vi.mock("sonner", () => ({
   },
 }));
 
-import { rtkQueryErrorLogger } from "@/lib/store";
+import { rtkQueryErrorLogger } from "@/lib/rtk-query-error-logger";
 import { toast } from "sonner";
 
 function createRejectedAction(payload: unknown) {


### PR DESCRIPTION
Closes #966

## What this does

The root layout mounted a single combined Redux/RTK store (all 12 feature APIs/slices, including the admin roster, catalog, rotation, autoDJ, and bin APIs) above **every** route, so unauthenticated pages parsed and initialized the full DJ-facing store.

This introduces a **reduced public store** (`lib/store-public.ts`: authentication, application, experiences, flowsheet, playlist-search) mounted at the root layout, and **nests the full store** (`lib/store.ts`) inside the authenticated dashboard layout. Public surfaces now carry exactly the slices they use.

## What actually needs the store where (verified with fresh greps — the issue's premises were partly wrong)

- **`/live` is NOT zero-Redux.** `NowPlaying` calls `useWhoIsLiveQuery` / `useGetNowPlayingQuery` (flowsheet RTK Query) and `useFlowsheetPollingInterval` (a selector), and `SSESubscription` → `useSSEConnection` dispatches the actions that the live-updates listener middleware turns into the SSE `EventSource`. `/live` genuinely needs the flowsheet cluster. It now ships the public store (flowsheet + playlist-search + experiences + auth/application), **not** the full store and **not** admin/catalog/rotation/autoDJ/bin/metadata/LML.
- **The shared shell needs a store on every route.** `ThemeRegistry` and the appbar theme controls persist a preference through `experienceApi` (RTK Query), so the root-level store can't be removed outright — hence a reduced store at the root rather than "no store on public routes."
- **`/playlists`** needs only `playlistSearchApi` + slice; the public store covers it and drops all five APIs named in the acceptance criteria.
- **Dashboard** keeps the full store via a nested provider; behavior unchanged.

Also extracted (bundle hygiene, since the analyzer counts the whole module graph): `usePublicRoutes` moved out of `applicationHooks` (which statically imports adminSlice/binApi/catalogApi) so the always-mounted appbar stops dragging the DJ feature graph into every bundle; and `rtkQueryErrorLogger` split into its own module so the public store reuses it without importing the full slice graph.

## Acceptance criteria (verified via an analyzer source-graph audit)

- `/live`, `/playlists`, `/` — full store **absent**; **no** admin/catalog/rotation/autoDJ/bin/metadata/LML slices or APIs in the client graph. ✅
- `/playlists` no longer pulls adminApi/rotationApi/catalogApi/autoDJApi/binApi. ✅
- Dashboard routes retain the full store and all features. ✅
- Full test suite passes (279 files / 3790 tests); `renderWithProviders` still uses the full `makeStore`, so no harness change was needed. ✅

## Bundle deltas (`npm run analyze`, vs committed `c01dbc8d` baseline; full table in `docs/plans/nextjs-modernization/bundle-baseline.md`)

| Route | raw Δ | gzip Δ |
| --- | --- | --- |
| `/` | −17.9 kB | −9.1 kB |
| `/login` | −13.5 kB | −5.7 kB |
| `/live` | −0.9 kB | −0.5 kB |
| `/playlists` | −16.5 kB | −8.5 kB |
| `/dashboard/*` | +25–41 kB | +12–20 kB |

The public-route win is architectural first, bytes second: the removed RTK slice/API code is small next to the MUI-Joy baseline, and on `/live` it overlaps shared chunks still loaded for the flowsheet cluster, so its byte total is nearly flat even though the modules are provably gone. Dashboard totals rise modestly because they now resolve two nested stores — the slice modules are **shared** (net new code is just the small `store-public`/provider modules); the larger swing is Turbopack re-attributing shared chunks across route graphs, not duplicated feature code.

## What to check (reviewer eyeball)

- **`/live`** — confirm live now-playing + the audio player still update and the SSE connection opens (it depends on flowsheet + the live-updates listener middleware being in the public store). This is the route most at risk.
- **`/playlists`** — playlist search still works (playlist-search API is in the public store).
- **`/dashboard/**`** — full functionality unchanged (flowsheet, catalog, admin roster, rotation, bin). The full store is nested in `app/dashboard/layout.tsx`; the shell/appbar above it reads the public store.
- **Provider order / classic dark mode** — `PublicStoreProvider` sits in the exact tree position the old `StoreProvider` did in `app/layout.tsx`, so `InitColorScheme` / `ThemeRegistry` attribute timing is unchanged; verify classic dark mode still paints on first load.
- **`/login`, `/onboarding`** — still carry admin+bin+catalog because the shared logout helper `resetApplication` resets every slice (and so references them). It is security-sensitive (clears a prior user's state) and off the public hot path targeted here, so it was intentionally left as-is.

## Gates

`tsc` clean; `lint` 0 errors; `vitest` 279 files / 3790 tests pass; `next build` + `build:opennext` OK. `wrangler pages dev` (port 3005): `/`, `/live`, `/playlists`, `/login` → 200; `/dashboard`, `/dashboard/flowsheet` → 307 auth redirect (no 500, no RSC serialization error).

## Deviation from the issue

The issue's literal criterion "`/live`'s client bundle no longer includes `lib/store.ts` or any RTK slice/API" is not achievable: `/live`'s now-playing feed and SSE genuinely require the flowsheet RTK Query API + slice + listener middleware. `/live` drops the **full** store and every dashboard-only API/slice, but keeps the minimal flowsheet + playlist-search public store it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)