### PR TITLE
feat(telemetry): enrich Web Vitals with route + navigation type

### DIFF
--- a/lib/web-vitals-reporter.ts
+++ b/lib/web-vitals-reporter.ts
@@ -11,17 +11,31 @@ import { safeCapture } from "./posthog";
 export interface WebVitalMetric {
   name: string;
   value: number;
+  delta: number;
   id: string;
   rating: "good" | "needs-improvement" | "poor";
+  navigationType?: string;
 }
 
 // Module-scope so the reference stays stable across renders: a changing
 // callback identity makes useReportWebVitals re-report already-seen metrics.
 export function reportWebVital(metric: WebVitalMetric): void {
+  // `pathname` is read at call time (not threaded through React state) so the
+  // callback identity stays stable, yet each vital is attributed to the route
+  // it fired on — the whole point being to filter cold-load LCP/TTFB to a
+  // specific page like /dashboard/catalog. `navigation_type` separates cold
+  // loads (navigate/reload) from warm back/forward restores. SSR-safe:
+  // useReportWebVitals only fires in the browser.
+  const pathname =
+    typeof window === "undefined" ? undefined : window.location.pathname;
+
   safeCapture("web_vitals", {
     name: metric.name,
     value: metric.value,
+    delta: metric.delta,
     id: metric.id,
     rating: metric.rating,
+    navigation_type: metric.navigationType,
+    pathname,
   });
 }

--- a/tests/unit/lib/web-vitals-reporter.test.ts
+++ b/tests/unit/lib/web-vitals-reporter.test.ts
@@ -13,8 +13,10 @@ function metric(overrides: Partial<WebVitalMetric> = {}): WebVitalMetric {
   return {
     name: "LCP",
     value: 1234.5,
+    delta: 1234.5,
     id: "v3-1700000000000-1234567890123",
     rating: "good",
+    navigationType: "navigate",
     ...overrides,
   };
 }
@@ -24,15 +26,20 @@ describe("reportWebVital", () => {
     vi.mocked(safeCapture).mockClear();
   });
 
-  it("captures a web_vitals event with the metric fields", () => {
+  it("captures a web_vitals event with the metric fields plus route context", () => {
     reportWebVital(metric());
 
     expect(safeCapture).toHaveBeenCalledTimes(1);
     expect(safeCapture).toHaveBeenCalledWith("web_vitals", {
       name: "LCP",
       value: 1234.5,
+      delta: 1234.5,
       id: "v3-1700000000000-1234567890123",
       rating: "good",
+      navigation_type: "navigate",
+      // jsdom's default location; in the browser this is the real route so
+      // cold-load LCP/TTFB can be filtered to e.g. /dashboard/catalog.
+      pathname: "/",
     });
   });
 
@@ -42,6 +49,15 @@ describe("reportWebVital", () => {
     expect(safeCapture).toHaveBeenCalledWith(
       "web_vitals",
       expect.objectContaining({ name: "CLS", value: 0.02, rating: "needs-improvement" })
+    );
+  });
+
+  it("distinguishes warm back/forward navigations from cold loads", () => {
+    reportWebVital(metric({ navigationType: "back-forward" }));
+
+    expect(safeCapture).toHaveBeenCalledWith(
+      "web_vitals",
+      expect.objectContaining({ navigation_type: "back-forward" })
     );
   });
 });


### PR DESCRIPTION
## Summary

Web Vitals already flow to PostHog through `TelemetryProvider` → `useReportWebVitals(reportWebVital)`, but the payload has no route context, so cold-load LCP/TTFB can't be filtered to `/dashboard/catalog`. Enrich `reportWebVital` with `pathname`, `delta`, and `navigation_type`.

## Changes

- `lib/web-vitals-reporter.ts`: extend `WebVitalMetric` with `delta` + `navigationType`; forward `pathname` (read from `window.location` at call time — keeps the callback a stable module-scope reference so `useReportWebVitals` doesn't re-report seen metrics), `delta`, and `navigation_type` (cold navigate/reload vs warm back/forward).
- Same `web_vitals` event name; still fail-open via `safeCapture`; SSR-safe; no new dependency.
- `tests/unit/lib/web-vitals-reporter.test.ts`: update the exact-match assertion + factory.

## Verification

Tests green (3); `eslint` + `tsc --noEmit` clean.

Second of a chained set from a catalog cold-load teardown. Independent of the background-image PR (#1038).

Closes #1039
