### PR TITLE
feat(catalog): legacy per-release permalink front door (/dashboard/album/legacy/[legacyId])

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,9 @@ yarn-error.log*
 next-env.d.ts
 
 
-# personal legacy analysis
-legacy/
+# personal legacy analysis (top-level scratch dir only; must not match route
+# segments like app/dashboard/album/legacy/)
+/legacy/
 
 # personal planning docs (kept locally; canonical plans live in WXYC/wiki)
 /plans/

--- a/app/dashboard/@information/album/legacy/[legacyId]/page.tsx
+++ b/app/dashboard/@information/album/legacy/[legacyId]/page.tsx
@@ -1,0 +1,68 @@
+import { cookies } from "next/headers";
+import { permanentRedirect } from "next/navigation";
+import Link from "next/link";
+import { Box, Button, Sheet, Stack, Typography } from "@mui/joy";
+import {
+  albumSerialPath,
+  resolveLegacyReleaseId,
+} from "@/lib/features/catalog/legacy-permalink.server";
+
+/**
+ * Legacy per-release permalink front door. External callers (LML lookups, the
+ * Slack request line, wxyc.info) hold the tubafrenzy legacy release id, not the
+ * Backend-Service serial the canonical album route is keyed on. This route
+ * resolves the legacy id to the serial and redirects to
+ * `/dashboard/album/[serial]`.
+ *
+ * It renders through the dashboard `@information` slot — the slot the layout
+ * actually renders (the `children`-slot sibling is a routability stub whose
+ * output is discarded). A cold external paste hits the dashboard `requireAuth()`
+ * gate first and bounces through login when unauthenticated.
+ *
+ * A resolved id 308-redirects: the serial is stable once assigned, so the hop
+ * is safe to cache permanently. A miss renders a non-cacheable "not in the
+ * catalog yet" state rather than a cacheable redirect, because the legacy id
+ * can start resolving once a daily `library.db` sync lands it in
+ * Backend-Service Postgres.
+ */
+export default async function LegacyAlbumInformation({
+  params,
+}: {
+  params: Promise<{ legacyId: string }>;
+}) {
+  const { legacyId } = await params;
+  const cookieHeader = (await cookies()).toString();
+
+  const resolution = await resolveLegacyReleaseId(legacyId, cookieHeader);
+  if (resolution.status === "resolved") {
+    permanentRedirect(albumSerialPath(resolution.serial));
+  }
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        minHeight: "80vh",
+        p: 2,
+      }}
+    >
+      <Sheet
+        variant="outlined"
+        sx={{ maxWidth: 480, width: "100%", borderRadius: "md", p: 4 }}
+      >
+        <Stack spacing={2} sx={{ textAlign: "center", alignItems: "center" }}>
+          <Typography level="h3">Not in the catalog yet</Typography>
+          <Typography level="body-md">
+            This release isn&apos;t in the WXYC catalog yet. Newly added records
+            can take until the next library sync to appear here.
+          </Typography>
+          <Button component={Link} href="/dashboard/catalog" variant="solid">
+            Browse the catalog
+          </Button>
+        </Stack>
+      </Sheet>
+    </Box>
+  );
+}

--- a/app/dashboard/album/legacy/[legacyId]/page.tsx
+++ b/app/dashboard/album/legacy/[legacyId]/page.tsx
@@ -1,0 +1,9 @@
+// Routability stub for /dashboard/album/legacy/[legacyId]. The dashboard layout
+// renders the @information / @modern / @classic parallel slots but not the
+// `children` slot, so this page's output is never displayed; it exists only so
+// the segment resolves instead of 404-ing. The legacy->serial resolve, the
+// redirect, and the not-found state all render through the @information slot
+// sibling.
+export default function LegacyAlbumPermalinkRoutable() {
+  return null;
+}

