### PR TITLE
feat(catalog): add MD-gated artist-add form

### DIFF
--- a/lib/features/catalog/adminCreateArtistValidation.ts
+++ b/lib/features/catalog/adminCreateArtistValidation.ts
@@ -9,21 +9,26 @@ export function parseRequiredPositiveInt(raw: string): number | null {
 }
 
 /**
- * True when a `POST /library/artists` 409 body names the artist already holding
- * the code, which is the only 409 a caller can report by name.
+ * True when a `POST /library/artists` rejection is the code-taken 409 naming
+ * the artist that already holds the code — the only one a caller can report by
+ * name instead of as a generic failure.
  *
- * Two places have to agree on this exact shape: the endpoint drops the body's
- * generic `message` so the recoverable code-taken outcome is reported once
- * rather than as a banner plus a toast, and the caller dereferences
- * `artist.artist_name` while rendering that banner with no error boundary
- * beneath it. If the strip were the broader test, a second 409 reason — or an
- * intermediary answering 409 with its own JSON — would lose its message before
- * anything could surface it, leaving only a generic fallback.
+ * Two places have to agree on this exact test, which is why it is one function
+ * rather than two: the endpoint drops the body's generic `message` so the
+ * recoverable outcome is reported once rather than as a banner plus a toast,
+ * and the caller dereferences `artist.artist_name` while rendering that banner
+ * with no error boundary beneath it. Were the strip the broader test, a second
+ * 409 reason — or an intermediary answering 409 with its own JSON — would lose
+ * its message before anything could surface it, leaving only a generic
+ * fallback. Were the banner's the broader one, it would throw on a body that
+ * carries no artist.
  */
