### PR TITLE
fix(flowsheet): preserve rotation_id when queuing library-unlinked rotation picks

### DIFF
--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -5,14 +5,20 @@ import { Rotation } from "../rotation/types";
 import { hasLinkedAlbumId } from "./linkage";
 import { clearQueueFromStorage, loadQueueFromStorage, saveQueueToStorage } from "./queue-storage";
 
-// Drop the catalog-anchored trio (album_id, rotation_id, rotation) from a
-// would-be queue entry when album_id isn't a real positive library.id.
-// SongEntry's "Play Now" handler (src/components/experiences/modern/flowsheet/
-// Entries/SongEntry/SongEntry.tsx) reads entry.album_id directly and bypasses
-// convertQueryToSubmission, so without sanitization here a synthesized
-// negative id from synthesizeAlbumId (library-unlinked rotation/catalog rows)
-// rides the wire and trips BS's `album_id != null` branch → TypeError 500 —
-// same shape PR #702 gated for the form-submit path. (dj-site#703)
+// Drop only a non-positive album_id from a would-be queue entry. SongEntry's
+// "Play Now" handler reads entry.album_id directly and bypasses
+// convertQueryToSubmission, so without this a synthesized negative id from
+// synthesizeAlbumId (library-unlinked rotation/catalog rows) rides the wire
+// and trips BS's `album_id != null` branch → getAlbumFromDB(-X) → TypeError.
+//
+// rotation_id and rotation are NOT album-scoped and must survive: rotation_id
+// is a first-class FK that BS persists on the freeform variant, and rotation
+// is the local badge field the queue row (and the eventual "Play Now" write)
+// carries. A library-unlinked rotation pick — typical of Various-Artists
+// compilations — would otherwise lose its rotation linkage the moment it was
+// queued, dropping the badge on dj-site/iOS and failing to propagate as
+// rotation to the wxyc.info archive. (Mirrors convertQueryToSubmission /
+// convertBinToFlowsheet, which forward rotation_id independent of album_id.)
 function withSanitizedAlbumLinkage<
   T extends {
     album_id?: number;
@@ -26,8 +32,6 @@ function withSanitizedAlbumLinkage<
   return {
     ...entry,
     album_id: undefined,
-    rotation_id: undefined,
-    rotation: undefined,
   };
 }
 

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -1337,7 +1337,7 @@ describe("flowsheetHooks", () => {
         expect(result.current.search.searchQuery.artist).toBe("");
       });
 
