### PR TITLE
MD catalog-edit UI: shared artist-search typeahead

### DIFF
--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -275,7 +275,7 @@ export const {
   useUpdateAlbumMutation,
   useAddArtistMutation,
   useLazyPeekArtistCodeQuery,
-  useLazySearchArtistsInGenreQuery,
+  useSearchArtistsInGenreQuery,
   useGetInformationQuery,
   useGetFormatsQuery,
   useAddFormatMutation,

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { RequireMD } from "@/src/components/shared/Authorization";
+import { useLazySearchArtistsInGenreQuery } from "@/lib/features/catalog/api";
+import type { ArtistInGenreOption } from "@/lib/features/catalog/types";
+import { ClickAwayListener } from "@mui/base/ClickAwayListener";
+import { Box, CircularProgress, Input, Sheet, Typography } from "@mui/joy";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const DEBOUNCE_MS = 300;
+const MIN_QUERY_LENGTH = 2;
+const RESULT_LIMIT = 10;
+
+/**
+ * Shared, MD-gated artist-search typeahead. This is the load-bearing prop
+ * contract for #1076 (Rightbar album panel artist link), #1079 (add-release
+ * panel), and #1080 (artist-add dedup step) — all three mount this component
+ * against their own surface, so changes here ripple to all of them.
+ *
+ * - A controlled search input: the query text is React state owned by this
+ *   component, not a caller-supplied `value`/`onChange` pair — callers only
+ *   observe outcomes (`onSelect`, `onCreateNew`), never raw keystrokes.
+ * - `genreId` scopes the search to `useLazySearchArtistsInGenreQuery`.
+ * - `onSelect(artist)` receives the full matched artist (id AND
+ *   artist_name), never just an id — downstream consumers render the name
+ *   without a second lookup.
+ * - `onCreateNew(searchTerm)` fires on the empty-state "create new" row and
+ *   only hands the current query string back to the caller. It does not
+ *   navigate or open a modal itself — the create flow (dedup, form, etc.)
+ *   belongs to the caller (see #1080).
+ */
+export interface ArtistSearchTypeaheadProps {
+  genreId: number;
+  onSelect: (artist: ArtistInGenreOption) => void;
+  onCreateNew: (searchTerm: string) => void;
+  disabled?: boolean;
+}
+
+function ArtistSearchTypeaheadInner({
+  genreId,
+  onSelect,
+  onCreateNew,
+  disabled,
+}: ArtistSearchTypeaheadProps) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [highlightIndex, setHighlightIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [trigger, { data, isFetching }] = useLazySearchArtistsInGenreQuery();
+
+  const trimmed = query.trim();
+  const hasValidQuery = trimmed.length >= MIN_QUERY_LENGTH;
+
+  useEffect(() => {
+    if (!hasValidQuery) return;
+    const timer = setTimeout(() => {
+      trigger({ genre_id: genreId, q: trimmed, limit: RESULT_LIMIT });
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [trigger, genreId, trimmed, hasValidQuery]);
+
+  const artists = hasValidQuery ? (data?.artists ?? []) : [];
+  const showPanel = open && hasValidQuery;
+  const totalRows = artists.length + 1;
+
+  const handleSelect = useCallback(
+    (artist: ArtistInGenreOption) => {
+      onSelect(artist);
+      setQuery(artist.artist_name);
+      setOpen(false);
+      setHighlightIndex(0);
+    },
+    [onSelect],
+  );
+
+  const handleCreateNew = useCallback(() => {
+    onCreateNew(trimmed);
+    setOpen(false);
+    setHighlightIndex(0);
+  }, [onCreateNew, trimmed]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!showPanel) return;
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setHighlightIndex((prev) => Math.min(prev + 1, totalRows - 1));
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setHighlightIndex((prev) => Math.max(prev - 1, 0));
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (highlightIndex === artists.length) {
+            handleCreateNew();
+          } else if (highlightIndex >= 0 && highlightIndex < artists.length) {
+            handleSelect(artists[highlightIndex]);
+          }
+          break;
+        case "Escape":
+          e.preventDefault();
+          setOpen(false);
+          inputRef.current?.blur();
+          break;
+      }
+    },
+    [showPanel, totalRows, highlightIndex, artists, handleSelect, handleCreateNew],
+  );
+
+  return (
+    <ClickAwayListener onClickAway={() => setOpen(false)}>
+      <Box sx={{ position: "relative", width: "100%" }}>
+        <Input
+          size="sm"
+          fullWidth
+          disabled={disabled}
+          placeholder="Search artists..."
+          value={query}
+          onFocus={() => setOpen(true)}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+            setHighlightIndex(0);
+          }}
+          onKeyDown={handleKeyDown}
+          startDecorator={
+            isFetching ? (
+              <CircularProgress
+                size="sm"
+                sx={{ "--CircularProgress-size": "14px" }}
+              />
+            ) : undefined
+          }
+          slotProps={{
+            input: {
+              ref: inputRef,
+              "aria-label": "Search artists",
+              autoComplete: "off",
+              spellCheck: false,
+            },
+          }}
+        />
+
+        {showPanel && (
+          <Sheet
+            variant="outlined"
+            sx={{
+              position: "absolute",
+              top: "calc(100% + 4px)",
+              left: 0,
+              right: 0,
+              zIndex: 8002,
+              borderRadius: "md",
+              maxHeight: "300px",
+              overflowY: "auto",
+              boxShadow: "0px 8px 24px -4px rgba(0,0,0,0.4)",
+              py: 0.5,
+            }}
+          >
+            {artists.map((artist, index) => (
+              <Box
+                key={artist.id}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => handleSelect(artist)}
+                onMouseEnter={() => setHighlightIndex(index)}
+                sx={{
+                  px: 1.5,
+                  py: 0.75,
+                  cursor: "pointer",
+                  backgroundColor:
+                    highlightIndex === index ? "primary.700" : "transparent",
+                  "&:hover": {
+                    backgroundColor:
+                      highlightIndex === index ? "primary.700" : "neutral.800",
+                  },
+                }}
+              >
+                <Typography
+                  level="body-sm"
+                  sx={{ color: highlightIndex === index ? "white" : "inherit" }}
+                >
+                  {artist.artist_name}
+                </Typography>
+              </Box>
+            ))}
+            <Box
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={handleCreateNew}
+              onMouseEnter={() => setHighlightIndex(artists.length)}
+              sx={{
+                px: 1.5,
+                py: 0.75,
+                cursor: "pointer",
+                borderTop: artists.length > 0 ? "1px solid" : undefined,
+                borderColor: "divider",
+                backgroundColor:
+                  highlightIndex === artists.length
+                    ? "primary.700"
+                    : "transparent",
+                "&:hover": {
+                  backgroundColor:
+                    highlightIndex === artists.length
+                      ? "primary.700"
+                      : "neutral.800",
+                },
+              }}
+            >
+              <Typography
+                level="body-sm"
+                sx={{
+                  fontStyle: "italic",
+                  color: highlightIndex === artists.length ? "white" : "inherit",
+                }}
+              >
+                {artists.length === 0
+                  ? `Create new artist "${trimmed}"`
+                  : `Create new artist "${trimmed}" instead`}
+              </Typography>
+            </Box>
+          </Sheet>
+        )}
+      </Box>
+    </ClickAwayListener>
+  );
+}
+
+export default function ArtistSearchTypeahead(props: ArtistSearchTypeaheadProps) {
+  return (
+    <RequireMD>
+      <ArtistSearchTypeaheadInner {...props} />
+    </RequireMD>
+  );
+}

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -5,29 +5,19 @@ import { useLazySearchArtistsInGenreQuery } from "@/lib/features/catalog/api";
 import type { ArtistInGenreOption } from "@/lib/features/catalog/types";
 import { ClickAwayListener } from "@mui/base/ClickAwayListener";
 import { Box, CircularProgress, Input, Sheet, Typography } from "@mui/joy";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 
 const DEBOUNCE_MS = 300;
 const MIN_QUERY_LENGTH = 2;
 const RESULT_LIMIT = 10;
 
 /**
- * Shared, MD-gated artist-search typeahead. This is the load-bearing prop
- * contract for #1076 (Rightbar album panel artist link), #1079 (add-release
- * panel), and #1080 (artist-add dedup step) — all three mount this component
- * against their own surface, so changes here ripple to all of them.
- *
- * - A controlled search input: the query text is React state owned by this
- *   component, not a caller-supplied `value`/`onChange` pair — callers only
- *   observe outcomes (`onSelect`, `onCreateNew`), never raw keystrokes.
- * - `genreId` scopes the search to `useLazySearchArtistsInGenreQuery`.
- * - `onSelect(artist)` receives the full matched artist (id AND
- *   artist_name), never just an id — downstream consumers render the name
- *   without a second lookup.
- * - `onCreateNew(searchTerm)` fires on the empty-state "create new" row and
- *   only hands the current query string back to the caller. It does not
- *   navigate or open a modal itself — the create flow (dedup, form, etc.)
- *   belongs to the caller (see #1080).
+ * Shared, MD-gated artist-search typeahead — the query text is state owned
+ * by this component rather than a caller-supplied `value`/`onChange` pair,
+ * so multiple consumers with different surrounding form shapes can mount it
+ * identically and only ever observe outcomes (`onSelect`, `onCreateNew`).
+ * `onCreateNew` hands back the raw search term instead of driving the
+ * create-artist flow itself, since which UI that opens is caller-specific.
  */
 export interface ArtistSearchTypeaheadProps {
   genreId: number;
@@ -46,26 +36,47 @@ function ArtistSearchTypeaheadInner({
   const [open, setOpen] = useState(false);
   const [highlightIndex, setHighlightIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listboxId = useId();
   const [trigger, { data, isFetching }] = useLazySearchArtistsInGenreQuery();
 
   const trimmed = query.trim();
   const hasValidQuery = trimmed.length >= MIN_QUERY_LENGTH;
 
+  // Selecting a result writes its name into `query` so the input reads back
+  // the pick, but that write must not re-arm a redundant search — one-shot
+  // skip flag consumed by the next debounce tick.
+  const skipNextSearch = useRef(false);
+
   useEffect(() => {
     if (!hasValidQuery) return;
+    if (skipNextSearch.current) {
+      skipNextSearch.current = false;
+      return;
+    }
     const timer = setTimeout(() => {
       trigger({ genre_id: genreId, q: trimmed, limit: RESULT_LIMIT });
     }, DEBOUNCE_MS);
     return () => clearTimeout(timer);
   }, [trigger, genreId, trimmed, hasValidQuery]);
 
-  const artists = hasValidQuery ? (data?.artists ?? []) : [];
+  const artists = useMemo(
+    () => (hasValidQuery ? (data?.artists ?? []) : []),
+    [hasValidQuery, data],
+  );
   const showPanel = open && hasValidQuery;
   const totalRows = artists.length + 1;
+
+  // The result set can shrink out from under a stale mouse-hover index
+  // (fewer rows in a later response), which would otherwise leave Enter as
+  // a silent no-op against a highlight index past the end of the list.
+  useEffect(() => {
+    setHighlightIndex((prev) => Math.min(prev, totalRows - 1));
+  }, [totalRows]);
 
   const handleSelect = useCallback(
     (artist: ArtistInGenreOption) => {
       onSelect(artist);
+      skipNextSearch.current = true;
       setQuery(artist.artist_name);
       setOpen(false);
       setHighlightIndex(0);
@@ -136,7 +147,14 @@ function ArtistSearchTypeaheadInner({
           slotProps={{
             input: {
               ref: inputRef,
+              role: "combobox",
               "aria-label": "Search artists",
+              "aria-expanded": showPanel,
+              "aria-controls": listboxId,
+              "aria-activedescendant": showPanel
+                ? `${listboxId}-option-${highlightIndex}`
+                : undefined,
+              "aria-autocomplete": "list",
               autoComplete: "off",
               spellCheck: false,
             },
@@ -146,6 +164,8 @@ function ArtistSearchTypeaheadInner({
         {showPanel && (
           <Sheet
             variant="outlined"
+            role="listbox"
+            id={listboxId}
             sx={{
               position: "absolute",
               top: "calc(100% + 4px)",
@@ -162,6 +182,9 @@ function ArtistSearchTypeaheadInner({
             {artists.map((artist, index) => (
               <Box
                 key={artist.id}
+                id={`${listboxId}-option-${index}`}
+                role="option"
+                aria-selected={highlightIndex === index}
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => handleSelect(artist)}
                 onMouseEnter={() => setHighlightIndex(index)}
@@ -186,6 +209,9 @@ function ArtistSearchTypeaheadInner({
               </Box>
             ))}
             <Box
+              id={`${listboxId}-option-${artists.length}`}
+              role="option"
+              aria-selected={highlightIndex === artists.length}
               onMouseDown={(e) => e.preventDefault()}
               onClick={handleCreateNew}
               onMouseEnter={() => setHighlightIndex(artists.length)}

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -47,8 +47,11 @@ const NO_ARTISTS: ArtistInGenreOption[] = [];
  * invalidates it. Without the retraction a caller that keeps the id would save
  * the old link under text that no longer names that artist, or under a genre
  * that has no such artist row — silently, since the field reads as whatever it
- * last read. It is required rather than optional so that holding an id and
- * never dropping it cannot be reached by omission.
+ * last read. It is required rather than optional so that a caller cannot wire
+ * up `onSelect` without also wiring up its retraction. The coverage is limited
+ * to selections this component reported: a caller that seeds `value` with a
+ * link obtained elsewhere holds an id this component never confirmed, and is
+ * responsible for invalidating that link itself when `genreId` changes.
  */
 export interface ArtistSearchTypeaheadProps {
   genreId: number;
@@ -65,8 +68,9 @@ export interface ArtistSearchTypeaheadProps {
    *
    * A genre change retracts the id but leaves the field's text standing: refiling
    * a release does not rename its artist, so the same text is what the user needs
-   * in order to re-pick that artist under the new genre. This component writes
-   * `value` only when a row is picked.
+   * in order to re-pick that artist under the new genre. This component never
+   * writes `value` in response to a prop change — only a row pick or the user's
+   * own edit.
    */
   onSelectionCleared: () => void;
   disabled?: boolean;
@@ -84,8 +88,9 @@ function ArtistSearchTypeaheadInner({
   const [open, setOpen] = useState(false);
   const [rawHighlightIndex, setHighlightIndex] = useState(NO_HIGHLIGHT);
   // The artist the caller was last told about, held in a ref because nothing
-  // rendered here depends on it — it exists only to decide, at the moment the
-  // text is edited, whether that report is still true.
+  // rendered here depends on it — it exists only to decide whether that report
+  // is still true, at the moment the text is edited or `genreId` moves off the
+  // genre the artist was found under.
   const confirmedArtist = useRef<ArtistInGenreOption | null>(null);
   // The genre the confirmed artist was found under, kept because the retraction
   // below turns on whether `genreId` moved — which the current prop alone cannot
@@ -291,9 +296,11 @@ function ArtistSearchTypeaheadInner({
   });
 
   return (
-    // Every close goes through `closePanel`: a close that left the highlight
-    // standing would reopen the panel pre-highlighted, turning the next Enter
-    // into a selection the user never navigated to.
+    // Clicking away goes through `closePanel`, which resets the highlight along
+    // with `open`. That pairing does not hold for every way the panel closes:
+    // disabling the input hides it only through the `panelOpen` derivation
+    // above, leaving `open` and the highlight standing, so re-enabling reopens
+    // the panel pre-highlighted rather than fresh.
     <ClickAwayListener onClickAway={closePanel}>
       <Box sx={{ position: "relative", width: "100%" }}>
         <Input

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -6,7 +6,7 @@ import type { ArtistInGenreOption } from "@/lib/features/catalog/types";
 import { useDebouncedValue } from "@/src/hooks/useDebouncedValue";
 import { ClickAwayListener } from "@mui/base/ClickAwayListener";
 import { Box, Button, CircularProgress, Input, Sheet, Typography } from "@mui/joy";
-import { useCallback, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 const DEBOUNCE_MS = 300;
 const MIN_QUERY_LENGTH = 2;
@@ -42,12 +42,13 @@ const NO_ARTISTS: ArtistInGenreOption[] = [];
  * create-artist flow itself, since which UI that opens is caller-specific.
  *
  * `onSelectionCleared` retracts an earlier `onSelect`: the artist id a caller
- * holds is only good for the exact text that produced it, so editing the field
- * after a pick invalidates it. Without the retraction a caller that keeps the
- * id would save the old link under text that no longer names that artist —
- * silently, since the field reads as whatever was typed last. It is required
- * rather than optional so that holding an id and never dropping it cannot be
- * reached by omission.
+ * holds is only good for the exact text that produced it and for the genre it
+ * was found under, so editing the field or moving `genreId` after a pick
+ * invalidates it. Without the retraction a caller that keeps the id would save
+ * the old link under text that no longer names that artist, or under a genre
+ * that has no such artist row — silently, since the field reads as whatever it
+ * last read. It is required rather than optional so that holding an id and
+ * never dropping it cannot be reached by omission.
  */
 export interface ArtistSearchTypeaheadProps {
   genreId: number;
@@ -56,9 +57,16 @@ export interface ArtistSearchTypeaheadProps {
   onSelect: (artist: ArtistInGenreOption) => void;
   onCreateNew: (searchTerm: string) => void;
   /**
-   * Fired when the field's text is edited away from the artist last passed to
-   * `onSelect`, once per selection. Callers holding that artist's id must drop
-   * it here; a later `onSelect` arms the signal again.
+   * Fired when the artist last passed to `onSelect` stops describing the field:
+   * its text was edited away from that artist's name, or `genreId` moved off the
+   * genre the artist was found under. Fires once per selection; a later
+   * `onSelect` arms the signal again. Callers holding that artist's id must drop
+   * it here.
+   *
+   * A genre change retracts the id but leaves the field's text standing: refiling
+   * a release does not rename its artist, so the same text is what the user needs
+   * in order to re-pick that artist under the new genre. This component writes
+   * `value` only when a row is picked.
    */
   onSelectionCleared: () => void;
   disabled?: boolean;
@@ -79,6 +87,11 @@ function ArtistSearchTypeaheadInner({
   // rendered here depends on it — it exists only to decide, at the moment the
   // text is edited, whether that report is still true.
   const confirmedArtist = useRef<ArtistInGenreOption | null>(null);
+  // The genre the confirmed artist was found under, kept because the retraction
+  // below turns on whether `genreId` moved — which the current prop alone cannot
+  // say. It tracks the prop even with nothing confirmed, so the first pick after
+  // a genre change is not read as having been made under the older genre.
+  const confirmedGenreId = useRef(genreId);
   const inputRef = useRef<HTMLInputElement>(null);
   const listboxId = useId();
 
@@ -87,10 +100,15 @@ function ArtistSearchTypeaheadInner({
 
   const hasValidQuery = trimmed.length >= MIN_QUERY_LENGTH;
   const debouncedIsValid = debouncedQuery.length >= MIN_QUERY_LENGTH;
+  // `disabled` can arrive while the panel is already open, so it has to shut the
+  // panel rather than only bar it from opening: a panel left standing under a
+  // greyed-out input is still clickable, and one click there hands the caller an
+  // artist id it is no longer allowed to accept.
+  const panelOpen = open && !disabled;
   // Nothing to search for while the panel is shut: a form that seeds the field
   // with an already-linked artist must not fire a request on mount, and closing
   // the panel after a pick must not re-query for the name just written back.
-  const skip = !open || !debouncedIsValid;
+  const skip = !panelOpen || !debouncedIsValid;
 
   // `currentData` is the payload for these exact args; `data` is the latest
   // payload for ANY args, falling back to the previous ones whenever the
@@ -118,7 +136,7 @@ function ArtistSearchTypeaheadInner({
   const resultsAreCurrent = hasValidQuery && !pendingDebounce && !skip;
   const artists = resultsAreCurrent ? (data?.artists ?? NO_ARTISTS) : NO_ARTISTS;
 
-  const showPanel = open && hasValidQuery;
+  const showPanel = panelOpen && hasValidQuery;
   const isSearching = showPanel && (pendingDebounce || isFetching);
   // A search that failed outright has no answer about existing artists, so it
   // gets its own presentation rather than passing for "no matches". A failed
@@ -145,6 +163,21 @@ function ArtistSearchTypeaheadInner({
     rawHighlightIndex >= artists.length ? artists.length - 1 : rawHighlightIndex;
   const createIndex = artists.length;
   const createHighlighted = highlightIndex === CREATE_HIGHLIGHT;
+
+  // Artist rows are scoped to a genre, so an id reported under one genre names
+  // no row under the next: a genre change invalidates a held selection exactly
+  // as a text edit does, and must retract it rather than leave the caller filing
+  // an album against an artist row its new genre does not have. The guard is a
+  // ref comparison rather than the dependency list alone because callers
+  // commonly pass an inline `onSelectionCleared`, whose identity changes every
+  // render.
+  useEffect(() => {
+    if (confirmedGenreId.current === genreId) return;
+    confirmedGenreId.current = genreId;
+    if (!confirmedArtist.current) return;
+    confirmedArtist.current = null;
+    onSelectionCleared();
+  }, [genreId, onSelectionCleared]);
 
   const openPanel = useCallback(() => {
     if (disabled) return;

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -1,26 +1,42 @@
 "use client";
 
 import { RequireMD } from "@/src/components/shared/Authorization";
-import { useLazySearchArtistsInGenreQuery } from "@/lib/features/catalog/api";
+import { useSearchArtistsInGenreQuery } from "@/lib/features/catalog/api";
 import type { ArtistInGenreOption } from "@/lib/features/catalog/types";
+import { useDebouncedValue } from "@/src/hooks/useDebouncedValue";
 import { ClickAwayListener } from "@mui/base/ClickAwayListener";
-import { Box, CircularProgress, Input, Sheet, Typography } from "@mui/joy";
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { Box, Button, CircularProgress, Input, Sheet, Typography } from "@mui/joy";
+import { useCallback, useId, useRef, useState } from "react";
 
 const DEBOUNCE_MS = 300;
 const MIN_QUERY_LENGTH = 2;
 const RESULT_LIMIT = 10;
 
+/** Nothing highlighted. Arrow keys and hover are the only way onto a row. */
+const NO_HIGHLIGHT = -1;
+
+/** Shared empty result so a render with no rows keeps a stable identity. */
+const NO_ARTISTS: ArtistInGenreOption[] = [];
+
 /**
- * Shared, MD-gated artist-search typeahead — the query text is state owned
- * by this component rather than a caller-supplied `value`/`onChange` pair,
- * so multiple consumers with different surrounding form shapes can mount it
- * identically and only ever observe outcomes (`onSelect`, `onCreateNew`).
- * `onCreateNew` hands back the raw search term instead of driving the
+ * Shared, MD-gated artist-search typeahead.
+ *
+ * The search text is caller-owned (`value` / `onChange`): consumers mount this
+ * inside forms that need to seed the field with an already-linked artist and to
+ * clear it on cancel or after a save, neither of which is reachable if the query
+ * string is private to this component.
+ *
+ * `onSelect` receives the full artist — downstream callers need the display name
+ * as well as the id — and runs after the `onChange` that writes the picked name
+ * into the field, so a caller that rewrites `value` from inside `onSelect` wins.
+ *
+ * `onCreateNew` hands the raw search term back rather than driving the
  * create-artist flow itself, since which UI that opens is caller-specific.
  */
 export interface ArtistSearchTypeaheadProps {
   genreId: number;
+  value: string;
+  onChange: (value: string) => void;
   onSelect: (artist: ArtistInGenreOption) => void;
   onCreateNew: (searchTerm: string) => void;
   disabled?: boolean;
@@ -28,97 +44,144 @@ export interface ArtistSearchTypeaheadProps {
 
 function ArtistSearchTypeaheadInner({
   genreId,
+  value,
+  onChange,
   onSelect,
   onCreateNew,
   disabled,
 }: ArtistSearchTypeaheadProps) {
-  const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
-  const [highlightIndex, setHighlightIndex] = useState(0);
+  const [rawHighlightIndex, setHighlightIndex] = useState(NO_HIGHLIGHT);
   const inputRef = useRef<HTMLInputElement>(null);
   const listboxId = useId();
-  const [trigger, { data, isFetching }] = useLazySearchArtistsInGenreQuery();
 
-  const trimmed = query.trim();
+  const trimmed = value.trim();
+  const debouncedQuery = useDebouncedValue(trimmed, DEBOUNCE_MS);
+
   const hasValidQuery = trimmed.length >= MIN_QUERY_LENGTH;
+  const debouncedIsValid = debouncedQuery.length >= MIN_QUERY_LENGTH;
+  // Nothing to search for while the panel is shut: a form that seeds the field
+  // with an already-linked artist must not fire a request on mount, and closing
+  // the panel after a pick must not re-query for the name just written back.
+  const skip = !open || !debouncedIsValid;
 
-  // Selecting a result writes its name into `query` so the input reads back
-  // the pick, but that write must not re-arm a redundant search — one-shot
-  // skip flag consumed by the next debounce tick.
-  const skipNextSearch = useRef(false);
-
-  useEffect(() => {
-    if (!hasValidQuery) return;
-    if (skipNextSearch.current) {
-      skipNextSearch.current = false;
-      return;
-    }
-    const timer = setTimeout(() => {
-      trigger({ genre_id: genreId, q: trimmed, limit: RESULT_LIMIT });
-    }, DEBOUNCE_MS);
-    return () => clearTimeout(timer);
-  }, [trigger, genreId, trimmed, hasValidQuery]);
-
-  const artists = useMemo(
-    () => (hasValidQuery ? (data?.artists ?? []) : []),
-    [hasValidQuery, data],
+  const { data, isFetching, isError, refetch } = useSearchArtistsInGenreQuery(
+    { genre_id: genreId, q: debouncedQuery, limit: RESULT_LIMIT },
+    { skip },
   );
-  const showPanel = open && hasValidQuery;
-  const totalRows = artists.length + 1;
 
-  // The result set can shrink out from under a stale mouse-hover index
-  // (fewer rows in a later response), which would otherwise leave Enter as
-  // a silent no-op against a highlight index past the end of the list.
-  useEffect(() => {
-    setHighlightIndex((prev) => Math.min(prev, totalRows - 1));
-  }, [totalRows]);
+  // The response is keyed to `genreId` and the DEBOUNCED query, so a genre swap
+  // or a new query string drops the previous rows on its own. The remaining
+  // stale window is the debounce itself, where the live text has already moved
+  // on: gate on the live value so backspacing below the minimum length, or
+  // retyping from scratch, clears the old rows immediately instead of leaving
+  // them selectable under text that no longer produced them.
+  const pendingDebounce = hasValidQuery && debouncedQuery !== trimmed;
+  const resultsAreCurrent = hasValidQuery && !pendingDebounce && !skip;
+  const artists = resultsAreCurrent ? (data?.artists ?? NO_ARTISTS) : NO_ARTISTS;
+
+  const showPanel = open && hasValidQuery;
+  const isSearching = showPanel && (pendingDebounce || isFetching);
+  // A search that failed outright has no answer about existing artists, so it
+  // gets its own presentation rather than passing for "no matches". A failed
+  // refetch that still has a prior response for these exact args keeps showing
+  // that response instead.
+  const showError = resultsAreCurrent && isError && data === undefined;
+  // Until the first rows land there is nothing to offer but "create new", and
+  // offering it against results that have not arrived is how a typeahead built
+  // to prevent duplicate artists ends up producing them. The panel reports
+  // progress instead, and the keyboard has no row to act on.
+  const showSearching = isSearching && artists.length === 0 && !showError;
+  const showListbox = showPanel && !showError && !showSearching;
+
+  // A shorter later response can leave the highlight pointing past the end of
+  // the list. Clamping at render time keeps highlight and rows in step without
+  // a corrective state write, and clamping to the last ARTIST row rather than
+  // the last row overall means a shrinking result set can never park the
+  // highlight on "create new" and turn Enter into an unintended creation.
+  const highlightIndex =
+    rawHighlightIndex > artists.length ? artists.length - 1 : rawHighlightIndex;
+  const createIndex = artists.length;
+
+  const openPanel = useCallback(() => {
+    if (disabled) return;
+    // Idempotent by construction — it touches nothing but `open`. Clicking an
+    // already-focused input does not refire `onFocus`, so `onClick` has to be
+    // able to run over an open panel without disturbing the live query or the
+    // current highlight.
+    setOpen(true);
+  }, [disabled]);
+
+  const closePanel = useCallback(() => {
+    setOpen(false);
+    setHighlightIndex(NO_HIGHLIGHT);
+  }, []);
 
   const handleSelect = useCallback(
     (artist: ArtistInGenreOption) => {
+      onChange(artist.artist_name);
       onSelect(artist);
-      skipNextSearch.current = true;
-      setQuery(artist.artist_name);
-      setOpen(false);
-      setHighlightIndex(0);
+      closePanel();
     },
-    [onSelect],
+    [onChange, onSelect, closePanel],
   );
 
   const handleCreateNew = useCallback(() => {
     onCreateNew(trimmed);
-    setOpen(false);
-    setHighlightIndex(0);
-  }, [onCreateNew, trimmed]);
+    closePanel();
+  }, [onCreateNew, trimmed, closePanel]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (!showPanel) return;
+      // Escape dismisses any open panel, including the error and in-progress
+      // states that have no rows to navigate.
+      if (e.key === "Escape" && showPanel) {
+        e.preventDefault();
+        closePanel();
+        inputRef.current?.blur();
+        return;
+      }
+      if (!showListbox) return;
       switch (e.key) {
         case "ArrowDown":
           e.preventDefault();
-          setHighlightIndex((prev) => Math.min(prev + 1, totalRows - 1));
+          setHighlightIndex(Math.min(highlightIndex + 1, createIndex));
           break;
         case "ArrowUp":
           e.preventDefault();
-          setHighlightIndex((prev) => Math.max(prev - 1, 0));
+          setHighlightIndex(Math.max(highlightIndex - 1, NO_HIGHLIGHT));
           break;
         case "Enter":
           e.preventDefault();
-          if (highlightIndex === artists.length) {
+          if (highlightIndex === createIndex) {
             handleCreateNew();
-          } else if (highlightIndex >= 0 && highlightIndex < artists.length) {
+          } else if (highlightIndex >= 0) {
             handleSelect(artists[highlightIndex]);
           }
           break;
-        case "Escape":
-          e.preventDefault();
-          setOpen(false);
-          inputRef.current?.blur();
-          break;
       }
     },
-    [showPanel, totalRows, highlightIndex, artists, handleSelect, handleCreateNew],
+    [
+      showPanel,
+      showListbox,
+      highlightIndex,
+      createIndex,
+      artists,
+      handleSelect,
+      handleCreateNew,
+      closePanel,
+    ],
   );
+
+  const rowSx = (highlighted: boolean) => ({
+    px: 1.5,
+    py: 0.75,
+    cursor: "pointer",
+    backgroundColor: highlighted ? "primary.700" : "transparent",
+    "&:hover": {
+      backgroundColor: highlighted ? "primary.700" : "neutral.800",
+    },
+  });
 
   return (
     <ClickAwayListener onClickAway={() => setOpen(false)}>
@@ -128,16 +191,17 @@ function ArtistSearchTypeaheadInner({
           fullWidth
           disabled={disabled}
           placeholder="Search artists..."
-          value={query}
-          onFocus={() => setOpen(true)}
+          value={value}
+          onFocus={openPanel}
+          onClick={openPanel}
           onChange={(e) => {
-            setQuery(e.target.value);
+            onChange(e.target.value);
             setOpen(true);
-            setHighlightIndex(0);
+            setHighlightIndex(NO_HIGHLIGHT);
           }}
           onKeyDown={handleKeyDown}
           startDecorator={
-            isFetching ? (
+            isSearching ? (
               <CircularProgress
                 size="sm"
                 sx={{ "--CircularProgress-size": "14px" }}
@@ -149,11 +213,16 @@ function ArtistSearchTypeaheadInner({
               ref: inputRef,
               role: "combobox",
               "aria-label": "Search artists",
-              "aria-expanded": showPanel,
-              "aria-controls": listboxId,
-              "aria-activedescendant": showPanel
-                ? `${listboxId}-option-${highlightIndex}`
-                : undefined,
+              // All three reference or describe the listbox, which only exists
+              // while `showListbox` holds — an unconditional `aria-controls`
+              // would leave a dangling IDREF whenever the panel is shut or the
+              // search failed.
+              "aria-expanded": showListbox,
+              "aria-controls": showListbox ? listboxId : undefined,
+              "aria-activedescendant":
+                showListbox && highlightIndex >= 0
+                  ? `${listboxId}-option-${highlightIndex}`
+                  : undefined,
               "aria-autocomplete": "list",
               autoComplete: "off",
               spellCheck: false,
@@ -164,8 +233,11 @@ function ArtistSearchTypeaheadInner({
         {showPanel && (
           <Sheet
             variant="outlined"
-            role="listbox"
-            id={listboxId}
+            {...(showError
+              ? { role: "alert" as const }
+              : showSearching
+                ? { role: "status" as const }
+                : { role: "listbox" as const, id: listboxId })}
             sx={{
               position: "absolute",
               top: "calc(100% + 4px)",
@@ -179,72 +251,85 @@ function ArtistSearchTypeaheadInner({
               py: 0.5,
             }}
           >
-            {artists.map((artist, index) => (
-              <Box
-                key={artist.id}
-                id={`${listboxId}-option-${index}`}
-                role="option"
-                aria-selected={highlightIndex === index}
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => handleSelect(artist)}
-                onMouseEnter={() => setHighlightIndex(index)}
-                sx={{
-                  px: 1.5,
-                  py: 0.75,
-                  cursor: "pointer",
-                  backgroundColor:
-                    highlightIndex === index ? "primary.700" : "transparent",
-                  "&:hover": {
-                    backgroundColor:
-                      highlightIndex === index ? "primary.700" : "neutral.800",
-                  },
-                }}
-              >
-                <Typography
-                  level="body-sm"
-                  sx={{ color: highlightIndex === index ? "white" : "inherit" }}
+            {showError ? (
+              // A failed search is not evidence that the artist is missing, so
+              // it must not offer creation as the way out — that would turn an
+              // outage into duplicate catalog rows.
+              <Box sx={{ px: 1.5, py: 0.75 }}>
+                <Typography level="body-sm">
+                  Artist search is unavailable. Existing artists can&apos;t be
+                  checked right now.
+                </Typography>
+                <Button
+                  size="sm"
+                  variant="plain"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => refetch()}
+                  sx={{ mt: 0.5, px: 0 }}
                 >
-                  {artist.artist_name}
+                  Try again
+                </Button>
+              </Box>
+            ) : showSearching ? (
+              <Box sx={{ px: 1.5, py: 0.75 }}>
+                <Typography level="body-sm" sx={{ fontStyle: "italic" }}>
+                  Searching artists...
                 </Typography>
               </Box>
-            ))}
-            <Box
-              id={`${listboxId}-option-${artists.length}`}
-              role="option"
-              aria-selected={highlightIndex === artists.length}
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={handleCreateNew}
-              onMouseEnter={() => setHighlightIndex(artists.length)}
-              sx={{
-                px: 1.5,
-                py: 0.75,
-                cursor: "pointer",
-                borderTop: artists.length > 0 ? "1px solid" : undefined,
-                borderColor: "divider",
-                backgroundColor:
-                  highlightIndex === artists.length
-                    ? "primary.700"
-                    : "transparent",
-                "&:hover": {
-                  backgroundColor:
-                    highlightIndex === artists.length
-                      ? "primary.700"
-                      : "neutral.800",
-                },
-              }}
-            >
-              <Typography
-                level="body-sm"
-                sx={{
-                  fontStyle: "italic",
-                  color: highlightIndex === artists.length ? "white" : "inherit",
-                }}
-              >
-                {artists.length === 0
-                  ? `Create new artist "${trimmed}"`
-                  : `Create new artist "${trimmed}" instead`}
-              </Typography>
-            </Box>
+            ) : (
+              <>
+                {artists.map((artist, index) => (
+                  <Box
+                    key={artist.id}
+                    id={`${listboxId}-option-${index}`}
+                    role="option"
+                    aria-selected={highlightIndex === index}
+                    // preventDefault keeps focus on the input so neither the
+                    // click-away nor the blur path closes the panel before this
+                    // row's `onClick` selection handler runs.
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => handleSelect(artist)}
+                    onMouseEnter={() => setHighlightIndex(index)}
+                    sx={rowSx(highlightIndex === index)}
+                  >
+                    <Typography
+                      level="body-sm"
+                      sx={{
+                        color: highlightIndex === index ? "white" : "inherit",
+                      }}
+                    >
+                      {artist.artist_name}
+                    </Typography>
+                  </Box>
+                ))}
+                <Box
+                  id={`${listboxId}-option-${createIndex}`}
+                  role="option"
+                  aria-selected={highlightIndex === createIndex}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={handleCreateNew}
+                  onMouseEnter={() => setHighlightIndex(createIndex)}
+                  sx={{
+                    ...rowSx(highlightIndex === createIndex),
+                    borderTop: artists.length > 0 ? "1px solid" : undefined,
+                    borderColor: "divider",
+                  }}
+                >
+                  <Typography
+                    level="body-sm"
+                    sx={{
+                      fontStyle: "italic",
+                      color:
+                        highlightIndex === createIndex ? "white" : "inherit",
+                    }}
+                  >
+                    {artists.length === 0
+                      ? `Create new artist "${trimmed}"`
+                      : `Create new artist "${trimmed}" instead`}
+                  </Typography>
+                </Box>
+              </>
+            )}
           </Sheet>
         )}
       </Box>

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -15,6 +15,14 @@ const RESULT_LIMIT = 10;
 /** Nothing highlighted. Arrow keys and hover are the only way onto a row. */
 const NO_HIGHLIGHT = -1;
 
+/**
+ * The "create new" row, held as a sentinel rather than as the index one past
+ * the last result. Those two are indistinguishable as numbers, so a result set
+ * that shrinks under a live highlight would silently slide it onto creation:
+ * the highlight must only land there when the user navigated there.
+ */
+const CREATE_HIGHLIGHT = -2;
+
 /** Shared empty result so a render with no rows keeps a stable identity. */
 const NO_ARTISTS: ArtistInGenreOption[] = [];
 
@@ -32,6 +40,14 @@ const NO_ARTISTS: ArtistInGenreOption[] = [];
  *
  * `onCreateNew` hands the raw search term back rather than driving the
  * create-artist flow itself, since which UI that opens is caller-specific.
+ *
+ * `onSelectionCleared` retracts an earlier `onSelect`: the artist id a caller
+ * holds is only good for the exact text that produced it, so editing the field
+ * after a pick invalidates it. Without the retraction a caller that keeps the
+ * id would save the old link under text that no longer names that artist —
+ * silently, since the field reads as whatever was typed last. It is required
+ * rather than optional so that holding an id and never dropping it cannot be
+ * reached by omission.
  */
 export interface ArtistSearchTypeaheadProps {
   genreId: number;
@@ -39,6 +55,12 @@ export interface ArtistSearchTypeaheadProps {
   onChange: (value: string) => void;
   onSelect: (artist: ArtistInGenreOption) => void;
   onCreateNew: (searchTerm: string) => void;
+  /**
+   * Fired when the field's text is edited away from the artist last passed to
+   * `onSelect`, once per selection. Callers holding that artist's id must drop
+   * it here; a later `onSelect` arms the signal again.
+   */
+  onSelectionCleared: () => void;
   disabled?: boolean;
 }
 
@@ -48,10 +70,15 @@ function ArtistSearchTypeaheadInner({
   onChange,
   onSelect,
   onCreateNew,
+  onSelectionCleared,
   disabled,
 }: ArtistSearchTypeaheadProps) {
   const [open, setOpen] = useState(false);
   const [rawHighlightIndex, setHighlightIndex] = useState(NO_HIGHLIGHT);
+  // The artist the caller was last told about, held in a ref because nothing
+  // rendered here depends on it — it exists only to decide, at the moment the
+  // text is edited, whether that report is still true.
+  const confirmedArtist = useRef<ArtistInGenreOption | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listboxId = useId();
 
@@ -65,7 +92,18 @@ function ArtistSearchTypeaheadInner({
   // the panel after a pick must not re-query for the name just written back.
   const skip = !open || !debouncedIsValid;
 
-  const { data, isFetching, isError, refetch } = useSearchArtistsInGenreQuery(
+  // `currentData` is the payload for these exact args; `data` is the latest
+  // payload for ANY args, falling back to the previous ones whenever the
+  // current args are not in a success state. Reading `data` would therefore
+  // serve the previous genre's or query's rows for the whole in-flight window
+  // after the args change, and permanently on args that error — rows the user
+  // can pick while the caller believes it is filing under the new genre.
+  const {
+    currentData: data,
+    isFetching,
+    isError,
+    refetch,
+  } = useSearchArtistsInGenreQuery(
     { genre_id: genreId, q: debouncedQuery, limit: RESULT_LIMIT },
     { skip },
   );
@@ -85,7 +123,8 @@ function ArtistSearchTypeaheadInner({
   // A search that failed outright has no answer about existing artists, so it
   // gets its own presentation rather than passing for "no matches". A failed
   // refetch that still has a prior response for these exact args keeps showing
-  // that response instead.
+  // that response instead — which is what the arg-scoped `data` above buys: an
+  // earlier query's payload must never suppress this query's error panel.
   const showError = resultsAreCurrent && isError && data === undefined;
   // Until the first rows land there is nothing to offer but "create new", and
   // offering it against results that have not arrived is how a typeahead built
@@ -96,12 +135,16 @@ function ArtistSearchTypeaheadInner({
 
   // A shorter later response can leave the highlight pointing past the end of
   // the list. Clamping at render time keeps highlight and rows in step without
-  // a corrective state write, and clamping to the last ARTIST row rather than
-  // the last row overall means a shrinking result set can never park the
-  // highlight on "create new" and turn Enter into an unintended creation.
+  // a corrective state write. Every index the list no longer has — including
+  // the one exactly one past the end — comes back to the last ARTIST row, and
+  // to NO_HIGHLIGHT when the list is empty, so a shrinking result set can never
+  // park the highlight on a row that is not there. The sentinels are negative
+  // and so pass through untouched: an explicit "create new" highlight survives
+  // a shrink, since the user chose it rather than drifting onto it.
   const highlightIndex =
-    rawHighlightIndex > artists.length ? artists.length - 1 : rawHighlightIndex;
+    rawHighlightIndex >= artists.length ? artists.length - 1 : rawHighlightIndex;
   const createIndex = artists.length;
+  const createHighlighted = highlightIndex === CREATE_HIGHLIGHT;
 
   const openPanel = useCallback(() => {
     if (disabled) return;
@@ -119,11 +162,33 @@ function ArtistSearchTypeaheadInner({
 
   const handleSelect = useCallback(
     (artist: ArtistInGenreOption) => {
+      confirmedArtist.current = artist;
+      // `onChange` runs first so that a caller which rewrites `value` from
+      // inside `onSelect` writes last and wins.
       onChange(artist.artist_name);
       onSelect(artist);
       closePanel();
     },
     [onChange, onSelect, closePanel],
+  );
+
+  const handleTextEdit = useCallback(
+    (next: string) => {
+      onChange(next);
+      // Text that no longer names the confirmed artist retracts it, and only
+      // once: the caller has dropped the id by the second keystroke, and a
+      // repeated retraction would read as a second, unrelated event.
+      if (
+        confirmedArtist.current &&
+        next.trim() !== confirmedArtist.current.artist_name
+      ) {
+        confirmedArtist.current = null;
+        onSelectionCleared();
+      }
+      setOpen(true);
+      setHighlightIndex(NO_HIGHLIGHT);
+    },
+    [onChange, onSelectionCleared],
   );
 
   const handleCreateNew = useCallback(() => {
@@ -143,17 +208,26 @@ function ArtistSearchTypeaheadInner({
       }
       if (!showListbox) return;
       switch (e.key) {
-        case "ArrowDown":
+        case "ArrowDown": {
           e.preventDefault();
-          setHighlightIndex(Math.min(highlightIndex + 1, createIndex));
+          // "create new" is the last row, so arrowing down from it stays put
+          // rather than wrapping back to the first result.
+          if (createHighlighted) break;
+          const next = highlightIndex + 1;
+          setHighlightIndex(next >= artists.length ? CREATE_HIGHLIGHT : next);
           break;
+        }
         case "ArrowUp":
           e.preventDefault();
-          setHighlightIndex(Math.max(highlightIndex - 1, NO_HIGHLIGHT));
+          setHighlightIndex(
+            createHighlighted
+              ? artists.length - 1
+              : Math.max(highlightIndex - 1, NO_HIGHLIGHT),
+          );
           break;
         case "Enter":
           e.preventDefault();
-          if (highlightIndex === createIndex) {
+          if (createHighlighted) {
             handleCreateNew();
           } else if (highlightIndex >= 0) {
             handleSelect(artists[highlightIndex]);
@@ -165,7 +239,7 @@ function ArtistSearchTypeaheadInner({
       showPanel,
       showListbox,
       highlightIndex,
-      createIndex,
+      createHighlighted,
       artists,
       handleSelect,
       handleCreateNew,
@@ -184,7 +258,10 @@ function ArtistSearchTypeaheadInner({
   });
 
   return (
-    <ClickAwayListener onClickAway={() => setOpen(false)}>
+    // Every close goes through `closePanel`: a close that left the highlight
+    // standing would reopen the panel pre-highlighted, turning the next Enter
+    // into a selection the user never navigated to.
+    <ClickAwayListener onClickAway={closePanel}>
       <Box sx={{ position: "relative", width: "100%" }}>
         <Input
           size="sm"
@@ -194,11 +271,7 @@ function ArtistSearchTypeaheadInner({
           value={value}
           onFocus={openPanel}
           onClick={openPanel}
-          onChange={(e) => {
-            onChange(e.target.value);
-            setOpen(true);
-            setHighlightIndex(NO_HIGHLIGHT);
-          }}
+          onChange={(e) => handleTextEdit(e.target.value)}
           onKeyDown={handleKeyDown}
           startDecorator={
             isSearching ? (
@@ -219,10 +292,15 @@ function ArtistSearchTypeaheadInner({
               // search failed.
               "aria-expanded": showListbox,
               "aria-controls": showListbox ? listboxId : undefined,
+              // The create row is the last option in DOM order, so it carries
+              // the option id one past the last result even though the
+              // highlight itself is held as a sentinel.
               "aria-activedescendant":
-                showListbox && highlightIndex >= 0
-                  ? `${listboxId}-option-${highlightIndex}`
-                  : undefined,
+                showListbox && createHighlighted
+                  ? `${listboxId}-option-${createIndex}`
+                  : showListbox && highlightIndex >= 0
+                    ? `${listboxId}-option-${highlightIndex}`
+                    : undefined,
               "aria-autocomplete": "list",
               autoComplete: "off",
               spellCheck: false,
@@ -305,12 +383,12 @@ function ArtistSearchTypeaheadInner({
                 <Box
                   id={`${listboxId}-option-${createIndex}`}
                   role="option"
-                  aria-selected={highlightIndex === createIndex}
+                  aria-selected={createHighlighted}
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={handleCreateNew}
-                  onMouseEnter={() => setHighlightIndex(createIndex)}
+                  onMouseEnter={() => setHighlightIndex(CREATE_HIGHLIGHT)}
                   sx={{
-                    ...rowSx(highlightIndex === createIndex),
+                    ...rowSx(createHighlighted),
                     borderTop: artists.length > 0 ? "1px solid" : undefined,
                     borderColor: "divider",
                   }}
@@ -319,8 +397,7 @@ function ArtistSearchTypeaheadInner({
                     level="body-sm"
                     sx={{
                       fontStyle: "italic",
-                      color:
-                        highlightIndex === createIndex ? "white" : "inherit",
+                      color: createHighlighted ? "white" : "inherit",
                     }}
                   >
                     {artists.length === 0

--- a/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
+++ b/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
+import { useState } from "react";
 import {
   renderWithProviders,
   server,
@@ -53,6 +54,9 @@ function sessionWithRole() {
 
 const ARTIST_SEARCH_URL = `${TEST_BACKEND_URL}/library/artists/search`;
 
+const ROCK_GENRE_ID = 7;
+const JAZZ_GENRE_ID = 99;
+
 const juanaMolina: ArtistInGenreOption = {
   id: 12,
   artist_name: "Juana Molina",
@@ -60,16 +64,75 @@ const juanaMolina: ArtistInGenreOption = {
   code_number: 3,
 };
 
-function mockArtistSearch(artists: ArtistInGenreOption[]) {
-  let capturedUrl: URL | undefined;
+const chuquimamaniCondori: ArtistInGenreOption = {
+  id: 20,
+  artist_name: "Chuquimamani-Condori",
+  code_letters: "CH",
+  code_number: 1,
+};
+
+const jessicaPratt: ArtistInGenreOption = {
+  id: 31,
+  artist_name: "Jessica Pratt",
+  code_letters: "PR",
+  code_number: 5,
+};
+
+type SearchResponder = (url: URL) => Response;
+
+/**
+ * Installs the artist-search handler and returns the list of requests it has
+ * served. Every request is appended, so a test can assert how many the
+ * component actually issued — a single last-write-wins capture cannot tell one
+ * debounced request from five.
+ */
+function mockArtistSearch(
+  respond: ArtistInGenreOption[] | SearchResponder,
+): URL[] {
+  const requests: URL[] = [];
   server.use(
     http.get(ARTIST_SEARCH_URL, ({ request }) => {
-      capturedUrl = new URL(request.url);
-      return HttpResponse.json({ artists });
+      const url = new URL(request.url);
+      requests.push(url);
+      return typeof respond === "function"
+        ? respond(url)
+        : HttpResponse.json({ artists: respond });
     }),
   );
-  return () => capturedUrl;
+  return requests;
 }
+
+/**
+ * The component's search text is caller-owned, so tests drive it through a
+ * host that holds the value — the same shape the consuming forms use.
+ */
+function ControlledTypeahead({
+  genreId = ROCK_GENRE_ID,
+  initialValue = "",
+  onSelect = vi.fn(),
+  onCreateNew = vi.fn(),
+  disabled,
+}: {
+  genreId?: number;
+  initialValue?: string;
+  onSelect?: (artist: ArtistInGenreOption) => void;
+  onCreateNew?: (searchTerm: string) => void;
+  disabled?: boolean;
+}) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <ArtistSearchTypeahead
+      genreId={genreId}
+      value={value}
+      onChange={setValue}
+      onSelect={onSelect}
+      onCreateNew={onCreateNew}
+      disabled={disabled}
+    />
+  );
+}
+
+const findInput = () => screen.findByPlaceholderText("Search artists...");
 
 describe("ArtistSearchTypeahead", () => {
   beforeEach(() => {
@@ -84,13 +147,7 @@ describe("ArtistSearchTypeahead", () => {
     it("renders nothing for a DJ", async () => {
       mockFetchOrgRole.mockResolvedValue("dj");
       mockUseSession.mockReturnValue(sessionWithRole());
-      renderWithProviders(
-        <ArtistSearchTypeahead
-          genreId={1}
-          onSelect={vi.fn()}
-          onCreateNew={vi.fn()}
-        />,
-      );
+      renderWithProviders(<ControlledTypeahead />);
 
       await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
       await mockFetchOrgRole.mock.results[0].value;
@@ -104,166 +161,346 @@ describe("ArtistSearchTypeahead", () => {
     it("renders the search input for a Music Director", async () => {
       mockFetchOrgRole.mockResolvedValue("musicDirector");
       mockUseSession.mockReturnValue(sessionWithRole());
-      renderWithProviders(
-        <ArtistSearchTypeahead
-          genreId={1}
-          onSelect={vi.fn()}
-          onCreateNew={vi.fn()}
-        />,
-      );
+      renderWithProviders(<ControlledTypeahead />);
 
-      expect(
-        await screen.findByPlaceholderText("Search artists..."),
-      ).toBeInTheDocument();
+      expect(await findInput()).toBeInTheDocument();
     });
   });
 
-  describe("querying", () => {
+  describe("as a Music Director", () => {
     beforeEach(() => {
       mockFetchOrgRole.mockResolvedValue("musicDirector");
       mockUseSession.mockReturnValue(sessionWithRole());
     });
 
-    it("debounces the query and scopes it to the given genre", async () => {
-      const getUrl = mockArtistSearch([juanaMolina]);
-      const { user } = renderWithProviders(
-        <ArtistSearchTypeahead
-          genreId={7}
-          onSelect={vi.fn()}
-          onCreateNew={vi.fn()}
-        />,
-      );
+    describe("querying", () => {
+      it("issues one debounced request scoped to the given genre", async () => {
+        const requests = mockArtistSearch([juanaMolina]);
+        const { user } = renderWithProviders(<ControlledTypeahead />);
 
-      const input = await screen.findByPlaceholderText("Search artists...");
-      await user.type(input, "Juana");
+        const input = await findInput();
+        await user.type(input, "Juana");
 
-      expect(getUrl()).toBeUndefined();
+        expect(requests).toHaveLength(0);
 
-      await vi.advanceTimersByTimeAsync(400);
-      await waitFor(() => expect(getUrl()).toBeDefined());
+        await vi.advanceTimersByTimeAsync(400);
+        await waitFor(() => expect(requests).toHaveLength(1));
 
-      expect(getUrl()!.searchParams.get("q")).toBe("Juana");
-      expect(getUrl()!.searchParams.get("genre_id")).toBe("7");
-    });
+        expect(requests[0].searchParams.get("q")).toBe("Juana");
+        expect(requests[0].searchParams.get("genre_id")).toBe(
+          String(ROCK_GENRE_ID),
+        );
+      });
 
-    it("does not query below the minimum query length", async () => {
-      const getUrl = mockArtistSearch([juanaMolina]);
-      const { user } = renderWithProviders(
-        <ArtistSearchTypeahead
-          genreId={7}
-          onSelect={vi.fn()}
-          onCreateNew={vi.fn()}
-        />,
-      );
+      it("does not query below the minimum query length", async () => {
+        const requests = mockArtistSearch([juanaMolina]);
+        const { user } = renderWithProviders(<ControlledTypeahead />);
 
-      const input = await screen.findByPlaceholderText("Search artists...");
-      await user.type(input, "J");
-      await vi.advanceTimersByTimeAsync(400);
+        const input = await findInput();
+        await user.type(input, "J");
+        await vi.advanceTimersByTimeAsync(400);
 
-      expect(getUrl()).toBeUndefined();
-    });
+        expect(requests).toHaveLength(0);
+      });
 
-    it("renders matching results", async () => {
-      mockArtistSearch([juanaMolina]);
-      const { user } = renderWithProviders(
-        <ArtistSearchTypeahead
-          genreId={7}
-          onSelect={vi.fn()}
-          onCreateNew={vi.fn()}
-        />,
-      );
+      it("does not query for a seeded value until the panel is opened", async () => {
+        const requests = mockArtistSearch([juanaMolina]);
+        renderWithProviders(<ControlledTypeahead initialValue="Juana Molina" />);
 
-      const input = await screen.findByPlaceholderText("Search artists...");
-      await user.type(input, "Juana");
-      await vi.advanceTimersByTimeAsync(400);
+        await findInput();
+        await vi.advanceTimersByTimeAsync(400);
 
-      expect(await screen.findByText("Juana Molina")).toBeInTheDocument();
-    });
-  });
+        expect(requests).toHaveLength(0);
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      });
 
-  describe("selection", () => {
-    beforeEach(() => {
-      mockFetchOrgRole.mockResolvedValue("musicDirector");
-      mockUseSession.mockReturnValue(sessionWithRole());
-    });
+      it("renders matching results", async () => {
+        mockArtistSearch([juanaMolina]);
+        const { user } = renderWithProviders(<ControlledTypeahead />);
 
-    it("calls onSelect with the full artist object on click", async () => {
-      mockArtistSearch([juanaMolina]);
-      const onSelect = vi.fn();
-      const { user } = renderWithProviders(
-        <ArtistSearchTypeahead
-          genreId={7}
-          onSelect={onSelect}
-          onCreateNew={vi.fn()}
-        />,
-      );
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
 
-      const input = await screen.findByPlaceholderText("Search artists...");
-      await user.type(input, "Juana");
-      await vi.advanceTimersByTimeAsync(400);
-
-      await user.click(await screen.findByText("Juana Molina"));
-
-      expect(onSelect).toHaveBeenCalledWith(juanaMolina);
-    });
-
-    it("navigates results with the keyboard and selects with Enter", async () => {
-      mockArtistSearch([
-        juanaMolina,
-        { id: 20, artist_name: "Chuquimamani-Condori", code_letters: "CH", code_number: 1 },
-      ]);
-      const onSelect = vi.fn();
-      const { user } = renderWithProviders(
-        <ArtistSearchTypeahead
-          genreId={7}
-          onSelect={onSelect}
-          onCreateNew={vi.fn()}
-        />,
-      );
-
-      const input = await screen.findByPlaceholderText("Search artists...");
-      await user.type(input, "Juana");
-      await vi.advanceTimersByTimeAsync(400);
-      await screen.findByText("Juana Molina");
-
-      await user.keyboard("{ArrowDown}{Enter}");
-
-      expect(onSelect).toHaveBeenCalledWith({
-        id: 20,
-        artist_name: "Chuquimamani-Condori",
-        code_letters: "CH",
-        code_number: 1,
+        expect(await screen.findByText("Juana Molina")).toBeInTheDocument();
       });
     });
-  });
 
-  describe("no matches", () => {
-    beforeEach(() => {
-      mockFetchOrgRole.mockResolvedValue("musicDirector");
-      mockUseSession.mockReturnValue(sessionWithRole());
+    describe("stale results", () => {
+      it("drops the previous genre's results when the genre changes", async () => {
+        const requests = mockArtistSearch((url) =>
+          HttpResponse.json({
+            artists:
+              url.searchParams.get("genre_id") === String(ROCK_GENRE_ID)
+                ? [juanaMolina]
+                : [jessicaPratt],
+          }),
+        );
+        const { user, rerender } = renderWithProviders(
+          <ControlledTypeahead genreId={ROCK_GENRE_ID} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        expect(await screen.findByText("Juana Molina")).toBeInTheDocument();
+
+        rerender(<ControlledTypeahead genreId={JAZZ_GENRE_ID} />);
+        await vi.advanceTimersByTimeAsync(400);
+
+        await waitFor(() =>
+          expect(screen.queryByText("Juana Molina")).not.toBeInTheDocument(),
+        );
+        expect(
+          requests.some(
+            (r) => r.searchParams.get("genre_id") === String(JAZZ_GENRE_ID),
+          ),
+        ).toBe(true);
+      });
+
+      it("drops results as soon as the query falls below the minimum length", async () => {
+        mockArtistSearch([juanaMolina]);
+        const { user } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        expect(await screen.findByText("Juana Molina")).toBeInTheDocument();
+
+        await user.clear(input);
+
+        expect(screen.queryByText("Juana Molina")).not.toBeInTheDocument();
+      });
+
+      it("drops results while a newly typed query is still debouncing", async () => {
+        mockArtistSearch([juanaMolina]);
+        const { user } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        expect(await screen.findByText("Juana Molina")).toBeInTheDocument();
+
+        // Still a valid query, but no longer the one that produced these rows.
+        await user.type(input, "s");
+
+        expect(screen.queryByText("Juana Molina")).not.toBeInTheDocument();
+      });
     });
 
-    it("offers to create a new artist with the current search term", async () => {
-      mockArtistSearch([]);
-      const onCreateNew = vi.fn();
-      const { user } = renderWithProviders(
-        <ArtistSearchTypeahead
-          genreId={7}
-          onSelect={vi.fn()}
-          onCreateNew={onCreateNew}
-        />,
-      );
+    describe("selection", () => {
+      it("calls onSelect with the full artist object on click", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onSelect = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead onSelect={onSelect} />,
+        );
 
-      const input = await screen.findByPlaceholderText("Search artists...");
-      await user.type(input, "Nonexistent Band");
-      await vi.advanceTimersByTimeAsync(400);
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
 
-      const createOption = await screen.findByText(
-        'Create new artist "Nonexistent Band"',
-      );
-      await user.click(createOption);
+        await user.click(await screen.findByText("Juana Molina"));
 
-      expect(onCreateNew).toHaveBeenCalledWith("Nonexistent Band");
+        expect(onSelect).toHaveBeenCalledWith(juanaMolina);
+        expect(input).toHaveValue("Juana Molina");
+      });
+
+      it("navigates results with the keyboard and selects with Enter", async () => {
+        mockArtistSearch([juanaMolina, chuquimamaniCondori]);
+        const onSelect = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead onSelect={onSelect} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Juana Molina");
+
+        await user.keyboard("{ArrowDown}{ArrowDown}{ArrowUp}{Enter}");
+
+        expect(onSelect).toHaveBeenCalledWith(juanaMolina);
+      });
+
+      it("issues no further request once a result has been picked", async () => {
+        const requests = mockArtistSearch([juanaMolina]);
+        const { user } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+
+        await user.click(await screen.findByText("Juana Molina"));
+        await vi.advanceTimersByTimeAsync(400);
+
+        expect(requests).toHaveLength(1);
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      });
+
+      it("reopens the panel when the already-focused input is clicked", async () => {
+        mockArtistSearch([juanaMolina]);
+        const { user } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await user.click(await screen.findByText("Juana Molina"));
+
+        // The options' onMouseDown preventDefault keeps focus on the input, so
+        // clicking it again cannot refire onFocus.
+        expect(input).toHaveFocus();
+        await user.click(input);
+        await vi.advanceTimersByTimeAsync(400);
+
+        expect(await screen.findByRole("listbox")).toBeInTheDocument();
+      });
+
+      it("closes the panel on Escape", async () => {
+        mockArtistSearch([juanaMolina]);
+        const { user } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByRole("listbox");
+
+        await user.keyboard("{Escape}");
+
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      });
+    });
+
+    describe("creating a new artist", () => {
+      it("offers to create a new artist with the current search term", async () => {
+        mockArtistSearch([]);
+        const onCreateNew = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead onCreateNew={onCreateNew} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Nonexistent Band");
+        await vi.advanceTimersByTimeAsync(400);
+
+        await user.click(
+          await screen.findByText('Create new artist "Nonexistent Band"'),
+        );
+
+        expect(onCreateNew).toHaveBeenCalledWith("Nonexistent Band");
+      });
+
+      it("reaches the create row with the keyboard past the last result", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onCreateNew = vi.fn();
+        const onSelect = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead onSelect={onSelect} onCreateNew={onCreateNew} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Juana Molina");
+
+        await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+
+        expect(onCreateNew).toHaveBeenCalledWith("Juana");
+        expect(onSelect).not.toHaveBeenCalled();
+      });
+
+      it("does not create on Enter before results have arrived", async () => {
+        const onCreateNew = vi.fn();
+        const onSelect = vi.fn();
+        mockArtistSearch([juanaMolina]);
+        const { user } = renderWithProviders(
+          <ControlledTypeahead onSelect={onSelect} onCreateNew={onCreateNew} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+
+        // Still inside the debounce window: no row exists to act on.
+        await user.keyboard("{Enter}");
+
+        expect(onCreateNew).not.toHaveBeenCalled();
+        expect(onSelect).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("failed search", () => {
+      it("reports the failure instead of offering to create a duplicate", async () => {
+        mockArtistSearch(() =>
+          HttpResponse.json({ message: "boom" }, { status: 500 }),
+        );
+        const { user } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+          /Artist search is unavailable/i,
+        );
+        expect(
+          screen.queryByText(/Create new artist/i),
+        ).not.toBeInTheDocument();
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      });
+
+      it("closes on Escape even though there are no rows to navigate", async () => {
+        mockArtistSearch(() =>
+          HttpResponse.json({ message: "boom" }, { status: 500 }),
+        );
+        const { user } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByRole("alert");
+
+        await user.keyboard("{Escape}");
+
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      });
+
+      it("retries the search on demand", async () => {
+        let failNext = true;
+        const requests = mockArtistSearch(() => {
+          if (failNext) {
+            failNext = false;
+            return HttpResponse.json({ message: "boom" }, { status: 500 });
+          }
+          return HttpResponse.json({ artists: [juanaMolina] });
+        });
+        const { user } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByRole("alert");
+
+        await user.click(screen.getByRole("button", { name: /try again/i }));
+        await vi.advanceTimersByTimeAsync(400);
+
+        expect(await screen.findByText("Juana Molina")).toBeInTheDocument();
+        expect(requests).toHaveLength(2);
+      });
+    });
+
+    describe("disabled", () => {
+      it("neither opens nor queries", async () => {
+        const requests = mockArtistSearch([juanaMolina]);
+        renderWithProviders(<ControlledTypeahead initialValue="Juana" disabled />);
+
+        const input = await findInput();
+        expect(input).toBeDisabled();
+
+        await vi.advanceTimersByTimeAsync(400);
+
+        expect(requests).toHaveLength(0);
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
+++ b/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
@@ -410,6 +410,42 @@ describe("ArtistSearchTypeahead", () => {
         expect(input).toHaveValue("Juana Molina");
       });
 
+      it("writes the picked name into the field before reporting the selection", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onSelect = vi.fn();
+
+        // A host that rewrites the field from inside `onSelect` — the ordering
+        // consumers are told they can rely on. It only holds while the
+        // component's own write to `value` lands first; reversed, the component
+        // would overwrite the caller and the rewrite would vanish.
+        function RewritingHost() {
+          const [value, setValue] = useState("");
+          return (
+            <ArtistSearchTypeahead
+              genreId={ROCK_GENRE_ID}
+              value={value}
+              onChange={setValue}
+              onSelect={(artist) => {
+                setValue(`${artist.artist_name} (linked)`);
+                onSelect(artist);
+              }}
+              onCreateNew={vi.fn()}
+              onSelectionCleared={vi.fn()}
+            />
+          );
+        }
+
+        const { user } = renderWithProviders(<RewritingHost />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await user.click(await screen.findByText("Juana Molina"));
+
+        expect(onSelect).toHaveBeenCalledWith(juanaMolina);
+        expect(input).toHaveValue("Juana Molina (linked)");
+      });
+
       it("navigates results with the keyboard and selects with Enter", async () => {
         mockArtistSearch([juanaMolina, chuquimamaniCondori]);
         const onSelect = vi.fn();
@@ -580,6 +616,92 @@ describe("ArtistSearchTypeahead", () => {
         expect(onSelectionCleared).toHaveBeenCalledTimes(2);
       });
 
+      it("retracts the picked artist when the genre moves under it", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onSelect = vi.fn();
+        const onSelectionCleared = vi.fn();
+        const { user, rerender } = renderWithProviders(
+          <ControlledTypeahead
+            genreId={ROCK_GENRE_ID}
+            onSelect={onSelect}
+            onSelectionCleared={onSelectionCleared}
+          />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await user.click(await screen.findByText("Juana Molina"));
+
+        expect(onSelect).toHaveBeenCalledWith(juanaMolina);
+        expect(onSelectionCleared).not.toHaveBeenCalled();
+
+        // Artist rows are scoped to a genre, so the id the caller is holding
+        // names no row once the form files the release under another one. A
+        // caller that kept it would save an artist link its own genre does not
+        // have.
+        rerender(
+          <ControlledTypeahead
+            genreId={JAZZ_GENRE_ID}
+            onSelect={onSelect}
+            onSelectionCleared={onSelectionCleared}
+          />,
+        );
+
+        expect(onSelectionCleared).toHaveBeenCalledTimes(1);
+
+        // The caller has already dropped the id; editing the text afterwards is
+        // not a second retraction.
+        await user.type(input, "s");
+
+        expect(onSelectionCleared).toHaveBeenCalledTimes(1);
+      });
+
+      it("leaves the field text standing when the genre moves under a picked artist", async () => {
+        mockArtistSearch([juanaMolina]);
+        const { user, rerender } = renderWithProviders(
+          <ControlledTypeahead genreId={ROCK_GENRE_ID} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await user.click(await screen.findByText("Juana Molina"));
+
+        rerender(<ControlledTypeahead genreId={JAZZ_GENRE_ID} />);
+
+        // Refiling a release does not rename its artist: the text is exactly
+        // what the user needs in order to re-pick that artist under the new
+        // genre, and clearing it would leave the form with no artist at all.
+        expect(input).toHaveValue("Juana Molina");
+      });
+
+      it("reports no retraction when the genre moves with nothing picked", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onSelectionCleared = vi.fn();
+        const { user, rerender } = renderWithProviders(
+          <ControlledTypeahead
+            genreId={ROCK_GENRE_ID}
+            onSelectionCleared={onSelectionCleared}
+          />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Juana Molina");
+
+        rerender(
+          <ControlledTypeahead
+            genreId={JAZZ_GENRE_ID}
+            onSelectionCleared={onSelectionCleared}
+          />,
+        );
+        await vi.advanceTimersByTimeAsync(400);
+
+        expect(onSelectionCleared).not.toHaveBeenCalled();
+      });
+
       it("reports no retraction for text that was never a selection", async () => {
         mockArtistSearch([juanaMolina]);
         const onSelectionCleared = vi.fn();
@@ -634,6 +756,69 @@ describe("ArtistSearchTypeahead", () => {
 
         expect(onCreateNew).toHaveBeenCalledWith("Juana");
         expect(onSelect).not.toHaveBeenCalled();
+      });
+
+      it("stays on the create row when arrowing down past it", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onCreateNew = vi.fn();
+        const onSelect = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead onSelect={onSelect} onCreateNew={onCreateNew} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Juana Molina");
+
+        // Result, create row, then one press past the end of the list: create
+        // is the last row, so the highlight holds there rather than wrapping
+        // off it and stranding the user mid-list.
+        await user.keyboard("{ArrowDown}{ArrowDown}{ArrowDown}{Enter}");
+
+        expect(onCreateNew).toHaveBeenCalledWith("Juana");
+        expect(onSelect).not.toHaveBeenCalled();
+      });
+
+      it("returns to the last result when arrowing up off the create row", async () => {
+        mockArtistSearch([juanaMolina, chuquimamaniCondori]);
+        const onCreateNew = vi.fn();
+        const onSelect = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead onSelect={onSelect} onCreateNew={onCreateNew} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Chuquimamani-Condori");
+
+        // The create row is held as a sentinel rather than as an index one past
+        // the last result, so backing out of it has to name the row to return
+        // to; the last result is the row directly above it.
+        await user.keyboard("{ArrowDown}{ArrowDown}{ArrowDown}{ArrowUp}{Enter}");
+
+        expect(onSelect).toHaveBeenCalledWith(chuquimamaniCondori);
+        expect(onCreateNew).not.toHaveBeenCalled();
+      });
+
+      it("names the create row in aria-activedescendant while it is highlighted", async () => {
+        mockArtistSearch([juanaMolina]);
+        const { user } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        const [resultOption, createOption] = await screen.findAllByRole("option");
+
+        await user.keyboard("{ArrowDown}");
+        expect(input).toHaveAttribute("aria-activedescendant", resultOption.id);
+
+        // The create row's highlight is a sentinel, not an index into the
+        // results, so it needs its own branch to name the option a screen
+        // reader should announce.
+        await user.keyboard("{ArrowDown}");
+        expect(input).toHaveAttribute("aria-activedescendant", createOption.id);
       });
 
       it("does not create on Enter before results have arrived", async () => {
@@ -754,6 +939,27 @@ describe("ArtistSearchTypeahead", () => {
 
         expect(requests).toHaveLength(0);
         expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      });
+
+      it("takes down a panel that is already open when the field is disabled", async () => {
+        mockArtistSearch([juanaMolina]);
+        const { user, rerender } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Juana Molina");
+
+        rerender(<ControlledTypeahead disabled />);
+
+        // The greyed-out input says the field is inert. A row left standing
+        // under it is not: one click hands the caller an artist id it is no
+        // longer allowed to accept, with nothing on screen to say so.
+        expect(input).toBeDisabled();
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+        expect(screen.queryAllByRole("option")).toHaveLength(0);
+        expect(screen.queryByText("Juana Molina")).not.toBeInTheDocument();
+        expect(screen.queryByText(/Create new artist/i)).not.toBeInTheDocument();
       });
     });
   });

--- a/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
+++ b/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
@@ -78,7 +78,21 @@ const jessicaPratt: ArtistInGenreOption = {
   code_number: 5,
 };
 
-type SearchResponder = (url: URL) => Response;
+const stereolab: ArtistInGenreOption = {
+  id: 44,
+  artist_name: "Stereolab",
+  code_letters: "ST",
+  code_number: 2,
+};
+
+const niluferYanya: ArtistInGenreOption = {
+  id: 57,
+  artist_name: "Nilüfer Yanya",
+  code_letters: "YA",
+  code_number: 4,
+};
+
+type SearchResponder = (url: URL) => Response | Promise<Response>;
 
 /**
  * Installs the artist-search handler and returns the list of requests it has
@@ -111,12 +125,14 @@ function ControlledTypeahead({
   initialValue = "",
   onSelect = vi.fn(),
   onCreateNew = vi.fn(),
+  onSelectionCleared = vi.fn(),
   disabled,
 }: {
   genreId?: number;
   initialValue?: string;
   onSelect?: (artist: ArtistInGenreOption) => void;
   onCreateNew?: (searchTerm: string) => void;
+  onSelectionCleared?: () => void;
   disabled?: boolean;
 }) {
   const [value, setValue] = useState(initialValue);
@@ -127,6 +143,7 @@ function ControlledTypeahead({
       onChange={setValue}
       onSelect={onSelect}
       onCreateNew={onCreateNew}
+      onSelectionCleared={onSelectionCleared}
       disabled={disabled}
     />
   );
@@ -258,6 +275,93 @@ describe("ArtistSearchTypeahead", () => {
         ).toBe(true);
       });
 
+      it("drops the previous genre's results while the new genre's request is still open", async () => {
+        let releaseJazz = () => {};
+        const jazzHeld = new Promise<void>((resolve) => {
+          releaseJazz = resolve;
+        });
+        mockArtistSearch(async (url) => {
+          if (url.searchParams.get("genre_id") === String(JAZZ_GENRE_ID)) {
+            await jazzHeld;
+            return HttpResponse.json({ artists: [niluferYanya] });
+          }
+          return HttpResponse.json({ artists: [juanaMolina] });
+        });
+        const { user, rerender } = renderWithProviders(
+          <ControlledTypeahead genreId={ROCK_GENRE_ID} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        expect(await screen.findByText("Juana Molina")).toBeInTheDocument();
+
+        rerender(<ControlledTypeahead genreId={JAZZ_GENRE_ID} />);
+
+        // The genre-7 answer is not an answer about genre 99, so it must be
+        // gone for the whole window in which the genre-99 request is open —
+        // not merely once that request settles. A row still standing here is
+        // selectable, and the caller would file it under the wrong genre.
+        expect(screen.queryByText("Juana Molina")).not.toBeInTheDocument();
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+        expect(screen.queryByText(/Create new artist/i)).not.toBeInTheDocument();
+        expect(screen.getByRole("status")).toHaveTextContent(
+          /Searching artists/i,
+        );
+
+        releaseJazz();
+        expect(await screen.findByText("Nilüfer Yanya")).toBeInTheDocument();
+      });
+
+      it("keeps the highlight on a real row when the result set shrinks", async () => {
+        const onSelect = vi.fn();
+        const onCreateNew = vi.fn();
+        mockArtistSearch((url) =>
+          HttpResponse.json({
+            artists:
+              url.searchParams.get("genre_id") === String(ROCK_GENRE_ID)
+                ? [juanaMolina, chuquimamaniCondori, jessicaPratt, stereolab]
+                : [niluferYanya, stereolab],
+          }),
+        );
+        const { user, rerender } = renderWithProviders(
+          <ControlledTypeahead
+            genreId={ROCK_GENRE_ID}
+            onSelect={onSelect}
+            onCreateNew={onCreateNew}
+          />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Jessica Pratt");
+
+        // Third result of four.
+        await user.keyboard("{ArrowDown}{ArrowDown}{ArrowDown}");
+
+        rerender(
+          <ControlledTypeahead
+            genreId={JAZZ_GENRE_ID}
+            onSelect={onSelect}
+            onCreateNew={onCreateNew}
+          />,
+        );
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Nilüfer Yanya");
+        await waitFor(() =>
+          expect(screen.queryByText("Juana Molina")).not.toBeInTheDocument(),
+        );
+
+        // Two results now: the index the highlight held no longer exists, and
+        // the row that moved into its place is "create new". Enter must land on
+        // the last real result rather than silently creating an artist.
+        await user.keyboard("{Enter}");
+
+        expect(onSelect).toHaveBeenCalledWith(stereolab);
+        expect(onCreateNew).not.toHaveBeenCalled();
+      });
+
       it("drops results as soon as the query falls below the minimum length", async () => {
         mockArtistSearch([juanaMolina]);
         const { user } = renderWithProviders(<ControlledTypeahead />);
@@ -356,6 +460,55 @@ describe("ArtistSearchTypeahead", () => {
         expect(await screen.findByRole("listbox")).toBeInTheDocument();
       });
 
+      it("does not act on Enter in a panel opened without navigating", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onSelect = vi.fn();
+        const onCreateNew = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead
+            initialValue="Juana Molina"
+            onSelect={onSelect}
+            onCreateNew={onCreateNew}
+          />,
+        );
+
+        // A seeded field opened by click, never typed into: nothing has reset
+        // the highlight, so this is the only path on which its initial value is
+        // what keeps Enter from acting on a row the user never chose.
+        const input = await findInput();
+        await user.click(input);
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Juana Molina");
+
+        await user.keyboard("{Enter}");
+
+        expect(onSelect).not.toHaveBeenCalled();
+        expect(onCreateNew).not.toHaveBeenCalled();
+      });
+
+      it("clears the highlight when the panel is closed by clicking away", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onSelect = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead onSelect={onSelect} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Juana Molina");
+        await user.keyboard("{ArrowDown}");
+
+        await user.click(document.body);
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+        await user.click(input);
+        await screen.findByRole("listbox");
+        await user.keyboard("{Enter}");
+
+        expect(onSelect).not.toHaveBeenCalled();
+      });
+
       it("closes the panel on Escape", async () => {
         mockArtistSearch([juanaMolina]);
         const { user } = renderWithProviders(<ControlledTypeahead />);
@@ -368,6 +521,80 @@ describe("ArtistSearchTypeahead", () => {
         await user.keyboard("{Escape}");
 
         expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      });
+    });
+
+    describe("retracting a selection", () => {
+      it("retracts the picked artist once the text is edited away from it", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onSelect = vi.fn();
+        const onSelectionCleared = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead
+            onSelect={onSelect}
+            onSelectionCleared={onSelectionCleared}
+          />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await user.click(await screen.findByText("Juana Molina"));
+
+        expect(onSelect).toHaveBeenCalledWith(juanaMolina);
+        expect(onSelectionCleared).not.toHaveBeenCalled();
+
+        // The field now reads something other than the artist the caller was
+        // told about, so the id it is holding no longer describes this text.
+        await user.type(input, "s");
+
+        expect(onSelectionCleared).toHaveBeenCalledTimes(1);
+
+        // The caller has already dropped the id; further edits are not further
+        // retractions.
+        await user.type(input, "x");
+
+        expect(onSelectionCleared).toHaveBeenCalledTimes(1);
+      });
+
+      it("re-arms the retraction after a second pick", async () => {
+        mockArtistSearch([juanaMolina, chuquimamaniCondori]);
+        const onSelectionCleared = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead onSelectionCleared={onSelectionCleared} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await user.click(await screen.findByText("Juana Molina"));
+        await user.type(input, "s");
+        expect(onSelectionCleared).toHaveBeenCalledTimes(1);
+
+        await user.clear(input);
+        await user.type(input, "Chuqui");
+        await vi.advanceTimersByTimeAsync(400);
+        await user.click(await screen.findByText("Chuquimamani-Condori"));
+        await user.type(input, "s");
+
+        expect(onSelectionCleared).toHaveBeenCalledTimes(2);
+      });
+
+      it("reports no retraction for text that was never a selection", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onSelectionCleared = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead onSelectionCleared={onSelectionCleared} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Juana Molina");
+        await user.type(input, " Molina");
+        await user.clear(input);
+
+        expect(onSelectionCleared).not.toHaveBeenCalled();
       });
     });
 
@@ -446,6 +673,33 @@ describe("ArtistSearchTypeahead", () => {
           screen.queryByText(/Create new artist/i),
         ).not.toBeInTheDocument();
         expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      });
+
+      it("reports a failure that follows a successful search", async () => {
+        mockArtistSearch((url) =>
+          url.searchParams.get("q") === "Juana"
+            ? HttpResponse.json({ artists: [juanaMolina] })
+            : HttpResponse.json({ message: "boom" }, { status: 500 }),
+        );
+        const { user } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Juana Molina");
+
+        await user.clear(input);
+        await user.type(input, "Stereolab");
+        await vi.advanceTimersByTimeAsync(400);
+
+        // The earlier query's answer must not stand in for this one: reporting
+        // it as a match would be a wrong positive, and the create row it comes
+        // with would offer duplication on the back of an outage.
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+          /Artist search is unavailable/i,
+        );
+        expect(screen.queryByText("Juana Molina")).not.toBeInTheDocument();
+        expect(screen.queryByText(/Create new artist/i)).not.toBeInTheDocument();
       });
 
       it("closes on Escape even though there are no rows to navigate", async () => {

--- a/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
+++ b/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import {
+  renderWithProviders,
+  server,
+  TEST_BACKEND_URL,
+} from "@/tests/helpers";
+import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTypeahead";
+import type { ArtistInGenreOption } from "@/lib/features/catalog/types";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+// No organization configured (the real production shape): the WXYC tier
+// resolves via fetchOrganizationRoleForUserClient's JWT decode, not the raw
+// session role, so every test drives that mock and awaits resolution.
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<
+  typeof vi.fn
+>;
+
+function sessionWithRole() {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role: null,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+    error: null,
+  };
+}
+
+const ARTIST_SEARCH_URL = `${TEST_BACKEND_URL}/library/artists/search`;
+
+const juanaMolina: ArtistInGenreOption = {
+  id: 12,
+  artist_name: "Juana Molina",
+  code_letters: "MO",
+  code_number: 3,
+};
+
+function mockArtistSearch(artists: ArtistInGenreOption[]) {
+  let capturedUrl: URL | undefined;
+  server.use(
+    http.get(ARTIST_SEARCH_URL, ({ request }) => {
+      capturedUrl = new URL(request.url);
+      return HttpResponse.json({ artists });
+    }),
+  );
+  return () => capturedUrl;
+}
+
+describe("ArtistSearchTypeahead", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("permission gating", () => {
+    it("renders nothing for a DJ", async () => {
+      mockFetchOrgRole.mockResolvedValue("dj");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(
+        <ArtistSearchTypeahead
+          genreId={1}
+          onSelect={vi.fn()}
+          onCreateNew={vi.fn()}
+        />,
+      );
+
+      await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
+      await mockFetchOrgRole.mock.results[0].value;
+      await waitFor(() =>
+        expect(
+          screen.queryByPlaceholderText("Search artists..."),
+        ).not.toBeInTheDocument(),
+      );
+    });
+
+    it("renders the search input for a Music Director", async () => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(
+        <ArtistSearchTypeahead
+          genreId={1}
+          onSelect={vi.fn()}
+          onCreateNew={vi.fn()}
+        />,
+      );
+
+      expect(
+        await screen.findByPlaceholderText("Search artists..."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("querying", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    it("debounces the query and scopes it to the given genre", async () => {
+      const getUrl = mockArtistSearch([juanaMolina]);
+      const { user } = renderWithProviders(
+        <ArtistSearchTypeahead
+          genreId={7}
+          onSelect={vi.fn()}
+          onCreateNew={vi.fn()}
+        />,
+      );
+
+      const input = await screen.findByPlaceholderText("Search artists...");
+      await user.type(input, "Juana");
+
+      expect(getUrl()).toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(400);
+      await waitFor(() => expect(getUrl()).toBeDefined());
+
+      expect(getUrl()!.searchParams.get("q")).toBe("Juana");
+      expect(getUrl()!.searchParams.get("genre_id")).toBe("7");
+    });
+
+    it("does not query below the minimum query length", async () => {
+      const getUrl = mockArtistSearch([juanaMolina]);
+      const { user } = renderWithProviders(
+        <ArtistSearchTypeahead
+          genreId={7}
+          onSelect={vi.fn()}
+          onCreateNew={vi.fn()}
+        />,
+      );
+
+      const input = await screen.findByPlaceholderText("Search artists...");
+      await user.type(input, "J");
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(getUrl()).toBeUndefined();
+    });
+
+    it("renders matching results", async () => {
+      mockArtistSearch([juanaMolina]);
+      const { user } = renderWithProviders(
+        <ArtistSearchTypeahead
+          genreId={7}
+          onSelect={vi.fn()}
+          onCreateNew={vi.fn()}
+        />,
+      );
+
+      const input = await screen.findByPlaceholderText("Search artists...");
+      await user.type(input, "Juana");
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(await screen.findByText("Juana Molina")).toBeInTheDocument();
+    });
+  });
+
+  describe("selection", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    it("calls onSelect with the full artist object on click", async () => {
+      mockArtistSearch([juanaMolina]);
+      const onSelect = vi.fn();
+      const { user } = renderWithProviders(
+        <ArtistSearchTypeahead
+          genreId={7}
+          onSelect={onSelect}
+          onCreateNew={vi.fn()}
+        />,
+      );
+
+      const input = await screen.findByPlaceholderText("Search artists...");
+      await user.type(input, "Juana");
+      await vi.advanceTimersByTimeAsync(400);
+
+      await user.click(await screen.findByText("Juana Molina"));
+
+      expect(onSelect).toHaveBeenCalledWith(juanaMolina);
+    });
+
+    it("navigates results with the keyboard and selects with Enter", async () => {
+      mockArtistSearch([
+        juanaMolina,
+        { id: 20, artist_name: "Chuquimamani-Condori", code_letters: "CH", code_number: 1 },
+      ]);
+      const onSelect = vi.fn();
+      const { user } = renderWithProviders(
+        <ArtistSearchTypeahead
+          genreId={7}
+          onSelect={onSelect}
+          onCreateNew={vi.fn()}
+        />,
+      );
+
+      const input = await screen.findByPlaceholderText("Search artists...");
+      await user.type(input, "Juana");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByText("Juana Molina");
+
+      await user.keyboard("{ArrowDown}{Enter}");
+
+      expect(onSelect).toHaveBeenCalledWith({
+        id: 20,
+        artist_name: "Chuquimamani-Condori",
+        code_letters: "CH",
+        code_number: 1,
+      });
+    });
+  });
+
+  describe("no matches", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    it("offers to create a new artist with the current search term", async () => {
+      mockArtistSearch([]);
+      const onCreateNew = vi.fn();
+      const { user } = renderWithProviders(
+        <ArtistSearchTypeahead
+          genreId={7}
+          onSelect={vi.fn()}
+          onCreateNew={onCreateNew}
+        />,
+      );
+
+      const input = await screen.findByPlaceholderText("Search artists...");
+      await user.type(input, "Nonexistent Band");
+      await vi.advanceTimersByTimeAsync(400);
+
+      const createOption = await screen.findByText(
+        'Create new artist "Nonexistent Band"',
+      );
+      await user.click(createOption);
+
+      expect(onCreateNew).toHaveBeenCalledWith("Nonexistent Band");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a reusable, MD-gated artist-search typeahead at `src/components/shared/inputs/ArtistSearchTypeahead.tsx`, wired to `useSearchArtistsInGenreQuery` (`lib/features/catalog/api.ts`), which previously had zero consumers.

This is filed as a shared input on its own — the prop contract is the deliverable, per the pinned issue comment. Three sibling leaves depend on it, so none are wired up here.

- **Controlled** search text: `value` / `onChange` are caller-owned, so a consuming form can seed the field with an already-linked artist and clear it on cancel or after a save
- `genreId` scopes the query
- `onSelect(artist)` hands back the full `ArtistInGenreOption` (id and artist_name), and runs after the `onChange` that writes the picked name into the field, so a caller that rewrites `value` from inside `onSelect` wins
- `onCreateNew(searchTerm)` hands the current query string back to the caller — no navigation or modal handling here, that belongs to the caller
- 300ms debounce via `useDebouncedValue` feeding an arg-keyed RTK query, so results are keyed to the current genre and query and a repeat query serves the cache
- Keyboard navigation (arrow keys, enter, escape) with the highlight starting off-list, listbox/option ARIA semantics gated on the listbox actually existing
- Distinct loading, empty ("create new"), and failed-search presentations — a failed search offers a retry rather than creation
- Gated with `<RequireMD>`

Closes #1074

## Test plan

- [x] Integration suite (`tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx`) covers MD gating, debounced genre-scoped queries (asserting request count, not just the last URL), result rendering, click and keyboard selection, panel reopen on click, a mid-flight genre change, stale-window transitions, a non-200 response and its retry, Enter before results resolve, Escape, Enter on the create row, and the `disabled` prop
- [x] `npm run lint` — 0 errors, no new warnings (199, same as base)
- [x] `npx tsc --noEmit` — clean
- [x] Full unit/integration suite — 292 files / 3938 tests pass