-export function isAddArtistConflictBody(
-  data: unknown,
-): data is AddArtistConflict {
-  if (!data || typeof data !== "object") return false;
+export function isAddArtistConflict(
+  err: unknown,
+): err is { status: 409; data: AddArtistConflict } {
+  if (!err || typeof err !== "object" || !("status" in err)) return false;
+  const { status, data } = err as { status?: unknown; data?: unknown };
+  if (status !== 409 || !data || typeof data !== "object") return false;
   const { artist } = data as { artist?: unknown };
   return (
     !!artist &&

--- a/lib/features/catalog/adminCreateArtistValidation.ts
+++ b/lib/features/catalog/adminCreateArtistValidation.ts
@@ -9,6 +9,24 @@ export function parseRequiredPositiveInt(raw: string): number | null {
 }
 
 /**
+ * True when a `POST /library/artists` submission was refused as conflicting,
+ * whatever the reason. Resubmitting the same triple unchanged can only be
+ * refused the same way, so this — not the body's shape — is what a caller
+ * gates resubmission on.
+ *
+ * Deliberately blind to the body: the backend's only 409 is the code-taken
+ * one, but an intermediary can answer 409 with JSON of its own, and a body
+ * that fails to parse narrows what can be *said* about the refusal, never
+ * whether one happened.
+ */
+export function isConflictRejection(
+  err: unknown,
+): err is { status: 409; data: unknown } {
+  if (!err || typeof err !== "object" || !("status" in err)) return false;
+  return (err as { status?: unknown }).status === 409;
+}
+
+/**
  * True when a `POST /library/artists` rejection is the code-taken 409 naming
  * the artist that already holds the code — the only one a caller can report by
  * name instead of as a generic failure.

--- a/lib/features/catalog/adminCreateArtistValidation.ts
+++ b/lib/features/catalog/adminCreateArtistValidation.ts
@@ -1,7 +1,33 @@
+import type { AddArtistConflict } from "./types";
+
 /** Empty or non-numeric strings must not become 0 (Number("") === 0). */
 export function parseRequiredPositiveInt(raw: string): number | null {
   const trimmed = raw.trim();
   // Base-10 positive integers only — reject scientific/hex (Number("1e3") === 1000).
   if (trimmed === "" || !/^[1-9]\d*$/.test(trimmed)) return null;
   return Number(trimmed);
+}
+
+/**
+ * True when a `POST /library/artists` 409 body names the artist already holding
+ * the code, which is the only 409 a caller can report by name.
+ *
+ * Two places have to agree on this exact shape: the endpoint drops the body's
+ * generic `message` so the recoverable code-taken outcome is reported once
+ * rather than as a banner plus a toast, and the caller dereferences
+ * `artist.artist_name` while rendering that banner with no error boundary
+ * beneath it. If the strip were the broader test, a second 409 reason — or an
+ * intermediary answering 409 with its own JSON — would lose its message before
+ * anything could surface it, leaving only a generic fallback.
+ */
+export function isAddArtistConflictBody(
+  data: unknown,
+): data is AddArtistConflict {
+  if (!data || typeof data !== "object") return false;
+  const { artist } = data as { artist?: unknown };
+  return (
+    !!artist &&
+    typeof artist === "object" &&
+    typeof (artist as { artist_name?: unknown }).artist_name === "string"
+  );
 }

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -1,7 +1,7 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import type { RootState } from "@/lib/store";
 import { backendBaseQuery } from "../backend";
-import { isAddArtistConflictBody } from "./adminCreateArtistValidation";
+import { isAddArtistConflict } from "./adminCreateArtistValidation";
 import { CATALOG_QUERY_PAGE_LIMIT } from "./constants";
 import { convertToAlbumEntry } from "./conversions";
 import { patchCatalogSearchCaches } from "./patchSearchCaches";
@@ -172,9 +172,7 @@ export const catalogApi = createApi({
       // the caller can actually name an artist from, so any other 409 keeps
       // whatever reason the server sent.
       transformErrorResponse: (error) => {
-        if (error.status !== 409 || !isAddArtistConflictBody(error.data)) {
-          return error;
-        }
+        if (!isAddArtistConflict(error)) return error;
         const data = { ...(error.data as unknown as Record<string, unknown>) };
         delete data.message;
         return { ...error, data };
@@ -187,12 +185,16 @@ export const catalogApi = createApi({
       // session, even though the backend would now reject it as taken.
       //
       // Invalidation fires on a rejected mutation as well as a fulfilled one,
-      // so this has to opt out explicitly: a rejected add wrote nothing, and a
-      // code-taken 409 is a routine outcome. Invalidating on it would flip the
-      // code preview the MD is reading back to a spinner and spend two more
-      // round trips reconfirming unchanged lists.
+      // so the rejections that provably wrote nothing opt out: every 4xx, of
+      // which the code-taken 409 is the routine one. Invalidating on those
+      // would flip the code preview the MD is reading back to a spinner and
+      // spend two more round trips reconfirming lists that cannot have
+      // changed. A 5xx or a transport failure still gets the tags — the row
+      // may well have been written on a response the client never saw, and
+      // ArtistSearch backs the typeahead that is all that stands between a
+      // retry and a duplicate artist.
       invalidatesTags: (_result, error, { code_letters, genre_id }) =>
-        error
+        error && typeof error.status === "number" && error.status < 500
           ? []
           : [
               { type: "CatalogList", id: "LIST" },

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -1,6 +1,7 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
 import type { RootState } from "@/lib/store";
 import { backendBaseQuery } from "../backend";
+import { isAddArtistConflictBody } from "./adminCreateArtistValidation";
 import { CATALOG_QUERY_PAGE_LIMIT } from "./constants";
 import { convertToAlbumEntry } from "./conversions";
 import { patchCatalogSearchCaches } from "./patchSearchCaches";
@@ -167,12 +168,14 @@ export const catalogApi = createApi({
       // inline by name. Its generic `message` is dropped here so the global
       // rejected-query middleware — which toasts any `data.message` — stays
       // quiet and that recoverable outcome is reported once rather than as a
-      // banner plus a generic failure toast.
+      // banner plus a generic failure toast. The strip is confined to bodies
+      // the caller can actually name an artist from, so any other 409 keeps
+      // whatever reason the server sent.
       transformErrorResponse: (error) => {
-        if (error.status !== 409 || !error.data || typeof error.data !== "object") {
+        if (error.status !== 409 || !isAddArtistConflictBody(error.data)) {
           return error;
         }
-        const data = { ...(error.data as Record<string, unknown>) };
+        const data = { ...(error.data as unknown as Record<string, unknown>) };
         delete data.message;
         return { ...error, data };
       },
@@ -182,11 +185,20 @@ export const catalogApi = createApi({
       // pair just filled: without this, a cached preview for that pair keeps
       // showing the pre-add code number to an MD who revisits it in the same
       // session, even though the backend would now reject it as taken.
-      invalidatesTags: (_result, _error, { code_letters, genre_id }) => [
-        { type: "CatalogList", id: "LIST" },
-        { type: "ArtistSearch", id: "LIST" },
-        { type: "ArtistCodePeek", id: `${genre_id}:${code_letters}` },
-      ],
+      //
+      // Invalidation fires on a rejected mutation as well as a fulfilled one,
+      // so this has to opt out explicitly: a rejected add wrote nothing, and a
+      // code-taken 409 is a routine outcome. Invalidating on it would flip the
+      // code preview the MD is reading back to a spinner and spend two more
+      // round trips reconfirming unchanged lists.
+      invalidatesTags: (_result, error, { code_letters, genre_id }) =>
+        error
+          ? []
+          : [
+              { type: "CatalogList", id: "LIST" },
+              { type: "ArtistSearch", id: "LIST" },
+              { type: "ArtistCodePeek", id: `${genre_id}:${code_letters}` },
+            ],
     }),
     peekArtistCode: builder.query<PeekArtistCodeResponse, PeekArtistCodeQuery>({
       query: ({ code_letters, genre_id }) => ({

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -185,9 +185,10 @@ export const catalogApi = createApi({
       // session, even though the backend would now reject it as taken.
       //
       // Invalidation fires on a rejected mutation as well as a fulfilled one,
-      // so the rejections that provably wrote nothing opt out: every 4xx, of
-      // which the code-taken 409 is the routine one. Invalidating on those
-      // would flip the code preview the MD is reading back to a spinner and
+      // so the rejections that provably wrote nothing opt out: anything the
+      // server answered below 500, of which the code-taken 409 is the routine
+      // one. Invalidating on those would flip the code preview back to a
+      // spinner in front of the MD who is reading it and
       // spend two more round trips reconfirming lists that cannot have
       // changed. A 5xx or a transport failure still gets the tags — the row
       // may well have been written on a response the client never saw, and

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -150,7 +150,12 @@ export const catalogApi = createApi({
       },
     }),
     addArtist: builder.mutation<
-      { id: number; code_number?: number; genre_id?: number } & Record<string, unknown>,
+      {
+        id: number;
+        code_letters?: string;
+        code_number?: number;
+        genre_id?: number;
+      } & Record<string, unknown>,
       AddArtistRequestBody
     >({
       query: (body) => ({
@@ -160,8 +165,7 @@ export const catalogApi = createApi({
       }),
       // A new artist would surface in the artist typeahead (searchArtistsInGenre)
       // and can gate later album rows; refetch both rather than patch —
-      // dj-site#624. Neither this mutation nor the typeahead has a UI consumer
-      // yet — tags are wired for the first adopter, not a live flow.
+      // dj-site#624.
       // Also invalidate the peek-code preview for the exact code_letters/genre_id
       // pair just filled: without this, a cached preview for that pair keeps
       // showing the pre-add code number to an MD who revisits it in the same

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -189,12 +189,17 @@ export const catalogApi = createApi({
       // server answered below 500, of which the code-taken 409 is the routine
       // one. Invalidating CatalogList/ArtistSearch on those would spend two
       // round trips reconfirming lists that cannot have changed. The peek tag
-      // is the one exception: a 409 IS the evidence that this cache entry —
-      // and only this one — is stale, since it names the exact pair the
-      // preview just showed as free. A 5xx or a transport failure still gets
-      // every tag — the row may well have been written on a response the
-      // client never saw, and ArtistSearch backs the typeahead that is all
-      // that stands between a retry and a duplicate artist.
+      // is the one exception: every 409 on this endpoint means the
+      // code_letters/genre_id/code_number triple is taken, so it IS the
+      // evidence that this cache entry — and only this one — is stale, since
+      // it names the exact pair the preview just showed as free. That holds
+      // regardless of whether the body happens to parse as
+      // `isAddArtistConflict` — that check exists so the caller can name the
+      // conflicting artist in a banner, not to decide whether the pair is
+      // actually free. A 5xx or a transport failure still gets every tag —
+      // the row may well have been written on a response the client never
+      // saw, and ArtistSearch backs the typeahead that is all that stands
+      // between a retry and a duplicate artist.
       invalidatesTags: (_result, error, { code_letters, genre_id }) => {
         const codePeekTag = {
           type: "ArtistCodePeek" as const,
@@ -209,7 +214,7 @@ export const catalogApi = createApi({
             codePeekTag,
           ];
         }
-        return isAddArtistConflict(error) ? [codePeekTag] : [];
+        return error.status === 409 ? [codePeekTag] : [];
       },
     }),
     peekArtistCode: builder.query<PeekArtistCodeResponse, PeekArtistCodeQuery>({

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -163,9 +163,21 @@ export const catalogApi = createApi({
         method: "POST",
         body,
       }),
+      // The 409 body carries the conflicting artist, which the caller renders
+      // inline by name. Its generic `message` is dropped here so the global
+      // rejected-query middleware — which toasts any `data.message` — stays
+      // quiet and that recoverable outcome is reported once rather than as a
+      // banner plus a generic failure toast.
+      transformErrorResponse: (error) => {
+        if (error.status !== 409 || !error.data || typeof error.data !== "object") {
+          return error;
+        }
+        const data = { ...(error.data as Record<string, unknown>) };
+        delete data.message;
+        return { ...error, data };
+      },
       // A new artist would surface in the artist typeahead (searchArtistsInGenre)
-      // and can gate later album rows; refetch both rather than patch —
-      // dj-site#624.
+      // and can gate later album rows; refetch both rather than patch.
       // Also invalidate the peek-code preview for the exact code_letters/genre_id
       // pair just filled: without this, a cached preview for that pair keeps
       // showing the pre-add code number to an MD who revisits it in the same

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -187,21 +187,30 @@ export const catalogApi = createApi({
       // Invalidation fires on a rejected mutation as well as a fulfilled one,
       // so the rejections that provably wrote nothing opt out: anything the
       // server answered below 500, of which the code-taken 409 is the routine
-      // one. Invalidating on those would flip the code preview back to a
-      // spinner in front of the MD who is reading it and
-      // spend two more round trips reconfirming lists that cannot have
-      // changed. A 5xx or a transport failure still gets the tags — the row
-      // may well have been written on a response the client never saw, and
-      // ArtistSearch backs the typeahead that is all that stands between a
-      // retry and a duplicate artist.
-      invalidatesTags: (_result, error, { code_letters, genre_id }) =>
-        error && typeof error.status === "number" && error.status < 500
-          ? []
-          : [
-              { type: "CatalogList", id: "LIST" },
-              { type: "ArtistSearch", id: "LIST" },
-              { type: "ArtistCodePeek", id: `${genre_id}:${code_letters}` },
-            ],
+      // one. Invalidating CatalogList/ArtistSearch on those would spend two
+      // round trips reconfirming lists that cannot have changed. The peek tag
+      // is the one exception: a 409 IS the evidence that this cache entry —
+      // and only this one — is stale, since it names the exact pair the
+      // preview just showed as free. A 5xx or a transport failure still gets
+      // every tag — the row may well have been written on a response the
+      // client never saw, and ArtistSearch backs the typeahead that is all
+      // that stands between a retry and a duplicate artist.
+      invalidatesTags: (_result, error, { code_letters, genre_id }) => {
+        const codePeekTag = {
+          type: "ArtistCodePeek" as const,
+          id: `${genre_id}:${code_letters}`,
+        };
+        const wroteNothing =
+          !!error && typeof error.status === "number" && error.status < 500;
+        if (!wroteNothing) {
+          return [
+            { type: "CatalogList", id: "LIST" },
+            { type: "ArtistSearch", id: "LIST" },
+            codePeekTag,
+          ];
+        }
+        return isAddArtistConflict(error) ? [codePeekTag] : [];
+      },
     }),
     peekArtistCode: builder.query<PeekArtistCodeResponse, PeekArtistCodeQuery>({
       query: ({ code_letters, genre_id }) => ({

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -95,6 +95,17 @@ export type AddArtistRequestBody = {
   alphabetical_name?: string;
 };
 
+/**
+ * Body of the 409 `POST /library/artists` returns when the
+ * (code_letters, genre_id, code_number) triple is already taken — the
+ * conflicting artist comes back alongside the message so the caller can name
+ * it rather than reporting a generic failure.
+ */
+export type AddArtistConflict = {
+  message: string;
+  artist: { artist_id: number; artist_name: string; code_letters: string };
+};
+
 export type PeekArtistCodeQuery = {
   code_letters: string;
   genre_id: number;

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -97,12 +97,13 @@ export type AddArtistRequestBody = {
 
 /**
  * Body of the 409 `POST /library/artists` returns when the
- * (code_letters, genre_id, code_number) triple is already taken — the
- * conflicting artist comes back alongside the message so the caller can name
- * it rather than reporting a generic failure.
+ * (code_letters, genre_id, code_number) triple is already taken, as the
+ * caller sees it: the conflicting artist, so it can be named rather than
+ * reported as a generic failure. The backend also sends a generic `message`
+ * alongside it; `addArtist` strips that before the rejection reaches any
+ * consumer, so nothing here should read it.
  */
 export type AddArtistConflict = {
-  message: string;
   artist: { artist_id: number; artist_name: string; code_letters: string };
 };
 

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
@@ -53,8 +53,8 @@ type SavedFields = {
  * artist rows are genre-scoped, and an id is only good for the text that
  * produced it. Carrying all three lets this form judge the link against what is
  * on screen at any moment, rather than depending on the typeahead to announce
- * every way it can go stale — that announcement fires at most once per
- * selection, so a link that outlives one is never spoken for again.
+ * every way it can go stale — its announcements cover only the selections it
+ * made itself, and a link read straight off the album is never one of them.
  */
 type ArtistLink = {
   id: number;
@@ -160,9 +160,11 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
   // true about what it names and the derivation below is what should weigh it;
   // dropping it here would defeat the round trip. Any other retraction is
   // acted on immediately. Either way the derivation below is the standing
-  // authority — it re-checks both the genre and the name on every render, and
-  // it has to, because the typeahead stops tracking a selection after the first
-  // retraction it fires and never speaks for that link again.
+  // authority — it re-checks both the genre and the name on every render.
+  // It has to, because the two retractions differ in what follows them: a
+  // text edit that lands back on the exact picked name re-announces that
+  // artist through `onSelect`, restoring the link with no new pick, while a
+  // genre move discards the selection for good.
   const handleArtistSelectionCleared = () => {
     setArtistLink((prev) => (prev !== null && prev.genreId !== resolvedGenreId ? prev : null));
   };

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -15,6 +15,7 @@ import {
   Typography,
 } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
+import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 import { useAddArtistMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
 import { parseRequiredPositiveInt } from "@/lib/features/catalog/adminCreateArtistValidation";
 import type {
@@ -26,13 +27,21 @@ import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTy
 import CallLetterPeekControl from "./CallLetterPeekControl";
 
 /**
- * `artists.code_letters` is a `varchar(4)` and nothing between this field and
- * the INSERT checks its length: an over-long value reaches PostgreSQL and
- * comes back as a 22001 500, not a validation error. The ceiling has to hold
- * here, and be visible to the MD rather than silently truncating what they
- * typed.
+ * Column ceilings on the rows this form writes. Nothing between these fields
+ * and the INSERT checks any of them — the handler validates only that the keys
+ * are present — so an over-long or over-large value reaches PostgreSQL and
+ * comes back as a 22001/22003 500 rather than a validation error. Each ceiling
+ * has to hold here, and be visible to the MD rather than failing at the far
+ * end of a submit.
+ *
+ * `artists.code_letters` is a `varchar(4)`; `artists.artist_name` and
+ * `artists.alphabetical_name` are `varchar(128)`; the code number is filed as
+ * `genre_artist_crossreference.artist_genre_code`, a PostgreSQL `integer`
+ * whose range check fires at bind time, before the insert.
  */
 const CODE_LETTERS_MAX_LENGTH = 4;
+const ARTIST_NAME_MAX_LENGTH = 128;
+const CODE_NUMBER_MAX = 2147483647;
 
 /**
  * Call letters are matched case-sensitively everywhere the backend uses them —
@@ -65,22 +74,6 @@ function isAddArtistConflict(
     typeof artist === "object" &&
     typeof (artist as { artist_name?: unknown }).artist_name === "string"
   );
-}
-
-/**
- * True when `err` is a genuine HTTP error response (fetchBaseQuery's numeric
- * `status`) whose body carries no `message`. This is the one rejection shape
- * the global `rtkQueryErrorLogger` middleware leaves untoasted — it only
- * toasts `data.message`, `FETCH_ERROR`, `TIMEOUT_ERROR`, or a top-level
- * `error` string, none of which this shape has.
- */
-function isUnmessagedHttpError(err: unknown): boolean {
-  if (!err || typeof err !== "object" || !("status" in err)) return false;
-  const { status, data } = err as { status?: unknown; data?: unknown };
-  if (typeof status !== "number") return false;
-  const message =
-    data && typeof data === "object" ? (data as { message?: unknown }).message : undefined;
-  return !(typeof message === "string" && message.trim().length > 0);
 }
 
 /**
@@ -123,8 +116,10 @@ function ArtistAddFields() {
   // the typeahead's panel stays shut, so nothing checks the typed name against
   // the new genre. Treating the retraction as "this name is new here" would
   // turn a blocked duplicate into an enabled submit at the exact moment the
-  // check matters, so the check is marked stale instead and the MD has to
-  // re-engage the field under the new genre.
+  // check matters, so the check is marked stale instead. It clears only on an
+  // answer about the current genre — a row picked, "create new" chosen, or the
+  // text changed to a different question altogether. Reopening the panel
+  // re-runs the search but reports nothing back, so it does not clear this.
   const [dedupCheckStale, setDedupCheckStale] = useState(false);
   const [genreId, setGenreId] = useState<number | null>(null);
   const [codeLetters, setCodeLetters] = useState("");
@@ -144,9 +139,19 @@ function ArtistAddFields() {
   );
 
   const trimmedName = name.trim();
+  const trimmedAlphabeticalName = alphabeticalName.trim();
   const trimmedCodeLetters = codeLetters.trim();
+  const nameTooLong = trimmedName.length > ARTIST_NAME_MAX_LENGTH;
+  const alphabeticalNameTooLong =
+    trimmedAlphabeticalName.length > ARTIST_NAME_MAX_LENGTH;
   const codeLettersTooLong = trimmedCodeLetters.length > CODE_LETTERS_MAX_LENGTH;
-  const codeNumber = parseRequiredPositiveInt(codeNumberRaw);
+  const parsedCodeNumber = parseRequiredPositiveInt(codeNumberRaw);
+  // parseRequiredPositiveInt only rejects non-integers; the column's range is
+  // this form's to enforce.
+  const codeNumber =
+    parsedCodeNumber !== null && parsedCodeNumber <= CODE_NUMBER_MAX
+      ? parsedCodeNumber
+      : null;
   const codeNumberInvalid = codeNumberRaw.trim().length > 0 && codeNumber === null;
   // A failed genres GET leaves an empty dropdown behind: fetchBaseQuery's
   // rejection sets `isError`, while the backend adapter's soft-fail turns a
@@ -160,6 +165,8 @@ function ArtistAddFields() {
     existingArtist === null &&
     !dedupCheckStale &&
     trimmedName.length > 0 &&
+    !nameTooLong &&
+    !alphabeticalNameTooLong &&
     genreId !== null &&
     trimmedCodeLetters.length > 0 &&
     !codeLettersTooLong &&
@@ -168,8 +175,10 @@ function ArtistAddFields() {
   const handleNameChange = (value: string) => {
     setName(value);
     setAdded(null);
-    // Editing the text reopens the typeahead's panel and re-runs the search
-    // under the current genre, which is the re-check the stale flag waits for.
+    // A different string is a different question: whatever the previous genre
+    // said about the old text has nothing left to be stale about, and the edit
+    // reopens the typeahead's panel to search the new text under the current
+    // genre.
     setDedupCheckStale(false);
   };
 
@@ -182,8 +191,8 @@ function ArtistAddFields() {
       code_letters: trimmedCodeLetters,
       genre_id: genreId,
       code_number: codeNumber,
-      ...(alphabeticalName.trim()
-        ? { alphabetical_name: alphabeticalName.trim() }
+      ...(trimmedAlphabeticalName
+        ? { alphabetical_name: trimmedAlphabeticalName }
         : {}),
     };
 
@@ -285,7 +294,7 @@ function ArtistAddFields() {
             )}
           </FormControl>
 
-          <FormControl>
+          <FormControl error={nameTooLong}>
             <FormLabel>Artist name</FormLabel>
             <ArtistSearchTypeahead
               genreId={genreId ?? -1}
@@ -302,27 +311,39 @@ function ArtistAddFields() {
               onSelectionCleared={() => setExistingArtist(null)}
               disabled={genreId === null || isLoading}
             />
-            {existingArtist ? (
+            {nameTooLong ? (
+              <FormHelperText>
+                At most {ARTIST_NAME_MAX_LENGTH} characters
+              </FormHelperText>
+            ) : existingArtist ? (
               <FormHelperText sx={{ color: "danger.500" }}>
                 {existingArtist.artist_name} already exists in this genre.
               </FormHelperText>
             ) : (
               dedupCheckStale && (
                 <FormHelperText sx={{ color: "warning.500" }}>
-                  Search this name again under the new genre before adding.
+                  Re-check this name under the new genre: pick the existing
+                  artist from the suggestions, or choose &quot;Create new
+                  artist&quot;.
                 </FormHelperText>
               )
             )}
           </FormControl>
 
-          <FormControl>
+          <FormControl error={alphabeticalNameTooLong}>
             <FormLabel>Alphabetical name (optional)</FormLabel>
             <Input
               value={alphabeticalName}
               disabled={isLoading}
               onChange={(e) => setAlphabeticalName(e.target.value)}
               placeholder="Defaults to artist name"
+              slotProps={{ input: { maxLength: ARTIST_NAME_MAX_LENGTH } }}
             />
+            {alphabeticalNameTooLong && (
+              <FormHelperText>
+                At most {ARTIST_NAME_MAX_LENGTH} characters
+              </FormHelperText>
+            )}
           </FormControl>
 
           <FormControl error={codeLettersTooLong}>
@@ -350,7 +371,11 @@ function ArtistAddFields() {
               placeholder="e.g. 42"
             />
             {codeNumberInvalid && (
-              <FormHelperText>Must be a positive whole number</FormHelperText>
+              <FormHelperText>
+                {parsedCodeNumber === null
+                  ? "Must be a positive whole number"
+                  : `Must be no greater than ${CODE_NUMBER_MAX}`}
+              </FormHelperText>
             )}
           </FormControl>
 

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -85,7 +85,6 @@ function ArtistAddForm() {
 function ArtistAddFields() {
   const {
     data: genres,
-    isUninitialized: genresUnstarted,
     isLoading: genresLoading,
     isFetching: genresFetching,
     refetch: refetchGenres,
@@ -168,12 +167,10 @@ function ArtistAddFields() {
   // exist". The test is the absence of a list, not `isError`: a refetch that
   // rejects leaves the last good list in the cache and the form still submits
   // perfectly well against it, so reading the error flag would put a "can't be
-  // filed right now" alert beside an enabled submit button. The query also
-  // subscribes from an effect, so the mount render reports neither a pending
-  // request nor data — reading that as an outage would announce the alert on
-  // every mount, before anything has been asked.
-  const genresUnavailable =
-    !genresUnstarted && !genresLoading && genres == null;
+  // filed right now" alert beside an enabled submit button. `genresLoading`
+  // alone covers the mount render: `useGetGenresQuery` passes no `skip`, so
+  // RTK Query synthesizes `isLoading: true` for that first render regardless.
+  const genresUnavailable = !genresLoading && genres == null;
 
   // Puts the caret back where the edit left it. React writes the normalized
   // value into the node during the commit's mutation phase, which is the write
@@ -191,6 +188,12 @@ function ArtistAddFields() {
     !isLoading &&
     existingArtist === null &&
     !dedupCheckStale &&
+    // The code_letters/code_number/genre handlers below already clear
+    // `conflict` on any edit that could change the outcome, so a standing
+    // conflict here means the (code_letters, genre_id, code_number) triple is
+    // still the exact one the server just rejected — resubmitting it
+    // unchanged can only reach the same 409.
+    conflict === null &&
     trimmedName.length > 0 &&
     !nameTooLong &&
     !alphabeticalNameTooLong &&
@@ -210,8 +213,13 @@ function ArtistAddFields() {
     // A different string is a different question: whatever the previous genre
     // said about the old text has nothing left to be stale about, and the edit
     // reopens the typeahead's panel to search the new text under the current
-    // genre.
-    setDedupCheckStale(false);
+    // genre. A whitespace-only edit is not a different string — it trims back
+    // to the exact name the stale flag was raised against — so it must leave
+    // the flag standing rather than dismiss a re-check the new genre's search
+    // hasn't answered yet.
+    if (value.trim() !== trimmedName) {
+      setDedupCheckStale(false);
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  Button,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  Option,
+  Select,
+  Sheet,
+  Stack,
+  Typography,
+} from "@mui/joy";
+import { RequireMD } from "@/src/components/shared/Authorization";
+import { useAddArtistMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
+import { parseRequiredPositiveInt } from "@/lib/features/catalog/adminCreateArtistValidation";
+import type { AddArtistRequestBody, ArtistInGenreOption } from "@/lib/features/catalog/types";
+import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTypeahead";
+import CallLetterPeekControl from "./CallLetterPeekControl";
+
+/**
+ * Body of the 409 Backend-Service returns from `POST /library/artists` when
+ * the (code_letters, genre_id, code_number) triple is already taken
+ * (library.controller.ts `addArtist`, via `getArtistByCode`).
+ */
+type AddArtistConflict = {
+  message: string;
+  artist: { artist_id: number; artist_name: string; code_letters: string };
+};
+
+function isAddArtistConflict(
+  err: unknown,
+): err is { status: 409; data: AddArtistConflict } {
+  if (!err || typeof err !== "object" || !("status" in err)) return false;
+  const { status, data } = err as { status?: unknown; data?: unknown };
+  return (
+    status === 409 &&
+    !!data &&
+    typeof data === "object" &&
+    "artist" in data
+  );
+}
+
+/**
+ * MD-gated artist-add form. Dedups against existing artists via
+ * `ArtistSearchTypeahead` and previews the call-letter assignment via
+ * `CallLetterPeekControl` before submitting `useAddArtistMutation`.
+ *
+ * Submits dj-site's local `AddArtistRequestBody` (code_number required), not
+ * the published `@wxyc/shared` `AddArtistRequest` — the latter omits
+ * `code_number`, which Backend-Service 400s without.
+ */
+function ArtistAddForm() {
+  return (
+    <RequireMD>
+      <ArtistAddFields />
+    </RequireMD>
+  );
+}
+
+function ArtistAddFields() {
+  const { data: genres } = useGetGenresQuery();
+  const [addArtist, { isLoading }] = useAddArtistMutation();
+
+  const [name, setName] = useState("");
+  // The artist the typeahead most recently confirmed. Non-null means the
+  // MD's search term names an artist that already exists in this genre, so
+  // submitting would create a duplicate — the create action stays disabled
+  // until either the text moves away from it or genreId changes, both of
+  // which the typeahead reports via onSelectionCleared.
+  const [existingArtist, setExistingArtist] = useState<ArtistInGenreOption | null>(
+    null,
+  );
+  const [genreId, setGenreId] = useState<number | null>(null);
+  const [codeLetters, setCodeLetters] = useState("");
+  const [codeNumberRaw, setCodeNumberRaw] = useState("");
+  const [alphabeticalName, setAlphabeticalName] = useState("");
+  const [conflict, setConflict] = useState<AddArtistConflict | null>(null);
+  const [added, setAdded] = useState<{ code_letters: string; code_number: number } | null>(
+    null,
+  );
+
+  const trimmedName = name.trim();
+  const trimmedCodeLetters = codeLetters.trim();
+  const codeNumber = parseRequiredPositiveInt(codeNumberRaw);
+  const codeNumberInvalid = codeNumberRaw.trim().length > 0 && codeNumber === null;
+
+  const canSubmit =
+    !isLoading &&
+    existingArtist === null &&
+    trimmedName.length > 0 &&
+    genreId !== null &&
+    trimmedCodeLetters.length > 0 &&
+    codeNumber !== null;
+
+  const handleNameChange = (value: string) => {
+    setName(value);
+    setAdded(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!canSubmit || genreId === null || codeNumber === null) return;
+
+    const body: AddArtistRequestBody = {
+      artist_name: trimmedName,
+      code_letters: trimmedCodeLetters,
+      genre_id: genreId,
+      code_number: codeNumber,
+      ...(alphabeticalName.trim()
+        ? { alphabetical_name: alphabeticalName.trim() }
+        : {}),
+    };
+
+    setConflict(null);
+    try {
+      const result = await addArtist(body).unwrap();
+      setAdded({
+        code_letters: trimmedCodeLetters,
+        code_number: result.code_number ?? codeNumber,
+      });
+      setName("");
+      setCodeLetters("");
+      setCodeNumberRaw("");
+      setAlphabeticalName("");
+      setExistingArtist(null);
+      toast.success(`Added ${trimmedName}`);
+    } catch (err) {
+      if (isAddArtistConflict(err)) {
+        setConflict(err.data);
+      } else {
+        toast.error("Failed to add artist");
+      }
+    }
+  };
+
+  return (
+    <Sheet variant="outlined" sx={{ p: 2, borderRadius: "md" }}>
+      <Typography level="title-md" sx={{ mb: 1 }}>
+        Add artist
+      </Typography>
+      <form onSubmit={handleSubmit}>
+        <Stack spacing={1.5}>
+          <FormControl>
+            <FormLabel>Genre</FormLabel>
+            <Select
+              placeholder="Select genre..."
+              value={genreId}
+              onChange={(_, value) => setGenreId(value)}
+            >
+              {(genres ?? []).map((genre) => (
+                <Option key={genre.id} value={genre.id}>
+                  {genre.genre_name}
+                </Option>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl>
+            <FormLabel>Artist name</FormLabel>
+            <ArtistSearchTypeahead
+              genreId={genreId ?? -1}
+              value={name}
+              onChange={handleNameChange}
+              onSelect={setExistingArtist}
+              onCreateNew={() => setExistingArtist(null)}
+              onSelectionCleared={() => setExistingArtist(null)}
+              disabled={genreId === null}
+            />
+            {existingArtist && (
+              <FormHelperText sx={{ color: "danger.500" }}>
+                {existingArtist.artist_name} already exists in this genre.
+              </FormHelperText>
+            )}
+          </FormControl>
+
+          <FormControl>
+            <FormLabel>Alphabetical name (optional)</FormLabel>
+            <Input
+              value={alphabeticalName}
+              onChange={(e) => setAlphabeticalName(e.target.value)}
+              placeholder="Defaults to artist name"
+            />
+          </FormControl>
+
+          <FormControl>
+            <FormLabel>Call letters</FormLabel>
+            <Input
+              value={codeLetters}
+              onChange={(e) => setCodeLetters(e.target.value)}
+              placeholder="e.g. MO"
+            />
+          </FormControl>
+
+          <FormControl error={codeNumberInvalid}>
+            <FormLabel>Code number</FormLabel>
+            <Input
+              value={codeNumberRaw}
+              onChange={(e) => setCodeNumberRaw(e.target.value)}
+              placeholder="e.g. 42"
+            />
+            {codeNumberInvalid && (
+              <FormHelperText>Must be a positive whole number</FormHelperText>
+            )}
+          </FormControl>
+
+          <CallLetterPeekControl code_letters={codeLetters} genre_id={genreId} />
+
+          {conflict && (
+            <Typography level="body-sm" color="danger" role="alert">
+              {trimmedCodeLetters}
+              {codeNumberRaw.trim()} is already taken by {conflict.artist.artist_name}.
+            </Typography>
+          )}
+
+          {added && (
+            <Typography level="body-sm" color="success" role="status">
+              Added as {added.code_letters}
+              {added.code_number}.
+            </Typography>
+          )}
+
+          <Button type="submit" loading={isLoading} disabled={!canSubmit}>
+            Add artist
+          </Button>
+        </Stack>
+      </form>
+    </Sheet>
+  );
+}
+
+export default ArtistAddForm;

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -17,31 +17,70 @@ import {
 import { RequireMD } from "@/src/components/shared/Authorization";
 import { useAddArtistMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
 import { parseRequiredPositiveInt } from "@/lib/features/catalog/adminCreateArtistValidation";
-import type { AddArtistRequestBody, ArtistInGenreOption } from "@/lib/features/catalog/types";
+import type {
+  AddArtistConflict,
+  AddArtistRequestBody,
+  ArtistInGenreOption,
+} from "@/lib/features/catalog/types";
 import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTypeahead";
 import CallLetterPeekControl from "./CallLetterPeekControl";
 
 /**
- * Body of the 409 Backend-Service returns from `POST /library/artists` when
- * the (code_letters, genre_id, code_number) triple is already taken
- * (library.controller.ts `addArtist`, via `getArtistByCode`).
+ * `artists.code_letters` is a `varchar(4)` and nothing between this field and
+ * the INSERT checks its length: an over-long value reaches PostgreSQL and
+ * comes back as a 22001 500, not a validation error. The ceiling has to hold
+ * here, and be visible to the MD rather than silently truncating what they
+ * typed.
  */
-type AddArtistConflict = {
-  message: string;
-  artist: { artist_id: number; artist_name: string; code_letters: string };
-};
+const CODE_LETTERS_MAX_LENGTH = 4;
+
+/**
+ * Call letters are matched case-sensitively everywhere the backend uses them —
+ * the duplicate pre-check and the next-code-number scan both compare the
+ * column for equality, over a plain btree on a non-citext column — and the
+ * existing card catalog is filed uppercase. Lowercase "mo" therefore matches
+ * no row of the "MO" series: it slips past the duplicate check and previews a
+ * next code of 1, opening a second series that shadows the real one while the
+ * form reports success. Normalizing at the edge keeps the field, the code
+ * preview, and the request body on the one casing the catalog actually uses.
+ */
+function normalizeCodeLetters(value: string): string {
+  return value.toUpperCase();
+}
 
 function isAddArtistConflict(
   err: unknown,
 ): err is { status: 409; data: AddArtistConflict } {
   if (!err || typeof err !== "object" || !("status" in err)) return false;
   const { status, data } = err as { status?: unknown; data?: unknown };
+  if (status !== 409 || !data || typeof data !== "object") return false;
+  // The banner dereferences `artist.artist_name` two levels down, so key
+  // presence is not enough: a 409 carrying a null or nameless artist would
+  // pass a `"artist" in data` guard and then throw during render, and there is
+  // no error boundary in this subtree to catch it — white-screening the form
+  // on an outcome that is supposed to be recoverable.
+  const { artist } = data as { artist?: unknown };
   return (
-    status === 409 &&
-    !!data &&
-    typeof data === "object" &&
-    "artist" in data
+    !!artist &&
+    typeof artist === "object" &&
+    typeof (artist as { artist_name?: unknown }).artist_name === "string"
   );
+}
+
+/**
+ * True when `err` is a genuine HTTP error response (fetchBaseQuery's numeric
+ * `status`) whose body carries no `message`. This is the one rejection shape
+ * the global `rtkQueryErrorLogger` middleware leaves untoasted — it only
+ * toasts `data.message`, `FETCH_ERROR`, `TIMEOUT_ERROR`, or a top-level
+ * `error` string, none of which this shape has.
+ */
+function isUnmessagedHttpError(err: unknown): boolean {
+  if (!err || typeof err !== "object" || !("status" in err)) return false;
+  const { status, data } = err as { status?: unknown; data?: unknown };
+  if (typeof status !== "number") return false;
+  const message =
+    data && typeof data === "object" ? (data as { message?: unknown }).message : undefined;
+  return !(typeof message === "string" && message.trim().length > 0);
 }
 
 /**
@@ -62,7 +101,13 @@ function ArtistAddForm() {
 }
 
 function ArtistAddFields() {
-  const { data: genres } = useGetGenresQuery();
+  const {
+    data: genres,
+    isError: genresErrored,
+    isLoading: genresLoading,
+    isFetching: genresFetching,
+    refetch: refetchGenres,
+  } = useGetGenresQuery();
   const [addArtist, { isLoading }] = useAddArtistMutation();
 
   const [name, setName] = useState("");
@@ -74,6 +119,13 @@ function ArtistAddFields() {
   const [existingArtist, setExistingArtist] = useState<ArtistInGenreOption | null>(
     null,
   );
+  // A genre change retracts a held selection but does not re-run the search:
+  // the typeahead's panel stays shut, so nothing checks the typed name against
+  // the new genre. Treating the retraction as "this name is new here" would
+  // turn a blocked duplicate into an enabled submit at the exact moment the
+  // check matters, so the check is marked stale instead and the MD has to
+  // re-engage the field under the new genre.
+  const [dedupCheckStale, setDedupCheckStale] = useState(false);
   const [genreId, setGenreId] = useState<number | null>(null);
   const [codeLetters, setCodeLetters] = useState("");
   const [codeNumberRaw, setCodeNumberRaw] = useState("");
@@ -93,20 +145,32 @@ function ArtistAddFields() {
 
   const trimmedName = name.trim();
   const trimmedCodeLetters = codeLetters.trim();
+  const codeLettersTooLong = trimmedCodeLetters.length > CODE_LETTERS_MAX_LENGTH;
   const codeNumber = parseRequiredPositiveInt(codeNumberRaw);
   const codeNumberInvalid = codeNumberRaw.trim().length > 0 && codeNumber === null;
+  // A failed genres GET leaves an empty dropdown behind: fetchBaseQuery's
+  // rejection sets `isError`, while the backend adapter's soft-fail turns a
+  // non-JSON GET failure into `{ data: null }` with no error at all. Either
+  // way `genre_id` is unreachable and the form can never submit, so the outage
+  // has to say so rather than presenting an empty list as "no genres exist".
+  const genresUnavailable = genresErrored || (!genresLoading && genres == null);
 
   const canSubmit =
     !isLoading &&
     existingArtist === null &&
+    !dedupCheckStale &&
     trimmedName.length > 0 &&
     genreId !== null &&
     trimmedCodeLetters.length > 0 &&
+    !codeLettersTooLong &&
     codeNumber !== null;
 
   const handleNameChange = (value: string) => {
     setName(value);
     setAdded(null);
+    // Editing the text reopens the typeahead's panel and re-runs the search
+    // under the current genre, which is the re-check the stale flag waits for.
+    setDedupCheckStale(false);
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -126,8 +190,10 @@ function ArtistAddFields() {
     setConflict(null);
     try {
       const result = await addArtist(body).unwrap();
+      // The assigned code comes from the 201 body, not from what was typed:
+      // the two agree today, but only the server's copy is what was filed.
       setAdded({
-        code_letters: trimmedCodeLetters,
+        code_letters: result.code_letters ?? trimmedCodeLetters,
         code_number: result.code_number ?? codeNumber,
       });
       setName("");
@@ -135,6 +201,7 @@ function ArtistAddFields() {
       setCodeNumberRaw("");
       setAlphabeticalName("");
       setExistingArtist(null);
+      setDedupCheckStale(false);
       toast.success(`Added ${trimmedName}`);
     } catch (err) {
       if (isAddArtistConflict(err)) {
@@ -143,14 +210,17 @@ function ArtistAddFields() {
           code_number: codeNumberRaw.trim(),
           response: err.data,
         });
-      } else {
+      } else if (isUnmessagedHttpError(err)) {
+        // The global rtkQueryErrorLogger middleware already toasts the server
+        // message for the common failure; only surface a fallback here for the
+        // gap it leaves silent.
         toast.error("Failed to add artist");
       }
     }
   };
 
   const handleCodeLettersChange = (value: string) => {
-    setCodeLetters(value);
+    setCodeLetters(normalizeCodeLetters(value));
     setConflict(null);
   };
 
@@ -164,6 +234,8 @@ function ArtistAddFields() {
     // Uniqueness is (code_letters, genre_id, code_number) — a code the
     // server rejected under one genre may be free under another.
     setConflict(null);
+    // Whatever the typeahead last reported was found under the previous genre.
+    setDedupCheckStale(trimmedName.length > 0);
   };
 
   return (
@@ -173,11 +245,12 @@ function ArtistAddFields() {
       </Typography>
       <form onSubmit={handleSubmit}>
         <Stack spacing={1.5}>
-          <FormControl>
+          <FormControl error={genresUnavailable}>
             <FormLabel>Genre</FormLabel>
             <Select
               placeholder="Select genre..."
               value={genreId}
+              disabled={isLoading || genresUnavailable}
               onChange={(_, value) => handleGenreChange(value)}
             >
               {(genres ?? []).map((genre) => (
@@ -186,6 +259,30 @@ function ArtistAddFields() {
                 </Option>
               ))}
             </Select>
+            {genresUnavailable && (
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                sx={{ mt: 0.5 }}
+                role="alert"
+              >
+                <Typography level="body-sm" color="danger">
+                  Genres are unavailable, so an artist can&apos;t be filed right now.
+                </Typography>
+                {/* An untyped button inside a form submits it. */}
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="plain"
+                  loading={genresFetching}
+                  onClick={() => refetchGenres()}
+                  sx={{ px: 0 }}
+                >
+                  Try again
+                </Button>
+              </Stack>
+            )}
           </FormControl>
 
           <FormControl>
@@ -194,15 +291,27 @@ function ArtistAddFields() {
               genreId={genreId ?? -1}
               value={name}
               onChange={handleNameChange}
-              onSelect={setExistingArtist}
-              onCreateNew={() => setExistingArtist(null)}
+              onSelect={(artist) => {
+                setExistingArtist(artist);
+                setDedupCheckStale(false);
+              }}
+              onCreateNew={() => {
+                setExistingArtist(null);
+                setDedupCheckStale(false);
+              }}
               onSelectionCleared={() => setExistingArtist(null)}
-              disabled={genreId === null}
+              disabled={genreId === null || isLoading}
             />
-            {existingArtist && (
+            {existingArtist ? (
               <FormHelperText sx={{ color: "danger.500" }}>
                 {existingArtist.artist_name} already exists in this genre.
               </FormHelperText>
+            ) : (
+              dedupCheckStale && (
+                <FormHelperText sx={{ color: "warning.500" }}>
+                  Search this name again under the new genre before adding.
+                </FormHelperText>
+              )
             )}
           </FormControl>
 
@@ -210,24 +319,33 @@ function ArtistAddFields() {
             <FormLabel>Alphabetical name (optional)</FormLabel>
             <Input
               value={alphabeticalName}
+              disabled={isLoading}
               onChange={(e) => setAlphabeticalName(e.target.value)}
               placeholder="Defaults to artist name"
             />
           </FormControl>
 
-          <FormControl>
+          <FormControl error={codeLettersTooLong}>
             <FormLabel>Call letters</FormLabel>
             <Input
               value={codeLetters}
+              disabled={isLoading}
               onChange={(e) => handleCodeLettersChange(e.target.value)}
               placeholder="e.g. MO"
+              slotProps={{ input: { maxLength: CODE_LETTERS_MAX_LENGTH } }}
             />
+            <FormHelperText>
+              {codeLettersTooLong
+                ? `At most ${CODE_LETTERS_MAX_LENGTH} characters`
+                : `Up to ${CODE_LETTERS_MAX_LENGTH} characters, filed uppercase`}
+            </FormHelperText>
           </FormControl>
 
           <FormControl error={codeNumberInvalid}>
             <FormLabel>Code number</FormLabel>
             <Input
               value={codeNumberRaw}
+              disabled={isLoading}
               onChange={(e) => handleCodeNumberChange(e.target.value)}
               placeholder="e.g. 42"
             />

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -19,6 +19,7 @@ import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 import { useAddArtistMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
 import {
   isAddArtistConflict,
+  isConflictRejection,
   parseRequiredPositiveInt,
 } from "@/lib/features/catalog/adminCreateArtistValidation";
 import type {
@@ -135,10 +136,16 @@ function ArtistAddFields() {
   // `conflict` must not be read against live `codeLetters`/`codeNumberRaw`,
   // since an MD editing either field after a 409 would otherwise have the
   // banner keep reporting the new, unsubmitted value as taken.
+  //
+  // `response` is null when the 409 named no artist the banner could render —
+  // an intermediary's own JSON, or a shape this form cannot read. The
+  // submission was refused either way, so what blocks resubmitting the same
+  // triple is the 409 itself, not whether its body happened to parse; the
+  // server's own message reaches the MD through the global toast instead.
   const [conflict, setConflict] = useState<{
     code_letters: string;
     code_number: string;
-    response: AddArtistConflict;
+    response: AddArtistConflict | null;
   } | null>(null);
   const [added, setAdded] = useState<{ code_letters: string; code_number: number } | null>(
     null,
@@ -253,13 +260,14 @@ function ArtistAddFields() {
       setDedupCheckStale(false);
       toast.success(`Added ${trimmedName}`);
     } catch (err) {
-      if (isAddArtistConflict(err)) {
+      if (isConflictRejection(err)) {
         setConflict({
           code_letters: trimmedCodeLetters,
           code_number: codeNumberRaw.trim(),
-          response: err.data,
+          response: isAddArtistConflict(err) ? err.data : null,
         });
-      } else if (isUnmessagedHttpError(err)) {
+      }
+      if (!isAddArtistConflict(err) && isUnmessagedHttpError(err)) {
         // The global rtkQueryErrorLogger middleware already toasts the server
         // message for the common failure; only surface a fallback here for the
         // gap it leaves silent.
@@ -456,7 +464,7 @@ function ArtistAddFields() {
             genre_id={genreId}
           />
 
-          {conflict && (
+          {conflict?.response && (
             <Typography level="body-sm" color="danger" role="alert">
               {conflict.code_letters}
               {conflict.code_number} is already taken by{" "}

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -18,7 +18,7 @@ import { RequireMD } from "@/src/components/shared/Authorization";
 import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 import { useAddArtistMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
 import {
-  isAddArtistConflictBody,
+  isAddArtistConflict,
   parseRequiredPositiveInt,
 } from "@/lib/features/catalog/adminCreateArtistValidation";
 import type {
@@ -65,20 +65,6 @@ function normalizeCodeLetters(value: string): string {
   return value.toUpperCase();
 }
 
-function isAddArtistConflict(
-  err: unknown,
-): err is { status: 409; data: AddArtistConflict } {
-  if (!err || typeof err !== "object" || !("status" in err)) return false;
-  const { status, data } = err as { status?: unknown; data?: unknown };
-  // The banner dereferences `artist.artist_name` two levels down, so key
-  // presence is not enough: a 409 carrying a null or nameless artist would
-  // pass a `"artist" in data` guard and then throw during render, and there is
-  // no error boundary in this subtree to catch it — white-screening the form
-  // on an outcome that is supposed to be recoverable. It is the same test the
-  // endpoint gates its `message` strip on, so the two cannot drift apart.
-  return status === 409 && isAddArtistConflictBody(data);
-}
-
 /**
  * MD-gated artist-add form. Dedups against existing artists via
  * `ArtistSearchTypeahead` and previews the call-letter assignment via
@@ -99,7 +85,6 @@ function ArtistAddForm() {
 function ArtistAddFields() {
   const {
     data: genres,
-    isError: genresErrored,
     isLoading: genresLoading,
     isFetching: genresFetching,
     refetch: refetchGenres,
@@ -134,10 +119,10 @@ function ArtistAddFields() {
   // keystroke, so the next one lands at the end and files a different — but
   // still valid-looking — four-character code with nothing reported wrong.
   // Codes are written onto the physical cards, so a wrong-but-valid one is the
-  // expensive outcome. Carrying the caret in the same state also guarantees the
-  // render the restore below depends on: an edit that only changed case
-  // normalizes back to the string already held, which on its own would be an
-  // identical value and skip the render entirely.
+  // expensive outcome. Pairing the caret with the value is also what guarantees
+  // the render the replacement below hangs off: an edit that only changed case
+  // normalizes back to the string already held, and a state write of an equal
+  // value would be skipped entirely.
   const [codeLettersField, setCodeLettersField] = useState<{
     value: string;
     caret: number | null;
@@ -175,23 +160,25 @@ function ArtistAddFields() {
       : null;
   const codeNumberInvalid = codeNumberRaw.trim().length > 0 && codeNumber === null;
   // A failed genres GET leaves an empty dropdown behind: fetchBaseQuery's
-  // rejection sets `isError`, while the backend adapter's soft-fail turns a
-  // non-JSON GET failure into `{ data: null }` with no error at all. Either
-  // way `genre_id` is unreachable and the form can never submit, so the outage
-  // has to say so rather than presenting an empty list as "no genres exist".
-  const genresUnavailable = genresErrored || (!genresLoading && genres == null);
+  // rejection leaves `data` undefined, while the backend adapter's soft-fail
+  // turns a non-JSON GET failure into `{ data: null }` with no error at all.
+  // Either way `genre_id` is unreachable and the form can never submit, so the
+  // outage has to say so rather than presenting an empty list as "no genres
+  // exist". The test is the absence of a list, not `isError`: a refetch that
+  // rejects leaves the last good list in the cache and the form still submits
+  // perfectly well against it, so reading the error flag would put a "can't be
+  // filed right now" alert beside an enabled submit button.
+  const genresUnavailable = !genresLoading && genres == null;
 
-  // Puts the caret back where the edit left it, after the commit that rewrote
-  // the field. Re-asserting the value first is what makes that stick: React's
-  // own controlled-value restore runs after layout effects, and on a case-only
-  // edit the committed props never changed, so the DOM would still be holding
-  // the pre-normalization text and get rewritten — moving the caret to the end
-  // again — immediately after it was placed.
+  // Puts the caret back where the edit left it. React writes the normalized
+  // value into the node during the commit's mutation phase, which is the write
+  // that moves the caret, so the replacement has to run after that — a layout
+  // effect, not an effect, or the field paints for a frame with the caret at
+  // the wrong end.
   useLayoutEffect(() => {
     const input = codeLettersInputRef.current;
-    const { value, caret } = codeLettersField;
+    const { caret } = codeLettersField;
     if (caret === null || input === null) return;
-    if (input.value !== value) input.value = value;
     input.setSelectionRange(caret, caret);
   }, [codeLettersField]);
 

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -78,7 +78,15 @@ function ArtistAddFields() {
   const [codeLetters, setCodeLetters] = useState("");
   const [codeNumberRaw, setCodeNumberRaw] = useState("");
   const [alphabeticalName, setAlphabeticalName] = useState("");
-  const [conflict, setConflict] = useState<AddArtistConflict | null>(null);
+  // Snapshots the code the server actually rejected, alongside the response —
+  // `conflict` must not be read against live `codeLetters`/`codeNumberRaw`,
+  // since an MD editing either field after a 409 would otherwise have the
+  // banner keep reporting the new, unsubmitted value as taken.
+  const [conflict, setConflict] = useState<{
+    code_letters: string;
+    code_number: string;
+    response: AddArtistConflict;
+  } | null>(null);
   const [added, setAdded] = useState<{ code_letters: string; code_number: number } | null>(
     null,
   );
@@ -130,11 +138,25 @@ function ArtistAddFields() {
       toast.success(`Added ${trimmedName}`);
     } catch (err) {
       if (isAddArtistConflict(err)) {
-        setConflict(err.data);
+        setConflict({
+          code_letters: trimmedCodeLetters,
+          code_number: codeNumberRaw.trim(),
+          response: err.data,
+        });
       } else {
         toast.error("Failed to add artist");
       }
     }
+  };
+
+  const handleCodeLettersChange = (value: string) => {
+    setCodeLetters(value);
+    setConflict(null);
+  };
+
+  const handleCodeNumberChange = (value: string) => {
+    setCodeNumberRaw(value);
+    setConflict(null);
   };
 
   return (
@@ -190,7 +212,7 @@ function ArtistAddFields() {
             <FormLabel>Call letters</FormLabel>
             <Input
               value={codeLetters}
-              onChange={(e) => setCodeLetters(e.target.value)}
+              onChange={(e) => handleCodeLettersChange(e.target.value)}
               placeholder="e.g. MO"
             />
           </FormControl>
@@ -199,7 +221,7 @@ function ArtistAddFields() {
             <FormLabel>Code number</FormLabel>
             <Input
               value={codeNumberRaw}
-              onChange={(e) => setCodeNumberRaw(e.target.value)}
+              onChange={(e) => handleCodeNumberChange(e.target.value)}
               placeholder="e.g. 42"
             />
             {codeNumberInvalid && (
@@ -211,8 +233,9 @@ function ArtistAddFields() {
 
           {conflict && (
             <Typography level="body-sm" color="danger" role="alert">
-              {trimmedCodeLetters}
-              {codeNumberRaw.trim()} is already taken by {conflict.artist.artist_name}.
+              {conflict.code_letters}
+              {conflict.code_number} is already taken by{" "}
+              {conflict.response.artist.artist_name}.
             </Typography>
           )}
 

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -159,6 +159,13 @@ function ArtistAddFields() {
     setConflict(null);
   };
 
+  const handleGenreChange = (value: number | null) => {
+    setGenreId(value);
+    // Uniqueness is (code_letters, genre_id, code_number) — a code the
+    // server rejected under one genre may be free under another.
+    setConflict(null);
+  };
+
   return (
     <Sheet variant="outlined" sx={{ p: 2, borderRadius: "md" }}>
       <Typography level="title-md" sx={{ mb: 1 }}>
@@ -171,7 +178,7 @@ function ArtistAddFields() {
             <Select
               placeholder="Select genre..."
               value={genreId}
-              onChange={(_, value) => setGenreId(value)}
+              onChange={(_, value) => handleGenreChange(value)}
             >
               {(genres ?? []).map((genre) => (
                 <Option key={genre.id} value={genre.id}>

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   Button,
@@ -17,7 +17,10 @@ import {
 import { RequireMD } from "@/src/components/shared/Authorization";
 import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 import { useAddArtistMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
-import { parseRequiredPositiveInt } from "@/lib/features/catalog/adminCreateArtistValidation";
+import {
+  isAddArtistConflictBody,
+  parseRequiredPositiveInt,
+} from "@/lib/features/catalog/adminCreateArtistValidation";
 import type {
   AddArtistConflict,
   AddArtistRequestBody,
@@ -52,6 +55,11 @@ const CODE_NUMBER_MAX = 2147483647;
  * next code of 1, opening a second series that shadows the real one while the
  * form reports success. Normalizing at the edge keeps the field, the code
  * preview, and the request body on the one casing the catalog actually uses.
+ *
+ * Case is the only thing normalized. The catalog files live codes that are not
+ * plain letters — "V/A" for Various Artists compilations, "??" placeholders,
+ * and codes carrying digits — so narrowing this field to A-Z would make those
+ * releases impossible to file. The permissiveness is load-bearing.
  */
 function normalizeCodeLetters(value: string): string {
   return value.toUpperCase();
@@ -62,18 +70,13 @@ function isAddArtistConflict(
 ): err is { status: 409; data: AddArtistConflict } {
   if (!err || typeof err !== "object" || !("status" in err)) return false;
   const { status, data } = err as { status?: unknown; data?: unknown };
-  if (status !== 409 || !data || typeof data !== "object") return false;
   // The banner dereferences `artist.artist_name` two levels down, so key
   // presence is not enough: a 409 carrying a null or nameless artist would
   // pass a `"artist" in data` guard and then throw during render, and there is
   // no error boundary in this subtree to catch it — white-screening the form
-  // on an outcome that is supposed to be recoverable.
-  const { artist } = data as { artist?: unknown };
-  return (
-    !!artist &&
-    typeof artist === "object" &&
-    typeof (artist as { artist_name?: unknown }).artist_name === "string"
-  );
+  // on an outcome that is supposed to be recoverable. It is the same test the
+  // endpoint gates its `message` strip on, so the two cannot drift apart.
+  return status === 409 && isAddArtistConflictBody(data);
 }
 
 /**
@@ -122,7 +125,25 @@ function ArtistAddFields() {
   // re-runs the search but reports nothing back, so it does not clear this.
   const [dedupCheckStale, setDedupCheckStale] = useState(false);
   const [genreId, setGenreId] = useState<number | null>(null);
-  const [codeLetters, setCodeLetters] = useState("");
+  // Value and caret are one state object because normalizing on every keystroke
+  // makes them inseparable. Writing the uppercased text back into a controlled
+  // input replaces `node.value`, and the HTML value setter drops the caret at
+  // the end of the field; React only restores a selection across a commit when
+  // focus moved, which it has not here. Left alone, an MD correcting a
+  // character mid-code has the caret jump silently after the first lowercase
+  // keystroke, so the next one lands at the end and files a different — but
+  // still valid-looking — four-character code with nothing reported wrong.
+  // Codes are written onto the physical cards, so a wrong-but-valid one is the
+  // expensive outcome. Carrying the caret in the same state also guarantees the
+  // render the restore below depends on: an edit that only changed case
+  // normalizes back to the string already held, which on its own would be an
+  // identical value and skip the render entirely.
+  const [codeLettersField, setCodeLettersField] = useState<{
+    value: string;
+    caret: number | null;
+  }>({ value: "", caret: null });
+  const codeLetters = codeLettersField.value;
+  const codeLettersInputRef = useRef<HTMLInputElement | null>(null);
   const [codeNumberRaw, setCodeNumberRaw] = useState("");
   const [alphabeticalName, setAlphabeticalName] = useState("");
   // Snapshots the code the server actually rejected, alongside the response —
@@ -159,6 +180,20 @@ function ArtistAddFields() {
   // way `genre_id` is unreachable and the form can never submit, so the outage
   // has to say so rather than presenting an empty list as "no genres exist".
   const genresUnavailable = genresErrored || (!genresLoading && genres == null);
+
+  // Puts the caret back where the edit left it, after the commit that rewrote
+  // the field. Re-asserting the value first is what makes that stick: React's
+  // own controlled-value restore runs after layout effects, and on a case-only
+  // edit the committed props never changed, so the DOM would still be holding
+  // the pre-normalization text and get rewritten — moving the caret to the end
+  // again — immediately after it was placed.
+  useLayoutEffect(() => {
+    const input = codeLettersInputRef.current;
+    const { value, caret } = codeLettersField;
+    if (caret === null || input === null) return;
+    if (input.value !== value) input.value = value;
+    input.setSelectionRange(caret, caret);
+  }, [codeLettersField]);
 
   const canSubmit =
     !isLoading &&
@@ -206,7 +241,7 @@ function ArtistAddFields() {
         code_number: result.code_number ?? codeNumber,
       });
       setName("");
-      setCodeLetters("");
+      setCodeLettersField({ value: "", caret: null });
       setCodeNumberRaw("");
       setAlphabeticalName("");
       setExistingArtist(null);
@@ -228,14 +263,28 @@ function ArtistAddFields() {
     }
   };
 
-  const handleCodeLettersChange = (value: string) => {
-    setCodeLetters(normalizeCodeLetters(value));
+  const handleCodeLettersChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const input = event.target;
+    const raw = input.value;
+    const caret = input.selectionStart;
+    setCodeLettersField({
+      value: normalizeCodeLetters(raw),
+      // Uppercasing can lengthen the text before the caret ("ß" becomes "SS"),
+      // so the caret's new home is the length of the normalized prefix, not
+      // the index the browser reported against the raw text.
+      caret:
+        caret === null ? null : normalizeCodeLetters(raw.slice(0, caret)).length,
+    });
     setConflict(null);
+    setAdded(null);
   };
 
   const handleCodeNumberChange = (value: string) => {
     setCodeNumberRaw(value);
     setConflict(null);
+    setAdded(null);
   };
 
   const handleGenreChange = (value: number | null) => {
@@ -243,8 +292,17 @@ function ArtistAddFields() {
     // Uniqueness is (code_letters, genre_id, code_number) — a code the
     // server rejected under one genre may be free under another.
     setConflict(null);
+    setAdded(null);
     // Whatever the typeahead last reported was found under the previous genre.
     setDedupCheckStale(trimmedName.length > 0);
+  };
+
+  const handleAlphabeticalNameChange = (value: string) => {
+    setAlphabeticalName(value);
+    // The confirmation names a code that was already filed; leaving it beside
+    // a half-typed next entry reads as that entry's outcome. It is not part of
+    // the uniqueness triple, so a standing conflict stays accurate.
+    setAdded(null);
   };
 
   return (
@@ -335,7 +393,7 @@ function ArtistAddFields() {
             <Input
               value={alphabeticalName}
               disabled={isLoading}
-              onChange={(e) => setAlphabeticalName(e.target.value)}
+              onChange={(e) => handleAlphabeticalNameChange(e.target.value)}
               placeholder="Defaults to artist name"
               slotProps={{ input: { maxLength: ARTIST_NAME_MAX_LENGTH } }}
             />
@@ -351,9 +409,14 @@ function ArtistAddFields() {
             <Input
               value={codeLetters}
               disabled={isLoading}
-              onChange={(e) => handleCodeLettersChange(e.target.value)}
+              onChange={handleCodeLettersChange}
               placeholder="e.g. MO"
-              slotProps={{ input: { maxLength: CODE_LETTERS_MAX_LENGTH } }}
+              slotProps={{
+                input: {
+                  ref: codeLettersInputRef,
+                  maxLength: CODE_LETTERS_MAX_LENGTH,
+                },
+              }}
             />
             <FormHelperText>
               {codeLettersTooLong
@@ -379,7 +442,14 @@ function ArtistAddFields() {
             )}
           </FormControl>
 
-          <CallLetterPeekControl code_letters={codeLetters} genre_id={genreId} />
+          {/* Gated on the same length the submit checks: uppercasing can push a
+              value past the field's own maxLength ("ßxß" becomes "SSXSS"),
+              which no series can ever hold, so previewing it would answer
+              "Next code: 1" beside the length error that blocks the submit. */}
+          <CallLetterPeekControl
+            code_letters={codeLettersTooLong ? "" : codeLetters}
+            genre_id={genreId}
+          />
 
           {conflict && (
             <Typography level="body-sm" color="danger" role="alert">

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -85,6 +85,7 @@ function ArtistAddForm() {
 function ArtistAddFields() {
   const {
     data: genres,
+    isUninitialized: genresUnstarted,
     isLoading: genresLoading,
     isFetching: genresFetching,
     refetch: refetchGenres,
@@ -167,8 +168,12 @@ function ArtistAddFields() {
   // exist". The test is the absence of a list, not `isError`: a refetch that
   // rejects leaves the last good list in the cache and the form still submits
   // perfectly well against it, so reading the error flag would put a "can't be
-  // filed right now" alert beside an enabled submit button.
-  const genresUnavailable = !genresLoading && genres == null;
+  // filed right now" alert beside an enabled submit button. The query also
+  // subscribes from an effect, so the mount render reports neither a pending
+  // request nor data — reading that as an outage would announce the alert on
+  // every mount, before anything has been asked.
+  const genresUnavailable =
+    !genresUnstarted && !genresLoading && genres == null;
 
   // Puts the caret back where the edit left it. React writes the normalized
   // value into the node during the commit's mutation phase, which is the write
@@ -190,6 +195,11 @@ function ArtistAddFields() {
     !nameTooLong &&
     !alphabeticalNameTooLong &&
     genreId !== null &&
+    // A list that goes away under a held selection leaves the dropdown showing
+    // its placeholder while `genreId` still names the old genre. Submitting
+    // then files under a genre the form has stopped displaying, beside an
+    // alert saying nothing can be filed at all.
+    !genresUnavailable &&
     trimmedCodeLetters.length > 0 &&
     !codeLettersTooLong &&
     codeNumber !== null;

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -248,6 +248,13 @@ function ArtistSearchTypeaheadInner({
           confirmedArtist.current.artist_name.normalize("NFC");
         if (stillMatches && !confirmedActive.current) {
           confirmedActive.current = true;
+          // Announcing a selection leaves the field holding that artist's name
+          // byte for byte, the same way a pick from the panel does. A caller
+          // deciding whether the link still describes the field compares the
+          // two directly, so re-announcing while the field keeps a different
+          // composition of the same name would have the caller retract what
+          // was just confirmed.
+          onChange(confirmedArtist.current.artist_name);
           onSelect(confirmedArtist.current);
         } else if (!stillMatches && confirmedActive.current) {
           confirmedActive.current = false;

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -52,6 +52,12 @@ const NO_ARTISTS: ArtistInGenreOption[] = [];
  * to selections this component reported: a caller that seeds `value` with a
  * link obtained elsewhere holds an id this component never confirmed, and is
  * responsible for invalidating that link itself when `genreId` changes.
+ *
+ * A text-driven retraction re-arms on its own: an edit that lands the field
+ * back on the exact name last picked re-fires `onSelect` with that same
+ * artist, without a new pick from the panel. A genre change does not — moving
+ * `genreId` discards the picked artist outright, since the match it named is
+ * only good for the genre it was found under.
  */
 export interface ArtistSearchTypeaheadProps {
   genreId: number;
@@ -90,8 +96,14 @@ function ArtistSearchTypeaheadInner({
   // The artist the caller was last told about, held in a ref because nothing
   // rendered here depends on it — it exists only to decide whether that report
   // is still true, at the moment the text is edited or `genreId` moves off the
-  // genre the artist was found under.
+  // genre the artist was found under. Kept even once the text has drifted off
+  // it, so a later edit that lands back on the exact same name can re-confirm
+  // without a new pick — a genre change is what discards it outright.
   const confirmedArtist = useRef<ArtistInGenreOption | null>(null);
+  // Whether the caller currently holds `confirmedArtist`'s id. Text drifting
+  // away deactivates without discarding the artist above, which is what makes
+  // the re-confirm possible; a genre change deactivates and discards together.
+  const confirmedActive = useRef(false);
   // The genre the confirmed artist was found under, kept because the retraction
   // below turns on whether `genreId` moved — which the current prop alone cannot
   // say. It tracks the prop even with nothing confirmed, so the first pick after
@@ -180,8 +192,10 @@ function ArtistSearchTypeaheadInner({
     if (confirmedGenreId.current === genreId) return;
     confirmedGenreId.current = genreId;
     if (!confirmedArtist.current) return;
+    const wasActive = confirmedActive.current;
     confirmedArtist.current = null;
-    onSelectionCleared();
+    confirmedActive.current = false;
+    if (wasActive) onSelectionCleared();
   }, [genreId, onSelectionCleared]);
 
   const openPanel = useCallback(() => {
@@ -201,6 +215,7 @@ function ArtistSearchTypeaheadInner({
   const handleSelect = useCallback(
     (artist: ArtistInGenreOption) => {
       confirmedArtist.current = artist;
+      confirmedActive.current = true;
       // `onChange` runs first so that a caller which rewrites `value` from
       // inside `onSelect` writes last and wins.
       onChange(artist.artist_name);
@@ -213,20 +228,27 @@ function ArtistSearchTypeaheadInner({
   const handleTextEdit = useCallback(
     (next: string) => {
       onChange(next);
-      // Text that no longer names the confirmed artist retracts it, and only
-      // once: the caller has dropped the id by the second keystroke, and a
-      // repeated retraction would read as a second, unrelated event.
-      if (
-        confirmedArtist.current &&
-        next.trim() !== confirmedArtist.current.artist_name
-      ) {
-        confirmedArtist.current = null;
-        onSelectionCleared();
+      // A picked artist is retracted the moment the text stops naming it, and
+      // re-confirmed the moment a later edit lands back on that exact name —
+      // an MD correcting a stray keystroke back onto the artist they already
+      // picked has not asked a new question. Each transition fires at most
+      // once: a retraction stays retracted through further edits that keep
+      // missing, and a re-confirmation stays confirmed through further edits
+      // that keep matching.
+      if (confirmedArtist.current) {
+        const stillMatches = next.trim() === confirmedArtist.current.artist_name;
+        if (stillMatches && !confirmedActive.current) {
+          confirmedActive.current = true;
+          onSelect(confirmedArtist.current);
+        } else if (!stillMatches && confirmedActive.current) {
+          confirmedActive.current = false;
+          onSelectionCleared();
+        }
       }
       setOpen(true);
       setHighlightIndex(NO_HIGHLIGHT);
     },
-    [onChange, onSelectionCleared],
+    [onChange, onSelect, onSelectionCleared],
   );
 
   const handleCreateNew = useCallback(() => {

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -236,7 +236,16 @@ function ArtistSearchTypeaheadInner({
       // missing, and a re-confirmation stays confirmed through further edits
       // that keep matching.
       if (confirmedArtist.current) {
-        const stillMatches = next.trim() === confirmedArtist.current.artist_name;
+        // Canonically-equivalent, byte-different compositions (NFD vs NFC —
+        // some IMEs and clipboard round-trips produce combining marks where
+        // the picked name has a precomposed character) must count as the
+        // same name on both sides of this check: it decides retraction as
+        // well as re-confirmation, and an MD who retypes what looks like the
+        // exact name they picked has not asked a new question just because
+        // the keystrokes composed differently.
+        const stillMatches =
+          next.trim().normalize("NFC") ===
+          confirmedArtist.current.artist_name.normalize("NFC");
         if (stillMatches && !confirmedActive.current) {
           confirmedActive.current = true;
           onSelect(confirmedArtist.current);
@@ -252,6 +261,14 @@ function ArtistSearchTypeaheadInner({
   );
 
   const handleCreateNew = useCallback(() => {
+    // An explicit "create new" overrides whatever match the panel is
+    // offering, including one this component still holds confirmed — the
+    // text can equal a picked artist's name and still show "create new"
+    // beside it. Discarding the artist here, not just deactivating it, stops
+    // a later edit that returns to that text from silently re-confirming a
+    // match the MD deliberately bypassed.
+    confirmedArtist.current = null;
+    confirmedActive.current = false;
     onCreateNew(trimmed);
     closePanel();
   }, [onCreateNew, trimmed, closePanel]);

--- a/tests/helpers/constants.ts
+++ b/tests/helpers/constants.ts
@@ -37,6 +37,7 @@ export const TEST_ENTITY_IDS = {
   },
   GENRE: {
     ROCK: 6001,
+    JAZZ: 6002,
   },
 } as const;
 

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
@@ -939,12 +939,11 @@ describe("AlbumEditForm", () => {
         );
       });
 
-      // The typeahead retracts at most once per selection and stops tracking
-      // that selection afterwards, so a link restored by a genre round trip has
-      // nothing left to announce a later text edit. The form has to judge the
-      // link against the field itself — otherwise Save re-attributes the album
-      // to an artist the field visibly does not name, and the server can burn a
-      // fresh call number doing it.
+      // A link restored by a genre round trip was never announced through
+      // `onSelect`, so the typeahead has nothing to retract when the text is
+      // later edited. The form has to judge the link against the field itself —
+      // otherwise Save re-attributes the album to an artist the field visibly
+      // does not name, and the server can burn a fresh call number doing it.
       it("blocks Save when a restored link's artist text is edited without a fresh pick", async () => {
         const { getCallCount } = mockPatch();
         mockArtistSearch([
@@ -983,6 +982,51 @@ describe("AlbumEditForm", () => {
           screen.getByText("Search and select an artist to continue."),
         ).toBeInTheDocument();
         expect(getCallCount()).toBe(0);
+      });
+
+      // Restoring a picked artist's name in a different Unicode composition is
+      // the same name to the MD, so it has to leave Save armed. The typeahead
+      // matches canonically but the form compares the held link's name against
+      // the field directly, so a re-announcement that left the field in the
+      // typed composition would be retracted again the moment it landed —
+      // stranding Save under an artist the field correctly names.
+      it("keeps Save armed when the picked artist's name is restored in another composition", async () => {
+        const NFC_NAME = "Nilüfer Yanya";
+        const NFD_NAME = "Nilüfer Yanya";
+        expect(NFD_NAME).not.toBe(NFC_NAME);
+        expect(NFD_NAME.normalize("NFC")).toBe(NFC_NAME);
+
+        const { getReceivedBody } = mockPatch();
+        mockArtistSearch([
+          {
+            id: JESSICA_ARTIST_ID,
+            artist_name: NFC_NAME,
+            code_letters: "YA",
+            code_number: 4,
+          },
+        ]);
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const artistInput = await screen.findByLabelText("Search artists");
+        await user.clear(artistInput);
+        await user.type(artistInput, "Nil");
+        await user.click(await screen.findByText(NFC_NAME));
+
+        const saveButton = screen.getByRole("button", SAVE_BUTTON);
+        await waitFor(() => expect(saveButton).toBeEnabled());
+
+        // Edit away, then restore the same name decomposed — what a clipboard
+        // round trip produces.
+        await user.type(artistInput, "x");
+        await waitFor(() => expect(saveButton).toBeDisabled());
+        await user.clear(artistInput);
+        await user.type(artistInput, NFD_NAME);
+
+        await waitFor(() => expect(saveButton).toBeEnabled());
+        await user.click(saveButton);
+        await waitFor(() =>
+          expect(getReceivedBody()).toEqual({ artist_id: JESSICA_ARTIST_ID }),
+        );
       });
     });
 

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -9,6 +9,7 @@ import {
   TEST_SEARCH_STRINGS,
 } from "@/tests/helpers";
 import ArtistAddForm from "@/src/components/experiences/modern/catalog/ArtistAddForm";
+import { catalogApi } from "@/lib/features/catalog/api";
 
 const GENRE_ID = TEST_ENTITY_IDS.GENRE.ROCK;
 const JAZZ_GENRE_ID = TEST_ENTITY_IDS.GENRE.JAZZ;
@@ -389,6 +390,10 @@ describe("ArtistAddForm", () => {
 
       it.each([
         ["a lowercase character", "l", "MLOI", 2],
+        // The control: an uppercase keystroke normalizes to what the DOM
+        // already holds, so nothing is written back and the browser's own
+        // caret is already right. It pins that the two cases agree, not the
+        // replacement itself.
         ["an already-uppercase character", "L", "MLOI", 2],
         // Uppercasing "ß" yields "SS", so the caret has to land past two
         // characters the keystroke did not itself type.
@@ -564,6 +569,28 @@ describe("ArtistAddForm", () => {
         expect(screen.getByTestId("next-code-number")).toHaveTextContent("7");
       });
 
+      it("re-previews after a failure that may still have written the row", async () => {
+        const { getQueries } = mockPeekCode();
+        mockAddArtist(() =>
+          HttpResponse.json({ message: "Artist could not be filed" }, { status: 500 }),
+        );
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await waitFor(() => expect(getQueries().length).toBeGreaterThan(0));
+        const peeksBeforeSubmit = getQueries().length;
+
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+        // Only the rejections that provably wrote nothing skip invalidation. A
+        // 500 can carry a row the client never saw, and the caches behind the
+        // dedup typeahead and this preview are what stand between a retry and
+        // a duplicate.
+        await waitFor(() =>
+          expect(getQueries().length).toBeGreaterThan(peeksBeforeSubmit),
+        );
+      });
+
       it("re-previews after a successful add, whose row the preview predates", async () => {
         const { getQueries } = mockPeekCode();
         mockAddArtist(() => created());
@@ -591,6 +618,8 @@ describe("ArtistAddForm", () => {
           user.type(screen.getByLabelText("Code number"), "3")],
         ["the alphabetical name", async (user: ReturnType<typeof renderWithProviders>["user"]) =>
           user.type(screen.getByLabelText(/alphabetical name/i), "Molina, Juana")],
+        ["the artist name", async (user: ReturnType<typeof renderWithProviders>["user"]) =>
+          user.type(screen.getByPlaceholderText("Search artists..."), "Stereolab")],
         ["the genre", async (user: ReturnType<typeof renderWithProviders>["user"]) =>
           selectGenre(user, "Jazz")],
       ])("drops the confirmation once %s moves on to the next entry", async (_label, edit) => {
@@ -839,6 +868,37 @@ describe("ArtistAddForm", () => {
         );
         expect(toast.error).toHaveBeenCalledTimes(1);
         expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      });
+
+      it("keeps filing against the last good genre list when a refetch fails", async () => {
+        let genreCalls = 0;
+        server.use(
+          http.get(`${TEST_BACKEND_URL}/library/genres`, () => {
+            genreCalls += 1;
+            return genreCalls === 1
+              ? HttpResponse.json([{ id: GENRE_ID, genre_name: "Rock" }])
+              : HttpResponse.json({ message: "genres unavailable" }, { status: 500 });
+          }),
+        );
+        const { getBodies } = mockAddArtist(() => created());
+        const { user, store } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+
+        // Adding a genre elsewhere invalidates this list; if that refetch
+        // rejects, the cached list is still there and every one of its genres
+        // is still fileable. Claiming an outage would sit a "can't be filed
+        // right now" alert beside a submit that works.
+        store.dispatch(
+          catalogApi.util.invalidateTags([{ type: "GenreList", id: "LIST" }]),
+        );
+        await waitFor(() => expect(genreCalls).toBe(2));
+
+        expect(screen.queryByText(/genres are unavailable/i)).not.toBeInTheDocument();
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+        await waitFor(() => expect(getBodies()).toHaveLength(1));
+        expect(getBodies()[0]).toMatchObject({ genre_id: GENRE_ID });
       });
 
       it("explains a genres outage and offers a retry instead of an empty dropdown", async () => {

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -870,6 +870,29 @@ describe("ArtistAddForm", () => {
         expect(screen.queryByRole("alert")).not.toBeInTheDocument();
       });
 
+      it("waits for the genres request rather than calling an outage on an empty cache", async () => {
+        let release: (() => void) | undefined;
+        const held = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        server.use(
+          http.get(`${TEST_BACKEND_URL}/library/genres`, async () => {
+            await held;
+            return HttpResponse.json([{ id: GENRE_ID, genre_name: "Rock" }]);
+          }),
+        );
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        // An unanswered request is not an outage. The dropdown is empty for
+        // the same reason either way, so the alert has to wait for the answer.
+        expect(await screen.findByRole("button", { name: /add artist/i })).toBeInTheDocument();
+        expect(screen.queryByText(/genres are unavailable/i)).not.toBeInTheDocument();
+
+        release?.();
+        await selectGenre(user);
+        expect(screen.queryByText(/genres are unavailable/i)).not.toBeInTheDocument();
+      });
+
       it("keeps filing against the last good genre list when a refetch fails", async () => {
         let genreCalls = 0;
         server.use(
@@ -899,6 +922,37 @@ describe("ArtistAddForm", () => {
 
         await waitFor(() => expect(getBodies()).toHaveLength(1));
         expect(getBodies()[0]).toMatchObject({ genre_id: GENRE_ID });
+      });
+
+      it("blocks the submit when the list goes away under a held genre", async () => {
+        let genreCalls = 0;
+        server.use(
+          http.get(`${TEST_BACKEND_URL}/library/genres`, () => {
+            genreCalls += 1;
+            return genreCalls === 1
+              ? HttpResponse.json([{ id: GENRE_ID, genre_name: "Rock" }])
+              : // The backend adapter soft-fails a non-JSON GET into a
+                // fulfilled `{ data: null }`, which replaces the cached array
+                // rather than leaving it standing.
+                HttpResponse.json(null);
+          }),
+        );
+        const { getBodies } = mockAddArtist(() => created());
+        const { user, store, container } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        store.dispatch(
+          catalogApi.util.invalidateTags([{ type: "GenreList", id: "LIST" }]),
+        );
+
+        // With no list, the dropdown falls back to its placeholder while
+        // genre_id still names the old genre. Filing then writes into a genre
+        // the form has stopped showing, beside an alert saying nothing can be
+        // filed at all.
+        expect(await screen.findByText(/genres are unavailable/i)).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+        fireEvent.submit(container.querySelector("form")!);
+        expect(getBodies()).toHaveLength(0);
       });
 
       it("explains a genres outage and offers a retry instead of an empty dropdown", async () => {

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -547,7 +547,7 @@ describe("ArtistAddForm", () => {
         ).not.toContain("SSXSS");
       });
 
-      it("leaves the preview alone when the add is rejected", async () => {
+      it("re-previews after a code-taken 409, since the rejection is evidence the preview was stale", async () => {
         const { getQueries } = mockPeekCode();
         const { getCallCount } = mockArtistSearch([]);
         mockAddArtist(() => conflictResponse());
@@ -561,9 +561,37 @@ describe("ArtistAddForm", () => {
         await user.click(screen.getByRole("button", { name: /add artist/i }));
         expect(await screen.findByRole("alert")).toHaveTextContent(/Stereolab/);
 
-        // A rejected add wrote nothing. Invalidating on it would flip the code
-        // number the MD is reading back to a spinner and spend two more round
-        // trips reconfirming lists that cannot have changed.
+        // The 409 names the exact code_letters/genre_id pair the preview just
+        // showed as free — unlike the catalog and typeahead lists, which the
+        // rejection proves are unchanged, the preview itself is exactly what
+        // the rejection contradicts and has to be refetched.
+        await waitFor(() =>
+          expect(getQueries().length).toBeGreaterThan(peeksBeforeSubmit),
+        );
+        expect(getCallCount()).toBe(searchesBeforeSubmit);
+      });
+
+      it("leaves the preview alone after a non-409 rejection below 500", async () => {
+        const { getQueries } = mockPeekCode();
+        const { getCallCount } = mockArtistSearch([]);
+        mockAddArtist(() =>
+          HttpResponse.json({ message: "Invalid request" }, { status: 400 }),
+        );
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await waitFor(() => expect(getQueries().length).toBeGreaterThan(0));
+        const peeksBeforeSubmit = getQueries().length;
+        const searchesBeforeSubmit = getCallCount();
+
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+        await waitFor(() =>
+          expect(toast.error).toHaveBeenCalledWith("Invalid request"),
+        );
+
+        // A 400 that isn't the code-taken 409 carries no evidence that this
+        // pair's preview is stale — the opt-out narrows to "409 only", it
+        // does not widen to "every sub-500".
         expect(getQueries()).toHaveLength(peeksBeforeSubmit);
         expect(getCallCount()).toBe(searchesBeforeSubmit);
         expect(screen.getByTestId("next-code-number")).toHaveTextContent("7");
@@ -788,6 +816,93 @@ describe("ArtistAddForm", () => {
         await waitFor(() =>
           expect(screen.queryByText(/already exists/i)).not.toBeInTheDocument(),
         );
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeEnabled();
+      });
+
+      it("keeps the duplicate block armed when an edit round-trips back to byte-identical text", async () => {
+        mockArtistSearch([
+          { id: 12, artist_name: "Juana Molina", code_letters: MOLINA, code_number: 3 },
+        ]);
+        const { getBodies } = mockAddArtist(() => created());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await selectGenre(user);
+        const nameInput = await screen.findByPlaceholderText("Search artists...");
+        await user.type(nameInput, "Juana Molina");
+        await user.click(await screen.findByText("Juana Molina"));
+        await user.type(screen.getByLabelText(/call letters/i), MOLINA);
+        await user.type(screen.getByLabelText("Code number"), "12");
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+
+        // A stray keystroke and its correction land the field back on the
+        // exact text the typeahead already confirmed as a duplicate — not a
+        // new question it has never answered.
+        await user.type(nameInput, "x");
+        await user.type(nameInput, "{Backspace}");
+
+        expect(screen.getByText(/already exists in this genre/i)).toBeInTheDocument();
+        // The disabled button cannot be clicked (MUI drops pointer-events on
+        // it); its disabled state plus the untouched body count together are
+        // what prove nothing was submitted.
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+        expect(getBodies()).toHaveLength(0);
+      });
+
+      it("keeps the re-check guard armed across a whitespace-only edit that trims back to the same name", async () => {
+        mockGenres([
+          { id: GENRE_ID, genre_name: "Rock" },
+          { id: JAZZ_GENRE_ID, genre_name: "Jazz" },
+        ]);
+        mockArtistSearch([]);
+        const { getBodies } = mockAddArtist(() => created());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await selectGenre(user, "Jazz");
+        expect(
+          screen.getByText(/re-check this name under the new genre/i),
+        ).toBeInTheDocument();
+
+        // Trims back to the exact name the stale check was raised against —
+        // not an answer about whether that name exists under the new genre.
+        await user.type(screen.getByPlaceholderText("Search artists..."), " ");
+
+        expect(
+          screen.getByText(/re-check this name under the new genre/i),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+        expect(getBodies()).toHaveLength(0);
+      });
+    });
+
+    describe("resubmission after a conflict", () => {
+      it("disables submission of the exact rejected triple until something changes", async () => {
+        const { getBodies } = mockAddArtist(() => conflictResponse());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+        expect(await screen.findByRole("alert")).toHaveTextContent(`${MOLINA}12`);
+
+        // The (code_letters, genre_id, code_number) triple the server just
+        // rejected has not changed, so a second click can only reach the same
+        // 409 — the button must not let the MD spend it. It is disabled
+        // (MUI drops pointer-events on it, so a click cannot even land), and
+        // only the one legitimate submit reached the server.
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+        expect(getBodies()).toHaveLength(1);
+      });
+
+      it("re-enables submission once the code letters move off the rejected value", async () => {
+        mockAddArtist(() => conflictResponse());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+        expect(await screen.findByRole("alert")).toHaveTextContent(`${MOLINA}12`);
+
+        await user.type(screen.getByLabelText(/call letters/i), "X");
+
         expect(screen.getByRole("button", { name: /add artist/i })).toBeEnabled();
       });
     });

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -1025,6 +1025,28 @@ describe("ArtistAddForm", () => {
         expect(screen.queryByRole("alert")).not.toBeInTheDocument();
       });
 
+      it("blocks resubmitting a triple refused by a 409 the banner cannot name", async () => {
+        // The refusal is what makes the triple unsubmittable, not the body's
+        // shape. A 409 this form cannot read still means the server rejected
+        // exactly these values, so resending them unchanged reaches the same
+        // answer — the button has to stay shut until something moves.
+        const { getBodies } = mockAddArtist(() => conflictResponse({ artist: null }));
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+        await waitFor(() =>
+          expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled(),
+        );
+        expect(getBodies()).toHaveLength(1);
+
+        // Moving the rejected code is what re-opens it.
+        await user.clear(screen.getByLabelText("Code number"));
+        await user.type(screen.getByLabelText("Code number"), "13");
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeEnabled();
+      });
+
       it("waits for the genres request rather than calling an outage on an empty cache", async () => {
         let release: (() => void) | undefined;
         const held = new Promise<void>((resolve) => {

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import {
+  renderWithProviders,
+  server,
+  TEST_BACKEND_URL,
+  TEST_ENTITY_IDS,
+  TEST_SEARCH_STRINGS,
+} from "@/tests/helpers";
+import ArtistAddForm from "@/src/components/experiences/modern/catalog/ArtistAddForm";
+
+const GENRE_ID = TEST_ENTITY_IDS.GENRE.ROCK;
+const { MOLINA } = TEST_SEARCH_STRINGS.CODE_LETTERS;
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+// No organization configured (the real production shape): the WXYC tier
+// resolves via fetchOrganizationRoleForUserClient's JWT decode, not the raw
+// session role, so every test drives that mock and awaits resolution.
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<
+  typeof vi.fn
+>;
+
+function sessionWithRole() {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role: null,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+    error: null,
+  };
+}
+
+function mockGenres() {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
+      HttpResponse.json([{ id: GENRE_ID, genre_name: "Rock" }]),
+    ),
+  );
+}
+
+function mockArtistSearch(artists: unknown[] = []) {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/artists/search`, () =>
+      HttpResponse.json({ artists }),
+    ),
+  );
+}
+
+function mockPeekCode(next_code_number = 7) {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/artists/peek-code`, () =>
+      HttpResponse.json({ next_code_number }),
+    ),
+  );
+}
+
+/** Captures the exact serialized JSON body POSTed to /library/artists. */
+function mockAddArtist(
+  respond: (body: unknown) => Response | Promise<Response>,
+): { getBodies: () => unknown[] } {
+  const bodies: unknown[] = [];
+  server.use(
+    http.post(`${TEST_BACKEND_URL}/library/artists`, async ({ request }) => {
+      const body = await request.json();
+      bodies.push(body);
+      return respond(body);
+    }),
+  );
+  return { getBodies: () => bodies };
+}
+
+async function fillCoreFields(user: ReturnType<typeof renderWithProviders>["user"]) {
+  const genreSelect = await screen.findByRole("combobox", { name: /genre/i });
+  await user.click(genreSelect);
+  await user.click(await screen.findByRole("option", { name: "Rock" }));
+
+  const nameInput = await screen.findByPlaceholderText("Search artists...");
+  await user.type(nameInput, "Juana Molina");
+
+  await user.type(screen.getByLabelText(/call letters/i), MOLINA);
+  await user.type(screen.getByLabelText("Code number"), "12");
+}
+
+describe("ArtistAddForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGenres();
+    mockArtistSearch([]);
+    mockPeekCode();
+  });
+
+  describe("permission gating", () => {
+    it("renders nothing for a DJ", async () => {
+      mockFetchOrgRole.mockResolvedValue("dj");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(<ArtistAddForm />);
+
+      await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
+      await mockFetchOrgRole.mock.results[0].value;
+      await waitFor(() =>
+        expect(screen.queryByText(/add artist/i)).not.toBeInTheDocument(),
+      );
+    });
+
+    it("renders the form for a Music Director", async () => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(<ArtistAddForm />);
+
+      expect(await screen.findByRole("button", { name: /add artist/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("as a Music Director", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    it("submits a valid AddArtistRequestBody, asserting the serialized outgoing body", async () => {
+      const { getBodies } = mockAddArtist((body) =>
+        HttpResponse.json(
+          { id: 99, artist_name: (body as { artist_name: string }).artist_name, code_number: 12, genre_id: GENRE_ID },
+          { status: 201 },
+        ),
+      );
+      const { user } = renderWithProviders(<ArtistAddForm />);
+
+      await fillCoreFields(user);
+      await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+      await waitFor(() => expect(getBodies()).toHaveLength(1));
+      expect(getBodies()[0]).toEqual({
+        artist_name: "Juana Molina",
+        code_letters: MOLINA,
+        genre_id: GENRE_ID,
+        code_number: 12,
+      });
+    });
+
+    it("shows the assigned code number from the 201 response", async () => {
+      mockAddArtist(() =>
+        HttpResponse.json(
+          { id: 99, artist_name: "Juana Molina", code_number: 12, genre_id: GENRE_ID },
+          { status: 201 },
+        ),
+      );
+      const { user } = renderWithProviders(<ArtistAddForm />);
+
+      await fillCoreFields(user);
+      await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+      expect(
+        await screen.findByText(new RegExp(`${MOLINA}12`)),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the conflicting artist by name on a 409 response instead of a generic failure", async () => {
+      mockAddArtist(() =>
+        HttpResponse.json(
+          {
+            message: "Artist code already exists for that genre and code letters.",
+            artist: { artist_id: 5, artist_name: "Stereolab", code_letters: MOLINA },
+          },
+          { status: 409 },
+        ),
+      );
+      const { user } = renderWithProviders(<ArtistAddForm />);
+
+      await fillCoreFields(user);
+      await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(/Stereolab/);
+    });
+
+    it("blocks submission and surfaces a duplicate when an existing artist is picked from the typeahead", async () => {
+      mockArtistSearch([
+        { id: 12, artist_name: "Juana Molina", code_letters: MOLINA, code_number: 3 },
+      ]);
+      const { getBodies } = mockAddArtist(() =>
+        HttpResponse.json({ id: 1 }, { status: 201 }),
+      );
+      const { user } = renderWithProviders(<ArtistAddForm />);
+
+      const genreSelect = await screen.findByRole("combobox", { name: /genre/i });
+      await user.click(genreSelect);
+      await user.click(await screen.findByRole("option", { name: "Rock" }));
+
+      const nameInput = await screen.findByPlaceholderText("Search artists...");
+      await user.type(nameInput, "Juana Molina");
+      await user.click(await screen.findByText("Juana Molina"));
+
+      await user.type(screen.getByLabelText(/call letters/i), MOLINA);
+      await user.type(screen.getByLabelText("Code number"), "12");
+
+      expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+      expect(screen.getByText(/already exists/i)).toBeInTheDocument();
+      expect(getBodies()).toHaveLength(0);
+    });
+
+    it("reuses parseRequiredPositiveInt to reject a non-numeric code number", async () => {
+      mockAddArtist(() => HttpResponse.json({ id: 1 }, { status: 201 }));
+      const { user } = renderWithProviders(<ArtistAddForm />);
+
+      const genreSelect = await screen.findByRole("combobox", { name: /genre/i });
+      await user.click(genreSelect);
+      await user.click(await screen.findByRole("option", { name: "Rock" }));
+
+      const nameInput = await screen.findByPlaceholderText("Search artists...");
+      await user.type(nameInput, "Juana Molina");
+      await user.type(screen.getByLabelText(/call letters/i), MOLINA);
+      await user.type(screen.getByLabelText("Code number"), "abc");
+
+      expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+    });
+  });
+});

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import {
   renderWithProviders,
@@ -138,6 +138,15 @@ function conflictResponse(overrides: Record<string, unknown> = {}) {
     },
     { status: 409 },
   );
+}
+
+/** The FormControl wrapping a field, so a helper-text assertion names its owner. */
+function fieldGroup(field: HTMLElement): HTMLElement {
+  const group = field.closest(".MuiFormControl-root");
+  if (!(group instanceof HTMLElement)) {
+    throw new Error("field is not inside a FormControl");
+  }
+  return group;
 }
 
 async function selectGenre(
@@ -378,6 +387,37 @@ describe("ArtistAddForm", () => {
         expect(getBodies()[0]).toMatchObject({ code_letters: "MOLI" });
       });
 
+      it.each([
+        ["a lowercase character", "l", "MLOI", 2],
+        ["an already-uppercase character", "L", "MLOI", 2],
+        // Uppercasing "ß" yields "SS", so the caret has to land past two
+        // characters the keystroke did not itself type.
+        ["a character that uppercases to two", "ß", "MSSOI", 3],
+      ])(
+        "leaves the caret where the edit put it after inserting %s mid-code",
+        async (_label, typed, expectedValue, expectedCaret) => {
+          const { user } = renderWithProviders(<ArtistAddForm />);
+
+          await selectGenre(user);
+          const field = screen.getByLabelText(
+            /call letters/i,
+          ) as HTMLInputElement;
+          await user.type(field, "MOI");
+
+          // Normalizing inside the change handler rewrites the controlled
+          // input on every keystroke, and the value setter drops the caret at
+          // the end. An MD fixing a typo mid-code would then have the second
+          // correction land at the end, filing a different but still valid
+          // four-character code with nothing reported wrong.
+          field.setSelectionRange(1, 1);
+          await user.keyboard(typed);
+
+          expect(field).toHaveValue(expectedValue);
+          expect(field.selectionStart).toBe(expectedCaret);
+          expect(field.selectionEnd).toBe(expectedCaret);
+        },
+      );
+
       it("blocks a value that arrives past the field's own cap", async () => {
         const { getBodies } = mockAddArtist(() => created());
         const { user } = renderWithProviders(<ArtistAddForm />);
@@ -411,7 +451,13 @@ describe("ArtistAddForm", () => {
             target: { value: "Nilüfer".padEnd(length, "!") },
           });
 
-          expect(screen.getAllByText(/at most 128 characters/i).length).toBeGreaterThan(0);
+          // Scoped to the field's own FormControl: a tree-wide query passes
+          // just as well with the two length guards wired to each other's
+          // fields, leaving each reporting the wrong one.
+          const field = screen.getByPlaceholderText(placeholder);
+          expect(
+            within(fieldGroup(field)).getByText(/at most 128 characters/i),
+          ).toBeInTheDocument();
           expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
           expect(getBodies()).toHaveLength(0);
         },
@@ -468,6 +514,107 @@ describe("ArtistAddForm", () => {
         await waitFor(() =>
           expect(screen.getByTestId("next-code-number")).toHaveTextContent("3"),
         );
+      });
+
+      it("stops previewing once the normalized value is longer than any code", async () => {
+        const { getQueries } = mockPeekCode();
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await selectGenre(user);
+        const codeLettersInput = screen.getByLabelText(/call letters/i);
+        await user.type(codeLettersInput, MOLINA);
+        expect(await screen.findByTestId("next-code-number")).toHaveTextContent("7");
+
+        // maxLength counts the keystroke, not the normalized write-back, so
+        // uppercasing can push the value past the column's four characters.
+        // No series can ever hold it, and previewing anyway would answer
+        // "Next code: 1" beside the length error that blocks the submit.
+        await user.clear(codeLettersInput);
+        await user.type(codeLettersInput, "ßxß");
+        expect(codeLettersInput).toHaveValue("SSXSS");
+
+        await waitFor(() =>
+          expect(screen.getByText(/at most 4 characters/i)).toBeInTheDocument(),
+        );
+        expect(screen.queryByText("Next code:")).not.toBeInTheDocument();
+        expect(
+          getQueries().map((query) => query.code_letters),
+        ).not.toContain("SSXSS");
+      });
+
+      it("leaves the preview alone when the add is rejected", async () => {
+        const { getQueries } = mockPeekCode();
+        const { getCallCount } = mockArtistSearch([]);
+        mockAddArtist(() => conflictResponse());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await waitFor(() => expect(getQueries().length).toBeGreaterThan(0));
+        const peeksBeforeSubmit = getQueries().length;
+        const searchesBeforeSubmit = getCallCount();
+
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+        expect(await screen.findByRole("alert")).toHaveTextContent(/Stereolab/);
+
+        // A rejected add wrote nothing. Invalidating on it would flip the code
+        // number the MD is reading back to a spinner and spend two more round
+        // trips reconfirming lists that cannot have changed.
+        expect(getQueries()).toHaveLength(peeksBeforeSubmit);
+        expect(getCallCount()).toBe(searchesBeforeSubmit);
+        expect(screen.getByTestId("next-code-number")).toHaveTextContent("7");
+      });
+
+      it("re-previews after a successful add, whose row the preview predates", async () => {
+        const { getQueries } = mockPeekCode();
+        mockAddArtist(() => created());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await waitFor(() => expect(getQueries().length).toBeGreaterThan(0));
+        const peeksBeforeSubmit = getQueries().length;
+
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+        // The cached preview for that letters/genre pair now predates a row
+        // holding the code it reports as free.
+        await waitFor(() =>
+          expect(getQueries().length).toBeGreaterThan(peeksBeforeSubmit),
+        );
+      });
+    });
+
+    describe("the success confirmation", () => {
+      it.each([
+        ["the call letters", async (user: ReturnType<typeof renderWithProviders>["user"]) =>
+          user.type(screen.getByLabelText(/call letters/i), "X")],
+        ["the code number", async (user: ReturnType<typeof renderWithProviders>["user"]) =>
+          user.type(screen.getByLabelText("Code number"), "3")],
+        ["the alphabetical name", async (user: ReturnType<typeof renderWithProviders>["user"]) =>
+          user.type(screen.getByLabelText(/alphabetical name/i), "Molina, Juana")],
+        ["the genre", async (user: ReturnType<typeof renderWithProviders>["user"]) =>
+          selectGenre(user, "Jazz")],
+      ])("drops the confirmation once %s moves on to the next entry", async (_label, edit) => {
+        mockGenres([
+          { id: GENRE_ID, genre_name: "Rock" },
+          { id: JAZZ_GENRE_ID, genre_name: "Jazz" },
+        ]);
+        mockAddArtist(() => created());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+        expect(await screen.findByRole("status")).toHaveTextContent(
+          `Added as ${MOLINA}12.`,
+        );
+
+        // An MD filing a batch who transcribes the next card's code before its
+        // name would otherwise keep the previous artist's confirmation
+        // standing beside a different half-typed entry.
+        await edit(user);
+
+        expect(
+          screen.queryByText(new RegExp(`Added as ${MOLINA}12`)),
+        ).not.toBeInTheDocument();
       });
     });
 
@@ -654,14 +801,44 @@ describe("ArtistAddForm", () => {
         await fillCoreFields(user);
         await user.click(screen.getByRole("button", { name: /add artist/i }));
 
+        // Only a 409 this form can name an artist from has its message
+        // suppressed in favour of the banner. Any other 409 keeps the server's
+        // reason, which is more use than a generic fallback.
         await waitFor(() =>
-          expect(toast.error).toHaveBeenCalledWith("Failed to add artist"),
+          expect(toast.error).toHaveBeenCalledWith(
+            "Artist code already exists for that genre and code letters.",
+          ),
         );
         expect(toast.error).toHaveBeenCalledTimes(1);
         // Rendering the banner would dereference `artist.artist_name`; there is
         // no error boundary here, so a malformed 409 must not reach it.
         expect(screen.queryByRole("alert")).not.toBeInTheDocument();
         expect(screen.getByRole("button", { name: /add artist/i })).toBeInTheDocument();
+      });
+
+      it("keeps a second 409 reason's message rather than dropping it", async () => {
+        // The strip exists for the one 409 shape the backend sends today. A
+        // different reason — or an intermediary answering 409 with its own
+        // JSON — must not have its message deleted before anything can toast
+        // it, leaving the MD a generic fallback and no server reason.
+        mockAddArtist(() =>
+          HttpResponse.json(
+            { message: "That genre is locked for the semester audit." },
+            { status: 409 },
+          ),
+        );
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+        await waitFor(() =>
+          expect(toast.error).toHaveBeenCalledWith(
+            "That genre is locked for the semester audit.",
+          ),
+        );
+        expect(toast.error).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
       });
 
       it("explains a genres outage and offers a retry instead of an empty dropdown", async () => {

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -221,6 +221,41 @@ describe("ArtistAddForm", () => {
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
 
+    it("clears the stale conflict banner when the genre changes", async () => {
+      const JAZZ_GENRE_ID = TEST_ENTITY_IDS.GENRE.ROCK + 1;
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
+          HttpResponse.json([
+            { id: GENRE_ID, genre_name: "Rock" },
+            { id: JAZZ_GENRE_ID, genre_name: "Jazz" },
+          ]),
+        ),
+      );
+      mockAddArtist(() =>
+        HttpResponse.json(
+          {
+            message: "Artist code already exists for that genre and code letters.",
+            artist: { artist_id: 5, artist_name: "Stereolab", code_letters: MOLINA },
+          },
+          { status: 409 },
+        ),
+      );
+      const { user } = renderWithProviders(<ArtistAddForm />);
+
+      await fillCoreFields(user);
+      await user.click(screen.getByRole("button", { name: /add artist/i }));
+      expect(await screen.findByRole("alert")).toHaveTextContent(`${MOLINA}12`);
+
+      // (code_letters, genre_id, code_number) is the uniqueness triple — a
+      // code rejected under one genre may be free under another, so moving
+      // genres must not leave the prior genre's rejection standing.
+      const genreSelect = screen.getByRole("combobox", { name: /genre/i });
+      await user.click(genreSelect);
+      await user.click(await screen.findByRole("option", { name: "Jazz" }));
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
     it("blocks submission and surfaces a duplicate when an existing artist is picked from the typeahead", async () => {
       mockArtistSearch([
         { id: 12, artist_name: "Juana Molina", code_letters: MOLINA, code_number: 3 },

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import {
   renderWithProviders,
@@ -11,7 +11,8 @@ import {
 import ArtistAddForm from "@/src/components/experiences/modern/catalog/ArtistAddForm";
 
 const GENRE_ID = TEST_ENTITY_IDS.GENRE.ROCK;
-const { MOLINA } = TEST_SEARCH_STRINGS.CODE_LETTERS;
+const JAZZ_GENRE_ID = TEST_ENTITY_IDS.GENRE.ROCK + 1;
+const { MOLINA, STEREOLAB } = TEST_SEARCH_STRINGS.CODE_LETTERS;
 
 vi.mock("@/lib/features/authentication/client", () => ({
   authClient: { useSession: vi.fn() },
@@ -29,8 +30,13 @@ vi.mock("@/lib/features/authentication/organization-utils", () => ({
   fetchOrganizationRoleForUserClient: vi.fn(),
 }));
 
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
 import { authClient } from "@/lib/features/authentication/client";
 import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+import { toast } from "sonner";
 
 const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
 const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<
@@ -55,28 +61,43 @@ function sessionWithRole() {
   };
 }
 
-function mockGenres() {
+function mockGenres(
+  genres: { id: number; genre_name: string }[] = [{ id: GENRE_ID, genre_name: "Rock" }],
+) {
   server.use(
-    http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
-      HttpResponse.json([{ id: GENRE_ID, genre_name: "Rock" }]),
-    ),
+    http.get(`${TEST_BACKEND_URL}/library/genres`, () => HttpResponse.json(genres)),
   );
 }
 
-function mockArtistSearch(artists: unknown[] = []) {
+function mockArtistSearch(artists: unknown[] = []): { getCallCount: () => number } {
+  let calls = 0;
   server.use(
-    http.get(`${TEST_BACKEND_URL}/library/artists/search`, () =>
-      HttpResponse.json({ artists }),
-    ),
+    http.get(`${TEST_BACKEND_URL}/library/artists/search`, () => {
+      calls += 1;
+      return HttpResponse.json({ artists });
+    }),
   );
+  return { getCallCount: () => calls };
 }
 
-function mockPeekCode(next_code_number = 7) {
+/** Captures the query params every peek-code preview request was made with. */
+function mockPeekCode(
+  respond: (code_letters: string) => number = () => 7,
+): { getQueries: () => { code_letters: string | null; genre_id: string | null }[] } {
+  const queries: { code_letters: string | null; genre_id: string | null }[] = [];
   server.use(
-    http.get(`${TEST_BACKEND_URL}/library/artists/peek-code`, () =>
-      HttpResponse.json({ next_code_number }),
-    ),
+    http.get(`${TEST_BACKEND_URL}/library/artists/peek-code`, ({ request }) => {
+      const params = new URL(request.url).searchParams;
+      queries.push({
+        code_letters: params.get("code_letters"),
+        genre_id: params.get("genre_id"),
+      });
+      return HttpResponse.json({
+        next_code_number: respond(params.get("code_letters") ?? ""),
+      });
+    }),
   );
+  return { getQueries: () => queries };
 }
 
 /** Captures the exact serialized JSON body POSTed to /library/artists. */
@@ -94,15 +115,50 @@ function mockAddArtist(
   return { getBodies: () => bodies };
 }
 
-async function fillCoreFields(user: ReturnType<typeof renderWithProviders>["user"]) {
+function created(overrides: Record<string, unknown> = {}) {
+  return HttpResponse.json(
+    {
+      id: 99,
+      artist_name: "Juana Molina",
+      code_letters: MOLINA,
+      code_number: 12,
+      genre_id: GENRE_ID,
+      ...overrides,
+    },
+    { status: 201 },
+  );
+}
+
+function conflictResponse(overrides: Record<string, unknown> = {}) {
+  return HttpResponse.json(
+    {
+      message: "Artist code already exists for that genre and code letters.",
+      artist: { artist_id: 5, artist_name: "Stereolab", code_letters: MOLINA },
+      ...overrides,
+    },
+    { status: 409 },
+  );
+}
+
+async function selectGenre(
+  user: ReturnType<typeof renderWithProviders>["user"],
+  name = "Rock",
+) {
   const genreSelect = await screen.findByRole("combobox", { name: /genre/i });
   await user.click(genreSelect);
-  await user.click(await screen.findByRole("option", { name: "Rock" }));
+  await user.click(await screen.findByRole("option", { name }));
+}
+
+async function fillCoreFields(
+  user: ReturnType<typeof renderWithProviders>["user"],
+  codeLetters: string = MOLINA,
+) {
+  await selectGenre(user);
 
   const nameInput = await screen.findByPlaceholderText("Search artists...");
   await user.type(nameInput, "Juana Molina");
 
-  await user.type(screen.getByLabelText(/call letters/i), MOLINA);
+  await user.type(screen.getByLabelText(/call letters/i), codeLetters);
   await user.type(screen.getByLabelText("Code number"), "12");
 }
 
@@ -144,10 +200,7 @@ describe("ArtistAddForm", () => {
 
     it("submits a valid AddArtistRequestBody, asserting the serialized outgoing body", async () => {
       const { getBodies } = mockAddArtist((body) =>
-        HttpResponse.json(
-          { id: 99, artist_name: (body as { artist_name: string }).artist_name, code_number: 12, genre_id: GENRE_ID },
-          { status: 201 },
-        ),
+        created({ artist_name: (body as { artist_name: string }).artist_name }),
       );
       const { user } = renderWithProviders(<ArtistAddForm />);
 
@@ -163,33 +216,45 @@ describe("ArtistAddForm", () => {
       });
     });
 
-    it("shows the assigned code number from the 201 response", async () => {
-      mockAddArtist(() =>
-        HttpResponse.json(
-          { id: 99, artist_name: "Juana Molina", code_number: 12, genre_id: GENRE_ID },
-          { status: 201 },
-        ),
+    it("carries alphabetical_name on the wire when one is typed", async () => {
+      const { getBodies } = mockAddArtist(() => created());
+      const { user } = renderWithProviders(<ArtistAddForm />);
+
+      await fillCoreFields(user);
+      await user.type(
+        screen.getByLabelText(/alphabetical name/i),
+        "Molina, Juana",
       );
+      await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+      await waitFor(() => expect(getBodies()).toHaveLength(1));
+      expect(getBodies()[0]).toEqual({
+        artist_name: "Juana Molina",
+        code_letters: MOLINA,
+        genre_id: GENRE_ID,
+        code_number: 12,
+        alphabetical_name: "Molina, Juana",
+      });
+    });
+
+    it("shows the assigned code from the 201 response rather than echoing what was typed", async () => {
+      // The response deliberately disagrees with the typed MO/12 so the
+      // assertion can only pass by reading the server's copy of what was
+      // filed — an echo of client state would render MO12.
+      mockAddArtist(() => created({ code_letters: STEREOLAB, code_number: 44 }));
       const { user } = renderWithProviders(<ArtistAddForm />);
 
       await fillCoreFields(user);
       await user.click(screen.getByRole("button", { name: /add artist/i }));
 
       expect(
-        await screen.findByText(new RegExp(`${MOLINA}12`)),
+        await screen.findByText(new RegExp(`${STEREOLAB}44`)),
       ).toBeInTheDocument();
+      expect(screen.queryByText(new RegExp(`${MOLINA}12`))).not.toBeInTheDocument();
     });
 
     it("renders the conflicting artist by name on a 409 response instead of a generic failure", async () => {
-      mockAddArtist(() =>
-        HttpResponse.json(
-          {
-            message: "Artist code already exists for that genre and code letters.",
-            artist: { artist_id: 5, artist_name: "Stereolab", code_letters: MOLINA },
-          },
-          { status: 409 },
-        ),
-      );
+      mockAddArtist(() => conflictResponse());
       const { user } = renderWithProviders(<ArtistAddForm />);
 
       await fillCoreFields(user);
@@ -198,48 +263,35 @@ describe("ArtistAddForm", () => {
       expect(await screen.findByRole("alert")).toHaveTextContent(/Stereolab/);
     });
 
-    it("clears the stale conflict banner once the rejected code is edited", async () => {
-      mockAddArtist(() =>
-        HttpResponse.json(
-          {
-            message: "Artist code already exists for that genre and code letters.",
-            artist: { artist_id: 5, artist_name: "Stereolab", code_letters: MOLINA },
-          },
-          { status: 409 },
-        ),
-      );
-      const { user } = renderWithProviders(<ArtistAddForm />);
+    it.each([
+      ["the code number", async (user: ReturnType<typeof renderWithProviders>["user"]) =>
+        user.type(screen.getByLabelText("Code number"), "3")],
+      ["the call letters", async (user: ReturnType<typeof renderWithProviders>["user"]) =>
+        user.type(screen.getByLabelText(/call letters/i), "X")],
+    ])(
+      "clears the stale conflict banner once %s is edited",
+      async (_label, edit) => {
+        mockAddArtist(() => conflictResponse());
+        const { user } = renderWithProviders(<ArtistAddForm />);
 
-      await fillCoreFields(user);
-      await user.click(screen.getByRole("button", { name: /add artist/i }));
-      expect(await screen.findByRole("alert")).toHaveTextContent(`${MOLINA}12`);
+        await fillCoreFields(user);
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+        expect(await screen.findByRole("alert")).toHaveTextContent(`${MOLINA}12`);
 
-      // Editing the field the server actually rejected must drop the banner
-      // rather than have it keep reporting the new, unsubmitted value as taken.
-      await user.type(screen.getByLabelText("Code number"), "3");
+        // Editing a field the server actually saw must drop the banner rather
+        // than have it keep reporting the new, unsubmitted value as taken.
+        await edit(user);
 
-      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    });
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      },
+    );
 
     it("clears the stale conflict banner when the genre changes", async () => {
-      const JAZZ_GENRE_ID = TEST_ENTITY_IDS.GENRE.ROCK + 1;
-      server.use(
-        http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
-          HttpResponse.json([
-            { id: GENRE_ID, genre_name: "Rock" },
-            { id: JAZZ_GENRE_ID, genre_name: "Jazz" },
-          ]),
-        ),
-      );
-      mockAddArtist(() =>
-        HttpResponse.json(
-          {
-            message: "Artist code already exists for that genre and code letters.",
-            artist: { artist_id: 5, artist_name: "Stereolab", code_letters: MOLINA },
-          },
-          { status: 409 },
-        ),
-      );
+      mockGenres([
+        { id: GENRE_ID, genre_name: "Rock" },
+        { id: JAZZ_GENRE_ID, genre_name: "Jazz" },
+      ]);
+      mockAddArtist(() => conflictResponse());
       const { user } = renderWithProviders(<ArtistAddForm />);
 
       await fillCoreFields(user);
@@ -249,45 +301,280 @@ describe("ArtistAddForm", () => {
       // (code_letters, genre_id, code_number) is the uniqueness triple — a
       // code rejected under one genre may be free under another, so moving
       // genres must not leave the prior genre's rejection standing.
-      const genreSelect = screen.getByRole("combobox", { name: /genre/i });
-      await user.click(genreSelect);
-      await user.click(await screen.findByRole("option", { name: "Jazz" }));
+      await selectGenre(user, "Jazz");
 
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
 
-    it("blocks submission and surfaces a duplicate when an existing artist is picked from the typeahead", async () => {
-      mockArtistSearch([
-        { id: 12, artist_name: "Juana Molina", code_letters: MOLINA, code_number: 3 },
-      ]);
-      const { getBodies } = mockAddArtist(() =>
-        HttpResponse.json({ id: 1 }, { status: 201 }),
-      );
+    describe("call letters", () => {
+      it("normalizes to uppercase on the wire and in the code preview", async () => {
+        const { getQueries } = mockPeekCode();
+        const { getBodies } = mockAddArtist(() => created());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user, "mo");
+
+        // Both backend lookups keyed on call letters compare the column for
+        // equality, and the catalog is filed uppercase: a lowercase value
+        // would miss the duplicate check and preview a next code of 1.
+        expect(screen.getByLabelText(/call letters/i)).toHaveValue(MOLINA);
+        await waitFor(() =>
+          expect(getQueries().at(-1)).toEqual({
+            code_letters: MOLINA,
+            genre_id: String(GENRE_ID),
+          }),
+        );
+
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+        await waitFor(() => expect(getBodies()).toHaveLength(1));
+        expect(getBodies()[0]).toMatchObject({ code_letters: MOLINA });
+      });
+
+      it("caps the field at the four characters the column holds and says so", async () => {
+        const { getBodies } = mockAddArtist(() => created());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user, "molina");
+
+        // artists.code_letters is a varchar(4) with no server-side guard: an
+        // over-long value reaches PostgreSQL and returns a 500.
+        expect(screen.getByLabelText(/call letters/i)).toHaveValue("MOLI");
+        expect(screen.getByText(/up to 4 characters/i)).toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+        await waitFor(() => expect(getBodies()).toHaveLength(1));
+        expect(getBodies()[0]).toMatchObject({ code_letters: "MOLI" });
+      });
+    });
+
+    describe("the call-letter preview", () => {
+      it("previews the next code for the current call-letters/genre pair", async () => {
+        const { getQueries } = mockPeekCode(() => 7);
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await selectGenre(user);
+        await user.type(screen.getByLabelText(/call letters/i), MOLINA);
+
+        expect(await screen.findByTestId("next-code-number")).toHaveTextContent("7");
+        expect(screen.getByText("Next code:")).toBeInTheDocument();
+        expect(getQueries()).toContainEqual({
+          code_letters: MOLINA,
+          genre_id: String(GENRE_ID),
+        });
+      });
+
+      it("re-previews when the call letters change", async () => {
+        mockPeekCode((code_letters) => (code_letters === MOLINA ? 7 : 3));
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await selectGenre(user);
+        const codeLettersInput = screen.getByLabelText(/call letters/i);
+        await user.type(codeLettersInput, MOLINA);
+        expect(await screen.findByTestId("next-code-number")).toHaveTextContent("7");
+
+        await user.clear(codeLettersInput);
+        await user.type(codeLettersInput, STEREOLAB);
+
+        await waitFor(() =>
+          expect(screen.getByTestId("next-code-number")).toHaveTextContent("3"),
+        );
+      });
+    });
+
+    describe("duplicate protection", () => {
+      it("blocks submission and surfaces a duplicate when an existing artist is picked from the typeahead", async () => {
+        mockArtistSearch([
+          { id: 12, artist_name: "Juana Molina", code_letters: MOLINA, code_number: 3 },
+        ]);
+        const { getBodies } = mockAddArtist(() => created());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await selectGenre(user);
+
+        const nameInput = await screen.findByPlaceholderText("Search artists...");
+        await user.type(nameInput, "Juana Molina");
+        await user.click(await screen.findByText("Juana Molina"));
+
+        await user.type(screen.getByLabelText(/call letters/i), MOLINA);
+        await user.type(screen.getByLabelText("Code number"), "12");
+
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+        expect(screen.getByText(/already exists/i)).toBeInTheDocument();
+        expect(getBodies()).toHaveLength(0);
+      });
+
+      it("keeps submission blocked when the genre changes after an existing artist was picked", async () => {
+        mockGenres([
+          { id: GENRE_ID, genre_name: "Rock" },
+          { id: JAZZ_GENRE_ID, genre_name: "Jazz" },
+        ]);
+        const { getCallCount } = mockArtistSearch([
+          { id: 12, artist_name: "Juana Molina", code_letters: MOLINA, code_number: 3 },
+        ]);
+        const { getBodies } = mockAddArtist(() => created());
+        const { user, container } = renderWithProviders(<ArtistAddForm />);
+
+        await selectGenre(user);
+        const nameInput = await screen.findByPlaceholderText("Search artists...");
+        await user.type(nameInput, "Juana Molina");
+        await user.click(await screen.findByText("Juana Molina"));
+        await user.type(screen.getByLabelText(/call letters/i), MOLINA);
+        await user.type(screen.getByLabelText("Code number"), "12");
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+
+        const searchesUnderRock = getCallCount();
+        await selectGenre(user, "Jazz");
+
+        // The typeahead retracts the held artist on a genre change but never
+        // reopens its panel, so nothing checks this name under Jazz. Treating
+        // the retraction as "new here" is how the form would create the very
+        // duplicate the typeahead exists to prevent.
+        expect(getCallCount()).toBe(searchesUnderRock);
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+        expect(
+          screen.getByText(/search this name again under the new genre/i),
+        ).toBeInTheDocument();
+
+        // Submitting past the disabled button (Enter in a field, say) must hit
+        // the same block rather than only the button's disabled state.
+        fireEvent.submit(container.querySelector("form")!);
+        expect(getBodies()).toHaveLength(0);
+      });
+
+      it("re-enables submission once the name is searched again under the new genre", async () => {
+        mockGenres([
+          { id: GENRE_ID, genre_name: "Rock" },
+          { id: JAZZ_GENRE_ID, genre_name: "Jazz" },
+        ]);
+        mockArtistSearch([]);
+        mockAddArtist(() => created());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await selectGenre(user, "Jazz");
+        expect(
+          screen.getByText(/search this name again under the new genre/i),
+        ).toBeInTheDocument();
+
+        await user.type(screen.getByPlaceholderText("Search artists..."), "!");
+
+        await waitFor(() =>
+          expect(
+            screen.queryByText(/search this name again under the new genre/i),
+          ).not.toBeInTheDocument(),
+        );
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeEnabled();
+      });
+    });
+
+    describe("failure handling", () => {
+      it("shows exactly one toast carrying the server's message when the add fails", async () => {
+        mockAddArtist(() =>
+          HttpResponse.json({ message: "Artist could not be filed" }, { status: 500 }),
+        );
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+        // The global rtkQueryErrorLogger middleware already toasts this; a
+        // second unconditional toast here would stack two on one failure.
+        await waitFor(() =>
+          expect(toast.error).toHaveBeenCalledWith("Artist could not be filed"),
+        );
+        expect(toast.error).toHaveBeenCalledTimes(1);
+      });
+
+      it("shows exactly one fallback toast when the add fails with no server message", async () => {
+        mockAddArtist(() => HttpResponse.json({ error: "rejected" }, { status: 500 }));
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+        await waitFor(() =>
+          expect(toast.error).toHaveBeenCalledWith("Failed to add artist"),
+        );
+        expect(toast.error).toHaveBeenCalledTimes(1);
+      });
+
+      it("survives a 409 whose body carries no usable artist", async () => {
+        mockAddArtist(() => conflictResponse({ artist: null }));
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+        await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
+        // Rendering the banner would dereference `artist.artist_name`; there is
+        // no error boundary here, so a malformed 409 must not reach it.
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeInTheDocument();
+      });
+
+      it("explains a genres outage and offers a retry instead of an empty dropdown", async () => {
+        let genreCalls = 0;
+        server.use(
+          http.get(`${TEST_BACKEND_URL}/library/genres`, () => {
+            genreCalls += 1;
+            return genreCalls === 1
+              ? HttpResponse.json({ message: "genres unavailable" }, { status: 500 })
+              : HttpResponse.json([{ id: GENRE_ID, genre_name: "Rock" }]);
+          }),
+        );
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        // genre_id is required to submit, so an empty dropdown leaves the form
+        // permanently un-submittable with nothing explaining why.
+        expect(await screen.findByText(/genres are unavailable/i)).toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: /try again/i }));
+
+        await waitFor(() =>
+          expect(screen.queryByText(/genres are unavailable/i)).not.toBeInTheDocument(),
+        );
+        await selectGenre(user);
+        expect(await screen.findByPlaceholderText("Search artists...")).toBeEnabled();
+      });
+    });
+
+    it("holds the fields while the add is in flight so mid-flight typing isn't cleared", async () => {
+      let release: () => void = () => {};
+      const inFlight = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      mockAddArtist(async () => {
+        await inFlight;
+        return created();
+      });
       const { user } = renderWithProviders(<ArtistAddForm />);
 
-      const genreSelect = await screen.findByRole("combobox", { name: /genre/i });
-      await user.click(genreSelect);
-      await user.click(await screen.findByRole("option", { name: "Rock" }));
+      await fillCoreFields(user);
+      await user.click(screen.getByRole("button", { name: /add artist/i }));
 
-      const nameInput = await screen.findByPlaceholderText("Search artists...");
-      await user.type(nameInput, "Juana Molina");
-      await user.click(await screen.findByText("Juana Molina"));
+      // The success handler clears every field unconditionally; anything typed
+      // during the request would be discarded with no signal.
+      await waitFor(() =>
+        expect(screen.getByLabelText("Code number")).toBeDisabled(),
+      );
+      expect(screen.getByLabelText(/call letters/i)).toBeDisabled();
+      expect(screen.getByLabelText(/alphabetical name/i)).toBeDisabled();
+      expect(screen.getByPlaceholderText("Search artists...")).toBeDisabled();
+      expect(screen.getByRole("combobox", { name: /genre/i })).toBeDisabled();
 
-      await user.type(screen.getByLabelText(/call letters/i), MOLINA);
-      await user.type(screen.getByLabelText("Code number"), "12");
-
-      expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
-      expect(screen.getByText(/already exists/i)).toBeInTheDocument();
-      expect(getBodies()).toHaveLength(0);
+      release();
+      await waitFor(() =>
+        expect(screen.getByLabelText("Code number")).toBeEnabled(),
+      );
     });
 
     it("reuses parseRequiredPositiveInt to reject a non-numeric code number", async () => {
-      mockAddArtist(() => HttpResponse.json({ id: 1 }, { status: 201 }));
+      mockAddArtist(() => created());
       const { user } = renderWithProviders(<ArtistAddForm />);
 
-      const genreSelect = await screen.findByRole("combobox", { name: /genre/i });
-      await user.click(genreSelect);
-      await user.click(await screen.findByRole("option", { name: "Rock" }));
+      await selectGenre(user);
 
       const nameInput = await screen.findByPlaceholderText("Search artists...");
       await user.type(nameInput, "Juana Molina");

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -198,6 +198,29 @@ describe("ArtistAddForm", () => {
       expect(await screen.findByRole("alert")).toHaveTextContent(/Stereolab/);
     });
 
+    it("clears the stale conflict banner once the rejected code is edited", async () => {
+      mockAddArtist(() =>
+        HttpResponse.json(
+          {
+            message: "Artist code already exists for that genre and code letters.",
+            artist: { artist_id: 5, artist_name: "Stereolab", code_letters: MOLINA },
+          },
+          { status: 409 },
+        ),
+      );
+      const { user } = renderWithProviders(<ArtistAddForm />);
+
+      await fillCoreFields(user);
+      await user.click(screen.getByRole("button", { name: /add artist/i }));
+      expect(await screen.findByRole("alert")).toHaveTextContent(`${MOLINA}12`);
+
+      // Editing the field the server actually rejected must drop the banner
+      // rather than have it keep reporting the new, unsubmitted value as taken.
+      await user.type(screen.getByLabelText("Code number"), "3");
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
     it("blocks submission and surfaces a duplicate when an existing artist is picked from the typeahead", async () => {
       mockArtistSearch([
         { id: 12, artist_name: "Juana Molina", code_letters: MOLINA, code_number: 3 },

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -11,7 +11,7 @@ import {
 import ArtistAddForm from "@/src/components/experiences/modern/catalog/ArtistAddForm";
 
 const GENRE_ID = TEST_ENTITY_IDS.GENRE.ROCK;
-const JAZZ_GENRE_ID = TEST_ENTITY_IDS.GENRE.ROCK + 1;
+const JAZZ_GENRE_ID = TEST_ENTITY_IDS.GENRE.JAZZ;
 const { MOLINA, STEREOLAB } = TEST_SEARCH_STRINGS.CODE_LETTERS;
 
 vi.mock("@/lib/features/authentication/client", () => ({
@@ -253,6 +253,32 @@ describe("ArtistAddForm", () => {
       expect(screen.queryByText(new RegExp(`${MOLINA}12`))).not.toBeInTheDocument();
     });
 
+    it("clears the fields and confirms by name after a successful add", async () => {
+      mockAddArtist(() => created());
+      const { user } = renderWithProviders(<ArtistAddForm />);
+
+      await fillCoreFields(user);
+      await user.type(
+        screen.getByLabelText(/alphabetical name/i),
+        "Molina, Juana",
+      );
+      await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+      // The next artist in a batch starts from an empty form, not from the
+      // last one's values.
+      await waitFor(() =>
+        expect(toast.success).toHaveBeenCalledWith("Added Juana Molina"),
+      );
+      expect(screen.getByPlaceholderText("Search artists...")).toHaveValue("");
+      expect(screen.getByLabelText(/alphabetical name/i)).toHaveValue("");
+      expect(screen.getByLabelText(/call letters/i)).toHaveValue("");
+      expect(screen.getByLabelText("Code number")).toHaveValue("");
+      // The genre is deliberately kept: an MD files a whole genre at a time.
+      expect(screen.getByRole("combobox", { name: /genre/i })).toHaveTextContent(
+        "Rock",
+      );
+    });
+
     it("renders the conflicting artist by name on a 409 response instead of a generic failure", async () => {
       mockAddArtist(() => conflictResponse());
       const { user } = renderWithProviders(<ArtistAddForm />);
@@ -261,6 +287,10 @@ describe("ArtistAddForm", () => {
       await user.click(screen.getByRole("button", { name: /add artist/i }));
 
       expect(await screen.findByRole("alert")).toHaveTextContent(/Stereolab/);
+      // A recoverable outcome gets one surface. The backend's 409 carries a
+      // generic message that the global rejected-query middleware would
+      // otherwise toast on top of this banner.
+      expect(toast.error).not.toHaveBeenCalled();
     });
 
     it.each([
@@ -331,7 +361,7 @@ describe("ArtistAddForm", () => {
         expect(getBodies()[0]).toMatchObject({ code_letters: MOLINA });
       });
 
-      it("caps the field at the four characters the column holds and says so", async () => {
+      it("caps typed input at the four characters the column holds and says so", async () => {
         const { getBodies } = mockAddArtist(() => created());
         const { user } = renderWithProviders(<ArtistAddForm />);
 
@@ -346,6 +376,64 @@ describe("ArtistAddForm", () => {
 
         await waitFor(() => expect(getBodies()).toHaveLength(1));
         expect(getBodies()[0]).toMatchObject({ code_letters: "MOLI" });
+      });
+
+      it("blocks a value that arrives past the field's own cap", async () => {
+        const { getBodies } = mockAddArtist(() => created());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        // maxLength constrains typing and pasting, but not a programmatic set
+        // (autofill, password managers) — so the ceiling is also checked before
+        // submit rather than trusted to the field alone.
+        fireEvent.change(screen.getByLabelText(/call letters/i), {
+          target: { value: "MOLINA" },
+        });
+
+        expect(screen.getByText(/at most 4 characters/i)).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+        expect(getBodies()).toHaveLength(0);
+      });
+    });
+
+    describe("the remaining column ceilings", () => {
+      it.each([
+        ["artist name", "Search artists...", 129],
+        ["alphabetical name", "Defaults to artist name", 129],
+      ])(
+        "blocks an over-long %s before it reaches the varchar(128) column",
+        async (_label, placeholder, length) => {
+          const { getBodies } = mockAddArtist(() => created());
+          const { user } = renderWithProviders(<ArtistAddForm />);
+
+          await fillCoreFields(user);
+          fireEvent.change(screen.getByPlaceholderText(placeholder), {
+            target: { value: "Nilüfer".padEnd(length, "!") },
+          });
+
+          expect(screen.getAllByText(/at most 128 characters/i).length).toBeGreaterThan(0);
+          expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+          expect(getBodies()).toHaveLength(0);
+        },
+      );
+
+      it("blocks a code number past the integer column's range", async () => {
+        const { getBodies } = mockAddArtist(() => created());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await selectGenre(user);
+        await user.type(
+          await screen.findByPlaceholderText("Search artists..."),
+          "Juana Molina",
+        );
+        await user.type(screen.getByLabelText(/call letters/i), MOLINA);
+        // artist_genre_code is a PG int4; a larger value raises 22003 at bind
+        // time in the duplicate pre-check, before anything is inserted.
+        await user.type(screen.getByLabelText("Code number"), "2147483648");
+
+        expect(screen.getByText(/no greater than 2147483647/i)).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+        expect(getBodies()).toHaveLength(0);
       });
     });
 
@@ -434,7 +522,7 @@ describe("ArtistAddForm", () => {
         expect(getCallCount()).toBe(searchesUnderRock);
         expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
         expect(
-          screen.getByText(/search this name again under the new genre/i),
+          screen.getByText(/re-check this name under the new genre/i),
         ).toBeInTheDocument();
 
         // Submitting past the disabled button (Enter in a field, say) must hit
@@ -443,7 +531,41 @@ describe("ArtistAddForm", () => {
         expect(getBodies()).toHaveLength(0);
       });
 
-      it("re-enables submission once the name is searched again under the new genre", async () => {
+      it("re-enables submission once the MD chooses to create the artist under the new genre", async () => {
+        mockGenres([
+          { id: GENRE_ID, genre_name: "Rock" },
+          { id: JAZZ_GENRE_ID, genre_name: "Jazz" },
+        ]);
+        mockArtistSearch([]);
+        const { getBodies } = mockAddArtist(() => created());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await selectGenre(user, "Jazz");
+        expect(
+          screen.getByText(/re-check this name under the new genre/i),
+        ).toBeInTheDocument();
+
+        // The "create new" row only renders once a search under the current
+        // genre has settled with no match, so choosing it is the answer the
+        // stale flag is waiting for.
+        await user.click(screen.getByPlaceholderText("Search artists..."));
+        await user.click(
+          await screen.findByRole("option", {
+            name: 'Create new artist "Juana Molina"',
+          }),
+        );
+
+        expect(
+          screen.queryByText(/re-check this name under the new genre/i),
+        ).not.toBeInTheDocument();
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+        await waitFor(() => expect(getBodies()).toHaveLength(1));
+        expect(getBodies()[0]).toMatchObject({ genre_id: JAZZ_GENRE_ID });
+      });
+
+      it("re-enables submission once the name itself is edited under the new genre", async () => {
         mockGenres([
           { id: GENRE_ID, genre_name: "Rock" },
           { id: JAZZ_GENRE_ID, genre_name: "Jazz" },
@@ -455,15 +577,40 @@ describe("ArtistAddForm", () => {
         await fillCoreFields(user);
         await selectGenre(user, "Jazz");
         expect(
-          screen.getByText(/search this name again under the new genre/i),
+          screen.getByText(/re-check this name under the new genre/i),
         ).toBeInTheDocument();
 
+        // A different string is a different question — nothing about the old
+        // genre's answer is left to be stale.
         await user.type(screen.getByPlaceholderText("Search artists..."), "!");
 
+        expect(
+          screen.queryByText(/re-check this name under the new genre/i),
+        ).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeEnabled();
+      });
+
+      it("re-enables submission when the name is edited away from a picked artist", async () => {
+        mockArtistSearch([
+          { id: 12, artist_name: "Juana Molina", code_letters: MOLINA, code_number: 3 },
+        ]);
+        mockAddArtist(() => created());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await selectGenre(user);
+        const nameInput = await screen.findByPlaceholderText("Search artists...");
+        await user.type(nameInput, "Juana Molina");
+        await user.click(await screen.findByText("Juana Molina"));
+        await user.type(screen.getByLabelText(/call letters/i), MOLINA);
+        await user.type(screen.getByLabelText("Code number"), "12");
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+
+        // The typeahead retracts the artist it reported once the text stops
+        // naming it; the id it handed over is only good for that exact text.
+        await user.type(nameInput, " Trio");
+
         await waitFor(() =>
-          expect(
-            screen.queryByText(/search this name again under the new genre/i),
-          ).not.toBeInTheDocument(),
+          expect(screen.queryByText(/already exists/i)).not.toBeInTheDocument(),
         );
         expect(screen.getByRole("button", { name: /add artist/i })).toBeEnabled();
       });
@@ -507,7 +654,10 @@ describe("ArtistAddForm", () => {
         await fillCoreFields(user);
         await user.click(screen.getByRole("button", { name: /add artist/i }));
 
-        await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
+        await waitFor(() =>
+          expect(toast.error).toHaveBeenCalledWith("Failed to add artist"),
+        );
+        expect(toast.error).toHaveBeenCalledTimes(1);
         // Rendering the banner would dereference `artist.artist_name`; there is
         // no error boundary here, so a malformed 409 must not reach it.
         expect(screen.queryByRole("alert")).not.toBeInTheDocument();
@@ -540,7 +690,7 @@ describe("ArtistAddForm", () => {
       });
     });
 
-    it("holds the fields while the add is in flight so mid-flight typing isn't cleared", async () => {
+    it("disables every field while the add is in flight", async () => {
       let release: () => void = () => {};
       const inFlight = new Promise<void>((resolve) => {
         release = resolve;

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -571,6 +571,27 @@ describe("ArtistAddForm", () => {
         expect(getCallCount()).toBe(searchesBeforeSubmit);
       });
 
+      it("re-previews after a 409 even when the body carries no usable artist", async () => {
+        const { getQueries } = mockPeekCode();
+        mockAddArtist(() => conflictResponse({ artist: null }));
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await waitFor(() => expect(getQueries().length).toBeGreaterThan(0));
+        const peeksBeforeSubmit = getQueries().length;
+
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+        await waitFor(() => expect(toast.error).toHaveBeenCalled());
+
+        // Every 409 on this endpoint means the code_letters/genre_id/code_number
+        // triple is taken, regardless of whether the body happens to carry a
+        // parseable `artist` to name in a banner — that shape only decides how
+        // the rejection is presented, not whether the pair is actually free.
+        await waitFor(() =>
+          expect(getQueries().length).toBeGreaterThan(peeksBeforeSubmit),
+        );
+      });
+
       it("leaves the preview alone after a non-409 rejection below 500", async () => {
         const { getQueries } = mockPeekCode();
         const { getCallCount } = mockArtistSearch([]);

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -926,6 +926,25 @@ describe("ArtistAddForm", () => {
 
         expect(screen.getByRole("button", { name: /add artist/i })).toBeEnabled();
       });
+
+      it("leaves the conflict banner and the submit block standing when only the artist name is edited", async () => {
+        mockAddArtist(() => conflictResponse());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+        expect(await screen.findByRole("alert")).toHaveTextContent(`${MOLINA}12`);
+
+        // The artist name is not part of the (code_letters, genre_id,
+        // code_number) triple the server rejected, so editing it must not
+        // read as an answer about that rejection — unlike the code_letters,
+        // code_number, and genre handlers, handleNameChange must not clear a
+        // still-accurate conflict.
+        await user.type(screen.getByPlaceholderText("Search artists..."), " II");
+
+        expect(screen.getByRole("alert")).toHaveTextContent(`${MOLINA}12`);
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+      });
     });
 
     describe("failure handling", () => {

--- a/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
+++ b/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
@@ -593,6 +593,40 @@ describe("ArtistSearchTypeahead", () => {
         expect(onSelectionCleared).toHaveBeenCalledTimes(1);
       });
 
+      it("re-confirms the picked artist once an edit returns the text to its exact name", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onSelect = vi.fn();
+        const onSelectionCleared = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead
+            onSelect={onSelect}
+            onSelectionCleared={onSelectionCleared}
+          />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await user.click(await screen.findByText("Juana Molina"));
+        expect(onSelect).toHaveBeenCalledTimes(1);
+
+        await user.type(input, "x");
+        expect(onSelectionCleared).toHaveBeenCalledTimes(1);
+
+        // The correction lands the field back on byte-identical text — not a
+        // new question, since this is the exact artist already confirmed.
+        // Nothing else tells a caller holding no id to check again.
+        await user.type(input, "{Backspace}");
+
+        expect(onSelect).toHaveBeenCalledTimes(2);
+        expect(onSelect).toHaveBeenLastCalledWith(juanaMolina);
+        expect(onSelectionCleared).toHaveBeenCalledTimes(1);
+
+        // Confirmed again; a further edit away retracts it a second time.
+        await user.type(input, "!");
+        expect(onSelectionCleared).toHaveBeenCalledTimes(2);
+      });
+
       it("re-arms the retraction after a second pick", async () => {
         mockArtistSearch([juanaMolina, chuquimamaniCondori]);
         const onSelectionCleared = vi.fn();

--- a/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
+++ b/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
@@ -627,6 +627,38 @@ describe("ArtistSearchTypeahead", () => {
         expect(onSelectionCleared).toHaveBeenCalledTimes(2);
       });
 
+      it("re-confirms across a Unicode-equivalent but differently-composed name", async () => {
+        mockArtistSearch([niluferYanya]);
+        const onSelect = vi.fn();
+        const onSelectionCleared = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead
+            onSelect={onSelect}
+            onSelectionCleared={onSelectionCleared}
+          />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Nilufer");
+        await vi.advanceTimersByTimeAsync(400);
+        await user.click(await screen.findByText("Nilüfer Yanya"));
+        expect(onSelect).toHaveBeenCalledTimes(1);
+
+        await user.type(input, "!");
+        expect(onSelectionCleared).toHaveBeenCalledTimes(1);
+
+        // Retypes the same name, but NFD-decomposed (a base "u" plus a
+        // combining diaeresis) rather than the NFC-composed form the artist
+        // was picked with — visually and canonically identical, byte
+        // different. A caller holding no id has no reason to expect one
+        // encoding over the other.
+        await user.clear(input);
+        await user.type(input, "Nilüfer Yanya");
+
+        expect(onSelect).toHaveBeenCalledTimes(2);
+        expect(onSelectionCleared).toHaveBeenCalledTimes(1);
+      });
+
       it("re-arms the retraction after a second pick", async () => {
         mockArtistSearch([juanaMolina, chuquimamaniCondori]);
         const onSelectionCleared = vi.fn();
@@ -771,6 +803,39 @@ describe("ArtistSearchTypeahead", () => {
         );
 
         expect(onCreateNew).toHaveBeenCalledWith("Nonexistent Band");
+      });
+
+      it("does not re-confirm a picked artist once 'create new' has overridden it", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onSelect = vi.fn();
+        const onCreateNew = vi.fn();
+        const { user } = renderWithProviders(
+          <ControlledTypeahead onSelect={onSelect} onCreateNew={onCreateNew} />,
+        );
+
+        const input = await findInput();
+        await user.type(input, "Juana Molina");
+        await vi.advanceTimersByTimeAsync(400);
+        await user.click(await screen.findByText("Juana Molina"));
+        expect(onSelect).toHaveBeenCalledTimes(1);
+
+        // Reopen the panel over the identical, already-picked text and choose
+        // "create new" instead — an explicit override the MD is allowed to
+        // make even though a match is right there.
+        await user.click(input);
+        await vi.advanceTimersByTimeAsync(400);
+        await user.click(
+          await screen.findByText('Create new artist "Juana Molina" instead'),
+        );
+        expect(onCreateNew).toHaveBeenCalledWith("Juana Molina");
+
+        // A stray keystroke and its correction land the field back on the
+        // exact text just overridden. The override must stick — the
+        // re-confirm mechanism must not silently undo it.
+        await user.type(input, "!");
+        await user.type(input, "{Backspace}");
+
+        expect(onSelect).toHaveBeenCalledTimes(1);
       });
 
       it("reaches the create row with the keyboard past the last result", async () => {


### PR DESCRIPTION
## Summary

- Adds `ArtistAddForm`, an MD-gated form under `src/components/experiences/modern/catalog/` that wires `useAddArtistMutation` (`lib/features/catalog/api.ts`) to a real UI consumer. It has no mount site yet — wiring it into a page is left for a follow-up, matching this branch's stepwise pattern where `ArtistSearchTypeahead` and `CallLetterPeekControl` landed as unmounted sibling leaves first.
- Composes `ArtistSearchTypeahead` (dedup against existing artists in the selected genre — submission blocks when an existing match is picked) and `CallLetterPeekControl` (live preview of the next assigned code number) as sibling leaves.
- Submits dj-site's local `AddArtistRequestBody` (`lib/features/catalog/types.ts`), which requires `code_number` — not the published `@wxyc/shared` `AddArtistRequest`, which omits it and would 400 on every submit.
- Handles the backend's 409 (the `(code_letters, genre_id, code_number)` triple already taken) as a real recoverable outcome, rendering the conflicting artist's name from the response body rather than a generic toast, snapshotted against the exact code and genre actually rejected so later field edits (call letters, code number, or genre) don't relabel the banner against a code the server never saw.
- Shows the assigned `code_number` back to the MD from the 201 response body.
- Reuses `parseRequiredPositiveInt` (`lib/features/catalog/adminCreateArtistValidation.ts`) to validate the code-number field, its contract confirmed unchanged against `AddArtistRequestBody`.

Closes #1080

## Test plan

- [x] Integration test suite (`tests/integration/components/modern/catalog/ArtistAddForm.test.tsx`) covers: MD-only rendering, submitting a valid body (asserting the *serialized* outgoing JSON, not a typed object), the assigned code shown from the 201 body, the 409 conflict rendering the existing artist by name, the conflict banner clearing on code-letters/code-number/genre edits, dedup blocking submission on an existing-artist pick, and code-number validation via `parseRequiredPositiveInt`.
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` — 0 errors, no new warnings.
- [x] Full unit/integration suite: 298 files / 4019 tests passing.