### PR TITLE
fix(flowsheet): track rotation picker highlight by release id, not position

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
@@ -20,6 +20,10 @@ function matchesQuery(release: AlbumEntry, query: string): boolean {
   );
 }
 
+function filterReleases(sorted: AlbumEntry[], query: string): AlbumEntry[] {
+  return query ? sorted.filter((r) => matchesQuery(r, query)) : sorted;
+}
+
 export default function RotationReleaseDropdown({
   releases,
   selectedRelease,
@@ -33,13 +37,26 @@ export default function RotationReleaseDropdown({
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [highlightIndex, setHighlightIndex] = useState(-1);
+  // The keyboard highlight is a release id, never a position. `releases` is
+  // shared server state — any DJ's rotation add or kill invalidates the cached
+  // bin and can reorder or shorten this list while the panel is open — so a
+  // positional highlight would silently come to rest on a different release and
+  // commit that one to the live air log on Enter. An id either still resolves
+  // to the release the DJ highlighted, or resolves to nothing.
+  const [highlightId, setHighlightId] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const visibleReleases = useMemo(() => {
-    const sorted = sortRotationReleases(releases);
-    return query ? sorted.filter((r) => matchesQuery(r, query)) : sorted;
-  }, [releases, query]);
+  const sortedReleases = useMemo(
+    () => sortRotationReleases(releases),
+    [releases]
+  );
+  const visibleReleases = useMemo(
+    () => filterReleases(sortedReleases, query),
+    [sortedReleases, query]
+  );
+  // -1 once the highlighted release has left the visible list (killed, or
+  // filtered out by the query), which is also the "nothing highlighted" state.
+  const highlightIndex = visibleReleases.findIndex((r) => r.id === highlightId);
 
   // While the panel is open the input mirrors the live filter query (which
   // starts empty so the DJ can see every release). While closed it mirrors
@@ -60,13 +77,13 @@ export default function RotationReleaseDropdown({
     if (open) return;
     setOpen(true);
     setQuery("");
-    setHighlightIndex(0);
-  }, [disabled, open]);
+    setHighlightId(sortedReleases[0]?.id ?? null);
+  }, [disabled, open, sortedReleases]);
 
   const closePanel = useCallback(() => {
     setOpen(false);
     setQuery("");
-    setHighlightIndex(-1);
+    setHighlightId(null);
   }, []);
 
   const handleSelect = useCallback(
@@ -87,22 +104,26 @@ export default function RotationReleaseDropdown({
         return;
       }
       switch (e.key) {
+        // Both arrows step from the highlight's *current* position in the
+        // *current* list. With nothing highlighted (index -1) either one
+        // re-enters at the top rather than leaving the DJ stuck.
         case "ArrowDown":
           e.preventDefault();
-          setHighlightIndex((prev) =>
-            Math.min(prev + 1, visibleReleases.length - 1)
+          setHighlightId(
+            visibleReleases[
+              Math.min(highlightIndex + 1, visibleReleases.length - 1)
+            ]?.id ?? null
           );
           break;
         case "ArrowUp":
           e.preventDefault();
-          setHighlightIndex((prev) => Math.max(prev - 1, 0));
+          setHighlightId(
+            visibleReleases[Math.max(highlightIndex - 1, 0)]?.id ?? null
+          );
           break;
         case "Enter":
           e.preventDefault();
-          if (
-            highlightIndex >= 0 &&
-            highlightIndex < visibleReleases.length
-          ) {
+          if (highlightIndex >= 0) {
             handleSelect(visibleReleases[highlightIndex]);
           }
           break;
@@ -140,9 +161,14 @@ export default function RotationReleaseDropdown({
           // the panel is already open).
           onClick={openPanel}
           onChange={(e) => {
+            const nextQuery = e.target.value;
             if (!open) openPanel();
-            setQuery(e.target.value);
-            setHighlightIndex(0);
+            setQuery(nextQuery);
+            // The filtered list for `nextQuery` doesn't exist yet this tick, so
+            // resolve the first match against the same filter the memo will run.
+            setHighlightId(
+              filterReleases(sortedReleases, nextQuery)[0]?.id ?? null
+            );
           }}
           onKeyDown={handleKeyDown}
           endDecorator={
@@ -233,7 +259,7 @@ export default function RotationReleaseDropdown({
                           : "neutral.800",
                     },
                   }}
-                  onMouseEnter={() => setHighlightIndex(index)}
+                  onMouseEnter={() => setHighlightId(release.id)}
                 >
                   <Typography
                     level="body-sm"

--- a/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown.tsx
@@ -41,8 +41,9 @@ export default function RotationReleaseDropdown({
   // shared server state — any DJ's rotation add or kill invalidates the cached
   // bin and can reorder or shorten this list while the panel is open — so a
   // positional highlight would silently come to rest on a different release and
-  // commit that one to the live air log on Enter. An id either still resolves
-  // to the release the DJ highlighted, or resolves to nothing.
+  // hand that one to the parent on Enter, filling the draft entry with a release
+  // the DJ never highlighted. An id either still resolves to the release the DJ
+  // highlighted, or resolves to nothing.
   const [highlightId, setHighlightId] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -56,6 +57,9 @@ export default function RotationReleaseDropdown({
   );
   // -1 once the highlighted release has left the visible list (killed, or
   // filtered out by the query), which is also the "nothing highlighted" state.
+  // Resolving by id assumes ids are unique within this list: the rotation feed
+  // returns one row per (album, bin) and the parent narrows to a single bin.
+  // The option render's `key` already rests on that same assumption.
   const highlightIndex = visibleReleases.findIndex((r) => r.id === highlightId);
 
   // While the panel is open the input mirrors the live filter query (which

--- a/tests/integration/components/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
@@ -411,8 +411,9 @@ describe("RotationReleaseDropdown — combobox (#745)", () => {
 // The bin is shared server state: any DJ's rotation add or kill invalidates the
 // cached list, so `releases` can be reordered, extended, or shortened while this
 // panel sits open. A keyboard highlight held as a raw position into the derived
-// list would come to rest on whichever release slid into that slot and commit it
-// to the live air log on Enter, with nothing on screen to explain the swap.
+// list would come to rest on whichever release slid into that slot and hand that
+// one to the parent on Enter, with nothing on screen to explain the swap — so the
+// draft entry the DJ goes on to submit names a release they never highlighted.
 describe("RotationReleaseDropdown — highlight across list changes", () => {
   const onSelect = vi.fn();
   beforeEach(() => vi.clearAllMocks());

--- a/tests/integration/components/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import RotationReleaseDropdown from "@/src/components/experiences/modern/flowsheet/Search/RotationReleaseDropdown";
-import { createTestAlbum, createTestArtist } from "@/tests/helpers";
+import {
+  createTestAlbum,
+  createTestArtist,
+  renderWithProviders,
+} from "@/tests/helpers";
 import type { AlbumEntry } from "@/lib/features/catalog/types";
 
 const releases = [
@@ -401,6 +405,118 @@ describe("RotationReleaseDropdown — combobox (#745)", () => {
         screen.queryByTestId("rotation-release-option-1")
       ).not.toBeInTheDocument();
     });
+  });
+});
+
+// The bin is shared server state: any DJ's rotation add or kill invalidates the
+// cached list, so `releases` can be reordered, extended, or shortened while this
+// panel sits open. A keyboard highlight held as a raw position into the derived
+// list would come to rest on whichever release slid into that slot and commit it
+// to the live air log on Enter, with nothing on screen to explain the swap.
+describe("RotationReleaseDropdown — highlight across list changes", () => {
+  const onSelect = vi.fn();
+  beforeEach(() => vi.clearAllMocks());
+
+  // Sorts ahead of every release in the shared fixture, so adding it shifts the
+  // whole list down by one.
+  const arthurRussell = createTestAlbum({
+    id: 4,
+    title: "World of Echo",
+    artist: createTestArtist({ name: "Arthur Russell" }),
+    label: "Audika",
+  });
+
+  function renderPicker(initial: AlbumEntry[]) {
+    const { rerender } = renderWithProviders(
+      <RotationReleaseDropdown
+        releases={initial}
+        selectedRelease={null}
+        onSelectRelease={onSelect}
+        disabled={false}
+      />
+    );
+    return (next: AlbumEntry[]) =>
+      rerender(
+        <RotationReleaseDropdown
+          releases={next}
+          selectedRelease={null}
+          onSelectRelease={onSelect}
+          disabled={false}
+        />
+      );
+  }
+
+  // Opens the panel (highlighting the first release) and arrows down onto
+  // Cat Power — the middle of the sorted fixture.
+  function highlightCatPower(input: HTMLInputElement) {
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+  }
+
+  it("commits the highlighted release after a concurrent add reorders the list", () => {
+    const setReleases = renderPicker(releases);
+    const input = getCombobox();
+    highlightCatPower(input);
+
+    setReleases([...releases, arthurRussell]);
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 2, title: "Moon Pix" })
+    );
+  });
+
+  it("commits the highlighted release after an earlier release is killed", () => {
+    const setReleases = renderPicker(releases);
+    const input = getCombobox();
+    highlightCatPower(input);
+
+    setReleases([releases[1], releases[2]]);
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 2, title: "Moon Pix" })
+    );
+  });
+
+  it("commits nothing when the highlighted release itself leaves the list", () => {
+    const setReleases = renderPicker(releases);
+    const input = getCombobox();
+    highlightCatPower(input);
+
+    setReleases([releases[0], releases[2]]);
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("commits nothing when the bin empties under the open panel", () => {
+    const setReleases = renderPicker(releases);
+    const input = getCombobox();
+    highlightCatPower(input);
+
+    setReleases([]);
+    expect(() => fireEvent.keyDown(input, { key: "Enter" })).not.toThrow();
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(screen.getByText(/no releases in this bin/i)).toBeInTheDocument();
+  });
+
+  it("re-enters the list from the top when the highlighted release is gone", () => {
+    const setReleases = renderPicker(releases);
+    const input = getCombobox();
+    highlightCatPower(input);
+
+    setReleases([releases[0], releases[2]]);
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, title: "Confield" })
+    );
   });
 });
 


### PR DESCRIPTION
Closes #1095.

## What was wrong

`RotationReleaseDropdown` held its keyboard highlight as a **raw position** into `visibleReleases` — a `useMemo` over `[releases, query]` — and nothing reset that position when `releases` changed. The only resets were user-driven (`openPanel`, `closePanel`, the query `onChange`, arrow keys, `mouseEnter`); none keyed on the list's identity.

`releases` is shared server state. `useGetRotationQuery`'s cache entry is invalidated by `invalidatesTags: ["Rotation"]` on both `addRotationEntry` and `killRotationEntry`, so a DJ's own add or kill refetches the bin and can reorder or shorten the list under an open panel. The highlight then stayed at its old slot, now occupied by a different release, and Enter handed **that** one to the parent — filling the draft flowsheet entry with a release the DJ never highlighted, silently, with the correct-looking row highlighted a moment earlier. (Enter does not itself write the air log: it calls `onSelectRelease`, and this handler's `preventDefault` is what stops the keystroke reaching the search form's submit. The wrong release reaches the log when the DJ submits the draft.)

## The fix

Hold the highlight as a release **id** and derive the index during render:

```ts
const [highlightId, setHighlightId] = useState<number | null>(null);
const highlightIndex = visibleReleases.findIndex((r) => r.id === highlightId);
```

`findIndex` returns `-1` when the highlighted release has left the list, which is already this component's "nothing highlighted" state — so the existing `highlightIndex === index` render path and the Enter guard both keep working unchanged, and Enter on a vanished highlight commits nothing rather than committing a neighbour.

This closes the class rather than the instance (the issue's second option): on a reorder the highlight *moves with the release* instead of being cleared, which is what a DJ mid-pick actually wants.

Supporting changes:

- `sortRotationReleases(releases)` is split into its own memo so `openPanel` can resolve "highlight the first release" to an id without re-sorting. No extra sort work — the previous single memo already re-ran on every `releases` change.
- The filter predicate is extracted to `filterReleases(sorted, query)` so the query `onChange` handler can resolve the first match for the *incoming* query, which the memo hasn't recomputed yet that tick.
- Both arrow keys now step from the highlight's current position in the current list. With nothing highlighted (`-1`) either arrow re-enters at the top rather than leaving the DJ stuck.

`AlbumEntry.id` is safe as an identity here: conversion already guarantees distinct, stable, non-null ids precisely so consumers can key off it (`convertToAlbumEntry`'s null-id fallback), and this component's own `key={release.id}` has always depended on that.

## Tests

Five new cases in `RotationReleaseDropdown.test.tsx` drive the reproduction — open the picker, highlight a row by keyboard, mutate `releases`, press Enter:

| Scenario | Before | After |
|---|---|---|
| Concurrent add reorders the list | commits the wrong release to the draft | commits the highlighted one |
| An earlier release is killed | commits the wrong release to the draft | commits the highlighted one |
| The highlighted release itself is killed | commits a neighbour | commits nothing |
| The bin empties | commits nothing | commits nothing |
| Arrow after the highlight is gone | lands mid-list | re-enters at the top |

Four of the five fail on `main`; the empty-bin case was already guarded and is kept as a regression pin.

## Verification

- `npx vitest run` — 4017 passed (297 files), including `RotationEntryFields.test.tsx`, `EntryForm.test.tsx`, and `catalogHooks.test.ts`
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors, 199 warnings (unchanged baseline)

`sortRotationReleases` ordering behaviour is untouched, and `refetchOnMountOrArgChange` was not reintroduced on `getRotation`.

