### PR TITLE
fix(flowsheet): keep rotation_id on the wire for library-unlinked rotation picks

### DIFF
--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -42,24 +42,29 @@ export function entryToFreezePayload(entry: {
 export function convertQueryToSubmission(
   query: FlowsheetQuery
 ): FlowsheetSubmissionParams {
-  // BS's `FlowsheetCreateSongFromCatalog` variant requires a positive
-  // `album_id` (a real `library.id`); the rotation-linkage fields
-  // (`rotation_id`, `rotation_bin`) and the Discogs tracklist position
-  // (`track_position`) only land on the wire when paired with it.
-  // `track_position` is a `release_track.position` reference into a specific
-  // Discogs release — orphaning it on the freeform variant produces a
-  // position string ("A1") with no album to position into, so reducers that
-  // overwrite `album_id` but leave a stale `track_position` (e.g.
-  // `setRotationMetadata`) must not leak it to the wire.
-  // The Modern rotation picker and the bin → queue path can both write a
-  // synthesized negative `album_id` for library-unlinked rotation rows
-  // (`synthesizeAlbumId` in `lib/features/catalog/conversions.ts`); on
-  // negative numbers BS takes the `album_id != null` branch, calls
-  // `getAlbumFromDB(-X)` → undefined → throws TypeError. Gate here so any
-  // caller that lands a non-positive `album_id` falls back to the freeform
-  // variant — at the cost of the rotation linkage, until BS-side schema work
-  // lands. Matches the Classic-side shape from PR #699. (dj-site#701)
+  // `album_id`, `rotation_bin`, and `track_position` are album-scoped and only
+  // ride the wire alongside a positive `library.id`:
+  //   - The Modern rotation picker and bin → queue path can dispatch a
+  //     synthesized negative `album_id` for library-unlinked rows
+  //     (`synthesizeAlbumId`); BS takes the `album_id != null` branch on a
+  //     negative number, calls `getAlbumFromDB(-X)` → undefined → TypeError.
+  //   - `track_position` is a `release_track.position` ("A1") into a specific
+  //     Discogs release; orphaned onto the freeform variant it points at
+  //     nothing (`setRotationMetadata` overwrites `album_id` without clearing
+  //     a stale position).
+  //   - `rotation_bin` is derived on read from the rotation JOIN, never a
+  //     write field.
+  // `rotation_id` is the exception: it's a first-class FK that BS persists on
+  // the freeform variant, and both badge paths (the read-time `rotation_bin`
+  // JOIN and the tubafrenzy mirror's `flowsheetEntryType` recompute)
+  // short-circuit on it. Forwarding it independent of `album_id` keeps the
+  // rotation badge on an unlinked release even after its `artist_name` is
+  // edited off "Various Artists" — the string-match fallbacks that would
+  // otherwise carry the badge break on that edit. (Matches
+  // `convertBinToFlowsheet`.)
   const hasLinkedAlbum = hasLinkedAlbumId(query.album_id);
+  const hasRotation =
+    typeof query.rotation_id === "number" && query.rotation_id > 0;
   return {
     track_title: query.song,
     artist_name: query.artist,
@@ -67,9 +72,9 @@ export function convertQueryToSubmission(
     record_label: query.label,
     request_flag: query.request,
     segue: query.segue,
+    ...(hasRotation && { rotation_id: query.rotation_id }),
     ...(hasLinkedAlbum && {
       album_id: query.album_id,
-      rotation_id: query.rotation_id,
       rotation_bin: query.rotation_bin,
       ...(query.track_position !== undefined && {
         track_position: query.track_position,

--- a/tests/unit/lib/features/catalog/conversions.test.ts
+++ b/tests/unit/lib/features/catalog/conversions.test.ts
@@ -477,7 +477,7 @@ describe("catalog conversions", () => {
         expect(submission.rotation_bin).toBe(Rotation.H);
       });
 
-      it("drops album_id + rotation linkage on the wire for a library-UNLINKED (id:undefined) row", () => {
+      it("drops album_id + rotation_bin but keeps rotation_id on the wire for a library-UNLINKED (id:undefined) row", () => {
         const albumEntry = convertToAlbumEntry(unlinkedRowUndefinedId);
         expect(albumEntry.rotation_id).toBe(5042);
         expect(albumEntry.rotation_bin).toBe(Rotation.S);
@@ -504,21 +504,21 @@ describe("catalog conversions", () => {
           rotation_id?: number;
           rotation_bin?: Rotation;
         };
-        // dj-site#701 fix: `convertQueryToSubmission` gates the catalog
-        // variant on `album_id > 0`. Synthesized negative ids fall through
-        // to the freeform variant — BS used to take `albumId != null` on
-        // negative numbers and TypeError; now the unlinked-row submit just
-        // loses rotation linkage on the wire (recoverable when BS-side
-        // schema work lets `rotation_id` ride without `album_id`).
+        // The synthesized negative id falls through to the freeform variant,
+        // so album_id (BS would TypeError on the negative) and the
+        // read-derived rotation_bin drop off the wire. rotation_id is exempt:
+        // it rides the freeform variant so the unlinked rotation release keeps
+        // its badge — including after a later artist_name edit, which is what
+        // the string-match badge fallbacks can't survive.
         // Freeform `artist_name` / `album_title` come from sibling
         // `setSearchProperty` dispatches in the live picker, not from
         // `setRotationMetadata`; out of scope for this e2e.
         expect(submission.album_id).toBeUndefined();
-        expect(submission.rotation_id).toBeUndefined();
         expect(submission.rotation_bin).toBeUndefined();
+        expect(submission.rotation_id).toBe(5042);
       });
 
-      it("drops album_id + rotation linkage on the wire for a library-UNLINKED (id omitted) row", () => {
+      it("drops album_id + rotation_bin but keeps rotation_id on the wire for a library-UNLINKED (id omitted) row", () => {
         // Sibling coverage for the omitted-key wire shape — JSON omission
         // is the most common upstream coercion mode. Both id-absence shapes
         // (id:undefined and id-omitted) take the FALSE branch of
@@ -550,10 +550,10 @@ describe("catalog conversions", () => {
           rotation_id?: number;
           rotation_bin?: Rotation;
         };
-        // See sibling id:undefined e2e for the dj-site#701 gate rationale.
+        // See sibling id:undefined e2e for the gate rationale.
         expect(submission.album_id).toBeUndefined();
-        expect(submission.rotation_id).toBeUndefined();
         expect(submission.rotation_bin).toBeUndefined();
+        expect(submission.rotation_id).toBe(5042);
       });
     });
   });

--- a/tests/unit/lib/features/flowsheet/conversions.test.ts
+++ b/tests/unit/lib/features/flowsheet/conversions.test.ts
@@ -139,12 +139,13 @@ describe("flowsheet conversions", () => {
     // unlinked (`synthesizeAlbumId` in catalog/conversions.ts hashes the
     // denormalized snapshot into a stable negative int for React keys). BS
     // takes the `album_id != null` branch on negative numbers, calls
-    // `getAlbumFromDB(-X)` → undefined → throws TypeError. Gate the wire
-    // payload at the chokepoint so picker / queue / future-caller leaks all
-    // route through the freeform variant for unlinked rows. (dj-site#701,
-    // sibling shape #608. Classic-side equivalent shipped in PR #699.)
+    // `getAlbumFromDB(-X)` → undefined → throws TypeError. Gate album_id (and
+    // the album-scoped rotation_bin / track_position) at the chokepoint so
+    // picker / queue / future-caller leaks route through the freeform variant
+    // for unlinked rows. rotation_id is exempt from the gate — it rides the
+    // freeform variant to keep the rotation badge on unlinked releases.
     describe("synthesized negative album_id", () => {
-      it("omits album_id, rotation_id, rotation_bin when album_id is negative", () => {
+      it("omits album_id and rotation_bin but keeps rotation_id when album_id is negative", () => {
         const query = createTestFlowsheetQuery({
           album_id: -987654321,
           rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
@@ -152,8 +153,11 @@ describe("flowsheet conversions", () => {
         });
         const result = convertQueryToSubmission(query) as QuerySubmission;
         expect(result.album_id).toBeUndefined();
-        expect(result.rotation_id).toBeUndefined();
         expect(result.rotation_bin).toBeUndefined();
+        // rotation_id rides the freeform variant so an unlinked rotation
+        // release keeps its badge — the synthesized negative id only bars
+        // album_id and the album-scoped fields, not the rotation linkage.
+        expect(result.rotation_id).toBe(TEST_ENTITY_IDS.ROTATION.HEAVY);
       });
 
       it("preserves freeform fields when falling back from a negative album_id", () => {
@@ -184,7 +188,7 @@ describe("flowsheet conversions", () => {
       // Zero is not a legitimate album_id (PG serial starts at 1), but the
       // sign check below is the load-bearing one; pin zero too so a future
       // fix can't quietly switch the guard to `!= 0` and drift the boundary.
-      it("omits album_id when album_id is zero", () => {
+      it("omits album_id and rotation_bin but keeps rotation_id when album_id is zero", () => {
         const query = createTestFlowsheetQuery({
           album_id: 0,
           rotation_id: 5001,
@@ -192,17 +196,15 @@ describe("flowsheet conversions", () => {
         });
         const result = convertQueryToSubmission(query) as QuerySubmission;
         expect(result.album_id).toBeUndefined();
-        expect(result.rotation_id).toBeUndefined();
         expect(result.rotation_bin).toBeUndefined();
+        expect(result.rotation_id).toBe(5001);
       });
 
-      // Orthogonal: rotation_id / rotation_bin set without album_id. No
-      // dispatcher currently produces this (rotation picker writes the trio
-      // together; setRotationMode clears all three), but pinning the case
-      // catches a future regression that decouples rotation pass-through
-      // from the album_id gate (e.g. moving rotation_id outside the
-      // hasLinkedAlbum spread).
-      it("omits rotation_id and rotation_bin when album_id is undefined", () => {
+      // The core of the fix: a rotation release picked without a linked
+      // library album lands with album_id NULL, but must still carry
+      // rotation_id so the badge survives. rotation_bin stays derived-on-read
+      // (never a write field), so it drops off the freeform variant.
+      it("keeps rotation_id but omits rotation_bin when album_id is undefined", () => {
         const query = createTestFlowsheetQuery({
           album_id: undefined,
           rotation_id: 5001,
@@ -210,8 +212,16 @@ describe("flowsheet conversions", () => {
         });
         const result = convertQueryToSubmission(query) as QuerySubmission;
         expect(result.album_id).toBeUndefined();
-        expect(result.rotation_id).toBeUndefined();
         expect(result.rotation_bin).toBeUndefined();
+        expect(result.rotation_id).toBe(5001);
+      });
+
+      // A plain freeform add (no rotation picked) carries no rotation_id —
+      // the exemption forwards a real rotation id, it doesn't invent one.
+      it("omits rotation_id when the query has none", () => {
+        const query = createTestFlowsheetQuery({ album_id: undefined });
+        const result = convertQueryToSubmission(query) as QuerySubmission;
+        expect(result.rotation_id).toBeUndefined();
       });
 
       // `track_position` is a `release_track.position` reference (e.g. "A1")


### PR DESCRIPTION
## Summary

Editing a "Various Artists" compilation rotation entry to the specific performer's name stripped the ROTATION badge from the track — on dj-site/iOS and the public wxyc.info flowsheet.

The symptom is at edit time, but the cause is at add time: `convertQueryToSubmission` gated `rotation_id` inside the positive-`album_id` spread, so a **library-unlinked** rotation pick landed with both `album_id` and `rotation_id` NULL. The badge was then held up only by read-time string matching on `artist_name` (the BS `rotation_bin` COALESCE fallback and the tubafrenzy mirror's `flowsheetEntryType` recompute). Editing the artist off "Various Artists" broke that match on both surfaces.

## Fix

Hoist `rotation_id` out of the album gate so it rides the freeform variant independent of `album_id` — matching `convertBinToFlowsheet`, which already does this. A real `rotation_id` makes both badge paths short-circuit (read-time FK JOIN; mirror `flowsheetEntryType = 2`), so the label survives the artist edit. `album_id`, `rotation_bin`, and `track_position` stay album-scoped.

## Tests

- Rewrote the `conversions.test.ts` cases that pinned the old (buggy) drop-on-unlinked behavior, plus the two end-to-end picker → wire assertions in `catalog/conversions.test.ts`, to assert `rotation_id` now survives while `album_id` / `rotation_bin` stay gated.
- Added a case asserting a plain freeform add (no rotation picked) still carries no `rotation_id`.
- Full unit suite green (3803 tests); `tsc --noEmit` clean; lint 0 errors.

## Scope

Forward fix. Entries already logged with NULL `rotation_id` still lose their badge on edit; given the 2026-08-31 tubafrenzy turndown a backfill is likely not worth it (called out in the issue).

Closes #1021
