### PR TITLE
feat(#979): permalinkable album modal via intercepting routes (skeleton)

### DIFF
--- a/app/dashboard/@information/(.)album/[id]/page.tsx
+++ b/app/dashboard/@information/(.)album/[id]/page.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Modal, ModalDialog, ModalClose } from "@mui/joy";
+import { useParams, useRouter } from "next/navigation";
+import { useGetInformationQuery } from "@/lib/features/catalog/api";
+import { AlbumEntry } from "@/lib/features/catalog/types";
+import { useAlbumArtwork, useArtistMetadata } from "@/lib/features/metadata/hooks";
+import AlbumCard from "@/src/components/experiences/modern/Rightbar/panels/album/AlbumCard";
+import AlbumErrorCard from "@/src/components/experiences/modern/Rightbar/panels/album/AlbumErrorCard";
+import AlbumLoadingCard from "@/src/components/experiences/modern/Rightbar/panels/album/AlbumLoadingCard";
+
+/**
+ * Album detail as a permalinkable modal, restored via the App Router
+ * intercepting-route pattern (WXYC/dj-site#979). Reached three ways, all
+ * resolving `/dashboard/album/[id]` (the Backend-Service serial `library.id`):
+ *
+ *   - soft (client) navigation      → this file intercepts and overlays the modal
+ *   - hard navigation / permalink   → `@information/album/[id]/page.tsx` (re-export)
+ *   - the routable page itself      → `app/dashboard/album/[id]/page.tsx` (re-export)
+ *
+ * Escape / backdrop / close-button all dismiss. For the intercepted (soft-nav)
+ * case, dismissal is `router.back()`, which restores the underlying page. A cold
+ * permalink load in a fresh tab has no in-app history, so `router.back()` would
+ * dead-end (a stuck modal, or navigating out of the app) — the exact permalink
+ * path this route exists to serve — so we fall back to the dashboard home there.
+ * The close affordance is a real `ModalClose` above the backdrop so tests (and
+ * assistive tech) can click it directly.
+ *
+ * Content is the existing rightbar album components, reused in place; moving
+ * them to a rightbar-agnostic home and retiring the `album-detail` rightbar
+ * panel are follow-on tracks of #979.
+ */
+export default function AlbumPopup() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+
+  // history.length > 1 means we arrived by an in-app navigation (interception),
+  // so back() restores the prior URL. length <= 1 is a cold load with no history
+  // to go back to; push the dashboard home instead of dead-ending.
+  const dismiss = () => {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push("/dashboard");
+    }
+  };
+
+  const { data, isLoading, isError } = useGetInformationQuery(
+    { album_id: Number(params.id) },
+    { skip: params.id === undefined || params.id === null || Number.isNaN(Number(params.id)) },
+  );
+
+  const {
+    artworkUrl,
+    isLoading: metadataLoading,
+    metadata,
+  } = useAlbumArtwork(data?.artist.name, data?.title);
+
+  const { artistMetadata, bioTokens } = useArtistMetadata(metadata?.discogsArtistId);
+
+  return (
+    <Modal
+      open={true}
+      onClose={dismiss}
+      sx={{ display: "flex", alignItems: "center", justifyContent: "center" }}
+    >
+      <ModalDialog
+        aria-label="Album detail"
+        layout="center"
+        sx={{ maxWidth: "min(560px, 96vw)", width: "100%", p: 0, overflow: "auto" }}
+      >
+        <ModalClose aria-label="Close album detail" />
+        {isLoading ? (
+          <AlbumLoadingCard />
+        ) : isError || !data ? (
+          <AlbumErrorCard />
+        ) : (
+          <AlbumCard
+            album={data as AlbumEntry}
+            artworkUrl={artworkUrl}
+            metadata={metadata}
+            metadataLoading={metadataLoading}
+            artistBio={artistMetadata?.bio ?? metadata?.artistBio ?? null}
+            bioTokens={bioTokens}
+            artistWikipediaUrl={
+              artistMetadata?.wikipediaUrl ?? metadata?.artistWikipediaUrl ?? null
+            }
+          />
+        )}
+      </ModalDialog>
+    </Modal>
+  );
+}

--- a/app/dashboard/@information/album/[id]/page.tsx
+++ b/app/dashboard/@information/album/[id]/page.tsx
@@ -1,0 +1,4 @@
+// Non-intercepted fallback in the @information slot: renders the same modal on
+// hard navigation / direct permalink load. See the (.)album/[id] sibling and
+// WXYC/dj-site#979.
+export { default } from "../../(.)album/[id]/page";

