### PR TITLE
MD catalog-edit UI: rotation classify control (add/kill rotation entry)

### DIFF
--- a/lib/features/rotation/api.ts
+++ b/lib/features/rotation/api.ts
@@ -67,7 +67,11 @@ export const rotationApi = createApi({
           // The request carries only `rotation_id`, so the album whose cached
           // catalog rows need clearing is knowable only from the updated row.
           // Entries that never linked to a library album have none, and there
-          // is nothing in the catalog to patch for them.
+          // is nothing in the catalog to patch for them. `RotationEntry.album_id`
+          // is typed as a required `number` in the shared contract, but the
+          // underlying column is nullable — this guard is reachable in
+          // production and must not be deleted as dead code on the strength
+          // of the type alone.
           if (typeof data.album_id !== "number") return;
           patchCatalogSearchRotation(
             dispatch,

--- a/lib/features/rotation/api.ts
+++ b/lib/features/rotation/api.ts
@@ -1,9 +1,14 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
+import type { RootState } from "@/lib/store";
 import { backendBaseQuery } from "../backend";
 import { convertToAlbumEntry } from "../catalog/conversions";
+import { patchCatalogSearchRotation } from "../catalog/patchSearchCaches";
 import { AlbumEntry, AlbumSearchResultJSON } from "../catalog/types";
-import type { AddRotationRequest } from "@wxyc/shared";
-import { KillRotationParams } from "./types";
+import type {
+  AddRotationRequest,
+  KillRotationRequest,
+  RotationEntry,
+} from "@wxyc/shared";
 
 export const rotationApi = createApi({
   reducerPath: "rotationApi",
@@ -21,21 +26,58 @@ export const rotationApi = createApi({
     // Typed against the shared OpenAPI contract (album_id: number) — the old
     // local RotationParams declared album_id: string, drifting from the wire
     // and forcing casts on future callers (#627).
-    addRotationEntry: builder.mutation<any, AddRotationRequest>({
+    addRotationEntry: builder.mutation<RotationEntry, AddRotationRequest>({
       query: (rotation) => ({
         url: "",
         method: "POST",
         body: rotation,
       }),
       invalidatesTags: ["Rotation"],
+      async onQueryStarted(
+        { album_id, rotation_bin },
+        { dispatch, getState, queryFulfilled },
+      ) {
+        try {
+          const { data } = await queryFulfilled;
+          patchCatalogSearchRotation(
+            dispatch,
+            getState as () => RootState,
+            album_id,
+            { rotation_bin, rotation_id: data.id },
+          );
+        } catch {
+        }
+      },
     }),
-    killRotationEntry: builder.mutation<any, KillRotationParams>({
+    // `kill_date` is optional on the wire and callers leave it off: the server
+    // stamps CURRENT_DATE in the database's own timezone. A date computed in
+    // the browser is a UTC calendar day, which runs a day ahead of Eastern
+    // evening hours, and the rotation read keeps any entry whose kill_date is
+    // still in the future.
+    killRotationEntry: builder.mutation<RotationEntry, KillRotationRequest>({
       query: (rotation) => ({
         url: "",
         method: "PATCH",
         body: rotation,
       }),
       invalidatesTags: ["Rotation"],
+      async onQueryStarted(_arg, { dispatch, getState, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          // The request carries only `rotation_id`, so the album whose cached
+          // catalog rows need clearing is knowable only from the updated row.
+          // Entries that never linked to a library album have none, and there
+          // is nothing in the catalog to patch for them.
+          if (typeof data.album_id !== "number") return;
+          patchCatalogSearchRotation(
+            dispatch,
+            getState as () => RootState,
+            data.album_id,
+            { rotation_bin: undefined, rotation_id: undefined },
+          );
+        } catch {
+        }
+      },
     }),
     getRotationTracks: builder.query<RotationTrack[], number>({
       query: (rotationId) => ({

--- a/lib/features/rotation/api.ts
+++ b/lib/features/rotation/api.ts
@@ -46,6 +46,12 @@ export const rotationApi = createApi({
             { rotation_bin, rotation_id: data.id },
           );
         } catch {
+          // A rejected `queryFulfilled` (mutation failure or the cache patch
+          // itself throwing) must not escape this handler: RTK Query treats
+          // an onQueryStarted rejection as an unhandled promise rejection,
+          // and the caller's own `.unwrap()` already owns surfacing the
+          // failure to the user (toast). Swallowing here avoids reporting
+          // the same failure twice.
         }
       },
     }),
@@ -80,6 +86,12 @@ export const rotationApi = createApi({
             { rotation_bin: undefined, rotation_id: undefined },
           );
         } catch {
+          // A rejected `queryFulfilled` (mutation failure or the cache patch
+          // itself throwing) must not escape this handler: RTK Query treats
+          // an onQueryStarted rejection as an unhandled promise rejection,
+          // and the caller's own `.unwrap()` already owns surfacing the
+          // failure to the user (toast). Swallowing here avoids reporting
+          // the same failure twice.
         }
       },
     }),

--- a/lib/features/rotation/types.ts
+++ b/lib/features/rotation/types.ts
@@ -10,9 +10,3 @@ export type RotationFrontendState = {
   orderBy: "title" | "artist" | "album";
   orderDirection: "asc" | "desc";
 };
-
-export type KillRotationParams = {
-  rotation_id: number;
-  kill_date: Date | undefined;
-};
-

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumCard.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumCard.tsx
@@ -19,6 +19,7 @@ import { NotOnDiscogsBadge } from "@/src/components/experiences/modern/catalog/A
 import DiscogsMarkup from "./DiscogsMarkupRenderer";
 import DiscogsUnavailableControl from "./DiscogsUnavailableControl";
 import LibraryStatus from "./LibraryStatus";
+import RotationClassifyControl from "./RotationClassifyControl";
 import StreamingLinks from "./StreamingLinks";
 import Tracklist from "./Tracklist";
 
@@ -144,6 +145,7 @@ export default function AlbumCard({
           </Stack>
         </Stack>
         <DiscogsUnavailableControl key={album.id} album={album} />
+        <RotationClassifyControl key={album.id} album={album} />
         {!isDiscogsUnavailable && <StreamingLinks metadata={metadata} />}
         {!isDiscogsUnavailable && artistBio && (
           <>

--- a/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button, Chip, FormControl, FormLabel, Stack } from "@mui/joy";
+import { RequireMD } from "@/src/components/shared/Authorization";
+import {
+  useAddRotationEntryMutation,
+  useKillRotationEntryMutation,
+} from "@/lib/features/rotation/api";
+import { Rotation } from "@/lib/features/rotation/types";
+import { AlbumEntry } from "@/lib/features/catalog/types";
+import RotationBinSelector from "@/src/components/experiences/modern/flowsheet/Search/RotationBinSelector";
+
+interface RotationClassifyControlProps {
+  album: AlbumEntry;
+}
+
+/**
+ * MD+ control for rotation classification: adds an album to a rotation bin
+ * via `useAddRotationEntryMutation`, or retires the active entry via
+ * `useKillRotationEntryMutation`. Add and kill are two states of one
+ * control, switched on whether the album already carries a `rotation_id` —
+ * mount with `key={album.id}` from the caller so local state reseeds from
+ * `album` rather than leaking the prior album's in-progress bin pick.
+ */
+function RotationClassifyControl({ album }: RotationClassifyControlProps) {
+  const [addRotationEntry, { isLoading: addPending }] = useAddRotationEntryMutation();
+  const [killRotationEntry, { isLoading: killPending }] = useKillRotationEntryMutation();
+
+  const [rotationId, setRotationId] = useState(album.rotation_id ?? null);
+  const [selectedBin, setSelectedBin] = useState<Rotation | null>(null);
+
+  const handleAdd = async () => {
+    if (!selectedBin) return;
+    try {
+      const entry = await addRotationEntry({
+        album_id: album.id,
+        rotation_bin: selectedBin,
+      }).unwrap();
+      setRotationId(entry.id);
+    } catch {
+      toast.error("Failed to add to rotation");
+    }
+  };
+
+  const handleKill = async () => {
+    if (rotationId === null) return;
+    try {
+      await killRotationEntry({ rotation_id: rotationId, kill_date: new Date() }).unwrap();
+      setRotationId(null);
+      setSelectedBin(null);
+    } catch {
+      toast.error("Failed to kill rotation entry");
+    }
+  };
+
+  return (
+    <RequireMD>
+      {rotationId !== null ? (
+        <Stack
+          direction="row"
+          spacing={1}
+          sx={{ alignItems: "center", justifyContent: "space-between" }}
+        >
+          <Chip size="sm" variant="soft">
+            In Rotation
+          </Chip>
+          <Button
+            size="sm"
+            color="warning"
+            variant="soft"
+            loading={killPending}
+            onClick={handleKill}
+          >
+            Kill
+          </Button>
+        </Stack>
+      ) : (
+        <FormControl
+          orientation="horizontal"
+          sx={{ justifyContent: "space-between", alignItems: "center" }}
+        >
+          <FormLabel>Rotation</FormLabel>
+          <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+            <RotationBinSelector
+              selectedBin={selectedBin}
+              onSelectBin={setSelectedBin}
+              disabled={addPending}
+            />
+            <Button
+              size="sm"
+              disabled={!selectedBin}
+              loading={addPending}
+              onClick={handleAdd}
+            >
+              Add to Rotation
+            </Button>
+          </Stack>
+        </FormControl>
+      )}
+    </RequireMD>
+  );
+}
+
+export default RotationClassifyControl;

--- a/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button, Chip, FormControl, FormLabel, Stack } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
 import {
   useAddRotationEntryMutation,
+  useGetRotationQuery,
   useKillRotationEntryMutation,
 } from "@/lib/features/rotation/api";
 import { Rotation } from "@/lib/features/rotation/types";
@@ -19,26 +20,69 @@ interface RotationClassifyControlProps {
 /**
  * MD+ control for rotation classification: adds an album to a rotation bin
  * via `useAddRotationEntryMutation`, or retires the active entry via
- * `useKillRotationEntryMutation`. Add and kill are two states of one
- * control, switched on whether the album already carries a `rotation_id` —
- * mount with `key={album.id}` from the caller so local state reseeds from
- * `album` rather than leaking the prior album's in-progress bin pick.
+ * `useKillRotationEntryMutation`. Add and kill are two states of one control.
+ *
+ * The fields live in a child so their hooks — including the rotation-list
+ * query the add/kill state is derived from — run only for an authorized
+ * viewer. Everyone else renders nothing and issues no request.
  */
 function RotationClassifyControl({ album }: RotationClassifyControlProps) {
-  const [addRotationEntry, { isLoading: addPending }] = useAddRotationEntryMutation();
-  const [killRotationEntry, { isLoading: killPending }] = useKillRotationEntryMutation();
+  return (
+    <RequireMD>
+      <RotationClassifyFields album={album} />
+    </RequireMD>
+  );
+}
 
-  const [rotationId, setRotationId] = useState(album.rotation_id ?? null);
+/**
+ * Mount with `key={album.id}` from the caller so an in-progress bin pick
+ * doesn't leak into the next album.
+ */
+function RotationClassifyFields({ album }: RotationClassifyControlProps) {
+  const [addRotationEntry, { isLoading: addPending }] =
+    useAddRotationEntryMutation();
+  const [killRotationEntry, { isLoading: killPending }] =
+    useKillRotationEntryMutation();
+
+  // The album-detail read (`GET /library/info`) joins no rotation table and
+  // selects no rotation columns, so `album.rotation_id` is always undefined
+  // here — whether the album is in rotation is only answerable from the
+  // active-rotation list. Subscribing with no options joins the cache entry
+  // the flowsheet rotation picker already holds instead of forcing a refetch
+  // underneath it.
+  const { data: rotationEntries, isFetching: rotationFetching } =
+    useGetRotationQuery();
+
   const [selectedBin, setSelectedBin] = useState<Rotation | null>(null);
+
+  // Both reads project `library.id` as the row id, so matching on it is
+  // matching library album to library album. Rotation rows that never linked
+  // to a library album carry a synthesized negative id instead, which no real
+  // album id can equal.
+  const activeEntry = useMemo(() => {
+    if (album.id <= 0) return undefined;
+    return rotationEntries?.find(
+      (entry) => entry.id === album.id && typeof entry.rotation_id === "number",
+    );
+  }, [rotationEntries, album.id]);
+
+  const rotationId = activeEntry?.rotation_id ?? null;
+
+  // Both mutations invalidate the rotation list and this control's state only
+  // flips once that refetch lands, so the actions stay busy while it is in
+  // flight — including the first load, when membership isn't known yet. That
+  // window is exactly where a second submit would open a duplicate active
+  // entry for the same album, which the backend's bare insert would accept.
+  const addBusy = addPending || rotationFetching;
+  const killBusy = killPending || rotationFetching;
 
   const handleAdd = async () => {
     if (!selectedBin) return;
     try {
-      const entry = await addRotationEntry({
+      await addRotationEntry({
         album_id: album.id,
         rotation_bin: selectedBin,
       }).unwrap();
-      setRotationId(entry.id);
     } catch {
       toast.error("Failed to add to rotation");
     }
@@ -47,59 +91,59 @@ function RotationClassifyControl({ album }: RotationClassifyControlProps) {
   const handleKill = async () => {
     if (rotationId === null) return;
     try {
-      await killRotationEntry({ rotation_id: rotationId, kill_date: new Date() }).unwrap();
-      setRotationId(null);
+      // `kill_date` is omitted so the server dates the kill itself. Computing
+      // it here would yield the browser's UTC calendar day, which is already
+      // tomorrow during Eastern evening hours; the rotation read keeps entries
+      // whose kill_date is in the future, so a tomorrow-dated kill would leave
+      // the retired album selectable in the flowsheet picker for another day.
+      await killRotationEntry({ rotation_id: rotationId }).unwrap();
       setSelectedBin(null);
     } catch {
       toast.error("Failed to kill rotation entry");
     }
   };
 
-  return (
-    <RequireMD>
-      {rotationId !== null ? (
-        <Stack
-          direction="row"
-          spacing={1}
-          sx={{ alignItems: "center", justifyContent: "space-between" }}
+  return rotationId !== null ? (
+    <Stack
+      direction="row"
+      spacing={1}
+      sx={{ alignItems: "center", justifyContent: "space-between" }}
+    >
+      <Chip size="sm" variant="soft">
+        In Rotation
+      </Chip>
+      <Button
+        size="sm"
+        color="warning"
+        variant="soft"
+        loading={killBusy}
+        onClick={handleKill}
+      >
+        Kill
+      </Button>
+    </Stack>
+  ) : (
+    <FormControl
+      orientation="horizontal"
+      sx={{ justifyContent: "space-between", alignItems: "center" }}
+    >
+      <FormLabel>Rotation</FormLabel>
+      <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+        <RotationBinSelector
+          selectedBin={selectedBin}
+          onSelectBin={setSelectedBin}
+          disabled={addBusy}
+        />
+        <Button
+          size="sm"
+          disabled={!selectedBin}
+          loading={addBusy}
+          onClick={handleAdd}
         >
-          <Chip size="sm" variant="soft">
-            In Rotation
-          </Chip>
-          <Button
-            size="sm"
-            color="warning"
-            variant="soft"
-            loading={killPending}
-            onClick={handleKill}
-          >
-            Kill
-          </Button>
-        </Stack>
-      ) : (
-        <FormControl
-          orientation="horizontal"
-          sx={{ justifyContent: "space-between", alignItems: "center" }}
-        >
-          <FormLabel>Rotation</FormLabel>
-          <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
-            <RotationBinSelector
-              selectedBin={selectedBin}
-              onSelectBin={setSelectedBin}
-              disabled={addPending}
-            />
-            <Button
-              size="sm"
-              disabled={!selectedBin}
-              loading={addPending}
-              onClick={handleAdd}
-            >
-              Add to Rotation
-            </Button>
-          </Stack>
-        </FormControl>
-      )}
-    </RequireMD>
+          Add to Rotation
+        </Button>
+      </Stack>
+    </FormControl>
   );
 }
 

--- a/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
@@ -41,8 +41,7 @@ function RotationClassifyControl({ album }: RotationClassifyControlProps) {
 function RotationClassifyFields({ album }: RotationClassifyControlProps) {
   const [addRotationEntry, { isLoading: addPending }] =
     useAddRotationEntryMutation();
-  const [killRotationEntry, { isLoading: killPending }] =
-    useKillRotationEntryMutation();
+  const [killRotationEntry] = useKillRotationEntryMutation();
 
   // The album-detail read (`GET /library/info`) joins no rotation table and
   // selects no rotation columns, so `album.rotation_id` is always undefined
@@ -56,7 +55,9 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
   } = useGetRotationQuery();
 
   const [selectedBin, setSelectedBin] = useState<Rotation | null>(null);
-  const [killTargetId, setKillTargetId] = useState<number | null>(null);
+  const [inFlightKillIds, setInFlightKillIds] = useState<Set<number>>(
+    () => new Set(),
+  );
 
   // `synthesizeAlbumId` hands out negative ids to rows the library never
   // linked (see conversions.ts); neither read nor write may treat one of
@@ -81,22 +82,24 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
   // album whose actual rotation membership is simply unknown, not "none".
   const rotationStateUnknown = rotationEntries === undefined;
 
-  // Both mutations invalidate the rotation list and this control's state only
-  // flips once that refetch lands, so the actions stay busy while it is in
-  // flight — including the first load, when membership isn't known yet. That
-  // window is exactly where a second submit would open a duplicate active
-  // entry for the same album, which the backend's bare insert would accept.
+  // The add mutation invalidates the rotation list, and this control's state
+  // only flips once that refetch lands, so `addBusy` stays true through the
+  // window between a successful POST and the list update — otherwise a
+  // second submit there would open a duplicate active entry for the same
+  // album, which the backend's bare insert would accept. `rotationFetching`
+  // is also true during the very first load, before membership is known at
+  // all, but that window never reaches this form: the `rotationStateUnknown`
+  // early return below renders a status chip in its place, so there is no
+  // Add affordance yet for `addBusy` to guard.
   const addBusy = addPending || rotationFetching;
 
-  // `killPending` and `rotationFetching` are both control-wide — the mutation
-  // hook is a single instance shared by every row, and the invalidation
-  // refetch it triggers updates the one list all rows read. Gating by
-  // `killTargetId` (set to the rotation_id a kill was issued for) scopes the
-  // busy signal to the row that started it; otherwise killing one bin's entry
-  // would spin every other active bin's Kill button as if it were being
-  // retired too.
-  const isRowKillBusy = (rotationId: number) =>
-    killTargetId === rotationId && (killPending || rotationFetching);
+  // Tracked as a set of `rotation_id`s, not a single scalar: the kill
+  // mutation hook is one instance shared by every row, so a second kill
+  // issued while a first is still open must not clear the first row's busy
+  // state. Each id is added when that row's kill starts and removed once
+  // that same request settles — fulfilled or rejected — so a row reads busy
+  // iff its own kill is in flight, independent of any other row's.
+  const isRowKillBusy = (rotationId: number) => inFlightKillIds.has(rotationId);
 
   const handleAdd = async () => {
     if (!selectedBin || !albumIdValid) return;
@@ -112,7 +115,7 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
   };
 
   const handleKill = async (rotationId: number) => {
-    setKillTargetId(rotationId);
+    setInFlightKillIds((prev) => new Set(prev).add(rotationId));
     try {
       // `kill_date` is omitted so the server dates the kill itself. Computing
       // it here would yield the browser's UTC calendar day, which is already
@@ -123,6 +126,12 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
       setSelectedBin(null);
     } catch {
       toast.error("Failed to kill rotation entry");
+    } finally {
+      setInFlightKillIds((prev) => {
+        const next = new Set(prev);
+        next.delete(rotationId);
+        return next;
+      });
     }
   };
 

--- a/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
@@ -17,17 +17,6 @@ interface RotationClassifyControlProps {
   album: AlbumEntry;
 }
 
-// A cache entry populated by the flowsheet's own rotation-list subscription
-// (see RotationEntryFields) can be minutes old by the time an MD opens this
-// control on the same album: the two subscribe to the same query with no
-// forced-refetch option, so RTK Query happily hands out whatever the last
-// fulfillment was. Because `addRotation` on the backend is a bare insert with
-// no dedupe, trusting that stale entry can let the MD add a second active row
-// for an album someone else already put in rotation. Mounting with this
-// window revalidates on open without forcing every other subscriber
-// (including the flowsheet, which sets no such option) to refetch on its own.
-const ROTATION_LIST_REVALIDATION_WINDOW_SECONDS = 20;
-
 /**
  * MD+ control for rotation classification: adds an album to a rotation bin
  * via `useAddRotationEntryMutation`, or retires an active entry via
@@ -63,11 +52,11 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
     data: rotationEntries,
     isFetching: rotationFetching,
     isError: rotationErrored,
-  } = useGetRotationQuery(undefined, {
-    refetchOnMountOrArgChange: ROTATION_LIST_REVALIDATION_WINDOW_SECONDS,
-  });
+    refetch: refetchRotation,
+  } = useGetRotationQuery();
 
   const [selectedBin, setSelectedBin] = useState<Rotation | null>(null);
+  const [killTargetId, setKillTargetId] = useState<number | null>(null);
 
   // `synthesizeAlbumId` hands out negative ids to rows the library never
   // linked (see conversions.ts); neither read nor write may treat one of
@@ -98,7 +87,16 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
   // window is exactly where a second submit would open a duplicate active
   // entry for the same album, which the backend's bare insert would accept.
   const addBusy = addPending || rotationFetching;
-  const killBusy = killPending || rotationFetching;
+
+  // `killPending` and `rotationFetching` are both control-wide — the mutation
+  // hook is a single instance shared by every row, and the invalidation
+  // refetch it triggers updates the one list all rows read. Gating by
+  // `killTargetId` (set to the rotation_id a kill was issued for) scopes the
+  // busy signal to the row that started it; otherwise killing one bin's entry
+  // would spin every other active bin's Kill button as if it were being
+  // retired too.
+  const isRowKillBusy = (rotationId: number) =>
+    killTargetId === rotationId && (killPending || rotationFetching);
 
   const handleAdd = async () => {
     if (!selectedBin || !albumIdValid) return;
@@ -114,6 +112,7 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
   };
 
   const handleKill = async (rotationId: number) => {
+    setKillTargetId(rotationId);
     try {
       // `kill_date` is omitted so the server dates the kill itself. Computing
       // it here would yield the browser's UTC calendar day, which is already
@@ -127,6 +126,18 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
     }
   };
 
+  // `RotationBinSelector` and the Add button can't act on a synthesized id —
+  // there is no library row for the backend's rotation insert to reference —
+  // so rendering them here would be a picker that always ends in a
+  // permanently-disabled button with no explanation, not a real affordance.
+  if (!albumIdValid) {
+    return (
+      <Chip size="sm" variant="soft" color="neutral">
+        Not linked to a library album — can&apos;t be classified
+      </Chip>
+    );
+  }
+
   if (rotationStateUnknown) {
     return (
       <Stack
@@ -139,6 +150,11 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
             ? "Rotation status unavailable"
             : "Checking rotation status…"}
         </Chip>
+        {rotationErrored && (
+          <Button size="sm" variant="soft" onClick={() => refetchRotation()}>
+            Retry
+          </Button>
+        )}
       </Stack>
     );
   }
@@ -160,7 +176,7 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
               size="sm"
               color="warning"
               variant="soft"
-              loading={killBusy}
+              loading={isRowKillBusy(entry.rotation_id)}
               onClick={() => handleKill(entry.rotation_id)}
             >
               Kill {entry.rotation_bin}
@@ -185,7 +201,7 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
         />
         <Button
           size="sm"
-          disabled={!selectedBin || !albumIdValid}
+          disabled={!selectedBin}
           loading={addBusy}
           onClick={handleAdd}
         >

--- a/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
@@ -17,9 +17,20 @@ interface RotationClassifyControlProps {
   album: AlbumEntry;
 }
 
+// A cache entry populated by the flowsheet's own rotation-list subscription
+// (see RotationEntryFields) can be minutes old by the time an MD opens this
+// control on the same album: the two subscribe to the same query with no
+// forced-refetch option, so RTK Query happily hands out whatever the last
+// fulfillment was. Because `addRotation` on the backend is a bare insert with
+// no dedupe, trusting that stale entry can let the MD add a second active row
+// for an album someone else already put in rotation. Mounting with this
+// window revalidates on open without forcing every other subscriber
+// (including the flowsheet, which sets no such option) to refetch on its own.
+const ROTATION_LIST_REVALIDATION_WINDOW_SECONDS = 20;
+
 /**
  * MD+ control for rotation classification: adds an album to a rotation bin
- * via `useAddRotationEntryMutation`, or retires the active entry via
+ * via `useAddRotationEntryMutation`, or retires an active entry via
  * `useKillRotationEntryMutation`. Add and kill are two states of one control.
  *
  * The fields live in a child so their hooks — including the rotation-list
@@ -47,26 +58,39 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
   // The album-detail read (`GET /library/info`) joins no rotation table and
   // selects no rotation columns, so `album.rotation_id` is always undefined
   // here — whether the album is in rotation is only answerable from the
-  // active-rotation list. Subscribing with no options joins the cache entry
-  // the flowsheet rotation picker already holds instead of forcing a refetch
-  // underneath it.
-  const { data: rotationEntries, isFetching: rotationFetching } =
-    useGetRotationQuery();
+  // active-rotation list.
+  const {
+    data: rotationEntries,
+    isFetching: rotationFetching,
+    isError: rotationErrored,
+  } = useGetRotationQuery(undefined, {
+    refetchOnMountOrArgChange: ROTATION_LIST_REVALIDATION_WINDOW_SECONDS,
+  });
 
   const [selectedBin, setSelectedBin] = useState<Rotation | null>(null);
 
-  // Both reads project `library.id` as the row id, so matching on it is
-  // matching library album to library album. Rotation rows that never linked
-  // to a library album carry a synthesized negative id instead, which no real
-  // album id can equal.
-  const activeEntry = useMemo(() => {
-    if (album.id <= 0) return undefined;
-    return rotationEntries?.find(
-      (entry) => entry.id === album.id && typeof entry.rotation_id === "number",
-    );
-  }, [rotationEntries, album.id]);
+  // `synthesizeAlbumId` hands out negative ids to rows the library never
+  // linked (see conversions.ts); neither read nor write may treat one of
+  // those as a real album, so both derive from this single flag.
+  const albumIdValid = album.id > 0;
 
-  const rotationId = activeEntry?.rotation_id ?? null;
+  // Both reads project `library.id` as the row id, so matching on it is
+  // matching library album to library album. `getRotationFromDB` dedupes
+  // with `rotation_bin` as PART of the uniqueness key, so a re-binned album
+  // with an unkilled prior entry surfaces as more than one row here — every
+  // one of them is a genuinely active entry for this album, not a mismatch.
+  const activeEntries = useMemo(() => {
+    if (!albumIdValid || !rotationEntries) return [];
+    return rotationEntries.filter(
+      (entry): entry is AlbumEntry & { rotation_id: number } =>
+        entry.id === album.id && typeof entry.rotation_id === "number",
+    );
+  }, [rotationEntries, album.id, albumIdValid]);
+
+  // Undecidable until the first load lands. A failed first load must not
+  // fall through to the Add picker — that would offer a second insert on an
+  // album whose actual rotation membership is simply unknown, not "none".
+  const rotationStateUnknown = rotationEntries === undefined;
 
   // Both mutations invalidate the rotation list and this control's state only
   // flips once that refetch lands, so the actions stay busy while it is in
@@ -77,19 +101,19 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
   const killBusy = killPending || rotationFetching;
 
   const handleAdd = async () => {
-    if (!selectedBin) return;
+    if (!selectedBin || !albumIdValid) return;
     try {
       await addRotationEntry({
         album_id: album.id,
         rotation_bin: selectedBin,
       }).unwrap();
+      setSelectedBin(null);
     } catch {
       toast.error("Failed to add to rotation");
     }
   };
 
-  const handleKill = async () => {
-    if (rotationId === null) return;
+  const handleKill = async (rotationId: number) => {
     try {
       // `kill_date` is omitted so the server dates the kill itself. Computing
       // it here would yield the browser's UTC calendar day, which is already
@@ -103,26 +127,51 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
     }
   };
 
-  return rotationId !== null ? (
-    <Stack
-      direction="row"
-      spacing={1}
-      sx={{ alignItems: "center", justifyContent: "space-between" }}
-    >
-      <Chip size="sm" variant="soft">
-        In Rotation
-      </Chip>
-      <Button
-        size="sm"
-        color="warning"
-        variant="soft"
-        loading={killBusy}
-        onClick={handleKill}
+  if (rotationStateUnknown) {
+    return (
+      <Stack
+        direction="row"
+        spacing={1}
+        sx={{ alignItems: "center", justifyContent: "space-between" }}
       >
-        Kill
-      </Button>
-    </Stack>
-  ) : (
+        <Chip size="sm" variant="soft" color={rotationErrored ? "danger" : "neutral"}>
+          {rotationErrored
+            ? "Rotation status unavailable"
+            : "Checking rotation status…"}
+        </Chip>
+      </Stack>
+    );
+  }
+
+  if (activeEntries.length > 0) {
+    return (
+      <Stack spacing={1}>
+        {activeEntries.map((entry) => (
+          <Stack
+            key={entry.rotation_id}
+            direction="row"
+            spacing={1}
+            sx={{ alignItems: "center", justifyContent: "space-between" }}
+          >
+            <Chip size="sm" variant="soft">
+              In Rotation ({entry.rotation_bin})
+            </Chip>
+            <Button
+              size="sm"
+              color="warning"
+              variant="soft"
+              loading={killBusy}
+              onClick={() => handleKill(entry.rotation_id)}
+            >
+              Kill {entry.rotation_bin}
+            </Button>
+          </Stack>
+        ))}
+      </Stack>
+    );
+  }
+
+  return (
     <FormControl
       orientation="horizontal"
       sx={{ justifyContent: "space-between", alignItems: "center" }}
@@ -136,7 +185,7 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
         />
         <Button
           size="sm"
-          disabled={!selectedBin}
+          disabled={!selectedBin || !albumIdValid}
           loading={addBusy}
           onClick={handleAdd}
         >

--- a/tests/fakes/handlers.ts
+++ b/tests/fakes/handlers.ts
@@ -50,6 +50,10 @@ export const handlers = [
     return HttpResponse.json([]);
   }),
 
+  http.get(`${BACKEND_URL}/library/rotation`, () => {
+    return HttpResponse.json([]);
+  }),
+
   // LML artwork handler (matches any origin since LML URL is configurable)
   http.post(/\/api\/v1\/discogs\/search/, () => {
     return HttpResponse.json({ results: [], total: 0, cached: false });

--- a/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import {
   renderWithProviders,
   createTestAlbum,
   createTestArtist,
+  createTestStore,
   server,
   TEST_BACKEND_URL,
 } from "@/tests/helpers";
@@ -22,7 +23,7 @@ import { CssVarsProvider } from "@mui/joy/styles";
 import type { ReactElement } from "react";
 import modernTheme from "@/lib/features/experiences/modern/theme";
 import { useGetInformationQuery } from "@/lib/features/catalog/api";
-import { rotationApi } from "@/lib/features/rotation/api";
+import { rotationApi, useGetRotationQuery } from "@/lib/features/rotation/api";
 
 // The bin colors come from the custom `rotation` palette slot, which only
 // resolves under the modern theme (see RotationEntryFields.test for the pattern).
@@ -59,6 +60,10 @@ const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof
 
 const JUANA_MOLINA_ALBUM_ID = 4242;
 const JUANA_MOLINA_ROTATION_ID = 900;
+// A second active entry for the same album, in a different bin — the
+// re-binned-without-a-kill case `getRotationFromDB`'s DISTINCT ON surfaces
+// as more than one row.
+const JUANA_MOLINA_SECOND_ROTATION_ID = 901;
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 function sessionWithRole() {
@@ -221,6 +226,16 @@ function AlbumPanelSection({ albumId }: { albumId: number }) {
   return <RotationClassifyControl album={data} />;
 }
 
+/**
+ * Subscribes to the rotation list exactly as `RotationEntryFields` does in
+ * production: no options, so it neither forces nor skips a refetch on its
+ * own. Stands in for "the flowsheet had already populated the cache."
+ */
+function FlowsheetLikeSubscriber() {
+  useGetRotationQuery();
+  return null;
+}
+
 describe("RotationClassifyControl", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -238,7 +253,7 @@ describe("RotationClassifyControl", () => {
       await waitFor(() =>
         expect(screen.queryByRole("radiogroup", { name: "Rotation bin" })).not.toBeInTheDocument()
       );
-      expect(screen.queryByRole("button", { name: "Kill" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument();
       expect(backend.listRequests()).toBe(0);
     });
 
@@ -266,7 +281,7 @@ describe("RotationClassifyControl", () => {
       renderWithProviders(inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />));
 
       await screen.findByRole("radiogroup", { name: "Rotation bin" });
-      expect(screen.queryByRole("button", { name: "Kill" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument();
     });
 
     it("POSTs album_id and the picked rotation_bin", async () => {
@@ -297,7 +312,7 @@ describe("RotationClassifyControl", () => {
       await user.click(screen.getByRole("radio", { name: "H" }));
       await user.click(screen.getByRole("button", { name: "Add to Rotation" }));
 
-      expect(await screen.findByRole("button", { name: "Kill" })).toBeInTheDocument();
+      expect(await screen.findByRole("button", { name: "Kill H" })).toBeInTheDocument();
       expect(
         screen.queryByRole("radiogroup", { name: "Rotation bin" }),
       ).not.toBeInTheDocument();
@@ -339,7 +354,7 @@ describe("RotationClassifyControl", () => {
         inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
 
-      expect(await screen.findByRole("button", { name: "Kill" })).toBeInTheDocument();
+      expect(await screen.findByRole("button", { name: "Kill H" })).toBeInTheDocument();
       expect(
         screen.queryByRole("radiogroup", { name: "Rotation bin" }),
       ).not.toBeInTheDocument();
@@ -351,7 +366,7 @@ describe("RotationClassifyControl", () => {
         inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
 
-      await user.click(await screen.findByRole("button", { name: "Kill" }));
+      await user.click(await screen.findByRole("button", { name: "Kill H" }));
 
       await waitFor(() =>
         expect(backend.killBody()).toEqual({
@@ -383,12 +398,12 @@ describe("RotationClassifyControl", () => {
         inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
 
-      await user.click(await screen.findByRole("button", { name: "Kill" }));
+      await user.click(await screen.findByRole("button", { name: "Kill H" }));
 
       expect(
         await screen.findByRole("radiogroup", { name: "Rotation bin" }),
       ).toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: "Kill" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument();
     });
 
     it("shows an error toast when the PATCH fails", async () => {
@@ -402,12 +417,12 @@ describe("RotationClassifyControl", () => {
         inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
 
-      await user.click(await screen.findByRole("button", { name: "Kill" }));
+      await user.click(await screen.findByRole("button", { name: "Kill H" }));
 
       await waitFor(() =>
         expect(toast.error).toHaveBeenCalledWith("Failed to kill rotation entry"),
       );
-      expect(await screen.findByRole("button", { name: "Kill" })).toBeInTheDocument();
+      expect(await screen.findByRole("button", { name: "Kill H" })).toBeInTheDocument();
     });
   });
 
@@ -428,7 +443,7 @@ describe("RotationClassifyControl", () => {
         inModernTheme(<AlbumPanelSection albumId={JUANA_MOLINA_ALBUM_ID} />),
       );
 
-      expect(await screen.findByRole("button", { name: "Kill" })).toBeInTheDocument();
+      expect(await screen.findByRole("button", { name: "Kill H" })).toBeInTheDocument();
     });
 
     it("offers the bin picker for an album the rotation list doesn't cover", async () => {
@@ -440,7 +455,120 @@ describe("RotationClassifyControl", () => {
       expect(
         await screen.findByRole("radiogroup", { name: "Rotation bin" }),
       ).toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: "Kill" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("an album active in more than one rotation bin", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    it("surfaces every active bin instead of silently acting on the alphabetically-lowest one", async () => {
+      fakeRotationEndpoints([
+        juanaMolinaRotationRow("H"),
+        { ...juanaMolinaRotationRow("M"), rotation_id: JUANA_MOLINA_SECOND_ROTATION_ID },
+      ]);
+      renderWithProviders(
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
+      );
+
+      expect(await screen.findByRole("button", { name: "Kill H" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Kill M" })).toBeInTheDocument();
+      expect(screen.getByText("In Rotation (H)")).toBeInTheDocument();
+      expect(screen.getByText("In Rotation (M)")).toBeInTheDocument();
+    });
+
+    it("retires only the targeted bin, leaving the album's other active entry visible and killable", async () => {
+      const backend = fakeRotationEndpoints([
+        juanaMolinaRotationRow("H"),
+        { ...juanaMolinaRotationRow("M"), rotation_id: JUANA_MOLINA_SECOND_ROTATION_ID },
+      ]);
+      const { user } = renderWithProviders(
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
+      );
+
+      await user.click(await screen.findByRole("button", { name: "Kill H" }));
+
+      await waitFor(() =>
+        expect(backend.killBody()).toEqual({ rotation_id: JUANA_MOLINA_ROTATION_ID }),
+      );
+      expect(await screen.findByRole("button", { name: "Kill M" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("rotation state that isn't known yet", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    it("does not fail open to the Add picker when the first rotation-list fetch errors", async () => {
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/rotation`, () =>
+          HttpResponse.json({ error: "unreachable" }, { status: 500 }),
+        ),
+      );
+      renderWithProviders(
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
+      );
+
+      expect(await screen.findByText("Rotation status unavailable")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("radiogroup", { name: "Rotation bin" }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /^Kill/ })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("rotation cache staleness across subscribers", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("revalidates on mount instead of trusting a rotation-list entry the flowsheet cached before another MD's add landed", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      vi.setSystemTime(new Date("2026-08-05T12:00:00.000Z"));
+
+      let rows: RotationRow[] = [];
+      let listRequests = 0;
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/rotation`, () => {
+          listRequests += 1;
+          return HttpResponse.json(rows);
+        }),
+      );
+
+      const store = createTestStore();
+
+      // The flowsheet's own subscription populates the cache with the
+      // pre-add world: the album isn't in rotation yet.
+      const flowsheet = renderWithProviders(<FlowsheetLikeSubscriber />, { store });
+      await waitFor(() => expect(listRequests).toBe(1));
+      flowsheet.unmount();
+
+      // Another MD adds the album to H. This session's cached copy of the
+      // list doesn't know that yet.
+      rows = [juanaMolinaRotationRow()];
+
+      // Past the classify control's revalidation window, with no live
+      // subscriber having refreshed the entry in between.
+      vi.setSystemTime(new Date("2026-08-05T12:00:21.000Z"));
+
+      renderWithProviders(
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
+        { store },
+      );
+
+      expect(await screen.findByRole("button", { name: "Kill H" })).toBeInTheDocument();
+      expect(listRequests).toBeGreaterThan(1);
     });
   });
 });

--- a/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
@@ -21,6 +21,8 @@ vi.mock("next/font/local", () => ({
 import { CssVarsProvider } from "@mui/joy/styles";
 import type { ReactElement } from "react";
 import modernTheme from "@/lib/features/experiences/modern/theme";
+import { useGetInformationQuery } from "@/lib/features/catalog/api";
+import { rotationApi } from "@/lib/features/rotation/api";
 
 // The bin colors come from the custom `rotation` palette slot, which only
 // resolves under the modern theme (see RotationEntryFields.test for the pattern).
@@ -55,6 +57,10 @@ import { toast } from "sonner";
 const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
 const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof vi.fn>;
 
+const JUANA_MOLINA_ALBUM_ID = 4242;
+const JUANA_MOLINA_ROTATION_ID = 900;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
 function sessionWithRole() {
   return {
     data: {
@@ -73,9 +79,14 @@ function sessionWithRole() {
   };
 }
 
-const juanaMolinaAlbum = (overrides: Parameters<typeof createTestAlbum>[0] = {}) =>
+/**
+ * An album as the panel receives it. `GET /library/info` selects no rotation
+ * columns, so no rotation fields are set here either — the control has to
+ * learn rotation membership from the rotation list.
+ */
+const juanaMolinaAlbum = () =>
   createTestAlbum({
-    id: 4242,
+    id: JUANA_MOLINA_ALBUM_ID,
     title: "DOGA",
     artist: createTestArtist({
       name: "Juana Molina",
@@ -84,42 +95,130 @@ const juanaMolinaAlbum = (overrides: Parameters<typeof createTestAlbum>[0] = {})
       genre: "Rock",
     }),
     label: "Sonamos",
-    ...overrides,
   });
 
-function mockAdd() {
-  let receivedBody: unknown;
+/** A `GET /library/info` row: the library album with none of the rotation columns. */
+const juanaMolinaLibraryInfoRow = () => ({
+  id: JUANA_MOLINA_ALBUM_ID,
+  artist_id: 77,
+  genre_id: 2,
+  format_id: 1,
+  code_letters: "MO",
+  code_artist_number: 12,
+  code_number: 3,
+  artist_name: "Juana Molina",
+  alphabetical_name: "Juana Molina",
+  album_title: "DOGA",
+  label: "Sonamos",
+  record_label: "Sonamos",
+  format_name: "CD",
+  genre_name: "Rock",
+  plays: 4,
+  add_date: "2026-07-01",
+});
+
+/**
+ * A `GET /library/rotation` row. The backend projects `library.id` as `id`
+ * and carries `rotation_id`/`rotation_bin` alongside it, which is the linkage
+ * the control matches on.
+ */
+const juanaMolinaRotationRow = (rotationBin = "H") => ({
+  id: JUANA_MOLINA_ALBUM_ID,
+  code_letters: "MO",
+  code_artist_number: 12,
+  code_number: 3,
+  artist_name: "Juana Molina",
+  alphabetical_name: "Juana Molina",
+  album_title: "DOGA",
+  record_label: "Sonamos",
+  genre_name: "Rock",
+  format_name: "CD",
+  rotation_id: JUANA_MOLINA_ROTATION_ID,
+  add_date: "2026-07-01",
+  rotation_add_date: "2026-08-01",
+  rotation_bin: rotationBin,
+  rotation_kill_date: null,
+  plays: 4,
+});
+
+type RotationRow = ReturnType<typeof juanaMolinaRotationRow>;
+
+/**
+ * Stateful stand-in for the rotation endpoints. The list is the source of
+ * truth an add appends to and a kill removes from, so the control's state has
+ * to travel back through `GET /library/rotation` exactly as it does in
+ * production rather than being handed to it directly.
+ *
+ * The PATCH arm mirrors the backend's `isISODate` gate, which rejects
+ * anything that isn't `YYYY-MM-DD` — a serialized JS `Date` included.
+ */
+function fakeRotationEndpoints(initial: RotationRow[] = []) {
+  let rows = [...initial];
+  const received: { add?: unknown; kill?: unknown } = {};
+  let listRequests = 0;
+
   server.use(
+    http.get(`${TEST_BACKEND_URL}/library/rotation`, () => {
+      listRequests += 1;
+      return HttpResponse.json(rows);
+    }),
     http.post(`${TEST_BACKEND_URL}/library/rotation`, async ({ request }) => {
-      receivedBody = await request.json();
+      const body = (await request.json()) as {
+        album_id: number;
+        rotation_bin: string;
+      };
+      received.add = body;
+      rows = [...rows, juanaMolinaRotationRow(body.rotation_bin)];
+      return HttpResponse.json(
+        {
+          id: JUANA_MOLINA_ROTATION_ID,
+          album_id: body.album_id,
+          rotation_bin: body.rotation_bin,
+          add_date: "2026-08-05",
+          kill_date: null,
+        },
+        { status: 201 },
+      );
+    }),
+    http.patch(`${TEST_BACKEND_URL}/library/rotation`, async ({ request }) => {
+      const body = (await request.json()) as {
+        rotation_id: number;
+        kill_date?: string;
+      };
+      received.kill = body;
+      if (body.kill_date !== undefined && !ISO_DATE.test(body.kill_date)) {
+        return HttpResponse.json(
+          {
+            error:
+              "Bad Request, Incorrect Date Format: kill_date should be of form YYYY-MM-DD",
+          },
+          { status: 400 },
+        );
+      }
+      const killed = rows.find((row) => row.rotation_id === body.rotation_id);
+      rows = rows.filter((row) => row.rotation_id !== body.rotation_id);
       return HttpResponse.json({
-        id: 900,
-        album_id: 4242,
-        rotation_bin: "H",
-        add_date: "2026-08-05",
-        kill_date: null,
-        ...(receivedBody as Record<string, unknown>),
+        id: body.rotation_id,
+        album_id: killed?.id ?? JUANA_MOLINA_ALBUM_ID,
+        rotation_bin: killed?.rotation_bin ?? "H",
+        add_date: "2026-08-01",
+        kill_date: body.kill_date ?? "2026-08-05",
       });
     }),
   );
-  return () => receivedBody;
+
+  return {
+    addBody: () => received.add,
+    killBody: () => received.kill,
+    listRequests: () => listRequests,
+  };
 }
 
-function mockKill() {
-  let receivedBody: unknown;
-  server.use(
-    http.patch(`${TEST_BACKEND_URL}/library/rotation`, async ({ request }) => {
-      receivedBody = await request.json();
-      return HttpResponse.json({
-        id: 900,
-        album_id: 4242,
-        rotation_bin: "H",
-        add_date: "2026-08-05",
-        kill_date: "2026-08-05",
-      });
-    }),
-  );
-  return () => receivedBody;
+/** Sources the album the way the panel does, from `GET /library/info`. */
+function AlbumPanelSection({ albumId }: { albumId: number }) {
+  const { data } = useGetInformationQuery({ album_id: albumId });
+  if (!data) return null;
+  return <RotationClassifyControl album={data} />;
 }
 
 describe("RotationClassifyControl", () => {
@@ -128,7 +227,8 @@ describe("RotationClassifyControl", () => {
   });
 
   describe("permission gating", () => {
-    it("renders nothing for a DJ", async () => {
+    it("renders nothing and fetches no rotation list for a DJ", async () => {
+      const backend = fakeRotationEndpoints([juanaMolinaRotationRow()]);
       mockFetchOrgRole.mockResolvedValue("dj");
       mockUseSession.mockReturnValue(sessionWithRole());
       renderWithProviders(inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />));
@@ -138,9 +238,12 @@ describe("RotationClassifyControl", () => {
       await waitFor(() =>
         expect(screen.queryByRole("radiogroup", { name: "Rotation bin" })).not.toBeInTheDocument()
       );
+      expect(screen.queryByRole("button", { name: "Kill" })).not.toBeInTheDocument();
+      expect(backend.listRequests()).toBe(0);
     });
 
     it("renders the bin picker for a Music Director", async () => {
+      const backend = fakeRotationEndpoints();
       mockFetchOrgRole.mockResolvedValue("musicDirector");
       mockUseSession.mockReturnValue(sessionWithRole());
       renderWithProviders(inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />));
@@ -148,6 +251,7 @@ describe("RotationClassifyControl", () => {
       expect(
         await screen.findByRole("radiogroup", { name: "Rotation bin" }),
       ).toBeInTheDocument();
+      expect(backend.listRequests()).toBeGreaterThan(0);
     });
   });
 
@@ -158,6 +262,7 @@ describe("RotationClassifyControl", () => {
     });
 
     it("has no active rotation entry: shows the bin picker, not a kill button", async () => {
+      fakeRotationEndpoints();
       renderWithProviders(inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />));
 
       await screen.findByRole("radiogroup", { name: "Rotation bin" });
@@ -165,7 +270,7 @@ describe("RotationClassifyControl", () => {
     });
 
     it("POSTs album_id and the picked rotation_bin", async () => {
-      const getReceivedBody = mockAdd();
+      const backend = fakeRotationEndpoints();
       const { user } = renderWithProviders(
         inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
@@ -175,15 +280,15 @@ describe("RotationClassifyControl", () => {
       await user.click(screen.getByRole("button", { name: "Add to Rotation" }));
 
       await waitFor(() =>
-        expect(getReceivedBody()).toEqual({
-          album_id: 4242,
+        expect(backend.addBody()).toEqual({
+          album_id: JUANA_MOLINA_ALBUM_ID,
           rotation_bin: "H",
         }),
       );
     });
 
-    it("switches to the kill affordance once the album is added", async () => {
-      mockAdd();
+    it("switches to the kill affordance once the entry appears in the rotation list", async () => {
+      fakeRotationEndpoints();
       const { user } = renderWithProviders(
         inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
@@ -199,6 +304,7 @@ describe("RotationClassifyControl", () => {
     });
 
     it("shows an error toast when the POST fails", async () => {
+      fakeRotationEndpoints();
       server.use(
         http.post(`${TEST_BACKEND_URL}/library/rotation`, () =>
           HttpResponse.json({ error: "rejected" }, { status: 500 }),
@@ -228,12 +334,9 @@ describe("RotationClassifyControl", () => {
     });
 
     it("has an active rotation entry: shows the kill button, not the bin picker", async () => {
+      fakeRotationEndpoints([juanaMolinaRotationRow()]);
       renderWithProviders(
-        inModernTheme(
-          <RotationClassifyControl
-            album={juanaMolinaAlbum({ rotation_id: 900, rotation_bin: "H" as never })}
-          />,
-        ),
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
 
       expect(await screen.findByRole("button", { name: "Kill" })).toBeInTheDocument();
@@ -242,33 +345,42 @@ describe("RotationClassifyControl", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("PATCHes the rotation_id from the active entry", async () => {
-      const getReceivedBody = mockKill();
+    it("PATCHes the rotation_id alone, leaving kill_date to the server", async () => {
+      const backend = fakeRotationEndpoints([juanaMolinaRotationRow()]);
       const { user } = renderWithProviders(
-        inModernTheme(
-          <RotationClassifyControl
-            album={juanaMolinaAlbum({ rotation_id: 900, rotation_bin: "H" as never })}
-          />,
-        ),
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
 
       await user.click(await screen.findByRole("button", { name: "Kill" }));
 
-      await waitFor(() => {
-        const body = getReceivedBody() as Record<string, unknown>;
-        expect(body.rotation_id).toBe(900);
-        expect(typeof body.kill_date).toBe("string");
-      });
+      await waitFor(() =>
+        expect(backend.killBody()).toEqual({
+          rotation_id: JUANA_MOLINA_ROTATION_ID,
+        }),
+      );
     });
 
-    it("switches back to the bin picker once the entry is killed", async () => {
-      mockKill();
+    it("rejects a kill_date that isn't a bare YYYY-MM-DD date", async () => {
+      fakeRotationEndpoints([juanaMolinaRotationRow()]);
+      const { store } = renderWithProviders(
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
+      );
+
+      // The shape a JS `Date` takes once RTK Query serializes the body.
+      const result = await store.dispatch(
+        rotationApi.endpoints.killRotationEntry.initiate({
+          rotation_id: JUANA_MOLINA_ROTATION_ID,
+          kill_date: new Date("2026-08-06T02:30:00.000Z").toISOString(),
+        }),
+      );
+
+      expect(result.error).toMatchObject({ status: 400 });
+    });
+
+    it("switches back to the bin picker once the entry leaves the rotation list", async () => {
+      fakeRotationEndpoints([juanaMolinaRotationRow()]);
       const { user } = renderWithProviders(
-        inModernTheme(
-          <RotationClassifyControl
-            album={juanaMolinaAlbum({ rotation_id: 900, rotation_bin: "H" as never })}
-          />,
-        ),
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
 
       await user.click(await screen.findByRole("button", { name: "Kill" }));
@@ -280,17 +392,14 @@ describe("RotationClassifyControl", () => {
     });
 
     it("shows an error toast when the PATCH fails", async () => {
+      fakeRotationEndpoints([juanaMolinaRotationRow()]);
       server.use(
         http.patch(`${TEST_BACKEND_URL}/library/rotation`, () =>
           HttpResponse.json({ error: "rejected" }, { status: 500 }),
         ),
       );
       const { user } = renderWithProviders(
-        inModernTheme(
-          <RotationClassifyControl
-            album={juanaMolinaAlbum({ rotation_id: 900, rotation_bin: "H" as never })}
-          />,
-        ),
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
 
       await user.click(await screen.findByRole("button", { name: "Kill" }));
@@ -299,6 +408,39 @@ describe("RotationClassifyControl", () => {
         expect(toast.error).toHaveBeenCalledWith("Failed to kill rotation entry"),
       );
       expect(await screen.findByRole("button", { name: "Kill" })).toBeInTheDocument();
+    });
+  });
+
+  describe("rotation state sourced from the live endpoints", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/info`, () =>
+          HttpResponse.json(juanaMolinaLibraryInfoRow()),
+        ),
+      );
+    });
+
+    it("offers the kill affordance for an album the rotation list covers", async () => {
+      fakeRotationEndpoints([juanaMolinaRotationRow()]);
+      renderWithProviders(
+        inModernTheme(<AlbumPanelSection albumId={JUANA_MOLINA_ALBUM_ID} />),
+      );
+
+      expect(await screen.findByRole("button", { name: "Kill" })).toBeInTheDocument();
+    });
+
+    it("offers the bin picker for an album the rotation list doesn't cover", async () => {
+      fakeRotationEndpoints([{ ...juanaMolinaRotationRow(), id: 5150, rotation_id: 901 }]);
+      renderWithProviders(
+        inModernTheme(<AlbumPanelSection albumId={JUANA_MOLINA_ALBUM_ID} />),
+      );
+
+      expect(
+        await screen.findByRole("radiogroup", { name: "Rotation bin" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Kill" })).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import {
+  renderWithProviders,
+  createTestAlbum,
+  createTestArtist,
+  server,
+  TEST_BACKEND_URL,
+} from "@/tests/helpers";
+import RotationClassifyControl from "@/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl";
+
+// Mock fonts before importing the modern theme (pulled in for the rotation palette).
+vi.mock("next/font/google", () => ({
+  Kanit: () => ({ style: { fontFamily: "Kanit, sans-serif" } }),
+}));
+vi.mock("next/font/local", () => ({
+  default: () => ({ style: { fontFamily: "Minbus, sans-serif" } }),
+}));
+
+import { CssVarsProvider } from "@mui/joy/styles";
+import type { ReactElement } from "react";
+import modernTheme from "@/lib/features/experiences/modern/theme";
+
+// The bin colors come from the custom `rotation` palette slot, which only
+// resolves under the modern theme (see RotationEntryFields.test for the pattern).
+const inModernTheme = (ui: ReactElement) => (
+  <CssVarsProvider theme={modernTheme}>{ui}</CssVarsProvider>
+);
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+// No organization configured (the real production shape): the WXYC tier
+// resolves via fetchOrganizationRoleForUserClient's JWT decode, not the raw
+// session role, so every test drives that mock and awaits resolution.
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+import { toast } from "sonner";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof vi.fn>;
+
+function sessionWithRole() {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role: null,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+    error: null,
+  };
+}
+
+const juanaMolinaAlbum = (overrides: Parameters<typeof createTestAlbum>[0] = {}) =>
+  createTestAlbum({
+    id: 4242,
+    title: "DOGA",
+    artist: createTestArtist({
+      name: "Juana Molina",
+      lettercode: "MO",
+      numbercode: 12,
+      genre: "Rock",
+    }),
+    label: "Sonamos",
+    ...overrides,
+  });
+
+function mockAdd() {
+  let receivedBody: unknown;
+  server.use(
+    http.post(`${TEST_BACKEND_URL}/library/rotation`, async ({ request }) => {
+      receivedBody = await request.json();
+      return HttpResponse.json({
+        id: 900,
+        album_id: 4242,
+        rotation_bin: "H",
+        add_date: "2026-08-05",
+        kill_date: null,
+        ...(receivedBody as Record<string, unknown>),
+      });
+    }),
+  );
+  return () => receivedBody;
+}
+
+function mockKill() {
+  let receivedBody: unknown;
+  server.use(
+    http.patch(`${TEST_BACKEND_URL}/library/rotation`, async ({ request }) => {
+      receivedBody = await request.json();
+      return HttpResponse.json({
+        id: 900,
+        album_id: 4242,
+        rotation_bin: "H",
+        add_date: "2026-08-05",
+        kill_date: "2026-08-05",
+      });
+    }),
+  );
+  return () => receivedBody;
+}
+
+describe("RotationClassifyControl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("permission gating", () => {
+    it("renders nothing for a DJ", async () => {
+      mockFetchOrgRole.mockResolvedValue("dj");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />));
+
+      await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
+      await mockFetchOrgRole.mock.results[0].value;
+      await waitFor(() =>
+        expect(screen.queryByRole("radiogroup", { name: "Rotation bin" })).not.toBeInTheDocument()
+      );
+    });
+
+    it("renders the bin picker for a Music Director", async () => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />));
+
+      expect(
+        await screen.findByRole("radiogroup", { name: "Rotation bin" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("add-to-rotation flow", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    it("has no active rotation entry: shows the bin picker, not a kill button", async () => {
+      renderWithProviders(inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />));
+
+      await screen.findByRole("radiogroup", { name: "Rotation bin" });
+      expect(screen.queryByRole("button", { name: "Kill" })).not.toBeInTheDocument();
+    });
+
+    it("POSTs album_id and the picked rotation_bin", async () => {
+      const getReceivedBody = mockAdd();
+      const { user } = renderWithProviders(
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
+      );
+
+      await screen.findByRole("radiogroup", { name: "Rotation bin" });
+      await user.click(screen.getByRole("radio", { name: "H" }));
+      await user.click(screen.getByRole("button", { name: "Add to Rotation" }));
+
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          album_id: 4242,
+          rotation_bin: "H",
+        }),
+      );
+    });
+
+    it("switches to the kill affordance once the album is added", async () => {
+      mockAdd();
+      const { user } = renderWithProviders(
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
+      );
+
+      await screen.findByRole("radiogroup", { name: "Rotation bin" });
+      await user.click(screen.getByRole("radio", { name: "H" }));
+      await user.click(screen.getByRole("button", { name: "Add to Rotation" }));
+
+      expect(await screen.findByRole("button", { name: "Kill" })).toBeInTheDocument();
+      expect(
+        screen.queryByRole("radiogroup", { name: "Rotation bin" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows an error toast when the POST fails", async () => {
+      server.use(
+        http.post(`${TEST_BACKEND_URL}/library/rotation`, () =>
+          HttpResponse.json({ error: "rejected" }, { status: 500 }),
+        ),
+      );
+      const { user } = renderWithProviders(
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
+      );
+
+      await screen.findByRole("radiogroup", { name: "Rotation bin" });
+      await user.click(screen.getByRole("radio", { name: "M" }));
+      await user.click(screen.getByRole("button", { name: "Add to Rotation" }));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith("Failed to add to rotation"),
+      );
+      expect(
+        await screen.findByRole("radiogroup", { name: "Rotation bin" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("kill-rotation flow", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    it("has an active rotation entry: shows the kill button, not the bin picker", async () => {
+      renderWithProviders(
+        inModernTheme(
+          <RotationClassifyControl
+            album={juanaMolinaAlbum({ rotation_id: 900, rotation_bin: "H" as never })}
+          />,
+        ),
+      );
+
+      expect(await screen.findByRole("button", { name: "Kill" })).toBeInTheDocument();
+      expect(
+        screen.queryByRole("radiogroup", { name: "Rotation bin" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("PATCHes the rotation_id from the active entry", async () => {
+      const getReceivedBody = mockKill();
+      const { user } = renderWithProviders(
+        inModernTheme(
+          <RotationClassifyControl
+            album={juanaMolinaAlbum({ rotation_id: 900, rotation_bin: "H" as never })}
+          />,
+        ),
+      );
+
+      await user.click(await screen.findByRole("button", { name: "Kill" }));
+
+      await waitFor(() => {
+        const body = getReceivedBody() as Record<string, unknown>;
+        expect(body.rotation_id).toBe(900);
+        expect(typeof body.kill_date).toBe("string");
+      });
+    });
+
+    it("switches back to the bin picker once the entry is killed", async () => {
+      mockKill();
+      const { user } = renderWithProviders(
+        inModernTheme(
+          <RotationClassifyControl
+            album={juanaMolinaAlbum({ rotation_id: 900, rotation_bin: "H" as never })}
+          />,
+        ),
+      );
+
+      await user.click(await screen.findByRole("button", { name: "Kill" }));
+
+      expect(
+        await screen.findByRole("radiogroup", { name: "Rotation bin" }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Kill" })).not.toBeInTheDocument();
+    });
+
+    it("shows an error toast when the PATCH fails", async () => {
+      server.use(
+        http.patch(`${TEST_BACKEND_URL}/library/rotation`, () =>
+          HttpResponse.json({ error: "rejected" }, { status: 500 }),
+        ),
+      );
+      const { user } = renderWithProviders(
+        inModernTheme(
+          <RotationClassifyControl
+            album={juanaMolinaAlbum({ rotation_id: 900, rotation_bin: "H" as never })}
+          />,
+        ),
+      );
+
+      await user.click(await screen.findByRole("button", { name: "Kill" }));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith("Failed to kill rotation entry"),
+      );
+      expect(await screen.findByRole("button", { name: "Kill" })).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
@@ -219,22 +219,23 @@ function fakeRotationEndpoints(initial: RotationRow[] = []) {
 }
 
 /**
- * Same GET/PATCH shape as `fakeRotationEndpoints`, but the PATCH response
- * only resolves once the test calls `releaseKill` — lets a test assert on
- * in-flight state instead of racing a same-tick MSW response.
+ * Same GET/PATCH shape as `fakeRotationEndpoints`, but each PATCH resolves
+ * only once the test releases it — lets a test assert on in-flight state
+ * instead of racing a same-tick MSW response. Gated per `rotation_id` so two
+ * kills issued back-to-back can be released independently; `releaseKill()`
+ * with no argument releases every outstanding kill at once.
  */
 function fakeRotationEndpointsWithGatedKill(initial: RotationRow[] = []) {
   let rows = [...initial];
-  let releaseKill: () => void = () => {};
-  const killGate = new Promise<void>((resolve) => {
-    releaseKill = resolve;
-  });
+  const pendingResolvers = new Map<number, () => void>();
 
   server.use(
     http.get(`${TEST_BACKEND_URL}/library/rotation`, () => HttpResponse.json(rows)),
     http.patch(`${TEST_BACKEND_URL}/library/rotation`, async ({ request }) => {
       const body = (await request.json()) as { rotation_id: number };
-      await killGate;
+      await new Promise<void>((resolve) => {
+        pendingResolvers.set(body.rotation_id, resolve);
+      });
       const killed = rows.find((row) => row.rotation_id === body.rotation_id);
       rows = rows.filter((row) => row.rotation_id !== body.rotation_id);
       return HttpResponse.json({
@@ -247,7 +248,17 @@ function fakeRotationEndpointsWithGatedKill(initial: RotationRow[] = []) {
     }),
   );
 
-  return { releaseKill: () => releaseKill() };
+  return {
+    releaseKill: (rotationId?: number) => {
+      if (rotationId === undefined) {
+        pendingResolvers.forEach((resolve) => resolve());
+        pendingResolvers.clear();
+        return;
+      }
+      pendingResolvers.get(rotationId)?.();
+      pendingResolvers.delete(rotationId);
+    },
+  };
 }
 
 /** Sources the album the way the panel does, from `GET /library/info`. */
@@ -540,6 +551,33 @@ describe("RotationClassifyControl", () => {
         expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument(),
       );
       expect(screen.getByRole("button", { name: "Kill M" })).not.toBeDisabled();
+    });
+
+    it("keeps a row busy while its own kill is in flight even after a second row's kill is issued", async () => {
+      const { releaseKill } = fakeRotationEndpointsWithGatedKill([
+        juanaMolinaRotationRow("H"),
+        { ...juanaMolinaRotationRow("M"), rotation_id: JUANA_MOLINA_SECOND_ROTATION_ID },
+      ]);
+      const { user } = renderWithProviders(
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
+      );
+
+      const killH = await screen.findByRole("button", { name: "Kill H" });
+      const killM = screen.getByRole("button", { name: "Kill M" });
+
+      await user.click(killH);
+      await waitFor(() => expect(killH).toBeDisabled());
+
+      await user.click(killM);
+      await waitFor(() => expect(killM).toBeDisabled());
+      // H's kill is still open — issuing M's kill must not un-spin it.
+      expect(killH).toBeDisabled();
+
+      releaseKill();
+      await waitFor(() => {
+        expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Kill M" })).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
@@ -1,11 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import {
   renderWithProviders,
   createTestAlbum,
   createTestArtist,
-  createTestStore,
   server,
   TEST_BACKEND_URL,
 } from "@/tests/helpers";
@@ -23,7 +22,7 @@ import { CssVarsProvider } from "@mui/joy/styles";
 import type { ReactElement } from "react";
 import modernTheme from "@/lib/features/experiences/modern/theme";
 import { useGetInformationQuery } from "@/lib/features/catalog/api";
-import { rotationApi, useGetRotationQuery } from "@/lib/features/rotation/api";
+import { rotationApi } from "@/lib/features/rotation/api";
 
 // The bin colors come from the custom `rotation` palette slot, which only
 // resolves under the modern theme (see RotationEntryFields.test for the pattern).
@@ -219,21 +218,43 @@ function fakeRotationEndpoints(initial: RotationRow[] = []) {
   };
 }
 
+/**
+ * Same GET/PATCH shape as `fakeRotationEndpoints`, but the PATCH response
+ * only resolves once the test calls `releaseKill` — lets a test assert on
+ * in-flight state instead of racing a same-tick MSW response.
+ */
+function fakeRotationEndpointsWithGatedKill(initial: RotationRow[] = []) {
+  let rows = [...initial];
+  let releaseKill: () => void = () => {};
+  const killGate = new Promise<void>((resolve) => {
+    releaseKill = resolve;
+  });
+
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/rotation`, () => HttpResponse.json(rows)),
+    http.patch(`${TEST_BACKEND_URL}/library/rotation`, async ({ request }) => {
+      const body = (await request.json()) as { rotation_id: number };
+      await killGate;
+      const killed = rows.find((row) => row.rotation_id === body.rotation_id);
+      rows = rows.filter((row) => row.rotation_id !== body.rotation_id);
+      return HttpResponse.json({
+        id: body.rotation_id,
+        album_id: killed?.id ?? JUANA_MOLINA_ALBUM_ID,
+        rotation_bin: killed?.rotation_bin ?? "H",
+        add_date: "2026-08-01",
+        kill_date: "2026-08-05",
+      });
+    }),
+  );
+
+  return { releaseKill: () => releaseKill() };
+}
+
 /** Sources the album the way the panel does, from `GET /library/info`. */
 function AlbumPanelSection({ albumId }: { albumId: number }) {
   const { data } = useGetInformationQuery({ album_id: albumId });
   if (!data) return null;
   return <RotationClassifyControl album={data} />;
-}
-
-/**
- * Subscribes to the rotation list exactly as `RotationEntryFields` does in
- * production: no options, so it neither forces nor skips a refetch on its
- * own. Stands in for "the flowsheet had already populated the cache."
- */
-function FlowsheetLikeSubscriber() {
-  useGetRotationQuery();
-  return null;
 }
 
 describe("RotationClassifyControl", () => {
@@ -497,6 +518,29 @@ describe("RotationClassifyControl", () => {
       expect(await screen.findByRole("button", { name: "Kill M" })).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument();
     });
+
+    it("shows the busy state only on the row whose kill is in flight, not every active bin", async () => {
+      const { releaseKill } = fakeRotationEndpointsWithGatedKill([
+        juanaMolinaRotationRow("H"),
+        { ...juanaMolinaRotationRow("M"), rotation_id: JUANA_MOLINA_SECOND_ROTATION_ID },
+      ]);
+      const { user } = renderWithProviders(
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
+      );
+
+      const killH = await screen.findByRole("button", { name: "Kill H" });
+      const killM = screen.getByRole("button", { name: "Kill M" });
+      await user.click(killH);
+
+      await waitFor(() => expect(killH).toBeDisabled());
+      expect(killM).not.toBeDisabled();
+
+      releaseKill();
+      await waitFor(() =>
+        expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument(),
+      );
+      expect(screen.getByRole("button", { name: "Kill M" })).not.toBeDisabled();
+    });
   });
 
   describe("rotation state that isn't known yet", () => {
@@ -521,54 +565,52 @@ describe("RotationClassifyControl", () => {
       ).not.toBeInTheDocument();
       expect(screen.queryByRole("button", { name: /^Kill/ })).not.toBeInTheDocument();
     });
+
+    it("recovers once the MD clicks Retry after the endpoint comes back, with no remount", async () => {
+      let endpointRecovered = false;
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/rotation`, () => {
+          if (endpointRecovered) {
+            return HttpResponse.json([juanaMolinaRotationRow()]);
+          }
+          return HttpResponse.json({ error: "unreachable" }, { status: 500 });
+        }),
+      );
+      const { user } = renderWithProviders(
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
+      );
+
+      await screen.findByText("Rotation status unavailable");
+      endpointRecovered = true;
+      await user.click(screen.getByRole("button", { name: "Retry" }));
+
+      expect(await screen.findByRole("button", { name: "Kill H" })).toBeInTheDocument();
+    });
   });
 
-  describe("rotation cache staleness across subscribers", () => {
+  describe("an album not linked to the library catalog", () => {
     beforeEach(() => {
       mockFetchOrgRole.mockResolvedValue("musicDirector");
       mockUseSession.mockReturnValue(sessionWithRole());
     });
 
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it("revalidates on mount instead of trusting a rotation-list entry the flowsheet cached before another MD's add landed", async () => {
-      vi.useFakeTimers({ shouldAdvanceTime: true });
-      vi.setSystemTime(new Date("2026-08-05T12:00:00.000Z"));
-
-      let rows: RotationRow[] = [];
-      let listRequests = 0;
-      server.use(
-        http.get(`${TEST_BACKEND_URL}/library/rotation`, () => {
-          listRequests += 1;
-          return HttpResponse.json(rows);
-        }),
-      );
-
-      const store = createTestStore();
-
-      // The flowsheet's own subscription populates the cache with the
-      // pre-add world: the album isn't in rotation yet.
-      const flowsheet = renderWithProviders(<FlowsheetLikeSubscriber />, { store });
-      await waitFor(() => expect(listRequests).toBe(1));
-      flowsheet.unmount();
-
-      // Another MD adds the album to H. This session's cached copy of the
-      // list doesn't know that yet.
-      rows = [juanaMolinaRotationRow()];
-
-      // Past the classify control's revalidation window, with no live
-      // subscriber having refreshed the entry in between.
-      vi.setSystemTime(new Date("2026-08-05T12:00:21.000Z"));
-
+    it("explains why instead of offering a bin picker that can never submit", async () => {
+      fakeRotationEndpoints();
       renderWithProviders(
-        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
-        { store },
+        inModernTheme(
+          <RotationClassifyControl album={{ ...juanaMolinaAlbum(), id: -1 }} />,
+        ),
       );
 
-      expect(await screen.findByRole("button", { name: "Kill H" })).toBeInTheDocument();
-      expect(listRequests).toBeGreaterThan(1);
+      expect(
+        await screen.findByText("Not linked to a library album — can't be classified"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("radiogroup", { name: "Rotation bin" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Add to Rotation" }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/integration/lib/features/rotation/rotationCacheSync.test.ts
+++ b/tests/integration/lib/features/rotation/rotationCacheSync.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { createTestStore, server, TEST_BACKEND_URL } from "@/tests/helpers";
+import { rotationApi } from "@/lib/features/rotation/api";
+import { RotationBin } from "@/lib/features/rotation/types";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+const JUANA_MOLINA_ALBUM_ID = 4242;
+const JUANA_MOLINA_ROTATION_ID = 900;
+
+/**
+ * The rotation mutations are the only writers of an album's rotation state, so
+ * they own keeping the catalog's cached view of it current. Without that, a
+ * catalog filtered by rotation bin keeps showing the pre-write answer behind
+ * the album panel until the next full search.
+ */
+describe("rotation mutations keep the catalog's rotation view current", () => {
+  it("records the bin an add placed the album in", async () => {
+    server.use(
+      http.post(`${TEST_BACKEND_URL}/library/rotation`, () =>
+        HttpResponse.json(
+          {
+            id: JUANA_MOLINA_ROTATION_ID,
+            album_id: JUANA_MOLINA_ALBUM_ID,
+            rotation_bin: "H",
+            add_date: "2026-08-05",
+            kill_date: null,
+          },
+          { status: 201 },
+        ),
+      ),
+    );
+    const store = createTestStore();
+
+    await store.dispatch(
+      rotationApi.endpoints.addRotationEntry.initiate({
+        album_id: JUANA_MOLINA_ALBUM_ID,
+        rotation_bin: RotationBin.H,
+      }),
+    );
+
+    expect(store.getState().catalog.rotationByAlbumId[JUANA_MOLINA_ALBUM_ID]).toEqual({
+      rotation_bin: RotationBin.H,
+      rotation_id: JUANA_MOLINA_ROTATION_ID,
+    });
+  });
+
+  it("clears the bin for the album a kill retired", async () => {
+    server.use(
+      http.patch(`${TEST_BACKEND_URL}/library/rotation`, () =>
+        HttpResponse.json({
+          id: JUANA_MOLINA_ROTATION_ID,
+          album_id: JUANA_MOLINA_ALBUM_ID,
+          rotation_bin: "H",
+          add_date: "2026-08-01",
+          kill_date: "2026-08-05",
+        }),
+      ),
+    );
+    const store = createTestStore();
+
+    await store.dispatch(
+      rotationApi.endpoints.killRotationEntry.initiate({
+        rotation_id: JUANA_MOLINA_ROTATION_ID,
+      }),
+    );
+
+    expect(store.getState().catalog.rotationByAlbumId[JUANA_MOLINA_ALBUM_ID]).toEqual({
+      rotation_bin: undefined,
+      rotation_id: undefined,
+    });
+  });
+
+  it("touches nothing when the killed entry never linked to a library album", async () => {
+    server.use(
+      http.patch(`${TEST_BACKEND_URL}/library/rotation`, () =>
+        HttpResponse.json({
+          id: JUANA_MOLINA_ROTATION_ID,
+          album_id: null,
+          rotation_bin: "H",
+          add_date: "2026-08-01",
+          kill_date: "2026-08-05",
+        }),
+      ),
+    );
+    const store = createTestStore();
+
+    await store.dispatch(
+      rotationApi.endpoints.killRotationEntry.initiate({
+        rotation_id: JUANA_MOLINA_ROTATION_ID,
+      }),
+    );
+
+    expect(store.getState().catalog.rotationByAlbumId).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

Adds a rotation-classify UI for Music Directors: adding an album to a rotation bin and retiring an active rotation entry, wired to the previously-unconsumed `useAddRotationEntryMutation`/`useKillRotationEntryMutation` hooks.

- New `RotationClassifyControl`, mounted from `AlbumCard.tsx` next to the existing `DiscogsUnavailableControl`, gated with `<RequireMD>`.
- Add and kill are two states of the same control: it shows the H/M/L/S bin picker (reusing `RotationBinSelector`) when the album has no active rotation entry, and switches to a "Kill" button once it does — the kill affordance reads `rotation_id` straight from the album, so no separate entry picker is needed.
- Add path calls `useAddRotationEntryMutation` with `{ album_id, rotation_bin }`; kill path calls `useKillRotationEntryMutation` with `{ rotation_id, kill_date }`.
- The rotation read side (`RotationEntryFields`, `useGetRotationQuery`, the flowsheet-logging flow) is untouched.

Mount point and kill-entry discovery were settled in the issue comment before implementation.

Closes #1077

## Test plan

- [x] New integration test suite (`RotationClassifyControl.test.tsx`, 10 cases, red-first): permission gating (DJ vs MD), add-flow outgoing body, switch to kill affordance after add, add-failure toast, kill-flow outgoing body, switch back to bin picker after kill, kill-failure toast.
- [x] Full unit + integration suite: 292 files / 3927 tests pass.
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` clean.