### PR TITLE
chore(deps): bump @wxyc/shared to 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
     "": {
       "name": "dj-site",
       "dependencies": {
-        "@ast-grep/napi-win32-x64-msvc": "0.45.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@mui/base": "5.0.0-beta.40-1",
@@ -15,7 +14,7 @@
         "@mui/system": "5.18.0",
         "@opennextjs/cloudflare": "^1.20.2",
         "@reduxjs/toolkit": "^2.12.0",
-        "@wxyc/shared": "^1.17.1",
+        "@wxyc/shared": "^2.6.0",
         "better-auth": "^1.6.23",
         "jwt-decode": "^4.0.0",
         "motion": "^12.42.2",
@@ -7092,9 +7091,9 @@
       "license": "MIT"
     },
     "node_modules/@wxyc/shared": {
-      "version": "1.17.1",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/1.17.1/9652c1d772c67377cdec0e5a6254f117bd3e5e59",
-      "integrity": "sha512-UtJmjCn6HOCg6MwgO52Z/bVn+osNYIHM89QQcpiEXYafNsFfDHZ9uVD+Wo/Ns/EPytLvgA3H2KyAI2Gsm1d+ow==",
+      "version": "2.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/2.6.0/9473a3aef11e99a8b0a0cee2f39064b228407c7e",
+      "integrity": "sha512-AXarRgyHvISrGtijbB/RqGBwBZZw+2fACi7aZZMq4GO7TG+1s/y4Zjkp9q2TZKOHHB0xLyYCUorB71qipfIhMQ==",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.4.0"
@@ -7104,7 +7103,7 @@
       },
       "peerDependencies": {
         "better-auth": "^1.5.0",
-        "typescript": "^5.0.0 || ^6.0.0"
+        "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/abort-controller": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@mui/system": "5.18.0",
     "@opennextjs/cloudflare": "^1.20.2",
     "@reduxjs/toolkit": "^2.12.0",
-    "@wxyc/shared": "^1.17.1",
+    "@wxyc/shared": "^2.6.0",
     "better-auth": "^1.6.23",
     "jwt-decode": "^4.0.0",
     "motion": "^12.42.2",


### PR DESCRIPTION
## What

Bumps `@wxyc/shared` from `^1.17.1` to `^2.6.0`.

## Why

The Album `discogsUnavailable` / `discogsUnavailableNote` / `lastDiscogsRecheckAt` fields — needed by the music-director "Not on Discogs" flag work — first shipped in `@wxyc/shared` v2.5.0 and are absent from the entire 1.x line. dj-site was pinned to `^1.17.1` (resolving to ≤1.18.0), so it literally could not see the type. This bump is the prerequisite for the toggle and render-gating surfaces.

## Breaking-change assessment

The only breaking change across the whole 1.x → 2.x range is v2.0.0: `OnAirDJ.id` went from `number` to a nullable `string` (BS#1547). Everything from 2.1 → 2.6 is purely additive. dj-site already treats on-air DJ ids as strings (fixtures use `{ id: "1", … }`), so there was zero fallout.

## Verification (local)

- `tsc --noEmit` — clean
- `eslint .` — 0 errors (199 pre-existing warnings)
- `vitest run` — 3859 tests passed (289 files)
- `next build` — success

Unblocks #693, #1058
