### PR TITLE
perf(auth): dedupe the per-request session and org-role fetches

### DIFF
--- a/lib/features/authentication/server-utils.ts
+++ b/lib/features/authentication/server-utils.ts
@@ -1,12 +1,11 @@
 import "server-only";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { serverAuthClient } from "./server-client";
-import { BetterAuthSessionResponse, BetterAuthSession } from "./utilities";
+import { BetterAuthSession } from "./utilities";
 import { Authorization } from "../admin/types";
 import { roleToAuthorization, VerifiedData } from "./types";
-import { getUserRoleInOrganization, getAppOrganizationId } from "./organization-utils.server";
-import { measure } from "@/lib/server-timing";
+import { getAppOrganizationId } from "./organization-utils.server";
+import { getSessionCached, getOrgRoleCached } from "./session-cache";
 import { DEFAULT_DASHBOARD_HOME_PAGE } from "@/lib/features/application/constants";
 
 /** Gets the current session from better-auth in a server component. */
@@ -14,18 +13,7 @@ export async function getServerSession(): Promise<BetterAuthSession | null> {
   const cookieStore = await cookies();
   const cookieHeader = cookieStore.toString();
 
-  const session = await measure("auth.getSession", () =>
-    serverAuthClient
-      .getSession({
-        fetchOptions: {
-          headers: { cookie: cookieHeader },
-        },
-      })
-      .catch((error) => {
-        // Swallow auth-server fetch errors to avoid noisy Next.js errors.
-        return { data: null, error } as BetterAuthSessionResponse;
-      })
-  );
+  const session = await getSessionCached(cookieHeader);
 
   if (!session.data) {
     return null;
@@ -85,8 +73,10 @@ async function getUserAuthority(session: BetterAuthSession, cookieHeader?: strin
 
   if (organizationId) {
     try {
-      const orgRole = await measure("auth.orgRole", () =>
-        getUserRoleInOrganization(session.user.id, organizationId, cookieHeader)
+      const orgRole = await getOrgRoleCached(
+        session.user.id,
+        organizationId,
+        cookieHeader
       );
 
       if (orgRole !== undefined) {

--- a/lib/features/authentication/session-cache.ts
+++ b/lib/features/authentication/session-cache.ts
@@ -21,6 +21,17 @@ import { measure } from "@/lib/server-timing";
  *
  * Keyed on the cookie header (session) and user+org+cookie (role); within one
  * request those are constant, so each resolves to a single fetch.
+ *
+ * Two caller invariants this relies on:
+ *  - The memoized result is SHARED by reference across callers in a request —
+ *    treat it as read-only. Today's callers (`getServerSession`,
+ *    `createServerSideProps`) spread-copy `session.data` before normalizing, so
+ *    they never mutate the shared object; new callers must do the same.
+ *  - Pass a CONSISTENT `cookieHeader` for the same user within a request. It is
+ *    part of the role key, so a caller that omitted it (`undefined`) while
+ *    another passed the string would key differently and lose the dedup (a
+ *    redundant round-trip — correctness is still preserved). Every current
+ *    call site resolves a concrete header, so they collide on one key.
  */
 export const getSessionCached = cache((cookieHeader: string) =>
   measure("auth.getSession", () =>

--- a/lib/features/authentication/session-cache.ts
+++ b/lib/features/authentication/session-cache.ts
@@ -1,0 +1,45 @@
+import { cache } from "react";
+import { serverAuthClient } from "./server-client";
+import { getUserRoleInOrganization } from "./organization-utils.server";
+import { BetterAuthSessionResponse } from "./utilities";
+import { measure } from "@/lib/server-timing";
+
+/**
+ * Per-request cached raw auth fetches. React `cache()` memoizes within a single
+ * RSC request, so the several session/org-role reads a dashboard render performs
+ * — `createServerSideProps` (root layout + `ThemedLayout`), `requireAuth` in the
+ * dashboard layout, and `requireAuth` + `getUserFromSession` in Leftbar —
+ * collapse to one backend round-trip each instead of ~3× getSession / ~2×
+ * org-role.
+ *
+ * Cached at the RAW fetch seam, not a normalized result: the callers normalize
+ * divergently (`session.ts` maps role/banned/appSkin/authority; `getServerSession`
+ * maps only `username`) and the org-role feeds authentication data in one path
+ * vs the fail-closed `Authorization` enum in `getUserAuthority` — sharing a
+ * normalized value would flatten those. The `measure()` wrapper keeps the
+ * `[server_timing]` per-phase logging on the deduped call.
+ *
+ * Keyed on the cookie header (session) and user+org+cookie (role); within one
+ * request those are constant, so each resolves to a single fetch.
+ */
+export const getSessionCached = cache((cookieHeader: string) =>
+  measure("auth.getSession", () =>
+    serverAuthClient
+      .getSession({
+        fetchOptions: {
+          headers: { cookie: cookieHeader },
+        },
+      })
+      .catch((error) => {
+        // Swallow auth-server fetch errors to avoid noisy Next.js errors.
+        return { data: null, error } as BetterAuthSessionResponse;
+      })
+  )
+);
+
+export const getOrgRoleCached = cache(
+  (userId: string, organizationId: string, cookieHeader?: string) =>
+    measure("auth.orgRole", () =>
+      getUserRoleInOrganization(userId, organizationId, cookieHeader)
+    )
+);

--- a/lib/features/session.ts
+++ b/lib/features/session.ts
@@ -2,13 +2,12 @@ import { cache } from "react";
 import { cookies } from "next/headers";
 import "server-only";
 import { defaultApplicationState } from "./application/types";
-import { defaultAuthenticationData, betterAuthSessionToAuthenticationData, BetterAuthSessionResponse, BetterAuthSession } from "./authentication/utilities";
-import { getUserRoleInOrganization, getAppOrganizationId } from "./authentication/organization-utils.server";
+import { defaultAuthenticationData, betterAuthSessionToAuthenticationData, BetterAuthSession } from "./authentication/utilities";
+import { getAppOrganizationId } from "./authentication/organization-utils.server";
 import { roleToAuthorization, isAuthenticated, AuthenticatedUser } from "./authentication/types";
 import { SiteProps } from "./types";
-import { serverAuthClient } from "./authentication/server-client";
 import { parseAppSkinPreference } from "./experiences/preferences";
-import { measure } from "@/lib/server-timing";
+import { getSessionCached, getOrgRoleCached } from "./authentication/session-cache";
 
 export const sessionOptions = {
   cookieOptions: {
@@ -51,20 +50,7 @@ export const createServerSideProps = cache(async (): Promise<SiteProps> => {
   let authentication = defaultAuthenticationData;
   try {
     const cookieHeader = cookieStore.toString();
-    const session = await measure("auth.getSession", () =>
-      serverAuthClient
-        .getSession({
-          fetchOptions: {
-            headers: {
-              cookie: cookieHeader,
-            },
-          },
-        })
-        .catch((error) => {
-          // Swallow auth-server fetch errors to avoid noisy Next.js errors.
-          return { data: null, error } as BetterAuthSessionResponse;
-        })
-    );
+    const session = await getSessionCached(cookieHeader);
 
     if (session.data) {
       const normalizedSession = {
@@ -82,12 +68,10 @@ export const createServerSideProps = cache(async (): Promise<SiteProps> => {
       const organizationId = getAppOrganizationId();
       if (organizationId) {
         try {
-          const orgRole = await measure("auth.orgRole", () =>
-            getUserRoleInOrganization(
-              normalizedSession.user.id,
-              organizationId,
-              cookieHeader
-            )
+          const orgRole = await getOrgRoleCached(
+            normalizedSession.user.id,
+            organizationId,
+            cookieHeader
           );
 
           if (orgRole !== undefined) {

--- a/tests/unit/lib/features/authentication/session-cache.test.ts
+++ b/tests/unit/lib/features/authentication/session-cache.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Identity-mock react cache() so behavior is deterministic (matches
+// session.test.ts). The ×N→×1 dedup that real cache() provides is a
+// request-scoped runtime property, not unit-observable here; it is verified via
+// the [server_timing] logs on a real render. These tests cover the seam's
+// behavior: correct pass-through of args + results, and the getSession catch.
+vi.mock("react", async () => {
+  const actual = await vi.importActual("react");
+  return { ...actual, cache: (fn: (...args: unknown[]) => unknown) => fn };
+});
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/features/authentication/server-client", () => ({
+  serverAuthClient: {
+    getSession: (options: unknown) => mockGetSession(options),
+  },
+}));
+
+const mockGetUserRoleInOrganization = vi.fn();
+vi.mock("@/lib/features/authentication/organization-utils.server", () => ({
+  getUserRoleInOrganization: (userId: string, orgId: string, cookie?: string) =>
+    mockGetUserRoleInOrganization(userId, orgId, cookie),
+}));
+
+import {
+  getSessionCached,
+  getOrgRoleCached,
+} from "@/lib/features/authentication/session-cache";
+
+describe("session-cache", () => {
+  beforeEach(() => {
+    mockGetSession.mockReset();
+    mockGetUserRoleInOrganization.mockReset();
+  });
+
+  describe("getSessionCached", () => {
+    it("forwards the cookie header to the auth client and returns its result", async () => {
+      const response = { data: { user: { id: "u1" } } };
+      mockGetSession.mockResolvedValue(response);
+
+      const result = await getSessionCached("better-auth.session=abc");
+
+      expect(mockGetSession).toHaveBeenCalledWith({
+        fetchOptions: { headers: { cookie: "better-auth.session=abc" } },
+      });
+      expect(result).toBe(response);
+    });
+
+    it("fails open to a null-data response when the auth fetch rejects", async () => {
+      const error = new Error("auth server unreachable");
+      mockGetSession.mockRejectedValue(error);
+
+      const result = await getSessionCached("cookie");
+
+      expect(result).toEqual({ data: null, error });
+    });
+  });
+
+  describe("getOrgRoleCached", () => {
+    it("forwards user, org, and cookie and returns the role", async () => {
+      mockGetUserRoleInOrganization.mockResolvedValue("dj");
+
+      const role = await getOrgRoleCached("u1", "org1", "cookie");
+
+      expect(mockGetUserRoleInOrganization).toHaveBeenCalledWith(
+        "u1",
+        "org1",
+        "cookie"
+      );
+      expect(role).toBe("dj");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fetch the auth session + org-role once per dashboard render instead of ~3×/2×. Introduce `getSessionCached` / `getOrgRoleCached` (React `cache()` at the raw fetch seam) so `createServerSideProps`, both `requireAuth` sites, and Leftbar's `getUserFromSession` share one backend round-trip each.

Cached at the raw seam (not a normalized value) to preserve each caller's divergent normalization and the fail-closed `Authorization.NO` in `getUserAuthority`. `getServerSession` — and therefore `session-guards`' CSRF gate — is behavior-preserving.

## Review outcome

Deep adversarial Opus review verified **session isolation is safe**: React `cache()` memoizes into a per-request store via the React dispatcher (not a module global), Cloudflare `nodejs_compat_v2` guarantees per-request AsyncLocalStorage isolation, `cookies()` forces dynamic rendering, and the identical `cache()` pattern already ships in `createServerSideProps`. Fail-closed authority, all redirects, the raw-seam catch consolidation, and the CSRF 403 path were each verified byte-equivalent to `main`. A follow-up commit documents the shared-result + cookie-key caller invariants the review flagged.

## Verification

- Full unit suite green (rebased onto main): 287 auth/session/server-timing tests + `tsc --noEmit` clean.
- The ×3→×1 dedup is request-scoped (no React dispatcher under vitest), confirmed via the `[server_timing]` logs from #1042, not a unit assertion.

Supersedes #1044, which GitHub auto-closed when its base branch (the now-merged server-timing PR) was deleted. Rebased onto `main`.

Closes #1043
