### PR TITLE
feat(catalog): add MD "Not on Discogs" toggle to album detail rightbar

### DIFF
--- a/lib/features/catalog/constants.ts
+++ b/lib/features/catalog/constants.ts
@@ -1,2 +1,5 @@
 /** Page size for GET /library/query (must match backend default/limit handling). */
 export const CATALOG_QUERY_PAGE_LIMIT = 50;
+
+/** Server CHECK constraint cap on library.discogs_unavailable_note (varchar(500)). */
+export const DISCOGS_UNAVAILABLE_NOTE_MAX_LENGTH = 500;

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -135,6 +135,15 @@ export function convertToAlbumEntry(
     disc_quantity: isSearchResult(response)
       ? (response as Record<string, unknown>).disc_quantity as number | undefined
       : undefined,
+    discogsUnavailable: isSearchResult(response)
+      ? (response as Record<string, unknown>).discogsUnavailable as boolean | undefined
+      : undefined,
+    discogsUnavailableNote: isSearchResult(response)
+      ? (response as Record<string, unknown>).discogsUnavailableNote as string | null | undefined
+      : undefined,
+    lastDiscogsRecheckAt: isSearchResult(response)
+      ? (response as Record<string, unknown>).lastDiscogsRecheckAt as string | null | undefined
+      : undefined,
   };
 }
 

