### PR TITLE
feat(catalog): gate LibraryStatus write actions behind RequireMD

### DIFF
--- a/src/components/experiences/modern/Rightbar/panels/album/LibraryStatus.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/LibraryStatus.tsx
@@ -6,6 +6,7 @@ import {
   useMarkMissingMutation,
 } from "@/lib/features/catalog/api";
 import { Chip, Stack } from "@mui/joy";
+import { RequireMD } from "@/src/components/shared/Authorization";
 
 interface LibraryStatusProps {
   album: AlbumEntry;
@@ -20,21 +21,26 @@ export default function LibraryStatus({ album }: LibraryStatusProps) {
     (!album.date_found ||
       new Date(album.date_found) < new Date(album.date_lost));
 
+  // The status chip (In Library / Missing since ...) is informational and
+  // stays visible to every DJ; only the write action next to it — the thing
+  // that actually mutates library state — is MD-gated.
   if (isMissing) {
     return (
       <Stack direction="row" spacing={1} alignItems="center">
         <Chip color="danger" size="sm">
           Missing since {new Date(album.date_lost!).toLocaleDateString()}
         </Chip>
-        <Chip
-          size="sm"
-          variant="outlined"
-          color="success"
-          onClick={() => markFound({ albumId: album.id })}
-          sx={{ cursor: "pointer" }}
-        >
-          Mark Found
-        </Chip>
+        <RequireMD>
+          <Chip
+            size="sm"
+            variant="outlined"
+            color="success"
+            onClick={() => markFound({ albumId: album.id })}
+            sx={{ cursor: "pointer" }}
+          >
+            Mark Found
+          </Chip>
+        </RequireMD>
       </Stack>
     );
   }
@@ -44,15 +50,17 @@ export default function LibraryStatus({ album }: LibraryStatusProps) {
       <Chip color="success" size="sm">
         In Library
       </Chip>
-      <Chip
-        size="sm"
-        variant="outlined"
-        color="danger"
-        onClick={() => markMissing({ albumId: album.id })}
-        sx={{ cursor: "pointer" }}
-      >
-        Mark Missing
-      </Chip>
+      <RequireMD>
+        <Chip
+          size="sm"
+          variant="outlined"
+          color="danger"
+          onClick={() => markMissing({ albumId: album.id })}
+          sx={{ cursor: "pointer" }}
+        >
+          Mark Missing
+        </Chip>
+      </RequireMD>
     </Stack>
   );
 }

--- a/tests/integration/components/modern/Rightbar/panels/album/LibraryStatus.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/LibraryStatus.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen } from "@testing-library/react";
 import {
   renderWithProviders,
@@ -6,6 +6,47 @@ import {
   createTestArtist,
 } from "@/tests/helpers";
 import LibraryStatus from "@/src/components/experiences/modern/Rightbar/panels/album/LibraryStatus";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+// No organization configured: AuthorizedView falls back to the raw session
+// role synchronously, so tests don't need to await an org-role fetch.
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+
+function sessionWithRole(role: string) {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+    error: null,
+  };
+}
+
+function noSession() {
+  return { data: null, isPending: false, error: null };
+}
 
 const catPowerAlbum = () =>
   createTestAlbum({
@@ -20,52 +61,107 @@ const catPowerAlbum = () =>
   });
 
 describe("LibraryStatus", () => {
-  it("shows 'In Library' chip when date_lost is undefined", () => {
-    const album = catPowerAlbum();
-
-    renderWithProviders(<LibraryStatus album={album} />);
-
-    expect(screen.getByText("In Library")).toBeInTheDocument();
-    expect(screen.getByText("Mark Missing")).toBeInTheDocument();
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it("shows 'Missing since...' chip when date_lost is set and date_found is not", () => {
-    const album = catPowerAlbum();
-    album.date_lost = "2025-03-15";
+  describe("permission gating", () => {
+    it("shows the Mark Missing action for a Music Director", () => {
+      mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
 
-    renderWithProviders(<LibraryStatus album={album} />);
+      renderWithProviders(<LibraryStatus album={catPowerAlbum()} />);
 
-    expect(
-      screen.getByText(
-        `Missing since ${new Date("2025-03-15").toLocaleDateString()}`,
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Mark Found")).toBeInTheDocument();
+      expect(screen.getByText("In Library")).toBeInTheDocument();
+      expect(screen.getByText("Mark Missing")).toBeInTheDocument();
+    });
+
+    it("shows the status chip but hides the Mark Missing action for a DJ", () => {
+      mockUseSession.mockReturnValue(sessionWithRole("dj"));
+
+      renderWithProviders(<LibraryStatus album={catPowerAlbum()} />);
+
+      expect(screen.getByText("In Library")).toBeInTheDocument();
+      expect(screen.queryByText("Mark Missing")).not.toBeInTheDocument();
+    });
+
+    it("shows the status chip but hides the Mark Found action for an unresolved session", () => {
+      mockUseSession.mockReturnValue(noSession());
+      const album = catPowerAlbum();
+      album.date_lost = "2025-03-15";
+
+      renderWithProviders(<LibraryStatus album={album} />);
+
+      expect(
+        screen.getByText(
+          `Missing since ${new Date("2025-03-15").toLocaleDateString()}`,
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Mark Found")).not.toBeInTheDocument();
+    });
+
+    it("shows the Mark Found action for a Station Manager", () => {
+      mockUseSession.mockReturnValue(sessionWithRole("stationManager"));
+      const album = catPowerAlbum();
+      album.date_lost = "2025-03-15";
+
+      renderWithProviders(<LibraryStatus album={album} />);
+
+      expect(screen.getByText("Mark Found")).toBeInTheDocument();
+    });
   });
 
-  it("shows 'In Library' when date_found is after date_lost", () => {
-    const album = catPowerAlbum();
-    album.date_lost = "2025-03-15";
-    album.date_found = "2025-04-01";
+  describe("status display", () => {
+    beforeEach(() => {
+      mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
+    });
 
-    renderWithProviders(<LibraryStatus album={album} />);
+    it("shows 'In Library' chip when date_lost is undefined", () => {
+      const album = catPowerAlbum();
 
-    expect(screen.getByText("In Library")).toBeInTheDocument();
-    expect(screen.getByText("Mark Missing")).toBeInTheDocument();
-  });
+      renderWithProviders(<LibraryStatus album={album} />);
 
-  it("shows missing when date_found is before date_lost", () => {
-    const album = catPowerAlbum();
-    album.date_lost = "2025-04-10";
-    album.date_found = "2025-03-01";
+      expect(screen.getByText("In Library")).toBeInTheDocument();
+      expect(screen.getByText("Mark Missing")).toBeInTheDocument();
+    });
 
-    renderWithProviders(<LibraryStatus album={album} />);
+    it("shows 'Missing since...' chip when date_lost is set and date_found is not", () => {
+      const album = catPowerAlbum();
+      album.date_lost = "2025-03-15";
 
-    expect(
-      screen.getByText(
-        `Missing since ${new Date("2025-04-10").toLocaleDateString()}`,
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Mark Found")).toBeInTheDocument();
+      renderWithProviders(<LibraryStatus album={album} />);
+
+      expect(
+        screen.getByText(
+          `Missing since ${new Date("2025-03-15").toLocaleDateString()}`,
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Mark Found")).toBeInTheDocument();
+    });
+
+    it("shows 'In Library' when date_found is after date_lost", () => {
+      const album = catPowerAlbum();
+      album.date_lost = "2025-03-15";
+      album.date_found = "2025-04-01";
+
+      renderWithProviders(<LibraryStatus album={album} />);
+
+      expect(screen.getByText("In Library")).toBeInTheDocument();
+      expect(screen.getByText("Mark Missing")).toBeInTheDocument();
+    });
+
+    it("shows missing when date_found is before date_lost", () => {
+      const album = catPowerAlbum();
+      album.date_lost = "2025-04-10";
+      album.date_found = "2025-03-01";
+
+      renderWithProviders(<LibraryStatus album={album} />);
+
+      expect(
+        screen.getByText(
+          `Missing since ${new Date("2025-04-10").toLocaleDateString()}`,
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Mark Found")).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Closes #1073

## What

`LibraryStatus.tsx`'s Mark Missing / Mark Found action chips were clickable for any authenticated DJ, relying entirely on the Backend `catalog:write` permission check to reject the mutation server-side. This wraps each write action in `<RequireMD>` (`src/components/shared/Authorization`), mirroring the already-shipped `DiscogsUnavailableControl.tsx` pattern, so non-MD users no longer see a control the backend would reject anyway.

The status chip itself (`In Library` / `Missing since ...`) stays visible to every DJ — it's informational (a DJ deciding what to pull for a show benefits from knowing an album is currently missing), not a write action, so it isn't gated. Only the clickable chip that fires `useMarkMissingMutation` / `useMarkFoundMutation` is wrapped.

```tsx
<Chip color="success" size="sm">In Library</Chip>
<RequireMD>
  <Chip onClick={() => markMissing({ albumId: album.id })}>Mark Missing</Chip>
</RequireMD>
```

Mount site (`AlbumCard.tsx:143`) is unchanged — the gate lives inside `LibraryStatus`, same as `DiscogsUnavailableControl` gates itself internally rather than being wrapped at its call site.

## Gating decision (disable vs. hide)

Per #1073's second deliverable: does this epic still need a boolean-returning `useCanEditCatalog`-style hook for a "disabled but still visible" control, now that `<RequireMD>` (hide) is settled as the pattern?

**Decision: no, not at this time — `<RequireMD>` alone covers the known surface.**

Reasoning:
- Every panel this epic will add (#1074 artist-search, #1075 peek-code, #1076 general edit form, #1077 rotation classify, #1078 format/genre admin, #1079 add-release, #1080 artist-add, #1081 V/A tracklist-confirm) is *net-new* UI with no existing consumer today — none of them are an existing always-visible control that needs to stay on-screen but greyed out for a non-MD viewer. They're whole panels/forms that simply shouldn't render for non-MDs, which is exactly the hide case `<RequireMD>` handles.
- The two shipped write surfaces (`DiscogsUnavailableControl`, and now `LibraryStatus`'s action chips) both use hide, and both work fine that way.
- A grep of the current write-panel code turns up no existing "greyed-out button that must stay visible for layout/discoverability reasons" pattern anywhere in `src/components/shared/Authorization` or the Rightbar panels.

If a later panel in this epic turns out to need disable-not-hide (e.g. a shared form where one field is MD-only but the rest of the form must render for every role), the right move then is a minimal boolean hook built directly on `AuthorizedView`'s session/org-role resolution — not a resurrection of the deleted `useCanEditCatalog` (commit `00af001f`), which had no tests and was tied to the never-landed PR #799 implementation. This PR doesn't add that hook since nothing in scope needs it yet; adding unused abstraction ahead of a real consumer would violate the "abstractions must pay for themselves" standard in `CLAUDE.md`.

I've posted this same decision as a comment on epic #1071.

## Testing

TDD: `tests/integration/components/modern/Rightbar/panels/album/LibraryStatus.test.tsx` — added a `permission gating` describe block (red first, confirmed failing before the `<RequireMD>` wrap landed) covering:
- Music Director / Station Manager: sees the write action.
- DJ: status chip renders, write action does not.
- Unresolved/no session: fails closed — write action does not render.

The pre-existing status-display tests (`In Library`, `Missing since ...`, found/lost date-ordering) are preserved verbatim under a `status display` describe block, now running with an explicit MD session mock (previously `authClient.useSession` was unmocked, since there was no gate to trigger it) — same assertions, so MD behavior is provably unchanged.

Session/role mocking mirrors `DiscogsUnavailableControl.test.tsx` exactly (mocks `authClient.useSession`, `getAppOrganizationIdClient` returning `undefined`, and `fetchOrganizationRoleForUserClient`) since there's no org configured in this test environment.

## Verification

- `npm run lint` — 0 errors (pre-existing warning count unchanged, none touch these files).
- `npx tsc --noEmit` — clean.
- `npx vitest run` — 291 files / 3920 tests pass.
- `npm run build` — succeeds.
- No `useCanEditCatalog` reintroduced (verified by grep).
- `e2e/tests/catalog/album-detail.spec.ts` only asserts the status chip's visibility (`expectLibraryStatusVisible`), never exercises the Mark Missing/Found buttons, so it's unaffected by this change.

## Related

Parent epic: #1071 (MD catalog-edit UI rebuild) — this is the Wave 1 foundation item; every later wave panel wraps in the same `<RequireMD>` pattern this PR demonstrates.
