### PR TITLE
chore(deps): replace @mui/material's two utility imports with @mui/base, drop the dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,10 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@mui/base": "5.0.0-beta.40-1",
         "@mui/icons-material": "^6.4.0",
         "@mui/joy": "^5.0.0-beta.51",
-        "@mui/material": "^6.4.0",
+        "@mui/system": "5.18.0",
         "@opennextjs/cloudflare": "^1.20.1",
         "@reduxjs/toolkit": "^2.12.0",
         "@wxyc/shared": "^1.17.1",
@@ -3772,6 +3773,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
       "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/core-downloads-tracker": "^6.5.0",
@@ -3821,6 +3823,7 @@
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-6.5.0.tgz",
       "integrity": "sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
@@ -3831,6 +3834,7 @@
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.9.tgz",
       "integrity": "sha512-LktcVmI5X17/Q5SkwjCcdOLBzt1hXuc14jYa7NPShog0GBDCDvKtcnP0V7a2s6EiVRlv7BzbWEJzH6+l/zaCxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/utils": "^6.4.9",
@@ -3858,6 +3862,7 @@
       "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.5.0.tgz",
       "integrity": "sha512-8woC2zAqF4qUDSPIBZ8v3sakj+WgweolpyM/FXf8jAx6FMls+IE4Y8VDZc+zS805J7PRz31vz73n2SovKGaYgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@emotion/cache": "^11.13.5",
@@ -3892,6 +3897,7 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.5.0.tgz",
       "integrity": "sha512-XcbBYxDS+h/lgsoGe78ExXFZXtuIlSBpn/KsZq8PtZcIkUNJInkuDqcLd2rVBQrDC1u+rvVovdaWPf2FHKJf3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/private-theming": "^6.4.9",
@@ -3932,6 +3938,7 @@
       "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.9.tgz",
       "integrity": "sha512-Y12Q9hbK9g+ZY0T3Rxrx9m2m10gaphDuUMgWxyV5kNJevVxXYCLclYUCC9vXaIk1/NdNDTcW2Yfr2OGvNFNmHg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@mui/types": "~7.2.24",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@mui/base": "5.0.0-beta.40-1",
     "@mui/icons-material": "^6.4.0",
     "@mui/joy": "^5.0.0-beta.51",
-    "@mui/material": "^6.4.0",
+    "@mui/system": "5.18.0",
     "@opennextjs/cloudflare": "^1.20.1",
     "@reduxjs/toolkit": "^2.12.0",
     "@wxyc/shared": "^1.17.1",

--- a/src/components/experiences/modern/Rightbar/Bin/BinEntryContextMenu.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/BinEntryContextMenu.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useShiftKey } from "@/src/hooks/applicationHooks";
+import { ClickAwayListener } from "@mui/base/ClickAwayListener";
+import { Popper } from "@mui/base/Popper";
 import { Chip, ListItemDecorator, MenuItem, MenuList, Typography } from "@mui/joy";
-import ClickAwayListener from "@mui/material/ClickAwayListener";
-import Popper from "@mui/material/Popper";
 import { useEffect } from "react";
 import type { BinEntryAction } from "./useBinEntryActions";
 

--- a/src/components/experiences/modern/admin/roster/NewAccountForm.tsx
+++ b/src/components/experiences/modern/admin/roster/NewAccountForm.tsx
@@ -3,9 +3,9 @@
 import { adminSlice } from "@/lib/features/admin/frontend";
 import { Authorization } from "@/lib/features/admin/types";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import { ClickAwayListener } from "@mui/base/ClickAwayListener";
 import { PersonAdd } from "@mui/icons-material";
 import { Button, FormControl, Input, Option, Select } from "@mui/joy";