--- a/lib/features/catalog/patchSearchResult.ts
+++ b/lib/features/catalog/patchSearchResult.ts
@@ -43,5 +43,16 @@ export function mergeAlbumIntoSearchResult(
     date_found:
       updated.date_found === undefined ? existing.date_found : updated.date_found,
     album_artist: updated.album_artist ?? existing.album_artist,
+    discogsUnavailable: updated.discogsUnavailable ?? existing.discogsUnavailable,
+    // `null` is a meaningful write (note cleared) and must pass through;
+    // only an absent (`undefined`) field falls back to the cached value.
+    discogsUnavailableNote:
+      updated.discogsUnavailableNote === undefined
+        ? existing.discogsUnavailableNote
+        : updated.discogsUnavailableNote,
+    lastDiscogsRecheckAt:
+      updated.lastDiscogsRecheckAt === undefined
+        ? existing.lastDiscogsRecheckAt
+        : updated.lastDiscogsRecheckAt,
   };
 }

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -20,10 +20,20 @@ export const TrackMatchSource = {
 /**
  * JSON boundary adapter for AlbumSearchResult.
  * RTK Query delivers raw JSON where add_date is a string, not a Date.
+ *
+ * discogsUnavailable/discogsUnavailableNote/lastDiscogsRecheckAt are declared
+ * here by hand rather than picked up from `AlbumSearchResult`: api.yaml only
+ * carries them on `Album`/`AlbumInfoResponse` (the `GET /library/info`
+ * response schema), not on `AlbumSearchResult`, even though `GET /library/`,
+ * `GET /library/query`, and `PATCH /library/:id` all serve from the same
+ * backend read model and carry the fields on the wire.
  */
 export type AlbumSearchResultJSON = Omit<AlbumSearchResult, "add_date"> & {
   add_date: string;
   matched_via?: TrackMatchHint[];
+  discogsUnavailable?: boolean;
+  discogsUnavailableNote?: string | null;
+  lastDiscogsRecheckAt?: string | null;
 };
 
 export type SearchCatalogQueryParams = {
@@ -48,15 +58,27 @@ export type AddAlbumRequestBody = {
   label_id?: number;
 };
 
+/**
+ * PATCH /library/:id is a true partial update on the backend — only fields
+ * present in the body are validated and written — so every field here is
+ * optional. discogsUnavailableNote must be null whenever discogsUnavailable
+ * is false or absent-with-existing-false-state (the backend CHECK constraint
+ * `discogs_unavailable OR discogs_unavailable_note IS NULL`); callers that
+ * only toggle the flag off must pass `discogsUnavailableNote: null` alongside
+ * it rather than omitting the note. lastDiscogsRecheckAt is deliberately
+ * absent — it is server-write-only.
+ */
 export type UpdateAlbumRequestBody = {
-  album_title: string;
-  label: string;
-  genre_id: number;
-  format_id: number;
-  artist_id: number;
+  album_title?: string;
+  label?: string;
+  genre_id?: number;
+  format_id?: number;
+  artist_id?: number;
   alternate_artist_name?: string;
   disc_quantity?: number;
   label_id?: number;
+  discogsUnavailable?: boolean;
+  discogsUnavailableNote?: string | null;
 };
 
 /**
@@ -153,6 +175,12 @@ export type AlbumEntry = {
   genre_id?: number;
   format_id?: number;
   disc_quantity?: number;
+  /** MD-set marker: this release is intentionally not on Discogs (embargoed promo, audience-segment release, etc). Writable via PATCH /library/:id. */
+  discogsUnavailable?: boolean;
+  /** Optional free-text reason for discogsUnavailable; null whenever the flag is false. Writable via PATCH /library/:id. */
+  discogsUnavailableNote?: string | null;
+  /** Stamped by the daily discogs-unavailable recheck cron. Read-only — never sent in a PATCH body. */
+  lastDiscogsRecheckAt?: string | null;
 };
 
 export type ArtistEntry = {

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumCard.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumCard.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/joy";
 import { useRef, useState, useEffect } from "react";
 import DiscogsMarkup from "./DiscogsMarkupRenderer";
+import DiscogsUnavailableControl from "./DiscogsUnavailableControl";
 import LibraryStatus from "./LibraryStatus";
 import StreamingLinks from "./StreamingLinks";
 import Tracklist from "./Tracklist";
@@ -113,6 +114,7 @@ export default function AlbumCard({
             <LibraryStatus album={album} />
           </Stack>
         </Stack>
+        <DiscogsUnavailableControl key={album.id} album={album} />
         <StreamingLinks metadata={metadata} />
         {artistBio && (
           <>

--- a/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Stack,
+  Switch,
+  Textarea,
+  Typography,
+} from "@mui/joy";
+import { RequireMD } from "@/src/components/shared/Authorization";
+import { useUpdateAlbumMutation } from "@/lib/features/catalog/api";
+import { AlbumEntry } from "@/lib/features/catalog/types";
+import { DISCOGS_UNAVAILABLE_NOTE_MAX_LENGTH } from "@/lib/features/catalog/constants";
+
+interface DiscogsUnavailableControlProps {
+  album: AlbumEntry;
+}
+
+/**
+ * MD+ control for the "Not on Discogs" flag: flips `discogsUnavailable` and
+ * an optional free-text reason via `PATCH /library/:id`. Mount with
+ * `key={album.id}` from the caller — local state is seeded from `album` on
+ * mount only, so switching albums without a remount would leak the prior
+ * album's draft note.
+ */
+function DiscogsUnavailableControl({ album }: DiscogsUnavailableControlProps) {
+  const [updateAlbum] = useUpdateAlbumMutation();
+
+  const [flag, setFlag] = useState(album.discogsUnavailable ?? false);
+  const [flagPending, setFlagPending] = useState(false);
+  const [note, setNote] = useState(album.discogsUnavailableNote ?? "");
+  const [savedNote, setSavedNote] = useState(album.discogsUnavailableNote ?? "");
+  const [notePending, setNotePending] = useState(false);
+
+  const noteChanged = note.trim() !== (savedNote ?? "").trim();
+
+  const handleFlagChange = async (next: boolean) => {
+    const previousFlag = flag;
+    const previousNote = savedNote;
+    // The backend CHECK constraint requires the note to be null whenever the
+    // flag is false, so turning the flag off clears the note in the same
+    // request rather than leaving an orphaned note server-side.
+    const nextNote = next ? (savedNote || null) : null;
+
+    setFlag(next);
+    setFlagPending(true);
+    if (!next) {
+      setNote("");
+      setSavedNote("");
+    }
+
+    try {
+      await updateAlbum({
+        albumId: album.id,
+        body: { discogsUnavailable: next, discogsUnavailableNote: nextNote },
+      }).unwrap();
+    } catch {
+      setFlag(previousFlag);
+      setSavedNote(previousNote);
+      setNote(previousNote);
+      toast.error("Failed to update Discogs availability");
+    } finally {
+      setFlagPending(false);
+    }
+  };
+
+  const handleSaveNote = async () => {
+    const trimmed = note.trim();
+    const nextNote = trimmed.length > 0 ? trimmed : null;
+
+    setNotePending(true);
+    try {
+      await updateAlbum({
+        albumId: album.id,
+        body: { discogsUnavailable: true, discogsUnavailableNote: nextNote },
+      }).unwrap();
+      setSavedNote(nextNote ?? "");
+      setNote(nextNote ?? "");
+    } catch {
+      toast.error("Failed to save note");
+    } finally {
+      setNotePending(false);
+    }
+  };
+
+  return (
+    <RequireMD>
+      <Stack spacing={1}>
+        <FormControl
+          orientation="horizontal"
+          sx={{ justifyContent: "space-between", alignItems: "center" }}
+        >
+          <FormLabel>Not on Discogs</FormLabel>
+          <Switch
+            checked={flag}
+            disabled={flagPending}
+            onChange={(e) => handleFlagChange(e.target.checked)}
+          />
+        </FormControl>
+        {flag && (
+          <FormControl>
+            <FormLabel>Reason (optional)</FormLabel>
+            <Textarea
+              value={note}
+              minRows={2}
+              maxRows={4}
+              placeholder='e.g. "embargoed until 2026-09-01" or "audience doesn&apos;t use Discogs"'
+              slotProps={{
+                textarea: { maxLength: DISCOGS_UNAVAILABLE_NOTE_MAX_LENGTH },
+              }}
+              onChange={(e) => setNote(e.target.value)}
+            />
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              alignItems="center"
+              sx={{ mt: 0.5 }}
+            >
+              <Typography level="body-xs" sx={{ color: "text.tertiary" }}>
+                {note.length}/{DISCOGS_UNAVAILABLE_NOTE_MAX_LENGTH}
+              </Typography>
+              {noteChanged && (
+                <Button size="sm" loading={notePending} onClick={handleSaveNote}>
+                  Save
+                </Button>
+              )}
+            </Stack>
+          </FormControl>
+        )}
+      </Stack>
+    </RequireMD>
+  );
+}
+
+export default DiscogsUnavailableControl;

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumCard.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumCard.test.tsx
@@ -15,6 +15,10 @@ vi.mock("@/src/components/experiences/modern/Rightbar/panels/album/LibraryStatus
   default: () => <span>mocked status</span>,
 }));
 
+vi.mock("@/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl", () => ({
+  default: () => <span>mocked discogs-unavailable control</span>,
+}));
+
 vi.mock("@/src/components/experiences/modern/Rightbar/panels/album/StreamingLinks", () => ({
   default: () => null,
 }));

--- a/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
@@ -1,0 +1,325 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import {
+  renderWithProviders,
+  createTestAlbum,
+  createTestArtist,
+  server,
+  TEST_BACKEND_URL,
+} from "@/tests/helpers";
+import DiscogsUnavailableControl from "@/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+// No organization configured: AuthorizedView falls back to the raw session
+// role synchronously, so tests don't need to await an org-role fetch.
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+import { toast } from "sonner";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+
+function sessionWithRole(role: string) {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+    error: null,
+  };
+}
+
+const juanaMolinaAlbum = (overrides: Parameters<typeof createTestAlbum>[0] = {}) =>
+  createTestAlbum({
+    id: 4242,
+    title: "DOGA",
+    artist: createTestArtist({
+      name: "Juana Molina",
+      lettercode: "MO",
+      numbercode: 12,
+      genre: "Rock",
+    }),
+    label: "Sonamos",
+    ...overrides,
+  });
+
+function mockPatch() {
+  let receivedBody: unknown;
+  server.use(
+    http.patch(`${TEST_BACKEND_URL}/library/:id`, async ({ request }) => {
+      receivedBody = await request.json();
+      return HttpResponse.json({
+        id: 4242,
+        album_title: "DOGA",
+        artist_name: "Juana Molina",
+        code_letters: "MO",
+        code_number: 1,
+        code_artist_number: 12,
+        format_name: "CD",
+        genre_name: "Rock",
+        label: "Sonamos",
+        ...(receivedBody as Record<string, unknown>),
+      });
+    }),
+  );
+  return () => receivedBody;
+}
+
+describe("DiscogsUnavailableControl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("permission gating", () => {
+    it("renders nothing for a DJ", () => {
+      mockUseSession.mockReturnValue(sessionWithRole("dj"));
+      renderWithProviders(<DiscogsUnavailableControl album={juanaMolinaAlbum()} />);
+
+      expect(screen.queryByLabelText("Not on Discogs")).not.toBeInTheDocument();
+    });
+
+    it("renders the toggle for a Music Director", () => {
+      mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
+      renderWithProviders(<DiscogsUnavailableControl album={juanaMolinaAlbum()} />);
+
+      expect(screen.getByLabelText("Not on Discogs")).toBeInTheDocument();
+    });
+
+    it("renders the toggle for a Station Manager", () => {
+      mockUseSession.mockReturnValue(sessionWithRole("stationManager"));
+      renderWithProviders(<DiscogsUnavailableControl album={juanaMolinaAlbum()} />);
+
+      expect(screen.getByLabelText("Not on Discogs")).toBeInTheDocument();
+    });
+  });
+
+  describe("initial state", () => {
+    beforeEach(() => {
+      mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
+    });
+
+    it("is unchecked with no note field when the album is not flagged", () => {
+      renderWithProviders(<DiscogsUnavailableControl album={juanaMolinaAlbum()} />);
+
+      expect(screen.getByLabelText("Not on Discogs")).not.toBeChecked();
+      expect(screen.queryByLabelText("Reason (optional)")).not.toBeInTheDocument();
+    });
+
+    it("is checked with the note prefilled when the album is already flagged", () => {
+      renderWithProviders(
+        <DiscogsUnavailableControl
+          album={juanaMolinaAlbum({
+            discogsUnavailable: true,
+            discogsUnavailableNote: "audience doesn't use Discogs",
+          })}
+        />,
+      );
+
+      expect(screen.getByLabelText("Not on Discogs")).toBeChecked();
+      expect(screen.getByLabelText("Reason (optional)")).toHaveValue(
+        "audience doesn't use Discogs",
+      );
+    });
+
+    it("caps the note field at 500 characters", () => {
+      renderWithProviders(
+        <DiscogsUnavailableControl
+          album={juanaMolinaAlbum({ discogsUnavailable: true })}
+        />,
+      );
+
+      expect(screen.getByLabelText("Reason (optional)")).toHaveAttribute(
+        "maxLength",
+        "500",
+      );
+    });
+  });
+
+  describe("toggling the flag", () => {
+    beforeEach(() => {
+      mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
+    });
+
+    it("PATCHes the flag and optimistically reflects the just-set value", async () => {
+      const getReceivedBody = mockPatch();
+      const { user } = renderWithProviders(
+        <DiscogsUnavailableControl album={juanaMolinaAlbum()} />,
+      );
+
+      const toggle = screen.getByLabelText("Not on Discogs");
+      await user.click(toggle);
+
+      // Reflected immediately, ahead of the PATCH resolving.
+      expect(toggle).toBeChecked();
+      expect(screen.getByLabelText("Reason (optional)")).toBeInTheDocument();
+
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          discogsUnavailable: true,
+          discogsUnavailableNote: null,
+        }),
+      );
+    });
+
+    it("sends null for the note (flag <-> note invariant) when turning the flag off", async () => {
+      const getReceivedBody = mockPatch();
+      const { user } = renderWithProviders(
+        <DiscogsUnavailableControl
+          album={juanaMolinaAlbum({
+            discogsUnavailable: true,
+            discogsUnavailableNote: "embargoed until 2026-09-01",
+          })}
+        />,
+      );
+
+      const toggle = screen.getByLabelText("Not on Discogs");
+      await user.click(toggle);
+
+      expect(toggle).not.toBeChecked();
+      expect(screen.queryByLabelText("Reason (optional)")).not.toBeInTheDocument();
+
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          discogsUnavailable: false,
+          discogsUnavailableNote: null,
+        }),
+      );
+    });
+
+    it("reverts the toggle and shows an error toast when the PATCH fails", async () => {
+      server.use(
+        http.patch(`${TEST_BACKEND_URL}/library/:id`, () =>
+          HttpResponse.json({ error: "rejected" }, { status: 500 }),
+        ),
+      );
+      const { user } = renderWithProviders(
+        <DiscogsUnavailableControl album={juanaMolinaAlbum()} />,
+      );
+
+      const toggle = screen.getByLabelText("Not on Discogs");
+      await user.click(toggle);
+
+      await waitFor(() => expect(toggle).not.toBeChecked());
+      expect(toast.error).toHaveBeenCalledWith(
+        "Failed to update Discogs availability",
+      );
+    });
+  });
+
+  describe("editing the note", () => {
+    beforeEach(() => {
+      mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
+    });
+
+    it("does not show a Save button until the note text changes", () => {
+      renderWithProviders(
+        <DiscogsUnavailableControl
+          album={juanaMolinaAlbum({ discogsUnavailable: true, discogsUnavailableNote: "old reason" })}
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+    });
+
+    it("saves the trimmed note via PATCH", async () => {
+      const getReceivedBody = mockPatch();
+      const { user } = renderWithProviders(
+        <DiscogsUnavailableControl
+          album={juanaMolinaAlbum({ discogsUnavailable: true, discogsUnavailableNote: "old reason" })}
+        />,
+      );
+
+      const note = screen.getByLabelText("Reason (optional)");
+      await user.clear(note);
+      await user.type(note, "  new reason  ");
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          discogsUnavailable: true,
+          discogsUnavailableNote: "new reason",
+        }),
+      );
+    });
+
+    it("saves an empty note as null", async () => {
+      const getReceivedBody = mockPatch();
+      const { user } = renderWithProviders(
+        <DiscogsUnavailableControl
+          album={juanaMolinaAlbum({ discogsUnavailable: true, discogsUnavailableNote: "old reason" })}
+        />,
+      );
+
+      const note = screen.getByLabelText("Reason (optional)");
+      await user.clear(note);
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          discogsUnavailable: true,
+          discogsUnavailableNote: null,
+        }),
+      );
+    });
+
+    it("hides the Save button again after a successful save", async () => {
+      mockPatch();
+      const { user } = renderWithProviders(
+        <DiscogsUnavailableControl
+          album={juanaMolinaAlbum({ discogsUnavailable: true, discogsUnavailableNote: "old reason" })}
+        />,
+      );
+
+      const note = screen.getByLabelText("Reason (optional)");
+      await user.clear(note);
+      await user.type(note, "new reason");
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() =>
+        expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument(),
+      );
+    });
+
+    it("shows an error toast when saving the note fails", async () => {
+      server.use(
+        http.patch(`${TEST_BACKEND_URL}/library/:id`, () =>
+          HttpResponse.json({ error: "rejected" }, { status: 500 }),
+        ),
+      );
+      const { user } = renderWithProviders(
+        <DiscogsUnavailableControl
+          album={juanaMolinaAlbum({ discogsUnavailable: true, discogsUnavailableNote: "old reason" })}
+        />,
+      );
+
+      const note = screen.getByLabelText("Reason (optional)");
+      await user.type(note, " updated");
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Failed to save note"));
+    });
+  });
+});

