### PR TITLE
fix(deploy): preview script uses Pages-mode wrangler

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:opennext": "opennextjs-cloudflare build && node scripts/post-build.js",
     "analyze": "next build --experimental-analyze && node scripts/analyze-bundle.mjs",
     "start": "next start",
-    "preview": "npm run build:opennext && opennextjs-cloudflare preview",
+    "preview": "npm run build:opennext && wrangler pages dev .open-next/assets",
     "deploy": "npm run build:opennext && wrangler pages deploy .open-next/assets",
     "test": "vitest",
     "test:ui": "vitest --ui",


### PR DESCRIPTION
## Summary
- `preview` npm script ran `opennextjs-cloudflare preview`, which shells to `wrangler dev` — a Workers-specific command that hard-errors against this repo's Pages-mode `wrangler.jsonc` (same class of bug as the `upload` script removed in #964).
- Repointed at `wrangler pages dev .open-next/assets`, mirroring the directory argument already used by the `deploy` script.
- Script is kept (not removed): it's the only local gate that catches request-time RSC errors on dynamic routes.

## Test plan
- [x] `node -e "JSON.parse(...)"` confirms `package.json` is still valid JSON
- [x] `npm run` lists the updated `preview` script
- [x] Did not run the preview build itself (heavy, out of scope per maintainer's standing rules)

Closes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)