### PR TITLE
fix(flowsheet): show-start reaches the Now Playing card instantly and 304s never blank it

### DIFF
--- a/lib/features/backend.ts
+++ b/lib/features/backend.ts
@@ -58,7 +58,54 @@ const isNonJsonParsingError = (
   originalStatus: number;
   data: string;
   error: string;
-} => error.status === "PARSING_ERROR";
+} =>
+  error.status === "PARSING_ERROR" &&
+  (error as { originalStatus?: number }).originalStatus !== 304;
+
+/**
+ * A revalidation that reaches `fetchBaseQuery` as a raw 304. Two shapes: an
+ * empty body surfaces as a numeric `status: 304`; a body the origin spliced in
+ * surfaces as `PARSING_ERROR` carrying `originalStatus: 304`.
+ */
+const isNotModified = (error: FetchBaseQueryError): boolean =>
+  error.status === 304 ||
+  (error.status === "PARSING_ERROR" &&
+    (error as { originalStatus?: number }).originalStatus === 304);
+
+/**
+ * Re-issue the same request unconditionally (`cache: "reload"` drops the
+ * conditional headers), so the origin must answer 200 with a full body.
+ */
+const withReload = (args: string | FetchArgs): FetchArgs =>
+  typeof args === "string"
+    ? { url: args, cache: "reload" }
+    : { ...args, cache: "reload" };
+
+const CONDITIONAL_HEADERS = ["if-none-match", "if-modified-since"];
+
+/**
+ * Whether the caller itself set a conditional validator header. Such a caller
+ * (the metadata conditional-GET wrapper) owns its 304 handling — it needs the
+ * empty 304 to restore its cached body — so the unconditional retry below must
+ * stand aside. A 304 with no app-set validator instead came from the transport
+ * (browser HTTP cache) and is the case the retry exists to repair.
+ */
+const hasAppConditionalHeader = (args: string | FetchArgs): boolean => {
+  if (typeof args === "string") return false;
+  const { headers } = args;
+  if (!headers) return false;
+  if (headers instanceof Headers) {
+    return CONDITIONAL_HEADERS.some((h) => headers.has(h));
+  }
+  if (Array.isArray(headers)) {
+    return headers.some(([key]) =>
+      CONDITIONAL_HEADERS.includes(key.toLowerCase())
+    );
+  }
+  return Object.keys(headers).some((key) =>
+    CONDITIONAL_HEADERS.includes(key.toLowerCase())
+  );
+};
 
 const logNonJsonResponse = (
   domain: string,
@@ -130,6 +177,23 @@ export const backendBaseQuery = (domain: string): BackendBaseQuery => {
 
   return async (args, api: BaseQueryApi, extraOptions) => {
     const result = await inner(args, api, extraOptions);
+
+    // Watermarked routes send two validators (a watermark Last-Modified and
+    // Express's per-body weak ETag) and no Cache-Control, so a dual-validator
+    // revalidation can surface an unspliced 304 with an empty body. An empty
+    // revalidation body must never overwrite populated cache: on GETs whose 304
+    // came from the transport (not an app-set conditional header), retry once
+    // unconditionally to get a full 200. If that retry also errors, let it
+    // propagate — RTK keeps the last-good data on a rejected refetch — so a 304
+    // can never collapse to the { data: null } soft-fail below.
+    if (
+      result.error &&
+      isNotModified(result.error) &&
+      isGetRequest(args) &&
+      !hasAppConditionalHeader(args)
+    ) {
+      return inner(withReload(args), api, extraOptions);
+    }
 
     if (result.error && isNonJsonParsingError(result.error)) {
       const optOut = (extraOptions as BackendExtraOptions | undefined)?.surfaceNonJsonAsError === true;

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -150,7 +150,7 @@ export const flowsheetApi = createApi({
         // (so `currentShow` — the newest entry's show_id — no longer resolves
         // to the prior show, leaving its tail editable) and the Now Playing
         // card (so "started the set" shows before any song is added, without
-        // waiting on the post-join refetch). Fresh (negative) show_id. (#619)
+        // waiting on the post-join refetch). Fresh (negative) show_id.
         const entriesCache =
           flowsheetApi.endpoints.getInfiniteEntries.select(undefined)(
             getState()

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -121,7 +121,7 @@ export const flowsheetApi = createApi({
         body: params,
       }),
       invalidatesTags: ["NowPlaying", "WhoIsLive"],
-      async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+      async onQueryStarted(arg, { dispatch, queryFulfilled, getState }) {
         // Seed the banner with the real dj_name so the public /live page never
         // renders a "Live" placeholder during the refetch window. A joiner
         // with no display name must not blank the banner or leave a trailing
@@ -146,28 +146,41 @@ export const flowsheetApi = createApi({
             }
           )
         );
-        // Push an optimistic show-start marker with a fresh (negative) show_id
-        // so `currentShow` (the newest entry's show_id) no longer resolves to
-        // the previous show. Without this, the prior show's tail partitions as
-        // the current show and stays editable until the refetch lands. (#619)
+        // One optimistic show-start marker seeds both caches: the entries feed
+        // (so `currentShow` — the newest entry's show_id — no longer resolves
+        // to the prior show, leaving its tail editable) and the Now Playing
+        // card (so "started the set" shows before any song is added, without
+        // waiting on the post-join refetch). Fresh (negative) show_id. (#619)
+        const entriesCache =
+          flowsheetApi.endpoints.getInfiniteEntries.select(undefined)(
+            getState()
+          );
+        const tempId = nextOptimisticTempId();
+        const marker: FlowsheetShowBlockEntry = {
+          id: tempId,
+          play_order:
+            (entriesCache.data ? maxPlayOrder(entriesCache.data) : 0) + 1,
+          show_id: tempId,
+          dj_name: arg.dj_name ?? "",
+          isStart: true,
+          day: "",
+          time: "",
+        };
         const patchEntries = dispatch(
           flowsheetApi.util.updateQueryData(
             "getInfiniteEntries",
             undefined,
             (draft) => {
               if (!draft.pages.length) return;
-              const tempId = nextOptimisticTempId();
-              const marker: FlowsheetShowBlockEntry = {
-                id: tempId,
-                play_order: maxPlayOrder(draft) + 1,
-                show_id: tempId,
-                dj_name: arg.dj_name ?? "",
-                isStart: true,
-                day: "",
-                time: "",
-              };
               insertEntrySortedFirstPage(draft, marker);
             }
+          )
+        );
+        const patchNowPlaying = dispatch(
+          flowsheetApi.util.updateQueryData(
+            "getNowPlaying",
+            undefined,
+            () => marker
           )
         );
         try {
@@ -177,6 +190,7 @@ export const flowsheetApi = createApi({
           flowsheetMutationCatch("joinShow", err);
           patchLive.undo();
           patchEntries.undo();
+          patchNowPlaying.undo();
         }
       },
     }),
@@ -187,7 +201,15 @@ export const flowsheetApi = createApi({
         body: params,
       }),
       invalidatesTags: ["NowPlaying", "WhoIsLive"],
-      async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+      async onQueryStarted(arg, { dispatch, queryFulfilled, getState }) {
+        // The leave arg carries no dj_name, so resolve the departing DJ's name
+        // from the whoIsLive cache before patchLive filters them out — the
+        // show-end card needs it.
+        const state = getState();
+        const departingDjName =
+          flowsheetApi.endpoints.whoIsLive
+            .select(undefined)(state)
+            .data?.djs.find((d) => d.id === arg.dj_id)?.dj_name ?? "";
         const patchLive = dispatch(
           flowsheetApi.util.updateQueryData(
             "whoIsLive",
@@ -218,6 +240,28 @@ export const flowsheetApi = createApi({
             }
           )
         );
+        // Mirror the show-end onto the Now Playing card so it flips to the
+        // show-end state immediately, without waiting on the refetch.
+        const entriesCache =
+          flowsheetApi.endpoints.getInfiniteEntries.select(undefined)(state);
+        const endTempId = nextOptimisticTempId();
+        const endMarker: FlowsheetShowBlockEntry = {
+          id: endTempId,
+          play_order:
+            (entriesCache.data ? maxPlayOrder(entriesCache.data) : 0) + 1,
+          show_id: endTempId,
+          dj_name: departingDjName,
+          isStart: false,
+          day: "",
+          time: "",
+        };
+        const patchNowPlaying = dispatch(
+          flowsheetApi.util.updateQueryData(
+            "getNowPlaying",
+            undefined,
+            () => endMarker
+          )
+        );
         try {
           await queryFulfilled;
           dispatch(flowsheetApi.util.invalidateTags(["Flowsheet"]));
@@ -225,6 +269,7 @@ export const flowsheetApi = createApi({
           flowsheetMutationCatch("leaveShow", err);
           patchLive.undo();
           patchEntries.undo();
+          patchNowPlaying.undo();
         }
       },
     }),

--- a/tests/unit/lib/features/backend.test.ts
+++ b/tests/unit/lib/features/backend.test.ts
@@ -480,5 +480,112 @@ describe("backend", () => {
         expect((result as { error?: unknown }).error).toBeUndefined();
       });
     });
+
+    describe("304 revalidation handling", () => {
+      const fakeApi = {} as any;
+      const fakeExtra = {} as any;
+
+      beforeEach(() => {
+        mockInnerBaseQuery.mockReset();
+        mockCaptureException.mockReset();
+      });
+
+      it("retries an empty-body 304 unconditionally and resolves with the reloaded body", async () => {
+        const reloaded = { data: { id: 7, entry_type: "show_start" }, meta: undefined };
+        mockInnerBaseQuery
+          .mockResolvedValueOnce({ error: { status: 304 }, meta: undefined })
+          .mockResolvedValueOnce(reloaded);
+
+        const baseQuery = backendBaseQuery("flowsheet");
+        const result = await baseQuery({ url: "/latest" }, fakeApi, fakeExtra);
+
+        expect(mockInnerBaseQuery).toHaveBeenCalledTimes(2);
+        expect(mockInnerBaseQuery.mock.calls[1][0]).toMatchObject({
+          url: "/latest",
+          cache: "reload",
+        });
+        expect(result).toBe(reloaded);
+        expect((result as { data?: unknown }).data).not.toBeNull();
+      });
+
+      it("retries a PARSING_ERROR carrying originalStatus 304 and never yields { data: null }", async () => {
+        // A 304 whose body an intermediary spliced back in fails JSON parsing
+        // and surfaces as PARSING_ERROR; it must still take the reload path.
+        const reloaded = { data: [{ id: 1 }], meta: undefined };
+        mockInnerBaseQuery
+          .mockResolvedValueOnce({
+            error: {
+              status: "PARSING_ERROR",
+              originalStatus: 304,
+              data: "not-json",
+              error: "SyntaxError",
+            },
+            meta: undefined,
+          })
+          .mockResolvedValueOnce(reloaded);
+
+        const baseQuery = backendBaseQuery("flowsheet");
+        const result = await baseQuery("/latest", fakeApi, fakeExtra);
+
+        expect(mockInnerBaseQuery).toHaveBeenCalledTimes(2);
+        expect(mockInnerBaseQuery.mock.calls[1][0]).toMatchObject({
+          cache: "reload",
+        });
+        expect((result as { data?: unknown }).data).not.toBeNull();
+        expect((result as { data?: unknown }).data).toEqual([{ id: 1 }]);
+      });
+
+      it("lets the retry's error propagate rather than collapsing to the soft-fail null", async () => {
+        const retryError = {
+          error: { status: 500, data: "boom" },
+          meta: undefined,
+        };
+        mockInnerBaseQuery
+          .mockResolvedValueOnce({ error: { status: 304 }, meta: undefined })
+          .mockResolvedValueOnce(retryError);
+
+        const baseQuery = backendBaseQuery("flowsheet");
+        const result = await baseQuery({ url: "/latest" }, fakeApi, fakeExtra);
+
+        expect(mockInnerBaseQuery).toHaveBeenCalledTimes(2);
+        expect(result).toBe(retryError);
+        expect((result as { data?: unknown }).data).toBeUndefined();
+      });
+
+      it("does not retry a 304 when the caller set its own conditional validator", async () => {
+        // A caller managing its own conditional GET owns the 304 (it restores a
+        // cached body from it); the transport-repair retry must stand aside.
+        const notModified = {
+          error: { status: 304 },
+          meta: { response: { status: 304 } },
+        };
+        mockInnerBaseQuery.mockResolvedValueOnce(notModified);
+
+        const baseQuery = backendBaseQuery("proxy");
+        const result = await baseQuery(
+          { url: "/artist/1", headers: { "If-None-Match": '"rev-1"' } },
+          fakeApi,
+          fakeExtra
+        );
+
+        expect(mockInnerBaseQuery).toHaveBeenCalledTimes(1);
+        expect(result).toBe(notModified);
+      });
+
+      it("does not retry a 304 on a mutation", async () => {
+        const notModified = { error: { status: 304 }, meta: undefined };
+        mockInnerBaseQuery.mockResolvedValueOnce(notModified);
+
+        const baseQuery = backendBaseQuery("flowsheet");
+        const result = await baseQuery(
+          { url: "/", method: "POST", body: {} },
+          fakeApi,
+          fakeExtra
+        );
+
+        expect(mockInnerBaseQuery).toHaveBeenCalledTimes(1);
+        expect(result).toBe(notModified);
+      });
+    });
   });
 });

--- a/tests/unit/lib/features/flowsheet/joinShow.optimistic.test.ts
+++ b/tests/unit/lib/features/flowsheet/joinShow.optimistic.test.ts
@@ -44,12 +44,24 @@ function selectWhoIsLiveCache(store: ReturnType<typeof createTestStore>) {
     .data;
 }
 
+function selectNowPlayingCache(store: ReturnType<typeof createTestStore>) {
+  return flowsheetApi.endpoints.getNowPlaying.select(undefined)(
+    store.getState()
+  ).data;
+}
+
+/** The seeded now-playing entry — a real track, not a show marker. */
+const SEEDED_NOW_PLAYING = priorEntries[1];
+
 async function seedStore(
   onAirDJs: { id: string | null; dj_name: string }[] = []
 ) {
   server.use(
     http.get(`${TEST_BACKEND_URL}/flowsheet/`, () =>
       HttpResponse.json(priorEntries)
+    ),
+    http.get(`${TEST_BACKEND_URL}/flowsheet/latest`, () =>
+      HttpResponse.json(SEEDED_NOW_PLAYING)
     ),
     http.get(`${TEST_BACKEND_URL}/flowsheet/djs-on-air`, () =>
       HttpResponse.json(onAirDJs)
@@ -61,12 +73,15 @@ async function seedStore(
   );
 
   const store = createTestStore();
-  // Prime both caches so the optimistic patches have data to work with.
+  // Prime the caches so the optimistic patches have data to work with.
   await store
     .dispatch(flowsheetApi.endpoints.getInfiniteEntries.initiate(undefined))
     .unwrap();
   await store
     .dispatch(flowsheetApi.endpoints.whoIsLive.initiate(undefined))
+    .unwrap();
+  await store
+    .dispatch(flowsheetApi.endpoints.getNowPlaying.initiate(undefined))
     .unwrap();
   return store;
 }
@@ -202,5 +217,68 @@ describe("joinShow optimistic patch", () => {
     );
 
     await Promise.all([joinPromise, leavePromise]);
+  });
+
+  it("reaches the Now Playing card with the show-start marker and DJ name before the refetch", async () => {
+    const store = await seedStore();
+
+    // Sanity: the seeded card is the prior track, not a show marker.
+    expect(selectNowPlayingCache(store)).toMatchObject({ id: 5002 });
+
+    const promise = store.dispatch(
+      flowsheetApi.endpoints.joinShow.initiate({
+        dj_id: "test-user-1",
+        dj_name: "Test DJ",
+      })
+    );
+
+    // The card flips to the show-start state synchronously, carrying the name.
+    expect(selectNowPlayingCache(store)).toMatchObject({
+      isStart: true,
+      dj_name: "Test DJ",
+    });
+
+    await promise;
+  });
+
+  it("restores the previous Now Playing card when the join fails", async () => {
+    const store = await seedStore();
+    server.use(
+      http.post(
+        `${TEST_BACKEND_URL}/flowsheet/join`,
+        () => new HttpResponse(null, { status: 500 })
+      )
+    );
+
+    const before = selectNowPlayingCache(store);
+
+    await store
+      .dispatch(
+        flowsheetApi.endpoints.joinShow.initiate({
+          dj_id: "test-user-1",
+          dj_name: "Test DJ",
+        })
+      )
+      .unwrap()
+      .catch(() => {});
+
+    // The optimistic marker is rolled back to the seeded track, never left as
+    // a stray marker or blanked.
+    expect(selectNowPlayingCache(store)).toEqual(before);
+  });
+
+  it("flips the Now Playing card to the show-end state carrying the departing DJ's name", async () => {
+    const store = await seedStore([{ id: "test-user-1", dj_name: "Test DJ" }]);
+
+    const promise = store.dispatch(
+      flowsheetApi.endpoints.leaveShow.initiate({ dj_id: "test-user-1" })
+    );
+
+    expect(selectNowPlayingCache(store)).toMatchObject({
+      isStart: false,
+      dj_name: "Test DJ",
+    });
+
+    await promise;
   });
 });


