### PR TITLE
fix(classic): flowsheet album titles truncate with the full text recoverable

### DIFF
--- a/src/components/experiences/classic/flowsheet/EntryRow.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryRow.tsx
@@ -304,13 +304,12 @@ export default function EntryRow({
               }
               onKeyDown={handleEditKeyDown}
             />
-          ) : (
-            <span
-              className="classic-cell-truncate"
-              title={entry.album_title || ""}
-            >
-              {entry.album_title || ""}
+          ) : entry.album_title ? (
+            <span className="classic-cell-truncate" title={entry.album_title}>
+              {entry.album_title}
             </span>
+          ) : (
+            ""
           )}
         </td>
         <td align="left">
@@ -325,13 +324,12 @@ export default function EntryRow({
               }
               onKeyDown={handleEditKeyDown}
             />
-          ) : (
-            <span
-              className="classic-cell-truncate"
-              title={entry.record_label || ""}
-            >
-              {entry.record_label || ""}
+          ) : entry.record_label ? (
+            <span className="classic-cell-truncate" title={entry.record_label}>
+              {entry.record_label}
             </span>
+          ) : (
+            ""
           )}
         </td>
         <td align="center" className="action-cell">

--- a/src/components/experiences/classic/flowsheet/EntryRow.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryRow.tsx
@@ -271,7 +271,9 @@ export default function EntryRow({
               onKeyDown={handleEditKeyDown}
             />
           ) : (
-            entry.artist_name
+            <span className="classic-cell-truncate" title={entry.artist_name}>
+              {entry.artist_name}
+            </span>
           )}
         </td>
         <td align="left">
@@ -303,7 +305,12 @@ export default function EntryRow({
               onKeyDown={handleEditKeyDown}
             />
           ) : (
-            entry.album_title || ""
+            <span
+              className="classic-cell-truncate"
+              title={entry.album_title || ""}
+            >
+              {entry.album_title || ""}
+            </span>
           )}
         </td>
         <td align="left">
@@ -319,7 +326,12 @@ export default function EntryRow({
               onKeyDown={handleEditKeyDown}
             />
           ) : (
-            entry.record_label || ""
+            <span
+              className="classic-cell-truncate"
+              title={entry.record_label || ""}
+            >
+              {entry.record_label || ""}
+            </span>
           )}
         </td>
         <td align="center" className="action-cell">

--- a/src/styles/classic/flowsheet.css
+++ b/src/styles/classic/flowsheet.css
@@ -54,6 +54,20 @@ body {
 	font-family: Verdana, Geneva, Arial, Helvetica, sans-serif;
 }
 
+/* Clamp long artist / release / label values to a single line with an
+   ellipsis; the full text stays reachable via the cell's title attribute.
+   inline-block + max-width so truncation works without a fixed table layout;
+   max-width in em keeps the character budget stable across the font-size
+   classes. */
+.classic-cell-truncate {
+	display: inline-block;
+	max-width: 20em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	vertical-align: bottom;
+}
+
 .fontSize7 {
 	font-size: 1.7em;
 }

--- a/tests/integration/components/classic/flowsheet/EntryRow.test.tsx
+++ b/tests/integration/components/classic/flowsheet/EntryRow.test.tsx
@@ -734,3 +734,63 @@ describe("Classic EntryRow action menu + inline edit (song rows)", () => {
     ).toBeNull();
   });
 });