--- a/lib/features/authentication/organization-utils.server.ts
+++ b/lib/features/authentication/organization-utils.server.ts
@@ -1,22 +1,7 @@
 import "server-only";
-import { serverAuthClient, serverAuthFetch } from "./server-client";
+import { serverAuthClient, serverAuthFetch, getServerJwtToken } from "./server-client";
 import { normalizeRole, organizationRoleFromJwtToken } from "./organization-utils";
 import { WXYCRole } from "./types";
-
-async function fetchAuthJwtToken(cookieHeader?: string): Promise<string | null> {
-  try {
-    const { ok, data } = await serverAuthFetch<{ token?: unknown }>("/token", {
-      method: "GET",
-      headers: cookieHeader ? { cookie: cookieHeader } : {},
-    });
-    if (!ok) {
-      return null;
-    }
-    return typeof data?.token === "string" ? data.token : null;
-  } catch {
-    return null;
-  }
-}
 
 // Re-export client-safe functions for convenience
 export { getAppOrganizationId, getAppOrganizationIdClient } from "./organization-utils";
@@ -78,7 +63,7 @@ export async function getUserRoleInOrganization(
 ): Promise<WXYCRole | undefined> {
   try {
     if (cookieHeader) {
-      const jwtToken = await fetchAuthJwtToken(cookieHeader);
+      const jwtToken = await getServerJwtToken(cookieHeader);
       if (jwtToken) {
         const jwtRole = organizationRoleFromJwtToken(jwtToken, userId);
         if (jwtRole) {

--- a/lib/features/authentication/server-client.ts
+++ b/lib/features/authentication/server-client.ts
@@ -32,6 +32,32 @@ export function serverAuthFetch<T = unknown>(
   return authFetchWithBase<T>(getServerAuthBaseURL(), path, init);
 }
 
+/**
+ * Mint a Backend-Service bearer JWT server-side by forwarding the caller's
+ * session cookie to the auth service's `/token` endpoint. This is the
+ * server-side counterpart to the client's `getJWTToken`: the browser session
+ * cookie is scoped to the dj-site origin, not to Backend-Service, so an
+ * authenticated server-side BS call must exchange the cookie for a JWT here
+ * rather than forward the cookie directly. Returns null on any failure (no
+ * cookie, auth error, unparseable body) so callers fail closed.
+ */
+export async function getServerJwtToken(
+  cookieHeader?: string,
+): Promise<string | null> {
+  try {
+    const { ok, data } = await serverAuthFetch<{ token?: unknown }>("/token", {
+      method: "GET",
+      headers: cookieHeader ? { cookie: cookieHeader } : {},
+    });
+    if (!ok) {
+      return null;
+    }
+    return typeof data?.token === "string" ? data.token : null;
+  } catch {
+    return null;
+  }
+}
+
 const baseURL = getServerAuthBaseURL();
 
 const baseConfig = {

--- a/lib/features/catalog/legacy-permalink.server.ts
+++ b/lib/features/catalog/legacy-permalink.server.ts
@@ -1,0 +1,101 @@
+import "server-only";
+import { getServerJwtToken } from "../authentication/server-client";
+
+/**
+ * The dj-site legacy permalink front door maps a tubafrenzy
+ * `LIBRARY_RELEASE.ID` — the id LML lookups, the Slack request line, and
+ * wxyc.info hand out — to the Backend-Service serial `library.id` that the
+ * canonical `/dashboard/album/[id]` route and `GET /library/info?album_id=`
+ * are keyed on. The two id spaces are distinct: Backend-Service stores the
+ * legacy id in a separate `library.legacy_release_id` column, so a legacy id
+ * can never be used as a serial directly. `GET /library/info?legacy_release_id=`
+ * performs the bridge server-side.
+ */
+
+export type LegacyPermalinkResolution =
+  | { status: "resolved"; serial: number }
+  | { status: "not-found" };
+
+const LIBRARY_INFO_PATH = "/library/info";
+
+/** The canonical serial-keyed album route the resolved front door redirects to. */
+export function albumSerialPath(serial: number): string {
+  return `/dashboard/album/${serial}`;
+}
+
+function parseLegacyReleaseId(raw: string): number | null {
+  // Strict Number() mirrors the Backend-Service guard: trailing garbage
+  // ("65880xyz") and a non-positive id are both rejected, rather than a partial
+  // parseInt fabricating an id from the leading digits.
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) {
+    return null;
+  }
+  return n;
+}
+
+// A wedged Backend-Service must not hang the permalink render forever. This is
+// the redirect critical path, not a fail-open seed, so the bound is generous —
+// a false "not in catalog" for a release that IS catalogued is worse than a
+// short wait — but finite.
+const RESOLVE_TIMEOUT_MS = 5000;
+
+/**
+ * Resolve a legacy release id (the `[legacyId]` route segment) to a
+ * Backend-Service serial via `GET /library/info?legacy_release_id=`. The call
+ * is authenticated with a server-minted bearer JWT (the browser session cookie
+ * is scoped to the dj-site origin, not to Backend-Service).
+ *
+ * Every non-resolving outcome — an invalid id, no catalog row (a `library.db`
+ * release not yet synced into Backend-Service Postgres), or a transient
+ * BS/auth failure — collapses to `not-found`, which the caller renders as a
+ * non-cacheable page so a later sync is picked up on retry.
+ */
+export async function resolveLegacyReleaseId(
+  legacyIdParam: string,
+  cookieHeader: string,
+): Promise<LegacyPermalinkResolution> {
+  const legacyId = parseLegacyReleaseId(legacyIdParam);
+  if (legacyId === null) {
+    return { status: "not-found" };
+  }
+
+  const base = process.env.NEXT_PUBLIC_BACKEND_URL;
+  if (!base) {
+    return { status: "not-found" };
+  }
+
+  const token = await getServerJwtToken(cookieHeader);
+  if (!token) {
+    return { status: "not-found" };
+  }
+
+  try {
+    const response = await fetch(
+      `${base}${LIBRARY_INFO_PATH}?legacy_release_id=${legacyId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+        },
+        cache: "no-store",
+        signal: AbortSignal.timeout(RESOLVE_TIMEOUT_MS),
+      },
+    );
+
+    // 200 => resolved; 404 (no row) / 400 (bad id) / 5xx / anything else =>
+    // not-found. None of the non-200 cases are cached, so a release that syncs
+    // later resolves on the next visit.
+    if (response.status !== 200) {
+      return { status: "not-found" };
+    }
+
+    const body = (await response.json()) as { id?: unknown };
+    if (typeof body.id === "number" && Number.isInteger(body.id) && body.id > 0) {
+      return { status: "resolved", serial: body.id };
+    }
+    return { status: "not-found" };
+  } catch {
+    return { status: "not-found" };
+  }
+}

--- a/tests/unit/app/dashboard/album/legacy/legacy-permalink-page.test.tsx
+++ b/tests/unit/app/dashboard/album/legacy/legacy-permalink-page.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockCookies = vi.fn();
+vi.mock("next/headers", () => ({
+  cookies: () => mockCookies(),
+}));
+
+const mockPermanentRedirect = vi.fn((url: string) => {
+  throw new Error(`REDIRECT:${url}`);
+});
+vi.mock("next/navigation", () => ({
+  permanentRedirect: (url: string) => mockPermanentRedirect(url),
+}));
+
+const mockResolve = vi.fn();
+vi.mock("@/lib/features/catalog/legacy-permalink.server", () => ({
+  resolveLegacyReleaseId: (legacyId: string, cookie: string) =>
+    mockResolve(legacyId, cookie),
+  albumSerialPath: (serial: number) => `/dashboard/album/${serial}`,
+}));
+
+import LegacyAlbumInformation from "@/app/dashboard/@information/album/legacy/[legacyId]/page";
+import { renderWithProviders, screen } from "@/tests/helpers";
+
+const COOKIE = "session=test-cookie";
+
+function renderPage(legacyId: string) {
+  return LegacyAlbumInformation({ params: Promise.resolve({ legacyId }) });
+}
+
+describe("legacy album permalink front door (@information slot)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCookies.mockReturnValue({ toString: () => COOKIE });
+  });
+
+  it("308-redirects to the canonical serial route when the legacy id resolves", async () => {
+    mockResolve.mockResolvedValue({ status: "resolved", serial: 7100 });
+
+    await expect(renderPage("65880")).rejects.toThrow(
+      "REDIRECT:/dashboard/album/7100",
+    );
+    expect(mockPermanentRedirect).toHaveBeenCalledWith("/dashboard/album/7100");
+  });
+
+  it("passes the awaited legacy id and forwarded cookie to the resolver", async () => {
+    mockResolve.mockResolvedValue({ status: "resolved", serial: 7100 });
+
+    await expect(renderPage("65880")).rejects.toThrow(/REDIRECT/);
+    expect(mockResolve).toHaveBeenCalledWith("65880", COOKIE);
+  });
+
+  it("renders a non-redirecting not-found state when the legacy id does not resolve", async () => {
+    mockResolve.mockResolvedValue({ status: "not-found" });
+
+    const element = await renderPage("999999999");
+    expect(mockPermanentRedirect).not.toHaveBeenCalled();
+
+    renderWithProviders(element);
+    expect(screen.getByText(/not in the catalog yet/i)).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /browse the catalog/i });
+    expect(link).toHaveAttribute("href", "/dashboard/catalog");
+  });
+});

--- a/tests/unit/lib/features/authentication/organization-utils.test.ts
+++ b/tests/unit/lib/features/authentication/organization-utils.test.ts
@@ -35,6 +35,16 @@ vi.mock("@/lib/features/authentication/server-client", () => ({
   },
   getServerAuthBaseURL: () => "https://api.wxyc.org/auth",
   serverAuthFetch: (path: string, init: any) => mockAuthFetch(path, init),
+  getServerJwtToken: async (cookieHeader?: string) => {
+    const { ok, data } = await mockAuthFetch("/token", {
+      method: "GET",
+      headers: cookieHeader ? { cookie: cookieHeader } : {},
+    });
+    if (!ok) return null;
+    return typeof (data as { token?: unknown })?.token === "string"
+      ? (data as { token: string }).token
+      : null;
+  },
 }));
 
 // Mock auth client (client-side)

--- a/tests/unit/lib/features/authentication/server-client.test.ts
+++ b/tests/unit/lib/features/authentication/server-client.test.ts
@@ -91,3 +91,68 @@ describe("server-client", () => {
     });
   });
 });
+
+describe("getServerJwtToken", () => {
+  const originalEnv = process.env;
+  const realFetch = global.fetch;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv, NEXT_PUBLIC_BETTER_AUTH_URL: "https://api.wxyc.org/auth" };
+    mockFetch = vi.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = realFetch;
+  });
+
+  async function importFresh() {
+    vi.resetModules();
+    return import("@/lib/features/authentication/server-client");
+  }
+
+  it("mints a token and forwards the session cookie to /token", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ token: "jwt-abc" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const { getServerJwtToken } = await importFresh();
+    await expect(getServerJwtToken("session=xyz")).resolves.toBe("jwt-abc");
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toBe("https://api.wxyc.org/auth/token");
+    expect(new Headers(init.headers).get("cookie")).toBe("session=xyz");
+  });
+
+  it("returns null on a non-ok response", async () => {
+    mockFetch.mockResolvedValue(new Response("{}", { status: 401 }));
+
+    const { getServerJwtToken } = await importFresh();
+    await expect(getServerJwtToken("session=xyz")).resolves.toBeNull();
+  });
+
+  it("returns null when the token field is not a string", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ token: null }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const { getServerJwtToken } = await importFresh();
+    await expect(getServerJwtToken("session=xyz")).resolves.toBeNull();
+  });
+
+  it("returns null when the fetch rejects", async () => {
+    mockFetch.mockRejectedValue(new Error("network down"));
+
+    const { getServerJwtToken } = await importFresh();
+    await expect(getServerJwtToken("session=xyz")).resolves.toBeNull();
+  });
+});

--- a/tests/unit/lib/features/catalog/legacy-permalink.server.test.ts
+++ b/tests/unit/lib/features/catalog/legacy-permalink.server.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mockGetServerJwtToken = vi.fn();
+vi.mock("@/lib/features/authentication/server-client", () => ({
+  getServerJwtToken: (cookieHeader?: string) =>
+    mockGetServerJwtToken(cookieHeader),
+}));
+
+import {
+  resolveLegacyReleaseId,
+  albumSerialPath,
+} from "@/lib/features/catalog/legacy-permalink.server";
+
+const BACKEND = "http://backend.test";
+const COOKIE = "session=test-cookie";
+const VALID_LEGACY = "65880";
+const SERIAL = 7100;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const realFetch = global.fetch;
+let mockFetch: ReturnType<typeof vi.fn>;
+
+describe("resolveLegacyReleaseId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("NEXT_PUBLIC_BACKEND_URL", BACKEND);
+    mockGetServerJwtToken.mockResolvedValue("jwt-token");
+    mockFetch = vi.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    vi.unstubAllEnvs();
+  });
+
+  it("resolves a 200 response to the serial in the body's id", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ id: SERIAL, album_title: "Confield" }));
+
+    await expect(resolveLegacyReleaseId(VALID_LEGACY, COOKIE)).resolves.toEqual({
+      status: "resolved",
+      serial: SERIAL,
+    });
+  });
+
+  it("calls /library/info with the legacy_release_id and a bearer token", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ id: SERIAL }));
+
+    await resolveLegacyReleaseId(VALID_LEGACY, COOKIE);
+
+    expect(mockGetServerJwtToken).toHaveBeenCalledWith(COOKIE);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(String(url)).toBe(`${BACKEND}/library/info?legacy_release_id=${VALID_LEGACY}`);
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer jwt-token");
+    expect(init.cache).toBe("no-store");
+  });
+
+  it("maps a 404 (no catalog row) to not-found", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ message: "No catalog album for that legacy_release_id" }, 404),
+    );
+
+    await expect(resolveLegacyReleaseId(VALID_LEGACY, COOKIE)).resolves.toEqual({
+      status: "not-found",
+    });
+  });
+
+  it("maps a 400 (bad id) to not-found", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ message: "Invalid legacy_release_id" }, 400));
+
+    await expect(resolveLegacyReleaseId(VALID_LEGACY, COOKIE)).resolves.toEqual({
+      status: "not-found",
+    });
+  });
+
+  it("maps a 5xx to not-found", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ message: "boom" }, 503));
+
+    await expect(resolveLegacyReleaseId(VALID_LEGACY, COOKIE)).resolves.toEqual({
+      status: "not-found",
+    });
+  });
+
+  it("maps a network failure to not-found", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await expect(resolveLegacyReleaseId(VALID_LEGACY, COOKIE)).resolves.toEqual({
+      status: "not-found",
+    });
+  });
+
+  it.each([
+    ["a non-number id", { id: "not-a-number" }],
+    ["a zero id", { id: 0 }],
+    ["a negative id", { id: -3 }],
+    ["a missing id", { album_title: "Confield" }],
+  ])("treats a 200 body with %s as not-found", async (_label, body) => {
+    mockFetch.mockResolvedValue(jsonResponse(body));
+
+    await expect(resolveLegacyReleaseId(VALID_LEGACY, COOKIE)).resolves.toEqual({
+      status: "not-found",
+    });
+  });
+
+  it.each([["not-a-number"], ["0"], ["-5"], ["65880xyz"], [""]])(
+    "rejects an invalid legacy id (%s) without a network call",
+    async (bad) => {
+      await expect(resolveLegacyReleaseId(bad, COOKIE)).resolves.toEqual({
+        status: "not-found",
+      });
+      expect(mockGetServerJwtToken).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it("returns not-found without fetching when no bearer token can be minted", async () => {
+    mockGetServerJwtToken.mockResolvedValue(null);
+
+    await expect(resolveLegacyReleaseId(VALID_LEGACY, COOKIE)).resolves.toEqual({
+      status: "not-found",
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns not-found when NEXT_PUBLIC_BACKEND_URL is unset", async () => {
+    vi.stubEnv("NEXT_PUBLIC_BACKEND_URL", "");
+
+    await expect(resolveLegacyReleaseId(VALID_LEGACY, COOKIE)).resolves.toEqual({
+      status: "not-found",
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("albumSerialPath", () => {
+  it("builds the canonical serial-keyed album route", () => {
+    expect(albumSerialPath(SERIAL)).toBe("/dashboard/album/7100");
+  });
+});


### PR DESCRIPTION
## What

Adds `/dashboard/album/legacy/[legacyId]` — a server-rendered front door that resolves a tubafrenzy **legacy release id** to the Backend-Service **serial** `library.id` and redirects to the canonical `/dashboard/album/[serial]`.

External callers (LML lookups, the Slack request line, wxyc.info) hold the legacy id, but the canonical album route and `GET /library/info?album_id=` are keyed on the serial — a distinct id space (BS stores the legacy id in a separate `library.legacy_release_id` column). A naive `/dashboard/album/{legacy_id}` would link to the *wrong* release; this front door bridges the two id spaces server-side via `GET /library/info?legacy_release_id=`, authenticated with a server-minted bearer JWT.

## Behavior

- **Resolved** → `permanentRedirect()` (308) to `/dashboard/album/<serial>`. The serial is stable once assigned, so the hop is safe to cache permanently.
- **Miss** (no catalog row / bad id / transient failure) → a **non-cacheable** "not in the catalog yet" 200 state, never a cacheable redirect. A `library.db` release not yet synced into BS Postgres can start resolving after a later daily sync, so the miss must not be cached. The page reads `cookies()` (forces dynamic render) and fetches with `cache: "no-store"`.

## Structure

The dashboard layout renders the `@information`/`@modern`/`@classic` parallel slots but not the `children` slot, so the resolve + redirect + not-found UI lives in the `@information` slot; the `children` page is a routability stub (the URL would 404 without it). Mirrors the merged route skeleton from #1036. Static `legacy` wins over the dynamic `[id]` sibling, so there is no collision.

Extracts a shared `getServerJwtToken` helper into `server-client` (behavior-preserving; replaces the private copy in `organization-utils.server`). Anchors the personal-scratch `.gitignore` rule to `/legacy/` so it no longer swallows the `legacy` route segment.

## Testing

`tsc --noEmit` clean; full unit suite green (3850 tests). New coverage: resolver status mapping (200/404/400/5xx/network/invalid-id/no-token/missing-backend-url), `getServerJwtToken`, and the page's redirect-vs-render behavior. Build/lint/E2E deferred to CI (local build blocked only by the worktree's `node_modules` symlink).

## Deploy note

Merging to `main` deploys dj-site to production via Cloudflare Pages. The Backend-Service endpoint this consumes (WXYC/Backend-Service#1880 / #1881) is already merged and deployed to prod, so end-to-end resolution works on merge.

Closes #1049. Builds on #1036 / #979. Unblocks the downstream LML `library_url` swap and the wxyc-shared `api.yaml` description update.
