### PR TITLE
fix(now-playing): track title is the headline of the song card

### DIFF
--- a/src/widgets/NowPlaying/EntryText.tsx
+++ b/src/widgets/NowPlaying/EntryText.tsx
@@ -27,10 +27,18 @@ export default function EntryText({
     return (
       <EntryStack>
         <Typography level="title-md" noWrap sx={{ overflow: "hidden", textOverflow: "ellipsis" }}>
-          {entry.album_title}
+          {entry.track_title}
         </Typography>
         <Typography level="body-sm" noWrap sx={{ overflow: "hidden", textOverflow: "ellipsis" }}>
           {entry.artist_name}
+        </Typography>
+        <Typography
+          level="body-sm"
+          textColor="text.tertiary"
+          noWrap
+          sx={{ overflow: "hidden", textOverflow: "ellipsis" }}
+        >
+          {entry.album_title}
         </Typography>
       </EntryStack>
     );

--- a/tests/integration/components/widgets/NowPlaying/EntryText.test.tsx
+++ b/tests/integration/components/widgets/NowPlaying/EntryText.test.tsx
@@ -15,8 +15,14 @@ vi.mock("@mui/joy", () => ({
       {children}
     </div>
   ),
-  Typography: ({ children, level, color, ...props }: any) => (
-    <span data-testid="typography" data-level={level} data-color={color} {...props}>
+  Typography: ({ children, level, color, textColor, ...props }: any) => (
+    <span
+      data-testid="typography"
+      data-level={level}
+      data-color={color}
+      data-text-color={textColor}
+      {...props}
+    >
       {children}
     </span>
   ),
@@ -39,21 +45,36 @@ describe("EntryText", () => {
   });
 
   describe("when entry is a song entry", () => {
-    it("should display album title and artist name", () => {
-      const songEntry: FlowsheetSongEntry = {
-        ...baseEntry,
-        track_title: "Test Track",
-        artist_name: "Test Artist",
-        album_title: "Test Album",
-        record_label: "Test Label",
-        request_flag: false,
-        segue: false,
-      };
+    const songEntry: FlowsheetSongEntry = {
+      ...baseEntry,
+      track_title: "la paradoja",
+      artist_name: "Juana Molina",
+      album_title: "DOGA",
+      record_label: "Sonamos",
+      request_flag: false,
+      segue: false,
+    };
 
+    it("should display track title, artist name, and album title", () => {
       render(<EntryText entry={songEntry} />);
 
-      expect(screen.getByText("Test Album")).toBeInTheDocument();
-      expect(screen.getByText("Test Artist")).toBeInTheDocument();
+      expect(screen.getByText("la paradoja")).toBeInTheDocument();
+      expect(screen.getByText("Juana Molina")).toBeInTheDocument();
+      expect(screen.getByText("DOGA")).toBeInTheDocument();
+    });
+
+    it("should render the track title as the headline, above artist and album", () => {
+      render(<EntryText entry={songEntry} />);
+
+      expect(screen.getByText("la paradoja")).toHaveAttribute("data-level", "title-md");
+      expect(screen.getByText("Juana Molina")).toHaveAttribute("data-level", "body-sm");
+      expect(screen.getByText("DOGA")).toHaveAttribute("data-level", "body-sm");
+    });
+
+    it("should render the album title with tertiary text color", () => {
+      render(<EntryText entry={songEntry} />);
+
+      expect(screen.getByText("DOGA")).toHaveAttribute("data-text-color", "text.tertiary");
     });
   });
 


### PR DESCRIPTION
## Summary
- The song branch of `EntryText` (shared by the Main and Mini NowPlaying widget variants) rendered only `album_title` and `artist_name` — `track_title` was never referenced, despite being the required discriminant field `isFlowsheetSongEntry` keys on.
- Track title is now the primary `title-md` line; artist name follows at `body-sm`; album title is demoted to a third `body-sm` line with `textColor="text.tertiary"`, matching the tertiary-text convention already used elsewhere in the widget. All three lines keep the existing `noWrap` + ellipsis treatment, and `EntryStack`'s `minHeight: 60px` is left untouched (a floor, not a cap — it grows for the third line).

## Test plan
- [x] Extended `tests/integration/components/widgets/NowPlaying/EntryText.test.tsx`: the Joy `Typography` mock now also exposes `data-text-color`; the song-entry case asserts all three fields render, that track title is `title-md` while artist/album are `body-sm`, and that album has `textColor="text.tertiary"`.
- [x] `npx vitest run tests/integration/components/widgets/NowPlaying/EntryText.test.tsx --maxWorkers=2` — 9/9 passed.
- [x] `npx tsc --noEmit` — clean.
- [x] Full suite: `npx vitest run --maxWorkers=2` — 281 files / 3793 tests passed.

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)