### PR TITLE
test(catalog): pin transparent location-union fold render in catalog results

### DIFF
--- a/tests/integration/components/classic/catalog/SearchResults.matchedVia.test.tsx
+++ b/tests/integration/components/classic/catalog/SearchResults.matchedVia.test.tsx
@@ -126,6 +126,47 @@ describe("Classic SearchResults matched_via chip", () => {
     expect(more.getAttribute("title")).toContain("Track Four");
   });
 
+  // A folded shelf location -- a V/A compilation or soundtrack that carries the
+  // queried track -- arrives as an ordinary catalog result row tagged with a
+  // matched_via hint of source "discogs_release", NOT as a separate "also
+  // available on" field. It must render through the existing result-row ->
+  // MatchedTrackChips path with zero location-specific handling, so a future
+  // source-based change cannot silently drop folded locations.
+  it("folds a V/A shelf location into results as a Various Artists row carrying a matched-on-track chip", () => {
+    const soundtrack = createTestAlbum({
+      album_artist: "Various Artists",
+      title: "Lost in Translation",
+      artist: createTestArtist({
+        name: "Soundtracks - L",
+        genre: "Soundtracks",
+        lettercode: "OST",
+        numbercode: 12,
+      }),
+      matched_via: [
+        {
+          source: "discogs_release",
+          title: "Tommib",
+          artist_credit: "Squarepusher",
+          position: "12",
+          confidence: 1.0,
+        },
+      ],
+    });
+    mockSearchCatalogQuery.mockReturnValue({
+      data: [soundtrack],
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderWithProviders(<SearchResults />);
+
+    // The shelf location surfaces as an ordinary result row...
+    expect(screen.getByText("Lost in Translation")).toBeDefined();
+    expect(screen.getByText("Various Artists")).toBeDefined();
+    // ...carrying its matched-on-track chip, rendered source-agnostically.
+    expect(screen.getByText("matched on track: Tommib")).toBeDefined();
+  });
+
   describe("CATALOG_TRACK_SEARCH_UI_ENABLED flag", () => {
     const FLAG_KEY = "NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED";
 


### PR DESCRIPTION
## Summary

The LML comprehensive multi-location union (LML#1018 / #1022) was reframed so an alternate library shelf location — a V/A compilation or soundtrack that carries the queried track — folds directly into `/lookup` `results` as an ordinary result row tagged via `matched_via` with `source: discogs_release`, rather than surfacing as a separate `also_available_on` field (contract WXYC/wxyc-shared#284, v3.0.0). We just present results; we never present "also available on X."

This makes dj-site's original #1061 scope obsolete: there is no `also_available_on` field, no `include_locations` opt-in, and no Backend-Service `include_locations` enabler. The catalog render path is already source-agnostic — `source` is used only as a React key, and all three result surfaces (classic `SearchResults`, modern `Result`, modern `MobileResult`) pipe `matched_via` into `MatchedTrackChips` unconditionally — so a `discogs_release`-sourced hint renders identically to `cta` / `discogs_master`. No functional dj-site change is needed to display folded locations.

## Change

One intent-named regression guard at the classic `SearchResults` integration level: a V/A shelf location surfaces as a "Various Artists" result row carrying its matched-on-track chip. The existing suites already exercise `discogs_release` hints, but only incidentally inside overflow/limit cases; this pins the fold guarantee by name so a future source-based change cannot silently drop folded locations. The fixture mirrors the workstream's live-validation probe (Tommib by Squarepusher folding in the Lost in Translation soundtrack).

## Remaining gates (not dj-site)

- Backend-Service projecting LML `/lookup` folded rows into `GET /library/query`'s `matched_via` — the same source-agnostic projection the Catalog Track Search feature already needs.
- Flipping `NEXT_PUBLIC_CATALOG_TRACK_SEARCH_UI_ENABLED` on in prod once BS serves `matched_via`.
- LML recall index populated in prod (discogs-etl#344 fixed; rides the next daily Sync Library run) — tracker LML#1027.

## Testing

- `npm run lint` — 0 errors (pre-existing warnings only, none in the changed file)
- `npx tsc --noEmit` — clean
- `npx vitest run tests/integration/components/classic/catalog/SearchResults.matchedVia.test.tsx` — 12/12 pass

Closes #1061
