### PR TITLE
feat(catalog): gate Discogs-derived rendering on discogsUnavailable

### DIFF
--- a/app/dashboard/@information/(.)album/[id]/page.tsx
+++ b/app/dashboard/@information/(.)album/[id]/page.tsx
@@ -54,7 +54,7 @@ export default function AlbumPopup() {
     artworkUrl,
     isLoading: metadataLoading,
     metadata,
-  } = useAlbumArtwork(data?.artist.name, data?.title);
+  } = useAlbumArtwork(data?.artist.name, data?.title, data?.discogsUnavailable === true);
 
   const { artistMetadata, bioTokens } = useArtistMetadata(metadata?.discogsArtistId);
 

--- a/lib/features/metadata/hooks.ts
+++ b/lib/features/metadata/hooks.ts
@@ -4,12 +4,19 @@ const DEFAULT_ARTWORK_URL = "/img/cassette.png";
 
 /**
  * Fetches album metadata from the Backend-Service metadata proxy and returns the artwork URL.
+ *
+ * `skip` should be `true` for a `discogsUnavailable`-flagged album: it has no
+ * Discogs match to look up by definition, so fetching would be a doomed
+ * request. Callers that pass `skip` are an optimization, not the gate itself
+ * — `AlbumCard` suppresses rendering of every metadata-derived block on the
+ * flag regardless of whether this fetch ran.
  */
 export function useAlbumArtwork(
   artistName: string | undefined,
   releaseTitle: string | undefined,
+  skip?: boolean,
 ) {
-  const shouldSkip = !artistName || !releaseTitle;
+  const shouldSkip = !artistName || !releaseTitle || skip === true;
 
   const { data, isLoading } = useGetAlbumMetadataQuery(
     { artistName: artistName!, releaseTitle: releaseTitle! },

--- a/src/components/experiences/modern/Rightbar/panels/AlbumDetailPanel.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/AlbumDetailPanel.tsx
@@ -21,6 +21,7 @@ export default function AlbumDetailPanel({ albumId }: { albumId: number }) {
   const { artworkUrl, isLoading: metadataLoading, metadata } = useAlbumArtwork(
     data?.artist.name,
     data?.title,
+    data?.discogsUnavailable === true,
   );
 
   const { artistMetadata, bioTokens } = useArtistMetadata(metadata?.discogsArtistId);

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumCard.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumCard.tsx
@@ -15,6 +15,7 @@ import {
   Typography,
 } from "@mui/joy";
 import { useRef, useState, useEffect } from "react";
+import { NotOnDiscogsBadge } from "@/src/components/experiences/modern/catalog/AlbumArtwork";
 import DiscogsMarkup from "./DiscogsMarkupRenderer";
 import DiscogsUnavailableControl from "./DiscogsUnavailableControl";
 import LibraryStatus from "./LibraryStatus";
@@ -51,6 +52,16 @@ export default function AlbumCard({
     }
   }, [artistBio]);
 
+  // MD-flagged release: the matched Discogs release is wrong or inapplicable
+  // (embargoed promo, audience-segment release, etc). Every block sourced
+  // from the /metadata/album proxy — artwork, label/year/genre/style,
+  // streaming links, artist bio, tracklist, and the Discogs footer link — is
+  // gated on this flag rather than on `metadata` being present, so the
+  // suppression holds even if a caller still fetches metadata for a flagged
+  // album. Library-owned data (title, LibraryStatus, plays/add date) is
+  // unaffected — the flag says nothing about the library entry itself.
+  const isDiscogsUnavailable = album.discogsUnavailable === true;
+
   return (
     <Card
       variant="outlined"
@@ -60,18 +71,25 @@ export default function AlbumCard({
     >
       <CardContent>
         <Stack direction="row" spacing={2} sx={{ mb: 1 }}>
-          <Box
-            component="img"
-            src={artworkUrl}
-            alt={`${album.title} cover`}
-            sx={{
-              width: { xs: 120, lg: 160 },
-              height: { xs: 120, lg: 160 },
-              objectFit: "cover",
-              borderRadius: "sm",
-              flexShrink: 0,
-            }}
-          />
+          {isDiscogsUnavailable ? (
+            <NotOnDiscogsBadge
+              size={{ xs: 120, lg: 160 }}
+              note={album.discogsUnavailableNote}
+            />
+          ) : (
+            <Box
+              component="img"
+              src={artworkUrl}
+              alt={`${album.title} cover`}
+              sx={{
+                width: { xs: 120, lg: 160 },
+                height: { xs: 120, lg: 160 },
+                objectFit: "cover",
+                borderRadius: "sm",
+                flexShrink: 0,
+              }}
+            />
+          )}
           <Stack sx={{ minWidth: 0, justifyContent: "center" }}>
             <Typography level="title-lg" sx={{ mb: 0.5 }}>
               {album.album_artist ? "Various Artists" : album.artist.name} &bull; {album.title}
@@ -81,42 +99,53 @@ export default function AlbumCard({
                 {album.album_artist}
               </Typography>
             )}
-            <Stack
-              direction="row"
-              spacing={1}
-              sx={{ mb: 1, flexWrap: "wrap", alignItems: "center" }}
-            >
-              {metadata?.label && (
-                <Typography level="body-sm">{metadata.label}</Typography>
-              )}
-              {metadata?.label && metadata.releaseYear ? (
-                <Typography level="body-sm">&bull;</Typography>
-              ) : null}
-              {metadata?.releaseYear ? (
-                <Typography level="body-sm">{metadata.releaseYear}</Typography>
-              ) : null}
-              {!metadata && !metadataLoading && (
-                <Typography level="body-sm">
-                  {album.label || ""}{album.label ? " \u2022 " : ""}{album?.format ?? ""}
+            {isDiscogsUnavailable ? (
+              album.discogsUnavailableNote && (
+                <Typography
+                  level="body-sm"
+                  sx={{ mb: 1, color: "text.tertiary", fontStyle: "italic" }}
+                >
+                  {album.discogsUnavailableNote}
                 </Typography>
-              )}
-              {metadata?.genres?.map((g) => (
-                <Chip key={g} size="sm" variant="soft">
-                  {g}
-                </Chip>
-              ))}
-              {metadata?.styles?.map((s) => (
-                <Chip key={s} size="sm" variant="outlined">
-                  {s}
-                </Chip>
-              ))}
-            </Stack>
+              )
+            ) : (
+              <Stack
+                direction="row"
+                spacing={1}
+                sx={{ mb: 1, flexWrap: "wrap", alignItems: "center" }}
+              >
+                {metadata?.label && (
+                  <Typography level="body-sm">{metadata.label}</Typography>
+                )}
+                {metadata?.label && metadata.releaseYear ? (
+                  <Typography level="body-sm">&bull;</Typography>
+                ) : null}
+                {metadata?.releaseYear ? (
+                  <Typography level="body-sm">{metadata.releaseYear}</Typography>
+                ) : null}
+                {!metadata && !metadataLoading && (
+                  <Typography level="body-sm">
+                    {album.label || ""}{album.label ? " \u2022 " : ""}{album?.format ?? ""}
+                  </Typography>
+                )}
+                {metadata?.genres?.map((g) => (
+                  <Chip key={g} size="sm" variant="soft">
+                    {g}
+                  </Chip>
+                ))}
+                {metadata?.styles?.map((s) => (
+                  <Chip key={s} size="sm" variant="outlined">
+                    {s}
+                  </Chip>
+                ))}
+              </Stack>
+            )}
             <LibraryStatus album={album} />
           </Stack>
         </Stack>
         <DiscogsUnavailableControl key={album.id} album={album} />
-        <StreamingLinks metadata={metadata} />
-        {artistBio && (
+        {!isDiscogsUnavailable && <StreamingLinks metadata={metadata} />}
+        {!isDiscogsUnavailable && artistBio && (
           <>
             <Divider sx={{ my: 1 }} />
             <Typography level="title-sm" sx={{ mb: 0.5 }}>
@@ -156,7 +185,7 @@ export default function AlbumCard({
           </>
         )}
         <Divider sx={{ my: 1 }} />
-        {metadataLoading ? (
+        {isDiscogsUnavailable ? null : metadataLoading ? (
           <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
             <CircularProgress size="sm" />
           </Box>
@@ -191,7 +220,7 @@ export default function AlbumCard({
               ? "Unknown Time"
               : new Date(album.add_date).toLocaleDateString()}
           </Typography>
-          {metadata?.discogsUrl && (
+          {!isDiscogsUnavailable && metadata?.discogsUrl && (
             <>
               <Divider orientation="vertical" />
               <Link

--- a/src/components/experiences/modern/catalog/AlbumArtwork.tsx
+++ b/src/components/experiences/modern/catalog/AlbumArtwork.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import type { JSX } from "react";
+import Box from "@mui/joy/Box";
+import Tooltip from "@mui/joy/Tooltip";
+import Typography from "@mui/joy/Typography";
+import BlockOutlinedIcon from "@mui/icons-material/BlockOutlined";
+
+import { AlbumEntry } from "@/lib/features/catalog/types";
+import { genreTone } from "@/lib/features/experiences/modern/tokens/roles";
+
+/** MUI Joy `sx` width/height value: a fixed pixel size, or a responsive breakpoint map. */
+type ArtworkSize = number | Partial<Record<"xs" | "sm" | "md" | "lg" | "xl", number>>;
+
+interface NotOnDiscogsBadgeProps {
+  size: ArtworkSize;
+  note?: string | null;
+}
+
+/**
+ * MD-flagged "Not on Discogs" placeholder. Renders wherever an album's
+ * `discogsUnavailable` flag is true, in place of any Discogs-sourced artwork —
+ * the possibly-wrong match data stays in the DB, this only gates rendering.
+ * Shape mirrors `ArtistAvatar.tsx` (Tooltip-wrapped fixed-size box); the
+ * optional MD note surfaces as the tooltip content, falling back to a plain
+ * "Not on Discogs" label when no note was recorded.
+ */
+export function NotOnDiscogsBadge({ size, note }: NotOnDiscogsBadgeProps): JSX.Element {
+  return (
+    <Tooltip variant="outlined" title={note || "Not on Discogs"} placement="top">
+      <Box
+        aria-label="Not on Discogs"
+        sx={{
+          width: size,
+          height: size,
+          borderRadius: "sm",
+          flexShrink: 0,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 0.25,
+          textAlign: "center",
+          bgcolor: "neutral.softBg",
+          border: "1px solid",
+          borderColor: "neutral.outlinedBorder",
+        }}
+      >
+        <BlockOutlinedIcon sx={{ color: "neutral.500" }} />
+        <Typography
+          level="body-xs"
+          sx={{
+            fontSize: "0.55rem",
+            lineHeight: 1.1,
+            color: "text.tertiary",
+            px: 0.5,
+          }}
+        >
+          Not on Discogs
+        </Typography>
+      </Box>
+    </Tooltip>
+  );
+}
+
+interface AlbumArtworkProps {
+  album: AlbumEntry;
+  size: ArtworkSize;
+}
+
+/**
+ * Single gate point for rendering catalog-card artwork. Priority:
+ *   1. `album.discogsUnavailable === true` -> `NotOnDiscogsBadge` (never
+ *      renders `artwork_url`, even if present — a flagged release's matched
+ *      Discogs image is exactly the data the flag says not to trust).
+ *   2. `album.artwork_url` -> `<img>`.
+ *   3. Neither -> the genre-gradient lettercode placeholder.
+ * `discogsUnavailable`/`discogsUnavailableNote` are optional fields on
+ * `AlbumEntry`; `undefined` means "not flagged", matching every other
+ * consumer of this gate (`AlbumCard.tsx`, `DiscogsUnavailableControl.tsx`).
+ */
+export function AlbumArtwork({ album, size }: AlbumArtworkProps): JSX.Element {
+  if (album.discogsUnavailable === true) {
+    return <NotOnDiscogsBadge size={size} note={album.discogsUnavailableNote} />;
+  }
+
+  if (album.artwork_url) {
+    return (
+      <Box
+        component="img"
+        src={album.artwork_url}
+        alt={`${album.artist.name} - ${album.title}`}
+        sx={{
+          width: size,
+          height: size,
+          borderRadius: "sm",
+          objectFit: "cover",
+          flexShrink: 0,
+        }}
+      />
+    );
+  }
+
+  const genreColor = genreTone(album.artist.genre).color;
+
+  return (
+    <Box
+      aria-hidden
+      sx={{
+        width: size,
+        height: size,
+        borderRadius: "sm",
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: (theme) =>
+          `linear-gradient(135deg, ${theme.vars.palette[genreColor][400]}, ${theme.vars.palette[genreColor][700]})`,
+      }}
+    >
+      <Typography
+        level="title-sm"
+        sx={{
+          color: "#fff",
+          opacity: 0.9,
+          fontWeight: 700,
+          letterSpacing: "0.08em",
+        }}
+      >
+        {album.artist.lettercode}
+      </Typography>
+    </Box>
+  );
+}
+
+export default AlbumArtwork;

--- a/src/components/experiences/modern/catalog/Results/MobileResult.tsx
+++ b/src/components/experiences/modern/catalog/Results/MobileResult.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { AlbumEntry } from "@/lib/features/catalog/types";
-import Box from "@mui/joy/Box";
 import IconButton from "@mui/joy/IconButton";
 import Sheet from "@mui/joy/Sheet";
 import Stack from "@mui/joy/Stack";
@@ -14,7 +13,7 @@ import { applicationSlice } from "@/lib/features/application/frontend";
 import { FlowsheetQuery } from "@/lib/features/flowsheet/types";
 import { useAppDispatch } from "@/lib/hooks";
 import { convertBinToQueue } from "@/lib/features/bin/conversions";
-import { genreTone } from "@/lib/features/experiences/modern/tokens/roles";
+import { AlbumArtwork } from "../AlbumArtwork";
 import AddRemoveBin from "./AddRemoveBin";
 import { MatchedTrackChips } from "./MatchedTrackChips";
 import { ReleaseChips } from "./ReleaseChips";
@@ -34,8 +33,6 @@ function CatalogMobileResult({
   addToQueue: (entry: FlowsheetQuery) => void;
 }) {
   const dispatch = useAppDispatch();
-
-  const genreColor = genreTone(album.artist.genre).color;
 
   const artistDisplay = album.album_artist ? "Various Artists" : album.artist.name;
 
@@ -70,36 +67,7 @@ function CatalogMobileResult({
         cursor: "pointer",
       }}
     >
-      {album.artwork_url ? (
-        <Box
-          component="img"
-          src={album.artwork_url}
-          alt={`${album.artist.name} - ${album.title}`}
-          sx={{ width: 56, height: 56, borderRadius: "sm", objectFit: "cover", flexShrink: 0 }}
-        />
-      ) : (
-        <Box
-          aria-hidden
-          sx={{
-            width: 56,
-            height: 56,
-            borderRadius: "sm",
-            flexShrink: 0,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            background: (theme) =>
-              `linear-gradient(135deg, ${theme.vars.palette[genreColor][400]}, ${theme.vars.palette[genreColor][700]})`,
-          }}
-        >
-          <Typography
-            level="title-sm"
-            sx={{ color: "#fff", opacity: 0.9, fontWeight: 700, letterSpacing: "0.08em" }}
-          >
-            {album.artist.lettercode}
-          </Typography>
-        </Box>
-      )}
+      <AlbumArtwork album={album} size={56} />
 
       <Stack sx={{ flex: 1, minWidth: 0 }} gap={0.25}>
         <Typography

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -15,7 +15,7 @@ import { useCatalogQuerySearch } from "@/src/hooks/catalogHooks";
 import { QueueMusic } from "@mui/icons-material";
 import { FlowsheetQuery } from "@/lib/features/flowsheet/types";
 import { useAppDispatch } from "@/lib/hooks";
-import { genreTone } from "@/lib/features/experiences/modern/tokens/roles";
+import { AlbumArtwork } from "../AlbumArtwork";
 import AddRemoveBin from "./AddRemoveBin";
 import { MatchedTrackChips } from "./MatchedTrackChips";
 import { ReleaseChips } from "./ReleaseChips";
@@ -39,7 +39,6 @@ function CatalogResult({
 
   const { selected, setSelection, sortBy } = useCatalogQuerySearch();
 
-  const genreColor = genreTone(album.artist.genre).color;
   const isSelected = selected.includes(album.id);
 
   const artistDisplay = album.album_artist ? "Various Artists" : album.artist.name;
@@ -81,45 +80,7 @@ function CatalogResult({
         />
       </td>
       <td>
-        {album.artwork_url ? (
-          <Box
-            component="img"
-            src={album.artwork_url}
-            alt={`${album.artist.name} - ${album.title}`}
-            sx={{
-              width: 48,
-              height: 48,
-              borderRadius: "sm",
-              objectFit: "cover",
-            }}
-          />
-        ) : (
-          <Box
-            aria-hidden
-            sx={{
-              width: 48,
-              height: 48,
-              borderRadius: "sm",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              background: (theme) =>
-                `linear-gradient(135deg, ${theme.vars.palette[genreColor][400]}, ${theme.vars.palette[genreColor][700]})`,
-            }}
-          >
-            <Typography
-              level="title-sm"
-              sx={{
-                color: "#fff",
-                opacity: 0.9,
-                fontWeight: 700,
-                letterSpacing: "0.08em",
-              }}
-            >
-              {album.artist.lettercode}
-            </Typography>
-          </Box>
-        )}
+        <AlbumArtwork album={album} size={48} />
       </td>
       <td>
         <Typography

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumCard.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumCard.test.tsx
@@ -6,6 +6,7 @@ import {
   createTestArtist,
 } from "@/tests/helpers";
 import AlbumCard from "@/src/components/experiences/modern/Rightbar/panels/album/AlbumCard";
+import type { AlbumMetadata } from "@/lib/features/metadata/types";
 
 vi.mock("@/src/components/experiences/modern/Rightbar/panels/album/DiscogsMarkupRenderer", () => ({
   default: () => <span>mocked bio</span>,
@@ -19,12 +20,14 @@ vi.mock("@/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavai
   default: () => <span>mocked discogs-unavailable control</span>,
 }));
 
+// Marker text (rather than the real `() => null` no-op) so gate tests can
+// assert the child was never invoked, not just that it rendered nothing.
 vi.mock("@/src/components/experiences/modern/Rightbar/panels/album/StreamingLinks", () => ({
-  default: () => null,
+  default: () => <span>mocked streaming links</span>,
 }));
 
 vi.mock("@/src/components/experiences/modern/Rightbar/panels/album/Tracklist", () => ({
-  default: () => null,
+  default: () => <span>mocked tracklist</span>,
 }));
 
 const defaultProps = {
@@ -35,6 +38,27 @@ const defaultProps = {
   bioTokens: null,
   artistWikipediaUrl: null,
 };
+
+function createTestMetadata(overrides: Partial<AlbumMetadata> = {}): AlbumMetadata {
+  return {
+    discogsReleaseId: 12345,
+    discogsArtistId: 678,
+    discogsUrl: "https://www.discogs.com/release/12345",
+    artworkUrl: "https://i.discogs.com/edits.jpg",
+    releaseYear: 2021,
+    spotifyUrl: "",
+    appleMusicUrl: "",
+    youtubeMusicUrl: "",
+    bandcampUrl: "",
+    soundcloudUrl: "",
+    tracklist: [{ position: "1", title: "Call Your Name", duration: "3:00" }],
+    genres: ["Electronic"],
+    styles: ["Experimental"],
+    label: "self-released",
+    fullReleaseDate: "2021-01-01",
+    ...overrides,
+  };
+}
 
 describe("AlbumCard Various Artists display", () => {
   it("should display 'Various Artists' in the title when album_artist is set", () => {
@@ -89,5 +113,122 @@ describe("AlbumCard Various Artists display", () => {
     );
 
     expect(screen.getByText(/About Autechre/)).toBeInTheDocument();
+  });
+});
+
+describe("AlbumCard discogsUnavailable gate", () => {
+  const flaggedAlbum = createTestAlbum({
+    artist: createTestArtist({ name: "Chuquimamani-Condori", lettercode: "EL", numbercode: 15 }),
+    title: "Edits",
+    label: "self-released",
+    discogsUnavailable: true,
+    discogsUnavailableNote: "audience doesn't use Discogs",
+  });
+  const metadata = createTestMetadata();
+
+  it("renders the Not on Discogs badge instead of the artwork image", () => {
+    renderWithProviders(<AlbumCard album={flaggedAlbum} {...defaultProps} metadata={metadata} />);
+
+    expect(screen.queryByAltText(`${flaggedAlbum.title} cover`)).not.toBeInTheDocument();
+    expect(screen.getByText("Not on Discogs")).toBeInTheDocument();
+  });
+
+  it("surfaces the discogsUnavailableNote as visible secondary text", () => {
+    renderWithProviders(<AlbumCard album={flaggedAlbum} {...defaultProps} />);
+
+    expect(screen.getByText("audience doesn't use Discogs")).toBeInTheDocument();
+  });
+
+  it("suppresses the label/year/genre/style metadata block", () => {
+    renderWithProviders(<AlbumCard album={flaggedAlbum} {...defaultProps} metadata={metadata} />);
+
+    expect(screen.queryByText(metadata.label)).not.toBeInTheDocument();
+    expect(screen.queryByText(String(metadata.releaseYear))).not.toBeInTheDocument();
+    expect(screen.queryByText("Electronic")).not.toBeInTheDocument();
+    expect(screen.queryByText("Experimental")).not.toBeInTheDocument();
+  });
+
+  it("suppresses streaming links", () => {
+    renderWithProviders(<AlbumCard album={flaggedAlbum} {...defaultProps} metadata={metadata} />);
+
+    expect(screen.queryByText("mocked streaming links")).not.toBeInTheDocument();
+  });
+
+  it("suppresses the artist bio", () => {
+    renderWithProviders(
+      <AlbumCard
+        album={flaggedAlbum}
+        {...defaultProps}
+        metadata={metadata}
+        artistBio="Chuquimamani-Condori is a producer and multi-instrumentalist."
+      />
+    );
+
+    expect(screen.queryByText(/About Chuquimamani-Condori/)).not.toBeInTheDocument();
+  });
+
+  it("suppresses the tracklist", () => {
+    renderWithProviders(<AlbumCard album={flaggedAlbum} {...defaultProps} metadata={metadata} />);
+
+    expect(screen.queryByText("mocked tracklist")).not.toBeInTheDocument();
+  });
+
+  it("suppresses the Discogs overflow-menu link", () => {
+    renderWithProviders(<AlbumCard album={flaggedAlbum} {...defaultProps} metadata={metadata} />);
+
+    expect(screen.queryByRole("link", { name: "Discogs" })).not.toBeInTheDocument();
+  });
+
+  it("still renders library-owned info: title, LibraryStatus, and the MD control", () => {
+    renderWithProviders(<AlbumCard album={flaggedAlbum} {...defaultProps} />);
+
+    expect(screen.getByText(/Edits/)).toBeInTheDocument();
+    expect(screen.getByText("mocked status")).toBeInTheDocument();
+    expect(screen.getByText("mocked discogs-unavailable control")).toBeInTheDocument();
+  });
+});
+
+describe("AlbumCard discogsUnavailable regression (false/undefined)", () => {
+  const metadata = createTestMetadata();
+
+  it("renders artwork, metadata block, streaming links, bio, and tracklist normally when not flagged", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Jessica Pratt", lettercode: "RO", numbercode: 112 }),
+      title: "On Your Own Love Again",
+      discogsUnavailable: false,
+    });
+
+    renderWithProviders(
+      <AlbumCard
+        album={album}
+        {...defaultProps}
+        metadata={metadata}
+        artistBio="Jessica Pratt is a singer-songwriter."
+      />
+    );
+
+    expect(screen.getByAltText(`${album.title} cover`)).toBeInTheDocument();
+    expect(screen.getByText(metadata.label)).toBeInTheDocument();
+    expect(screen.getByText(String(metadata.releaseYear))).toBeInTheDocument();
+    expect(screen.getByText("Electronic")).toBeInTheDocument();
+    expect(screen.getByText("Experimental")).toBeInTheDocument();
+    expect(screen.getByText("mocked streaming links")).toBeInTheDocument();
+    expect(screen.getByText(/About Jessica Pratt/)).toBeInTheDocument();
+    expect(screen.getByText("mocked tracklist")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Discogs" })).toBeInTheDocument();
+    expect(screen.queryByText("Not on Discogs")).not.toBeInTheDocument();
+  });
+
+  it("treats discogsUnavailable undefined (optional-field default) as not flagged", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Jessica Pratt" }),
+      title: "On Your Own Love Again",
+      discogsUnavailable: undefined,
+    });
+
+    renderWithProviders(<AlbumCard album={album} {...defaultProps} metadata={metadata} />);
+
+    expect(screen.getByAltText(`${album.title} cover`)).toBeInTheDocument();
+    expect(screen.queryByText("Not on Discogs")).not.toBeInTheDocument();
   });
 });

--- a/tests/integration/components/modern/catalog/AlbumArtwork.test.tsx
+++ b/tests/integration/components/modern/catalog/AlbumArtwork.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { createTestAlbum, createTestArtist } from "@/tests/helpers";
+import { renderWithProviders } from "@/tests/helpers/render";
+import { AlbumArtwork } from "@/src/components/experiences/modern/catalog/AlbumArtwork";
+
+describe("AlbumArtwork artwork_url priority", () => {
+  it("renders an <img> when artwork_url is set and the release is not flagged", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Jessica Pratt" }),
+      title: "On Your Own Love Again",
+      artwork_url: "https://i.discogs.com/on-your-own-love-again.jpg",
+    });
+
+    renderWithProviders(<AlbumArtwork album={album} size={48} />);
+
+    const img = screen.getByAltText(`${album.artist.name} - ${album.title}`);
+    expect(img.getAttribute("src")).toBe(
+      "https://i.discogs.com/on-your-own-love-again.jpg"
+    );
+  });
+});
+
+describe("AlbumArtwork genre-gradient placeholder", () => {
+  it("falls back to the lettercode placeholder when artwork_url is undefined", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Stereolab", lettercode: "RO" }),
+      artwork_url: undefined,
+    });
+
+    renderWithProviders(<AlbumArtwork album={album} size={48} />);
+
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.getByText("RO")).toBeInTheDocument();
+  });
+
+  it("falls back to the lettercode placeholder when artwork_url is null", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Cat Power", lettercode: "RO" }),
+      artwork_url: null,
+    });
+
+    renderWithProviders(<AlbumArtwork album={album} size={48} />);
+
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.getByText("RO")).toBeInTheDocument();
+  });
+});
+
+describe("AlbumArtwork discogsUnavailable gate", () => {
+  it("renders the Not on Discogs badge instead of artwork_url when flagged", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Juana Molina" }),
+      title: "DOGA",
+      artwork_url: "https://i.discogs.com/doga.jpg",
+      discogsUnavailable: true,
+    });
+
+    renderWithProviders(<AlbumArtwork album={album} size={48} />);
+
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.getByText("Not on Discogs")).toBeInTheDocument();
+  });
+
+  it("renders the Not on Discogs badge instead of the gradient placeholder when flagged", () => {
+    const album = createTestAlbum({
+      artist: createTestArtist({ name: "Chuquimamani-Condori", lettercode: "EL" }),
+      artwork_url: undefined,
+      discogsUnavailable: true,
+    });
+
+    renderWithProviders(<AlbumArtwork album={album} size={48} />);
+
+    expect(screen.queryByText("EL")).toBeNull();
+    expect(screen.getByText("Not on Discogs")).toBeInTheDocument();
+  });
+
+  it("treats discogsUnavailable undefined as not flagged (optional-field default)", () => {
+    const album = createTestAlbum({ discogsUnavailable: undefined, artwork_url: undefined });
+
+    renderWithProviders(<AlbumArtwork album={album} size={48} />);
+
+    expect(screen.queryByText("Not on Discogs")).toBeNull();
+  });
+
+  it("treats discogsUnavailable false as not flagged", () => {
+    const album = createTestAlbum({
+      discogsUnavailable: false,
+      artwork_url: "https://i.discogs.com/duke-ellington-coltrane.jpg",
+    });
+
+    renderWithProviders(<AlbumArtwork album={album} size={48} />);
+
+    expect(screen.queryByText("Not on Discogs")).toBeNull();
+    expect(screen.getByRole("img")).toBeInTheDocument();
+  });
+
+  it("surfaces discogsUnavailableNote via tooltip on hover", async () => {
+    const album = createTestAlbum({
+      discogsUnavailable: true,
+      discogsUnavailableNote: "embargoed until 2026-09-01",
+    });
+
+    const { user } = renderWithProviders(<AlbumArtwork album={album} size={48} />);
+
+    await user.hover(screen.getByLabelText("Not on Discogs"));
+
+    expect(await screen.findByText("embargoed until 2026-09-01")).toBeInTheDocument();
+  });
+
+  it("falls back to a generic tooltip label when no note is present", async () => {
+    const album = createTestAlbum({
+      discogsUnavailable: true,
+      discogsUnavailableNote: null,
+    });
+
+    const { user } = renderWithProviders(<AlbumArtwork album={album} size={48} />);
+
+    await user.hover(screen.getByLabelText("Not on Discogs"));
+
+    // The visible badge label and the tooltip content both read "Not on Discogs".
+    expect((await screen.findAllByText("Not on Discogs")).length).toBeGreaterThan(1);
+  });
+});

--- a/tests/integration/components/modern/catalog/Results/MobileResult.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/MobileResult.test.tsx
@@ -68,3 +68,47 @@ describe("CatalogMobileResult", () => {
     expect(screen.getByText("WXYC EXCLUSIVE")).toBeDefined();
   });
 });
+
+describe("CatalogMobileResult album artwork", () => {
+  const artworkAlbum = createTestAlbum({
+    title: "On Your Own Love Again",
+    artist: createTestArtist({ name: "Jessica Pratt", lettercode: "RO", numbercode: 87 }),
+  });
+
+  it("renders album artwork when artwork_url is provided", () => {
+    const withArtwork = createTestAlbum({
+      ...artworkAlbum,
+      artwork_url: "https://i.discogs.com/on-your-own-love-again.jpg",
+    });
+
+    renderWithProviders(<CatalogMobileResult album={withArtwork} live={false} addToQueue={vi.fn()} />);
+
+    const img = screen.getByAltText(`${withArtwork.artist.name} - ${withArtwork.title}`);
+    expect(img.getAttribute("src")).toBe("https://i.discogs.com/on-your-own-love-again.jpg");
+  });
+
+  it("falls back to the lettercode placeholder when artwork_url is absent", () => {
+    renderWithProviders(
+      <CatalogMobileResult
+        album={createTestAlbum({ ...artworkAlbum, artwork_url: undefined })}
+        live={false}
+        addToQueue={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("renders the Not on Discogs badge instead of artwork when discogsUnavailable is true", () => {
+    const flagged = createTestAlbum({
+      ...artworkAlbum,
+      artwork_url: "https://i.discogs.com/on-your-own-love-again.jpg",
+      discogsUnavailable: true,
+    });
+
+    renderWithProviders(<CatalogMobileResult album={flagged} live={false} addToQueue={vi.fn()} />);
+
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.getByText("Not on Discogs")).toBeInTheDocument();
+  });
+});

--- a/tests/integration/components/modern/catalog/Results/Result.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/Result.test.tsx
@@ -334,4 +334,40 @@ describe("CatalogResult album artwork", () => {
 
     expect(screen.queryByRole("img")).toBeNull();
   });
+
+  it("should render the Not on Discogs badge instead of artwork when discogsUnavailable is true", () => {
+    const album = createTestAlbum({
+      artwork_url: "https://i.discogs.com/confield.jpg",
+      discogsUnavailable: true,
+    });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.getByText("Not on Discogs")).toBeInTheDocument();
+  });
+
+  it("should still render artwork_url when discogsUnavailable is false", () => {
+    const album = createTestAlbum({
+      artwork_url: "https://i.discogs.com/confield.jpg",
+      discogsUnavailable: false,
+    });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={album} live={false} addToQueue={vi.fn()} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByAltText(`${album.artist.name} - ${album.title}`)).toBeInTheDocument();
+    expect(screen.queryByText("Not on Discogs")).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Part of #1058 (render-gating half of the BS#1280 "Not on Discogs" flag epic). The write side (MD toggle) shipped in #693; this PR gates rendering everywhere Discogs-sourced data could otherwise surface for a flagged album. The possibly-wrong Discogs match data stays in the DB — nothing here deletes or overwrites it — this only gates what the UI renders.

- **New centralized `<AlbumArtwork>`** (`src/components/experiences/modern/catalog/AlbumArtwork.tsx`): extracts the duplicated img-or-genre-gradient-placeholder block out of `Result.tsx` (desktop catalog table) and `MobileResult.tsx` (mobile catalog card) into one component. Priority: `album.discogsUnavailable === true` → `NotOnDiscogsBadge` (never renders `artwork_url`, even if present) → `artwork_url` present → `<img>` → neither → the existing genre-gradient lettercode placeholder. Unflagged albums render byte-identical to before.
- **`NotOnDiscogsBadge`** (exported from the same file): a Tooltip-wrapped fixed-size box modeled on `ArtistAvatar.tsx`'s shape, showing a "Not on Discogs" label with the optional MD note as tooltip content.
- **Album-detail gate** (`AlbumCard.tsx`, used by both the rightbar panel and the permalink modal): when flagged, swaps the artwork for the same `NotOnDiscogsBadge`, shows the MD note as visible secondary text, and suppresses every other Discogs-metadata-derived block — label/year/genre/style chips, `StreamingLinks`, artist bio, `Tracklist`, and the Discogs link in the card footer. `LibraryStatus`, title, and the MD `DiscogsUnavailableControl` toggle are untouched — they're library-owned, not Discogs-derived.
- **`useAlbumArtwork`** gains an optional `skip` param so a flagged album's two callers (`AlbumDetailPanel.tsx` and the `@information` permalink modal) skip the `/metadata/album` fetch entirely instead of firing a doomed lookup. This is an optimization only — `AlbumCard`'s render-suppression is the actual gate and holds even if metadata is present.

## Carve-outs / follow-up

- **Flowsheet entries** (`SongEntry.tsx`, `MobileSongEntry.tsx`, `AlbumArtAndIcons.tsx`) are untouched. `FlowsheetSongEntry` carries flat strings with no album object and no `discogsUnavailable`, and Backend does not emit the flag on the V2 flowsheet embed — a gate there would read an always-undefined field. Needs a DTO field + BS emit first; tracked as a follow-up on #1058.
- **Classic experience** needs no artwork gate — it renders no album artwork (text-only catalog + flowsheet).

## Test plan

- [x] New `AlbumArtwork.test.tsx` — three-way priority (flagged → badge+note / artwork_url → img / neither → gradient placeholder), plus note-as-tooltip-on-hover and generic-fallback-label cases.
- [x] Extended `Result.test.tsx` and `MobileResult.test.tsx` — flagged case renders the badge and never the `<img>`, even with `artwork_url` set; `discogsUnavailable: false` still renders artwork normally.
- [x] Extended `AlbumCard.test.tsx` — flagged case suppresses label/year/genre/style, streaming links, bio, tracklist, and the Discogs footer link while still rendering title, `LibraryStatus`, and the MD control; regression cases cover `discogsUnavailable: false` and `undefined`.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — 0 errors, 199 warnings (pre-existing backlog, unchanged by this PR).
- [x] `npx vitest run` — full suite, 291 files / 3904 tests passing.

Closes: relates to WXYC/dj-site#1058, epic WXYC/Backend-Service#1280 (BS#1280 "Not on Discogs" flag).