### PR TITLE
fix(live): Now Playing card keeps polling — whoIsLive on the shared cadence, background polling on /live

### DIFF
--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -41,6 +41,7 @@ export default async function LivePage() {
           mini={false}
           initialEntry={initialEntry}
           initialOnAirData={initialOnAirData}
+          pollInBackground
         />
       </Box>
     </WXYCPage>

--- a/src/widgets/NowPlaying/index.tsx
+++ b/src/widgets/NowPlaying/index.tsx
@@ -20,6 +20,10 @@ export type NowPlayingWidgetProps = {
   // (e.g. the Rightbar), where the widget keeps its client-fetched behavior.
   initialEntry?: FlowsheetEntry | null;
   initialOnAirData?: OnAirDJData;
+  // The public listen-live surface plays audio in background tabs, so its polls
+  // must survive blur to stay current for a backgrounded listener. The
+  // dashboard keeps the blur-skip (no reason to poll a hidden control panel).
+  pollInBackground?: boolean;
 };
 
 const AUDIO_SRC = "https://audio-mp3.ibiblio.org/wxyc.mp3";
@@ -44,6 +48,7 @@ export default function NowPlaying({
   mini = false,
   initialEntry,
   initialOnAirData,
+  pollInBackground = false,
 }: NowPlayingWidgetProps) {
   const audioRef = useRef<HTMLAudioElement>(null);
 
@@ -56,11 +61,17 @@ export default function NowPlaying({
 
   const [isPlaying, setIsPlaying] = useState(false);
 
+  const nowPlayingPollingInterval = useFlowsheetPollingInterval();
+
   const {
     data: whoIsLiveData,
     isLoading: whoIsLiveLoading,
     isError: djError,
-  } = useWhoIsLiveQuery();
+  } = useWhoIsLiveQuery(undefined, {
+    pollingInterval: nowPlayingPollingInterval,
+    skipPollingIfUnfocused: !pollInBackground,
+    refetchOnFocus: true,
+  });
 
   // The client query owns this value once it resolves; before then fall back to
   // the server seed so the public page renders the on-air state on first paint.
@@ -71,12 +82,10 @@ export default function NowPlaying({
   // with a seed there is already content to render.
   const djLoading = whoIsLiveLoading && onAirData === undefined;
 
-  const nowPlayingPollingInterval = useFlowsheetPollingInterval();
-
   const { data: nowPlayingData } = useGetNowPlayingQuery(undefined, {
     pollingInterval: nowPlayingPollingInterval,
-    // Don't keep hitting the backend on a hidden/blurred tab. (#634)
-    skipPollingIfUnfocused: true,
+    skipPollingIfUnfocused: !pollInBackground,
+    refetchOnFocus: true,
   });
 
   // `data` is undefined only until the first client fetch resolves; once it

--- a/tests/integration/components/widgets/NowPlaying/GradientAudioVisualizer.test.tsx
+++ b/tests/integration/components/widgets/NowPlaying/GradientAudioVisualizer.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { createRef } from "react";
 import { GradientAudioVisualizer } from "@/src/widgets/NowPlaying/GradientAudioVisualizer";
 
 // Mock MUI Joy components

--- a/tests/integration/components/widgets/NowPlaying/index.test.tsx
+++ b/tests/integration/components/widgets/NowPlaying/index.test.tsx
@@ -21,7 +21,8 @@ vi.mock("@/lib/features/flowsheet/api", async (importOriginal) => {
     ...actual,
     useGetNowPlayingQuery: (arg: unknown, options: unknown) =>
       mockUseGetNowPlayingQuery(arg, options),
-    useWhoIsLiveQuery: () => mockUseWhoIsLiveQuery(),
+    useWhoIsLiveQuery: (arg: unknown, options: unknown) =>
+      mockUseWhoIsLiveQuery(arg, options),
   };
 });
 
@@ -433,12 +434,37 @@ describe("NowPlaying", () => {
   });
 
   describe("API polling", () => {
-    it("should call useGetNowPlayingQuery with pollingInterval and skip when unfocused", () => {
+    it("polls both hooks on the shared cadence, skipping unfocused, refetching on focus by default", () => {
       render(<NowPlaying mini={false} />);
-      // skipPollingIfUnfocused pauses the 60s poll on a hidden/blurred tab. (#634)
+      // The dashboard default pauses the poll on a hidden/blurred tab but
+      // resyncs the moment it regains focus.
       expect(mockUseGetNowPlayingQuery).toHaveBeenCalledWith(undefined, {
         pollingInterval: 60000,
         skipPollingIfUnfocused: true,
+        refetchOnFocus: true,
+      });
+      // whoIsLive rides the same cadence so the LIVE/OFF-AIR badge and DJ names
+      // stay current without a flowsheet mutation to invalidate them.
+      expect(mockUseWhoIsLiveQuery).toHaveBeenCalledWith(undefined, {
+        pollingInterval: 60000,
+        skipPollingIfUnfocused: true,
+        refetchOnFocus: true,
+      });
+    });
+
+    it("keeps both polls alive on blurred tabs when pollInBackground is set", () => {
+      render(<NowPlaying mini={false} pollInBackground />);
+      // The listen-live surface plays audio in a background tab, so polls must
+      // survive blur.
+      expect(mockUseGetNowPlayingQuery).toHaveBeenCalledWith(undefined, {
+        pollingInterval: 60000,
+        skipPollingIfUnfocused: false,
+        refetchOnFocus: true,
+      });
+      expect(mockUseWhoIsLiveQuery).toHaveBeenCalledWith(undefined, {
+        pollingInterval: 60000,
+        skipPollingIfUnfocused: false,
+        refetchOnFocus: true,
       });
     });
   });


### PR DESCRIPTION
The Now Playing card on `/live` went permanently stale: entry data, the LIVE/OFF-AIR badge, and DJ names stopped reflecting reality shortly after page load.

## Two compounding gaps, both in the widget data layer

**`whoIsLive` never refreshed.** `useWhoIsLiveQuery()` was subscribed with no `pollingInterval`. On the dashboard this is masked because flowsheet mutations invalidate the `WhoIsLive` tag, but `/live` visitors never mutate anything, so the on-air state froze at mount-time values. It now rides `useFlowsheetPollingInterval()` — the same SSE-aware, drag-suspending cadence as `getNowPlaying` — so a DJ signing on or off is reflected within one interval with no interaction.

**`getNowPlaying` polling was suspended in the `/live` use case.** The poll ran with `skipPollingIfUnfocused: true` (added for the dashboard), but `/live`'s primary usage is *listening in a background tab* — audio keeps playing while the tab is blurred and polling halted entirely. A new `pollInBackground` prop drops the blur-skip for the public listen-live surface; `app/live/page.tsx` passes it. The dashboard keeps the skip.

Both hooks also get `refetchOnFocus: true` (`setupListeners` is already wired in `StoreProvider`), so a tab backgrounded for a long stretch resyncs the moment it regains focus rather than waiting a full interval.

SSE for the live view stays flag-disabled (`NEXT_PUBLIC_FLOWSHEET_SSE_LIVE_VIEW_ENABLED` untouched) — polling correctness must not depend on it. The 304/blank-card factor noted in the issue is addressed separately in #983 (`backendBaseQuery` never feeds `{ data: null }` into a populated cache on a 304).

## Tests
`tests/integration/components/widgets/NowPlaying/index.test.tsx` — the `useWhoIsLiveQuery` mock now forwards `(arg, options)`; default render asserts both hooks poll at the shared cadence with `skipPollingIfUnfocused: true` + `refetchOnFocus: true`; a `pollInBackground` render asserts both drop to `skipPollingIfUnfocused: false`.

Closes #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)