### PR TITLE
fix(auth): resolve RequireMD role from the JWT unconditionally

### DIFF
--- a/src/components/shared/Authorization/AuthorizedView.tsx
+++ b/src/components/shared/Authorization/AuthorizedView.tsx
@@ -3,9 +3,38 @@
 import { ReactNode, useEffect, useState } from "react";
 import { Authorization } from "@/lib/features/admin/types";
 import { authClient } from "@/lib/features/authentication/client";
-import { roleToAuthorization } from "@/lib/features/authentication/types";
+import { roleToAuthorization, type WXYCRole } from "@/lib/features/authentication/types";
 import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
 import { getAppOrganizationIdClient } from "@/lib/features/authentication/organization-config";
+
+/**
+ * Module-level cache of in-flight/resolved org-role lookups, keyed by userId
+ * + organizationId. A single panel can mount several gated controls
+ * (RequireMD/RequireSM/RequireDJ), each its own AuthorizedView instance; without
+ * this cache every one of them would independently decode the JWT / hit
+ * listMembers for the same session.
+ */
+const orgRoleCache = new Map<string, Promise<WXYCRole | undefined>>();
+
+function orgRoleCacheKey(userId: string, organizationId: string | undefined) {
+  return `${userId}:${organizationId ?? ""}`;
+}
+
+function getCachedOrgRole(userId: string, organizationId: string | undefined) {
+  const key = orgRoleCacheKey(userId, organizationId);
+  let cached = orgRoleCache.get(key);
+  if (!cached) {
+    cached = fetchOrganizationRoleForUserClient(userId, organizationId);
+    cached.catch(() => orgRoleCache.delete(key));
+    orgRoleCache.set(key, cached);
+  }
+  return cached;
+}
+
+/** @internal test-only: clear the module-level org-role cache between tests. */
+export function _resetAuthorizedViewCacheForTesting() {
+  orgRoleCache.clear();
+}
 
 export interface AuthorizedViewProps {
   requiredRole: Authorization;
@@ -22,14 +51,10 @@ export function AuthorizedView({
 }: AuthorizedViewProps) {
   const session = authClient.useSession();
   const userId = session.data?.user?.id as string | undefined;
-  const rawRole = (session.data?.user as any)?.role as string | undefined;
 
   // Resolved authority is keyed to the userId it was computed for: on a live
   // session identity swap the stale value must not paint the old user's
   // privileges for even one render, so a key mismatch reads as unresolved.
-  // When an organization is configured, authority is org-scoped and fails
-  // closed to NO — the session base role is never trusted (mirrors
-  // getUserAuthority in server-utils.ts).
   const [resolved, setResolved] = useState<
     { forUserId: string; authority: Authorization } | undefined
   >(undefined);
@@ -40,23 +65,19 @@ export function AuthorizedView({
       return;
     }
 
-    // NEXT_PUBLIC_APP_ORGANIZATION must be set wherever the server sets
-    // APP_ORGANIZATION (organization-config.ts documents the pairing): if the
-    // server is org-scoped and this is unset, this branch trusts the raw
-    // session role while the server fails closed — the client would show UI
-    // the server denies.
+    // session.data.user.role is better-auth's admin-plugin column (only ever
+    // "admin" or null on this app) — it is NOT the WXYC tier and must never be
+    // trusted here. The WXYC tier reaches the client only via the auth JWT.
+    // fetchOrganizationRoleForUserClient decodes that JWT unconditionally and
+    // only needs an organizationId for its listMembers fallback, so this
+    // resolves correctly whether or not NEXT_PUBLIC_APP_ORGANIZATION is set
+    // in this build (it currently isn't, in production). An unresolved role
+    // — no JWT claim and no org membership — fails closed to NO.
     const organizationId = getAppOrganizationIdClient();
-    if (!organizationId) {
-      setResolved({ forUserId: userId, authority: roleToAuthorization(rawRole) });
-      return;
-    }
-
     let cancelled = false;
-    fetchOrganizationRoleForUserClient(userId, organizationId)
+    getCachedOrgRole(userId, organizationId)
       .then((orgRole) => {
         if (cancelled) return;
-        // An unresolved org role (not a member, or a transient failure) fails
-        // closed to NO rather than falling back to the raw session role.
         setResolved({
           forUserId: userId,
           authority:
@@ -72,7 +93,7 @@ export function AuthorizedView({
     return () => {
       cancelled = true;
     };
-  }, [userId, rawRole]);
+  }, [userId]);
 
   const authority =
     userId && resolved?.forUserId === userId ? resolved.authority : undefined;

--- a/src/components/shared/Authorization/AuthorizedView.tsx
+++ b/src/components/shared/Authorization/AuthorizedView.tsx
@@ -3,38 +3,9 @@
 import { ReactNode, useEffect, useState } from "react";
 import { Authorization } from "@/lib/features/admin/types";
 import { authClient } from "@/lib/features/authentication/client";
-import { roleToAuthorization, type WXYCRole } from "@/lib/features/authentication/types";
+import { roleToAuthorization } from "@/lib/features/authentication/types";
 import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
 import { getAppOrganizationIdClient } from "@/lib/features/authentication/organization-config";
-
-/**
- * Module-level cache of in-flight/resolved org-role lookups, keyed by userId
- * + organizationId. A single panel can mount several gated controls
- * (RequireMD/RequireSM/RequireDJ), each its own AuthorizedView instance; without
- * this cache every one of them would independently decode the JWT / hit
- * listMembers for the same session.
- */
-const orgRoleCache = new Map<string, Promise<WXYCRole | undefined>>();
-
-function orgRoleCacheKey(userId: string, organizationId: string | undefined) {
-  return `${userId}:${organizationId ?? ""}`;
-}
-
-function getCachedOrgRole(userId: string, organizationId: string | undefined) {
-  const key = orgRoleCacheKey(userId, organizationId);
-  let cached = orgRoleCache.get(key);
-  if (!cached) {
-    cached = fetchOrganizationRoleForUserClient(userId, organizationId);
-    cached.catch(() => orgRoleCache.delete(key));
-    orgRoleCache.set(key, cached);
-  }
-  return cached;
-}
-
-/** @internal test-only: clear the module-level org-role cache between tests. */
-export function _resetAuthorizedViewCacheForTesting() {
-  orgRoleCache.clear();
-}
 
 export interface AuthorizedViewProps {
   requiredRole: Authorization;
@@ -73,9 +44,14 @@ export function AuthorizedView({
     // resolves correctly whether or not NEXT_PUBLIC_APP_ORGANIZATION is set
     // in this build (it currently isn't, in production). An unresolved role
     // — no JWT claim and no org membership — fails closed to NO.
+    //
+    // No extra caching is added here: getJWTToken (client.ts) already caches
+    // the token with a TTL and coalesces concurrent in-flight requests, so
+    // multiple AuthorizedView instances mounted on one panel share the same
+    // underlying fetch and only pay for a cheap synchronous JWT decode each.
     const organizationId = getAppOrganizationIdClient();
     let cancelled = false;
-    getCachedOrgRole(userId, organizationId)
+    fetchOrganizationRoleForUserClient(userId, organizationId)
       .then((orgRole) => {
         if (cancelled) return;
         setResolved({

--- a/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
@@ -8,7 +8,6 @@ import {
   server,
   TEST_BACKEND_URL,
 } from "@/tests/helpers";
-import { _resetAuthorizedViewCacheForTesting } from "@/src/components/shared/Authorization/AuthorizedView";
 import DiscogsUnavailableControl from "@/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl";
 
 vi.mock("@/lib/features/authentication/client", () => ({
@@ -39,10 +38,10 @@ const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
 const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof vi.fn>;
 
 // session.user.role is better-auth's admin-plugin column (null in
-// production for ordinary members) — it is never the WXYC tier. The tier
-// comes from mockFetchOrgRole, mirroring what the JWT carries in production.
-function sessionWithRole(tier: string) {
-  mockFetchOrgRole.mockResolvedValue(tier);
+// production for ordinary members) — it is never the WXYC tier. Callers must
+// also set mockFetchOrgRole to the intended tier; this only builds the
+// session shape.
+function sessionWithRole() {
   return {
     data: {
       user: {
@@ -99,27 +98,35 @@ function mockPatch() {
 describe("DiscogsUnavailableControl", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    _resetAuthorizedViewCacheForTesting();
   });
 
   describe("permission gating", () => {
     it("renders nothing for a DJ", async () => {
-      mockUseSession.mockReturnValue(sessionWithRole("dj"));
+      mockFetchOrgRole.mockResolvedValue("dj");
+      mockUseSession.mockReturnValue(sessionWithRole());
       renderWithProviders(<DiscogsUnavailableControl album={juanaMolinaAlbum()} />);
 
       await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
-      expect(screen.queryByLabelText("Not on Discogs")).not.toBeInTheDocument();
+      // Wait for the org-role fetch to actually settle (not just have been
+      // called) before asserting the negative, so this doesn't pass vacuously
+      // while resolution is still pending.
+      await mockFetchOrgRole.mock.results[0].value;
+      await waitFor(() =>
+        expect(screen.queryByLabelText("Not on Discogs")).not.toBeInTheDocument()
+      );
     });
 
     it("renders the toggle for a Music Director", async () => {
-      mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
       renderWithProviders(<DiscogsUnavailableControl album={juanaMolinaAlbum()} />);
 
       expect(await screen.findByLabelText("Not on Discogs")).toBeInTheDocument();
     });
 
     it("renders the toggle for a Station Manager", async () => {
-      mockUseSession.mockReturnValue(sessionWithRole("stationManager"));
+      mockFetchOrgRole.mockResolvedValue("stationManager");
+      mockUseSession.mockReturnValue(sessionWithRole());
       renderWithProviders(<DiscogsUnavailableControl album={juanaMolinaAlbum()} />);
 
       expect(await screen.findByLabelText("Not on Discogs")).toBeInTheDocument();
@@ -128,7 +135,8 @@ describe("DiscogsUnavailableControl", () => {
 
   describe("initial state", () => {
     beforeEach(() => {
-      mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
     });
 
     it("is unchecked with no note field when the album is not flagged", async () => {
@@ -170,7 +178,8 @@ describe("DiscogsUnavailableControl", () => {
 
   describe("toggling the flag", () => {
     beforeEach(() => {
-      mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
     });
 
     it("PATCHes the flag and optimistically reflects the just-set value", async () => {
@@ -241,7 +250,8 @@ describe("DiscogsUnavailableControl", () => {
 
   describe("editing the note", () => {
     beforeEach(() => {
-      mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
     });
 
     it("does not show a Save button until the note text changes", async () => {

--- a/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
@@ -8,6 +8,7 @@ import {
   server,
   TEST_BACKEND_URL,
 } from "@/tests/helpers";
+import { _resetAuthorizedViewCacheForTesting } from "@/src/components/shared/Authorization/AuthorizedView";
 import DiscogsUnavailableControl from "@/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl";
 
 vi.mock("@/lib/features/authentication/client", () => ({
@@ -15,8 +16,9 @@ vi.mock("@/lib/features/authentication/client", () => ({
   getJWTToken: vi.fn().mockResolvedValue("test-token"),
 }));
 
-// No organization configured: AuthorizedView falls back to the raw session
-// role synchronously, so tests don't need to await an org-role fetch.
+// No organization configured (the real production shape): the WXYC tier
+// resolves via fetchOrganizationRoleForUserClient's JWT decode, not the raw
+// session role, so every test drives that mock and awaits resolution.
 vi.mock("@/lib/features/authentication/organization-config", () => ({
   getAppOrganizationIdClient: vi.fn(() => undefined),
 }));
@@ -30,11 +32,17 @@ vi.mock("sonner", () => ({
 }));
 
 import { authClient } from "@/lib/features/authentication/client";
+import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
 import { toast } from "sonner";
 
 const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof vi.fn>;
 
-function sessionWithRole(role: string) {
+// session.user.role is better-auth's admin-plugin column (null in
+// production for ordinary members) — it is never the WXYC tier. The tier
+// comes from mockFetchOrgRole, mirroring what the JWT carries in production.
+function sessionWithRole(tier: string) {
+  mockFetchOrgRole.mockResolvedValue(tier);
   return {
     data: {
       user: {
@@ -42,7 +50,7 @@ function sessionWithRole(role: string) {
         email: "test@wxyc.org",
         name: "Test User",
         username: "testuser",
-        role,
+        role: null,
         emailVerified: true,
       },
       session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
@@ -91,28 +99,30 @@ function mockPatch() {
 describe("DiscogsUnavailableControl", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetAuthorizedViewCacheForTesting();
   });
 
   describe("permission gating", () => {
-    it("renders nothing for a DJ", () => {
+    it("renders nothing for a DJ", async () => {
       mockUseSession.mockReturnValue(sessionWithRole("dj"));
       renderWithProviders(<DiscogsUnavailableControl album={juanaMolinaAlbum()} />);
 
+      await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
       expect(screen.queryByLabelText("Not on Discogs")).not.toBeInTheDocument();
     });
 
-    it("renders the toggle for a Music Director", () => {
+    it("renders the toggle for a Music Director", async () => {
       mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
       renderWithProviders(<DiscogsUnavailableControl album={juanaMolinaAlbum()} />);
 
-      expect(screen.getByLabelText("Not on Discogs")).toBeInTheDocument();
+      expect(await screen.findByLabelText("Not on Discogs")).toBeInTheDocument();
     });
 
-    it("renders the toggle for a Station Manager", () => {
+    it("renders the toggle for a Station Manager", async () => {
       mockUseSession.mockReturnValue(sessionWithRole("stationManager"));
       renderWithProviders(<DiscogsUnavailableControl album={juanaMolinaAlbum()} />);
 
-      expect(screen.getByLabelText("Not on Discogs")).toBeInTheDocument();
+      expect(await screen.findByLabelText("Not on Discogs")).toBeInTheDocument();
     });
   });
 
@@ -121,14 +131,14 @@ describe("DiscogsUnavailableControl", () => {
       mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
     });
 
-    it("is unchecked with no note field when the album is not flagged", () => {
+    it("is unchecked with no note field when the album is not flagged", async () => {
       renderWithProviders(<DiscogsUnavailableControl album={juanaMolinaAlbum()} />);
 
-      expect(screen.getByLabelText("Not on Discogs")).not.toBeChecked();
+      expect(await screen.findByLabelText("Not on Discogs")).not.toBeChecked();
       expect(screen.queryByLabelText("Reason (optional)")).not.toBeInTheDocument();
     });
 
-    it("is checked with the note prefilled when the album is already flagged", () => {
+    it("is checked with the note prefilled when the album is already flagged", async () => {
       renderWithProviders(
         <DiscogsUnavailableControl
           album={juanaMolinaAlbum({
@@ -138,20 +148,20 @@ describe("DiscogsUnavailableControl", () => {
         />,
       );
 
-      expect(screen.getByLabelText("Not on Discogs")).toBeChecked();
+      expect(await screen.findByLabelText("Not on Discogs")).toBeChecked();
       expect(screen.getByLabelText("Reason (optional)")).toHaveValue(
         "audience doesn't use Discogs",
       );
     });
 
-    it("caps the note field at 500 characters", () => {
+    it("caps the note field at 500 characters", async () => {
       renderWithProviders(
         <DiscogsUnavailableControl
           album={juanaMolinaAlbum({ discogsUnavailable: true })}
         />,
       );
 
-      expect(screen.getByLabelText("Reason (optional)")).toHaveAttribute(
+      expect(await screen.findByLabelText("Reason (optional)")).toHaveAttribute(
         "maxLength",
         "500",
       );
@@ -169,7 +179,7 @@ describe("DiscogsUnavailableControl", () => {
         <DiscogsUnavailableControl album={juanaMolinaAlbum()} />,
       );
 
-      const toggle = screen.getByLabelText("Not on Discogs");
+      const toggle = await screen.findByLabelText("Not on Discogs");
       await user.click(toggle);
 
       // Reflected immediately, ahead of the PATCH resolving.
@@ -195,7 +205,7 @@ describe("DiscogsUnavailableControl", () => {
         />,
       );
 
-      const toggle = screen.getByLabelText("Not on Discogs");
+      const toggle = await screen.findByLabelText("Not on Discogs");
       await user.click(toggle);
 
       expect(toggle).not.toBeChecked();
@@ -219,7 +229,7 @@ describe("DiscogsUnavailableControl", () => {
         <DiscogsUnavailableControl album={juanaMolinaAlbum()} />,
       );
 
-      const toggle = screen.getByLabelText("Not on Discogs");
+      const toggle = await screen.findByLabelText("Not on Discogs");
       await user.click(toggle);
 
       await waitFor(() => expect(toggle).not.toBeChecked());
@@ -234,13 +244,14 @@ describe("DiscogsUnavailableControl", () => {
       mockUseSession.mockReturnValue(sessionWithRole("musicDirector"));
     });
 
-    it("does not show a Save button until the note text changes", () => {
+    it("does not show a Save button until the note text changes", async () => {
       renderWithProviders(
         <DiscogsUnavailableControl
           album={juanaMolinaAlbum({ discogsUnavailable: true, discogsUnavailableNote: "old reason" })}
         />,
       );
 
+      await screen.findByLabelText("Reason (optional)");
       expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
     });
 
@@ -252,7 +263,7 @@ describe("DiscogsUnavailableControl", () => {
         />,
       );
 
-      const note = screen.getByLabelText("Reason (optional)");
+      const note = await screen.findByLabelText("Reason (optional)");
       await user.clear(note);
       await user.type(note, "  new reason  ");
       await user.click(screen.getByRole("button", { name: "Save" }));
@@ -273,7 +284,7 @@ describe("DiscogsUnavailableControl", () => {
         />,
       );
 
-      const note = screen.getByLabelText("Reason (optional)");
+      const note = await screen.findByLabelText("Reason (optional)");
       await user.clear(note);
       await user.click(screen.getByRole("button", { name: "Save" }));
 
@@ -293,7 +304,7 @@ describe("DiscogsUnavailableControl", () => {
         />,
       );
 
-      const note = screen.getByLabelText("Reason (optional)");
+      const note = await screen.findByLabelText("Reason (optional)");
       await user.clear(note);
       await user.type(note, "new reason");
       await user.click(screen.getByRole("button", { name: "Save" }));
@@ -315,7 +326,7 @@ describe("DiscogsUnavailableControl", () => {
         />,
       );
 
-      const note = screen.getByLabelText("Reason (optional)");
+      const note = await screen.findByLabelText("Reason (optional)");
       await user.type(note, " updated");
       await user.click(screen.getByRole("button", { name: "Save" }));
 

--- a/tests/integration/components/shared/Authorization/AuthorizedView.test.tsx
+++ b/tests/integration/components/shared/Authorization/AuthorizedView.test.tsx
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { Authorization } from "@/lib/features/admin/types";
-import { AuthorizedView, RequireDJ, RequireMD, RequireSM } from "@/src/components/shared/Authorization/AuthorizedView";
+import {
+  AuthorizedView,
+  RequireDJ,
+  RequireMD,
+  RequireSM,
+  _resetAuthorizedViewCacheForTesting,
+} from "@/src/components/shared/Authorization/AuthorizedView";
 
 // Mock the auth client
 vi.mock("@/lib/features/authentication/client", () => ({
@@ -10,9 +16,9 @@ vi.mock("@/lib/features/authentication/client", () => ({
   },
 }));
 
-// Org resolution is mocked so the org-scoped path can be driven independently
-// of env config. Defaults to "no organization configured" so the existing
-// raw-role tests exercise the base-role path.
+// getAppOrganizationIdClient defaults to undefined — this is the real
+// production shape: NEXT_PUBLIC_APP_ORGANIZATION is absent from the prod
+// build env, so authority must resolve via the JWT with no organizationId.
 vi.mock("@/lib/features/authentication/organization-config", () => ({
   getAppOrganizationIdClient: vi.fn(() => undefined),
 }));
@@ -29,52 +35,59 @@ const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
 const mockGetOrgId = getAppOrganizationIdClient as ReturnType<typeof vi.fn>;
 const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof vi.fn>;
 
-function createMockSession(role: string) {
+// The realistic production session shape: better-auth's admin-plugin role
+// column is null for ordinary members (musicDirector/dj/stationManager never
+// appear there — see organization-utils tests). The WXYC tier only ever
+// reaches this component via the org-role fetch, which the JWT backs.
+function createMockSession(userId = "user-123", sessionRole: string | null = null) {
   return {
     data: {
       user: {
-        id: "user-123",
-        email: "test@wxyc.org",
+        id: userId,
+        email: `${userId}@wxyc.org`,
         name: "Test User",
-        username: "testuser",
-        role,
+        username: userId,
+        role: sessionRole,
         emailVerified: true,
       },
-      session: { id: "sess-123", userId: "user-123", expiresAt: new Date() },
+      session: { id: `sess-${userId}`, userId, expiresAt: new Date() },
     },
     isPending: false,
     error: null,
   };
 }
 
-describe("AuthorizedView", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetAuthorizedViewCacheForTesting();
+  mockGetOrgId.mockReturnValue(undefined);
+});
 
+describe("AuthorizedView", () => {
   describe("when user is not authenticated", () => {
     it("should render fallback when no session", () => {
       mockUseSession.mockReturnValue({ data: null, isPending: false, error: null });
-      
+
       render(
         <AuthorizedView requiredRole={Authorization.DJ} fallback={<div>Access denied</div>}>
           <div>Protected content</div>
         </AuthorizedView>
       );
-      
+
       expect(screen.getByText("Access denied")).toBeInTheDocument();
       expect(screen.queryByText("Protected content")).not.toBeInTheDocument();
+      expect(mockFetchOrgRole).not.toHaveBeenCalled();
     });
 
     it("should render nothing when no fallback provided", () => {
       mockUseSession.mockReturnValue({ data: null, isPending: false, error: null });
-      
+
       const { container } = render(
         <AuthorizedView requiredRole={Authorization.DJ}>
           <div>Protected content</div>
         </AuthorizedView>
       );
-      
+
       expect(container.textContent).toBe("");
     });
   });
@@ -82,106 +95,157 @@ describe("AuthorizedView", () => {
   describe("when session is loading", () => {
     it("should render loading state if provided", () => {
       mockUseSession.mockReturnValue({ data: null, isPending: true, error: null });
-      
+
       render(
-        <AuthorizedView 
-          requiredRole={Authorization.DJ} 
+        <AuthorizedView
+          requiredRole={Authorization.DJ}
           loading={<div>Loading...</div>}
         >
           <div>Protected content</div>
         </AuthorizedView>
       );
-      
+
       expect(screen.getByText("Loading...")).toBeInTheDocument();
     });
   });
 
-  describe("when user has insufficient role", () => {
-    it("should render fallback for DJ trying to access SM content", () => {
-      mockUseSession.mockReturnValue(createMockSession("dj"));
-      
+  describe("when the WXYC tier resolves to an insufficient role", () => {
+    it("should render fallback for a DJ trying to access SM content", async () => {
+      mockUseSession.mockReturnValue(createMockSession());
+      mockFetchOrgRole.mockResolvedValue("dj");
+
       render(
         <AuthorizedView requiredRole={Authorization.SM} fallback={<div>Access denied</div>}>
           <div>SM only content</div>
         </AuthorizedView>
       );
-      
-      expect(screen.getByText("Access denied")).toBeInTheDocument();
+
+      expect(await screen.findByText("Access denied")).toBeInTheDocument();
       expect(screen.queryByText("SM only content")).not.toBeInTheDocument();
     });
   });
 
-  describe("when user has sufficient role", () => {
-    it("should render children for exact role match", () => {
-      mockUseSession.mockReturnValue(createMockSession("stationManager"));
-      
+  describe("when the WXYC tier resolves to a sufficient role", () => {
+    it("should render children for exact role match", async () => {
+      mockUseSession.mockReturnValue(createMockSession());
+      mockFetchOrgRole.mockResolvedValue("stationManager");
+
       render(
         <AuthorizedView requiredRole={Authorization.SM} fallback={<div>Access denied</div>}>
           <div>SM content</div>
         </AuthorizedView>
       );
-      
-      expect(screen.getByText("SM content")).toBeInTheDocument();
+
+      expect(await screen.findByText("SM content")).toBeInTheDocument();
       expect(screen.queryByText("Access denied")).not.toBeInTheDocument();
     });
 
-    it("should render children when user has higher role", () => {
-      mockUseSession.mockReturnValue(createMockSession("admin"));
-      
+    it("should render children when user has a higher role", async () => {
+      mockUseSession.mockReturnValue(createMockSession());
+      mockFetchOrgRole.mockResolvedValue("admin");
+
       render(
         <AuthorizedView requiredRole={Authorization.DJ} fallback={<div>Access denied</div>}>
           <div>DJ content</div>
         </AuthorizedView>
       );
-      
-      expect(screen.getByText("DJ content")).toBeInTheDocument();
+
+      expect(await screen.findByText("DJ content")).toBeInTheDocument();
+    });
+  });
+
+  describe("production session shape: session.user.role is null, tier is org-scoped", () => {
+    it("resolves a real Music Director to Authorization.MD via the JWT-backed org role, with no organizationId configured", async () => {
+      // This is the shape that previously broke RequireMD in production:
+      // NEXT_PUBLIC_APP_ORGANIZATION unset (mockGetOrgId -> undefined) and
+      // session.user.role null (better-auth admin-plugin column, never the
+      // WXYC tier). Only a fix that resolves via fetchOrganizationRoleForUserClient
+      // unconditionally can grant MD here.
+      mockUseSession.mockReturnValue(createMockSession("md-user", null));
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+
+      render(
+        <RequireMD fallback={<div>Access denied</div>}>
+          <div>MD-gated content</div>
+        </RequireMD>
+      );
+
+      expect(await screen.findByText("MD-gated content")).toBeInTheDocument();
+      expect(screen.queryByText("Access denied")).not.toBeInTheDocument();
+      expect(mockFetchOrgRole).toHaveBeenCalledWith("md-user", undefined);
+    });
+  });
+
+  describe("repeated mounts on one panel", () => {
+    it("issues at most one org-role fetch for the same user across multiple AuthorizedView instances", async () => {
+      mockUseSession.mockReturnValue(createMockSession());
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+
+      render(
+        <>
+          <RequireMD fallback={<div>Denied 1</div>}>
+            <div>Content 1</div>
+          </RequireMD>
+          <RequireMD fallback={<div>Denied 2</div>}>
+            <div>Content 2</div>
+          </RequireMD>
+          <RequireDJ fallback={<div>Denied 3</div>}>
+            <div>Content 3</div>
+          </RequireDJ>
+        </>
+      );
+
+      await waitFor(() => expect(screen.getByText("Content 1")).toBeInTheDocument());
+      expect(screen.getByText("Content 2")).toBeInTheDocument();
+      expect(screen.getByText("Content 3")).toBeInTheDocument();
+      expect(mockFetchOrgRole).toHaveBeenCalledTimes(1);
     });
   });
 });
 
 describe("Convenience Components", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  it("RequireDJ renders for DJ users", async () => {
+    mockUseSession.mockReturnValue(createMockSession());
+    mockFetchOrgRole.mockResolvedValue("dj");
 
-  it("RequireDJ renders for DJ users", () => {
-    mockUseSession.mockReturnValue(createMockSession("dj"));
-    
     render(
       <RequireDJ fallback={<div>No access</div>}>
         <div>DJ content</div>
       </RequireDJ>
     );
-    
-    expect(screen.getByText("DJ content")).toBeInTheDocument();
+
+    expect(await screen.findByText("DJ content")).toBeInTheDocument();
   });
 
-  it("RequireMD renders for Music Director users", () => {
-    mockUseSession.mockReturnValue(createMockSession("musicDirector"));
-    
+  it("RequireMD renders for Music Director users", async () => {
+    mockUseSession.mockReturnValue(createMockSession());
+    mockFetchOrgRole.mockResolvedValue("musicDirector");
+
     render(
       <RequireMD fallback={<div>No access</div>}>
         <div>MD content</div>
       </RequireMD>
     );
-    
-    expect(screen.getByText("MD content")).toBeInTheDocument();
+
+    expect(await screen.findByText("MD content")).toBeInTheDocument();
   });
 
-  it("RequireSM renders for Station Manager users", () => {
-    mockUseSession.mockReturnValue(createMockSession("stationManager"));
-    
+  it("RequireSM renders for Station Manager users", async () => {
+    mockUseSession.mockReturnValue(createMockSession());
+    mockFetchOrgRole.mockResolvedValue("stationManager");
+
     render(
       <RequireSM fallback={<div>No access</div>}>
         <div>SM content</div>
       </RequireSM>
     );
-    
-    expect(screen.getByText("SM content")).toBeInTheDocument();
+
+    expect(await screen.findByText("SM content")).toBeInTheDocument();
   });
 
-  it("RequireSM renders for Admin users (admin maps to SM)", () => {
-    mockUseSession.mockReturnValue(createMockSession("admin"));
+  it("RequireSM renders for Admin users (admin maps to SM)", async () => {
+    mockUseSession.mockReturnValue(createMockSession());
+    mockFetchOrgRole.mockResolvedValue("admin");
 
     render(
       <RequireSM fallback={<div>No access</div>}>
@@ -189,20 +253,19 @@ describe("Convenience Components", () => {
       </RequireSM>
     );
 
-    expect(screen.getByText("Admin content")).toBeInTheDocument();
+    expect(await screen.findByText("Admin content")).toBeInTheDocument();
   });
 });
 
 describe("when an organization is configured", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     mockGetOrgId.mockReturnValue("wxyc-org-123");
   });
 
   it("gates on the org-scoped role, not the raw session role, when they disagree", async () => {
     // Raw session role would map to SM, but the org-scoped role is only DJ —
     // the server-side check would deny SM content, so this must too.
-    mockUseSession.mockReturnValue(createMockSession("stationManager"));
+    mockUseSession.mockReturnValue(createMockSession("user-123", "stationManager"));
     mockFetchOrgRole.mockResolvedValue("dj");
 
     render(
@@ -217,7 +280,7 @@ describe("when an organization is configured", () => {
   });
 
   it("grants on the org-scoped role even when the raw session role is lower", async () => {
-    mockUseSession.mockReturnValue(createMockSession("dj"));
+    mockUseSession.mockReturnValue(createMockSession("user-123", "dj"));
     mockFetchOrgRole.mockResolvedValue("stationManager");
 
     render(
@@ -230,7 +293,7 @@ describe("when an organization is configured", () => {
   });
 
   it("fails closed to NO when org resolution returns undefined (not a member)", async () => {
-    mockUseSession.mockReturnValue(createMockSession("stationManager"));
+    mockUseSession.mockReturnValue(createMockSession("user-123", "stationManager"));
     mockFetchOrgRole.mockResolvedValue(undefined);
 
     render(
@@ -244,7 +307,7 @@ describe("when an organization is configured", () => {
   });
 
   it("fails closed to NO when org resolution throws", async () => {
-    mockUseSession.mockReturnValue(createMockSession("stationManager"));
+    mockUseSession.mockReturnValue(createMockSession("user-123", "stationManager"));
     mockFetchOrgRole.mockRejectedValue(new Error("org service down"));
 
     render(
@@ -257,7 +320,7 @@ describe("when an organization is configured", () => {
   });
 
   it("shows the loading state while the org role is still resolving", async () => {
-    mockUseSession.mockReturnValue(createMockSession("stationManager"));
+    mockUseSession.mockReturnValue(createMockSession("user-123", "stationManager"));
     let resolveRole: (role: string) => void = () => {};
     mockFetchOrgRole.mockReturnValue(
       new Promise<string>((resolve) => {

--- a/tests/integration/components/shared/Authorization/AuthorizedView.test.tsx
+++ b/tests/integration/components/shared/Authorization/AuthorizedView.test.tsx
@@ -6,7 +6,6 @@ import {
   RequireDJ,
   RequireMD,
   RequireSM,
-  _resetAuthorizedViewCacheForTesting,
 } from "@/src/components/shared/Authorization/AuthorizedView";
 
 // Mock the auth client
@@ -59,7 +58,6 @@ function createMockSession(userId = "user-123", sessionRole: string | null = nul
 
 beforeEach(() => {
   vi.clearAllMocks();
-  _resetAuthorizedViewCacheForTesting();
   mockGetOrgId.mockReturnValue(undefined);
 });
 
@@ -176,31 +174,6 @@ describe("AuthorizedView", () => {
     });
   });
 
-  describe("repeated mounts on one panel", () => {
-    it("issues at most one org-role fetch for the same user across multiple AuthorizedView instances", async () => {
-      mockUseSession.mockReturnValue(createMockSession());
-      mockFetchOrgRole.mockResolvedValue("musicDirector");
-
-      render(
-        <>
-          <RequireMD fallback={<div>Denied 1</div>}>
-            <div>Content 1</div>
-          </RequireMD>
-          <RequireMD fallback={<div>Denied 2</div>}>
-            <div>Content 2</div>
-          </RequireMD>
-          <RequireDJ fallback={<div>Denied 3</div>}>
-            <div>Content 3</div>
-          </RequireDJ>
-        </>
-      );
-
-      await waitFor(() => expect(screen.getByText("Content 1")).toBeInTheDocument());
-      expect(screen.getByText("Content 2")).toBeInTheDocument();
-      expect(screen.getByText("Content 3")).toBeInTheDocument();
-      expect(mockFetchOrgRole).toHaveBeenCalledTimes(1);
-    });
-  });
 });
 
 describe("Convenience Components", () => {


### PR DESCRIPTION
## Problem

`AuthorizedView` only fetched the org-scoped WXYC tier via `fetchOrganizationRoleForUserClient` when `NEXT_PUBLIC_APP_ORGANIZATION` was set, and otherwise fell back to `roleToAuthorization(session.data.user.role)`. `NEXT_PUBLIC_APP_ORGANIZATION` is deliberately absent from the production build env (its client-side reads use a `globalThis.process?.env` pattern the bundler never inlines), so every real browser took the fallback branch. `session.data.user.role` is better-auth's admin-plugin column, which every Backend write sets to `'admin'` or `null` — never the WXYC tier. The result: `RequireMD` could never grant a real music director access in production, while a station manager (whose admin-plugin role happens to be `'admin'`, mapping to SM) would see it.

## Fix

`fetchOrganizationRoleForUserClient` → `organizationRoleFromJwtToken` already decodes the WXYC tier from the auth JWT unconditionally, and only needs an `organizationId` for its `listMembers` fallback. `AuthorizedView` now always resolves authority through it instead of branching on whether an organization is configured, so it works correctly with or without `NEXT_PUBLIC_APP_ORGANIZATION` set. An unresolved role (no JWT claim, no org membership) still fails closed to `Authorization.NO`.

Also fixed the stale comment at the top of the resolution effect, which predicted the opposite failure direction ("the client would show UI the server denies") from what actually happens (the client under-grants).

No new caching was added: `getJWTToken` (`lib/features/authentication/client.ts`) already caches the token with a TTL and coalesces concurrent in-flight requests, so multiple `AuthorizedView` instances mounted on one panel already share the same underlying fetch.

## Tests

- `AuthorizedView.test.tsx`: reworked to drive the org-role fetch mock directly (the actual client-side resolution path) instead of relying on the removed session-role fallback. Added a test with the realistic production session shape — `role: null` on the session plus an org-role fetch resolving to `musicDirector`, with no `organizationId` configured — proving `RequireMD` now grants a real MD.
- `DiscogsUnavailableControl.test.tsx` (the one shipped `RequireMD` consumer): updated to mock the org-role fetch with the same realistic shape and await resolution, proving the shipped consumer renders correctly for a real MD, not only for a station manager.

## Scope decisions

- **`LibraryStatus.tsx` (Mark Missing/Mark Found) is untouched and remains ungated.** It does not use `AuthorizedView` at all. This is deliberate per the corrected ticket scope: those routes are gated to `catalog:read` server-side (BS#393), not `catalog:write`, so DJs are meant to use them. Wrapping them in `RequireMD` was the regression that closed #1082.
- **No new hook was introduced.** The epic's remaining ~8 MD-only surfaces (#1074–#1081) are all net-new UI where hiding leaves no layout hole, so the existing hide-based `RequireMD`/`RequireSM`/`RequireDJ` wrapper is sufficient. Flagging #1076/#1079 (new MD-only entry points on surfaces DJs already browse) and #1077 (shared `RotationBinSelector`/`RotationEntryFields` reuse) as the cases most likely to need a disabled-but-visible variant later — noting this on #1071 as requested.
- `useCanEditCatalog` was not reintroduced.

Closes #1073