### PR TITLE
feat(telemetry): flag-gated server-phase timing for the SSR auth path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,13 @@ NEXT_PUBLIC_BETTER_AUTH_URL=http://localhost:8082/auth
 # (e.g. docker compose). Falls back to NEXT_PUBLIC_BETTER_AUTH_URL when unset.
 # AUTH_REWRITE_URL=http://auth:8082/auth
 
+# Optional server-only debug flag. Set to 1 to log per-phase SSR auth timing
+# ([server_timing] lines: getSession, org-role) to the server / Cloudflare
+# Workers Logs for a cold-load measurement window. Off (any other value) by
+# default — zero cost on the hot authenticated path. Not NEXT_PUBLIC_ (never
+# inlined into the client bundle).
+# SERVER_TIMING=1
+
 # Routing / experience system
 NEXT_PUBLIC_DASHBOARD_HOME_PAGE=/dashboard/catalog
 NEXT_PUBLIC_DEFAULT_EXPERIENCE=modern

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -24,6 +24,12 @@ NEXT_PUBLIC_QR_LOGIN_ENABLED=false
 # the dj-site server.
 # AUTH_REWRITE_URL=http://auth:8082/auth
 
+# Optional, server-only debug flag — set to 1 to log per-phase SSR auth timing
+# ([server_timing] lines for getSession + org-role) to Cloudflare Workers Logs
+# during a cold-load measurement window. Off by default (zero cost on the hot
+# authenticated path); read at call time, so no rebuild is needed to toggle.
+# SERVER_TIMING=1
+
 # Optional — OAuth 2.0 Device Authorization Grant (RFC 8628) client_id for the
 # QR shared-computer sign-in. Sent to /auth/device/code and /auth/device/token.
 # Defaults to "dj-site" when unset.

--- a/lib/features/authentication/server-utils.ts
+++ b/lib/features/authentication/server-utils.ts
@@ -6,6 +6,7 @@ import { BetterAuthSessionResponse, BetterAuthSession } from "./utilities";
 import { Authorization } from "../admin/types";
 import { roleToAuthorization, VerifiedData } from "./types";
 import { getUserRoleInOrganization, getAppOrganizationId } from "./organization-utils.server";
+import { measure } from "@/lib/server-timing";
 import { DEFAULT_DASHBOARD_HOME_PAGE } from "@/lib/features/application/constants";
 
 /** Gets the current session from better-auth in a server component. */
