### PR TITLE
fix(flowsheet): hover actions no longer cover the entry status chips

### DIFF
--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
@@ -10,7 +10,7 @@ import { useDragControls } from "motion/react";
 import { memo, useState } from "react";
 import DragButton from "../Components/DragButton";
 import DraggableEntryWrapper from "../DraggableEntryWrapper";
-import { FLOWSHEET_XL_QUERY } from "../tableStyles";
+import { flowsheetChipsReservePx, FLOWSHEET_XL_QUERY } from "../tableStyles";
 import FlowsheetEntryField from "./FlowsheetEntryField";
 import SongEntryControls from "./SongEntryControls";
 import SongEntryStatusChips from "./SongEntryStatusChips";
@@ -225,13 +225,12 @@ const SongEntry = memo(function SongEntry({
           gap={0.75}
           alignItems="center"
           flexWrap="wrap"
-          className="status-chips"
-          // Reserve room for the hover action cluster, which overlays this cell
-          // from the right edge (the absolutely-positioned Stack below). Without
-          // it the chips extend under the actions and get covered — unclickable
-          // while the row is hovered. Editable rows expose four controls
-          // (segue, request, info, remove); read-only rows only the info button.
-          style={{ paddingRight: editable ? "160px" : "48px" }}
+          // Reserve the hover action cluster's footprint (it overlays this cell
+          // from the right edge — the absolutely-positioned Stack below) so no
+          // chip renders underneath it, where it would be covered and
+          // unclickable on hover. The reserve tracks how many controls the row
+          // shows; the column is sized to leave a chip's width beside it.
+          sx={{ pr: `${flowsheetChipsReservePx(editable)}px` }}
         >
           <SongEntryStatusChips entry={entry} editable={editable} />
         </Stack>

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
@@ -220,7 +220,19 @@ const SongEntry = memo(function SongEntry({
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
-        <Stack direction="row" gap={0.75} alignItems="center" flexWrap="wrap">
+        <Stack
+          direction="row"
+          gap={0.75}
+          alignItems="center"
+          flexWrap="wrap"
+          className="status-chips"
+          // Reserve room for the hover action cluster, which overlays this cell
+          // from the right edge (the absolutely-positioned Stack below). Without
+          // it the chips extend under the actions and get covered — unclickable
+          // while the row is hovered. Editable rows expose four controls
+          // (segue, request, info, remove); read-only rows only the info button.
+          style={{ paddingRight: editable ? "160px" : "48px" }}
+        >
           <SongEntryStatusChips entry={entry} editable={editable} />
         </Stack>
         <Stack

--- a/src/components/experiences/modern/flowsheet/Entries/tableStyles.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/tableStyles.tsx
@@ -22,8 +22,47 @@ export const FLOWSHEET_DRAG_GUTTER_NARROW_PX = 16;
 // exact template so they align with the columns below as de-facto headers.
 // Change these only in lock-step with FLOWSHEET_TABLE_SX's breakpoints.
 export const FLOWSHEET_COL_ART_PX = 60;
-export const FLOWSHEET_COL_ACTIONS_PX = 150;
-export const FLOWSHEET_CELL_PADDING_X = "12px";
+export const FLOWSHEET_CELL_PADDING_X_PX = 12;
+export const FLOWSHEET_CELL_PADDING_X = `${FLOWSHEET_CELL_PADDING_X_PX}px`;
+
+// The last column holds the status chips (in flow) and the hover action
+// cluster (an absolute overlay pinned to the cell's right edge). Both the
+// column width and the chips' reserved padding derive from the controls'
+// real footprint so the two can never disagree: every control is a 32px sm
+// icon-button/checkbox target laid out in a 4px-gap row.
+export const FLOWSHEET_ACTION_CONTROL_PX = 32;
+export const FLOWSHEET_ACTION_GAP_PX = 4;
+
+// Width of a row of `count` action controls.
+const actionsRowWidthPx = (count: number) =>
+  count * FLOWSHEET_ACTION_CONTROL_PX +
+  Math.max(0, count - 1) * FLOWSHEET_ACTION_GAP_PX;
+
+// Editable rows expose four controls (segue, request, info, remove); read-only
+// rows only the info button.
+export const FLOWSHEET_ACTIONS_EDITABLE_PX = actionsRowWidthPx(4);
+export const FLOWSHEET_ACTIONS_READONLY_PX = actionsRowWidthPx(1);
+
+// Room kept to the left of the action cluster for a status chip so no chip
+// ever renders under the overlay. Sized for the widest single pill
+// (EXCLUSIVE); extra chips wrap onto a second line within this zone (the row
+// is tall enough), still clear of the actions.
+export const FLOWSHEET_STATUS_CHIP_MIN_PX = 72;
+
+// Padding-right the chip row reserves for the overlay, by row editability, so
+// the actions never paint over a chip. One gap separates the last chip from
+// the first control.
+export const flowsheetChipsReservePx = (editable: boolean) =>
+  (editable ? FLOWSHEET_ACTIONS_EDITABLE_PX : FLOWSHEET_ACTIONS_READONLY_PX) +
+  FLOWSHEET_ACTION_GAP_PX;
+
+// The column must fit the widest reserve (editable) plus a chip beside it,
+// within the cell's horizontal padding — otherwise fixed table layout would
+// clip the chip zone to zero and the overlay would sit on the chips again.
+export const FLOWSHEET_COL_ACTIONS_PX =
+  flowsheetChipsReservePx(true) +
+  FLOWSHEET_STATUS_CHIP_MIN_PX +
+  2 * FLOWSHEET_CELL_PADDING_X_PX;
 
 // Shared row/hover/action treatment for the entries and queue tables. The
 // queue never renders a `row-playing` row, so those rules are inert there.

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
@@ -1025,3 +1025,87 @@ describe("SongEntry two-line row structure", () => {
     expect(screen.queryByText("REQ")).toBeNull();
   });
 });
+
+describe("SongEntry status chips reserve space for the hover actions", () => {
+  const mockEntry: FlowsheetSongEntry = {
+    id: 1,
+    play_order: 0,
+    show_id: 100,
+    track_title: "On Your Own Love Again",
+    artist_name: "Jessica Pratt",
+    album_title: "On Your Own Love Again",
+    record_label: "Drag City",
+    request_flag: false,
+    segue: false,
+    album_id: 42,
+    rotation: "H",
+    rotation_id: 10,
+    artwork_url: "/test-album-art.jpg",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseFlowsheet.mockReturnValue({ updateFlowsheet: mockUpdateFlowsheet });
+  });
+
+  const chipContainer = () =>
+    screen
+      .getByTestId("draggable-wrapper")
+      .querySelector<HTMLElement>(".status-chips");
+
+  it("reserves the wider four-control gap on editable rows", () => {
+    mockUseShowControl.mockReturnValue({
+      live: true,
+      autoplay: false,
+      currentShow: 100,
+    });
+    render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
+
+    const container = chipContainer();
+    expect(container).not.toBeNull();
+    expect(container).toHaveStyle({ paddingRight: "160px" });
+    // The chips still render inside the reserved container.
+    expect(container!.textContent).toContain("H");
+  });
+
+  it("reserves the narrow info-only gap on read-only rows", () => {
+    mockUseShowControl.mockReturnValue({
+      live: true,
+      autoplay: false,
+      currentShow: 999,
+    });
+    render(
+      <SongEntry
+        entry={{ ...mockEntry, request_flag: true, segue: true }}
+        playing={false}
+        queue={false}
+      />
+    );
+
+    const container = chipContainer();
+    expect(container).not.toBeNull();
+    expect(container).toHaveStyle({ paddingRight: "48px" });
+    // Read-only rows surface request/segue as chips; they live in the
+    // reserved container too.
+    expect(container!.textContent).toContain("REQ");
+    expect(container!.textContent).toContain("SEGUE");
+  });
+
+  it("still renders the action controls alongside the reserved chips", () => {
+    mockUseShowControl.mockReturnValue({
+      live: true,
+      autoplay: false,
+      currentShow: 100,
+    });
+    render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
+
+    expect(chipContainer()).not.toBeNull();
+    // The info button (album detail) is part of the overlaid controls.
+    const infoButton = screen
+      .getAllByRole("button")
+      .find((btn) =>
+        btn.querySelector('[data-testid="InfoOutlinedIcon"]')
+      );
+    expect(infoButton).toBeDefined();
+  });
+});

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
@@ -1,6 +1,14 @@
 import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import SongEntry from "@/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry";
+import {
+  flowsheetChipsReservePx,
+  FLOWSHEET_ACTIONS_EDITABLE_PX,
+  FLOWSHEET_ACTIONS_READONLY_PX,
+  FLOWSHEET_CELL_PADDING_X_PX,
+  FLOWSHEET_COL_ACTIONS_PX,
+  FLOWSHEET_STATUS_CHIP_MIN_PX,
+} from "@/src/components/experiences/modern/flowsheet/Entries/tableStyles";
 import { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
 
 // Mock hooks
@@ -1048,12 +1056,38 @@ describe("SongEntry status chips reserve space for the hover actions", () => {
     mockUseFlowsheet.mockReturnValue({ updateFlowsheet: mockUpdateFlowsheet });
   });
 
-  const chipContainer = () =>
-    screen
-      .getByTestId("draggable-wrapper")
-      .querySelector<HTMLElement>(".status-chips");
+  // jsdom does no layout, so the geometry contract is proven against the
+  // shared constants the overlay and the column derive from — not by reading
+  // back computed pixels.
+  describe("reserve geometry contract", () => {
+    it("reserves at least the full action-cluster footprint on each row type", () => {
+      expect(flowsheetChipsReservePx(true)).toBeGreaterThanOrEqual(
+        FLOWSHEET_ACTIONS_EDITABLE_PX
+      );
+      expect(flowsheetChipsReservePx(false)).toBeGreaterThanOrEqual(
+        FLOWSHEET_ACTIONS_READONLY_PX
+      );
+    });
 
-  it("reserves the wider four-control gap on editable rows", () => {
+    it("reserves more room on editable rows (four controls) than read-only (info only)", () => {
+      expect(flowsheetChipsReservePx(true)).toBeGreaterThan(
+        flowsheetChipsReservePx(false)
+      );
+    });
+
+    it("keeps a chip's width beside the widest reserve within the column", () => {
+      // The invariant the whole fix rests on: even the editable reserve leaves
+      // at least one pill's width of chip space inside the fixed column, so a
+      // chip can never be clipped to zero and forced under the overlay.
+      const chipZone =
+        FLOWSHEET_COL_ACTIONS_PX -
+        2 * FLOWSHEET_CELL_PADDING_X_PX -
+        flowsheetChipsReservePx(true);
+      expect(chipZone).toBeGreaterThanOrEqual(FLOWSHEET_STATUS_CHIP_MIN_PX);
+    });
+  });
+
+  it("renders both the status chips and the overlaid controls on an editable row", () => {
     mockUseShowControl.mockReturnValue({
       live: true,
       autoplay: false,
@@ -1061,14 +1095,15 @@ describe("SongEntry status chips reserve space for the hover actions", () => {
     });
     render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
 
-    const container = chipContainer();
-    expect(container).not.toBeNull();
-    expect(container).toHaveStyle({ paddingRight: "160px" });
-    // The chips still render inside the reserved container.
-    expect(container!.textContent).toContain("H");
+    // Chip present (rotation "H") next to the action controls (info button).
+    expect(screen.getByText("H")).toBeInTheDocument();
+    const infoButton = screen
+      .getAllByRole("button")
+      .find((btn) => btn.querySelector('[data-testid="InfoOutlinedIcon"]'));
+    expect(infoButton).toBeDefined();
   });
 
-  it("reserves the narrow info-only gap on read-only rows", () => {
+  it("renders the request/segue chips beside the info control on read-only rows", () => {
     mockUseShowControl.mockReturnValue({
       live: true,
       autoplay: false,
@@ -1082,30 +1117,9 @@ describe("SongEntry status chips reserve space for the hover actions", () => {
       />
     );
 
-    const container = chipContainer();
-    expect(container).not.toBeNull();
-    expect(container).toHaveStyle({ paddingRight: "48px" });
-    // Read-only rows surface request/segue as chips; they live in the
-    // reserved container too.
-    expect(container!.textContent).toContain("REQ");
-    expect(container!.textContent).toContain("SEGUE");
-  });
-
-  it("still renders the action controls alongside the reserved chips", () => {
-    mockUseShowControl.mockReturnValue({
-      live: true,
-      autoplay: false,
-      currentShow: 100,
-    });
-    render(<SongEntry entry={mockEntry} playing={false} queue={false} />);
-
-    expect(chipContainer()).not.toBeNull();
-    // The info button (album detail) is part of the overlaid controls.
-    const infoButton = screen
-      .getAllByRole("button")
-      .find((btn) =>
-        btn.querySelector('[data-testid="InfoOutlinedIcon"]')
-      );
-    expect(infoButton).toBeDefined();
+    expect(screen.getByText("REQ")).toBeInTheDocument();
+    expect(screen.getByText("SEGUE")).toBeInTheDocument();
+    // Read-only rows drop the editable checkboxes; only the info button remains.
+    expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
   });
 });


### PR DESCRIPTION
On a flowsheet song entry row the edit/info hover actions overlaid the status pills (rotation / request / segue) in the last cell. The chips render in-flow while the `.row-actions` cluster is an absolute overlay pinned to the cell's right edge, and nothing kept the chips clear of it.

## Why a plain reserve wasn't enough
The last column is `table-layout: fixed` and pinned to a shared width constant (used by both the entries/queue tables via `FlowsheetColumnSizingRow` and by the entry bar via `ENTRY_BAR_GRID_TEMPLATE`). At the old 150px, the editable action cluster (segue + request + info + remove ≈ 140px) already fills the column, so an always-on padding reserve just collapsed the chip zone to zero and wrapped chips vertically under the overlay. Reserve-space cannot work *inside* a 150px column for editable rows.

## Fix (issue direction: reserve space, made geometrically honest)
Derive everything from the controls' real footprint instead of guessing:
- Each control is a 32px `sm` target in a 4px-gap row -> editable cluster = `4·32 + 3·4 = 140px`, read-only = `32px` (info only).
- The chips' reserved `padding-right` = that cluster width + one gap (`144px` editable, `36px` read-only).
- The shared column width is **derived** as `editableReserve(144) + oneChipWidth(72) + 2·cellPadding(12) = 240px`, guaranteeing the fixed column always leaves at least one pill's width of chip space beside the overlay. No free-floating pixel constants; no test-only DOM hooks.

So chips never render under the actions on either row type, and multiple read-only chips (rotation + REQ + SEGUE) wrap within their zone, clear of the info button.

### Tradeoff (honest)
Widening the shared column 150 -> 240px redistributes width under fixed layout. Below `xl` (e.g. 1024px) the visible columns are art(60) | title(1fr) | album(1fr) | actions(240), so title+album lose ~90px combined vs before; the composer's four input fields (which share the template) narrow by the same amount to stay aligned. Modern title/album already truncate with a tooltip, so text stays recoverable.

**Needs a maintainer eyeball post-merge** (no dev server / screenshots taken): editable rows carrying both a rotation chip *and* the rare EXCLUSIVE pill at 1024–1440px — confirm the chips sit cleanly beside the revealed actions.

Mobile (`MobileSongEntry.tsx`, controls on a separate bottom row) is untouched.

## Tests
`SongEntry.test.tsx` asserts the geometry contract against the shared constants (editable reserve ≥ cluster width; editable reserve > read-only; the column leaves ≥ one pill's width beside the widest reserve) plus behavioral render of chips + controls on editable and read-only rows. jsdom does no layout, so the contract is proven via the constants the overlay and column both derive from — not by reading back pixels. Targeted file 62/62; full vitest 3796/3796; `tsc --noEmit` clean; lint 0 errors.

Considered the issue's option 3 (dedicated actions column): it needs the same horizontal space **and** touches every marker `colSpan`, the queue table, and the composer template — strictly more blast radius for no geometric gain, so I kept the single shared-constant approach.

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)