### PR TITLE
fix(bin): remove-from-bin action uses the Unarchive icon

### DIFF
--- a/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions.ts
+++ b/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions.ts
@@ -12,10 +12,10 @@ import {
 } from "@/lib/features/flowsheet/types";
 import { useAppDispatch } from "@/lib/hooks";
 import {
-  DeleteOutline,
   InfoOutlined,
   PlayArrowOutlined,
   PlaylistAdd,
+  Unarchive,
 } from "@mui/icons-material";
 import { ColorPaletteProp } from "@mui/joy";
 import { useMemo } from "react";
@@ -109,7 +109,7 @@ export function useBinEntryActions(
     actions.push({
       id: "remove",
       label: "Remove from Bin",
-      Icon: DeleteOutline,
+      Icon: Unarchive,
       color: "warning",
       run: () => deleteFromBin(entry.id),
     });

--- a/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
+++ b/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
+import { Unarchive } from "@mui/icons-material";
 import type { AlbumEntry } from "@/lib/features/catalog/types";
 
 const dispatch = vi.fn();
@@ -62,6 +63,12 @@ describe("useBinEntryActions", () => {
 
     byId.remove.run();
     expect(deleteFromBin).toHaveBeenCalledWith(7);
+  });
+
+  it("uses the Unarchive icon for remove, matching RemoveFromBin", () => {
+    const { result } = renderHook(() => useBinEntryActions(entry, false, deps));
+    const remove = result.current.find((a) => a.id === "remove");
+    expect(remove?.Icon).toBe(Unarchive);
   });
 
   it("marks queue and play as Shift-removable, but not info/remove", () => {


### PR DESCRIPTION
## Summary
- `useBinEntryActions.ts`'s remove action rendered `DeleteOutline` (a trash can), inconsistent with the catalog results pairing where `AddToBin.tsx` uses `Archive` and `RemoveFromBin.tsx` uses `Unarchive`.
- Swapped the icon to `Unarchive` so all three remove-from-bin surfaces (`BinEntryActions`, `BinEntryContextMenu`, `RemoveFromBin`) speak the same icon language. Label stays "Remove from Bin".
- `ClearBinButton`'s `DeleteSweep` is untouched — clearing the whole bin is a genuine delete, not an inverse-of-add action.

## Test plan
- [x] `npx vitest run tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx tests/integration/components/modern/Rightbar/Bin/BinEntryActions.test.tsx --maxWorkers=2` — 13 passing, includes a new assertion that the remove action's `Icon` is `Unarchive`
- [x] `npx tsc --noEmit` — clean

Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)