### PR DESCRIPTION
The Now Playing widget stayed stale after a DJ started a show — "started the set" only appeared once the first song was added. Two layers, both wanted:

## Optimistic layer (makes the UI correct regardless of transport)
`joinShow.onQueryStarted` already inserted a show-start marker into the `getInfiniteEntries` feed. That marker is now hoisted out so a single `FlowsheetShowBlockEntry` serves both caches, and additionally seeds `getNowPlaying` via `updateQueryData`. The card flips to "*<DJ> started the set*" instantly, before any song add, and rolls back on error. `leaveShow` gets the symmetric show-end marker; because its arg carries no `dj_name`, the departing DJ's name is resolved from the `whoIsLive` cache before the banner patch filters it out.

## Transport layer (root-causes the staleness)
`backendBaseQuery` now retries a raw `304` once with `cache: "reload"` on GET requests, handling both shapes RTK 2.12 can surface (`{ error: { status: 304 } }` for an empty body, or `PARSING_ERROR` with `originalStatus: 304` for a spliced body). A dual-validator revalidation on the watermarked `/flowsheet/latest` route (watermark `Last-Modified` + Express weak `ETag`, no `Cache-Control`) can otherwise reach `fetchBaseQuery` as an unspliced 304 and collapse to the `{ data: null }` non-JSON soft-fail, blanking a populated card. The retry is skipped when the caller set its own conditional validator (the metadata conditional-GET wrapper owns its 304), and if the retry also errors the error propagates so RTK keeps last-good data — a 304 can never yield `{ data: null }`. `isNonJsonParsingError` also excludes `originalStatus: 304` as defense-in-depth.

The dual-validator contract itself is tracked upstream at WXYC/Backend-Service#1689 (recommend a single validator on watermarked routes); polling correctness no longer depends on that fix landing.

## Tests
- `tests/unit/lib/features/backend.test.ts` — 304-as-status and PARSING_ERROR+304 both retried with `cache:"reload"`; retry-failure propagates (never `{data:null}`); POST 304 untouched; app-conditional-validator 304 not retried.
- `tests/unit/lib/features/flowsheet/joinShow.optimistic.test.ts` — show-start marker with DJ name reaches the `getNowPlaying` cache before settle; undo restores on join failure; leaveShow produces the show-end marker carrying the departing DJ's name.

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)