### PR TITLE
feat(catalog): pilot "use cache" server accessor for genres

### DIFF
--- a/app/dashboard/@modern/catalog/page.tsx
+++ b/app/dashboard/@modern/catalog/page.tsx
@@ -3,6 +3,7 @@ import PageHeader from "@/src/components/experiences/modern/Header/PageHeader";
 import MobileSearchBar from "@/src/components/experiences/modern/catalog/Search/MobileSearchBar";
 import SearchBar from "@/src/components/experiences/modern/catalog/Search/SearchBar";
 import Results from "@/src/components/experiences/modern/catalog/Results/Results";
+import { getCachedGenres } from "@/lib/features/catalog/server";
 import { Metadata } from "next";
 import { getPageTitle } from "@/lib/utils/page-title";
 
@@ -10,13 +11,19 @@ export const metadata: Metadata = {
   title: getPageTitle("Card Catalog"),
 };
 
-export default function CatalogPage() {
+export default async function CatalogPage() {
+  // Seed the desktop Filters' genre list from the server cache so the
+  // autocomplete has options on first paint; the client query still owns the
+  // value once it resolves. Cached accessor is argument-pure (no request state),
+  // so it composes with this auth-gated route.
+  const initialGenres = await getCachedGenres();
+
   return (
     <>
       <PageHeader title="Card Catalog" />
       <>
         <MobileSearchBar color="primary" />
-        <SearchBar color="primary" />
+        <SearchBar color="primary" initialGenres={initialGenres} />
         <Results color="primary" />
       </>
     </>

--- a/app/dashboard/@modern/catalog/page.tsx
+++ b/app/dashboard/@modern/catalog/page.tsx
@@ -12,17 +12,18 @@ export const metadata: Metadata = {
 };
 
 export default async function CatalogPage() {
-  // Seed the desktop Filters' genre list from the server cache so the
-  // autocomplete has options on first paint; the client query still owns the
-  // value once it resolves. Cached accessor is argument-pure (no request state),
-  // so it composes with this auth-gated route.
+  // Seed the Filters' genre list from the server cache so the autocomplete has
+  // options on first paint; the client query still owns the value once it
+  // resolves. `undefined` on failure keeps the client loading affordance. The
+  // cached accessor is argument-pure (no request state), so it composes with
+  // this auth-gated route.
   const initialGenres = await getCachedGenres();
 
   return (
     <>
       <PageHeader title="Card Catalog" />
       <>
-        <MobileSearchBar color="primary" />
+        <MobileSearchBar color="primary" initialGenres={initialGenres} />
         <SearchBar color="primary" initialGenres={initialGenres} />
         <Results color="primary" />
       </>

--- a/lib/features/catalog/actions.ts
+++ b/lib/features/catalog/actions.ts
@@ -1,0 +1,15 @@
+"use server";
+
+import { revalidateTag } from "next/cache";
+
+/**
+ * Invalidation hook for the cached genre list (`getCachedGenres`, tagged
+ * "genres"). Wired into the `addGenre` mutation path so an admin adding a genre
+ * expires the seed. INERT until the OpenNext KV/R2 tag-cache adapter replaces
+ * the "dummy" tag cache in `open-next.config.ts`: with the no-op backend,
+ * `revalidateTag` has no store to clear.
+ */
+export async function revalidateGenres(): Promise<void> {
+  // The "max" profile expires the tag regardless of the accessor's cacheLife.
+  revalidateTag("genres", "max");
+}

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -1,5 +1,6 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import type { RootState } from "@/lib/store";
+import { revalidateGenres } from "./actions";
 import { backendBaseQuery } from "../backend";
 import { CATALOG_QUERY_PAGE_LIMIT } from "./constants";
 import { convertToAlbumEntry } from "./conversions";
@@ -250,6 +251,17 @@ export const catalogApi = createApi({
         method: "POST",
         body,
       }),
+      // Expire the server-cached genre seed (getCachedGenres, tagged "genres")
+      // once the write lands. No UI dispatches this mutation yet; the hook is
+      // wired for the first adopter. See revalidateGenres for why this is inert
+      // until the OpenNext tag-cache adapter replaces the dummy tag cache.
+      async onQueryStarted(_arg, { queryFulfilled }) {
+        try {
+          await queryFulfilled;
+          await revalidateGenres();
+        } catch {
+        }
+      },
     }),
   }),
 });

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -60,7 +60,7 @@ function transformLibraryQueryResponse(
 export const catalogApi = createApi({
   reducerPath: "catalogApi",
   baseQuery: backendBaseQuery("library"),
-  tagTypes: ["Rotation", "AlbumDetail", "CatalogList", "ArtistSearch"],
+  tagTypes: ["Rotation", "AlbumDetail", "CatalogList", "ArtistSearch", "Genres"],
   endpoints: (builder) => ({
     searchCatalog: builder.query<AlbumEntry[], SearchCatalogQueryParams>({
       query: ({ artist_name, album_title, n, on_streaming }) => ({
@@ -244,6 +244,7 @@ export const catalogApi = createApi({
       query: () => ({
         url: "/genres",
       }),
+      providesTags: [{ type: "Genres", id: "LIST" }],
     }),
     addGenre: builder.mutation<LibraryGenreRow, AddGenreRequestBody>({
       query: (body) => ({
@@ -251,10 +252,13 @@ export const catalogApi = createApi({
         method: "POST",
         body,
       }),
-      // Expire the server-cached genre seed (getCachedGenres, tagged "genres")
-      // once the write lands. No UI dispatches this mutation yet; the hook is
-      // wired for the first adopter. See revalidateGenres for why this is inert
-      // until the OpenNext tag-cache adapter replaces the dummy tag cache.
+      // Client-side: refetch the in-session genre list so an add is reflected
+      // without a reload. No UI dispatches this mutation yet; the tag is wired
+      // for the first adopter.
+      invalidatesTags: [{ type: "Genres", id: "LIST" }],
+      // Server-side: expire the server-cached genre seed (getCachedGenres,
+      // tagged "genres"). Inert until the OpenNext tag-cache adapter replaces
+      // the no-op tag cache; see revalidateGenres.
       async onQueryStarted(_arg, { queryFulfilled }) {
         try {
           await queryFulfilled;

--- a/lib/features/catalog/server.ts
+++ b/lib/features/catalog/server.ts
@@ -1,0 +1,45 @@
+import "server-only";
+
+import { cacheLife, cacheTag } from "next/cache";
+
+import type { LibraryGenreRow } from "./types";
+
+/**
+ * Server-side cached accessor for the near-static library genre list, for
+ * seeding the catalog Filters on first paint. The result is memoized under the
+ * "genres" cache tag with an hours-scale lifetime; `revalidateGenres()` in
+ * `actions.ts` is the invalidation hook for the `addGenre` mutation path.
+ *
+ * CONSTRAINT: cross-request persistence and tag revalidation are INERT on the
+ * current OpenNext/Cloudflare deployment. `open-next.config.ts` wires the
+ * incremental cache and tag cache to the "dummy" (no-op) backends, so there is
+ * no store behind `cacheLife`/`cacheTag` — each fresh request re-fetches and
+ * `revalidateTag("genres")` does nothing. Only same-request/same-isolate
+ * memoization is live today. Real cross-request caching requires the OpenNext
+ * KV/R2 cache adapter work to replace those dummy backends.
+ *
+ * Must stay argument-pure: a `"use cache"` function cannot read cookies or
+ * headers, so it reads only build/runtime env and never request state — which
+ * is what lets it compose inside the auth-gated catalog route.
+ */
+export async function getCachedGenres(): Promise<LibraryGenreRow[]> {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("genres");
+
+  const base = process.env.NEXT_PUBLIC_BACKEND_URL;
+  if (!base) return [];
+
+  try {
+    const response = await fetch(`${base}/library/genres`, {
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) return [];
+
+    const body = await response.text();
+    if (!body) return [];
+    return JSON.parse(body) as LibraryGenreRow[];
+  } catch {
+    return [];
+  }
+}

--- a/lib/features/catalog/server.ts
+++ b/lib/features/catalog/server.ts
@@ -2,44 +2,53 @@ import "server-only";
 
 import { cacheLife, cacheTag } from "next/cache";
 
+import { fetchBackendJson } from "../server-fetch";
 import type { LibraryGenreRow } from "./types";
 
 /**
- * Server-side cached accessor for the near-static library genre list, for
- * seeding the catalog Filters on first paint. The result is memoized under the
- * "genres" cache tag with an hours-scale lifetime; `revalidateGenres()` in
- * `actions.ts` is the invalidation hook for the `addGenre` mutation path.
- *
- * CONSTRAINT: cross-request persistence and tag revalidation are INERT on the
- * current OpenNext/Cloudflare deployment. `open-next.config.ts` wires the
- * incremental cache and tag cache to the "dummy" (no-op) backends, so there is
- * no store behind `cacheLife`/`cacheTag` — each fresh request re-fetches and
- * `revalidateTag("genres")` does nothing. Only same-request/same-isolate
- * memoization is live today. Real cross-request caching requires the OpenNext
- * KV/R2 cache adapter work to replace those dummy backends.
+ * Cached inner accessor for the near-static library genre list, tagged "genres"
+ * with an hours-scale lifetime. THROWS on any failure (non-2xx, empty/non-JSON
+ * body, or a non-array payload): Next's use-cache runtime does not persist an
+ * errored stream, so throwing is what prevents a transient failure from being
+ * cached as an empty list for the whole cacheLife window.
  *
  * Must stay argument-pure: a `"use cache"` function cannot read cookies or
  * headers, so it reads only build/runtime env and never request state — which
  * is what lets it compose inside the auth-gated catalog route.
+ *
+ * CONSTRAINTS on real effect today:
+ *  - The backend genre endpoint requires an authenticated caller, and this
+ *    accessor is header-less by construction (a cached function cannot read the
+ *    session), so the request is rejected and the wrapper yields an empty seed
+ *    on every request in every environment. A live seed needs Backend-Service
+ *    to expose the genre list on a public tier first.
+ *  - Cross-request persistence and tag revalidation are inert: the OpenNext
+ *    deployment wires the incremental cache and tag cache to no-op ("dummy")
+ *    backends, so there is no store behind `cacheLife`/`cacheTag` and
+ *    `revalidateTag("genres")` clears nothing. Only same-request memoization is
+ *    live. Real caching requires the OpenNext KV/R2 cache adapter work.
  */
-export async function getCachedGenres(): Promise<LibraryGenreRow[]> {
+async function fetchCachedGenres(): Promise<LibraryGenreRow[]> {
   "use cache";
   cacheLife("hours");
   cacheTag("genres");
 
-  const base = process.env.NEXT_PUBLIC_BACKEND_URL;
-  if (!base) return [];
+  const data = await fetchBackendJson<unknown>("/library/genres");
+  if (!Array.isArray(data)) {
+    throw new Error("expected an array of genres");
+  }
+  return data as LibraryGenreRow[];
+}
 
+/**
+ * Uncached wrapper that fails open for the catalog Filters seed: returns
+ * `undefined` on any failure so the page passes no seed and the client query's
+ * loading affordance stays reachable (matches the established seed contract).
+ */
+export async function getCachedGenres(): Promise<LibraryGenreRow[] | undefined> {
   try {
-    const response = await fetch(`${base}/library/genres`, {
-      headers: { Accept: "application/json" },
-    });
-    if (!response.ok) return [];
-
-    const body = await response.text();
-    if (!body) return [];
-    return JSON.parse(body) as LibraryGenreRow[];
+    return await fetchCachedGenres();
   } catch {
-    return [];
+    return undefined;
   }
 }

--- a/lib/features/server-fetch.ts
+++ b/lib/features/server-fetch.ts
@@ -1,11 +1,39 @@
 import "server-only";
 
-// Request-time seed fetches for public Server Components must fail open: a slow
-// or unreachable backend renders the page's normal loading state, never an
-// error page. The short timeout keeps a hung backend from stalling the route.
-// Seed fetches run before the first byte of the document: this bound is
-// the worst-case TTFB penalty a degraded backend can add to a public page.
+// Request-time backend reads for Server Components run before the first byte of
+// the document, so a hung backend must not stall the route: this bound is the
+// worst-case TTFB penalty a degraded backend can add.
 const SEED_FETCH_TIMEOUT_MS = 800;
+
+/**
+ * Shared GET-and-parse core for server-side Backend-Service reads. Applies the
+ * request-time timeout and THROWS on any failure (missing backend URL, network
+ * error/timeout, non-2xx, or an empty/non-JSON body). Callers decide how to
+ * treat a throw: a seed swallows it and falls back to client state; a cached
+ * accessor must let it propagate so an errored result is never persisted.
+ *
+ * `init` carries per-caller fetch semantics — seeds pass `cache: "no-store"`; a
+ * `"use cache"` accessor omits it so the use-cache runtime owns caching. The
+ * timeout signal is applied here and must not be overridden by `init`.
+ */
+export async function fetchBackendJson<T>(
+  path: string,
+  init?: Omit<RequestInit, "signal">,
+): Promise<T> {
+  const base = process.env.NEXT_PUBLIC_BACKEND_URL;
+  if (!base) throw new Error("NEXT_PUBLIC_BACKEND_URL is not set");
+
+  const response = await fetch(`${base}${path}`, {
+    headers: { Accept: "application/json" },
+    ...init,
+    signal: AbortSignal.timeout(SEED_FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`backend responded ${response.status}`);
+
+  const body = await response.text();
+  if (!body) throw new Error("empty response body");
+  return JSON.parse(body) as T;
+}
 
 /**
  * Unauthenticated GET against Backend-Service for server-rendered initial data.
@@ -15,20 +43,8 @@ const SEED_FETCH_TIMEOUT_MS = 800;
 export async function fetchBackendSeed<T>(
   path: string,
 ): Promise<T | undefined> {
-  const base = process.env.NEXT_PUBLIC_BACKEND_URL;
-  if (!base) return undefined;
-
   try {
-    const response = await fetch(`${base}${path}`, {
-      signal: AbortSignal.timeout(SEED_FETCH_TIMEOUT_MS),
-      cache: "no-store",
-      headers: { Accept: "application/json" },
-    });
-    if (!response.ok) return undefined;
-
-    const body = await response.text();
-    if (!body) return undefined;
-    return JSON.parse(body) as T;
+    return await fetchBackendJson<T>(path, { cache: "no-store" });
   } catch {
     return undefined;
   }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -159,6 +159,10 @@ const nextConfig = {
     // optimizePackageImports list; @mui/joy (this app's primary UI kit) is not,
     // so it must be listed explicitly.
     optimizePackageImports: ["@mui/joy"],
+    // Enables the `"use cache"` directive (getCachedGenres) WITHOUT the full
+    // `cacheComponents` PPR strict mode, which would force Suspense/`"use cache"`
+    // on every dynamic data access across the app. Scoped-pilot flag only.
+    useCache: true,
   },
   // Explicitly set workspace root to silence lockfile warning
   outputFileTracingRoot: import.meta.dirname,

--- a/src/components/experiences/modern/catalog/Search/Filters.tsx
+++ b/src/components/experiences/modern/catalog/Search/Filters.tsx
@@ -4,6 +4,7 @@ import {
   useGetFormatsQuery,
   useGetGenresQuery,
 } from "@/lib/features/catalog/api";
+import type { LibraryGenreRow } from "@/lib/features/catalog/types";
 import { Box, Divider } from "@mui/joy";
 
 import { CatalogFilterSection } from "./CatalogFilterSection";
@@ -23,9 +24,20 @@ export function catalogFiltersActive(filters: {
   );
 }
 
-export const Filters = () => {
+export const Filters = ({
+  initialGenres,
+}: {
+  initialGenres?: LibraryGenreRow[];
+}) => {
   const { data: genres, isLoading: genresLoading } = useGetGenresQuery();
   const { data: formats, isLoading: formatsLoading } = useGetFormatsQuery();
+
+  // Seed from the server-cached genres until the client query resolves, then
+  // the client query owns the value (mirrors the NowPlaying seed pattern). Only
+  // show the loading affordance when neither a seed nor client data is present.
+  const seededGenres = genres ?? initialGenres;
+  const genresPending =
+    genresLoading && genres === undefined && initialGenres === undefined;
 
   return (
     <Box
@@ -37,7 +49,10 @@ export const Filters = () => {
       }}
     >
       <CatalogFilterSection>
-        <GenreFilterAutocomplete genres={genres} isLoading={genresLoading} />
+        <GenreFilterAutocomplete
+          genres={seededGenres}
+          isLoading={genresPending}
+        />
       </CatalogFilterSection>
 
       <Divider orientation="vertical" />

--- a/src/components/experiences/modern/catalog/Search/Filters.tsx
+++ b/src/components/experiences/modern/catalog/Search/Filters.tsx
@@ -36,8 +36,7 @@ export const Filters = ({
   // the client query owns the value (mirrors the NowPlaying seed pattern). Only
   // show the loading affordance when neither a seed nor client data is present.
   const seededGenres = genres ?? initialGenres;
-  const genresPending =
-    genresLoading && genres === undefined && initialGenres === undefined;
+  const genresPending = genresLoading && initialGenres === undefined;
 
   return (
     <Box

--- a/src/components/experiences/modern/catalog/Search/MobileSearchBar.tsx
+++ b/src/components/experiences/modern/catalog/Search/MobileSearchBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { catalogSlice } from "@/lib/features/catalog/frontend";
+import type { LibraryGenreRow } from "@/lib/features/catalog/types";
 import { useAppSelector } from "@/lib/hooks";
 import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
 import { Troubleshoot } from "@mui/icons-material";
@@ -19,8 +20,10 @@ import QueryBuilder from "./QueryBuilder";
 
 export default function MobileSearchBar({
   color,
+  initialGenres,
 }: {
   color: ColorPaletteProp | undefined;
+  initialGenres?: LibraryGenreRow[];
 }) {
   const { openMobileSearch, closeMobileSearch, filters, effectiveQuery } =
     useCatalogQuerySearch();
@@ -75,7 +78,7 @@ export default function MobileSearchBar({
           />
           <Sheet sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
             <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-              <QueryBuilder color={color} />
+              <QueryBuilder color={color} initialGenres={initialGenres} />
             </Box>
             <Button color={color ?? "primary"} onClick={closeMobileSearch}>
               Done

--- a/src/components/experiences/modern/catalog/Search/QueryBuilder.tsx
+++ b/src/components/experiences/modern/catalog/Search/QueryBuilder.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import type { CatalogSearchField, CatalogSearchRow } from "@/lib/features/catalog/types";
+import type {
+  CatalogSearchField,
+  CatalogSearchRow,
+  LibraryGenreRow,
+} from "@/lib/features/catalog/types";
 import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
 import { Add, Cancel, Remove, Troubleshoot } from "@mui/icons-material";
 import {
@@ -255,9 +259,13 @@ function CatalogSearchRowSegment({
 
 export type QueryBuilderProps = {
   color?: ColorPaletteProp;
+  initialGenres?: LibraryGenreRow[];
 };
 
-export default function QueryBuilder({ color = "primary" }: QueryBuilderProps) {
+export default function QueryBuilder({
+  color = "primary",
+  initialGenres,
+}: QueryBuilderProps) {
   const { rows, addRow, removeRow, updateRow } = useCatalogQuerySearch();
 
   const multiRow = rows.length > 1;
@@ -297,7 +305,7 @@ export default function QueryBuilder({ color = "primary" }: QueryBuilderProps) {
         </Box>
         <Divider sx={{ my: 0.25 }} />
         <Box sx={catalogSearchFiltersGutterSx}>
-          <Filters />
+          <Filters initialGenres={initialGenres} />
         </Box>
       </Sheet>
     </Box>

--- a/src/components/experiences/modern/catalog/Search/SearchBar.tsx
+++ b/src/components/experiences/modern/catalog/Search/SearchBar.tsx
@@ -1,12 +1,15 @@
 "use client";
 
+import type { LibraryGenreRow } from "@/lib/features/catalog/types";
 import { Box, ColorPaletteProp } from "@mui/joy";
 import QueryBuilder from "./QueryBuilder";
 
 export default function SearchBar({
   color,
+  initialGenres,
 }: {
   color: ColorPaletteProp | undefined;
+  initialGenres?: LibraryGenreRow[];
 }) {
   return (
     <Box
@@ -22,7 +25,7 @@ export default function SearchBar({
         minWidth: 0,
       }}
     >
-      <QueryBuilder color={color} />
+      <QueryBuilder color={color} initialGenres={initialGenres} />
     </Box>
   );
 }

--- a/tests/integration/components/modern/catalog/Search/Filters.test.tsx
+++ b/tests/integration/components/modern/catalog/Search/Filters.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, within } from "@testing-library/react";
 import { Filters } from "@/src/components/experiences/modern/catalog/Search/Filters";
+import { useGetGenresQuery } from "@/lib/features/catalog/api";
 import { createComponentHarnessWithQueries } from "@/tests/helpers";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 
@@ -113,6 +114,35 @@ describe("Filters", () => {
       "Rock",
       "Jazz",
     ]);
+  });
+
+  it("seeds genre options from initialGenres before the client query resolves", async () => {
+    vi.mocked(useGetGenresQuery).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useGetGenresQuery>);
+
+    const { genreInput, user } = setup({ initialGenres: mockGenres });
+    await user.click(genreInput());
+    expect(
+      await screen.findByRole("option", { name: "Rock" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Jazz" })).toBeInTheDocument();
+  });
+
+  it("prefers the resolved client query over the initial seed", async () => {
+    const clientGenres = [{ id: 9, genre_name: "Ambient" }];
+    vi.mocked(useGetGenresQuery).mockReturnValue({
+      data: clientGenres,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useGetGenresQuery>);
+
+    const { genreInput, user } = setup({ initialGenres: mockGenres });
+    await user.click(genreInput());
+    expect(
+      await screen.findByRole("option", { name: "Ambient" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Rock" })).not.toBeInTheDocument();
   });
 
   it("selects formats via autocomplete", async () => {

--- a/tests/integration/components/modern/catalog/Search/Filters.test.tsx
+++ b/tests/integration/components/modern/catalog/Search/Filters.test.tsx
@@ -44,6 +44,12 @@ const setup = createComponentHarnessWithQueries(
 describe("Filters", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Re-establish the default so a per-test genre override never leaks into the
+    // next test (clearAllMocks resets calls, not the implementation).
+    vi.mocked(useGetGenresQuery).mockReturnValue({
+      data: mockGenres,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useGetGenresQuery>);
   });
 
   it("renders three sections separated by vertical dividers", () => {
@@ -128,6 +134,21 @@ describe("Filters", () => {
       await screen.findByRole("option", { name: "Rock" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "Jazz" })).toBeInTheDocument();
+  });
+
+  it("shows the genre loading affordance when pending with no seed", () => {
+    vi.mocked(useGetGenresQuery).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useGetGenresQuery>);
+
+    setup();
+    // Skeleton replaces the combobox while the client query is pending and no
+    // server seed was provided.
+    expect(
+      screen.queryByRole("combobox", { name: "Genre" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Format" })).toBeInTheDocument();
   });
 
   it("prefers the resolved client query over the initial seed", async () => {

--- a/tests/unit/lib/features/catalog/api.test.tsx
+++ b/tests/unit/lib/features/catalog/api.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   catalogApi,
   useSearchCatalogQuery,
@@ -11,11 +11,19 @@ import {
   useGetGenresQuery,
   useAddGenreMutation,
 } from "@/lib/features/catalog/api";
+import { revalidateGenres } from "@/lib/features/catalog/actions";
+import { makeStore } from "@/lib/store";
 import { describeApi } from "@/tests/helpers";
 
 // Mock the authentication client
 vi.mock("@/lib/features/authentication/client", () => ({
   getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+// The `revalidateTag` server action can't run outside a Next server request, so
+// stub the wrapper and assert the mutation path invokes it.
+vi.mock("@/lib/features/catalog/actions", () => ({
+  revalidateGenres: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("catalogApi", () => {
@@ -223,6 +231,49 @@ describe("catalogApi", () => {
     it("should have initiate method", () => {
       expect(catalogApi.endpoints.addGenre.initiate).toBeDefined();
       expect(typeof catalogApi.endpoints.addGenre.initiate).toBe("function");
+    });
+
+    describe("cache invalidation", () => {
+      const originalFetch = global.fetch;
+
+      beforeEach(() => {
+        vi.mocked(revalidateGenres).mockClear();
+      });
+
+      afterEach(() => {
+        global.fetch = originalFetch;
+      });
+
+      it("revalidates the genres tag after a successful add", async () => {
+        global.fetch = vi.fn().mockResolvedValue(
+          new Response(JSON.stringify({ id: 3, genre_name: "Noise" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+        const store = makeStore();
+        await store.dispatch(
+          catalogApi.endpoints.addGenre.initiate({
+            name: "Noise",
+            description: "",
+          }),
+        );
+        expect(revalidateGenres).toHaveBeenCalledTimes(1);
+      });
+
+      it("does not revalidate when the add fails", async () => {
+        global.fetch = vi
+          .fn()
+          .mockResolvedValue(new Response("nope", { status: 500 }));
+        const store = makeStore();
+        await store.dispatch(
+          catalogApi.endpoints.addGenre.initiate({
+            name: "Noise",
+            description: "",
+          }),
+        );
+        expect(revalidateGenres).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/tests/unit/lib/features/catalog/api.test.tsx
+++ b/tests/unit/lib/features/catalog/api.test.tsx
@@ -274,6 +274,43 @@ describe("catalogApi", () => {
         );
         expect(revalidateGenres).not.toHaveBeenCalled();
       });
+
+      it("refetches the client genre list after a successful add", async () => {
+        let getCount = 0;
+        global.fetch = vi.fn(
+          async (_url: RequestInfo | URL, opts?: RequestInit) => {
+            const method = opts?.method ?? "GET";
+            if (method === "GET") {
+              getCount += 1;
+              return new Response(JSON.stringify([]), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              });
+            }
+            return new Response(
+              JSON.stringify({ id: 3, genre_name: "Noise" }),
+              { status: 200, headers: { "Content-Type": "application/json" } },
+            );
+          },
+        ) as typeof global.fetch;
+
+        const store = makeStore();
+        store.dispatch(catalogApi.endpoints.getGenres.initiate());
+        await vi.waitFor(() => expect(getCount).toBeGreaterThanOrEqual(1));
+        const afterInitialLoad = getCount;
+
+        await store.dispatch(
+          catalogApi.endpoints.addGenre.initiate({
+            name: "Noise",
+            description: "",
+          }),
+        );
+        // invalidatesTags on the "Genres" tag forces the subscribed list query
+        // to refetch.
+        await vi.waitFor(() =>
+          expect(getCount).toBeGreaterThan(afterInitialLoad),
+        );
+      });
     });
   });
 

--- a/tests/unit/lib/features/catalog/server.test.ts
+++ b/tests/unit/lib/features/catalog/server.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+// The use-cache directive/profile helpers only run inside a Next server
+// request; stub them so the accessor's fetch/validate logic is testable.
+vi.mock("next/cache", () => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+}));
+
+import { getCachedGenres } from "@/lib/features/catalog/server";
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    text: async () => (body === undefined ? "" : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+const BACKEND_URL = "http://backend.test";
+const genres = [
+  { id: 1, genre_name: "Noise" },
+  { id: 2, genre_name: "Ambient" },
+];
+
+describe("getCachedGenres", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_BACKEND_URL = BACKEND_URL;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the genre list on a successful array response", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(genres)));
+    expect(await getCachedGenres()).toEqual(genres);
+  });
+
+  it("fails open to undefined on a non-2xx response", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(genres, false)));
+    expect(await getCachedGenres()).toBeUndefined();
+  });
+
+  it("fails open to undefined on a valid-JSON non-array body", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ genres })));
+    expect(await getCachedGenres()).toBeUndefined();
+  });
+
+  it("fails open to undefined on an empty body", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse(undefined)));
+    expect(await getCachedGenres()).toBeUndefined();
+  });
+
+  it("fails open to undefined when the fetch rejects (e.g. timeout)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("timeout");
+      }),
+    );
+    expect(await getCachedGenres()).toBeUndefined();
+  });
+
+  it("fails open to undefined when the backend url is unset", async () => {
+    delete process.env.NEXT_PUBLIC_BACKEND_URL;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await getCachedGenres()).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #963

Experimental pilot of Next 16 Cache Components (`"use cache"`), scoped to the near-static library genre list only. No other RTK Query endpoint's data flow is touched.

> **Draft — do not merge yet.** A design-level blocker (below) means the seed is inert until a Backend-Service change lands. This PR delivers the code-level pattern + invalidation wiring the issue asks for; the runtime win switches on once the blocker and the OpenNext cache adapter work land.

## Blocker (needs a maintainer decision — not fixable in this PR)

`GET /library/genres` is guarded by `requirePermissions({ catalog: ['read'] })` in Backend-Service (`apps/backend/routes/library.route.ts`), and that middleware 401s any request without an `Authorization` header — including under `AUTH_BYPASS`. A `"use cache"` function **cannot read cookies or headers** (and keying a shared cache by a user token would be wrong anyway), so the cached accessor is header-less by construction. It therefore gets **401 → empty seed on every request, in every environment.** As shipped, the seed is permanently empty; the client RTK query remains the real source of truth, so nothing regresses, but the pilot delivers no first-paint benefit until the endpoint is reachable unauthenticated.

Unblock condition: **WXYC/Backend-Service#1682** — expose `GET /library/genres` (or an equivalent) on a public tier. That is a Backend-Service call, out of scope here.

## What changed
- **`getCachedGenres()`** (`lib/features/catalog/server.ts`) — split into a throwing cached inner (`"use cache"` + `cacheLife("hours")` + `cacheTag("genres")`) and an undefined-returning wrapper. The inner throws on any failure — non-2xx, empty/non-JSON body, or a **non-array** payload (`Array.isArray` guard, so a valid-JSON non-array 200 can't reach `genres?.map` and throw) — because Next's use-cache runtime does not persist an errored stream, so throwing is what stops a transient failure being cached as an empty list for the whole `cacheLife` window. The wrapper fails open to `undefined`.
- **Shared fetch core** (`lib/features/server-fetch.ts`) — extracted `fetchBackendJson` (timeout + parse, throws on failure) from `fetchBackendSeed`; both now share the request-time timeout so the cached path can't stall the catalog route before first byte. `fetchBackendSeed`'s external contract is unchanged.
- **`revalidateGenres()`** (`lib/features/catalog/actions.ts`) — `"use server"` action calling `revalidateTag("genres", "max")`, wired into `addGenre`'s `onQueryStarted`.
- **`Genres` RTK tag** — `getGenres` provides it, `addGenre` invalidates it, so an in-session add refreshes the client list without a reload (independent of the server tag cache).
- **`experimental.useCache: true`** (`next.config.mjs`) — enables the directive *without* the full `cacheComponents` PPR strict mode (which would force `Suspense`/`"use cache"` on every dynamic data access app-wide). Deliberately the lighter flag.
- **Seed wiring** — the catalog page (now an async Server Component) passes the cached genres through **both** the desktop `SearchBar` and the mobile `MobileSearchBar` → `QueryBuilder` → `Filters` as `initialGenres`. `undefined` on failure keeps the client loading skeleton reachable; the client `useGetGenresQuery` owns the value once it resolves (same seed pattern as `/live` NowPlaying).

## Experiment result
**Pattern + wiring: correct and building. Runtime benefit: currently inert on two independent axes.**

- **Works today (verified):** The `"use cache"` directive compiles and bundles under both `next build` and `npm run build:opennext` (`@opennextjs/cloudflare` 1.20.1 ships a `use-cache` build patch and supports it). No route regressed. Same-request / same-isolate memoization is live (the page awaits the cached fn once per render).
- **Inert today (verified):**
  - **Seed content** — blocked by the auth guard above (Backend-Service#1682). Empty on every request until the endpoint is public.
  - **Cross-request persistence + tag revalidation** — `open-next.config.ts` wires `incrementalCache`/`tagCache` to the `"dummy"` no-op backends, so there is no store behind `cacheLife`/`cacheTag` and `revalidateTag("genres")` clears nothing. Requires the OpenNext KV/R2 cache adapter work (separate cross-team effort).

## What to check
- The two independent inert axes are understood: the auth guard (Backend-Service#1682) gates *seed content*; the dummy OpenNext caches gate *cross-request persistence*. Both must resolve for a real first-paint cache win; neither is a defect in this PR.
- `experimental.useCache: true` is the intended flag (not `cacheComponents`).
- `revalidateTag` runs through a `"use server"` action because it is server-only and `addGenre` dispatches client-side.
- The `Genres` RTK tag gives correct in-session client behavior today regardless of the server cache.
- Caveat comments name dependencies in prose only — no tracker numbers in code, comments, or tests.

## Verification gate
- `npx tsc --noEmit` — clean.
- `npm run lint` — 0 errors (pre-existing warnings only; none added).
- Targeted + full `npx vitest run` — 282 files / 3803 tests pass. New coverage: `getCachedGenres` fail-open paths (non-2xx, non-array body, empty body, timeout/rejection, unset URL → `undefined`), the reachable loading affordance when no seed is present, and the in-session genre refetch after an add.
- `npm run build` — success.
- `npm run build:opennext` — success (the make-or-break; the directive is not an OpenNext blocker at 1.20.1).
- `npx wrangler pages dev --port 3001` + curl: `/`, `/live`, `/playlists`, `/login` → 200; `/dashboard` → 307 → `/dashboard/catalog`; `/dashboard/catalog` → 307 → `/login?bounced=no-session`.
  - **Caveat on that last check:** the `/dashboard/catalog` 307 is the *unauthenticated* auth bounce, which fires in the middleware/layout **before** the page component — and therefore before the cached accessor — ever runs. So this proves the auth gate and unrelated routes are intact, but it does **not** exercise the authed render path or `getCachedGenres()` locally. The authed render was not exercised in this environment (no local session); it is covered by the unit/integration tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
