### PR TITLE
ci(e2e): pin Backend-Service to a verified-green commit and resolve SHAs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,15 +8,29 @@ on:
   workflow_dispatch:
     inputs:
       backend_ref:
-        description: 'Backend-Service branch/tag to use'
+        description: 'Backend-Service branch or commit SHA (blank = the pinned ref)'
         required: false
-        default: 'main'
+        default: ''
 
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 
 env:
+  # Backend-Service commit this suite runs against by default.
+  #
+  # This job used to check Backend-Service out at `main`, so dj-site's merge gate
+  # floated on another repo's default branch: an upstream commit could — and did —
+  # turn every dj-site PR red with no signal at the boundary. Backend-Service
+  # bb84c63f/fb81e2b2 broke 14 admin/auth specs on 2026-08-03 and closed this
+  # repo's merge gate for two days (#1088).
+  #
+  # ef60c249 is the last commit verified green here (4/4 shards, run 31026323488).
+  #
+  # TEMPORARY. Unpin — restore `main` — once WXYC/Backend-Service#1999 lands, or
+  # this suite silently stops testing the Backend that production actually runs.
+  # Advance the pin deliberately when a newer Backend commit is verified green.
+  BACKEND_PINNED_REF: ef60c2492a48cce2f210a9dbdf877c9bb9e39903
   # Frontend configuration
   NEXT_PUBLIC_BACKEND_URL: http://localhost:8085
   NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:8084/auth
@@ -134,19 +148,46 @@ jobs:
           INPUT_BACKEND_REF: ${{ github.event.inputs.backend_ref }}
           HEAD_REF: ${{ github.head_ref }}
           EVENT_NAME: ${{ github.event_name }}
+          OWNER: ${{ github.repository_owner }}
         run: |
+          set -euo pipefail
+
+          # Accepts a branch name OR a commit SHA. The branch lookup used to be the
+          # whole check, so a SHA fell through to the fallback and the run tested
+          # something other than what it named — while still printing a ref line
+          # that looked deliberate. A pinned SHA cannot work without this.
+          resolve() {
+            gh api "repos/${OWNER}/Backend-Service/git/ref/heads/$1" >/dev/null 2>&1 && return 0
+            gh api "repos/${OWNER}/Backend-Service/commits/$1" >/dev/null 2>&1 && return 0
+            return 1
+          }
+
           REF="$INPUT_BACKEND_REF"
           if [ -z "$REF" ] && [ "$EVENT_NAME" = "pull_request" ]; then
+            # Paired-branch convention: a same-named Backend-Service branch is used
+            # when one exists, so a cross-repo change can be tested as a unit.
             REF="$HEAD_REF"
           fi
-          REF="${REF:-main}"
-          if gh api "repos/${{ github.repository_owner }}/Backend-Service/git/ref/heads/${REF}" >/dev/null 2>&1; then
+
+          if [ -n "$REF" ] && resolve "$REF"; then
             echo "ref=${REF}" >> "$GITHUB_OUTPUT"
             echo "Using Backend-Service ref: ${REF}"
-          else
-            echo "ref=main" >> "$GITHUB_OUTPUT"
-            echo "Backend-Service ref ${REF} not found; falling back to main"
+            exit 0
           fi
+
+          # An explicit request that does not resolve is a mistake, not a cue to
+          # test something else. Failing here is what makes a bisection trustworthy.
+          if [ -n "$INPUT_BACKEND_REF" ]; then
+            echo "::error::backend_ref '${INPUT_BACKEND_REF}' is not a branch or commit in ${OWNER}/Backend-Service."
+            exit 1
+          fi
+
+          if ! resolve "$BACKEND_PINNED_REF"; then
+            echo "::error::BACKEND_PINNED_REF '${BACKEND_PINNED_REF}' is not a branch or commit in ${OWNER}/Backend-Service."
+            exit 1
+          fi
+          echo "ref=${BACKEND_PINNED_REF}" >> "$GITHUB_OUTPUT"
+          echo "Using Backend-Service ref: ${BACKEND_PINNED_REF} (pinned)"
 
       - name: Checkout Backend-Service
         uses: actions/checkout@v7


### PR DESCRIPTION
## Why

dj-site E2E checked Backend-Service out at `main`, so this repo's merge gate floated on another repo's default branch. On 2026-08-03 Backend-Service `bb84c63f`/`fb81e2b2` broke 14 admin/auth specs, and the breakage arrived here as **red CI on every unrelated dj-site PR** — no signal at the boundary, nothing in this repo to point at. The gate has been closed since.

Full diagnosis in #1088; upstream root-cause ticket is WXYC/Backend-Service#1999.

## What this changes

**1. Default to a pinned Backend commit instead of `main`.**

`BACKEND_PINNED_REF` is `ef60c249` — the last Backend commit verified green here, 4/4 shards, [run 31026323488](https://github.com/WXYC/dj-site/actions/runs/31026323488). Precedence is unchanged where it matters:

| Case | Backend ref used |
|---|---|
| explicit `backend_ref` input | that ref |
| PR whose branch name exists in Backend-Service | that paired branch |
| everything else | **the pinned commit** (was `main`) |

Cross-repo changes can still be tested as a unit via the paired-branch convention.

**2. The resolver now accepts a commit SHA, and fails loudly.**

It only ever did `git/ref/heads/${REF}`. A SHA missed that lookup, fell through to the fallback, and the run tested `main` **while printing a ref line that looked deliberate** — so a "pinned" run silently proved nothing. This nearly invalidated the bisection that produced this PR. It now tries branch then commit, and an explicit `backend_ref` matching neither **fails the job** rather than quietly substituting a different Backend.

This isn't incidental cleanup: pinning to a SHA cannot work without it. The old resolver would have discarded the pin on the first lookup.

## Verification

- Pinned SHA confirmed to resolve through the new commit path (branch lookup misses, as expected for a SHA; `commits/` hits).
- `actionlint` findings identical before and after — 7 pre-existing, **0 in the changed step**.
- YAML parses; input default and pinned ref read back correctly.
- The real proof is this PR's own E2E run: its branch has no Backend counterpart, so it exercises the pin path end-to-end. If E2E is green here, the mechanism works.

Not run: the JS unit/lint suites. The diff contains no TS/JS — CI covers them anyway.

## Scope and limits

This is a **mitigation, not a fix.** It restores the merge gate; it does not repair the Backend defect. While pinned, this suite is not testing the Backend that production runs — real coverage loss, accepted deliberately and time-boxed.

Deliberately **not** closing #1088. Its remaining value is the unpin: the pin comes out when WXYC/Backend-Service#1999 lands, and that is tracked as an acceptance criterion there. A temporary pin that outlives its cause is the predictable failure mode, so the tracking issue stays open until it's removed.

Safe to pin to a pre-CTA Backend commit: no E2E spec references `compilation-track*`, `discogsUnavailable`, or `legacy_release_id`.

## Unblocks

#1087 (green on every other required check), and behind it the eight remaining #1071 leaves — the MD catalog-edit epic on the WXYC/wiki#89 `/wxycdb` cutover path.

## Related

- #1088 — outage diagnosis, control runs, bisection evidence
- WXYC/Backend-Service#1999 — upstream root cause; unpin is gated on it
- WXYC/Backend-Service#1969 — the change whose implementation regressed