+
+describe("Classic EntryRow truncates long text with the full value recoverable", () => {
+  const LONG_ALBUM =
+    "On Your Own Love Again (Deluxe Expanded Anniversary Edition, Remastered)";
+  const LONG_ARTIST = "Chuquimamani-Condori and Joshua Chuquimia Crampton";
+  const LONG_LABEL = "Sonamos Recordings International Distribution Division";
+
+  const longEntry = () =>
+    createTestFlowsheetEntry({
+      artist_name: LONG_ARTIST,
+      album_title: LONG_ALBUM,
+      record_label: LONG_LABEL,
+    });
+
+  it("clamps the album cell and keeps the full title in its title attribute", () => {
+    const { container } = renderRow({ entry: longEntry() });
+    const cell = container.querySelector<HTMLElement>(
+      'span.classic-cell-truncate[title="' + LONG_ALBUM + '"]'
+    );
+    expect(cell).not.toBeNull();
+    expect(cell!.textContent).toBe(LONG_ALBUM);
+  });
+
+  it("applies the same treatment to the artist and label cells", () => {
+    const { container } = renderRow({ entry: longEntry() });
+    const artist = container.querySelector<HTMLElement>(
+      'span.classic-cell-truncate[title="' + LONG_ARTIST + '"]'
+    );
+    const label = container.querySelector<HTMLElement>(
+      'span.classic-cell-truncate[title="' + LONG_LABEL + '"]'
+    );
+    expect(artist).not.toBeNull();
+    expect(artist!.textContent).toBe(LONG_ARTIST);
+    expect(label).not.toBeNull();
+    expect(label!.textContent).toBe(LONG_LABEL);
+  });
+
+  it("carries the truncation class on each affected cell", () => {
+    const { container } = renderRow({ entry: longEntry() });
+    // Artist, album, and label each get one truncating wrapper.
+    expect(
+      container.querySelectorAll("span.classic-cell-truncate")
+    ).toHaveLength(3);
+  });
+
+  it("does not truncate while the row is being edited (inputs stay full)", () => {
+    const { container } = renderRow({ entry: longEntry() });
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Edit" }));
+    // In edit mode the values live in inputs, not truncating spans.
+    expect(
+      container.querySelectorAll("span.classic-cell-truncate")
+    ).toHaveLength(0);
+    expect(
+      (container.querySelector(
+        'input[name="album_title"]'
+      ) as HTMLInputElement).value
+    ).toBe(LONG_ALBUM);
+  });
+});

--- a/tests/integration/components/classic/flowsheet/EntryRow.test.tsx
+++ b/tests/integration/components/classic/flowsheet/EntryRow.test.tsx
@@ -779,6 +779,21 @@ describe("Classic EntryRow truncates long text with the full value recoverable",
     ).toHaveLength(3);
   });
 
+  it("renders no truncating wrapper for an absent album or label (no empty span)", () => {
+    const { container } = renderRow({
+      entry: createTestFlowsheetEntry({
+        artist_name: LONG_ARTIST,
+        album_title: undefined,
+        record_label: undefined,
+      }),
+    });
+    // Only the artist cell wraps; empty album/label stay bare so there's no
+    // empty span advertising an empty title.
+    const wrappers = container.querySelectorAll("span.classic-cell-truncate");
+    expect(wrappers).toHaveLength(1);
+    expect(wrappers[0].getAttribute("title")).toBe(LONG_ARTIST);
+  });
+
   it("does not truncate while the row is being edited (inputs stay full)", () => {
     const { container } = renderRow({ entry: longEntry() });
     fireEvent.click(screen.getByRole("button", { name: /actions/i }));


### PR DESCRIPTION
DJ feedback (impact 10/10): long album titles were cut off on the flowsheet with no way to see the full text. The **modern** experience already meets the acceptance criteria (`FlowsheetEntryField.tsx` renders nowrap + ellipsis and a Joy `Tooltip` carrying the full value). The gap was the **classic** experience, which rendered artist/album/label as plain text with no truncation or affordance.

## Fix (classic only)
Wrap the non-edit display of artist, album, and label in a truncating span (only when a value exists, so absent album/label don't emit an empty span):
- CSS `.classic-cell-truncate`: `inline-block` + `max-width: 20em` + `overflow: hidden` + `text-overflow: ellipsis` + `white-space: nowrap` (works without changing the table's layout algorithm; `em` keeps the character budget stable across the font-size classes).
- The cell's `title` attribute carries the full value — the recover-the-text affordance, matching classic's plain-HTML table weight (classic deliberately avoids Joy components).

`track_title` (Song) is deliberately left untruncated: the issue is album-centric, and the song title is the row's primary content DJs most want fully visible. If truncating it later proves desirable that's a conscious follow-up, not an oversight in this change. Edit-mode inputs are unaffected.

## Tests
`EntryRow.test.tsx`: long artist/album/label each get a truncating wrapper whose `title` holds the full text; an absent album/label emits no wrapper; edit mode shows full inputs (no truncation). Targeted file 65/65; full vitest 3796/3796; `tsc --noEmit` clean; lint 0 errors.

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)