### PR TITLE
fix: give each store its own live-updates SSE connection

### DIFF
--- a/lib/features/flowsheet/live-updates-listener.ts
+++ b/lib/features/flowsheet/live-updates-listener.ts
@@ -1,5 +1,5 @@
 import { createListenerMiddleware } from "@reduxjs/toolkit";
-import type { TypedStartListening } from "@reduxjs/toolkit";
+import type { Middleware, TypedStartListening } from "@reduxjs/toolkit";
 import { safeCapture, safeCaptureException } from "@/lib/posthog";
 import type { AppDispatch, RootState } from "@/lib/store";
 import { flowsheetApi } from "./api";
@@ -17,7 +17,7 @@ const LIVE_FS_TOPIC = "live-fs-topic";
 const REFETCH_DEBOUNCE_MS = 500;
 
 // Drop benign SSE handshake frames so `sse_unknown_event_type` stays a
-// contract-drift signal, not per-connection noise. See WXYC/dj-site#673.
+// contract-drift signal, not per-connection noise.
 const BENIGN_HANDSHAKE_TYPES = new Set<string>([
   "connection-established",
   "subscription",
@@ -50,17 +50,6 @@ type LiveFsRefetchEvent = {
 
 type LiveFsEvent = LiveFsUpdateEvent | LiveFsRefetchEvent;
 
-let eventSource: EventSource | null = null;
-let debouncedInvalidateTimer: ReturnType<typeof setTimeout> | null = null;
-let pendingInvalidateTags: Set<FlowsheetTag> = new Set();
-// Tracks whether the current EventSource has ever fired onopen. The browser
-// fires onopen again after a transparent reconnect; if hasEverConnected was
-// already true when onopen fires, anything the backend pushed during the
-// blackout window is missing from local cache, so we schedule an explicit
-// refetch to repair it. Reset on connectionReleased so a fresh subscriber's
-// first open is treated as an initial connect, not a reconnect. See #682.
-let hasEverConnected = false;
-
 function isLiveFsEvent(value: unknown): value is LiveFsEvent {
   if (typeof value !== "object" || value === null) return false;
   const v = value as { type?: unknown; payload?: unknown };
@@ -74,254 +63,310 @@ function isLiveFsEvent(value: unknown): value is LiveFsEvent {
   return v.type === "refetch";
 }
 
-function clearDebouncedInvalidate(): void {
-  if (debouncedInvalidateTimer !== null) {
-    clearTimeout(debouncedInvalidateTimer);
-    debouncedInvalidateTimer = null;
-  }
-  pendingInvalidateTags = new Set();
-}
+/**
+ * Inspection surface for one store's live-updates connection. The EventSource,
+ * reconnect flag, and debounce timer live in the middleware instance's closure,
+ * so this is the only way to observe them.
+ */
+export type LiveUpdatesListenerHandle = {
+  middleware: Middleware;
+  getEventSource: () => EventSource | null;
+  getHasEverConnected: () => boolean;
+  /** Closes the connection and clears the reconnect flag and pending timer. */
+  reset: () => void;
+};
 
-function setConnectionStatusIfChanged(
-  listenerApi: { dispatch: AppDispatch; getState: () => RootState },
-  next: LiveUpdatesConnectionStatus
-): boolean {
-  const current = liveUpdatesSlice.selectors.selectLiveUpdatesConnectionStatus(
-    listenerApi.getState()
-  );
-  if (current === next) return false;
-  listenerApi.dispatch(liveUpdatesConnectionStateChanged(next));
-  return true;
-}
+/**
+ * Builds a live-updates listener middleware bound to a single store. The
+ * connection lifecycle (EventSource, reconnect-detect flag, debounce timer) is
+ * owned per instance and MUST NOT be shared across stores: each store scopes
+ * its own `liveUpdates` ref-count, so a shared connection could be closed by
+ * one store's release while another store still holds a positive ref-count,
+ * leaving that store with a ref-count but no stream. Per-store ownership makes
+ * request/release from different stores independent, so a store with
+ * ref-count > 0 always retains its own live EventSource.
+ */
+export function createLiveUpdatesListenerMiddleware(): LiveUpdatesListenerHandle {
+  const listenerMiddleware = createListenerMiddleware();
+  const startListening =
+    listenerMiddleware.startListening as TypedStartListening<
+      RootState,
+      AppDispatch
+    >;
 
-function scheduleDebouncedInvalidate(
-  dispatch: AppDispatch,
-  tags: FlowsheetTag[]
-) {
-  for (const t of tags) pendingInvalidateTags.add(t);
-  if (debouncedInvalidateTimer !== null) {
-    clearTimeout(debouncedInvalidateTimer);
-  }
-  debouncedInvalidateTimer = setTimeout(() => {
-    debouncedInvalidateTimer = null;
-    const toInvalidate = Array.from(pendingInvalidateTags);
+  let eventSource: EventSource | null = null;
+  let debouncedInvalidateTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingInvalidateTags: Set<FlowsheetTag> = new Set();
+  // Tracks whether the current EventSource has ever fired onopen. The browser
+  // fires onopen again after a transparent reconnect; if hasEverConnected was
+  // already true when onopen fires, anything the backend pushed during the
+  // blackout window is missing from local cache, so we schedule an explicit
+  // refetch to repair it. Reset on connectionReleased so a fresh subscriber's
+  // first open is treated as an initial connect, not a reconnect.
+  let hasEverConnected = false;
+
+  function clearDebouncedInvalidate(): void {
+    if (debouncedInvalidateTimer !== null) {
+      clearTimeout(debouncedInvalidateTimer);
+      debouncedInvalidateTimer = null;
+    }
     pendingInvalidateTags = new Set();
-    if (toInvalidate.length === 0) return;
-    dispatch(flowsheetApi.util.invalidateTags(toInvalidate));
-  }, REFETCH_DEBOUNCE_MS);
-}
-
-function routeUpdateEvent(
-  dispatch: AppDispatch,
-  getState: () => RootState,
-  payload: FlowsheetEntry
-) {
-  const state = getState();
-  const infiniteData = flowsheetApi.endpoints.getInfiniteEntries.select(
-    undefined
-  )(state).data;
-  const nowPlayingData = flowsheetApi.endpoints.getNowPlaying.select(undefined)(
-    state
-  ).data;
-
-  const inInfinite = (infiniteData?.pages ?? []).some((page) =>
-    page.some((e) => e.id === payload.id)
-  );
-  const inNowPlaying = nowPlayingData?.id === payload.id;
-
-  if (inInfinite || inNowPlaying) {
-    try {
-      if (inInfinite) {
-        dispatch(
-          flowsheetApi.util.updateQueryData(
-            "getInfiniteEntries",
-            undefined,
-            (draft) => {
-              patchEntryById(draft, payload.id, payload);
-            }
-          )
-        );
-      }
-      if (inNowPlaying) {
-        dispatch(
-          flowsheetApi.util.updateQueryData(
-            "getNowPlaying",
-            undefined,
-            (draft) => {
-              if (draft) Object.assign(draft, payload);
-            }
-          )
-        );
-      }
-    } catch (err) {
-      safeCaptureException(err, {
-        context: SSE_EVENTS.DISPATCH_FAILURE,
-        event_type: "update",
-        payload_id: payload.id,
-      });
-    }
-    return;
   }
 
-  const currentShowId =
-    (infiniteData?.pages ?? []).find((p) => p.length > 0)?.[0]?.show_id ?? null;
-  safeCapture(SSE_EVENTS.UNKNOWN_EVENT_ID, {
-    surface: "listener",
-    event_type: "update",
-    payload_id: payload.id,
-    current_show_id: currentShowId,
-  });
-  scheduleDebouncedInvalidate(dispatch, ["Flowsheet"]);
-}
+  function setConnectionStatusIfChanged(
+    listenerApi: { dispatch: AppDispatch; getState: () => RootState },
+    next: LiveUpdatesConnectionStatus
+  ): boolean {
+    const current =
+      liveUpdatesSlice.selectors.selectLiveUpdatesConnectionStatus(
+        listenerApi.getState()
+      );
+    if (current === next) return false;
+    listenerApi.dispatch(liveUpdatesConnectionStateChanged(next));
+    return true;
+  }
 
-export const liveUpdatesListenerMiddleware = createListenerMiddleware();
-
-const startListening =
-  liveUpdatesListenerMiddleware.startListening as TypedStartListening<
-    RootState,
-    AppDispatch
-  >;
-
-startListening({
-  actionCreator: liveUpdatesConnectionRequested,
-  effect: (_action, listenerApi) => {
-    const refCount = liveUpdatesSlice.selectors.selectLiveUpdatesRefCount(
-      listenerApi.getState()
-    );
-    if (refCount !== 1 || eventSource !== null) return;
-
-    const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL ?? "";
-    const url = `${backendUrl}/events/stream?topics=${LIVE_FS_TOPIC}`;
-
-    setConnectionStatusIfChanged(listenerApi, "connecting");
-
-    let es: EventSource;
-    try {
-      es = new EventSource(url);
-    } catch (err) {
-      safeCaptureException(err, { context: SSE_EVENTS.CONNECTION_ERROR, url });
-      setConnectionStatusIfChanged(listenerApi, "closed");
-      return;
+  function scheduleDebouncedInvalidate(
+    dispatch: AppDispatch,
+    tags: FlowsheetTag[]
+  ) {
+    for (const t of tags) pendingInvalidateTags.add(t);
+    if (debouncedInvalidateTimer !== null) {
+      clearTimeout(debouncedInvalidateTimer);
     }
-    eventSource = es;
+    debouncedInvalidateTimer = setTimeout(() => {
+      debouncedInvalidateTimer = null;
+      const toInvalidate = Array.from(pendingInvalidateTags);
+      pendingInvalidateTags = new Set();
+      if (toInvalidate.length === 0) return;
+      dispatch(flowsheetApi.util.invalidateTags(toInvalidate));
+    }, REFETCH_DEBOUNCE_MS);
+  }
 
-    es.onopen = () => {
-      const isReconnect = hasEverConnected;
-      if (setConnectionStatusIfChanged(listenerApi, "connected")) {
-        safeCapture(SSE_EVENTS.CONNECTED, { topic: LIVE_FS_TOPIC });
-      }
-      if (isReconnect) {
-        scheduleDebouncedInvalidate(listenerApi.dispatch, [
-          "Flowsheet",
-          "NowPlaying",
-          "WhoIsLive",
-        ]);
-      }
-      // Set last so a throwing dispatch above leaves the flag false and the
-      // next onopen is treated as the first observable connect, not a
-      // reconnect.
-      hasEverConnected = true;
-    };
+  function routeUpdateEvent(
+    dispatch: AppDispatch,
+    getState: () => RootState,
+    payload: FlowsheetEntry
+  ) {
+    const state = getState();
+    const infiniteData = flowsheetApi.endpoints.getInfiniteEntries.select(
+      undefined
+    )(state).data;
+    const nowPlayingData = flowsheetApi.endpoints.getNowPlaying.select(
+      undefined
+    )(state).data;
 
-    es.onerror = () => {
-      // EventSource sets readyState before firing onerror.
-      // 0 = CONNECTING (browser is retrying transparently);
-      // 2 = CLOSED (permanently closed).
-      if (es.readyState === EventSource.CONNECTING) {
-        if (setConnectionStatusIfChanged(listenerApi, "reconnecting")) {
-          safeCapture(SSE_EVENTS.RECONNECTING, { topic: LIVE_FS_TOPIC });
-        }
-      } else if (es.readyState === EventSource.CLOSED) {
-        if (setConnectionStatusIfChanged(listenerApi, "closed")) {
-          safeCapture(SSE_EVENTS.DISCONNECTED, {
-            topic: LIVE_FS_TOPIC,
-            reason: "permanent",
-          });
-        }
-      }
-    };
+    const inInfinite = (infiniteData?.pages ?? []).some((page) =>
+      page.some((e) => e.id === payload.id)
+    );
+    const inNowPlaying = nowPlayingData?.id === payload.id;
 
-    es.onmessage = (msgEvent: MessageEvent) => {
-      let parsed: unknown;
+    if (inInfinite || inNowPlaying) {
       try {
-        parsed = JSON.parse(msgEvent.data as string);
+        if (inInfinite) {
+          dispatch(
+            flowsheetApi.util.updateQueryData(
+              "getInfiniteEntries",
+              undefined,
+              (draft) => {
+                patchEntryById(draft, payload.id, payload);
+              }
+            )
+          );
+        }
+        if (inNowPlaying) {
+          dispatch(
+            flowsheetApi.util.updateQueryData(
+              "getNowPlaying",
+              undefined,
+              (draft) => {
+                if (draft) Object.assign(draft, payload);
+              }
+            )
+          );
+        }
       } catch (err) {
         safeCaptureException(err, {
-          context: SSE_EVENTS.PARSE_FAILURE,
-          raw_sample:
-            typeof msgEvent.data === "string"
-              ? msgEvent.data.slice(0, 200)
-              : null,
+          context: SSE_EVENTS.DISPATCH_FAILURE,
+          event_type: "update",
+          payload_id: payload.id,
         });
-        return;
       }
-      const rawType =
-        typeof parsed === "object" && parsed !== null
-          ? (parsed as { type?: unknown }).type
-          : null;
-      if (typeof rawType === "string" && BENIGN_HANDSHAKE_TYPES.has(rawType)) {
-        return;
-      }
-      if (!isLiveFsEvent(parsed)) {
-        safeCapture(SSE_EVENTS.UNKNOWN_EVENT_TYPE, {
-          topic: LIVE_FS_TOPIC,
-          raw_type: rawType,
-        });
-        return;
-      }
-
-      if (parsed.type === "refetch") {
-        scheduleDebouncedInvalidate(listenerApi.dispatch, [
-          "Flowsheet",
-          "NowPlaying",
-          "WhoIsLive",
-        ]);
-        return;
-      }
-
-      routeUpdateEvent(listenerApi.dispatch, listenerApi.getState, parsed.payload);
-    };
-  },
-});
-
-startListening({
-  actionCreator: liveUpdatesConnectionReleased,
-  effect: (_action, listenerApi) => {
-    const refCount = liveUpdatesSlice.selectors.selectLiveUpdatesRefCount(
-      listenerApi.getState()
-    );
-    if (refCount !== 0 || eventSource === null) return;
-    eventSource.close();
-    eventSource = null;
-    hasEverConnected = false;
-    clearDebouncedInvalidate();
-    setConnectionStatusIfChanged(listenerApi, "closed");
-  },
-});
-
-/** Test-only escape hatch: clears the module-scoped EventSource reference. */
-export function __resetLiveUpdatesEventSourceForTests(): void {
-  if (eventSource) {
-    try {
-      eventSource.close();
-    } catch {
-      // ignore
+      return;
     }
+
+    const currentShowId =
+      (infiniteData?.pages ?? []).find((p) => p.length > 0)?.[0]?.show_id ??
+      null;
+    safeCapture(SSE_EVENTS.UNKNOWN_EVENT_ID, {
+      surface: "listener",
+      event_type: "update",
+      payload_id: payload.id,
+      current_show_id: currentShowId,
+    });
+    scheduleDebouncedInvalidate(dispatch, ["Flowsheet"]);
   }
-  eventSource = null;
-  hasEverConnected = false;
-  clearDebouncedInvalidate();
+
+  startListening({
+    actionCreator: liveUpdatesConnectionRequested,
+    effect: (_action, listenerApi) => {
+      const refCount = liveUpdatesSlice.selectors.selectLiveUpdatesRefCount(
+        listenerApi.getState()
+      );
+      if (refCount !== 1 || eventSource !== null) return;
+
+      const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL ?? "";
+      const url = `${backendUrl}/events/stream?topics=${LIVE_FS_TOPIC}`;
+
+      setConnectionStatusIfChanged(listenerApi, "connecting");
+
+      let es: EventSource;
+      try {
+        es = new EventSource(url);
+      } catch (err) {
+        safeCaptureException(err, {
+          context: SSE_EVENTS.CONNECTION_ERROR,
+          url,
+        });
+        setConnectionStatusIfChanged(listenerApi, "closed");
+        return;
+      }
+      eventSource = es;
+
+      es.onopen = () => {
+        const isReconnect = hasEverConnected;
+        if (setConnectionStatusIfChanged(listenerApi, "connected")) {
+          safeCapture(SSE_EVENTS.CONNECTED, { topic: LIVE_FS_TOPIC });
+        }
+        if (isReconnect) {
+          scheduleDebouncedInvalidate(listenerApi.dispatch, [
+            "Flowsheet",
+            "NowPlaying",
+            "WhoIsLive",
+          ]);
+        }
+        // Set last so a throwing dispatch above leaves the flag false and the
+        // next onopen is treated as the first observable connect, not a
+        // reconnect.
+        hasEverConnected = true;
+      };
+
+      es.onerror = () => {
+        // EventSource sets readyState before firing onerror.
+        // 0 = CONNECTING (browser is retrying transparently);
+        // 2 = CLOSED (permanently closed).
+        if (es.readyState === EventSource.CONNECTING) {
+          if (setConnectionStatusIfChanged(listenerApi, "reconnecting")) {
+            safeCapture(SSE_EVENTS.RECONNECTING, { topic: LIVE_FS_TOPIC });
+          }
+        } else if (es.readyState === EventSource.CLOSED) {
+          if (setConnectionStatusIfChanged(listenerApi, "closed")) {
+            safeCapture(SSE_EVENTS.DISCONNECTED, {
+              topic: LIVE_FS_TOPIC,
+              reason: "permanent",
+            });
+          }
+        }
+      };
+
+      es.onmessage = (msgEvent: MessageEvent) => {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(msgEvent.data as string);
+        } catch (err) {
+          safeCaptureException(err, {
+            context: SSE_EVENTS.PARSE_FAILURE,
+            raw_sample:
+              typeof msgEvent.data === "string"
+                ? msgEvent.data.slice(0, 200)
+                : null,
+          });
+          return;
+        }
+        const rawType =
+          typeof parsed === "object" && parsed !== null
+            ? (parsed as { type?: unknown }).type
+            : null;
+        if (
+          typeof rawType === "string" &&
+          BENIGN_HANDSHAKE_TYPES.has(rawType)
+        ) {
+          return;
+        }
+        if (!isLiveFsEvent(parsed)) {
+          safeCapture(SSE_EVENTS.UNKNOWN_EVENT_TYPE, {
+            topic: LIVE_FS_TOPIC,
+            raw_type: rawType,
+          });
+          return;
+        }
+
+        if (parsed.type === "refetch") {
+          scheduleDebouncedInvalidate(listenerApi.dispatch, [
+            "Flowsheet",
+            "NowPlaying",
+            "WhoIsLive",
+          ]);
+          return;
+        }
+
+        routeUpdateEvent(
+          listenerApi.dispatch,
+          listenerApi.getState,
+          parsed.payload
+        );
+      };
+    },
+  });
+
+  startListening({
+    actionCreator: liveUpdatesConnectionReleased,
+    effect: (_action, listenerApi) => {
+      const refCount = liveUpdatesSlice.selectors.selectLiveUpdatesRefCount(
+        listenerApi.getState()
+      );
+      if (refCount !== 0 || eventSource === null) return;
+      eventSource.close();
+      eventSource = null;
+      hasEverConnected = false;
+      clearDebouncedInvalidate();
+      setConnectionStatusIfChanged(listenerApi, "closed");
+    },
+  });
+
+  return {
+    middleware: listenerMiddleware.middleware,
+    getEventSource: () => eventSource,
+    getHasEverConnected: () => hasEverConnected,
+    reset: () => {
+      if (eventSource) {
+        try {
+          eventSource.close();
+        } catch {
+          // ignore
+        }
+      }
+      eventSource = null;
+      hasEverConnected = false;
+      clearDebouncedInvalidate();
+    },
+  };
 }
 
-/** Test-only accessor for the live EventSource reference. */
-export function __getLiveUpdatesEventSourceForTests(): EventSource | null {
-  return eventSource;
+// Associates a store with its live-updates connection handle so the SSE
+// lifecycle can be inspected or torn down per store. Weak so a discarded
+// store's handle is collectible and per-request server stores don't accumulate.
+const handleByStore = new WeakMap<object, LiveUpdatesListenerHandle>();
+
+export function attachLiveUpdatesListener(
+  store: object,
+  handle: LiveUpdatesListenerHandle
+): void {
+  handleByStore.set(store, handle);
 }
 
-/** Test-only accessor for the reconnect-detect flag. Lets tests pin the
- * ordering invariant that `hasEverConnected` is assigned only after the
- * status-dispatch path in `onopen` completes, so a throwing dispatch can't
- * leave the flag sticky-true. See #682, #685. */
-export function __getHasEverConnectedForTests(): boolean {
-  return hasEverConnected;
+export function getLiveUpdatesListenerHandle(
+  store: object
+): LiveUpdatesListenerHandle | undefined {
+  return handleByStore.get(store);
 }

--- a/lib/store-public.ts
+++ b/lib/store-public.ts
@@ -5,7 +5,10 @@ import { authenticationSlice } from "./features/authentication/frontend";
 import { experienceApi } from "./features/experiences/api";
 import { flowsheetApi } from "./features/flowsheet/api";
 import { flowsheetSlice } from "./features/flowsheet/frontend";
-import { liveUpdatesListenerMiddleware } from "./features/flowsheet/live-updates-listener";
+import {
+  attachLiveUpdatesListener,
+  createLiveUpdatesListenerMiddleware,
+} from "./features/flowsheet/live-updates-listener";
 import { liveUpdatesSlice } from "./features/flowsheet/live-updates-slice";
 import { playlistSearchApi } from "./features/playlist-search/api";
 import { playlistSearchSlice } from "./features/playlist-search/frontend";
@@ -32,17 +35,20 @@ const publicRootReducer = combineSlices(
 );
 
 export const makePublicStore = () => {
-  return configureStore({
+  const liveUpdatesListener = createLiveUpdatesListenerMiddleware();
+  const store = configureStore({
     reducer: publicRootReducer,
     middleware: (getDefaultMiddleware) => {
       return getDefaultMiddleware()
-        .prepend(liveUpdatesListenerMiddleware.middleware)
+        .prepend(liveUpdatesListener.middleware)
         .concat(rtkQueryErrorLogger)
         .concat(experienceApi.middleware)
         .concat(flowsheetApi.middleware)
         .concat(playlistSearchApi.middleware);
     },
   });
+  attachLiveUpdatesListener(store, liveUpdatesListener);
+  return store;
 };
 
 export type PublicAppStore = ReturnType<typeof makePublicStore>;

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -13,7 +13,10 @@ import { catalogSlice } from "./features/catalog/frontend";
 import { experienceApi } from "./features/experiences/api";
 import { flowsheetApi } from "./features/flowsheet/api";
 import { flowsheetSlice } from "./features/flowsheet/frontend";
-import { liveUpdatesListenerMiddleware } from "./features/flowsheet/live-updates-listener";
+import {
+  attachLiveUpdatesListener,
+  createLiveUpdatesListenerMiddleware,
+} from "./features/flowsheet/live-updates-listener";
 import { liveUpdatesSlice } from "./features/flowsheet/live-updates-slice";
 import { lmlApi } from "./features/lml/api";
 import { metadataApi } from "./features/metadata/api";
@@ -47,11 +50,12 @@ const rootReducer = combineSlices(
 export type RootState = ReturnType<typeof rootReducer>;
 
 export const makeStore = () => {
-  return configureStore({
+  const liveUpdatesListener = createLiveUpdatesListenerMiddleware();
+  const store = configureStore({
     reducer: rootReducer,
     middleware: (getDefaultMiddleware) => {
       return getDefaultMiddleware()
-        .prepend(liveUpdatesListenerMiddleware.middleware)
+        .prepend(liveUpdatesListener.middleware)
         .concat(rtkQueryErrorLogger)
         .concat(applicationApi.middleware)
         .concat(autoDJApi.middleware)
@@ -66,6 +70,8 @@ export const makeStore = () => {
         .concat(adminApi.middleware);
     },
   });
+  attachLiveUpdatesListener(store, liveUpdatesListener);
+  return store;
 };
 
 export type AppStore = ReturnType<typeof makeStore>;

--- a/tests/unit/lib/features/flowsheet/live-updates-listener.test.ts
+++ b/tests/unit/lib/features/flowsheet/live-updates-listener.test.ts
@@ -1,12 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 
 import { flowsheetApi } from "@/lib/features/flowsheet/api";
-import {
-  __getHasEverConnectedForTests,
-  __getLiveUpdatesEventSourceForTests,
-  __resetLiveUpdatesEventSourceForTests,
-} from "@/lib/features/flowsheet/live-updates-listener";
+import { getLiveUpdatesListenerHandle } from "@/lib/features/flowsheet/live-updates-listener";
 import {
   liveUpdatesConnectionReleased,
   liveUpdatesConnectionRequested,
@@ -14,7 +10,21 @@ import {
 } from "@/lib/features/flowsheet/live-updates-slice";
 import type { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
 import { makeStore } from "@/lib/store";
+import { makePublicStore } from "@/lib/store-public";
 import { server, TEST_BACKEND_URL } from "@/tests/helpers";
+
+// The live-updates connection state is owned per store. Reach a store's
+// EventSource / reconnect flag through its listener handle.
+function esOf(store: object): EventSource | null {
+  const handle = getLiveUpdatesListenerHandle(store);
+  if (!handle) throw new Error("store has no live-updates listener handle");
+  return handle.getEventSource();
+}
+function hasEverConnectedOf(store: object): boolean {
+  const handle = getLiveUpdatesListenerHandle(store);
+  if (!handle) throw new Error("store has no live-updates listener handle");
+  return handle.getHasEverConnected();
+}
 
 const { captureSpy, captureExceptionSpy } = vi.hoisted(() => ({
   captureSpy: vi.fn(),
@@ -68,24 +78,19 @@ function frame(payload: unknown): string {
   return JSON.stringify(payload);
 }
 
-describe("liveUpdatesListenerMiddleware", () => {
+describe("live-updates listener middleware", () => {
   beforeEach(() => {
     captureSpy.mockClear();
     captureExceptionSpy.mockClear();
-    __resetLiveUpdatesEventSourceForTests();
-  });
-
-  afterEach(() => {
-    __resetLiveUpdatesEventSourceForTests();
   });
 
   it("opens an EventSource on the 0->1 refCount transition", () => {
     const store = makeStore();
-    expect(__getLiveUpdatesEventSourceForTests()).toBeNull();
+    expect(esOf(store)).toBeNull();
 
     store.dispatch(liveUpdatesConnectionRequested());
 
-    expect(__getLiveUpdatesEventSourceForTests()).not.toBeNull();
+    expect(esOf(store)).not.toBeNull();
     const es = getLastMock();
     expect(es.url).toContain("/events/stream?topics=live-fs-topic");
     expect(
@@ -96,9 +101,9 @@ describe("liveUpdatesListenerMiddleware", () => {
   it("does not open a second EventSource on the 1->2 refCount transition", () => {
     const store = makeStore();
     store.dispatch(liveUpdatesConnectionRequested());
-    const first = __getLiveUpdatesEventSourceForTests();
+    const first = esOf(store);
     store.dispatch(liveUpdatesConnectionRequested());
-    expect(__getLiveUpdatesEventSourceForTests()).toBe(first);
+    expect(esOf(store)).toBe(first);
     expect(MockEventSourceCtor._instances).toHaveLength(1);
   });
 
@@ -106,41 +111,80 @@ describe("liveUpdatesListenerMiddleware", () => {
     const store = makeStore();
     store.dispatch(liveUpdatesConnectionRequested());
     store.dispatch(liveUpdatesConnectionRequested());
-    expect(__getLiveUpdatesEventSourceForTests()).not.toBeNull();
+    expect(esOf(store)).not.toBeNull();
     store.dispatch(liveUpdatesConnectionReleased());
-    expect(__getLiveUpdatesEventSourceForTests()).not.toBeNull();
+    expect(esOf(store)).not.toBeNull();
     store.dispatch(liveUpdatesConnectionReleased());
-    expect(__getLiveUpdatesEventSourceForTests()).toBeNull();
+    expect(esOf(store)).toBeNull();
     expect(
       liveUpdatesSlice.selectors.selectLiveUpdatesConnectionStatus(store.getState())
     ).toBe("closed");
   });
 
-  it("a second store's request opens a fresh EventSource only after the first closes", () => {
-    // Module-scope EventSource ref + per-store ref-count means concurrent
-    // stores must not double-open. After the first store releases, the second
-    // store's first request must open a new ES against its own listenerApi.
+  it("gives each store its own EventSource, independently held", () => {
+    // Each store scopes its own ref-count, so each owns a separate connection.
+    // A second store requesting while the first is still connected opens its
+    // OWN stream rather than aliasing the first's.
     const storeA = makeStore();
     storeA.dispatch(liveUpdatesConnectionRequested());
-    const esA = __getLiveUpdatesEventSourceForTests();
+    const esA = esOf(storeA);
     expect(esA).not.toBeNull();
+    expect(MockEventSourceCtor._instances).toHaveLength(1);
 
     const storeB = makeStore();
     storeB.dispatch(liveUpdatesConnectionRequested());
-    expect(__getLiveUpdatesEventSourceForTests()).toBe(esA);
-    expect(MockEventSourceCtor._instances).toHaveLength(1);
+    const esB = esOf(storeB);
+    expect(esB).not.toBeNull();
+    expect(esB).not.toBe(esA);
+    expect(MockEventSourceCtor._instances).toHaveLength(2);
 
-    // storeB's refCount is independently tracked.
-    expect(
-      liveUpdatesSlice.selectors.selectLiveUpdatesRefCount(storeB.getState())
-    ).toBe(1);
-
+    // Releasing storeA closes only storeA's stream; storeB keeps its own.
     storeA.dispatch(liveUpdatesConnectionReleased());
-    // storeA's refCount drops to 0 but the module-scope ES is still held by
-    // storeB conceptually. The listener checks storeA's refCount === 0 and
-    // closes the ES — this is the documented limitation of the module-scoped
-    // singleton across multiple stores; tests must reset between makeStore()s.
-    expect(__getLiveUpdatesEventSourceForTests()).toBeNull();
+    expect(esOf(storeA)).toBeNull();
+    expect((esA as unknown as MockES).readyState).toBe(MockEventSourceCtor.CLOSED);
+    expect(esOf(storeB)).toBe(esB);
+    expect((esB as unknown as MockES).readyState).not.toBe(
+      MockEventSourceCtor.CLOSED
+    );
+  });
+
+  it("keeps the surviving store connected when a subscriber moves between stores and the new request lands before the old release", () => {
+    // Soft nav between a public route (public store) and the dashboard (full
+    // store) can run the destination's connectionRequested before the source's
+    // connectionReleased cleanup. With connection state shared across stores,
+    // the old store's release would close a stream the new store still needs,
+    // stranding it at ref-count 1 with no EventSource. Per-store ownership must
+    // keep the surviving store's stream live through the overlap.
+    const oldStore = makePublicStore();
+    oldStore.dispatch(liveUpdatesConnectionRequested());
+    getLastMock()._fireOpen();
+    const oldEs = esOf(oldStore);
+    expect(oldEs).not.toBeNull();
+
+    const newStore = makeStore();
+    // New subtree mounts and requests BEFORE the old subtree's release fires.
+    newStore.dispatch(liveUpdatesConnectionRequested());
+    getLastMock()._fireOpen();
+    const newEs = esOf(newStore);
+    expect(newEs).not.toBeNull();
+    expect(newEs).not.toBe(oldEs);
+
+    // Old subtree finally unmounts and releases.
+    oldStore.dispatch(liveUpdatesConnectionReleased());
+
+    // Invariant: a store with ref-count > 0 still owns a live EventSource.
+    expect(
+      liveUpdatesSlice.selectors.selectLiveUpdatesRefCount(newStore.getState())
+    ).toBe(1);
+    expect(esOf(newStore)).toBe(newEs);
+    expect((newEs as unknown as MockES).readyState).not.toBe(
+      MockEventSourceCtor.CLOSED
+    );
+    expect(
+      liveUpdatesSlice.selectors.selectLiveUpdatesConnectionStatus(
+        newStore.getState()
+      )
+    ).toBe("connected");
   });
 
   it("marks status connected on onopen", () => {
@@ -351,7 +395,7 @@ describe("liveUpdatesListenerMiddleware", () => {
     }
   });
 
-  describe("reconnect refetch (issue #682)", () => {
+  describe("reconnect refetch", () => {
     it("does not schedule an invalidate on the first onopen (initial connect)", () => {
       vi.useFakeTimers();
       const invalidateSpy = vi.spyOn(flowsheetApi.util, "invalidateTags");
@@ -458,18 +502,18 @@ describe("liveUpdatesListenerMiddleware", () => {
       }
     });
 
-    it("__getHasEverConnectedForTests follows the request → open → release lifecycle", () => {
+    it("the reconnect-detect flag follows the request → open → release lifecycle", () => {
       const store = makeStore();
-      expect(__getHasEverConnectedForTests()).toBe(false);
+      expect(hasEverConnectedOf(store)).toBe(false);
       store.dispatch(liveUpdatesConnectionRequested());
-      expect(__getHasEverConnectedForTests()).toBe(false);
+      expect(hasEverConnectedOf(store)).toBe(false);
       getLastMock()._fireOpen();
-      expect(__getHasEverConnectedForTests()).toBe(true);
+      expect(hasEverConnectedOf(store)).toBe(true);
       store.dispatch(liveUpdatesConnectionReleased());
-      expect(__getHasEverConnectedForTests()).toBe(false);
+      expect(hasEverConnectedOf(store)).toBe(false);
     });
 
-    it("does not set hasEverConnected when the onopen handler's status read throws (pins commit 7b56287 ordering invariant)", () => {
+    it("does not set the reconnect-detect flag when the onopen handler's status read throws", () => {
       const store = makeStore();
       store.dispatch(liveUpdatesConnectionRequested());
       // Spy AFTER the requested-effect's initial "connecting" status set, so
@@ -486,7 +530,7 @@ describe("liveUpdatesListenerMiddleware", () => {
         // If a future refactor moves `hasEverConnected = true` back above the
         // status dispatch, this assertion flips to true and the test fails —
         // which is the regression we want.
-        expect(__getHasEverConnectedForTests()).toBe(false);
+        expect(hasEverConnectedOf(store)).toBe(false);
       } finally {
         selectorSpy.mockRestore();
       }


### PR DESCRIPTION
Follow-up to #998 (store scoping), which merged before this fix could land on its branch. Addresses a hazard found in adversarial review of that PR.

## The bug

The store-scoping change put the live-updates listener middleware in **two** stores (the app-wide public store and the dashboard's full store). But `liveUpdatesListenerMiddleware` was a **module singleton**, gating a single module-level `eventSource` (and `hasEverConnected` / debounce timer) against ref-counts that now live **separately** in each store's `liveUpdatesSlice`.

On a soft nav between a public route and `/dashboard/flowsheet`, the destination store's `connectionRequested` effect can run **before** the source store's `connectionReleased` cleanup (the old subtree's unmount can be deferred across a Suspense/loading boundary). Sequence:

1. old store open → shared `eventSource` set, connected
2. new store requests (before old release) → sees `eventSource !== null` → **short-circuits**, opens nothing
3. old store releases → its ref-count hits 0 → **closes the shared `eventSource`**

Result: the new store sits at ref-count 1 with **no** EventSource — live updates silently degrade to fast polling (extra backend load) until a hard reload.

## The fix

Build the listener **per store** via a factory (`createLiveUpdatesListenerMiddleware()`), so the EventSource, reconnect-detect flag, and debounce timer are owned in each instance's closure. RTK's guidance is that a listener-middleware instance should not be shared across stores anyway. Each store now opens and closes its own connection independently, so **any** interleaving of request/release across the two stores leaves a store with ref-count > 0 holding a live EventSource. `makeStore` / `makePublicStore` each create their own instance; a weak per-store registry (`attachLiveUpdatesListener` / `getLiveUpdatesListenerHandle`) exposes each store's connection handle for lifecycle inspection and teardown.

Invariant pinned: after any interleaving of request/release across the two stores, a store with ref-count > 0 has a live EventSource.

## Tests

Rewrote `tests/unit/lib/features/flowsheet/live-updates-listener.test.ts` to reach connection state per store (via the handle) instead of the removed module accessors, and added:

- **"gives each store its own EventSource, independently held"** — two stores each open their own stream; releasing one closes only its own.
- **"keeps the surviving store connected when a subscriber moves between stores and the new request lands before the old release"** — the required regression test: builds `makePublicStore()` + `makeStore()`, requests on the new store **before** releasing the old, and asserts the surviving store still owns a connected EventSource with ref-count 1. This fails on the old shared-singleton code.

The previous test that documented the shared-singleton "limitation" as expected behavior is replaced by the two above.

## What to check

- **/live ⇄ /dashboard/flowsheet soft nav** — live now-playing keeps updating through the transition (the surviving store keeps its SSE stream; no silent drop to polling).
- Single-store behavior unchanged: open on 0→1, no second open on 1→2, close on N→0, reconnect-refetch semantics.

## Gate

`tsc` clean; `lint` 0 errors; `vitest` full suite 3816 passed; `next build` + `build:opennext` OK; `wrangler pages dev` (port 3005): `/`, `/live`, `/playlists`, `/login` → 200, `/dashboard` → 307 auth redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)