### PR TITLE
fix(landing): authenticated, verified users are redirected to the dashboard

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 
 export default async function HomePage() {
   const session = await getServerSession();
-  if (session) {
+  if (session?.user?.emailVerified) {
     redirect(
       process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE || DEFAULT_DASHBOARD_HOME_PAGE
     );

--- a/tests/integration/app/page.test.tsx
+++ b/tests/integration/app/page.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/features/authentication/server-utils", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock("@/src/Layout/WXYCPage", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="wxyc-page">{children}</div>
+  ),
+}));
+
+import { getServerSession } from "@/lib/features/authentication/server-utils";
+import { redirect } from "next/navigation";
+import HomePage from "@/app/page";
+
+const mockGetServerSession = vi.mocked(getServerSession);
+const mockRedirect = vi.mocked(redirect);
+
+const verifiedSession = {
+  user: { emailVerified: true },
+} as unknown as Awaited<ReturnType<typeof getServerSession>>;
+
+const unverifiedSession = {
+  user: { emailVerified: false },
+} as unknown as Awaited<ReturnType<typeof getServerSession>>;
+
+describe("root page", () => {
+  const originalDashboardHomePage = process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE;
+
+  beforeEach(() => {
+    mockGetServerSession.mockReset();
+    mockRedirect.mockClear();
+    delete process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE;
+  });
+
+  afterAll(() => {
+    if (originalDashboardHomePage === undefined) {
+      delete process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE;
+    } else {
+      process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE = originalDashboardHomePage;
+    }
+  });
+
+  it("renders the landing page for a signed-out visitor", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const result = await HomePage();
+    render(result);
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(screen.getByText("Log In")).toBeInTheDocument();
+    expect(screen.getByText("Listen")).toBeInTheDocument();
+  });
+
+  it("redirects a signed-in, verified visitor to the dashboard", async () => {
+    mockGetServerSession.mockResolvedValue(verifiedSession);
+
+    await expect(HomePage()).rejects.toThrow(
+      "NEXT_REDIRECT:/dashboard/catalog"
+    );
+  });
+
+  it("renders the landing page for a signed-in but unverified visitor", async () => {
+    mockGetServerSession.mockResolvedValue(unverifiedSession);
+
+    const result = await HomePage();
+    render(result);
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(screen.getByText("Log In")).toBeInTheDocument();
+    expect(screen.getByText("Listen")).toBeInTheDocument();
+  });
+
+  it("respects NEXT_PUBLIC_DASHBOARD_HOME_PAGE for the redirect target", async () => {
+    process.env.NEXT_PUBLIC_DASHBOARD_HOME_PAGE = "/dashboard/flowsheet";
+    mockGetServerSession.mockResolvedValue(verifiedSession);
+
+    await expect(HomePage()).rejects.toThrow(
+      "NEXT_REDIRECT:/dashboard/flowsheet"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `app/page.tsx` already redirected signed-in visitors to the dashboard, but the check was `if (session)` — `getServerSession()` does not filter on `emailVerified`, so a logged-in-but-unverified visitor to `/` was redirected to the dashboard too.
- Narrowed the guard to `session?.user?.emailVerified`, mirroring the same check already used in `requireAuth()` (`lib/features/authentication/server-utils.ts`) and `app/login/@modern/@normal/page.tsx`. Unverified users now stay on the landing page, matching the issue's test plan.

## Test plan
- [x] New `tests/integration/app/page.test.tsx` covers all four cases: no session renders landing page, verified session redirects to `/dashboard/catalog`, unverified session renders landing page (no redirect), and `NEXT_PUBLIC_DASHBOARD_HOME_PAGE` overrides the redirect target.
- [x] `npx vitest run tests/integration/app/page.test.tsx --maxWorkers=2` — 4/4 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint app/page.tsx tests/integration/app/page.test.tsx` — clean
- [x] Full `npx vitest run --maxWorkers=2` — 282 files / 3795 tests pass

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)