### PR TITLE
test(auth): stop three component tests instantiating the real better-auth client

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -140,6 +140,21 @@ describeConversion("convertToSong", convertToSong, [
 ]);
 ```
 
+### Auth Client Mock
+
+`createAuthClientModuleMock()` (`tests/helpers/auth-client-mock.ts`) replaces `@/lib/features/authentication/client` with an unauthenticated session. Every test that renders a component reaching `useAuthentication` — directly, or through `useRegistry` / `useBin` / `usePlayNow` — must use it. Letting the real module instantiate installs a better-auth session store whose teardown is deferred a second past the last subscriber; a short test file finishes inside that second, the deferred teardown then runs against removed jsdom globals, and the resulting `window is not defined` is reported as an unhandled error that fails the run with every test green.
+
+```typescript
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import(
+    "@/tests/helpers/auth-client-mock"
+  );
+  return createAuthClientModuleMock();
+});
+```
+
+Import the helper by path inside the factory: `vi.mock` factories cannot close over imports, and the `@/tests/helpers` barrel pulls in the Redux store, which imports the module being replaced.
+
 ### MSW Setup
 
 Default handlers in `tests/fakes/handlers.ts` return empty responses for `/library/`, `/authentication/`, `/flowsheet/`, `/rotation/`. Override in individual tests:

--- a/tests/helpers/auth-client-mock.ts
+++ b/tests/helpers/auth-client-mock.ts
@@ -1,0 +1,54 @@
+import { vi } from "vitest";
+
+/**
+ * Replacement module for `@/lib/features/authentication/client`, shaped as an
+ * unauthenticated browser session.
+ *
+ * The real module builds a better-auth client at import time. Reading its
+ * `useSession` store installs polling plus `storage`, `visibilitychange`,
+ * `online` and `offline` listeners, and the matching teardown is deferred a
+ * second past the last subscriber. A short test file finishes inside that
+ * second, so the deferred teardown runs after jsdom's globals are gone and
+ * throws `window is not defined` out of a timer, which vitest counts as an
+ * unhandled error and fails the whole run even though every test passed.
+ *
+ * Any test that renders a component reaching `useAuthentication` (directly, or
+ * through `useRegistry` / `useBin` / `usePlayNow`) must therefore replace the
+ * module instead of letting it instantiate. `vi.mock` factories cannot close
+ * over imports, so pull this in from inside the factory:
+ *
+ * ```ts
+ * vi.mock("@/lib/features/authentication/client", async () => {
+ *   const { createAuthClientModuleMock } = await import(
+ *     "@/tests/helpers/auth-client-mock"
+ *   );
+ *   return createAuthClientModuleMock();
+ * });
+ * ```
+ *
+ * Import it by path, never through `@/tests/helpers`: the barrel pulls in the
+ * Redux store, which imports the very module being replaced.
+ */
+export function createAuthClientModuleMock() {
+  return {
+    authBaseURL: "http://localhost:8082/auth",
+    authFetch: vi.fn(async () => ({ ok: false, status: 401, data: null })),
+    authClient: {
+      useSession: () => ({
+        data: null,
+        error: null,
+        isPending: false,
+        isRefetching: false,
+        refetch: vi.fn(),
+      }),
+      getSession: vi.fn(async () => ({ data: null, error: null })),
+      signOut: vi.fn(async () => ({ data: null, error: null })),
+    },
+    getJWTToken: vi.fn(async () => null),
+    clearTokenCache: vi.fn(),
+    lookupEmailByIdentifier: vi.fn(async () => null),
+    completeOnboarding: vi.fn(async () => {
+      throw new Error("completeOnboarding is not stubbed in this test");
+    }),
+  };
+}

--- a/tests/integration/components/modern/catalog/Results/MobileResult.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/MobileResult.test.tsx
@@ -18,6 +18,15 @@ vi.mock("@/src/hooks/flowsheetHooks", () => ({
   useQueue: () => ({ addToQueue: vi.fn() }),
 }));
 
+// The bin control reaches useRegistry -> useAuthentication -> the better-auth
+// session store, whose deferred teardown outlives this file's jsdom environment.
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import(
+    "@/tests/helpers/auth-client-mock"
+  );
+  return createAuthClientModuleMock();
+});
+
 import CatalogMobileResult from "@/src/components/experiences/modern/catalog/Results/MobileResult";
 
 describe("CatalogMobileResult", () => {

--- a/tests/integration/components/modern/catalog/Results/Result.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/Result.test.tsx
@@ -26,6 +26,15 @@ vi.mock("@/src/hooks/catalogHooks", () => ({
   }),
 }));
 
+// The bin control reaches useRegistry -> useAuthentication -> the better-auth
+// session store, whose deferred teardown outlives this file's jsdom environment.
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import(
+    "@/tests/helpers/auth-client-mock"
+  );
+  return createAuthClientModuleMock();
+});
+
 import CatalogResult from "@/src/components/experiences/modern/catalog/Results/Result";
 
 describe("CatalogResult plays metadata (Bug 12)", () => {

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
@@ -112,6 +112,15 @@ vi.mock("sonner", () => ({
   },
 }));
 
+// usePlayNow reaches useRegistry -> useAuthentication -> the better-auth session
+// store, whose deferred teardown outlives this file's jsdom environment.
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import(
+    "@/tests/helpers/auth-client-mock"
+  );
+  return createAuthClientModuleMock();
+});
+
 describe("SongEntry", () => {
   const mockEntry: FlowsheetSongEntry = {
     id: 1,


### PR DESCRIPTION
## Symptom

The `Unit Tests (N/3)` CI job fails while every test passes:

```
Test Files  49 passed (49)
      Tests  680 passed (680)
     Errors  1 error