@@ -13,16 +14,18 @@ export async function getServerSession(): Promise<BetterAuthSession | null> {
   const cookieStore = await cookies();
   const cookieHeader = cookieStore.toString();
 
-  const session = await serverAuthClient
-    .getSession({
-      fetchOptions: {
-        headers: { cookie: cookieHeader },
-      },
-    })
-    .catch((error) => {
-      // Swallow auth-server fetch errors to avoid noisy Next.js errors.
-      return { data: null, error } as BetterAuthSessionResponse;
-    });
+  const session = await measure("auth.getSession", () =>
+    serverAuthClient
+      .getSession({
+        fetchOptions: {
+          headers: { cookie: cookieHeader },
+        },
+      })
+      .catch((error) => {
+        // Swallow auth-server fetch errors to avoid noisy Next.js errors.
+        return { data: null, error } as BetterAuthSessionResponse;
+      })
+  );
 
   if (!session.data) {
     return null;
@@ -82,10 +85,8 @@ async function getUserAuthority(session: BetterAuthSession, cookieHeader?: strin
 
   if (organizationId) {
     try {
-      const orgRole = await getUserRoleInOrganization(
-        session.user.id,
-        organizationId,
-        cookieHeader
+      const orgRole = await measure("auth.orgRole", () =>
+        getUserRoleInOrganization(session.user.id, organizationId, cookieHeader)
       );
 
       if (orgRole !== undefined) {

--- a/lib/features/session.ts
+++ b/lib/features/session.ts
@@ -8,6 +8,7 @@ import { roleToAuthorization, isAuthenticated, AuthenticatedUser } from "./authe
 import { SiteProps } from "./types";
 import { serverAuthClient } from "./authentication/server-client";
 import { parseAppSkinPreference } from "./experiences/preferences";
+import { measure } from "@/lib/server-timing";
 
 export const sessionOptions = {
   cookieOptions: {
@@ -50,18 +51,20 @@ export const createServerSideProps = cache(async (): Promise<SiteProps> => {
   let authentication = defaultAuthenticationData;
   try {
     const cookieHeader = cookieStore.toString();
-    const session = await serverAuthClient
-      .getSession({
-        fetchOptions: {
-          headers: {
-            cookie: cookieHeader,
+    const session = await measure("auth.getSession", () =>
+      serverAuthClient
+        .getSession({
+          fetchOptions: {
+            headers: {
+              cookie: cookieHeader,
+            },
           },
-        },
-      })
-      .catch((error) => {
-        // Swallow auth-server fetch errors to avoid noisy Next.js errors.
-        return { data: null, error } as BetterAuthSessionResponse;
-      });
+        })
+        .catch((error) => {
+          // Swallow auth-server fetch errors to avoid noisy Next.js errors.
+          return { data: null, error } as BetterAuthSessionResponse;
+        })
+    );
 
     if (session.data) {
       const normalizedSession = {
@@ -79,10 +82,12 @@ export const createServerSideProps = cache(async (): Promise<SiteProps> => {
       const organizationId = getAppOrganizationId();
       if (organizationId) {
         try {
-          const orgRole = await getUserRoleInOrganization(
-            normalizedSession.user.id,
-            organizationId,
-            cookieHeader
+          const orgRole = await measure("auth.orgRole", () =>
+            getUserRoleInOrganization(
+              normalizedSession.user.id,
+              organizationId,
+              cookieHeader
+            )
           );
 
           if (orgRole !== undefined) {

--- a/lib/server-timing.ts
+++ b/lib/server-timing.ts
@@ -1,0 +1,34 @@
+/**
+ * Flag-gated server-phase timing for the SSR critical path.
+ *
+ * The literal `Server-Timing` HTTP header isn't reachable for RSC-rendered
+ * routes in this OpenNext/Cloudflare setup: middleware doesn't run on
+ * `/dashboard/catalog` (its matcher is `/dashboard/admin/*`), and Server
+ * Components can't set response headers. So instead of a header, each
+ * instrumented call self-reports its own duration inline — wherever in the
+ * render tree it executes — which sidesteps any need for `after()` and captures
+ * work that renders later (e.g. behind a Suspense boundary). The lines are
+ * picked up by Cloudflare Workers Logs.
+ *
+ * Off by default (zero steady-state cost on the hot authenticated path). Enable
+ * for a measurement window with `SERVER_TIMING=1`. The flag is read at call
+ * time so it can be toggled without a rebuild.
+ */
+export async function measure<T>(
+  phase: string,
+  fn: () => Promise<T>,
+  meta?: Record<string, unknown>
+): Promise<T> {
+  if (process.env.SERVER_TIMING !== "1") return fn();
+
+  const start = performance.now();
+  try {
+    return await fn();
+  } finally {
+    const dur = Math.round((performance.now() - start) * 10) / 10;
+    // Bracketed tag matches the repo's greppable `[flowsheet]`/`[roster]`
+    // console convention; the structured second arg is the Workers-Logs query
+    // payload. `finally` so a failed phase is timed too.
+    console.warn("[server_timing]", { phase, dur, ...meta });
+  }
+}

--- a/tests/unit/lib/server-timing.test.ts
+++ b/tests/unit/lib/server-timing.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { measure } from "@/lib/server-timing";
+
+describe("measure", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("returns the wrapped result (enabled)", async () => {
+    vi.stubEnv("SERVER_TIMING", "1");
+    await expect(measure("auth.getSession", async () => 42)).resolves.toBe(42);
+  });
+
+  it("returns the wrapped result (disabled — passthrough)", async () => {
+    vi.stubEnv("SERVER_TIMING", "0");
+    await expect(measure("auth.getSession", async () => "ok")).resolves.toBe("ok");
+  });
+
+  it("does not log when the flag is off", async () => {
+    vi.stubEnv("SERVER_TIMING", "0");
+    await measure("auth.getSession", async () => 1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("logs one [server_timing] line with phase, numeric dur, and meta when enabled", async () => {
+    vi.stubEnv("SERVER_TIMING", "1");
+    await measure("auth.orgRole", async () => 1, { org: "app" });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [tag, payload] = warn.mock.calls[0] as [string, Record<string, unknown>];
+    expect(tag).toBe("[server_timing]");
+    expect(payload).toMatchObject({ phase: "auth.orgRole", org: "app" });
+    expect(typeof payload.dur).toBe("number");
+  });
+
+  it("still logs and rethrows on failure", async () => {
+    vi.stubEnv("SERVER_TIMING", "1");
+    await expect(
+      measure("auth.getSession", async () => {
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Instrument the SSR auth critical path so cold-load server time is observable. A cold dashboard render fetches `getSession` ~3× and org-role ~2× before first byte; there was no per-phase visibility, and a literal `Server-Timing` header isn't reachable for this route (middleware matches only `/dashboard/admin/*`; RSC can't set response headers).

## Changes

- `lib/server-timing.ts`: `measure(phase, fn, meta?)` — flag-gated on `SERVER_TIMING` (read at call time), passthrough when off, one `console.warn("[server_timing]", { phase, dur })` when on. Self-reports inline so it captures calls that render later (behind Suspense), no `after()` dependency.
- Wrap `auth.getSession` + `auth.orgRole` at their call sites in `server-utils.ts` and `session.ts`.
- Document the server-only `SERVER_TIMING` flag in `.env.example` + `docs/env-vars.md`.
- `tests/unit/lib/server-timing.test.ts`.

## Verification

server-timing + auth + session suites green (284 tests); `eslint` (0 errors) + `tsc --noEmit` clean.

Third of a chained set from a catalog cold-load teardown. The auth-session dedup PR stacks on this branch and uses `[server_timing]` logs to prove the ×3→×1 reduction.

Closes #1041
