### PR TITLE
perf(flowsheet): split live-status from useShowControl so catalog stops subscribing to the entries query

### DIFF
--- a/src/components/experiences/modern/Leftbar/FlowsheetLink.tsx
+++ b/src/components/experiences/modern/Leftbar/FlowsheetLink.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useShowControl } from "@/src/hooks/flowsheetHooks";
+import { useLiveStatus } from "@/src/hooks/flowsheetHooks";
 import { CellTower } from "@mui/icons-material";
 import { Badge } from "@mui/joy";
 import LeftbarLink from "./LeftbarLink";
 
 export default function FlowsheetLink() {
-  const { live } = useShowControl();
+  const { live } = useLiveStatus();
 
   return (
     <Badge

--- a/src/components/experiences/modern/Rightbar/Bin/BinContent.tsx
+++ b/src/components/experiences/modern/Rightbar/Bin/BinContent.tsx
@@ -10,15 +10,15 @@ import ClearBinButton from "./ClearBinButton";
 import ExportBinButton from "./ExportBinButton";
 import {
   useFlowsheetActions,
+  useLiveStatus,
   useQueue,
-  useShowControl,
 } from "@/src/hooks/flowsheetHooks";
 import type { BinEntryActionDeps } from "./useBinEntryActions";
 
 export default function BinContent() {
   const { bin, isError, loading } = useBin();
   // Hoist the live subscription once for all rows (shared, like the catalog).
-  const { live } = useShowControl();
+  const { live } = useLiveStatus();
   // Same for the write callbacks the row actions need: useQueue subscribes
   // to the whole queue state (plus a localStorage load on mount), far too
   // heavy to run once per bin row.

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -24,7 +24,7 @@ import { toast } from "sonner";
 import { memo } from "react";
 
 // `live` and `addToQueue` are hoisted into Results and passed down so every
-// row shares one useShowControl/useQueue subscription; memoized so a query
+// row shares one useLiveStatus/useQueue subscription; memoized so a query
 // keystroke doesn't re-render rows whose album is unchanged.
 function CatalogResult({
   album,

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -11,7 +11,7 @@ import {
   useCatalogQueryResults,
   useCatalogQuerySearch,
 } from "@/src/hooks/catalogHooks";
-import { useQueue, useShowControl } from "@/src/hooks/flowsheetHooks";
+import { useLiveStatus, useQueue } from "@/src/hooks/flowsheetHooks";
 import { useMediaQuery } from "@/src/hooks/useMediaQuery";
 import { ColorPaletteProp } from "@mui/joy";
 import CatalogResult from "./Result";
@@ -67,8 +67,8 @@ export default function Results({
 
   // Hoisted once for the whole list instead of per row: every row shares this
   // `live` flag and the stable `addToQueue` callback rather than each mounting
-  // its own useShowControl + useQueue (polling-query) subscriptions.
-  const { live } = useShowControl();
+  // its own useLiveStatus + useQueue (polling-query) subscriptions.
+  const { live } = useLiveStatus();
   const { addToQueue } = useQueue();
 
   const loadMoreButton = hasMore ? (

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
-import { useFlowsheetActions, useShowControl } from "@/src/hooks/flowsheetHooks";
+import { useFlowsheetActions, useLiveStatus } from "@/src/hooks/flowsheetHooks";
 import { toTitleCase } from "@/src/utilities/stringutilities";
 import { Box, IconButton, Tooltip, Typography, TypographyProps } from "@mui/joy";
 import { CheckRounded, EditOutlined } from "@mui/icons-material";
@@ -33,7 +33,7 @@ export default function FlowsheetEntryField({
   playing: boolean;
   editable: boolean;
 } & Omit<TypographyProps, "whiteSpace" | "overflow" | "textOverflow">) {
-  const { live } = useShowControl();
+  const { live } = useLiveStatus();
   const dispatch = useAppDispatch();
 
   const [editing, setEditing] = useState(false);

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -63,17 +63,24 @@ export function selectFlowsheetMutationPending(state: RootState): boolean {
   );
 }
 
-export const useShowControl = () => {
+/**
+ * Live/on-air status alone — for consumers that need `live` but never touch
+ * `currentShow`, the entries list, autoplay, or the go-live/leave actions.
+ * Split out of useShowControl (#1056) so the persistent chrome (Leftbar,
+ * Mail Bin), per-row, and per-field consumers subscribe to the lightweight
+ * WhoIsLive poll without dragging in the heavy paginated entries query that
+ * useShowControl also carries for the flowsheet's currentShow derivation.
+ *
+ * This hook runs in every entry row (and per editable field), so the query
+ * subscription is narrowed to primitives: rows re-render only when `live`
+ * actually changes, not on fetch-status flips or unrelated cache updates.
+ */
+export const useLiveStatus = () => {
   const { loading: userloading, info: userData } = useRegistry();
-  const flowsheetPollingInterval = useFlowsheetPollingInterval();
 
   const skip = !userData || userloading;
   const userId = userData?.id;
 
-  // This hook runs in every entry row (and per editable field), so both query
-  // subscriptions are narrowed to primitives: rows re-render only when
-  // live/currentShow actually change, not on fetch-status flips or unrelated
-  // cache updates — and no per-row flatten/sort of the entry list.
   const { live, loadingLiveList } = useWhoIsLiveQuery(undefined, {
     skip,
     pollingInterval: 60000,
@@ -86,6 +93,22 @@ export const useShowControl = () => {
     }),
   });
 
+  return { live, loading: loadingLiveList };
+};
+
+export const useShowControl = () => {
+  const { loading: userloading, info: userData } = useRegistry();
+  const flowsheetPollingInterval = useFlowsheetPollingInterval();
+
+  const skip = !userData || userloading;
+
+  // One authoritative `live` definition, shared with every other consumer.
+  const { live, loading: loadingLiveList } = useLiveStatus();
+
+  // This hook also runs in every entry row (for currentShow), so the entries
+  // subscription stays narrowed to a primitive: rows re-render only when
+  // currentShow actually changes, not on fetch-status flips or unrelated
+  // cache updates — and no per-row flatten/sort of the entry list.
   const { currentShow } = useGetInfiniteEntriesInfiniteQuery(undefined, {
     skip,
     pollingInterval: flowsheetPollingInterval,
@@ -487,14 +510,17 @@ export const useFlowsheetPagination = () => {
 };
 
 export const useQueue = () => {
-  const { live, loading } = useShowControl();
+  // live-only: useQueue never reads currentShow, so pulling the full
+  // useShowControl here would drag its heavy entries subscription into every
+  // page that renders the Mail Bin or catalog results (#1056).
+  const { live, loading } = useLiveStatus();
   const { loading: userloading, info: userData } = useRegistry();
   const dispatch = useAppDispatch();
 
   const queue = useAppSelector((state) => state.flowsheet.queue);
 
   // A settled WhoIsLive read: a successful response that isn't mid-refetch.
-  // isLoading (behind useShowControl's `loading`) is true only on the first
+  // isLoading (behind useLiveStatus's `loading`) is true only on the first
   // fetch, so it doesn't cover the invalidate→refetch gaps (e.g. an
   // optimistic-miss during go-live) where WhoIsLive momentarily reads
   // off-air; isFetching does. (#644)
@@ -569,7 +595,7 @@ export const useQueue = () => {
     queue,
     addToQueue,
     removeFromQueue,
-    loading,
+    loading: loading || userloading,
   };
 };
 

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -74,6 +74,10 @@ export function selectFlowsheetMutationPending(state: RootState): boolean {
  * This hook runs in every entry row (and per editable field), so the query
  * subscription is narrowed to primitives: rows re-render only when `live`
  * actually changes, not on fetch-status flips or unrelated cache updates.
+ *
+ * It also surfaces the `userData`/`userloading` it already reads so composing
+ * hooks (useShowControl, useQueue) can share this one registry subscription
+ * instead of each opening a second useSession + role-resolution effect.
  */
 export const useLiveStatus = () => {
   const { loading: userloading, info: userData } = useRegistry();
@@ -93,17 +97,24 @@ export const useLiveStatus = () => {
     }),
   });
 
-  return { live, loading: loadingLiveList };
+  return { live, loading: loadingLiveList, userData, userloading };
 };
 
 export const useShowControl = () => {
-  const { loading: userloading, info: userData } = useRegistry();
   const flowsheetPollingInterval = useFlowsheetPollingInterval();
 
-  const skip = !userData || userloading;
+  // One authoritative `live` definition — and one registry read — shared with
+  // every other consumer: useLiveStatus already owns the useRegistry
+  // subscription, so reuse its userData/userloading rather than opening a
+  // second one in every entry row.
+  const {
+    live,
+    loading: loadingLiveList,
+    userData,
+    userloading,
+  } = useLiveStatus();
 
-  // One authoritative `live` definition, shared with every other consumer.
-  const { live, loading: loadingLiveList } = useLiveStatus();
+  const skip = !userData || userloading;
 
   // This hook also runs in every entry row (for currentShow), so the entries
   // subscription stays narrowed to a primitive: rows re-render only when
@@ -513,8 +524,7 @@ export const useQueue = () => {
   // live-only: useQueue never reads currentShow, so pulling the full
   // useShowControl here would drag its heavy entries subscription into every
   // page that renders the Mail Bin or catalog results (#1056).
-  const { live, loading } = useLiveStatus();
-  const { loading: userloading, info: userData } = useRegistry();
+  const { live, loading, userData, userloading } = useLiveStatus();
   const dispatch = useAppDispatch();
 
   const queue = useAppSelector((state) => state.flowsheet.queue);

--- a/tests/integration/components/modern/Leftbar/FlowsheetLink.test.tsx
+++ b/tests/integration/components/modern/Leftbar/FlowsheetLink.test.tsx
@@ -4,7 +4,7 @@ import FlowsheetLink from "@/src/components/experiences/modern/Leftbar/Flowsheet
 
 // Mock hooks
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
-  useShowControl: vi.fn(() => ({
+  useLiveStatus: vi.fn(() => ({
     live: false,
   })),
 }));
@@ -55,8 +55,8 @@ describe("FlowsheetLink", () => {
   });
 
   it("should show 'ON AIR' indicator when live", async () => {
-    const { useShowControl } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useShowControl).mockReturnValue({
+    const { useLiveStatus } = await import("@/src/hooks/flowsheetHooks");
+    vi.mocked(useLiveStatus).mockReturnValue({
       live: true,
     } as any);
 
@@ -83,8 +83,8 @@ describe("FlowsheetLink", () => {
   });
 
   it("should have visible badge when live", async () => {
-    const { useShowControl } = await import("@/src/hooks/flowsheetHooks");
-    vi.mocked(useShowControl).mockReturnValue({
+    const { useLiveStatus } = await import("@/src/hooks/flowsheetHooks");
+    vi.mocked(useLiveStatus).mockReturnValue({
       live: true,
     } as any);
 

--- a/tests/integration/components/modern/Rightbar/Bin/BinContent.consoleError.test.tsx
+++ b/tests/integration/components/modern/Rightbar/Bin/BinContent.consoleError.test.tsx
@@ -15,7 +15,7 @@ vi.mock("@/src/hooks/binHooks", () => ({
 }));
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
-  useShowControl: () => ({ live: false }),
+  useLiveStatus: () => ({ live: false }),
   useQueue: () => ({ addToQueue: vi.fn() }),
   useFlowsheetActions: () => ({ addToFlowsheet: vi.fn(() => Promise.resolve()) }),
 }));

--- a/tests/integration/components/modern/Rightbar/Bin/BinContent.test.tsx
+++ b/tests/integration/components/modern/Rightbar/Bin/BinContent.test.tsx
@@ -17,7 +17,7 @@ vi.mock("@/lib/features/application/api", () => ({
 }));
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
-  useShowControl: () => ({ live: false }),
+  useLiveStatus: () => ({ live: false }),
   // Hoisted once here (not per row) so the rows can stay hook-free.
   useQueue: () => ({ addToQueue: vi.fn() }),
   useFlowsheetActions: () => ({ addToFlowsheet: vi.fn(() => Promise.resolve()) }),

--- a/tests/integration/components/modern/catalog/Results/MobileResult.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/MobileResult.test.tsx
@@ -14,7 +14,7 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
-  useShowControl: () => ({ live: false }),
+  useLiveStatus: () => ({ live: false }),
   useQueue: () => ({ addToQueue: vi.fn() }),
 }));
 

--- a/tests/integration/components/modern/catalog/Results/Result.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/Result.test.tsx
@@ -14,7 +14,7 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
-  useShowControl: () => ({ live: false }),
+  useLiveStatus: () => ({ live: false }),
   useQueue: () => ({ addToQueue: vi.fn() }),
 }));
 

--- a/tests/integration/components/modern/catalog/Results/Results.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/Results.test.tsx
@@ -15,7 +15,7 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
-  useShowControl: () => ({ live: false }),
+  useLiveStatus: () => ({ live: false }),
   useQueue: () => ({ addToQueue: vi.fn() }),
 }));
 

--- a/tests/integration/components/modern/catalog/catalogRouteSubscriptions.test.tsx
+++ b/tests/integration/components/modern/catalog/catalogRouteSubscriptions.test.tsx
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders } from "@/tests/helpers/render";
+import FlowsheetLink from "@/src/components/experiences/modern/Leftbar/FlowsheetLink";
+import BinContent from "@/src/components/experiences/modern/Rightbar/Bin/BinContent";
+import Results from "@/src/components/experiences/modern/catalog/Results/Results";
+
+// Proves the WXYC/dj-site#1056 fix: mounting the catalog route's persistent
+// chrome (Leftbar's FlowsheetLink, Rightbar's Mail Bin) alongside the catalog
+// Results table must never subscribe to the heavy paginated
+// useGetInfiniteEntriesInfiniteQuery. Before the useLiveStatus split, all
+// three components called useShowControl for `{ live }` alone and dragged
+// that subscription onto every catalog page load. `@/src/hooks/flowsheetHooks`
+// is intentionally left UNMOCKED here so the real useLiveStatus/useQueue/
+// useFlowsheetActions implementations run; only their RTK Query and
+// authentication dependencies are stubbed for determinism.
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/dashboard/catalog",
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@mui/icons-material", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mui/icons-material")>();
+  return {
+    ...actual,
+    CellTower: () => <span data-testid="celltower-icon" />,
+    Inbox: () => <span data-testid="inbox-icon" />,
+  };
+});
+
+vi.mock("@/src/hooks/authenticationHooks", () => ({
+  useRegistry: () => ({
+    loading: false,
+    info: { id: "test-user-1", real_name: "Test User", dj_name: "Test DJ" },
+  }),
+}));
+
+vi.mock("@/src/hooks/binHooks", () => ({
+  useBin: () => ({ bin: [], isError: false, loading: false }),
+  useDeleteFromBin: () => ({ deleteFromBin: vi.fn() }),
+}));
+
+vi.mock(
+  "@/src/components/experiences/modern/Rightbar/RightBarContentContainer",
+  () => ({
+    default: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+  })
+);
+vi.mock("@/src/components/experiences/modern/Rightbar/Bin/BinEntry", () => ({
+  default: () => null,
+}));
+vi.mock(
+  "@/src/components/experiences/modern/Rightbar/Bin/ClearBinButton",
+  () => ({ default: () => null })
+);
+vi.mock(
+  "@/src/components/experiences/modern/Rightbar/Bin/ExportBinButton",
+  () => ({ default: () => null })
+);
+
+vi.mock("@/src/hooks/catalogHooks", () => ({
+  useCatalogQueryResults: () => ({
+    results: [],
+    total: 0,
+    isLoadingInitial: false,
+    isFetchingMore: false,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+    isError: false,
+  }),
+  useCatalogQuerySearch: () => ({
+    selected: [],
+    setSelection: vi.fn(),
+    sortBy: "album",
+    sortOrder: "asc",
+    hasActiveQuery: false,
+    setSort: vi.fn(),
+  }),
+}));
+
+vi.mock("@/src/hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
+}));
+
+vi.mock(
+  "@/src/components/experiences/modern/catalog/Results/ResultsContainer",
+  () => ({
+    default: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+  })
+);
+vi.mock("@/src/components/experiences/modern/catalog/Results/Result", () => ({
+  default: () => null,
+}));
+vi.mock(
+  "@/src/components/experiences/modern/catalog/Results/MobileResult",
+  () => ({ default: () => null })
+);
+
+// Applies options.selectFromResult over a base result, mirroring RTK Query's
+// own behavior, so the real useLiveStatus/useShowControl/useQueue
+// implementations (kept unmocked below) narrow exactly as they do in
+// production instead of receiving the whole unshaped mock object.
+type QueryHookOptions = {
+  selectFromResult?: (r: unknown) => Record<string, unknown>;
+};
+function withSelectFromResult(
+  result: Record<string, unknown>,
+  options?: QueryHookOptions
+) {
+  return options?.selectFromResult
+    ? { ...result, ...options.selectFromResult(result) }
+    : result;
+}
+
+const mockUseWhoIsLiveQuery = vi.fn(() => ({
+  data: { djs: [], onAir: "" },
+  isLoading: false,
+  isSuccess: true,
+  isFetching: false,
+}));
+
+const mockUseGetInfiniteEntriesInfiniteQuery = vi.fn(() => ({
+  data: undefined,
+  isLoading: false,
+  isSuccess: false,
+  isError: false,
+  isFetching: false,
+  hasNextPage: false,
+  fetchNextPage: vi.fn(),
+}));
+
+// `flowsheetApi` (the RTK Query object with its `.reducer`/`.middleware`) is
+// kept REAL via importOriginal — `lib/store.ts` wires it straight into
+// `configureStore`, so replacing it outright would break every test's store,
+// not just this one. Only the hook exports the components under test call
+// are swapped for deterministic spies/stubs.
+vi.mock("@/lib/features/flowsheet/api", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/features/flowsheet/api")>();
+  return {
+    ...actual,
+    useWhoIsLiveQuery: (_arg: unknown, options?: QueryHookOptions) =>
+      withSelectFromResult(mockUseWhoIsLiveQuery(), options),
+    useGetInfiniteEntriesInfiniteQuery: (
+      _arg: unknown,
+      options?: QueryHookOptions
+    ) => withSelectFromResult(mockUseGetInfiniteEntriesInfiniteQuery(), options),
+    useJoinShowMutation: () => [vi.fn(), { isLoading: false }],
+    useLeaveShowMutation: () => [vi.fn(), { isLoading: false }],
+    useAddToFlowsheetMutation: () => [
+      vi.fn(() => ({ unwrap: () => Promise.resolve({ id: 1 }) })),
+      { isLoading: false },
+    ],
+    useRemoveFromFlowsheetMutation: () => [vi.fn(), { isLoading: false }],
+    useUpdateFlowsheetMutation: () => [vi.fn(), { isLoading: false }],
+    useSwitchEntriesMutation: () => [vi.fn(), { isLoading: false }],
+  };
+});
+
+describe("catalog route subscription profile (#1056)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWhoIsLiveQuery.mockReturnValue({
+      data: { djs: [], onAir: "" },
+      isLoading: false,
+      isSuccess: true,
+      isFetching: false,
+    });
+  });
+
+  it("never subscribes to the heavy paginated entries query when the chrome and Results are mounted together", () => {
+    renderWithProviders(
+      <>
+        <FlowsheetLink />
+        <BinContent />
+        <Results color={undefined} />
+      </>
+    );
+
+    expect(mockUseGetInfiniteEntriesInfiniteQuery).not.toHaveBeenCalled();
+    // Sanity check: the lightweight WhoIsLive poll IS still exercised (by
+    // useLiveStatus inside FlowsheetLink/BinContent/Results, and again inside
+    // useQueue) — proving the assertion above isn't vacuously true because
+    // nothing in the tree subscribed to flowsheetApi at all.
+    expect(mockUseWhoIsLiveQuery).toHaveBeenCalled();
+  });
+});

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.test.tsx
@@ -4,13 +4,13 @@ import FlowsheetEntryField from "@/src/components/experiences/modern/flowsheet/E
 import { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
 
 // Mock hooks
-const mockUseShowControl = vi.fn();
+const mockUseLiveStatus = vi.fn();
 const mockUseFlowsheet = vi.fn();
 const mockDispatch = vi.fn();
 const mockUpdateFlowsheet = vi.fn();
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
-  useShowControl: () => mockUseShowControl(),
+  useLiveStatus: () => mockUseLiveStatus(),
   useFlowsheetActions: () => mockUseFlowsheet(),
 }));
 
