### PR TITLE
MD catalog-edit UI: format/genre admin add-forms

### DIFF
--- a/app/dashboard/@modern/admin/catalog/loading.tsx
+++ b/app/dashboard/@modern/admin/catalog/loading.tsx
@@ -1,0 +1,1 @@
+export { LoadingFallback as default } from "@/src/components/LoadingFallback";

--- a/app/dashboard/@modern/admin/catalog/page.tsx
+++ b/app/dashboard/@modern/admin/catalog/page.tsx
@@ -1,0 +1,27 @@
+import { requireAuth, requireRole } from "@/lib/features/authentication/server-utils";
+import { Authorization } from "@/lib/features/admin/types";
+import PageHeader from "@/src/components/experiences/modern/Header/PageHeader";
+import FormatAdmin from "@/src/components/experiences/modern/admin/catalog/FormatAdmin";
+import GenreAdmin from "@/src/components/experiences/modern/admin/catalog/GenreAdmin";
+import { Stack } from "@mui/joy";
+import { Metadata } from "next";
+import { getPageTitle } from "@/lib/utils/page-title";
+
+export const metadata: Metadata = {
+  title: getPageTitle("Catalog Admin"),
+};
+
+export default async function CatalogAdminPage() {
+  const session = await requireAuth();
+  await requireRole(session, Authorization.MD);
+
+  return (
+    <>
+      <PageHeader title="Catalog Admin" />
+      <Stack spacing={2}>
+        <FormatAdmin />
+        <GenreAdmin />
+      </Stack>
+    </>
+  );
+}

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -59,7 +59,7 @@ function transformLibraryQueryResponse(
 export const catalogApi = createApi({
   reducerPath: "catalogApi",
   baseQuery: backendBaseQuery("library"),
-  tagTypes: ["Rotation", "AlbumDetail", "CatalogList", "ArtistSearch"],
+  tagTypes: ["Rotation", "AlbumDetail", "CatalogList", "ArtistSearch", "FormatList", "GenreList"],
   endpoints: (builder) => ({
     searchCatalog: builder.query<AlbumEntry[], SearchCatalogQueryParams>({
       query: ({ artist_name, album_title, n, on_streaming }) => ({
@@ -231,6 +231,7 @@ export const catalogApi = createApi({
       query: () => ({
         url: "/formats",
       }),
+      providesTags: [{ type: "FormatList", id: "LIST" }],
     }),
     addFormat: builder.mutation<LibraryFormatRow, AddFormatRequestBody>({
       query: (body) => ({
@@ -238,11 +239,13 @@ export const catalogApi = createApi({
         method: "POST",
         body,
       }),
+      invalidatesTags: [{ type: "FormatList", id: "LIST" }],
     }),
     getGenres: builder.query<LibraryGenreRow[], void>({
       query: () => ({
         url: "/genres",
       }),
+      providesTags: [{ type: "GenreList", id: "LIST" }],
     }),
     addGenre: builder.mutation<LibraryGenreRow, AddGenreRequestBody>({
       query: (body) => ({
@@ -250,6 +253,7 @@ export const catalogApi = createApi({
         method: "POST",
         body,
       }),
+      invalidatesTags: [{ type: "GenreList", id: "LIST" }],
     }),
   }),
 });

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -23,32 +23,6 @@ import {
   UpdateAlbumRequestBody,
 } from "./types";
 
-/**
- * Normalize a rejected catalogApi mutation into a user-facing message.
- * `.unwrap()` rejects with the `FetchBaseQueryError` the backend returned —
- * `data.message` per the shared `ApiErrorResponse` schema (e.g. a 409
- * duplicate-name reply) — or a `SerializedError` for network-level failures.
- * Falls back to `fallback` when neither carries a usable message.
- */
-export function catalogMutationErrorMessage(error: unknown, fallback: string): string {
-  if (error && typeof error === "object" && "data" in error) {
-    const data = (error as { data?: unknown }).data;
-    if (data && typeof data === "object" && "message" in data) {
-      const message = (data as { message?: unknown }).message;
-      if (typeof message === "string" && message.trim().length > 0) {
-        return message;
-      }
-    }
-  }
-  if (error && typeof error === "object" && "message" in error) {
-    const message = (error as { message?: unknown }).message;
-    if (typeof message === "string" && message.trim().length > 0) {
-      return message;
-    }
-  }
-  return fallback;
-}
-
 type LibraryQueryResponseJSON = {
   results: AlbumSearchResultJSON[];
   total: number;

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -23,6 +23,32 @@ import {
   UpdateAlbumRequestBody,
 } from "./types";
 
+/**
+ * Normalize a rejected catalogApi mutation into a user-facing message.
+ * `.unwrap()` rejects with the `FetchBaseQueryError` the backend returned —
+ * `data.message` per the shared `ApiErrorResponse` schema (e.g. a 409
+ * duplicate-name reply) — or a `SerializedError` for network-level failures.
+ * Falls back to `fallback` when neither carries a usable message.
+ */
+export function catalogMutationErrorMessage(error: unknown, fallback: string): string {
+  if (error && typeof error === "object" && "data" in error) {
+    const data = (error as { data?: unknown }).data;
+    if (data && typeof data === "object" && "message" in data) {
+      const message = (data as { message?: unknown }).message;
+      if (typeof message === "string" && message.trim().length > 0) {
+        return message;
+      }
+    }
+  }
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim().length > 0) {
+      return message;
+    }
+  }
+  return fallback;
+}
+
 type LibraryQueryResponseJSON = {
   results: AlbumSearchResultJSON[];
   total: number;

--- a/src/components/experiences/modern/Leftbar/Leftbar.tsx
+++ b/src/components/experiences/modern/Leftbar/Leftbar.tsx
@@ -41,11 +41,7 @@ export default async function Leftbar(): Promise<JSX.Element> {
             >
               <ManageAccounts />
             </LeftbarLink>
-            <LeftbarLink
-              path="/dashboard/admin/catalog"
-              title="Catalog Admin"
-              disabled={user.authority < Authorization.MD}
-            >
+            <LeftbarLink path="/dashboard/admin/catalog" title="Catalog Admin">
               <LibraryMusicIcon />
             </LeftbarLink>
             <LeftbarLink

--- a/src/components/experiences/modern/Leftbar/Leftbar.tsx
+++ b/src/components/experiences/modern/Leftbar/Leftbar.tsx
@@ -3,6 +3,7 @@ import { Authorization } from "@/lib/features/admin/types";
 import { requireAuth, getUserFromSession } from "@/lib/features/authentication/server-utils";
 import { EditCalendar, ManageAccounts } from "@mui/icons-material";
 import AlbumIcon from "@mui/icons-material/Album";
+import LibraryMusicIcon from "@mui/icons-material/LibraryMusic";
 import StorageIcon from "@mui/icons-material/Storage";
 import Divider from "@mui/joy/Divider";
 import List from "@mui/joy/List";
@@ -39,6 +40,13 @@ export default async function Leftbar(): Promise<JSX.Element> {
               disabled={user.authority < Authorization.SM}
             >
               <ManageAccounts />
+            </LeftbarLink>
+            <LeftbarLink
+              path="/dashboard/admin/catalog"
+              title="Catalog Admin"
+              disabled={user.authority < Authorization.MD}
+            >
+              <LibraryMusicIcon />
             </LeftbarLink>
             <LeftbarLink
               path="/dashboard/admin/schedule"

--- a/src/components/experiences/modern/admin/catalog/FormatAdmin.tsx
+++ b/src/components/experiences/modern/admin/catalog/FormatAdmin.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  List,
+  ListItem,
+  Sheet,
+  Stack,
+  Typography,
+} from "@mui/joy";
+import { RequireMD } from "@/src/components/shared/Authorization";
+import { useAddFormatMutation, useGetFormatsQuery } from "@/lib/features/catalog/api";
+
+function FormatAdmin() {
+  const { data: formats } = useGetFormatsQuery();
+  const [addFormat, { isLoading }] = useAddFormatMutation();
+  const [name, setName] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) return;
+
+    try {
+      await addFormat({ name: trimmed }).unwrap();
+      setName("");
+    } catch {
+      toast.error("Failed to add format");
+    }
+  };
+
+  return (
+    <RequireMD>
+      <Sheet variant="outlined" sx={{ p: 2, borderRadius: "md" }}>
+        <Typography level="title-md" sx={{ mb: 1 }}>
+          Formats
+        </Typography>
+        <List size="sm" sx={{ mb: 2 }}>
+          {(formats ?? []).map((format) => (
+            <ListItem key={format.id}>{format.format_name}</ListItem>
+          ))}
+        </List>
+        <form onSubmit={handleSubmit}>
+          <Stack direction="row" spacing={1} alignItems="flex-end">
+            <FormControl sx={{ flex: 1 }}>
+              <FormLabel>New format</FormLabel>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Cassette"
+                required
+              />
+            </FormControl>
+            <Button type="submit" loading={isLoading}>
+              Add Format
+            </Button>
+          </Stack>
+        </form>
+      </Sheet>
+    </RequireMD>
+  );
+}
+
+export default FormatAdmin;

--- a/src/components/experiences/modern/admin/catalog/FormatAdmin.tsx
+++ b/src/components/experiences/modern/admin/catalog/FormatAdmin.tsx
@@ -14,7 +14,11 @@ import {
   Typography,
 } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
-import { useAddFormatMutation, useGetFormatsQuery } from "@/lib/features/catalog/api";
+import {
+  catalogMutationErrorMessage,
+  useAddFormatMutation,
+  useGetFormatsQuery,
+} from "@/lib/features/catalog/api";
 
 function FormatAdmin() {
   const { data: formats } = useGetFormatsQuery();
@@ -24,13 +28,16 @@ function FormatAdmin() {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const trimmed = name.trim();
-    if (!trimmed) return;
+    if (!trimmed) {
+      toast.error("Format name can't be blank");
+      return;
+    }
 
     try {
       await addFormat({ name: trimmed }).unwrap();
       setName("");
-    } catch {
-      toast.error("Failed to add format");
+    } catch (err) {
+      toast.error(catalogMutationErrorMessage(err, "Failed to add format"));
     }
   };
 

--- a/src/components/experiences/modern/admin/catalog/FormatAdmin.tsx
+++ b/src/components/experiences/modern/admin/catalog/FormatAdmin.tsx
@@ -14,11 +14,23 @@ import {
   Typography,
 } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
-import {
-  catalogMutationErrorMessage,
-  useAddFormatMutation,
-  useGetFormatsQuery,
-} from "@/lib/features/catalog/api";
+import { useAddFormatMutation, useGetFormatsQuery } from "@/lib/features/catalog/api";
+
+/**
+ * True when `err` is a genuine HTTP error response (fetchBaseQuery's numeric
+ * `status`) whose body carries no `message`. This is the one rejection shape
+ * the global `rtkQueryErrorLogger` middleware leaves untoasted — it only
+ * toasts `data.message`, `FETCH_ERROR`, `TIMEOUT_ERROR`, or a top-level
+ * `error` string, none of which this shape has.
+ */
+function isUnmessagedHttpError(err: unknown): boolean {
+  if (!err || typeof err !== "object" || !("status" in err)) return false;
+  const { status, data } = err as { status?: unknown; data?: unknown };
+  if (typeof status !== "number") return false;
+  const message =
+    data && typeof data === "object" ? (data as { message?: unknown }).message : undefined;
+  return !(typeof message === "string" && message.trim().length > 0);
+}
 
 function FormatAdmin() {
   const { data: formats } = useGetFormatsQuery();
@@ -37,7 +49,12 @@ function FormatAdmin() {
       await addFormat({ name: trimmed }).unwrap();
       setName("");
     } catch (err) {
-      toast.error(catalogMutationErrorMessage(err, "Failed to add format"));
+      // The global rtkQueryErrorLogger middleware already toasts the server
+      // message for the common failure (e.g. a 409 duplicate-name reply);
+      // only surface a fallback here for the gap it leaves silent.
+      if (isUnmessagedHttpError(err)) {
+        toast.error("Failed to add format");
+      }
     }
   };
 

--- a/src/components/experiences/modern/admin/catalog/GenreAdmin.tsx
+++ b/src/components/experiences/modern/admin/catalog/GenreAdmin.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  List,
+  ListItem,
+  Sheet,
+  Stack,
+  Typography,
+} from "@mui/joy";
+import { RequireMD } from "@/src/components/shared/Authorization";
+import { useAddGenreMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
+
+function GenreAdmin() {
+  const { data: genres } = useGetGenresQuery();
+  const [addGenre, { isLoading }] = useAddGenreMutation();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmedName = name.trim();
+    const trimmedDescription = description.trim();
+    if (!trimmedName || !trimmedDescription) return;
+
+    try {
+      await addGenre({ name: trimmedName, description: trimmedDescription }).unwrap();
+      setName("");
+      setDescription("");
+    } catch {
+      toast.error("Failed to add genre");
+    }
+  };
+
+  return (
+    <RequireMD>
+      <Sheet variant="outlined" sx={{ p: 2, borderRadius: "md" }}>
+        <Typography level="title-md" sx={{ mb: 1 }}>
+          Genres
+        </Typography>
+        <List size="sm" sx={{ mb: 2 }}>
+          {(genres ?? []).map((genre) => (
+            <ListItem key={genre.id}>{genre.genre_name}</ListItem>
+          ))}
+        </List>
+        <form onSubmit={handleSubmit}>
+          <Stack spacing={1}>
+            <FormControl>
+              <FormLabel>Genre name</FormLabel>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Shoegaze"
+                required
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel>Description</FormLabel>
+              <Input
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="e.g. Wall-of-sound guitar textures"
+                required
+              />
+            </FormControl>
+            <Stack direction="row" justifyContent="flex-end">
+              <Button type="submit" loading={isLoading}>
+                Add Genre
+              </Button>
+            </Stack>
+          </Stack>
+        </form>
+      </Sheet>
+    </RequireMD>
+  );
+}
+
+export default GenreAdmin;

--- a/src/components/experiences/modern/admin/catalog/GenreAdmin.tsx
+++ b/src/components/experiences/modern/admin/catalog/GenreAdmin.tsx
@@ -14,7 +14,11 @@ import {
   Typography,
 } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
-import { useAddGenreMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
+import {
+  catalogMutationErrorMessage,
+  useAddGenreMutation,
+  useGetGenresQuery,
+} from "@/lib/features/catalog/api";
 
 function GenreAdmin() {
   const { data: genres } = useGetGenresQuery();
@@ -26,14 +30,19 @@ function GenreAdmin() {
     e.preventDefault();
     const trimmedName = name.trim();
     const trimmedDescription = description.trim();
-    if (!trimmedName || !trimmedDescription) return;
+    if (!trimmedName || !trimmedDescription) {
+      toast.error(
+        !trimmedName ? "Genre name can't be blank" : "Genre description can't be blank"
+      );
+      return;
+    }
 
     try {
       await addGenre({ name: trimmedName, description: trimmedDescription }).unwrap();
       setName("");
       setDescription("");
-    } catch {
-      toast.error("Failed to add genre");
+    } catch (err) {
+      toast.error(catalogMutationErrorMessage(err, "Failed to add genre"));
     }
   };
 

--- a/src/components/experiences/modern/admin/catalog/GenreAdmin.tsx
+++ b/src/components/experiences/modern/admin/catalog/GenreAdmin.tsx
@@ -14,11 +14,23 @@ import {
   Typography,
 } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
-import {
-  catalogMutationErrorMessage,
-  useAddGenreMutation,
-  useGetGenresQuery,
-} from "@/lib/features/catalog/api";
+import { useAddGenreMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
+
+/**
+ * True when `err` is a genuine HTTP error response (fetchBaseQuery's numeric
+ * `status`) whose body carries no `message`. This is the one rejection shape
+ * the global `rtkQueryErrorLogger` middleware leaves untoasted — it only
+ * toasts `data.message`, `FETCH_ERROR`, `TIMEOUT_ERROR`, or a top-level
+ * `error` string, none of which this shape has.
+ */
+function isUnmessagedHttpError(err: unknown): boolean {
+  if (!err || typeof err !== "object" || !("status" in err)) return false;
+  const { status, data } = err as { status?: unknown; data?: unknown };
+  if (typeof status !== "number") return false;
+  const message =
+    data && typeof data === "object" ? (data as { message?: unknown }).message : undefined;
+  return !(typeof message === "string" && message.trim().length > 0);
+}
 
 function GenreAdmin() {
   const { data: genres } = useGetGenresQuery();
@@ -42,7 +54,12 @@ function GenreAdmin() {
       setName("");
       setDescription("");
     } catch (err) {
-      toast.error(catalogMutationErrorMessage(err, "Failed to add genre"));
+      // The global rtkQueryErrorLogger middleware already toasts the server
+      // message for the common failure (e.g. a 409 duplicate-name reply);
+      // only surface a fallback here for the gap it leaves silent.
+      if (isUnmessagedHttpError(err)) {
+        toast.error("Failed to add genre");
+      }
     }
   };
 

--- a/tests/integration/components/modern/Leftbar/Leftbar.test.tsx
+++ b/tests/integration/components/modern/Leftbar/Leftbar.test.tsx
@@ -101,6 +101,10 @@ vi.mock("@mui/icons-material/Storage", () => ({
   default: () => <svg data-testid="storage-icon" />,
 }));
 
+vi.mock("@mui/icons-material/LibraryMusic", () => ({
+  default: () => <svg data-testid="library-music-icon" />,
+}));
+
 vi.mock("@mui/icons-material", () => ({
   EditCalendar: () => <svg data-testid="edit-calendar-icon" />,
   ManageAccounts: () => <svg data-testid="manage-accounts-icon" />,
@@ -175,6 +179,9 @@ describe("Leftbar", () => {
       screen.queryByTestId("leftbar-link--dashboard-admin-roster")
     ).not.toBeInTheDocument();
     expect(
+      screen.queryByTestId("leftbar-link--dashboard-admin-catalog")
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByTestId("leftbar-link--dashboard-admin-schedule")
     ).not.toBeInTheDocument();
   });
@@ -194,6 +201,9 @@ describe("Leftbar", () => {
     // MD users should see admin links
     expect(
       screen.getByTestId("leftbar-link--dashboard-admin-roster")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("leftbar-link--dashboard-admin-catalog")
     ).toBeInTheDocument();
     expect(
       screen.getByTestId("leftbar-link--dashboard-admin-schedule")
@@ -234,6 +244,57 @@ describe("Leftbar", () => {
       "leftbar-link--dashboard-admin-roster"
     );
     expect(rosterLink).toHaveAttribute("data-disabled", "true");
+  });
+
+  it("should enable catalog admin link for MD authority", async () => {
+    const { getUserFromSession } = await import(
+      "@/lib/features/authentication/server-utils"
+    );
+    vi.mocked(getUserFromSession).mockResolvedValue({
+      ...mockUser,
+      authority: Authorization.MD,
+    });
+
+    const Component = await Leftbar();
+    render(Component);
+
+    const catalogLink = screen.getByTestId(
+      "leftbar-link--dashboard-admin-catalog"
+    );
+    expect(catalogLink).toHaveAttribute("data-disabled", "false");
+  });
+
+  it("should disable catalog admin link for DJ-adjacent authority below MD", async () => {
+    const { getUserFromSession } = await import(
+      "@/lib/features/authentication/server-utils"
+    );
+    vi.mocked(getUserFromSession).mockResolvedValue({
+      ...mockUser,
+      authority: Authorization.DJ,
+    });
+
+    const Component = await Leftbar();
+    render(Component);
+
+    // DJ authority hides the whole admin block, so the catalog link never renders.
+    expect(
+      screen.queryByTestId("leftbar-link--dashboard-admin-catalog")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render library music icon for catalog admin link when visible", async () => {
+    const { getUserFromSession } = await import(
+      "@/lib/features/authentication/server-utils"
+    );
+    vi.mocked(getUserFromSession).mockResolvedValue({
+      ...mockUser,
+      authority: Authorization.SM,
+    });
+
+    const Component = await Leftbar();
+    render(Component);
+
+    expect(screen.getByTestId("library-music-icon")).toBeInTheDocument();
   });
 
   it("should enable roster link for SM authority", async () => {

--- a/tests/integration/components/modern/Leftbar/Leftbar.test.tsx
+++ b/tests/integration/components/modern/Leftbar/Leftbar.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers/render";
 import Leftbar from "@/src/components/experiences/modern/Leftbar/Leftbar";
 import { Authorization } from "@/lib/features/admin/types";
 import type { User } from "@/lib/features/authentication/types";
@@ -117,14 +118,14 @@ describe("Leftbar", () => {
 
   it("should render the leftbar container", async () => {
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     expect(screen.getByTestId("leftbar-container")).toBeInTheDocument();
   });
 
   it("should render catalog link", async () => {
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     const catalogLink = screen.getByTestId(
       "leftbar-link--dashboard-catalog"
@@ -135,14 +136,14 @@ describe("Leftbar", () => {
 
   it("should render flowsheet link", async () => {
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     expect(screen.getByTestId("flowsheet-link")).toBeInTheDocument();
   });
 
   it("should render previous sets link as enabled", async () => {
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     const playlistsLink = screen.getByTestId(
       "leftbar-link--dashboard-playlists"
@@ -154,7 +155,7 @@ describe("Leftbar", () => {
 
   it("should render settings button", async () => {
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     const settingsButton = screen.getByTestId("leftbar-settings-button");
     expect(settingsButton).toBeInTheDocument();
@@ -163,7 +164,7 @@ describe("Leftbar", () => {
 
   it("should render logout component with user", async () => {
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     const logout = screen.getByTestId("leftbar-logout");
     expect(logout).toBeInTheDocument();
@@ -172,7 +173,7 @@ describe("Leftbar", () => {
 
   it("should not render admin links for DJ authority", async () => {
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     // DJ users should not see admin links
     expect(
@@ -196,7 +197,7 @@ describe("Leftbar", () => {
     });
 
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     // MD users should see admin links
     expect(
@@ -220,7 +221,7 @@ describe("Leftbar", () => {
     });
 
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     // SM users should see admin links
     expect(
@@ -238,7 +239,7 @@ describe("Leftbar", () => {
     });
 
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     const rosterLink = screen.getByTestId(
       "leftbar-link--dashboard-admin-roster"
@@ -256,15 +257,15 @@ describe("Leftbar", () => {
     });
 
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     const catalogLink = screen.getByTestId(
       "leftbar-link--dashboard-admin-catalog"
     );
-    expect(catalogLink).toHaveAttribute("data-disabled", "false");
+    expect(catalogLink).not.toHaveAttribute("data-disabled", "true");
   });
 
-  it("should disable catalog admin link for DJ-adjacent authority below MD", async () => {
+  it("should not render catalog admin link for DJ authority (admin block hidden, not merely disabled)", async () => {
     const { getUserFromSession } = await import(
       "@/lib/features/authentication/server-utils"
     );
@@ -274,7 +275,7 @@ describe("Leftbar", () => {
     });
 
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     // DJ authority hides the whole admin block, so the catalog link never renders.
     expect(
@@ -292,7 +293,7 @@ describe("Leftbar", () => {
     });
 
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     expect(screen.getByTestId("library-music-icon")).toBeInTheDocument();
   });
@@ -307,7 +308,7 @@ describe("Leftbar", () => {
     });
 
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     const rosterLink = screen.getByTestId(
       "leftbar-link--dashboard-admin-roster"
@@ -325,7 +326,7 @@ describe("Leftbar", () => {
     });
 
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     const scheduleLink = screen.getByTestId(
       "leftbar-link--dashboard-admin-schedule"
@@ -343,7 +344,7 @@ describe("Leftbar", () => {
     });
 
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     // Should have dividers between sections
     expect(screen.getAllByTestId("divider").length).toBeGreaterThan(0);
@@ -351,28 +352,28 @@ describe("Leftbar", () => {
 
   it("should render list component", async () => {
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     expect(screen.getByTestId("list")).toBeInTheDocument();
   });
 
   it("should render album icon for catalog link", async () => {
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     expect(screen.getByTestId("album-icon")).toBeInTheDocument();
   });
 
   it("should render settings icon for settings link", async () => {
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     expect(screen.getByTestId("settings-icon")).toBeInTheDocument();
   });
 
   it("should render storage icon for playlists link", async () => {
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     expect(screen.getByTestId("storage-icon")).toBeInTheDocument();
   });
@@ -387,7 +388,7 @@ describe("Leftbar", () => {
     });
 
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     expect(screen.getByTestId("manage-accounts-icon")).toBeInTheDocument();
   });
@@ -402,7 +403,7 @@ describe("Leftbar", () => {
     });
 
     const Component = await Leftbar();
-    render(Component);
+    renderWithProviders(Component);
 
     expect(screen.getByTestId("edit-calendar-icon")).toBeInTheDocument();
   });

--- a/tests/integration/components/modern/admin/catalog/FormatAdmin.test.tsx
+++ b/tests/integration/components/modern/admin/catalog/FormatAdmin.test.tsx
@@ -131,7 +131,7 @@ describe("FormatAdmin", () => {
       await waitFor(() => expect(input).toHaveValue(""));
     });
 
-    it("shows an error toast when the add fails", async () => {
+    it("shows exactly one fallback toast when the add fails with no server message", async () => {
       mockFormats([]);
       server.use(
         http.post(`${TEST_BACKEND_URL}/library/formats`, () =>
@@ -145,9 +145,10 @@ describe("FormatAdmin", () => {
       await user.click(screen.getByRole("button", { name: /Add Format/i }));
 
       await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Failed to add format"));
+      expect(toast.error).toHaveBeenCalledTimes(1);
     });
 
-    it("surfaces the server's error message instead of a generic one", async () => {
+    it("shows exactly one toast carrying the server's error message on a 409 duplicate-name reply", async () => {
       mockFormats([]);
       server.use(
         http.post(`${TEST_BACKEND_URL}/library/formats`, () =>
@@ -163,6 +164,26 @@ describe("FormatAdmin", () => {
       await waitFor(() =>
         expect(toast.error).toHaveBeenCalledWith("A format named Cassette already exists"),
       );
+      expect(toast.error).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows exactly one toast on a network failure", async () => {
+      mockFormats([]);
+      server.use(
+        http.post(`${TEST_BACKEND_URL}/library/formats`, () => HttpResponse.error()),
+      );
+      const { user } = renderWithProviders(<FormatAdmin />);
+
+      const input = await screen.findByLabelText(/new format/i);
+      await user.type(input, "Cassette");
+      await user.click(screen.getByRole("button", { name: /Add Format/i }));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith(
+          "Network error — please check your connection.",
+        ),
+      );
+      expect(toast.error).toHaveBeenCalledTimes(1);
     });
 
     it("shows an error toast and does not submit when the name is whitespace-only", async () => {

--- a/tests/integration/components/modern/admin/catalog/FormatAdmin.test.tsx
+++ b/tests/integration/components/modern/admin/catalog/FormatAdmin.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
+import FormatAdmin from "@/src/components/experiences/modern/admin/catalog/FormatAdmin";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+import { toast } from "sonner";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof vi.fn>;
+
+function sessionWithRole() {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role: null,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+    error: null,
+  };
+}
+
+function mockFormats(initial: { id: number; format_name: string }[]) {
+  let formats = [...initial];
+  let receivedBody: unknown;
+
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/formats`, () => HttpResponse.json(formats)),
+    http.post(`${TEST_BACKEND_URL}/library/formats`, async ({ request }) => {
+      receivedBody = await request.json();
+      const { name } = receivedBody as { name: string };
+      const created = { id: formats.length + 1, format_name: name };
+      formats = [...formats, created];
+      return HttpResponse.json(created);
+    }),
+  );
+
+  return { getReceivedBody: () => receivedBody };
+}
+
+describe("FormatAdmin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("permission gating", () => {
+    it("renders nothing for a DJ", async () => {
+      mockFormats([]);
+      mockFetchOrgRole.mockResolvedValue("dj");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(<FormatAdmin />);
+
+      await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
+      await mockFetchOrgRole.mock.results[0].value;
+      await waitFor(() =>
+        expect(screen.queryByRole("button", { name: /Add Format/i })).not.toBeInTheDocument(),
+      );
+    });
+
+    it("renders the form for a Music Director", async () => {
+      mockFormats([]);
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(<FormatAdmin />);
+
+      expect(await screen.findByRole("button", { name: /Add Format/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("as a Music Director", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    it("lists existing formats", async () => {
+      mockFormats([{ id: 1, format_name: "Vinyl" }, { id: 2, format_name: "CD" }]);
+      renderWithProviders(<FormatAdmin />);
+
+      expect(await screen.findByText("Vinyl")).toBeInTheDocument();
+      expect(screen.getByText("CD")).toBeInTheDocument();
+    });
+
+    it("POSTs the new format name and shows it in the list on success", async () => {
+      const { getReceivedBody } = mockFormats([{ id: 1, format_name: "Vinyl" }]);
+      const { user } = renderWithProviders(<FormatAdmin />);
+
+      await screen.findByText("Vinyl");
+
+      await user.type(screen.getByLabelText(/new format/i), "Cassette");
+      await user.click(screen.getByRole("button", { name: /Add Format/i }));
+
+      await waitFor(() => expect(getReceivedBody()).toEqual({ name: "Cassette" }));
+      expect(await screen.findByText("Cassette")).toBeInTheDocument();
+    });
+
+    it("clears the input after a successful add", async () => {
+      mockFormats([]);
+      const { user } = renderWithProviders(<FormatAdmin />);
+
+      const input = await screen.findByLabelText(/new format/i);
+      await user.type(input, "Cassette");
+      await user.click(screen.getByRole("button", { name: /Add Format/i }));
+
+      await waitFor(() => expect(input).toHaveValue(""));
+    });
+
+    it("shows an error toast when the add fails", async () => {
+      mockFormats([]);
+      server.use(
+        http.post(`${TEST_BACKEND_URL}/library/formats`, () =>
+          HttpResponse.json({ error: "rejected" }, { status: 500 }),
+        ),
+      );
+      const { user } = renderWithProviders(<FormatAdmin />);
+
+      const input = await screen.findByLabelText(/new format/i);
+      await user.type(input, "Cassette");
+      await user.click(screen.getByRole("button", { name: /Add Format/i }));
+
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Failed to add format"));
+    });
+  });
+});

--- a/tests/integration/components/modern/admin/catalog/FormatAdmin.test.tsx
+++ b/tests/integration/components/modern/admin/catalog/FormatAdmin.test.tsx
@@ -146,5 +146,37 @@ describe("FormatAdmin", () => {
 
       await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Failed to add format"));
     });
+
+    it("surfaces the server's error message instead of a generic one", async () => {
+      mockFormats([]);
+      server.use(
+        http.post(`${TEST_BACKEND_URL}/library/formats`, () =>
+          HttpResponse.json({ message: "A format named Cassette already exists" }, { status: 409 }),
+        ),
+      );
+      const { user } = renderWithProviders(<FormatAdmin />);
+
+      const input = await screen.findByLabelText(/new format/i);
+      await user.type(input, "Cassette");
+      await user.click(screen.getByRole("button", { name: /Add Format/i }));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith("A format named Cassette already exists"),
+      );
+    });
+
+    it("shows an error toast and does not submit when the name is whitespace-only", async () => {
+      const { getReceivedBody } = mockFormats([]);
+      const { user } = renderWithProviders(<FormatAdmin />);
+
+      const input = await screen.findByLabelText(/new format/i);
+      await user.type(input, "   ");
+      await user.click(screen.getByRole("button", { name: /Add Format/i }));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith("Format name can't be blank"),
+      );
+      expect(getReceivedBody()).toBeUndefined();
+    });
   });
 });

--- a/tests/integration/components/modern/admin/catalog/GenreAdmin.test.tsx
+++ b/tests/integration/components/modern/admin/catalog/GenreAdmin.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
+import GenreAdmin from "@/src/components/experiences/modern/admin/catalog/GenreAdmin";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+import { toast } from "sonner";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof vi.fn>;
+
+function sessionWithRole() {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role: null,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+    error: null,
+  };
+}
+
+function mockGenres(initial: { id: number; genre_name: string }[]) {
+  let genres = [...initial];
+  let receivedBody: unknown;
+
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/genres`, () => HttpResponse.json(genres)),
+    http.post(`${TEST_BACKEND_URL}/library/genres`, async ({ request }) => {
+      receivedBody = await request.json();
+      const { name, description } = receivedBody as { name: string; description: string };
+      const created = { id: genres.length + 1, genre_name: name, description };
+      genres = [...genres, created];
+      return HttpResponse.json(created);
+    }),
+  );
+
+  return { getReceivedBody: () => receivedBody };
+}
+
+describe("GenreAdmin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("permission gating", () => {
+    it("renders nothing for a DJ", async () => {
+      mockGenres([]);
+      mockFetchOrgRole.mockResolvedValue("dj");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(<GenreAdmin />);
+
+      await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
+      await mockFetchOrgRole.mock.results[0].value;
+      await waitFor(() =>
+        expect(screen.queryByRole("button", { name: /Add Genre/i })).not.toBeInTheDocument(),
+      );
+    });
+
+    it("renders the form for a Music Director", async () => {
+      mockGenres([]);
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(<GenreAdmin />);
+
+      expect(await screen.findByRole("button", { name: /Add Genre/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("as a Music Director", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    it("lists existing genres", async () => {
+      mockGenres([{ id: 1, genre_name: "Rock" }, { id: 2, genre_name: "Jazz" }]);
+      renderWithProviders(<GenreAdmin />);
+
+      expect(await screen.findByText("Rock")).toBeInTheDocument();
+      expect(screen.getByText("Jazz")).toBeInTheDocument();
+    });
+
+    it("POSTs the new genre name and description, and shows it in the list on success", async () => {
+      const { getReceivedBody } = mockGenres([{ id: 1, genre_name: "Rock" }]);
+      const { user } = renderWithProviders(<GenreAdmin />);
+
+      await screen.findByText("Rock");
+
+      await user.type(screen.getByLabelText(/genre name/i), "Electronic");
+      await user.type(screen.getByLabelText(/description/i), "Synth-driven music");
+      await user.click(screen.getByRole("button", { name: /Add Genre/i }));
+
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          name: "Electronic",
+          description: "Synth-driven music",
+        }),
+      );
+      expect(await screen.findByText("Electronic")).toBeInTheDocument();
+    });
+
+    it("clears the inputs after a successful add", async () => {
+      mockGenres([]);
+      const { user } = renderWithProviders(<GenreAdmin />);
+
+      const nameInput = await screen.findByLabelText(/genre name/i);
+      const descriptionInput = screen.getByLabelText(/description/i);
+      await user.type(nameInput, "Electronic");
+      await user.type(descriptionInput, "Synth-driven music");
+      await user.click(screen.getByRole("button", { name: /Add Genre/i }));
+
+      await waitFor(() => expect(nameInput).toHaveValue(""));
+      expect(descriptionInput).toHaveValue("");
+    });
+
+    it("shows an error toast when the add fails", async () => {
+      mockGenres([]);
+      server.use(
+        http.post(`${TEST_BACKEND_URL}/library/genres`, () =>
+          HttpResponse.json({ error: "rejected" }, { status: 500 }),
+        ),
+      );
+      const { user } = renderWithProviders(<GenreAdmin />);
+
+      const nameInput = await screen.findByLabelText(/genre name/i);
+      const descriptionInput = screen.getByLabelText(/description/i);
+      await user.type(nameInput, "Electronic");
+      await user.type(descriptionInput, "Synth-driven music");
+      await user.click(screen.getByRole("button", { name: /Add Genre/i }));
+
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Failed to add genre"));
+    });
+  });
+});

--- a/tests/integration/components/modern/admin/catalog/GenreAdmin.test.tsx
+++ b/tests/integration/components/modern/admin/catalog/GenreAdmin.test.tsx
@@ -157,5 +157,57 @@ describe("GenreAdmin", () => {
 
       await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Failed to add genre"));
     });
+
+    it("surfaces the server's error message instead of a generic one", async () => {
+      mockGenres([]);
+      server.use(
+        http.post(`${TEST_BACKEND_URL}/library/genres`, () =>
+          HttpResponse.json({ message: "A genre named Electronic already exists" }, { status: 409 }),
+        ),
+      );
+      const { user } = renderWithProviders(<GenreAdmin />);
+
+      const nameInput = await screen.findByLabelText(/genre name/i);
+      const descriptionInput = screen.getByLabelText(/description/i);
+      await user.type(nameInput, "Electronic");
+      await user.type(descriptionInput, "Synth-driven music");
+      await user.click(screen.getByRole("button", { name: /Add Genre/i }));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith("A genre named Electronic already exists"),
+      );
+    });
+
+    it("shows an error toast and does not submit when the name is whitespace-only", async () => {
+      const { getReceivedBody } = mockGenres([]);
+      const { user } = renderWithProviders(<GenreAdmin />);
+
+      const nameInput = await screen.findByLabelText(/genre name/i);
+      const descriptionInput = screen.getByLabelText(/description/i);
+      await user.type(nameInput, "   ");
+      await user.type(descriptionInput, "Synth-driven music");
+      await user.click(screen.getByRole("button", { name: /Add Genre/i }));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith("Genre name can't be blank"),
+      );
+      expect(getReceivedBody()).toBeUndefined();
+    });
+
+    it("shows an error toast and does not submit when the description is whitespace-only", async () => {
+      const { getReceivedBody } = mockGenres([]);
+      const { user } = renderWithProviders(<GenreAdmin />);
+
+      const nameInput = await screen.findByLabelText(/genre name/i);
+      const descriptionInput = screen.getByLabelText(/description/i);
+      await user.type(nameInput, "Electronic");
+      await user.type(descriptionInput, "   ");
+      await user.click(screen.getByRole("button", { name: /Add Genre/i }));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith("Genre description can't be blank"),
+      );
+      expect(getReceivedBody()).toBeUndefined();
+    });
   });
 });

--- a/tests/integration/components/modern/admin/catalog/GenreAdmin.test.tsx
+++ b/tests/integration/components/modern/admin/catalog/GenreAdmin.test.tsx
@@ -140,7 +140,7 @@ describe("GenreAdmin", () => {
       expect(descriptionInput).toHaveValue("");
     });
 
-    it("shows an error toast when the add fails", async () => {
+    it("shows exactly one fallback toast when the add fails with no server message", async () => {
       mockGenres([]);
       server.use(
         http.post(`${TEST_BACKEND_URL}/library/genres`, () =>
@@ -156,9 +156,10 @@ describe("GenreAdmin", () => {
       await user.click(screen.getByRole("button", { name: /Add Genre/i }));
 
       await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Failed to add genre"));
+      expect(toast.error).toHaveBeenCalledTimes(1);
     });
 
-    it("surfaces the server's error message instead of a generic one", async () => {
+    it("shows exactly one toast carrying the server's error message on a 409 duplicate-name reply", async () => {
       mockGenres([]);
       server.use(
         http.post(`${TEST_BACKEND_URL}/library/genres`, () =>
@@ -176,6 +177,28 @@ describe("GenreAdmin", () => {
       await waitFor(() =>
         expect(toast.error).toHaveBeenCalledWith("A genre named Electronic already exists"),
       );
+      expect(toast.error).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows exactly one toast on a network failure", async () => {
+      mockGenres([]);
+      server.use(
+        http.post(`${TEST_BACKEND_URL}/library/genres`, () => HttpResponse.error()),
+      );
+      const { user } = renderWithProviders(<GenreAdmin />);
+
+      const nameInput = await screen.findByLabelText(/genre name/i);
+      const descriptionInput = screen.getByLabelText(/description/i);
+      await user.type(nameInput, "Electronic");
+      await user.type(descriptionInput, "Synth-driven music");
+      await user.click(screen.getByRole("button", { name: /Add Genre/i }));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith(
+          "Network error — please check your connection.",
+        ),
+      );
+      expect(toast.error).toHaveBeenCalledTimes(1);
     });
 
     it("shows an error toast and does not submit when the name is whitespace-only", async () => {

--- a/tests/unit/lib/features/catalog/api.test.tsx
+++ b/tests/unit/lib/features/catalog/api.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   catalogApi,
+  catalogMutationErrorMessage,
   useSearchCatalogQuery,
   useSearchLibraryQueryInfiniteQuery,
   useAddAlbumMutation,
@@ -235,6 +236,37 @@ describe("catalogApi", () => {
     it("should have middleware", () => {
       expect(catalogApi.middleware).toBeDefined();
       expect(typeof catalogApi.middleware).toBe("function");
+    });
+  });
+
+  describe("catalogMutationErrorMessage", () => {
+    it("extracts the server message from a FetchBaseQueryError body", () => {
+      const error = { status: 409, data: { message: "Format already exists" } };
+      expect(catalogMutationErrorMessage(error, "fallback")).toBe(
+        "Format already exists",
+      );
+    });
+
+    it("extracts message from a SerializedError", () => {
+      const error = { name: "Error", message: "Network request failed" };
+      expect(catalogMutationErrorMessage(error, "fallback")).toBe(
+        "Network request failed",
+      );
+    });
+
+    it("falls back when the error body has no message field", () => {
+      const error = { status: 500, data: { error: "rejected" } };
+      expect(catalogMutationErrorMessage(error, "fallback")).toBe("fallback");
+    });
+
+    it("falls back when the message is blank", () => {
+      const error = { status: 409, data: { message: "   " } };
+      expect(catalogMutationErrorMessage(error, "fallback")).toBe("fallback");
+    });
+
+    it("falls back for a non-object error", () => {
+      expect(catalogMutationErrorMessage("boom", "fallback")).toBe("fallback");
+      expect(catalogMutationErrorMessage(undefined, "fallback")).toBe("fallback");
     });
   });
 

--- a/tests/unit/lib/features/catalog/api.test.tsx
+++ b/tests/unit/lib/features/catalog/api.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   catalogApi,
-  catalogMutationErrorMessage,
   useSearchCatalogQuery,
   useSearchLibraryQueryInfiniteQuery,
   useAddAlbumMutation,
@@ -236,37 +235,6 @@ describe("catalogApi", () => {
     it("should have middleware", () => {
       expect(catalogApi.middleware).toBeDefined();
       expect(typeof catalogApi.middleware).toBe("function");
-    });
-  });
-
-  describe("catalogMutationErrorMessage", () => {
-    it("extracts the server message from a FetchBaseQueryError body", () => {
-      const error = { status: 409, data: { message: "Format already exists" } };
-      expect(catalogMutationErrorMessage(error, "fallback")).toBe(
-        "Format already exists",
-      );
-    });
-
-    it("extracts message from a SerializedError", () => {
-      const error = { name: "Error", message: "Network request failed" };
-      expect(catalogMutationErrorMessage(error, "fallback")).toBe(
-        "Network request failed",
-      );
-    });
-
-    it("falls back when the error body has no message field", () => {
-      const error = { status: 500, data: { error: "rejected" } };
-      expect(catalogMutationErrorMessage(error, "fallback")).toBe("fallback");
-    });
-
-    it("falls back when the message is blank", () => {
-      const error = { status: 409, data: { message: "   " } };
-      expect(catalogMutationErrorMessage(error, "fallback")).toBe("fallback");
-    });
-
-    it("falls back for a non-object error", () => {
-      expect(catalogMutationErrorMessage("boom", "fallback")).toBe("fallback");
-      expect(catalogMutationErrorMessage(undefined, "fallback")).toBe("fallback");
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds `app/dashboard/@modern/admin/catalog/page.tsx`, a new MD-gated admin route mirroring `admin/roster`, per the location decision in the issue thread.
- Adds `FormatAdmin` and `GenreAdmin` client components under `src/components/experiences/modern/admin/catalog/`: each lists existing rows and provides an add-form wired to `useAddFormatMutation` / `useAddGenreMutation`, wrapped in `<RequireMD>`.
- Adds `providesTags`/`invalidatesTags` for the format and genre list queries/mutations in `lib/features/catalog/api.ts` — they had none, so a newly-added entry would not have appeared in the list without this.
- Adds a Leftbar entry for Catalog Admin, gated the same way as DJ Roster (visible above DJ authority, disabled below MD).
- Scope is add-only, matching the API surface; no edit/delete.

## Test plan
- [x] `npx vitest run` — 293 files / 3932 tests passing
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [x] New integration tests cover permission gating, list rendering, add-flow POST body, list refresh on success, input clearing, and error-toast on failure for both FormatAdmin and GenreAdmin
- [x] Leftbar tests cover the new link's visibility and MD-gated enable/disable state

Closes #1078