### PR TITLE
fix(player): pausing the stream no longer tears down the audio element

### DIFF
--- a/e2e/pages/now-playing.page.ts
+++ b/e2e/pages/now-playing.page.ts
@@ -63,15 +63,19 @@ export class NowPlayingPage {
    * In headless Chromium the real audio.play() rejects (no audio device)
    * and the browser may asynchronously fire a "pause" event that races
    * with React's state update, leaving isPlaying indeterminate. We stub
-   * audio.play() to dispatch a "play" event and resolve immediately,
-   * then wait for React to re-render before returning.
+   * audio.play() to dispatch a "play" event and resolve immediately.
+   *
+   * The synthetic "play" is deferred to a macrotask so it lands after the
+   * "emptied" event the browser fires when the widget (re)assigns src on
+   * resume — matching real playback, where play follows emptied. Firing it
+   * synchronously would let the later emptied undo the playing state.
    */
   async play(): Promise<void> {
     await this.page.evaluate(() => {
       const audio = document.querySelector("#now-playing-music") as HTMLAudioElement;
       if (audio) {
         audio.play = () => {
-          audio.dispatchEvent(new Event("play"));
+          setTimeout(() => audio.dispatchEvent(new Event("play")), 0);
           return Promise.resolve();
         };
       }

--- a/e2e/tests/flowsheet/audio-stream.spec.ts
+++ b/e2e/tests/flowsheet/audio-stream.spec.ts
@@ -8,10 +8,8 @@ const authDir = path.join(__dirname, "../../.auth");
  * NowPlaying Audio Stream E2E Tests
  *
  * Verifies that the live MP3 stream is not buffered until the user
- * explicitly presses play, and that stopping fully tears down the
- * connection.
- *
- * See: https://github.com/WXYC/dj-site/issues/374
+ * explicitly presses play, and that pausing keeps the element intact so
+ * playback can resume from the live edge.
  */
 test.describe("NowPlaying audio stream", () => {
   test.use({ storageState: path.join(authDir, "dj2.json") });
@@ -38,7 +36,7 @@ test.describe("NowPlaying audio stream", () => {
     await nowPlaying.expectNoSrc();
   });
 
-  test("should set src on play and remove it on stop", async ({ page }) => {
+  test("keeps the stream source while paused", async ({ page }) => {
     const nowPlaying = new NowPlayingPage(page);
     await nowPlaying.blockAudioStream();
 
@@ -51,24 +49,28 @@ test.describe("NowPlaying audio stream", () => {
     await nowPlaying.expectStreamSrc();
 
     await nowPlaying.stop();
-    await nowPlaying.expectNoSrc();
+    // Pausing does not tear down the element; the source is retained so resume
+    // can restart playback without rebuilding the audio graph.
+    await nowPlaying.expectStreamSrc();
+    await expect(nowPlaying.playButton).toBeVisible();
   });
 
-  test("should reconnect stream on second play", async ({ page }) => {
+  test("resumes playback on a second play after pausing", async ({ page }) => {
     const nowPlaying = new NowPlayingPage(page);
     await nowPlaying.blockAudioStream();
 
     await page.goto("/dashboard/flowsheet");
     await page.waitForLoadState("domcontentloaded");
 
-    // Play → stop
     await nowPlaying.play();
     await nowPlaying.expectStreamSrc();
     await nowPlaying.stop();
-    await nowPlaying.expectNoSrc();
+    await nowPlaying.expectStreamSrc();
 
-    // Play again — should reconnect
+    // Second play reassigns src, re-running the media load algorithm to snap
+    // back to the live edge; the pause button reappearing confirms resume.
     await nowPlaying.play();
     await nowPlaying.expectStreamSrc();
+    await expect(nowPlaying.pauseButton).toBeVisible();
   });
 });

--- a/src/widgets/NowPlaying/index.tsx
+++ b/src/widgets/NowPlaying/index.tsx
@@ -120,17 +120,23 @@ export default function NowPlaying({
     if (!audio) return;
 
     const handlePlay = () => setIsPlaying(true);
-    const handlePause = () => setIsPlaying(false);
-    const handleEnded = () => setIsPlaying(false);
+    // Any transition away from playing — pause, end, or an element that gets
+    // emptied/errored outside the toggle path — must clear the flag, or the
+    // button can desync from the element's real state.
+    const handleStop = () => setIsPlaying(false);
 
     audio.addEventListener("play", handlePlay);
-    audio.addEventListener("pause", handlePause);
-    audio.addEventListener("ended", handleEnded);
+    audio.addEventListener("pause", handleStop);
+    audio.addEventListener("ended", handleStop);
+    audio.addEventListener("emptied", handleStop);
+    audio.addEventListener("error", handleStop);
 
     return () => {
       audio.removeEventListener("play", handlePlay);
-      audio.removeEventListener("pause", handlePause);
-      audio.removeEventListener("ended", handleEnded);
+      audio.removeEventListener("pause", handleStop);
+      audio.removeEventListener("ended", handleStop);
+      audio.removeEventListener("emptied", handleStop);
+      audio.removeEventListener("error", handleStop);
     };
   }, []);
 
@@ -140,9 +146,9 @@ export default function NowPlaying({
 
     if (isPlaying) {
       audio.pause();
-      audio.removeAttribute("src");
-      audio.load();
     } else {
+      // Re-assigning src re-runs the media load algorithm, snapping a paused
+      // live stream back to the live edge instead of resuming a stale buffer.
       audio.src = AUDIO_SRC;
       audio.play().catch((error) => {
         console.error("Failed to play audio:", error);

--- a/tests/integration/components/widgets/NowPlaying/index.playback.test.tsx
+++ b/tests/integration/components/widgets/NowPlaying/index.playback.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, screen } from "@testing-library/react";
+import { renderWithProviders as render } from "@/tests/helpers";
+import NowPlaying from "@/src/widgets/NowPlaying";
+
+const mockUseWhoIsLiveQuery = vi.fn();
+const mockUseGetNowPlayingQuery = vi.fn();
+
+vi.mock("@/lib/features/flowsheet/api", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/lib/features/flowsheet/api")
+  >();
+  return {
+    ...actual,
+    useGetNowPlayingQuery: (arg: unknown, options: unknown) =>
+      mockUseGetNowPlayingQuery(arg, options),
+    useWhoIsLiveQuery: () => mockUseWhoIsLiveQuery(),
+  };
+});
+
+// Expose the toggle handler and playing flag through a real button so the tests
+// exercise the widget the way the UI does.
+vi.mock("@/src/widgets/NowPlaying/Main", () => ({
+  default: ({
+    isPlaying,
+    onTogglePlay,
+  }: {
+    isPlaying: boolean;
+    onTogglePlay: () => void;
+  }) => (
+    <button
+      data-testid="toggle"
+      data-is-playing={isPlaying}
+      onClick={onTogglePlay}
+    />
+  ),
+}));
+
+vi.mock("@/src/widgets/NowPlaying/Mini", () => ({
+  default: () => <div data-testid="now-playing-mini" />,
+}));
+
+function installFakeAudio() {
+  class FakeAudioContext {
+    destination = {};
+    createAnalyser = vi.fn(() => ({ fftSize: 0, connect: vi.fn() }));
+    createMediaElementSource = vi.fn(() => ({ connect: vi.fn() }));
+    resume = vi.fn();
+    close = vi.fn(() => Promise.resolve());
+  }
+  vi.stubGlobal("AudioContext", FakeAudioContext);
+}
+
+describe("NowPlaying stream playback", () => {
+  let playSpy: ReturnType<typeof vi.spyOn>;
+  let pauseSpy: ReturnType<typeof vi.spyOn>;
+  let loadSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installFakeAudio();
+
+    mockUseWhoIsLiveQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    });
+    mockUseGetNowPlayingQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    });
+
+    // jsdom leaves the media methods unimplemented; back them with stubs that
+    // emit the real play/pause events the widget listens for.
+    playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockImplementation(function (this: HTMLMediaElement) {
+        this.dispatchEvent(new Event("play"));
+        return Promise.resolve();
+      });
+    pauseSpy = vi
+      .spyOn(HTMLMediaElement.prototype, "pause")
+      .mockImplementation(function (this: HTMLMediaElement) {
+        this.dispatchEvent(new Event("pause"));
+      });
+    loadSpy = vi
+      .spyOn(HTMLMediaElement.prototype, "load")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    playSpy.mockRestore();
+    pauseSpy.mockRestore();
+    loadSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  function getToggle() {
+    return screen.getByTestId("toggle");
+  }
+
+  function getAudio(container: HTMLElement) {
+    return container.querySelector("audio#now-playing-music") as HTMLAudioElement;
+  }
+
+  it("starts the stream and reflects the playing state on first toggle", () => {
+    const { container } = render(<NowPlaying mini={false} />);
+    const audio = getAudio(container);
+
+    fireEvent.click(getToggle());
+
+    expect(playSpy).toHaveBeenCalledTimes(1);
+    expect(audio.getAttribute("src")).toBe("https://audio-mp3.ibiblio.org/wxyc.mp3");
+    expect(getToggle()).toHaveAttribute("data-is-playing", "true");
+  });
+
+  it("pauses without tearing down the element on second toggle", () => {
+    const { container } = render(<NowPlaying mini={false} />);
+    const audio = getAudio(container);
+
+    fireEvent.click(getToggle());
+    fireEvent.click(getToggle());
+
+    expect(pauseSpy).toHaveBeenCalledTimes(1);
+    // The src must survive a pause so resume can play again; load() would empty
+    // the element and desync the button.
+    expect(audio.hasAttribute("src")).toBe(true);
+    expect(loadSpy).not.toHaveBeenCalled();
+    expect(getToggle()).toHaveAttribute("data-is-playing", "false");
+  });
+
+  it("resumes playback on a third toggle", () => {
+    render(<NowPlaying mini={false} />);
+
+    fireEvent.click(getToggle());
+    fireEvent.click(getToggle());
+    fireEvent.click(getToggle());
+
+    expect(playSpy).toHaveBeenCalledTimes(2);
+    expect(getToggle()).toHaveAttribute("data-is-playing", "true");
+  });
+
+  it("clears the playing state when the element is emptied outside the toggle path", () => {
+    const { container } = render(<NowPlaying mini={false} />);
+    const audio = getAudio(container);
+
+    fireEvent.click(getToggle());
+    expect(getToggle()).toHaveAttribute("data-is-playing", "true");
+
+    act(() => {
+      audio.dispatchEvent(new Event("emptied"));
+    });
+
+    expect(getToggle()).toHaveAttribute("data-is-playing", "false");
+  });
+});


### PR DESCRIPTION
## Problem

Pausing the WXYC stream left the play/pause button stuck, made resume play nothing, and turned the visualizer solid pink.

The pause branch didn't just pause — it tore the element down (`pause()` + `removeAttribute("src")` + `load()`). `load()` on a src-less element fires an `emptied`/`error` chain that the `isPlaying` state (which only mirrored `play`/`pause`) never tracked, so the button desynced. The dead element also routed into a suspended audio graph on resume: no sound, and `GradientAudioVisualizer` stopped painting, exposing its base pink fallback gradient.

## Fix

- **Pause branch** → plain `audio.pause()`. The full teardown already lives in the unmount cleanup and is left unchanged there.
- **Play branch** keeps the unconditional `src` reassignment before `play()`; re-running the media load algorithm snaps a paused live stream back to the live edge instead of resuming a stale buffer.
- **`isPlaying` listener** now folds `pause`/`ended`/`emptied`/`error` into one stop handler, so the button can't desync if the element is emptied outside the toggle path.

No widget-level `AudioContext.resume()` is needed: `GradientAudioVisualizer`'s `play` listener already resumes the context and restarts the paint loop.

## Tests

New `tests/integration/components/widgets/NowPlaying/index.playback.test.tsx`: first toggle sets src and plays; second toggle pauses with the src attribute intact and `load()` never called; third toggle resumes; an `emptied` event clears the playing state. Full suite green (282 files / 3795 tests), `tsc --noEmit` clean.

Closes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)