@@ -50,7 +50,7 @@ describe("FlowsheetEntryField", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockUseShowControl.mockReturnValue({
+    mockUseLiveStatus.mockReturnValue({
       live: true,
     });
 
@@ -218,7 +218,7 @@ describe("FlowsheetEntryField", () => {
     });
 
     it("should NOT enter edit mode on double click when not live", () => {
-      mockUseShowControl.mockReturnValue({
+      mockUseLiveStatus.mockReturnValue({
         live: false,
       });
 

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import {
   useShowControl,
+  useLiveStatus,
   useFlowsheetSearch,
   useFlowsheet,
   useQueue,
@@ -220,6 +221,46 @@ describe("flowsheetHooks", () => {
     if (typeof window !== "undefined") {
       window.localStorage.clear();
     }
+  });
+
+  describe("useLiveStatus", () => {
+    it("should return live status", () => {
+      const { result } = renderHook(() => useLiveStatus(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.live).toBe(true);
+    });
+
+    it("should return live as false when user is not in live list", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: { djs: [], onAir: "" },
+        isLoading: false,
+        isSuccess: true,
+      });
+
+      const { result } = renderHook(() => useLiveStatus(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.live).toBe(false);
+    });
+
+    it("should return loading status", () => {
+      const { result } = renderHook(() => useLiveStatus(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(typeof result.current.loading).toBe("boolean");
+    });
+
+    it("should never subscribe to the heavy entries query (#1056)", () => {
+      renderHook(() => useLiveStatus(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(mockUseGetInfiniteEntriesInfiniteQuery).not.toHaveBeenCalled();
+    });
   });
 
   describe("useShowControl", () => {


### PR DESCRIPTION
Closes #1056.

## What

`useShowControl` bundled the lightweight `useWhoIsLiveQuery` poll together with the heavy paginated `useGetInfiniteEntriesInfiniteQuery` (entries) query purely to derive `currentShow`. Every `{ live }`-only consumer — the persistent modern chrome (`FlowsheetLink`, `BinContent`) and catalog `Results` — dragged that entries subscription along, so the **catalog route subscribed to (and polled) the flowsheet entries query even though nothing on catalog reads `currentShow`.**

## Change

- Add `useLiveStatus`, subscribing to `useWhoIsLiveQuery` alone — reusing the exact `selectFromResult` membership check, `skip` gating, and 60s poll interval. `useShowControl` now composes its `live` from `useLiveStatus` (one authoritative definition of `live`) while keeping its own entries subscription for the flowsheet's `currentShow`.
- Migrate the `{ live }`-only consumers to `useLiveStatus`: `FlowsheetLink`, `BinContent`, `Results`, `FlowsheetEntryField`.
- Also migrate `useQueue`: it's called by both `BinContent` and `Results` (for `addToQueue`) and read only `{ live, loading }` from `useShowControl`, so it would otherwise have kept the heavy subscription alive on catalog regardless of the four call-site migrations. No consumer reads `useQueue().loading` (both call sites destructure only `addToQueue`), so recomposing its `loading` is behavior-preserving.

Flowsheet behavior is unchanged — `useShowControl`'s public shape and `currentShow` derivation are intact.

## Tests

- New `catalogRouteSubscriptions.test.tsx`: mounts `FlowsheetLink` + `BinContent` + `Results` together with the real `flowsheetHooks` module and asserts `useGetInfiniteEntriesInfiniteQuery` is never subscribed, with a non-vacuous sanity check that `useWhoIsLiveQuery` *is*. Verified load-bearing — it fails (9 stray entries-query calls) without the migration.
- Added a `useLiveStatus` unit block to `flowsheetHooks.test.tsx`; updated the consumer test mocks.

## Verification

`tsc --noEmit` clean · `npm run lint` 0 errors (warning count unchanged) · full suite **3859 tests pass** · no `package-lock.json` change.