-      it("sanitizes synthesized negative album linkage on the queue path", () => {
+      it("drops a synthesized negative album_id but keeps rotation linkage on the queue path", () => {
         const { result } = renderCombined();
 
         act(() => {
@@ -1359,8 +1359,13 @@ describe("flowsheetHooks", () => {
 
         expect(result.current.queue.queue.length).toBe(1);
         const queued = result.current.queue.queue[0];
+        // The synthesized negative id must not reach the queue (SongEntry
+        // "Play Now" would forward it to BS and 500), but rotation_id/rotation
+        // ride the freeform variant so the library-unlinked rotation pick keeps
+        // its badge and propagates as rotation to the wxyc.info archive.
         expect(queued.album_id).toBeUndefined();
-        expect(queued.rotation_id).toBeUndefined();
+        expect(queued.rotation_id).toBe(7);
+        expect(queued.rotation).toBe("H");
       });
     });
 

--- a/tests/unit/lib/features/flowsheet/flowsheet.test.ts
+++ b/tests/unit/lib/features/flowsheet/flowsheet.test.ts
@@ -379,15 +379,18 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(mockedSaveQueue).toHaveBeenCalled();
     });
 
-    describe("addToQueue album-linkage sanitization (dj-site#703)", () => {
+    describe("addToQueue album-linkage sanitization", () => {
       // The Modern rotation picker + bin/catalog deposit paths can feed
       // addToQueue with a synthesized negative album_id (from
       // synthesizeAlbumId, for library-unlinked rows). SongEntry's "Play Now"
       // bypasses convertQueryToSubmission and would forward the negative id to
-      // BS — same 500 PR #702 fixed for the form-submit path. Sanitize at the
-      // reducer so the queue never holds a synthesized id, mirroring the
-      // chokepoint logic in convertQueryToSubmission.
-      it("strips album_id, rotation_id, and rotation when album_id is a synthesized negative hash", () => {
+      // BS, which branches on `album_id != null`, calls getAlbumFromDB(-X), and
+      // throws. Drop only the non-positive album_id at the reducer. rotation_id
+      // is a first-class FK that BS persists on the freeform variant, and
+      // rotation is the local badge field — both must survive an unlinked pick
+      // so the queued row keeps its rotation linkage all the way to "Play Now"
+      // (mirrors convertQueryToSubmission / convertBinToFlowsheet).
+      it("drops a synthesized negative album_id but keeps rotation_id and rotation", () => {
         const query = createTestFlowsheetQuery({
           album_id: -123456,
           rotation_id: 7,
@@ -395,11 +398,11 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         });
         const result = harness().reduce(actions.addToQueue(query));
         expect(result.queue[0].album_id).toBeUndefined();
-        expect(result.queue[0].rotation_id).toBeUndefined();
-        expect(result.queue[0].rotation).toBeUndefined();
+        expect(result.queue[0].rotation_id).toBe(7);
+        expect(result.queue[0].rotation).toBe("H");
       });
 
-      it("strips the catalog-anchored trio when album_id is zero", () => {
+      it("drops a zero album_id but keeps rotation_id and rotation", () => {
         const query = createTestFlowsheetQuery({
           album_id: 0,
           rotation_id: 7,
@@ -407,11 +410,11 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         });
         const result = harness().reduce(actions.addToQueue(query));
         expect(result.queue[0].album_id).toBeUndefined();
-        expect(result.queue[0].rotation_id).toBeUndefined();
-        expect(result.queue[0].rotation).toBeUndefined();
+        expect(result.queue[0].rotation_id).toBe(7);
+        expect(result.queue[0].rotation).toBe("H");
       });
 
-      it("strips orphaned rotation linkage when album_id is undefined", () => {
+      it("keeps rotation_id and rotation when album_id is undefined (freeform rotation pick)", () => {
         const query = createTestFlowsheetQuery({
           album_id: undefined,
           rotation_id: 7,
@@ -419,8 +422,8 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         });
         const result = harness().reduce(actions.addToQueue(query));
         expect(result.queue[0].album_id).toBeUndefined();
-        expect(result.queue[0].rotation_id).toBeUndefined();
-        expect(result.queue[0].rotation).toBeUndefined();
+        expect(result.queue[0].rotation_id).toBe(7);
+        expect(result.queue[0].rotation).toBe("H");
       });
 
       it("preserves the catalog-anchored trio when album_id is a positive library.id", () => {
@@ -514,12 +517,13 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.queueIdCounter).toBe(0);
     });
 
-    describe("loadQueue album-linkage sanitization (dj-site#703)", () => {
-      // Queues persisted to localStorage before #703 shipped may contain rows
-      // with synthesized negative album_id. Sanitize on load so a stale
-      // poisoned queue can't leak a negative album_id via SongEntry "Play Now"
-      // after the user reloads the page.
-      it("sanitizes poisoned localStorage entries with negative album_id", () => {
+    describe("loadQueue album-linkage sanitization", () => {
+      // Queues persisted to localStorage before the album_id gate shipped may
+      // contain rows with a synthesized negative album_id. Drop the poisoned
+      // album_id on load so it can't leak to BS via SongEntry "Play Now" after
+      // a reload — but keep rotation_id and rotation so the reloaded queue row
+      // still carries its rotation linkage.
+      it("drops a poisoned negative album_id on load but keeps rotation_id and rotation", () => {
         const poisoned = createTestFlowsheetEntry({
           id: 1,
           album_id: -42,
@@ -530,8 +534,8 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
 
         const result = harness().reduce(actions.loadQueue());
         expect(result.queue[0].album_id).toBeUndefined();
-        expect(result.queue[0].rotation_id).toBeUndefined();
-        expect(result.queue[0].rotation).toBeUndefined();
+        expect(result.queue[0].rotation_id).toBe(7);
+        expect(result.queue[0].rotation).toBe("H");
       });
 
       it("preserves linkage for library-linked entries on load", () => {


### PR DESCRIPTION
## Summary

Preserve `rotation_id`/`rotation` when queuing a library-unlinked rotation pick. `withSanitizedAlbumLinkage` (`lib/features/flowsheet/frontend.ts`) now drops only the non-positive `album_id` instead of also nulling the rotation linkage.

## Why

Queuing an unlinked rotation track (Various-Artists comps, etc.) stored the entry with `rotation_id`/`rotation` stripped, so on commit the POST carried no `rotation_id`, `flowsheet.rotation_id` landed NULL, and the ROTATION badge was left to a fragile read-time `(artist, album)` match — and never reached the wxyc.info archive, where the BS→tubafrenzy mirror only stamps `flowsheetEntryType = 2` when `rotation_id > 0` (or an active match hits). That is exactly the DJ-reported queue-vs-direct asymmetry ("queue → no rotation in the archive; direct add → rotation shows").

`withSanitizedAlbumLinkage` exists only to keep a synthesized negative `album_id` off the wire (dj-site#701/#703) — stripping `rotation_id`/`rotation` was collateral. Post-BS#1308 `rotation_id` is valid on the freeform variant, which `convertQueryToSubmission` (fixed in feff6693), `convertBinToFlowsheet`, and `usePlayNow` already rely on. The queue store was the last hole.

## Change

- `withSanitizedAlbumLinkage`: else-branch returns `{ ...entry, album_id: undefined }` (was `{ ...entry, album_id: undefined, rotation_id: undefined, rotation: undefined }`). The `hasLinkedAlbumId` guard is unchanged, so a positive `album_id` still short-circuits and a non-positive one is still forced to `undefined` — the dj-site#701/#703 protection is intact.

## Tests (TDD, red → green)

- `tests/unit/lib/features/flowsheet/flowsheet.test.ts` — `addToQueue` (negative-hash / zero / undefined `album_id`) and the `loadQueue` poisoned-localStorage case now assert `album_id` dropped but `rotation_id`/`rotation` preserved.
- `tests/unit/hooks/flowsheetHooks.test.tsx` — hook-level `submitToQueue` end-to-end: freeze a `-42` synthesized id + `rotation_id: 7` + `rotation_bin: "H"`, queue it, assert `album_id` undefined and `rotation_id === 7`, `rotation === "H"`.
- Full suite: 3803 tests pass. `npm run lint` clean (no new warnings), `npx tsc --noEmit` exit 0.

## Scope

Queue path only. Direct submit was fixed in feff6693; the rotation picker writes into the live search query, not the queue. See #1025 for the full root cause and the out-of-scope optimistic-row follow-up.

Closes #1025
Contributes to #933