-import { ClickAwayListener } from "@mui/material";
 
 export default function NewAccountForm() {
   const dispatch = useAppDispatch();

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.tsx
@@ -5,7 +5,7 @@ import { useFlowsheetActions, useShowControl } from "@/src/hooks/flowsheetHooks"
 import { toTitleCase } from "@/src/utilities/stringutilities";
 import { Box, IconButton, Tooltip, Typography, TypographyProps } from "@mui/joy";
 import { CheckRounded, EditOutlined } from "@mui/icons-material";
-import { ClickAwayListener } from "@mui/material";
+import { ClickAwayListener } from "@mui/base/ClickAwayListener";
 import { useCallback, useEffect, useState, type FormEvent } from "react";
 import { useAppDispatch } from "@/lib/hooks";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";

--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
@@ -8,9 +8,11 @@ import {
   useFlowsheetSubmit,
 } from "@/src/hooks/flowsheetHooks";
 import { useGhostText } from "@/src/hooks/useGhostText";
+import { ClickAwayListener } from "@mui/base/ClickAwayListener";
+import { Popper } from "@mui/base/Popper";
 import { Close, PlayArrow, QueueMusic } from "@mui/icons-material";
 import { Box, Divider, IconButton, Sheet, Tooltip } from "@mui/joy";
-import { ClickAwayListener, Popper, useMediaQuery } from "@mui/material";
+import useMediaQuery from "@mui/system/useMediaQuery";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Transition } from "react-transition-group";
 import BreakpointButton from "./BreakpointButton";

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
@@ -2,9 +2,9 @@
 
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { sortRotationReleases } from "@/lib/features/rotation/sort";
+import { ClickAwayListener } from "@mui/base/ClickAwayListener";
 import { KeyboardArrowDown } from "@mui/icons-material";
 import { Box, Input, Sheet, Typography } from "@mui/joy";
-import { ClickAwayListener } from "@mui/material";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 function formatRelease(release: AlbumEntry): string {

--- a/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/TrackPickerDropdown.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { normalizeTrackArtists } from "@/lib/features/rotation/normalize-track-artists";
+import { ClickAwayListener } from "@mui/base/ClickAwayListener";
 import { KeyboardArrowDown } from "@mui/icons-material";
 import { Box, CircularProgress, Input, Sheet, Typography } from "@mui/joy";
-import { ClickAwayListener } from "@mui/material";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 /**

--- a/src/components/shared/Theme/ThemePicker.tsx
+++ b/src/components/shared/Theme/ThemePicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState, type JSX } from "react";
+import { ClickAwayListener } from "@mui/base/ClickAwayListener";
 import { Check, PaletteRounded } from "@mui/icons-material";
 import {
   Box,
@@ -11,7 +12,6 @@ import {
   Typography,
 } from "@mui/joy";
 import { useColorScheme } from "@mui/joy/styles";
-import { ClickAwayListener } from "@mui/material";
 import {
   MODERN_THEME_LIST,
   getThemeSwatches,


### PR DESCRIPTION
## Summary

- Swaps the 7 import sites of `ClickAwayListener`/`Popper` from `@mui/material` to `@mui/base` (already in the tree as `@mui/joy`'s dependency, exports drop-in equivalents).
- `FlowsheetSearchbar.tsx` also imported `useMediaQuery` from `@mui/material` (on the same line, not called out in the issue) — moved to `@mui/system`, the package `@mui/material`'s `useMediaQuery` wrapper delegates to internally. No behavior change: same options shape (`noSsr`), same underlying implementation.
- `@mui/base` added to `package.json` `dependencies`, pinned to the exact version already resolved in the tree (`5.0.0-beta.40-1`). `@mui/system` likewise added and pinned (`5.18.0`) since it's now directly imported, not just transitive.
- `@mui/material` removed from `dependencies` and `package-lock.json` regenerated.

## `@mui/material` in node_modules — does not fully disappear

`@mui/material` remains installed after `npm install`, but it is **not** a runtime dependency of anything in this repo's own source (verified: zero remaining `@mui/material` imports/references in `src/`, `app/`, `lib/`, `tests/`, `next.config.mjs`, `vitest.config.mts`).

It stays because `@mui/icons-material`'s `createSvgIcon` helper (`node_modules/@mui/icons-material/utils/createSvgIcon.js`) does `require("@mui/material/utils")`, which pulls in `@mui/material/SvgIcon` — this is a real, load-bearing runtime dependency of every icon we render, not merely a `peerDependencies` formality. Since the issue explicitly says to keep `@mui/icons-material`, `@mui/material` cannot be fully eliminated from the dependency graph without also replacing the icon package. Filing this as a known, documented outcome rather than a follow-up bug.

## Verification

- `npx tsc --noEmit` — clean.
- Targeted vitest run of the 7 touched components' existing test files: 127 tests passed, no changes needed.
- Full `npx vitest run --maxWorkers=2`: 3791 tests passed.
- `npm run build` — compiles and generates all routes successfully.

## Test plan

- [x] `npx tsc --noEmit`
- [x] Existing tests for all 7 touched components pass unmodified
- [x] Full vitest suite passes
- [x] Production build succeeds

Closes #970

🤖 Generated with [Claude Code](https://claude.com/claude-code)