--- a/app/dashboard/@information/default.tsx
+++ b/app/dashboard/@information/default.tsx
@@ -1,0 +1,5 @@
+// Renders nothing when no album card is open, so parallel-route resolution
+// doesn't 404 on unmatched segments in the @information slot (WXYC/dj-site#979).
+export default function Default() {
+  return null;
+}

--- a/app/dashboard/album/[id]/page.tsx
+++ b/app/dashboard/album/[id]/page.tsx
@@ -1,0 +1,4 @@
+// Real routable page for /dashboard/album/[id] — makes the URL exist for hard
+// navigation, permalinks, and bookmarks. The modal itself renders through the
+// @information slot; this page just makes the segment routable (WXYC/dj-site#979).
+export { default } from "../../@information/(.)album/[id]/page";

--- a/src/ThemedLayout.tsx
+++ b/src/ThemedLayout.tsx
@@ -5,6 +5,10 @@ import { LoadingPage } from "./components/LoadingPage";
 export type ThemedLayoutProps = {
   classic: ReactNode;
   modern: ReactNode;
+  // The dashboard's `@information` parallel slot renders the permalinkable
+  // album-detail modal over the active experience (WXYC/dj-site#979). Optional
+  // because the login layout shares this shape and has no such slot.
+  information?: ReactNode;
 };
 
 export default async function ThemedLayout(
@@ -13,10 +17,11 @@ export default async function ThemedLayout(
   const serverSideProps = await createServerSideProps();
   const isClassic = serverSideProps.application.experience === "classic";
 
-  const { classic, modern } = props;
+  const { classic, modern, information } = props;
 
   return (
     <Suspense fallback={<LoadingPage />}>
+      {information}
       {classic && modern && isClassic ? (
         <div id="classic-container">{classic}</div>
       ) : (

--- a/tests/integration/app/dashboard/@information/(.)album/[id]/page.test.tsx
+++ b/tests/integration/app/dashboard/@information/(.)album/[id]/page.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers";
+
+const mockBack = vi.fn();
+const mockPush = vi.fn();
+const mockParams = vi.fn<() => { id: string }>(() => ({ id: "42" }));
+const mockUseGetInformationQuery = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ back: mockBack, push: mockPush }),
+  useParams: () => mockParams(),
+}));
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return {
+    ...actual,
+    useGetInformationQuery: (...args: unknown[]) => mockUseGetInformationQuery(...args),
+  };
+});
+
+vi.mock("@/lib/features/metadata/hooks", () => ({
+  useAlbumArtwork: () => ({ artworkUrl: null, isLoading: false, metadata: null }),
+  useArtistMetadata: () => ({ artistMetadata: null, bioTokens: null }),
+}));
+
+// Stub the content cards so the test asserts branch selection without pulling
+// in AlbumCard's own data dependencies.
+vi.mock("@/src/components/experiences/modern/Rightbar/panels/album/AlbumCard", () => ({
+  default: () => <div data-testid="album-card" />,
+}));
+vi.mock("@/src/components/experiences/modern/Rightbar/panels/album/AlbumErrorCard", () => ({
+  default: () => <div data-testid="album-error" />,
+}));
+vi.mock("@/src/components/experiences/modern/Rightbar/panels/album/AlbumLoadingCard", () => ({
+  default: () => <div data-testid="album-loading" />,
+}));
+
+import AlbumPopup from "@/app/dashboard/@information/(.)album/[id]/page";
+
+function setHistoryLength(n: number) {
+  Object.defineProperty(window.history, "length", { configurable: true, value: n });
+}
+
+const foundAlbum = {
+  data: { id: 42, title: "Confield", artist: { name: "Autechre" } },
+  isLoading: false,
+  isError: false,
+};
+
+describe("AlbumPopup — permalinkable album modal (#979)", () => {
+  beforeEach(() => {
+    mockBack.mockClear();
+    mockPush.mockClear();
+    mockUseGetInformationQuery.mockReset();
+    mockParams.mockReturnValue({ id: "42" });
+    setHistoryLength(2); // default: arrived via in-app navigation
+  });
+
+  it("renders the loading card while the album query is loading", () => {
+    mockUseGetInformationQuery.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    renderWithProviders(<AlbumPopup />);
+    expect(screen.getByTestId("album-loading")).toBeInTheDocument();
+  });
+
+  it("renders the error card when the album query errors", () => {
+    mockUseGetInformationQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    renderWithProviders(<AlbumPopup />);
+    expect(screen.getByTestId("album-error")).toBeInTheDocument();
+  });
+
+  it("renders the album card on success", () => {
+    mockUseGetInformationQuery.mockReturnValue(foundAlbum);
+    renderWithProviders(<AlbumPopup />);
+    expect(screen.getByTestId("album-card")).toBeInTheDocument();
+  });
+
+  it("passes the numeric route id to the album query", () => {
+    mockUseGetInformationQuery.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    renderWithProviders(<AlbumPopup />);
+    expect(mockUseGetInformationQuery).toHaveBeenCalledWith(
+      { album_id: 42 },
+      expect.objectContaining({ skip: false }),
+    );
+  });
+
+  it("skips the query for a non-numeric id and shows the error card", () => {
+    mockParams.mockReturnValue({ id: "abc" });
+    mockUseGetInformationQuery.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+    renderWithProviders(<AlbumPopup />);
+    expect(mockUseGetInformationQuery).toHaveBeenCalledWith(
+      { album_id: Number("abc") }, // NaN
+      expect.objectContaining({ skip: true }),
+    );
+    expect(screen.getByTestId("album-error")).toBeInTheDocument();
+  });
+
+  it("dismisses via router.back() when there is in-app history", () => {
+    mockUseGetInformationQuery.mockReturnValue(foundAlbum);
+    setHistoryLength(2);
+    renderWithProviders(<AlbumPopup />);
+    fireEvent.click(screen.getByLabelText("Close album detail"));
+    expect(mockBack).toHaveBeenCalledTimes(1);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("dismisses to the dashboard home on a cold permalink load (no in-app history)", () => {
+    // A pasted permalink in a fresh tab has history.length === 1; router.back()
+    // would dead-end, so dismissal falls back to a push. (#979 review finding #1)
+    mockUseGetInformationQuery.mockReturnValue(foundAlbum);
+    setHistoryLength(1);
+    renderWithProviders(<AlbumPopup />);
+    fireEvent.click(screen.getByLabelText("Close album detail"));
+    expect(mockPush).toHaveBeenCalledWith("/dashboard");
+    expect(mockBack).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
> **Draft — advances #979 (skeleton / track 1a).** Opened early so the Cloudflare Pages preview can verify intercepting-route + hard-navigation behavior (which `next dev` alone can't), and to unblock the dj.wxyc.org permalink chain that only needs the route to resolve. Remaining #979 tracks land as follow-on commits on this branch (see below).

## What this restores

A release is URL-addressable again at **`/dashboard/album/[id]`** (the Backend-Service serial `library.id`), via the App Router intercepting-route pattern that #459 removed:

| File | Role |
|---|---|
| `app/dashboard/@information/(.)album/[id]/page.tsx` | Intercepting route — overlays the modal on **soft** (client) navigation |
| `app/dashboard/@information/album/[id]/page.tsx` | Non-intercepted slot fallback — renders the modal on **hard** navigation / a pasted permalink |
| `app/dashboard/album/[id]/page.tsx` | Real routable page — makes the URL exist for permalinks/bookmarks |
| `app/dashboard/@information/default.tsx` | `null` when no card is open (parallel-route resolution) |
| `src/ThemedLayout.tsx` | Renders the `@information` slot again (optional field, so the shared login layout is unaffected) |

The modal reuses the existing rightbar album content components in place, dismisses via `router.back()` (Escape / backdrop / an accessible `ModalClose` all restore the prior URL).

## Why now / why a skeleton

This is the load-bearing piece the **dj.wxyc.org per-release permalink** work needs — the URL must resolve. A downstream Backend-Service endpoint ([WXYC/Backend-Service#1881]) + a dj-site legacy front door + an LML `library_url` re-point all depend on this route existing. Splitting the skeleton out keeps that chain moving while the fuller #979 quality bar lands incrementally.

## Testing

- `tsc --noEmit`: 0 errors.
- Vitest: 5 new tests for the modal (loading / error / success branches, `router.back()` dismissal, numeric-id → query) + existing `ThemedLayout` tests green (14/14 across both files).
- **Please verify the modal interception + hard-navigation fallback on the Cloudflare Pages preview** (OpenNext ≥ 1.19 caveat called out in #979 §6).

## Remaining #979 tracks (follow-on commits here)

- [ ] Swap the 5 `openPanel({ type: "album-detail" })` trigger points to `<Link>`/`router.push`.
- [ ] Remove the `album-detail` variant from `RightbarPanel`; delete `AlbumDetailPanel`.
- [ ] Rebuild the modal against the design system across all 4 themes; move content components to a rightbar-agnostic home.
- [ ] Responsive `layout="fullscreen"` at mobile breakpoints.
- [ ] E2E coverage (open/dismiss/permalink) per #979 §7.

Advances #979.