##[error]Process completed with exit code 1.
```

The failure is a post-teardown unhandled error, not an assertion:

```
⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯
ReferenceError: window is not defined
 ❯ Object.cleanupBroadcastSetup node_modules/better-auth/dist/client/broadcast-channel.mjs:35:4
 ❯ Object.cleanup node_modules/better-auth/dist/client/session-refresh.mjs:109:10
 ❯ node_modules/better-auth/dist/client/session-atom.mjs:144:19
 ❯ Timeout._onTimeout node_modules/nanostores/lifecycle/index.js:139:55
```

It has cost two full billed reruns (including four E2E shards each) in a day.

## Mechanism

`lib/features/authentication/client.ts` calls `createAuthClient()` at module load. Reading the resulting `useSession` store mounts a nanostores atom, and better-auth's `createSessionRefreshManager` then installs polling plus `storage`, `visibilitychange`, `online` and `offline` listeners.

nanostores does not tear a store down the moment its last subscriber leaves — `onMount` schedules the unmount callbacks on a `setTimeout(…, STORE_UNMOUNT_DELAY)` with `STORE_UNMOUNT_DELAY = 1000`. When a component unmounts near the end of a short test file, that one-second timer is still pending when vitest tears down the jsdom environment and deletes `window` from the worker's globals. The timer then fires into a dead environment, better-auth's `cleanupBroadcastSetup` closure calls `window.removeEventListener`, and the bare `window` reference raises `ReferenceError`. Vitest reports it as an unhandled error and exits 1.

Nothing about the store is per-test: the leak exists in any file whose component graph reaches `authClient.useSession()` without replacing the module. Three files did:

| File | Path to the session store |
|---|---|
| `tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx` | `SongEntry` → `usePlayNow` → `useRegistry` → `useAuthentication` |
| `tests/integration/components/modern/catalog/Results/Result.test.tsx` | `CatalogResult` → `AddRemoveBin` → `useBin` → `useRegistry` → `useAuthentication` |
| `tests/integration/components/modern/catalog/Results/MobileResult.test.tsx` | `CatalogMobileResult` → `AddRemoveBin` → `useBin` → `useRegistry` → `useAuthentication` |

Instrumenting `session-atom.mjs` to log the mounting test file across the full 293-file suite produced exactly four mounts, all from those three files (`SongEntry.test.tsx` mounts twice). Every other component test already replaces `@/lib/features/authentication/client`.

Why it looked intermittent: whether the pending timer ever fires depends on how long the worker survives its own environment teardown, which varies with runner load. It also depends on the *selection*, because PRs run `npx vitest run --changed origin/main --shard=N/3` — a change to anything under `lib/` that `lib/store.ts` imports widens the selection until an affected file lands in a shard that normally skips it.

## Fix

Add `createAuthClientModuleMock()` (`tests/helpers/auth-client-mock.ts`), a module replacement presenting an unauthenticated session, and use it from the three files. This matches what the other 29 test files that touch auth already do, and it removes the possibility rather than reacting to it: the real client is never constructed, so no store is ever mounted and no timer is ever scheduled.

Two alternatives were rejected:

- **An `afterEach`/`afterAll` that tears the session-refresh subscription down.** There is no supported handle on it — the atom is private to better-auth's client, and the only reachable lever is nanostores' `cleanStores`, which would require importing the real client in `tests/setup/vitest.setup.ts` and thereby instantiating it for all 294 files.
- **A global guard in the setup file.** The leak is not cross-cutting; it is three files that drifted from the established pattern. A blanket mock would also silently change behaviour for the tests that legitimately exercise the real module (`getJWTToken` caching, `organization-utils`).

The failure signal is untouched: no vitest option was relaxed, no error swallowed, no CI exit code changed. `ci.yml`'s sharding and `--changed` strategy are out of scope here.

## Verification

Because the failure depends on a race between the pending timer and the worker's death, it was made deterministic with a throwaway vitest environment that wraps the stock jsdom one, idles 1.5 s after teardown, and captures anything thrown in that window — the CI worker shape, amplified. Before:

```
tests/…/SongEntry/SongEntry.test.tsx     65 passed   post-teardown leaks: 2
tests/…/catalog/Results/Result.test.tsx        20 passed   post-teardown leaks: 2
tests/…/catalog/Results/MobileResult.test.tsx   8 passed   post-teardown leaks: 2
```

each leak being `ReferenceError: window is not defined` with the CI stack above. A control file that already mocks the client (`AccountEntry.test.tsx`) reported 0. After this change, all three report `post-teardown leaks: 0` with the same test counts.

Independently, re-running the instrumented full suite now logs **zero** session-store mounts across all 294 files — the timer can no longer be scheduled anywhere in the unit suite.

Local gate green on this branch: `npm run lint` (0 errors, 199 warnings — unchanged baseline), `npx tsc --noEmit`, `npx vitest run` (294 files, 3952 tests, 0 errors).

## Note on better-auth 1.6.25

Dependabot PR #1066 bumps better-auth 1.6.23 → 1.6.25. It is unrelated to this bug: `broadcast-channel.mjs`, `session-refresh.mjs`, `session-atom.mjs`, `focus-manager.mjs` and `online-manager.mjs` are byte-identical between the two versions. The bump neither fixes nor worsens the leak, and this change does not affect its priority.