--- a/tests/unit/lib/features/catalog/catalog.test.ts
+++ b/tests/unit/lib/features/catalog/catalog.test.ts
@@ -229,6 +229,46 @@ describe("convertToAlbumEntry", () => {
   );
 
   describeConversionWithAssertions(
+    "discogsUnavailable fields",
+    convertToAlbumEntry,
+    [
+      {
+        name: "should pass through discogsUnavailable, discogsUnavailableNote, and lastDiscogsRecheckAt when present",
+        input: createTestAlbumSearchResult({
+          discogsUnavailable: true,
+          discogsUnavailableNote: "audience doesn't use Discogs",
+          lastDiscogsRecheckAt: "2026-07-24T06:00:00.000Z",
+        } as any),
+        assertions: (result) => {
+          expect(result.discogsUnavailable).toBe(true);
+          expect(result.discogsUnavailableNote).toBe("audience doesn't use Discogs");
+          expect(result.lastDiscogsRecheckAt).toBe("2026-07-24T06:00:00.000Z");
+        },
+      },
+      {
+        name: "should default discogsUnavailable fields to undefined when absent",
+        input: createTestAlbumSearchResult(),
+        assertions: (result) => {
+          expect(result.discogsUnavailable).toBeUndefined();
+          expect(result.discogsUnavailableNote).toBeUndefined();
+          expect(result.lastDiscogsRecheckAt).toBeUndefined();
+        },
+      },
+      {
+        name: "should pass through an explicit null note",
+        input: createTestAlbumSearchResult({
+          discogsUnavailable: false,
+          discogsUnavailableNote: null,
+        } as any),
+        assertions: (result) => {
+          expect(result.discogsUnavailable).toBe(false);
+          expect(result.discogsUnavailableNote).toBeNull();
+        },
+      },
+    ]
+  );
+
+  describeConversionWithAssertions(
     "album_artist (compilation handling)",
     convertToAlbumEntry,
     [

--- a/tests/unit/lib/features/catalog/patchSearchResult.test.ts
+++ b/tests/unit/lib/features/catalog/patchSearchResult.test.ts
@@ -55,6 +55,58 @@ describe("mergeAlbumIntoSearchResult", () => {
     expect(merged.date_found).toBe("2024-02-01");
   });
 
+  it("applies a defined discogsUnavailable flag from the mutation response", () => {
+    const existing = createTestAlbum({ id: 42, discogsUnavailable: false });
+    const updated = createTestAlbum({ id: 42, discogsUnavailable: true });
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.discogsUnavailable).toBe(true);
+  });
+
+  it("falls back to the cached discogsUnavailable flag when the response omits it", () => {
+    const existing = createTestAlbum({ id: 42, discogsUnavailable: true });
+    const updated = createTestAlbum({ id: 42, discogsUnavailable: undefined });
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.discogsUnavailable).toBe(true);
+  });
+
+  it("passes through an explicit null discogsUnavailableNote (cleared on the server)", () => {
+    const existing = createTestAlbum({
+      id: 42,
+      discogsUnavailable: true,
+      discogsUnavailableNote: "embargoed until 2026-09-01",
+    });
+    const updated = createTestAlbum({
+      id: 42,
+      discogsUnavailable: false,
+      discogsUnavailableNote: null,
+    });
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.discogsUnavailableNote).toBeNull();
+  });
+
+  it("falls back to the cached discogsUnavailableNote when the response omits it", () => {
+    const existing = createTestAlbum({
+      id: 42,
+      discogsUnavailable: true,
+      discogsUnavailableNote: "embargoed until 2026-09-01",
+    });
+    const updated = createTestAlbum({
+      id: 42,
+      discogsUnavailable: true,
+      discogsUnavailableNote: undefined,
+    });
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.discogsUnavailableNote).toBe("embargoed until 2026-09-01");
+  });
+
   it("merges albums with empty title fields from LML-only rows", () => {
     const existing = createTestAlbum({
       id: 42,


### PR DESCRIPTION
Closes #693

## Summary

- Extends `AlbumEntry` / `AlbumSearchResultJSON` / `UpdateAlbumRequestBody` (`lib/features/catalog/types.ts`) with `discogsUnavailable` (bool), `discogsUnavailableNote` (`string | null`), and the read-only `lastDiscogsRecheckAt`, matching `@wxyc/shared@2.6.0`'s `Album` schema.
- Adds a music-director-gated `DiscogsUnavailableControl` (toggle + 500-char note) to the album detail card (`AlbumCard.tsx`), reusing the existing `RequireMD` role gate and the `updateAlbum` mutation (`PATCH /library/:id`).
- Toggling the flag PATCHes immediately with an optimistic local reflect-and-revert-on-failure; the note field appears only while the flag is on and saves via an explicit Save action once its text diverges from the last-saved value (mirrors `AccountEditForm`'s pattern). Both paths always send `discogsUnavailableNote: null` whenever `discogsUnavailable` is false, enforcing the flag↔note invariant the backend CHECK constraint requires.
- `UpdateAlbumRequestBody`'s legacy fields become optional to match the backend's true partial-update semantics for `PATCH /library/:id` — the two new fields are the first payload that doesn't populate every legacy field.
- `mergeAlbumIntoSearchResult` gains the same undefined-vs-null handling already used for `date_lost`/`date_found` so a PATCH response that omits the new fields can't clobber a cached value.

Render-gating (badges on catalog cards / album-detail / flowsheet entries) is out of scope per the 2026-07-31 ticket split — that's #1058, blocked on the Backend read-emit landing (BS#1895, now merged, so #1058 is unblocked separately).

## Note on a pre-existing contract gap (not fixed here)

While wiring the conversion I found that `wxyc-shared/api.yaml`'s `AlbumSearchResult` schema (used by `GET /library/`, `GET /library/query`, and the `PATCH /library/:id` response) doesn't declare `discogsUnavailable`/`discogsUnavailableNote`/`lastDiscogsRecheckAt` — only `Album`/`AlbumInfoResponse` (`GET /library/info`) does, even though all of these serve from the same backend read model and (per the epic's closed-out state) carry the fields on the wire. dj-site's `AlbumSearchResultJSON` type is hand-maintained rather than codegen'd from api.yaml, so this doesn't block the client, but it's worth a follow-up in wxyc-shared to make the schema match the wire shape.

## Test plan

- [x] `npx vitest run` — 3880 tests pass (290 files), including new coverage for the toggle's MD/DJ/SM gating, initial state, 500-char cap, optimistic PATCH + revert-on-failure, the flag↔note invariant, note save/cancel, and `convertToAlbumEntry`/`mergeAlbumIntoSearchResult` handling of the three new fields.
- [x] `npm run lint` — 0 errors (pre-existing warning count unchanged).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — succeeds.