### PR TITLE
feat(flowsheet): gate Discogs-derived artwork on discogsUnavailable

### DIFF
--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -173,6 +173,8 @@ export function convertV2Entry(entry: FlowsheetV2EntryJSON): FlowsheetEntry {
         rotation: entry.rotation_bin as Rotation,
         on_streaming: entry.on_streaming ?? undefined,
         artwork_url: entry.artwork_url ?? undefined,
+        discogsUnavailable: entry.discogsUnavailable ?? undefined,
+        discogsUnavailableNote: entry.discogsUnavailableNote ?? undefined,
       };
 
     case "show_start": {

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -72,6 +72,8 @@ export type FlowsheetSongBase = {
   rotation?: Rotation;
   on_streaming?: boolean;
   artwork_url?: string;
+  discogsUnavailable?: boolean;
+  discogsUnavailableNote?: string | null;
 };
 
 export type FlowsheetSongEntry = FlowsheetEntryBase & FlowsheetSongBase;
@@ -221,7 +223,13 @@ type JSONDates<T> = {
   [K in keyof T]: T[K] extends Date ? string : T[K];
 };
 
-export type FlowsheetV2TrackEntryJSON = JSONDates<FlowsheetV2TrackEntry>;
+export type FlowsheetV2TrackEntryJSON = JSONDates<FlowsheetV2TrackEntry> & {
+  // BS serves discogsUnavailable flat on the V2 track entry; the pinned
+  // @wxyc/shared predates it, so the field is declared locally here until the
+  // dependency is bumped. camelCase matches the wire.
+  discogsUnavailable?: boolean;
+  discogsUnavailableNote?: string | null;
+};
 export type FlowsheetV2ShowStartEntryJSON = JSONDates<FlowsheetV2ShowStartEntry>;
 export type FlowsheetV2ShowEndEntryJSON = JSONDates<FlowsheetV2ShowEndEntry>;
 export type FlowsheetV2DJJoinEntryJSON = JSONDates<FlowsheetV2DJJoinEntry>;

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/MobileSongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/MobileSongEntry.tsx
@@ -5,6 +5,7 @@ import { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
 import { useAppDispatch } from "@/lib/hooks";
 import { useFlowsheetActions, useShowControl } from "@/src/hooks/flowsheetHooks";
 import { useFlowsheetMoveContext } from "@/src/components/experiences/modern/flowsheet/Entries/dragContext";
+import { NotOnDiscogsBadge } from "@/src/components/experiences/modern/catalog/AlbumArtwork";
 import { entryFieldTextColor } from "@/src/utilities/modern/entryFieldColors";
 import {
   CheckRounded,
@@ -146,7 +147,11 @@ const MobileSongEntry = memo(function MobileSongEntry({
       <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
       <Box sx={{ position: "relative", flexShrink: 0 }}>
         <AspectRatio ratio={1} sx={{ width: 68, borderRadius: "12px" }}>
-          <img src={image} alt="album art" />
+          {entry.discogsUnavailable === true ? (
+            <NotOnDiscogsBadge size={68} note={entry.discogsUnavailableNote} />
+          ) : (
+            <img src={image} alt="album art" />
+          )}
         </AspectRatio>
         {queue && live && (
           <Button

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry.tsx
@@ -3,6 +3,7 @@
 import { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
 import { useShowControl } from "@/src/hooks/flowsheetHooks";
 import { useMediaQuery } from "@/src/hooks/useMediaQuery";
+import { NotOnDiscogsBadge } from "@/src/components/experiences/modern/catalog/AlbumArtwork";
 import { entryFieldTextColor } from "@/src/utilities/modern/entryFieldColors";
 import { PlayArrow } from "@mui/icons-material";
 import { AspectRatio, Box, IconButton, Stack, Tooltip } from "@mui/joy";
@@ -89,11 +90,15 @@ const SongEntry = memo(function SongEntry({
               minHeight: "48px",
             }}
           >
-            <img
-              src={image}
-              alt="album art"
-              style={{ minWidth: "48px", minHeight: "48px" }}
-            />
+            {entry.discogsUnavailable === true ? (
+              <NotOnDiscogsBadge size={48} note={entry.discogsUnavailableNote} />
+            ) : (
+              <img
+                src={image}
+                alt="album art"
+                style={{ minWidth: "48px", minHeight: "48px" }}
+              />
+            )}
           </AspectRatio>
           {canClose && queue && (
             <Tooltip

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/MobileSongEntry.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/MobileSongEntry.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
 import { FlowsheetMoveContext } from "@/src/components/experiences/modern/flowsheet/Entries/dragContext";
 import MobileSongEntry from "@/src/components/experiences/modern/flowsheet/Entries/SongEntry/MobileSongEntry";
+import { createTestFlowsheetEntry, renderWithProviders } from "@/tests/helpers";
 
 const mockUseShowControl = vi.fn(() => ({
   live: true,
@@ -100,5 +101,70 @@ describe("MobileSongEntry move buttons", () => {
 
     expect(screen.queryByLabelText("Move up")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Move down")).not.toBeInTheDocument();
+  });
+});
+
+describe("MobileSongEntry discogsUnavailable artwork gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseShowControl.mockReturnValue({ live: true, currentShow: 100 });
+  });
+
+  it("renders the Not on Discogs badge instead of artwork_url when flagged", () => {
+    const flaggedEntry = createTestFlowsheetEntry({
+      track_title: "la paradoja",
+      artist_name: "Juana Molina",
+      album_title: "DOGA",
+      record_label: "Sonamos",
+      artwork_url: "https://i.discogs.com/doga.jpg",
+      discogsUnavailable: true,
+    });
+
+    renderWithProviders(
+      <MobileSongEntry entry={flaggedEntry} playing={false} queue={false} />
+    );
+
+    expect(screen.getByLabelText("Not on Discogs")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("renders the artwork <img> and no badge when unflagged", () => {
+    const unflaggedEntry = createTestFlowsheetEntry({
+      track_title: "la paradoja",
+      artist_name: "Juana Molina",
+      album_title: "DOGA",
+      record_label: "Sonamos",
+      artwork_url: "https://i.discogs.com/doga.jpg",
+      discogsUnavailable: undefined,
+    });
+
+    renderWithProviders(
+      <MobileSongEntry entry={unflaggedEntry} playing={false} queue={false} />
+    );
+
+    expect(screen.queryByLabelText("Not on Discogs")).toBeNull();
+    const image = screen.getByRole("img");
+    expect(image).toHaveAttribute("src", "https://i.discogs.com/doga.jpg");
+  });
+
+  it("surfaces discogsUnavailableNote via the badge tooltip", async () => {
+    const flaggedEntry = createTestFlowsheetEntry({
+      track_title: "la paradoja",
+      artist_name: "Juana Molina",
+      album_title: "DOGA",
+      record_label: "Sonamos",
+      discogsUnavailable: true,
+      discogsUnavailableNote: "embargoed until 2026-09-01",
+    });
+
+    const { user } = renderWithProviders(
+      <MobileSongEntry entry={flaggedEntry} playing={false} queue={false} />
+    );
+
+    await user.hover(screen.getByLabelText("Not on Discogs"));
+
+    expect(
+      await screen.findByText("embargoed until 2026-09-01")
+    ).toBeInTheDocument();
   });
 });

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import SongEntry from "@/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntry";
 import {
   flowsheetChipsReservePx,
@@ -10,6 +11,11 @@ import {
   FLOWSHEET_STATUS_CHIP_MIN_PX,
 } from "@/src/components/experiences/modern/flowsheet/Entries/tableStyles";
 import { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
+// Imported from the fixtures module directly (not the "@/tests/helpers"
+// barrel) — the barrel re-exports render.tsx, which pulls in "@/lib/store",
+// and this file's flowsheet/api mock only stubs useAddToFlowsheetMutation,
+// not the flowsheetApi slice the store needs.
+import { createTestFlowsheetEntry } from "@/tests/fixtures/fixtures";
 
 // Mock hooks
 const mockUseShowControl = vi.fn();
@@ -1121,5 +1127,70 @@ describe("SongEntry status chips reserve space for the hover actions", () => {
     expect(screen.getByText("SEGUE")).toBeInTheDocument();
     // Read-only rows drop the editable checkboxes; only the info button remains.
     expect(screen.queryAllByRole("checkbox")).toHaveLength(0);
+  });
+});
+
+describe("SongEntry discogsUnavailable artwork gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseShowControl.mockReturnValue({
+      live: true,
+      autoplay: false,
+      currentShow: 100,
+    });
+    mockUseFlowsheet.mockReturnValue({ updateFlowsheet: mockUpdateFlowsheet });
+  });
+
+  it("renders the Not on Discogs badge instead of artwork_url when flagged", () => {
+    const entry = createTestFlowsheetEntry({
+      track_title: "la paradoja",
+      artist_name: "Juana Molina",
+      album_title: "DOGA",
+      record_label: "Sonamos",
+      artwork_url: "https://i.discogs.com/doga.jpg",
+      discogsUnavailable: true,
+    });
+
+    render(<SongEntry entry={entry} playing={false} queue={false} />);
+
+    expect(screen.getByLabelText("Not on Discogs")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("renders the artwork <img> and no badge when unflagged", () => {
+    const entry = createTestFlowsheetEntry({
+      track_title: "la paradoja",
+      artist_name: "Juana Molina",
+      album_title: "DOGA",
+      record_label: "Sonamos",
+      artwork_url: "https://i.discogs.com/doga.jpg",
+      discogsUnavailable: undefined,
+    });
+
+    render(<SongEntry entry={entry} playing={false} queue={false} />);
+
+    expect(screen.queryByLabelText("Not on Discogs")).toBeNull();
+    const image = screen.getByRole("img");
+    expect(image).toHaveAttribute("src", "https://i.discogs.com/doga.jpg");
+  });
+
+  it("surfaces discogsUnavailableNote via the badge tooltip", async () => {
+    const entry = createTestFlowsheetEntry({
+      track_title: "la paradoja",
+      artist_name: "Juana Molina",
+      album_title: "DOGA",
+      record_label: "Sonamos",
+      discogsUnavailable: true,
+      discogsUnavailableNote: "embargoed until 2026-09-01",
+    });
+
+    const user = userEvent.setup();
+    render(<SongEntry entry={entry} playing={false} queue={false} />);
+
+    await user.hover(screen.getByLabelText("Not on Discogs"));
+
+    expect(
+      await screen.findByText("embargoed until 2026-09-01")
+    ).toBeInTheDocument();
   });
 });

--- a/tests/unit/lib/features/flowsheet/conversions.test.ts
+++ b/tests/unit/lib/features/flowsheet/conversions.test.ts
@@ -387,6 +387,44 @@ describe("flowsheet conversions", () => {
         expect(result.artwork_url).toBeUndefined();
       });
 
+      it("should convert discogsUnavailable: true on track entries", () => {
+        const entry = createTestV2TrackEntry({ discogsUnavailable: true });
+        const result = convertV2Entry(entry) as FlowsheetSongEntry;
+
+        expect(result.discogsUnavailable).toBe(true);
+      });
+
+      it("should convert discogsUnavailable: false on track entries", () => {
+        const entry = createTestV2TrackEntry({ discogsUnavailable: false });
+        const result = convertV2Entry(entry) as FlowsheetSongEntry;
+
+        expect(result.discogsUnavailable).toBe(false);
+      });
+
+      it("should default discogsUnavailable to undefined when absent", () => {
+        const entry = createTestV2TrackEntry();
+        const result = convertV2Entry(entry) as FlowsheetSongEntry;
+
+        expect(result.discogsUnavailable).toBeUndefined();
+      });
+
+      it("should pass discogsUnavailableNote through on track entries", () => {
+        const entry = createTestV2TrackEntry({
+          discogsUnavailable: true,
+          discogsUnavailableNote: "embargoed until 2026-09-01",
+        });
+        const result = convertV2Entry(entry) as FlowsheetSongEntry;
+
+        expect(result.discogsUnavailableNote).toBe("embargoed until 2026-09-01");
+      });
+
+      it("should default discogsUnavailableNote to undefined when absent", () => {
+        const entry = createTestV2TrackEntry();
+        const result = convertV2Entry(entry) as FlowsheetSongEntry;
+
+        expect(result.discogsUnavailableNote).toBeUndefined();
+      });
+
       it.each([
         { wire: true, expected: true },
         { wire: false, expected: false },


### PR DESCRIPTION
## Summary

Completes the flowsheet render gate, the final unchecked half of #1058's acceptance criteria — the catalog card and album-detail gates already shipped in #1064 using the shared `NotOnDiscogsBadge`/`AlbumArtwork` component.

- `SongEntry` and `MobileSongEntry` now render `NotOnDiscogsBadge` in place of `artwork_url` when `entry.discogsUnavailable === true`, matching the catalog gate rule: a flagged release's matched Discogs image is exactly the data the flag says not to trust, so the artwork is suppressed rather than shown.
- `discogsUnavailable` / `discogsUnavailableNote` added to `FlowsheetSongBase` and threaded through `convertV2Entry`.
- `FlowsheetV2TrackEntryJSON` (the local wire-adjacent alias) is augmented with both fields since the pinned `@wxyc/shared@^2.6.0` predates them on the V2 track entry — no dependency bump.

## Test plan

- [x] `npm run lint` — 0 errors (pre-existing warning backlog unchanged)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 291 files / 3916 tests passed
- [x] New coverage: flagged track renders the badge and not the `<img>`; unflagged track renders the `<img>` and no badge; `discogsUnavailableNote` surfaces via the badge tooltip — for both `SongEntry` and `MobileSongEntry`, plus `convertV2Entry` conversion coverage for both fields

Closes #1058