### PR TITLE
feat(catalog): general catalog edit form (MD-gated)

### DIFF
--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -130,8 +130,14 @@ export const catalogApi = createApi({
         method: "PATCH",
         body,
       }),
-      transformResponse: (response: AlbumSearchResultJSON) =>
-        convertToAlbumEntry(response),
+      // A JSON `null` body (malformed upstream response) is guarded here
+      // rather than left to crash inside `convertToAlbumEntry` — its opening
+      // `"id" in response` throws on `null` — so the rejection this endpoint
+      // produces is an intentional one, not a stray `TypeError`.
+      transformResponse: (response: AlbumSearchResultJSON | null) => {
+        if (!response) throw new Error("updateAlbum: response body was empty");
+        return convertToAlbumEntry(response);
+      },
       invalidatesTags: (_result, _error, { albumId }) => [
         { type: "AlbumDetail", id: albumId },
       ],
@@ -204,8 +210,12 @@ export const catalogApi = createApi({
         url: `/${albumId}/missing`,
         method: "PATCH",
       }),
-      transformResponse: (response: AlbumSearchResultJSON) =>
-        convertToAlbumEntry(response),
+      // See updateAlbum's transformResponse: guards the same JSON-`null`-body
+      // case with an intentional rejection instead of an unguarded crash.
+      transformResponse: (response: AlbumSearchResultJSON | null) => {
+        if (!response) throw new Error("markMissing: response body was empty");
+        return convertToAlbumEntry(response);
+      },
       invalidatesTags: (_result, _error, { albumId }) => [
         { type: "AlbumDetail", id: albumId },
       ],
@@ -222,8 +232,12 @@ export const catalogApi = createApi({
         url: `/${albumId}/found`,
         method: "PATCH",
       }),
-      transformResponse: (response: AlbumSearchResultJSON) =>
-        convertToAlbumEntry(response),
+      // See updateAlbum's transformResponse: guards the same JSON-`null`-body
+      // case with an intentional rejection instead of an unguarded crash.
+      transformResponse: (response: AlbumSearchResultJSON | null) => {
+        if (!response) throw new Error("markFound: response body was empty");
+        return convertToAlbumEntry(response);
+      },
       invalidatesTags: (_result, _error, { albumId }) => [
         { type: "AlbumDetail", id: albumId },
       ],

--- a/lib/features/catalog/constants.ts
+++ b/lib/features/catalog/constants.ts
@@ -3,3 +3,14 @@ export const CATALOG_QUERY_PAGE_LIMIT = 50;
 
 /** Server CHECK constraint cap on library.discogs_unavailable_note (varchar(500)). */
 export const DISCOGS_UNAVAILABLE_NOTE_MAX_LENGTH = 500;
+
+/**
+ * `library.album_title`, `library.alternate_artist_name`, and `library.label`
+ * are all `varchar(128)`. PATCH /library/:id rejects longer values with a 400,
+ * so an edit UI must cap them client-side rather than let the round trip fail.
+ */
+export const ALBUM_TEXT_MAX_LENGTH = 128;
+
+/** PATCH /library/:id requires disc_quantity to be an integer in this range. */
+export const DISC_QUANTITY_MIN = 1;
+export const DISC_QUANTITY_MAX = 99;

--- a/lib/features/catalog/patchSearchResult.ts
+++ b/lib/features/catalog/patchSearchResult.ts
@@ -25,19 +25,26 @@ export function mergeAlbumIntoSearchResult(
     };
   }
 
+  // A nonzero `updated.entry` (Backend-Service's `code_number`) is
+  // authoritative: an artist re-attribution can move the album onto a
+  // freshly-issued call number (`updateAlbum` -> `generateAlbumCodeNumber`
+  // when the new artist already owns the album's current one), and the
+  // cached row must pick that up or it renders a call number nobody holds.
+  // `0` is not a real call number — it's `convertToAlbumEntry`'s fallback
+  // for an LML-only row that never got a `code_number` — so that sentinel
+  // falls back to the cached call number instead of zeroing it out. The
+  // fallback has to take the whole call number — `artist` (lettercode +
+  // numbercode) together with `entry` — from the cached row: pairing the
+  // response's (possibly re-attributed) artist with the cached entry digit
+  // would print a call number that belongs to neither row.
+  const callNumberFromResponse = updated.entry !== 0;
+
   return {
     ...existing,
     ...updated,
     id: existing.id,
-    // A nonzero `updated.entry` (Backend-Service's `code_number`) is
-    // authoritative: an artist re-attribution can move the album onto a
-    // freshly-issued call number (`updateAlbum` -> `generateAlbumCodeNumber`
-    // when the new artist already owns the album's current one), and the
-    // cached row must pick that up or it renders a call number nobody holds.
-    // `0` is not a real call number — it's `convertToAlbumEntry`'s fallback
-    // for an LML-only row that never got a `code_number` — so only that
-    // sentinel falls back to the cached value instead of zeroing it out.
-    entry: updated.entry === 0 ? existing.entry : updated.entry,
+    artist: callNumberFromResponse ? updated.artist : existing.artist,
+    entry: callNumberFromResponse ? updated.entry : existing.entry,
     matched_via: existing.matched_via,
     artwork_url: updated.artwork_url ?? existing.artwork_url,
     rotation_bin: existing.rotation_bin,

--- a/lib/features/catalog/patchSearchResult.ts
+++ b/lib/features/catalog/patchSearchResult.ts
@@ -29,8 +29,15 @@ export function mergeAlbumIntoSearchResult(
     ...existing,
     ...updated,
     id: existing.id,
-    // Preserve search-row entry number; artist lettercode/number can update via spread.
-    entry: existing.entry,
+    // A nonzero `updated.entry` (Backend-Service's `code_number`) is
+    // authoritative: an artist re-attribution can move the album onto a
+    // freshly-issued call number (`updateAlbum` -> `generateAlbumCodeNumber`
+    // when the new artist already owns the album's current one), and the
+    // cached row must pick that up or it renders a call number nobody holds.
+    // `0` is not a real call number — it's `convertToAlbumEntry`'s fallback
+    // for an LML-only row that never got a `code_number` — so only that
+    // sentinel falls back to the cached value instead of zeroing it out.
+    entry: updated.entry === 0 ? existing.entry : updated.entry,
     matched_via: existing.matched_via,
     artwork_url: updated.artwork_url ?? existing.artwork_url,
     rotation_bin: existing.rotation_bin,

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -66,7 +66,10 @@ export type AddAlbumRequestBody = {
  * `discogs_unavailable OR discogs_unavailable_note IS NULL`); callers that
  * only toggle the flag off must pass `discogsUnavailableNote: null` alongside
  * it rather than omitting the note. lastDiscogsRecheckAt is deliberately
- * absent — it is server-write-only.
+ * absent — it is server-write-only. label_id and alternate_artist_name are
+ * nullable (matching the published contract) so a caller can explicitly clear
+ * either — omitting them is a no-op under true-partial-update semantics, so
+ * omission can never clear a value.
  */
 export type UpdateAlbumRequestBody = {
   album_title?: string;
@@ -74,9 +77,9 @@ export type UpdateAlbumRequestBody = {
   genre_id?: number;
   format_id?: number;
   artist_id?: number;
-  alternate_artist_name?: string;
+  alternate_artist_name?: string | null;
   disc_quantity?: number;
-  label_id?: number;
+  label_id?: number | null;
   discogsUnavailable?: boolean;
   discogsUnavailableNote?: string | null;
 };

--- a/lib/rtk-query-error-logger.ts
+++ b/lib/rtk-query-error-logger.ts
@@ -4,20 +4,45 @@ import { toast } from "sonner";
 import { safeCaptureException } from "./posthog";
 
 /**
- * True when `err` is a genuine HTTP error response (fetchBaseQuery's numeric
- * `status`) whose body carries no `message`. This is the one rejection shape
- * the middleware below leaves untoasted — it only toasts `data.message`,
- * `FETCH_ERROR`, `TIMEOUT_ERROR`, or a top-level `error` string, none of which
- * this shape has. A caller's own `catch` must gate its generic fallback toast
- * on this, or a server-supplied reason gets buried under a second, vaguer one.
+ * True when a rejection carries no server-supplied `data.message`.
+ *
+ * `data.message` is the only thing the middleware below re-toasts verbatim, so
+ * it is the one shape a caller must stay quiet for: a generic fallback on top
+ * of it buries the reason the server gave. Nothing else the middleware emits
+ * names the operation that failed. `PARSING_ERROR` — a mutation answered with
+ * an HTML body, e.g. Express's default 404 page or a gateway 502 — surfaces
+ * only the raw `SyntaxError: Unexpected token '<'` from the JSON parse.
+ * `FETCH_ERROR` / `TIMEOUT_ERROR` surface only a generic transport line. An
+ * HTTP error whose body carries no message surfaces nothing. A
+ * `SerializedError` — what `.unwrap()` throws when a `transformResponse`
+ * throws or the request aborts — is not `isRejectedWithValue`, so the
+ * middleware never sees it and nothing is toasted at all. A caller whose own
+ * toast is the only thing that will name the failure must gate on this.
  */
-export function isUnmessagedHttpError(err: unknown): boolean {
-  if (!err || typeof err !== "object" || !("status" in err)) return false;
-  const { status, data } = err as { status?: unknown; data?: unknown };
-  if (typeof status !== "number") return false;
+export function isUnmessagedRejection(err: unknown): boolean {
+  if (!err || typeof err !== "object") return true;
+  const { data } = err as { data?: unknown };
   const message =
     data && typeof data === "object" ? (data as { message?: unknown }).message : undefined;
   return !(typeof message === "string" && message.trim().length > 0);
+}
+
+/**
+ * True when `err` is an HTTP error response (fetchBaseQuery's numeric
+ * `status`) whose body carries no `message`.
+ *
+ * Deliberately narrower than `isUnmessagedRejection`: false for
+ * `PARSING_ERROR`, `FETCH_ERROR`, `TIMEOUT_ERROR` and for a `SerializedError`,
+ * none of which carry an HTTP status. Gate on this only where a non-HTTP
+ * rejection genuinely needs no local toast; a caller whose fallback is the
+ * only message naming the failed operation must gate on
+ * `isUnmessagedRejection` instead, or those shapes leave the user with a raw
+ * JSON-parse error, a bare transport line, or silence.
+ */
+export function isUnmessagedHttpError(err: unknown): boolean {
+  if (!err || typeof err !== "object" || !("status" in err)) return false;
+  if (typeof (err as { status?: unknown }).status !== "number") return false;
+  return isUnmessagedRejection(err);
 }
 
 // Shared by every store variant so a rejected RTK Query surfaces the same

--- a/lib/rtk-query-error-logger.ts
+++ b/lib/rtk-query-error-logger.ts
@@ -3,6 +3,23 @@ import { isRejectedWithValue } from "@reduxjs/toolkit";
 import { toast } from "sonner";
 import { safeCaptureException } from "./posthog";
 
+/**
+ * True when `err` is a genuine HTTP error response (fetchBaseQuery's numeric
+ * `status`) whose body carries no `message`. This is the one rejection shape
+ * the middleware below leaves untoasted — it only toasts `data.message`,
+ * `FETCH_ERROR`, `TIMEOUT_ERROR`, or a top-level `error` string, none of which
+ * this shape has. A caller's own `catch` must gate its generic fallback toast
+ * on this, or a server-supplied reason gets buried under a second, vaguer one.
+ */
+export function isUnmessagedHttpError(err: unknown): boolean {
+  if (!err || typeof err !== "object" || !("status" in err)) return false;
+  const { status, data } = err as { status?: unknown; data?: unknown };
+  if (typeof status !== "number") return false;
+  const message =
+    data && typeof data === "object" ? (data as { message?: unknown }).message : undefined;
+  return !(typeof message === "string" && message.trim().length > 0);
+}
+
 // Shared by every store variant so a rejected RTK Query surfaces the same
 // toast + telemetry regardless of which scoped store dispatched it. Lives in
 // its own module (not the full store's) so smaller stores can reuse it without

--- a/lib/rtk-query-error-logger.ts
+++ b/lib/rtk-query-error-logger.ts
@@ -10,11 +10,17 @@ import { safeCaptureException } from "./posthog";
  * Two shapes qualify. An HTTP error response (fetchBaseQuery's numeric
  * `status`) whose body carries no `message`: the middleware only re-toasts
  * `data.message`, and a numeric-status rejection has no top-level `error`
- * string to fall through to either. And a rejection with no fetchBaseQuery
- * `status` at all — a `SerializedError`, which is what `.unwrap()` throws when
- * a `transformResponse` throws or the request aborts. That one is not
- * `isRejectedWithValue`, so the middleware never even runs for it, and without
- * a caller speaking up the failure is completely silent.
+ * string to fall through to either. And any rejection payload with no
+ * `status` key at all: every other branch below keys off `status`
+ * (`FETCH_ERROR`, `TIMEOUT_ERROR`) or a top-level `error` string, so a
+ * payload lacking `status` never matches any of them. That covers a
+ * `SerializedError` — what `.unwrap()` throws when a `transformResponse`
+ * throws or the request aborts — as well as a `fakeBaseQuery` rejection such
+ * as `adminApi`'s (`{ message }`, no `status`): that one *is*
+ * `isRejectedWithValue` and does reach the middleware below, it just carries
+ * nothing the middleware reads (`payload.data.message`, not a top-level
+ * `payload.message`). Either way, without a caller speaking up the failure is
+ * completely silent.
  *
  * Every string `status` is excluded on purpose: `FETCH_ERROR`,
  * `TIMEOUT_ERROR` and the rest are already answered with a plain-language

--- a/lib/rtk-query-error-logger.ts
+++ b/lib/rtk-query-error-logger.ts
@@ -4,45 +4,31 @@ import { toast } from "sonner";
 import { safeCaptureException } from "./posthog";
 
 /**
- * True when a rejection carries no server-supplied `data.message`.
+ * True when the middleware below will have said nothing about this rejection,
+ * so a caller's own `catch` is the only place a message can come from.
  *
- * `data.message` is the only thing the middleware below re-toasts verbatim, so
- * it is the one shape a caller must stay quiet for: a generic fallback on top
- * of it buries the reason the server gave. Nothing else the middleware emits
- * names the operation that failed. `PARSING_ERROR` — a mutation answered with
- * an HTML body, e.g. Express's default 404 page or a gateway 502 — surfaces
- * only the raw `SyntaxError: Unexpected token '<'` from the JSON parse.
- * `FETCH_ERROR` / `TIMEOUT_ERROR` surface only a generic transport line. An
- * HTTP error whose body carries no message surfaces nothing. A
- * `SerializedError` — what `.unwrap()` throws when a `transformResponse`
- * throws or the request aborts — is not `isRejectedWithValue`, so the
- * middleware never sees it and nothing is toasted at all. A caller whose own
- * toast is the only thing that will name the failure must gate on this.
+ * Two shapes qualify. An HTTP error response (fetchBaseQuery's numeric
+ * `status`) whose body carries no `message`: the middleware only re-toasts
+ * `data.message`, and a numeric-status rejection has no top-level `error`
+ * string to fall through to either. And a rejection with no fetchBaseQuery
+ * `status` at all — a `SerializedError`, which is what `.unwrap()` throws when
+ * a `transformResponse` throws or the request aborts. That one is not
+ * `isRejectedWithValue`, so the middleware never even runs for it, and without
+ * a caller speaking up the failure is completely silent.
+ *
+ * Every string `status` is excluded on purpose: `FETCH_ERROR`,
+ * `TIMEOUT_ERROR` and the rest are already answered with a plain-language
+ * line, and stacking a vaguer message on top of one adds noise rather than
+ * information. A server-supplied `data.message` is excluded for the stronger
+ * reason that a second, vaguer toast would bury it.
  */
-export function isUnmessagedRejection(err: unknown): boolean {
-  if (!err || typeof err !== "object") return true;
-  const { data } = err as { data?: unknown };
+export function isUnmessagedHttpError(err: unknown): boolean {
+  if (!err || typeof err !== "object" || !("status" in err)) return true;
+  const { status, data } = err as { status?: unknown; data?: unknown };
+  if (typeof status !== "number") return false;
   const message =
     data && typeof data === "object" ? (data as { message?: unknown }).message : undefined;
   return !(typeof message === "string" && message.trim().length > 0);
-}
-
-/**
- * True when `err` is an HTTP error response (fetchBaseQuery's numeric
- * `status`) whose body carries no `message`.
- *
- * Deliberately narrower than `isUnmessagedRejection`: false for
- * `PARSING_ERROR`, `FETCH_ERROR`, `TIMEOUT_ERROR` and for a `SerializedError`,
- * none of which carry an HTTP status. Gate on this only where a non-HTTP
- * rejection genuinely needs no local toast; a caller whose fallback is the
- * only message naming the failed operation must gate on
- * `isUnmessagedRejection` instead, or those shapes leave the user with a raw
- * JSON-parse error, a bare transport line, or silence.
- */
-export function isUnmessagedHttpError(err: unknown): boolean {
-  if (!err || typeof err !== "object" || !("status" in err)) return false;
-  if (typeof (err as { status?: unknown }).status !== "number") return false;
-  return isUnmessagedRejection(err);
 }
 
 // Shared by every store variant so a rejected RTK Query surfaces the same

--- a/lib/rtk-query-error-logger.ts
+++ b/lib/rtk-query-error-logger.ts
@@ -3,38 +3,67 @@ import { isRejectedWithValue } from "@reduxjs/toolkit";
 import { toast } from "sonner";
 import { safeCaptureException } from "./posthog";
 
+type RejectionPayload = {
+  data?: { message?: unknown };
+  status?: unknown;
+  error?: unknown;
+};
+
+/**
+ * The plain-language message the middleware below would toast for this
+ * rejection payload, or `undefined` when it has nothing to say. Both the
+ * middleware and `isUnmessagedHttpError` read from this one place so the two
+ * can never disagree about which shapes the middleware speaks for — the
+ * bug that shipped before this existed was exactly that disagreement: the
+ * predicate treated "no `status`" as sufficient proof the middleware would
+ * stay quiet, but the `error`-string branch below fires independently of
+ * `status`, so a `{ error: "…" }` rejection (RTK's own documented
+ * `rejectWithValue` shape) was toasted by both the middleware and the
+ * caller's fallback.
+ */
+function friendlyMiddlewareMessage(payload: RejectionPayload): string | undefined {
+  const serverMessage =
+    payload.data && typeof payload.data === "object" ? payload.data.message : undefined;
+  if (typeof serverMessage === "string" && serverMessage.trim().length > 0) {
+    return serverMessage;
+  }
+  if (payload.status === "FETCH_ERROR") {
+    return "Network error — please check your connection.";
+  }
+  if (payload.status === "TIMEOUT_ERROR") {
+    return "Request timed out — please try again.";
+  }
+  // A mutation answered with a body that isn't JSON (a gateway's HTML error
+  // page, a route that isn't there) — `fetchBaseQuery`'s numeric `status`
+  // never arrives, only this string. Without a dedicated line here this fell
+  // through to the raw parser complaint below (`SyntaxError: Unexpected
+  // token '<' …`), which is not a message any DJ should have to read.
+  if (payload.status === "PARSING_ERROR") {
+    return "Server returned an unexpected response — please try again.";
+  }
+  if (typeof payload.error === "string" && payload.error.trim().length > 0) {
+    return payload.error;
+  }
+  return undefined;
+}
+
 /**
  * True when the middleware below will have said nothing about this rejection,
  * so a caller's own `catch` is the only place a message can come from.
  *
- * Two shapes qualify. An HTTP error response (fetchBaseQuery's numeric
- * `status`) whose body carries no `message`: the middleware only re-toasts
- * `data.message`, and a numeric-status rejection has no top-level `error`
- * string to fall through to either. And any rejection payload with no
- * `status` key at all: every other branch below keys off `status`
- * (`FETCH_ERROR`, `TIMEOUT_ERROR`) or a top-level `error` string, so a
- * payload lacking `status` never matches any of them. That covers a
- * `SerializedError` — what `.unwrap()` throws when a `transformResponse`
- * throws or the request aborts — as well as a `fakeBaseQuery` rejection such
- * as `adminApi`'s (`{ message }`, no `status`): that one *is*
- * `isRejectedWithValue` and does reach the middleware below, it just carries
- * nothing the middleware reads (`payload.data.message`, not a top-level
- * `payload.message`). Either way, without a caller speaking up the failure is
- * completely silent.
- *
- * Every string `status` is excluded on purpose: `FETCH_ERROR`,
- * `TIMEOUT_ERROR` and the rest are already answered with a plain-language
- * line, and stacking a vaguer message on top of one adds noise rather than
- * information. A server-supplied `data.message` is excluded for the stronger
- * reason that a second, vaguer toast would bury it.
+ * Delegates to the same decision the middleware makes for its own toast
+ * (`friendlyMiddlewareMessage`) rather than re-deriving it from `status`
+ * alone — `status` is a strong signal (present and numeric with no body
+ * `message` is the classic silent HTTP error; absent entirely covers a
+ * `SerializedError`, what `.unwrap()` throws when a `transformResponse`
+ * throws or the request aborts, as well as a `fakeBaseQuery` rejection such
+ * as `adminApi`'s `{ message }` shape), but it is not the whole story: a
+ * payload with no `status` can still carry a top-level `error` string, which
+ * the middleware toasts unconditionally.
  */
 export function isUnmessagedHttpError(err: unknown): boolean {
-  if (!err || typeof err !== "object" || !("status" in err)) return true;
-  const { status, data } = err as { status?: unknown; data?: unknown };
-  if (typeof status !== "number") return false;
-  const message =
-    data && typeof data === "object" ? (data as { message?: unknown }).message : undefined;
-  return !(typeof message === "string" && message.trim().length > 0);
+  if (!err || typeof err !== "object") return true;
+  return friendlyMiddlewareMessage(err as RejectionPayload) === undefined;
 }
 
 // Shared by every store variant so a rejected RTK Query surfaces the same
@@ -44,17 +73,15 @@ export function isUnmessagedHttpError(err: unknown): boolean {
 export const rtkQueryErrorLogger: Middleware =
   () => (next) => (action) => {
     if (isRejectedWithValue(action)) {
-      const payload = action.payload as {
-        data?: { message?: string };
-        status?: string;
-        error?: string;
-      };
+      const payload = action.payload as RejectionPayload;
 
       const endpointName = (action as any)?.meta?.arg?.endpointName;
 
       safeCaptureException(
         new Error(
-          payload?.data?.message || payload?.error || "RTK Query error"
+          (typeof payload?.data?.message === "string" ? payload.data.message : undefined) ||
+            (typeof payload?.error === "string" ? payload.error : undefined) ||
+            "RTK Query error"
         ),
         {
           endpoint: endpointName,
@@ -62,16 +89,8 @@ export const rtkQueryErrorLogger: Middleware =
         }
       );
 
-      const serverMessage = payload?.data?.message;
-      if (serverMessage && serverMessage.trim().length > 0) {
-        toast.error(serverMessage);
-      } else if (payload?.status === "FETCH_ERROR") {
-        toast.error("Network error — please check your connection.");
-      } else if (payload?.status === "TIMEOUT_ERROR") {
-        toast.error("Request timed out — please try again.");
-      } else if (payload?.error && typeof payload.error === "string") {
-        toast.error(payload.error);
-      }
+      const message = friendlyMiddlewareMessage(payload);
+      if (message) toast.error(message);
     }
 
     return next(action);

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumCard.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumCard.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/joy";
 import { useRef, useState, useEffect } from "react";
 import { NotOnDiscogsBadge } from "@/src/components/experiences/modern/catalog/AlbumArtwork";
+import AlbumEditForm from "./AlbumEditForm";
 import DiscogsMarkup from "./DiscogsMarkupRenderer";
 import DiscogsUnavailableControl from "./DiscogsUnavailableControl";
 import LibraryStatus from "./LibraryStatus";
@@ -145,6 +146,7 @@ export default function AlbumCard({
           </Stack>
         </Stack>
         <DiscogsUnavailableControl key={album.id} album={album} />
+        <AlbumEditForm key={album.id} album={album} />
         <RotationClassifyControl key={album.id} album={album} />
         {!isDiscogsUnavailable && <StreamingLinks metadata={metadata} />}
         {!isDiscogsUnavailable && artistBio && (

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
@@ -30,7 +30,7 @@ import {
   ArtistInGenreOption,
   UpdateAlbumRequestBody,
 } from "@/lib/features/catalog/types";
-import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
+import { isUnmessagedRejection } from "@/lib/rtk-query-error-logger";
 import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTypeahead";
 
 interface AlbumEditFormProps {
@@ -196,8 +196,16 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
   // draft from being silently discarded on the post-save reseed below.
   const discQuantityCleared =
     discQuantity === undefined && saved.discQuantity !== undefined;
+  // The 1-99 range is a PATCH-time rule, not a storage constraint:
+  // `disc_quantity` is a plain smallint with no CHECK behind it, so rows
+  // written by other paths already sit outside it. Only a value this draft
+  // moved is held to the rule. Judging the stored value instead would strand
+  // every such album — no unrelated field could be edited, and the range
+  // message would sit under a field the MD never touched, until someone
+  // invented a disc count for it.
   const discQuantityOutOfRange =
     discQuantity !== undefined &&
+    discQuantity !== saved.discQuantity &&
     (!Number.isInteger(discQuantity) ||
       discQuantity < DISC_QUANTITY_MIN ||
       discQuantity > DISC_QUANTITY_MAX);
@@ -265,13 +273,14 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
       setDiscQuantity(nextSaved.discQuantity);
       toast.success("Album updated");
     } catch (err) {
-      // The global rtkQueryErrorLogger middleware already toasts the server's
-      // own message, and Backend-Service answers every rejection here with a
-      // specific one ("Artist is not catalogued in the selected genre",
-      // "format_id does not reference an existing format", …). A second
-      // unconditional toast would bury it, so only speak for the one rejection
-      // shape the middleware leaves silent.
-      if (isUnmessagedHttpError(err)) {
+      // The global rtkQueryErrorLogger middleware re-toasts the server's own
+      // message verbatim, and Backend-Service answers every rejection here with
+      // a specific one ("Artist is not catalogued in the selected genre",
+      // "format_id does not reference an existing format", …); a second generic
+      // toast would bury it. Every other rejection reaches the MD as a raw
+      // JSON-parse error, a bare transport line, or nothing at all — none of
+      // which say the save failed — so this fallback still has to speak.
+      if (isUnmessagedRejection(err)) {
         toast.error("Failed to update album");
       }
     }

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
@@ -128,10 +128,11 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
   // invalidates it by comparison rather than by erasing it. Erasing is what
   // makes the round trip unrecoverable: an MD who changes the genre and changes
   // it back is left on an album whose every field reads its original value with
-  // Save permanently blocked and nothing on screen explaining why. The seeded
-  // link starts here too — the typeahead's own `onSelectionCleared` only
-  // retracts selections it reported through `onSelect`, so it never speaks for
-  // a link this form read straight off the album.
+  // Save permanently blocked and nothing on screen explaining why. The link
+  // seeded off the album starts here too — the typeahead's own
+  // `onSelectionCleared` only retracts selections it reported through
+  // `onSelect`, so it never speaks for a link this form read straight off the
+  // album, and a genre change has to invalidate that one here instead.
   const [artistLink, setArtistLink] = useState<ArtistLink | null>(() =>
     artistLinkFrom(saved),
   );
@@ -140,14 +141,16 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
     setArtistLink({ id: artist.id, genreId });
   };
 
-  // A retraction from the typeahead is unconditional: it fires both when the
-  // text is edited away from the picked artist and when the genre moves, and
-  // the two are indistinguishable here. Dropping the link outright is the safe
-  // reading — a pick can always be redone, whereas restoring a link the
-  // typeahead disowned would file the album under an artist the field no longer
-  // names.
+  // The typeahead retracts on two different events: the text was edited away
+  // from the picked artist, or the genre moved off the one it was picked under.
+  // Only the first invalidates the pair — a genre move leaves the text standing
+  // deliberately, so the link is still true about the genre it names and the
+  // comparison above is what should judge it. Telling them apart by whether
+  // `genreId` has already moved past the link's is what lets a genre round trip
+  // restore a picked link, exactly as it restores a seeded one; a same-genre
+  // retraction still drops the link, because the text no longer names it.
   const handleArtistSelectionCleared = () => {
-    setArtistLink(null);
+    setArtistLink((prev) => (prev !== null && prev.genreId !== genreId ? prev : null));
   };
 
   const handleArtistCreateNew = () => {

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
@@ -31,7 +31,10 @@ import {
   UpdateAlbumRequestBody,
 } from "@/lib/features/catalog/types";
 import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
-import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTypeahead";
+// The ungated variant: AlbumEditFormFields only ever renders inside this
+// module's own <RequireMD> below, so the default export's self-gating would
+// re-resolve authority a second time on every mount for no reason.
+import { ArtistSearchTypeaheadInner as ArtistSearchTypeahead } from "@/src/components/shared/inputs/ArtistSearchTypeahead";
 
 interface AlbumEditFormProps {
   album: AlbumEntry;
@@ -368,7 +371,7 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
         </Select>
       </FormControl>
 
-      <FormControl>
+      <FormControl error={artistLinkMissing}>
         <FormLabel>Artist</FormLabel>
         <ArtistSearchTypeahead
           genreId={genreId ?? saved.genreId ?? 0}

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
@@ -30,7 +30,7 @@ import {
   ArtistInGenreOption,
   UpdateAlbumRequestBody,
 } from "@/lib/features/catalog/types";
-import { isUnmessagedRejection } from "@/lib/rtk-query-error-logger";
+import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTypeahead";
 
 interface AlbumEditFormProps {
@@ -158,9 +158,13 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
     setArtistLink((prev) => (prev !== null && prev.genreId !== genreId ? prev : null));
   };
 
-  const handleArtistCreateNew = () => {
+  // The typeahead always offers a create-new affordance; this form has no way
+  // to honour it, and there is no artist-add surface anywhere to send the MD
+  // to yet. The message must therefore say what is possible here rather than
+  // name a detour that doesn't exist.
+  const handleArtistCreateNew = (searchTerm: string) => {
     toast.info(
-      "Creating a new artist isn't supported from this form yet — use the artist-add flow first, then search for it here.",
+      `Adding a new artist isn't supported from this form — "${searchTerm}" must already be catalogued under the selected genre to be picked here.`,
     );
   };
 
@@ -277,10 +281,12 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
       // message verbatim, and Backend-Service answers every rejection here with
       // a specific one ("Artist is not catalogued in the selected genre",
       // "format_id does not reference an existing format", …); a second generic
-      // toast would bury it. Every other rejection reaches the MD as a raw
-      // JSON-parse error, a bare transport line, or nothing at all — none of
-      // which say the save failed — so this fallback still has to speak.
-      if (isUnmessagedRejection(err)) {
+      // toast would bury it, as it would bury the middleware's transport lines.
+      // What it cannot speak for is an HTTP error with no body message, or a
+      // rejection carrying no status at all (an aborted request, a response the
+      // transform couldn't read) — that one it never even sees, so without this
+      // the save would fail in total silence.
+      if (isUnmessagedHttpError(err)) {
         toast.error("Failed to update album");
       }
     }

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
@@ -31,10 +31,7 @@ import {
   UpdateAlbumRequestBody,
 } from "@/lib/features/catalog/types";
 import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
-// The ungated variant: AlbumEditFormFields only ever renders inside this
-// module's own <RequireMD> below, so the default export's self-gating would
-// re-resolve authority a second time on every mount for no reason.
-import { ArtistSearchTypeaheadInner as ArtistSearchTypeahead } from "@/src/components/shared/inputs/ArtistSearchTypeahead";
+import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTypeahead";
 
 interface AlbumEditFormProps {
   album: AlbumEntry;
@@ -144,8 +141,17 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
     artistLinkFrom(saved, album.artist.name),
   );
 
+  // The genre the typeahead actually searches under: the Select has no "no
+  // genre" option, so `genreId` only reads undefined before the MD has ever
+  // touched it, and until then the search — and anything resolved from it —
+  // has to fall back to the album's saved genre instead of going out scoped
+  // to nothing. Every comparison against "the genre currently in effect" below
+  // reads this, not the raw `genreId` state, so a pick resolved through the
+  // fallback is never judged against a value it was never searched under.
+  const resolvedGenreId = genreId ?? saved.genreId;
+
   const handleArtistSelect = (artist: ArtistInGenreOption) => {
-    setArtistLink({ id: artist.id, genreId, name: artist.artist_name });
+    setArtistLink({ id: artist.id, genreId: resolvedGenreId, name: artist.artist_name });
   };
 
   // The typeahead retracts on two different events: the text was edited away
@@ -158,7 +164,7 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
   // it has to, because the typeahead stops tracking a selection after the first
   // retraction it fires and never speaks for that link again.
   const handleArtistSelectionCleared = () => {
-    setArtistLink((prev) => (prev !== null && prev.genreId !== genreId ? prev : null));
+    setArtistLink((prev) => (prev !== null && prev.genreId !== resolvedGenreId ? prev : null));
   };
 
   // The typeahead always offers a create-new affordance; this form has no way
@@ -181,7 +187,7 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
   // re-attribution the field contradicts is silent on screen and permanent on
   // the shelf, since the server can burn a fresh call number for it.
   const artistLinkStaleForGenre =
-    artistLink !== null && artistLink.genreId !== genreId;
+    artistLink !== null && artistLink.genreId !== resolvedGenreId;
   const artistLinkStaleForName =
     artistLink !== null && artistLink.name.trim() !== artistName.trim();
   const artistId =
@@ -270,15 +276,6 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
     try {
       updated = await updateAlbum({ albumId: album.id, body: changes }).unwrap();
     } catch (err) {
-      // The global rtkQueryErrorLogger middleware re-toasts the server's own
-      // message verbatim, and Backend-Service answers every rejection here with
-      // a specific one ("Artist is not catalogued in the selected genre",
-      // "format_id does not reference an existing format", …); a second generic
-      // toast would bury it, as it would bury the middleware's transport lines.
-      // What it cannot speak for is an HTTP error with no body message, or a
-      // rejection carrying no status at all (an aborted request, a response the
-      // transform couldn't read) — that one it never even sees, so without this
-      // the save would fail in total silence.
       if (isUnmessagedHttpError(err)) {
         toast.error("Failed to update album");
       }
@@ -374,19 +371,27 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
       <FormControl error={artistLinkMissing}>
         <FormLabel>Artist</FormLabel>
         <ArtistSearchTypeahead
-          genreId={genreId ?? saved.genreId ?? 0}
+          // `resolvedGenreId` is only undefined for a legacy row with no genre
+          // at all — there is no artist-in-genre search to run yet, and
+          // `genre_id: 0` is not a real fallback: Backend-Service rejects it
+          // outright, which would toast that rejection on every debounce tick
+          // while the MD types. `disabled` below keeps the field inert (and
+          // this prop unused) until a real genre resolves.
+          genreId={resolvedGenreId ?? 0}
           value={artistName}
           onChange={setArtistName}
           onSelect={handleArtistSelect}
           onCreateNew={handleArtistCreateNew}
           onSelectionCleared={handleArtistSelectionCleared}
-          disabled={saving}
+          disabled={saving || resolvedGenreId === undefined}
         />
         {artistLinkMissing && (
           <FormHelperText>
-            {artistLinkStaleForGenre
-              ? "Search and select an artist to continue — the previous link no longer applies under this genre."
-              : "Search and select an artist to continue."}
+            {resolvedGenreId === undefined
+              ? "Choose a genre before searching for an artist."
+              : artistLinkStaleForGenre
+                ? "Search and select an artist to continue — the previous link no longer applies under this genre."
+                : "Search and select an artist to continue."}
           </FormHelperText>
         )}
       </FormControl>

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+  Button,
+  Divider,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  Option,
+  Select,
+  Stack,
+  Switch,
+  Typography,
+} from "@mui/joy";
+import { RequireMD } from "@/src/components/shared/Authorization";
+import {
+  useGetFormatsQuery,
+  useGetGenresQuery,
+  useUpdateAlbumMutation,
+} from "@/lib/features/catalog/api";
+import {
+  AlbumEntry,
+  ArtistInGenreOption,
+  UpdateAlbumRequestBody,
+} from "@/lib/features/catalog/types";
+import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTypeahead";
+
+interface AlbumEditFormProps {
+  album: AlbumEntry;
+}
+
+type SavedFields = {
+  title: string;
+  label: string;
+  genreId: number | undefined;
+  formatId: number | undefined;
+  artistId: number | undefined;
+  alternateArtistName: string;
+  discQuantity: number | undefined;
+};
+
+function snapshotFromAlbum(album: AlbumEntry): SavedFields {
+  return {
+    title: album.title,
+    label: album.label ?? "",
+    genreId: album.genre_id,
+    formatId: album.format_id,
+    artistId: album.artist_id ?? album.artist.id,
+    alternateArtistName: album.alternate_artist ?? "",
+    discQuantity: album.disc_quantity,
+  };
+}
+
+/**
+ * MD+ general catalog edit form: batches title/label/genre/format/artist-link/
+ * alternate-artist-name/disc-quantity edits into one `PATCH /library/:id`
+ * carrying only the changed fields. Mount with `key={album.id}` from the
+ * caller, alongside `DiscogsUnavailableControl` — local state is seeded from
+ * `album` on mount only, matching that control's pattern.
+ *
+ * One Save button rather than per-field auto-save: artist rows are
+ * genre-scoped, so a genre change has to retract a stale `artist_id` in the
+ * same request that carries the new `genre_id`. Across two independent
+ * PATCHes there would be a window where the album is filed under an artist
+ * that doesn't exist in its new genre, with the artist field still reading
+ * the old (correct-looking) name. A single batched request makes that
+ * invariant enforceable before anything goes out.
+ */
+function AlbumEditForm({ album }: AlbumEditFormProps) {
+  return (
+    <RequireMD>
+      <AlbumEditFormFields album={album} />
+    </RequireMD>
+  );
+}
+
+function AlbumEditFormFields({ album }: AlbumEditFormProps) {
+  const [updateAlbum, { isLoading: saving }] = useUpdateAlbumMutation();
+  const { data: genres } = useGetGenresQuery();
+  const { data: formats } = useGetFormatsQuery();
+
+  const [saved, setSaved] = useState<SavedFields>(() => snapshotFromAlbum(album));
+
+  const [title, setTitle] = useState(saved.title);
+  const [label, setLabel] = useState(saved.label);
+  const [genreId, setGenreId] = useState<number | undefined>(saved.genreId);
+  const [formatId, setFormatId] = useState<number | undefined>(saved.formatId);
+  const [artistName, setArtistName] = useState(album.artist.name);
+  const [artistId, setArtistId] = useState<number | undefined>(saved.artistId);
+  const [alternateArtistName, setAlternateArtistName] = useState(
+    saved.alternateArtistName,
+  );
+  const [discQuantity, setDiscQuantity] = useState<number | undefined>(
+    saved.discQuantity,
+  );
+  const [clearLabelId, setClearLabelId] = useState(false);
+
+  // True once the current `artistId` has been confirmed via a fresh pick
+  // (ArtistSearchTypeahead's `onSelect`) under the genre presently held here.
+  // The seeded id read from `album` starts unconfirmed: the typeahead's own
+  // `onSelectionCleared` only retracts selections it reported through
+  // `onSelect` (its docblock states this explicitly), so a genre change while
+  // this stays false has to invalidate the seeded id here instead — the
+  // typeahead never confirmed it and so never retracts it.
+  const artistConfirmedForGenre = useRef(false);
+
+  const handleGenreChange = (nextGenreId: number | undefined) => {
+    setGenreId(nextGenreId);
+    if (
+      !artistConfirmedForGenre.current &&
+      nextGenreId !== undefined &&
+      nextGenreId !== saved.genreId
+    ) {
+      setArtistId(undefined);
+    }
+  };
+
+  const handleArtistSelect = (artist: ArtistInGenreOption) => {
+    artistConfirmedForGenre.current = true;
+    setArtistId(artist.id);
+  };
+
+  const handleArtistSelectionCleared = () => {
+    artistConfirmedForGenre.current = false;
+    setArtistId(undefined);
+  };
+
+  const handleArtistCreateNew = () => {
+    toast.info(
+      "Creating a new artist isn't supported from this form yet — use the artist-add flow first, then search for it here.",
+    );
+  };
+
+  const trimmedTitle = title.trim();
+  const trimmedLabel = label.trim();
+  const trimmedAlternateArtistName = alternateArtistName.trim();
+
+  const changes: UpdateAlbumRequestBody = {};
+  if (trimmedTitle !== saved.title) changes.album_title = trimmedTitle;
+  if (trimmedLabel !== saved.label) changes.label = trimmedLabel;
+  if (genreId !== undefined && genreId !== saved.genreId) changes.genre_id = genreId;
+  if (formatId !== undefined && formatId !== saved.formatId)
+    changes.format_id = formatId;
+  if (artistId !== undefined && artistId !== saved.artistId)
+    changes.artist_id = artistId;
+  if (trimmedAlternateArtistName !== saved.alternateArtistName) {
+    changes.alternate_artist_name =
+      trimmedAlternateArtistName.length > 0 ? trimmedAlternateArtistName : null;
+  }
+  if (discQuantity !== undefined && discQuantity !== saved.discQuantity) {
+    changes.disc_quantity = discQuantity;
+  }
+  if (clearLabelId) changes.label_id = null;
+
+  const hasChanges = Object.keys(changes).length > 0;
+  // An album always needs a definite artist link, so Save must stay blocked
+  // while it's unresolved — whether that's from a genre change invalidating
+  // the seeded id or from editing the artist text away from a confirmed pick.
+  const artistLinkMissing = artistId === undefined;
+  const canSave = hasChanges && !artistLinkMissing && !saving;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    try {
+      const updated = await updateAlbum({ albumId: album.id, body: changes }).unwrap();
+      const nextSaved = snapshotFromAlbum(updated);
+      setSaved(nextSaved);
+      setTitle(nextSaved.title);
+      setLabel(nextSaved.label);
+      setGenreId(nextSaved.genreId);
+      setFormatId(nextSaved.formatId);
+      setArtistName(updated.artist.name);
+      setArtistId(nextSaved.artistId);
+      artistConfirmedForGenre.current = false;
+      setAlternateArtistName(nextSaved.alternateArtistName);
+      setDiscQuantity(nextSaved.discQuantity);
+      setClearLabelId(false);
+      toast.success("Album updated");
+    } catch {
+      toast.error("Failed to update album");
+    }
+  };
+
+  return (
+    <Stack spacing={1.5}>
+      <FormControl>
+        <FormLabel>Title</FormLabel>
+        <Input size="sm" value={title} onChange={(e) => setTitle(e.target.value)} />
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>Label</FormLabel>
+        <Input size="sm" value={label} onChange={(e) => setLabel(e.target.value)} />
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>Genre</FormLabel>
+        <Select
+          size="sm"
+          aria-label="Genre"
+          value={genreId ?? null}
+          onChange={(_, value) => handleGenreChange(value ?? undefined)}
+        >
+          {(genres ?? []).map((genre) => (
+            <Option key={genre.id} value={genre.id}>
+              {genre.genre_name}
+            </Option>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>Format</FormLabel>
+        <Select
+          size="sm"
+          aria-label="Format"
+          value={formatId ?? null}
+          onChange={(_, value) => setFormatId(value ?? undefined)}
+        >
+          {(formats ?? []).map((format) => (
+            <Option key={format.id} value={format.id}>
+              {format.format_name}
+            </Option>
+          ))}
+        </Select>
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>Artist</FormLabel>
+        <ArtistSearchTypeahead
+          genreId={genreId ?? saved.genreId ?? 0}
+          value={artistName}
+          onChange={setArtistName}
+          onSelect={handleArtistSelect}
+          onCreateNew={handleArtistCreateNew}
+          onSelectionCleared={handleArtistSelectionCleared}
+        />
+        {artistLinkMissing && (
+          <FormHelperText>
+            Search and select an artist to continue — the previous link no
+            longer applies under this genre.
+          </FormHelperText>
+        )}
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>Alternate Artist Name</FormLabel>
+        <Input
+          size="sm"
+          value={alternateArtistName}
+          onChange={(e) => setAlternateArtistName(e.target.value)}
+        />
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>Disc Quantity</FormLabel>
+        <Input
+          size="sm"
+          type="number"
+          slotProps={{ input: { min: 1 } }}
+          value={discQuantity ?? ""}
+          onChange={(e) =>
+            setDiscQuantity(e.target.value === "" ? undefined : Number(e.target.value))
+          }
+        />
+      </FormControl>
+
+      <FormControl
+        orientation="horizontal"
+        sx={{ justifyContent: "space-between", alignItems: "center" }}
+      >
+        <FormLabel>Clear linked label record</FormLabel>
+        <Switch
+          checked={clearLabelId}
+          onChange={(e) => setClearLabelId(e.target.checked)}
+        />
+      </FormControl>
+      {clearLabelId && (
+        <Typography level="body-xs" sx={{ color: "text.tertiary" }}>
+          Unlinks the label record (label_id) without changing the Label text
+          above.
+        </Typography>
+      )}
+
+      <Divider />
+
+      <FormControl>
+        <FormLabel>Album Artist</FormLabel>
+        <Input size="sm" value={album.album_artist ?? ""} disabled />
+        <Typography level="body-xs" sx={{ mt: 0.5, color: "text.tertiary" }}>
+          Set by tubafrenzy for compilations; editing it here isn&apos;t
+          supported yet.
+        </Typography>
+      </FormControl>
+
+      <Stack direction="row" justifyContent="flex-end">
+        <Button size="sm" disabled={!canSave} loading={saving} onClick={handleSave}>
+          Save
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}
+
+export default AlbumEditForm;

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import {
   Button,
@@ -21,10 +21,16 @@ import {
   useUpdateAlbumMutation,
 } from "@/lib/features/catalog/api";
 import {
+  ALBUM_TEXT_MAX_LENGTH,
+  DISC_QUANTITY_MAX,
+  DISC_QUANTITY_MIN,
+} from "@/lib/features/catalog/constants";
+import {
   AlbumEntry,
   ArtistInGenreOption,
   UpdateAlbumRequestBody,
 } from "@/lib/features/catalog/types";
+import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTypeahead";
 
 interface AlbumEditFormProps {
@@ -41,16 +47,39 @@ type SavedFields = {
   discQuantity: number | undefined;
 };
 
+/**
+ * An artist id together with the genre it was resolved under. Artist rows are
+ * genre-scoped, so an id alone cannot say whether it still describes the form:
+ * the pair does, by comparison against the genre currently held.
+ */
+type ArtistLink = {
+  id: number;
+  genreId: number | undefined;
+};
+
+/**
+ * Baseline values are trimmed, not stored verbatim. Rows predating the write
+ * path's trimming can carry padding, and an untrimmed baseline compared against
+ * a trimmed draft reads as a change nobody made — arming Save on open and
+ * letting a trim-only PATCH advance the catalog's conditional-GET watermark and
+ * re-fire metadata enrichment.
+ */
 function snapshotFromAlbum(album: AlbumEntry): SavedFields {
   return {
-    title: album.title,
-    label: album.label ?? "",
+    title: album.title.trim(),
+    label: (album.label ?? "").trim(),
     genreId: album.genre_id,
     formatId: album.format_id,
     artistId: album.artist_id ?? album.artist.id,
-    alternateArtistName: album.alternate_artist ?? "",
+    alternateArtistName: (album.alternate_artist ?? "").trim(),
     discQuantity: album.disc_quantity,
   };
+}
+
+function artistLinkFrom(saved: SavedFields): ArtistLink | null {
+  return saved.artistId === undefined
+    ? null
+    : { id: saved.artistId, genreId: saved.genreId };
 }
 
 /**
@@ -88,7 +117,6 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
   const [genreId, setGenreId] = useState<number | undefined>(saved.genreId);
   const [formatId, setFormatId] = useState<number | undefined>(saved.formatId);
   const [artistName, setArtistName] = useState(album.artist.name);
-  const [artistId, setArtistId] = useState<number | undefined>(saved.artistId);
   const [alternateArtistName, setAlternateArtistName] = useState(
     saved.alternateArtistName,
   );
@@ -96,34 +124,30 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
     saved.discQuantity,
   );
 
-  // True once the current `artistId` has been confirmed via a fresh pick
-  // (ArtistSearchTypeahead's `onSelect`) under the genre presently held here.
-  // The seeded id read from `album` starts unconfirmed: the typeahead's own
-  // `onSelectionCleared` only retracts selections it reported through
-  // `onSelect` (its docblock states this explicitly), so a genre change while
-  // this stays false has to invalidate the seeded id here instead — the
-  // typeahead never confirmed it and so never retracts it.
-  const artistConfirmedForGenre = useRef(false);
-
-  const handleGenreChange = (nextGenreId: number | undefined) => {
-    setGenreId(nextGenreId);
-    if (
-      !artistConfirmedForGenre.current &&
-      nextGenreId !== undefined &&
-      nextGenreId !== saved.genreId
-    ) {
-      setArtistId(undefined);
-    }
-  };
+  // The held link carries the genre it was resolved under so a genre change
+  // invalidates it by comparison rather than by erasing it. Erasing is what
+  // makes the round trip unrecoverable: an MD who changes the genre and changes
+  // it back is left on an album whose every field reads its original value with
+  // Save permanently blocked and nothing on screen explaining why. The seeded
+  // link starts here too — the typeahead's own `onSelectionCleared` only
+  // retracts selections it reported through `onSelect`, so it never speaks for
+  // a link this form read straight off the album.
+  const [artistLink, setArtistLink] = useState<ArtistLink | null>(() =>
+    artistLinkFrom(saved),
+  );
 
   const handleArtistSelect = (artist: ArtistInGenreOption) => {
-    artistConfirmedForGenre.current = true;
-    setArtistId(artist.id);
+    setArtistLink({ id: artist.id, genreId });
   };
 
+  // A retraction from the typeahead is unconditional: it fires both when the
+  // text is edited away from the picked artist and when the genre moves, and
+  // the two are indistinguishable here. Dropping the link outright is the safe
+  // reading — a pick can always be redone, whereas restoring a link the
+  // typeahead disowned would file the album under an artist the field no longer
+  // names.
   const handleArtistSelectionCleared = () => {
-    artistConfirmedForGenre.current = false;
-    setArtistId(undefined);
+    setArtistLink(null);
   };
 
   const handleArtistCreateNew = () => {
@@ -136,22 +160,41 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
   const trimmedLabel = label.trim();
   const trimmedAlternateArtistName = alternateArtistName.trim();
 
+  // A link resolved under a different genre names no row under the current one.
+  const artistLinkStaleForGenre =
+    artistLink !== null && artistLink.genreId !== genreId;
+  const artistId = artistLinkStaleForGenre ? undefined : artistLink?.id;
+
   // Backend-Service rejects an empty album_title outright (400), so an empty
-  // draft must block Save rather than reach the request at all.
+  // draft must block Save rather than reach the request at all. The length caps
+  // mirror the server's `varchar(128)` columns, which it rejects with a 400 of
+  // its own.
   const titleInvalid = trimmedTitle.length === 0;
+  const titleTooLong = trimmedTitle.length > ALBUM_TEXT_MAX_LENGTH;
+  const labelTooLong = trimmedLabel.length > ALBUM_TEXT_MAX_LENGTH;
+  const alternateArtistNameTooLong =
+    trimmedAlternateArtistName.length > ALBUM_TEXT_MAX_LENGTH;
   // Blanking a previously-set disc_quantity has no way to reach the server
   // (the field isn't nullable in this contract) — blocking Save keeps the
   // draft from being silently discarded on the post-save reseed below.
-  const discQuantityInvalid = discQuantity === undefined && saved.discQuantity !== undefined;
+  const discQuantityCleared =
+    discQuantity === undefined && saved.discQuantity !== undefined;
+  const discQuantityOutOfRange =
+    discQuantity !== undefined &&
+    (!Number.isInteger(discQuantity) ||
+      discQuantity < DISC_QUANTITY_MIN ||
+      discQuantity > DISC_QUANTITY_MAX);
+  const discQuantityInvalid = discQuantityCleared || discQuantityOutOfRange;
 
   const changes: UpdateAlbumRequestBody = {};
-  if (!titleInvalid && trimmedTitle !== saved.title) changes.album_title = trimmedTitle;
+  if (!titleInvalid && !titleTooLong && trimmedTitle !== saved.title)
+    changes.album_title = trimmedTitle;
   // Backend-Service rejects an empty `label` string outright — clearing the
   // label is only reachable through `label_id: null`, which the server
   // treats as clearing both columns together. Sending `label` and
   // `label_id: null` in the same request is also rejected, so these two
   // branches must stay mutually exclusive.
-  if (trimmedLabel !== saved.label) {
+  if (!labelTooLong && trimmedLabel !== saved.label) {
     if (trimmedLabel.length > 0) {
       changes.label = trimmedLabel;
     } else {
@@ -163,7 +206,10 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
     changes.format_id = formatId;
   if (artistId !== undefined && artistId !== saved.artistId)
     changes.artist_id = artistId;
-  if (trimmedAlternateArtistName !== saved.alternateArtistName) {
+  if (
+    !alternateArtistNameTooLong &&
+    trimmedAlternateArtistName !== saved.alternateArtistName
+  ) {
     changes.alternate_artist_name =
       trimmedAlternateArtistName.length > 0 ? trimmedAlternateArtistName : null;
   }
@@ -177,7 +223,14 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
   // the seeded id or from editing the artist text away from a confirmed pick.
   const artistLinkMissing = artistId === undefined;
   const canSave =
-    hasChanges && !artistLinkMissing && !titleInvalid && !discQuantityInvalid && !saving;
+    hasChanges &&
+    !artistLinkMissing &&
+    !titleInvalid &&
+    !titleTooLong &&
+    !labelTooLong &&
+    !alternateArtistNameTooLong &&
+    !discQuantityInvalid &&
+    !saving;
 
   const handleSave = async () => {
     if (!canSave) return;
@@ -190,28 +243,57 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
       setGenreId(nextSaved.genreId);
       setFormatId(nextSaved.formatId);
       setArtistName(updated.artist.name);
-      setArtistId(nextSaved.artistId);
-      artistConfirmedForGenre.current = false;
+      setArtistLink(artistLinkFrom(nextSaved));
       setAlternateArtistName(nextSaved.alternateArtistName);
       setDiscQuantity(nextSaved.discQuantity);
       toast.success("Album updated");
-    } catch {
-      toast.error("Failed to update album");
+    } catch (err) {
+      // The global rtkQueryErrorLogger middleware already toasts the server's
+      // own message, and Backend-Service answers every rejection here with a
+      // specific one ("Artist is not catalogued in the selected genre",
+      // "format_id does not reference an existing format", …). A second
+      // unconditional toast would bury it, so only speak for the one rejection
+      // shape the middleware leaves silent.
+      if (isUnmessagedHttpError(err)) {
+        toast.error("Failed to update album");
+      }
     }
   };
 
   return (
     <Stack spacing={1.5}>
-      <FormControl error={titleInvalid}>
+      <Divider />
+      <Typography level="title-sm">Edit Release</Typography>
+
+      <FormControl error={titleInvalid || titleTooLong}>
         <FormLabel>Title</FormLabel>
-        <Input size="sm" value={title} onChange={(e) => setTitle(e.target.value)} />
+        <Input
+          size="sm"
+          value={title}
+          disabled={saving}
+          onChange={(e) => setTitle(e.target.value)}
+        />
         {titleInvalid && <FormHelperText>Title can&apos;t be empty.</FormHelperText>}
+        {titleTooLong && (
+          <FormHelperText>
+            Title must be {ALBUM_TEXT_MAX_LENGTH} characters or fewer.
+          </FormHelperText>
+        )}
       </FormControl>
 
-      <FormControl>
+      <FormControl error={labelTooLong}>
         <FormLabel>Label</FormLabel>
-        <Input size="sm" value={label} onChange={(e) => setLabel(e.target.value)} />
-        <FormHelperText>Clearing this unlinks the label record too.</FormHelperText>
+        <Input
+          size="sm"
+          value={label}
+          disabled={saving}
+          onChange={(e) => setLabel(e.target.value)}
+        />
+        <FormHelperText>
+          {labelTooLong
+            ? `Label must be ${ALBUM_TEXT_MAX_LENGTH} characters or fewer.`
+            : "Clearing this unlinks the label record too."}
+        </FormHelperText>
       </FormControl>
 
       <FormControl>
@@ -220,7 +302,8 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
           size="sm"
           aria-label="Genre"
           value={genreId ?? null}
-          onChange={(_, value) => handleGenreChange(value ?? undefined)}
+          disabled={saving}
+          onChange={(_, value) => setGenreId(value ?? undefined)}
         >
           {(genres ?? []).map((genre) => (
             <Option key={genre.id} value={genre.id}>
@@ -236,6 +319,7 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
           size="sm"
           aria-label="Format"
           value={formatId ?? null}
+          disabled={saving}
           onChange={(_, value) => setFormatId(value ?? undefined)}
         >
           {(formats ?? []).map((format) => (
@@ -255,23 +339,31 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
           onSelect={handleArtistSelect}
           onCreateNew={handleArtistCreateNew}
           onSelectionCleared={handleArtistSelectionCleared}
+          disabled={saving}
         />
         {artistLinkMissing && (
           <FormHelperText>
-            {genreId !== saved.genreId
+            {artistLinkStaleForGenre
               ? "Search and select an artist to continue — the previous link no longer applies under this genre."
               : "Search and select an artist to continue."}
           </FormHelperText>
         )}
       </FormControl>
 
-      <FormControl>
+      <FormControl error={alternateArtistNameTooLong}>
         <FormLabel>Alternate Artist Name</FormLabel>
         <Input
           size="sm"
           value={alternateArtistName}
+          disabled={saving}
           onChange={(e) => setAlternateArtistName(e.target.value)}
         />
+        {alternateArtistNameTooLong && (
+          <FormHelperText>
+            Alternate artist name must be {ALBUM_TEXT_MAX_LENGTH} characters or
+            fewer.
+          </FormHelperText>
+        )}
       </FormControl>
 
       <FormControl error={discQuantityInvalid}>
@@ -279,15 +371,24 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
         <Input
           size="sm"
           type="number"
-          slotProps={{ input: { min: 1 } }}
+          slotProps={{
+            input: { min: DISC_QUANTITY_MIN, max: DISC_QUANTITY_MAX, step: 1 },
+          }}
           value={discQuantity ?? ""}
+          disabled={saving}
           onChange={(e) =>
             setDiscQuantity(e.target.value === "" ? undefined : Number(e.target.value))
           }
         />
-        {discQuantityInvalid && (
+        {discQuantityCleared && (
           <FormHelperText>
             Disc quantity can&apos;t be cleared — restore a value to continue.
+          </FormHelperText>
+        )}
+        {discQuantityOutOfRange && (
+          <FormHelperText>
+            Disc quantity must be a whole number between {DISC_QUANTITY_MIN} and{" "}
+            {DISC_QUANTITY_MAX}.
           </FormHelperText>
         )}
       </FormControl>
@@ -305,7 +406,7 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
 
       <Stack direction="row" justifyContent="flex-end">
         <Button size="sm" disabled={!canSave} loading={saving} onClick={handleSave}>
-          Save
+          Save Release
         </Button>
       </Stack>
     </Stack>

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
@@ -263,19 +263,9 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
 
   const handleSave = async () => {
     if (!canSave) return;
+    let updated: AlbumEntry;
     try {
-      const updated = await updateAlbum({ albumId: album.id, body: changes }).unwrap();
-      const nextSaved = snapshotFromAlbum(updated);
-      setSaved(nextSaved);
-      setTitle(nextSaved.title);
-      setLabel(nextSaved.label);
-      setGenreId(nextSaved.genreId);
-      setFormatId(nextSaved.formatId);
-      setArtistName(updated.artist.name);
-      setArtistLink(artistLinkFrom(nextSaved, updated.artist.name));
-      setAlternateArtistName(nextSaved.alternateArtistName);
-      setDiscQuantity(nextSaved.discQuantity);
-      toast.success("Album updated");
+      updated = await updateAlbum({ albumId: album.id, body: changes }).unwrap();
     } catch (err) {
       // The global rtkQueryErrorLogger middleware re-toasts the server's own
       // message verbatim, and Backend-Service answers every rejection here with
@@ -289,7 +279,23 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
       if (isUnmessagedHttpError(err)) {
         toast.error("Failed to update album");
       }
+      return;
     }
+
+    // Deliberately outside the try: the write has already landed by this
+    // point, so a throw here (a reseed bug, a toast call failing) must not be
+    // reported as a failed save.
+    const nextSaved = snapshotFromAlbum(updated);
+    setSaved(nextSaved);
+    setTitle(nextSaved.title);
+    setLabel(nextSaved.label);
+    setGenreId(nextSaved.genreId);
+    setFormatId(nextSaved.formatId);
+    setArtistName(updated.artist.name);
+    setArtistLink(artistLinkFrom(nextSaved, updated.artist.name));
+    setAlternateArtistName(nextSaved.alternateArtistName);
+    setDiscQuantity(nextSaved.discQuantity);
+    toast.success("Album updated");
   };
 
   return (

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
@@ -48,13 +48,18 @@ type SavedFields = {
 };
 
 /**
- * An artist id together with the genre it was resolved under. Artist rows are
- * genre-scoped, so an id alone cannot say whether it still describes the form:
- * the pair does, by comparison against the genre currently held.
+ * An artist id together with the genre it was resolved under and the name it
+ * was resolved for. An id alone cannot say whether it still describes the form:
+ * artist rows are genre-scoped, and an id is only good for the text that
+ * produced it. Carrying all three lets this form judge the link against what is
+ * on screen at any moment, rather than depending on the typeahead to announce
+ * every way it can go stale — that announcement fires at most once per
+ * selection, so a link that outlives one is never spoken for again.
  */
 type ArtistLink = {
   id: number;
   genreId: number | undefined;
+  name: string;
 };
 
 /**
@@ -76,10 +81,10 @@ function snapshotFromAlbum(album: AlbumEntry): SavedFields {
   };
 }
 
-function artistLinkFrom(saved: SavedFields): ArtistLink | null {
+function artistLinkFrom(saved: SavedFields, name: string): ArtistLink | null {
   return saved.artistId === undefined
     ? null
-    : { id: saved.artistId, genreId: saved.genreId };
+    : { id: saved.artistId, genreId: saved.genreId, name };
 }
 
 /**
@@ -124,31 +129,31 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
     saved.discQuantity,
   );
 
-  // The held link carries the genre it was resolved under so a genre change
-  // invalidates it by comparison rather than by erasing it. Erasing is what
-  // makes the round trip unrecoverable: an MD who changes the genre and changes
-  // it back is left on an album whose every field reads its original value with
-  // Save permanently blocked and nothing on screen explaining why. The link
-  // seeded off the album starts here too — the typeahead's own
-  // `onSelectionCleared` only retracts selections it reported through
-  // `onSelect`, so it never speaks for a link this form read straight off the
-  // album, and a genre change has to invalidate that one here instead.
+  // The link is kept whole and judged by comparison rather than erased on the
+  // first sign of trouble. Erasing is what makes a genre round trip
+  // unrecoverable: an MD who changes the genre and changes it back would be
+  // left on an album whose every field reads its original value with Save
+  // permanently blocked and nothing on screen explaining why. The link seeded
+  // off the album starts here too — the typeahead's `onSelectionCleared` only
+  // retracts selections it reported through `onSelect`, so it never speaks for
+  // a link this form read straight off the album.
   const [artistLink, setArtistLink] = useState<ArtistLink | null>(() =>
-    artistLinkFrom(saved),
+    artistLinkFrom(saved, album.artist.name),
   );
 
   const handleArtistSelect = (artist: ArtistInGenreOption) => {
-    setArtistLink({ id: artist.id, genreId });
+    setArtistLink({ id: artist.id, genreId, name: artist.artist_name });
   };
 
   // The typeahead retracts on two different events: the text was edited away
   // from the picked artist, or the genre moved off the one it was picked under.
-  // Only the first invalidates the pair — a genre move leaves the text standing
-  // deliberately, so the link is still true about the genre it names and the
-  // comparison above is what should judge it. Telling them apart by whether
-  // `genreId` has already moved past the link's is what lets a genre round trip
-  // restore a picked link, exactly as it restores a seeded one; a same-genre
-  // retraction still drops the link, because the text no longer names it.
+  // A genre move leaves the text standing deliberately, so the link is still
+  // true about what it names and the derivation below is what should weigh it;
+  // dropping it here would defeat the round trip. Any other retraction is
+  // acted on immediately. Either way the derivation below is the standing
+  // authority — it re-checks both the genre and the name on every render, and
+  // it has to, because the typeahead stops tracking a selection after the first
+  // retraction it fires and never speaks for that link again.
   const handleArtistSelectionCleared = () => {
     setArtistLink((prev) => (prev !== null && prev.genreId !== genreId ? prev : null));
   };
@@ -163,10 +168,19 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
   const trimmedLabel = label.trim();
   const trimmedAlternateArtistName = alternateArtistName.trim();
 
-  // A link resolved under a different genre names no row under the current one.
+  // A link resolved under a different genre names no row under the current one,
+  // and a link whose name no longer matches the field names an artist the MD is
+  // no longer looking at. Either way the id must not reach the request: a
+  // re-attribution the field contradicts is silent on screen and permanent on
+  // the shelf, since the server can burn a fresh call number for it.
   const artistLinkStaleForGenre =
     artistLink !== null && artistLink.genreId !== genreId;
-  const artistId = artistLinkStaleForGenre ? undefined : artistLink?.id;
+  const artistLinkStaleForName =
+    artistLink !== null && artistLink.name.trim() !== artistName.trim();
+  const artistId =
+    artistLink === null || artistLinkStaleForGenre || artistLinkStaleForName
+      ? undefined
+      : artistLink.id;
 
   // Backend-Service rejects an empty album_title outright (400), so an empty
   // draft must block Save rather than reach the request at all. The length caps
@@ -246,7 +260,7 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
       setGenreId(nextSaved.genreId);
       setFormatId(nextSaved.formatId);
       setArtistName(updated.artist.name);
-      setArtistLink(artistLinkFrom(nextSaved));
+      setArtistLink(artistLinkFrom(nextSaved, updated.artist.name));
       setAlternateArtistName(nextSaved.alternateArtistName);
       setDiscQuantity(nextSaved.discQuantity);
       toast.success("Album updated");

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
@@ -12,7 +12,6 @@ import {
   Option,
   Select,
   Stack,
-  Switch,
   Typography,
 } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
@@ -96,7 +95,6 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
   const [discQuantity, setDiscQuantity] = useState<number | undefined>(
     saved.discQuantity,
   );
-  const [clearLabelId, setClearLabelId] = useState(false);
 
   // True once the current `artistId` has been confirmed via a fresh pick
   // (ArtistSearchTypeahead's `onSelect`) under the genre presently held here.
@@ -138,9 +136,28 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
   const trimmedLabel = label.trim();
   const trimmedAlternateArtistName = alternateArtistName.trim();
 
+  // Backend-Service rejects an empty album_title outright (400), so an empty
+  // draft must block Save rather than reach the request at all.
+  const titleInvalid = trimmedTitle.length === 0;
+  // Blanking a previously-set disc_quantity has no way to reach the server
+  // (the field isn't nullable in this contract) — blocking Save keeps the
+  // draft from being silently discarded on the post-save reseed below.
+  const discQuantityInvalid = discQuantity === undefined && saved.discQuantity !== undefined;
+
   const changes: UpdateAlbumRequestBody = {};
-  if (trimmedTitle !== saved.title) changes.album_title = trimmedTitle;
-  if (trimmedLabel !== saved.label) changes.label = trimmedLabel;
+  if (!titleInvalid && trimmedTitle !== saved.title) changes.album_title = trimmedTitle;
+  // Backend-Service rejects an empty `label` string outright — clearing the
+  // label is only reachable through `label_id: null`, which the server
+  // treats as clearing both columns together. Sending `label` and
+  // `label_id: null` in the same request is also rejected, so these two
+  // branches must stay mutually exclusive.
+  if (trimmedLabel !== saved.label) {
+    if (trimmedLabel.length > 0) {
+      changes.label = trimmedLabel;
+    } else {
+      changes.label_id = null;
+    }
+  }
   if (genreId !== undefined && genreId !== saved.genreId) changes.genre_id = genreId;
   if (formatId !== undefined && formatId !== saved.formatId)
     changes.format_id = formatId;
@@ -150,17 +167,17 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
     changes.alternate_artist_name =
       trimmedAlternateArtistName.length > 0 ? trimmedAlternateArtistName : null;
   }
-  if (discQuantity !== undefined && discQuantity !== saved.discQuantity) {
+  if (!discQuantityInvalid && discQuantity !== undefined && discQuantity !== saved.discQuantity) {
     changes.disc_quantity = discQuantity;
   }
-  if (clearLabelId) changes.label_id = null;
 
   const hasChanges = Object.keys(changes).length > 0;
   // An album always needs a definite artist link, so Save must stay blocked
   // while it's unresolved — whether that's from a genre change invalidating
   // the seeded id or from editing the artist text away from a confirmed pick.
   const artistLinkMissing = artistId === undefined;
-  const canSave = hasChanges && !artistLinkMissing && !saving;
+  const canSave =
+    hasChanges && !artistLinkMissing && !titleInvalid && !discQuantityInvalid && !saving;
 
   const handleSave = async () => {
     if (!canSave) return;
@@ -177,7 +194,6 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
       artistConfirmedForGenre.current = false;
       setAlternateArtistName(nextSaved.alternateArtistName);
       setDiscQuantity(nextSaved.discQuantity);
-      setClearLabelId(false);
       toast.success("Album updated");
     } catch {
       toast.error("Failed to update album");
@@ -186,14 +202,16 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
 
   return (
     <Stack spacing={1.5}>
-      <FormControl>
+      <FormControl error={titleInvalid}>
         <FormLabel>Title</FormLabel>
         <Input size="sm" value={title} onChange={(e) => setTitle(e.target.value)} />
+        {titleInvalid && <FormHelperText>Title can&apos;t be empty.</FormHelperText>}
       </FormControl>
 
       <FormControl>
         <FormLabel>Label</FormLabel>
         <Input size="sm" value={label} onChange={(e) => setLabel(e.target.value)} />
+        <FormHelperText>Clearing this unlinks the label record too.</FormHelperText>
       </FormControl>
 
       <FormControl>
@@ -240,8 +258,9 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
         />
         {artistLinkMissing && (
           <FormHelperText>
-            Search and select an artist to continue — the previous link no
-            longer applies under this genre.
+            {genreId !== saved.genreId
+              ? "Search and select an artist to continue — the previous link no longer applies under this genre."
+              : "Search and select an artist to continue."}
           </FormHelperText>
         )}
       </FormControl>
@@ -255,7 +274,7 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
         />
       </FormControl>
 
-      <FormControl>
+      <FormControl error={discQuantityInvalid}>
         <FormLabel>Disc Quantity</FormLabel>
         <Input
           size="sm"
@@ -266,24 +285,12 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
             setDiscQuantity(e.target.value === "" ? undefined : Number(e.target.value))
           }
         />
+        {discQuantityInvalid && (
+          <FormHelperText>
+            Disc quantity can&apos;t be cleared — restore a value to continue.
+          </FormHelperText>
+        )}
       </FormControl>
-
-      <FormControl
-        orientation="horizontal"
-        sx={{ justifyContent: "space-between", alignItems: "center" }}
-      >
-        <FormLabel>Clear linked label record</FormLabel>
-        <Switch
-          checked={clearLabelId}
-          onChange={(e) => setClearLabelId(e.target.checked)}
-        />
-      </FormControl>
-      {clearLabelId && (
-        <Typography level="body-xs" sx={{ color: "text.tertiary" }}>
-          Unlinks the label record (label_id) without changing the Label text
-          above.
-        </Typography>
-      )}
 
       <Divider />
 

--- a/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl.tsx
@@ -15,7 +15,7 @@ import { RequireMD } from "@/src/components/shared/Authorization";
 import { useUpdateAlbumMutation } from "@/lib/features/catalog/api";
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { DISCOGS_UNAVAILABLE_NOTE_MAX_LENGTH } from "@/lib/features/catalog/constants";
-import { isUnmessagedRejection } from "@/lib/rtk-query-error-logger";
+import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 
 interface DiscogsUnavailableControlProps {
   album: AlbumEntry;
@@ -63,12 +63,13 @@ function DiscogsUnavailableControl({ album }: DiscogsUnavailableControlProps) {
       setFlag(previousFlag);
       setSavedNote(previousNote);
       setNote(previousNote);
-      // The global rtkQueryErrorLogger middleware re-toasts a server-supplied
-      // reason verbatim, so a second generic toast would bury it. Every other
-      // rejection reaches the MD as a raw JSON-parse error, a bare transport
-      // line, or nothing at all — none of which say which control failed — so
-      // this one still has to speak.
-      if (isUnmessagedRejection(err)) {
+      // The global rtkQueryErrorLogger middleware speaks for the shapes it can
+      // describe — a server-supplied reason, a transport failure — and a second
+      // vaguer toast on top of one of those only adds noise. It says nothing at
+      // all for an HTTP error with no body message, and never even runs for a
+      // rejection that carries no status (an aborted request, a response the
+      // transform couldn't read), which would otherwise fail in total silence.
+      if (isUnmessagedHttpError(err)) {
         toast.error("Failed to update Discogs availability");
       }
     } finally {
@@ -89,7 +90,7 @@ function DiscogsUnavailableControl({ album }: DiscogsUnavailableControlProps) {
       setSavedNote(nextNote ?? "");
       setNote(nextNote ?? "");
     } catch (err) {
-      if (isUnmessagedRejection(err)) {
+      if (isUnmessagedHttpError(err)) {
         toast.error("Failed to save note");
       }
     } finally {

--- a/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl.tsx
@@ -15,6 +15,7 @@ import { RequireMD } from "@/src/components/shared/Authorization";
 import { useUpdateAlbumMutation } from "@/lib/features/catalog/api";
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { DISCOGS_UNAVAILABLE_NOTE_MAX_LENGTH } from "@/lib/features/catalog/constants";
+import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 
 interface DiscogsUnavailableControlProps {
   album: AlbumEntry;
@@ -58,11 +59,16 @@ function DiscogsUnavailableControl({ album }: DiscogsUnavailableControlProps) {
         albumId: album.id,
         body: { discogsUnavailable: next, discogsUnavailableNote: nextNote },
       }).unwrap();
-    } catch {
+    } catch (err) {
       setFlag(previousFlag);
       setSavedNote(previousNote);
       setNote(previousNote);
-      toast.error("Failed to update Discogs availability");
+      // The global rtkQueryErrorLogger middleware already toasts the server's
+      // own message; a second unconditional toast would bury it. Only speak for
+      // the one rejection shape that middleware leaves silent.
+      if (isUnmessagedHttpError(err)) {
+        toast.error("Failed to update Discogs availability");
+      }
     } finally {
       setFlagPending(false);
     }
@@ -80,8 +86,10 @@ function DiscogsUnavailableControl({ album }: DiscogsUnavailableControlProps) {
       }).unwrap();
       setSavedNote(nextNote ?? "");
       setNote(nextNote ?? "");
-    } catch {
-      toast.error("Failed to save note");
+    } catch (err) {
+      if (isUnmessagedHttpError(err)) {
+        toast.error("Failed to save note");
+      }
     } finally {
       setNotePending(false);
     }

--- a/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl.tsx
@@ -15,7 +15,7 @@ import { RequireMD } from "@/src/components/shared/Authorization";
 import { useUpdateAlbumMutation } from "@/lib/features/catalog/api";
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { DISCOGS_UNAVAILABLE_NOTE_MAX_LENGTH } from "@/lib/features/catalog/constants";
-import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
+import { isUnmessagedRejection } from "@/lib/rtk-query-error-logger";
 
 interface DiscogsUnavailableControlProps {
   album: AlbumEntry;
@@ -63,10 +63,12 @@ function DiscogsUnavailableControl({ album }: DiscogsUnavailableControlProps) {
       setFlag(previousFlag);
       setSavedNote(previousNote);
       setNote(previousNote);
-      // The global rtkQueryErrorLogger middleware already toasts the server's
-      // own message; a second unconditional toast would bury it. Only speak for
-      // the one rejection shape that middleware leaves silent.
-      if (isUnmessagedHttpError(err)) {
+      // The global rtkQueryErrorLogger middleware re-toasts a server-supplied
+      // reason verbatim, so a second generic toast would bury it. Every other
+      // rejection reaches the MD as a raw JSON-parse error, a bare transport
+      // line, or nothing at all — none of which say which control failed — so
+      // this one still has to speak.
+      if (isUnmessagedRejection(err)) {
         toast.error("Failed to update Discogs availability");
       }
     } finally {
@@ -87,7 +89,7 @@ function DiscogsUnavailableControl({ album }: DiscogsUnavailableControlProps) {
       setSavedNote(nextNote ?? "");
       setNote(nextNote ?? "");
     } catch (err) {
-      if (isUnmessagedHttpError(err)) {
+      if (isUnmessagedRejection(err)) {
         toast.error("Failed to save note");
       }
     } finally {

--- a/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl.tsx
@@ -63,12 +63,6 @@ function DiscogsUnavailableControl({ album }: DiscogsUnavailableControlProps) {
       setFlag(previousFlag);
       setSavedNote(previousNote);
       setNote(previousNote);
-      // The global rtkQueryErrorLogger middleware speaks for the shapes it can
-      // describe — a server-supplied reason, a transport failure — and a second
-      // vaguer toast on top of one of those only adds noise. It says nothing at
-      // all for an HTTP error with no body message, and never even runs for a
-      // rejection that carries no status (an aborted request, a response the
-      // transform couldn't read), which would otherwise fail in total silence.
       if (isUnmessagedHttpError(err)) {
         toast.error("Failed to update Discogs availability");
       }

--- a/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
@@ -111,12 +111,6 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
       }).unwrap();
       setSelectedBin(null);
     } catch (err) {
-      // The global rtkQueryErrorLogger middleware speaks for the shapes it can
-      // describe — a server-supplied reason, a transport failure — and a second
-      // vaguer toast on top of one of those only adds noise. It says nothing at
-      // all for an HTTP error with no body message, and never even runs for a
-      // rejection that carries no status (an aborted request, a response the
-      // transform couldn't read), which would otherwise fail in total silence.
       if (isUnmessagedHttpError(err)) {
         toast.error("Failed to add to rotation");
       }

--- a/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/lib/features/rotation/api";
 import { Rotation } from "@/lib/features/rotation/types";
 import { AlbumEntry } from "@/lib/features/catalog/types";
-import { isUnmessagedRejection } from "@/lib/rtk-query-error-logger";
+import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 import RotationBinSelector from "@/src/components/experiences/modern/flowsheet/Search/RotationBinSelector";
 
 interface RotationClassifyControlProps {
@@ -111,12 +111,13 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
       }).unwrap();
       setSelectedBin(null);
     } catch (err) {
-      // The global rtkQueryErrorLogger middleware re-toasts a server-supplied
-      // reason verbatim, so a second generic toast would bury it. Every other
-      // rejection reaches the MD as a raw JSON-parse error, a bare transport
-      // line, or nothing at all — none of which say which control failed — so
-      // this one still has to speak.
-      if (isUnmessagedRejection(err)) {
+      // The global rtkQueryErrorLogger middleware speaks for the shapes it can
+      // describe — a server-supplied reason, a transport failure — and a second
+      // vaguer toast on top of one of those only adds noise. It says nothing at
+      // all for an HTTP error with no body message, and never even runs for a
+      // rejection that carries no status (an aborted request, a response the
+      // transform couldn't read), which would otherwise fail in total silence.
+      if (isUnmessagedHttpError(err)) {
         toast.error("Failed to add to rotation");
       }
     }
@@ -133,7 +134,7 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
       await killRotationEntry({ rotation_id: rotationId }).unwrap();
       setSelectedBin(null);
     } catch (err) {
-      if (isUnmessagedRejection(err)) {
+      if (isUnmessagedHttpError(err)) {
         toast.error("Failed to kill rotation entry");
       }
     } finally {

--- a/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/features/rotation/api";
 import { Rotation } from "@/lib/features/rotation/types";
 import { AlbumEntry } from "@/lib/features/catalog/types";
+import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 import RotationBinSelector from "@/src/components/experiences/modern/flowsheet/Search/RotationBinSelector";
 
 interface RotationClassifyControlProps {
@@ -109,8 +110,13 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
         rotation_bin: selectedBin,
       }).unwrap();
       setSelectedBin(null);
-    } catch {
-      toast.error("Failed to add to rotation");
+    } catch (err) {
+      // The global rtkQueryErrorLogger middleware already toasts the server's
+      // own message; a second unconditional toast would bury it. Only speak for
+      // the one rejection shape that middleware leaves silent.
+      if (isUnmessagedHttpError(err)) {
+        toast.error("Failed to add to rotation");
+      }
     }
   };
 
@@ -124,8 +130,10 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
       // the retired album selectable in the flowsheet picker for another day.
       await killRotationEntry({ rotation_id: rotationId }).unwrap();
       setSelectedBin(null);
-    } catch {
-      toast.error("Failed to kill rotation entry");
+    } catch (err) {
+      if (isUnmessagedHttpError(err)) {
+        toast.error("Failed to kill rotation entry");
+      }
     } finally {
       setInFlightKillIds((prev) => {
         const next = new Set(prev);

--- a/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/lib/features/rotation/api";
 import { Rotation } from "@/lib/features/rotation/types";
 import { AlbumEntry } from "@/lib/features/catalog/types";
-import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
+import { isUnmessagedRejection } from "@/lib/rtk-query-error-logger";
 import RotationBinSelector from "@/src/components/experiences/modern/flowsheet/Search/RotationBinSelector";
 
 interface RotationClassifyControlProps {
@@ -111,10 +111,12 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
       }).unwrap();
       setSelectedBin(null);
     } catch (err) {
-      // The global rtkQueryErrorLogger middleware already toasts the server's
-      // own message; a second unconditional toast would bury it. Only speak for
-      // the one rejection shape that middleware leaves silent.
-      if (isUnmessagedHttpError(err)) {
+      // The global rtkQueryErrorLogger middleware re-toasts a server-supplied
+      // reason verbatim, so a second generic toast would bury it. Every other
+      // rejection reaches the MD as a raw JSON-parse error, a bare transport
+      // line, or nothing at all — none of which say which control failed — so
+      // this one still has to speak.
+      if (isUnmessagedRejection(err)) {
         toast.error("Failed to add to rotation");
       }
     }
@@ -131,7 +133,7 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
       await killRotationEntry({ rotation_id: rotationId }).unwrap();
       setSelectedBin(null);
     } catch (err) {
-      if (isUnmessagedHttpError(err)) {
+      if (isUnmessagedRejection(err)) {
         toast.error("Failed to kill rotation entry");
       }
     } finally {

--- a/src/components/experiences/modern/admin/catalog/FormatAdmin.tsx
+++ b/src/components/experiences/modern/admin/catalog/FormatAdmin.tsx
@@ -15,22 +15,7 @@ import {
 } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
 import { useAddFormatMutation, useGetFormatsQuery } from "@/lib/features/catalog/api";
-
-/**
- * True when `err` is a genuine HTTP error response (fetchBaseQuery's numeric
- * `status`) whose body carries no `message`. This is the one rejection shape
- * the global `rtkQueryErrorLogger` middleware leaves untoasted — it only
- * toasts `data.message`, `FETCH_ERROR`, `TIMEOUT_ERROR`, or a top-level
- * `error` string, none of which this shape has.
- */
-function isUnmessagedHttpError(err: unknown): boolean {
-  if (!err || typeof err !== "object" || !("status" in err)) return false;
-  const { status, data } = err as { status?: unknown; data?: unknown };
-  if (typeof status !== "number") return false;
-  const message =
-    data && typeof data === "object" ? (data as { message?: unknown }).message : undefined;
-  return !(typeof message === "string" && message.trim().length > 0);
-}
+import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 
 function FormatAdmin() {
   const { data: formats } = useGetFormatsQuery();

--- a/src/components/experiences/modern/admin/catalog/FormatAdmin.tsx
+++ b/src/components/experiences/modern/admin/catalog/FormatAdmin.tsx
@@ -34,15 +34,8 @@ function FormatAdmin() {
       await addFormat({ name: trimmed }).unwrap();
       setName("");
     } catch (err) {
-      // The global rtkQueryErrorLogger middleware already toasts the server
-      // message for the common failure (e.g. a 409 duplicate-name reply);
-      // only surface a fallback here for the gap it leaves silent. That gap
-      // now also covers a rejection with no `status` at all (a `SerializedError`
-      // — the shared predicate's own no-`status` branch): this used to stay
-      // silent when this file carried its own local copy of the predicate,
-      // which returned `false` for that shape. Toasting it is intentional —
-      // the alternative is a failed add nobody is ever told about — but it is
-      // a behavior change from before the shared extraction.
+      // A no-status rejection is toasted here on purpose: the alternative is
+      // a failed add nobody is ever told about.
       if (isUnmessagedHttpError(err)) {
         toast.error("Failed to add format");
       }

--- a/src/components/experiences/modern/admin/catalog/FormatAdmin.tsx
+++ b/src/components/experiences/modern/admin/catalog/FormatAdmin.tsx
@@ -36,7 +36,13 @@ function FormatAdmin() {
     } catch (err) {
       // The global rtkQueryErrorLogger middleware already toasts the server
       // message for the common failure (e.g. a 409 duplicate-name reply);
-      // only surface a fallback here for the gap it leaves silent.
+      // only surface a fallback here for the gap it leaves silent. That gap
+      // now also covers a rejection with no `status` at all (a `SerializedError`
+      // — the shared predicate's own no-`status` branch): this used to stay
+      // silent when this file carried its own local copy of the predicate,
+      // which returned `false` for that shape. Toasting it is intentional —
+      // the alternative is a failed add nobody is ever told about — but it is
+      // a behavior change from before the shared extraction.
       if (isUnmessagedHttpError(err)) {
         toast.error("Failed to add format");
       }

--- a/src/components/experiences/modern/admin/catalog/GenreAdmin.tsx
+++ b/src/components/experiences/modern/admin/catalog/GenreAdmin.tsx
@@ -39,15 +39,8 @@ function GenreAdmin() {
       setName("");
       setDescription("");
     } catch (err) {
-      // The global rtkQueryErrorLogger middleware already toasts the server
-      // message for the common failure (e.g. a 409 duplicate-name reply);
-      // only surface a fallback here for the gap it leaves silent. That gap
-      // now also covers a rejection with no `status` at all (a `SerializedError`
-      // — the shared predicate's own no-`status` branch): this used to stay
-      // silent when this file carried its own local copy of the predicate,
-      // which returned `false` for that shape. Toasting it is intentional —
-      // the alternative is a failed add nobody is ever told about — but it is
-      // a behavior change from before the shared extraction.
+      // A no-status rejection is toasted here on purpose: the alternative is
+      // a failed add nobody is ever told about.
       if (isUnmessagedHttpError(err)) {
         toast.error("Failed to add genre");
       }

--- a/src/components/experiences/modern/admin/catalog/GenreAdmin.tsx
+++ b/src/components/experiences/modern/admin/catalog/GenreAdmin.tsx
@@ -41,7 +41,13 @@ function GenreAdmin() {
     } catch (err) {
       // The global rtkQueryErrorLogger middleware already toasts the server
       // message for the common failure (e.g. a 409 duplicate-name reply);
-      // only surface a fallback here for the gap it leaves silent.
+      // only surface a fallback here for the gap it leaves silent. That gap
+      // now also covers a rejection with no `status` at all (a `SerializedError`
+      // — the shared predicate's own no-`status` branch): this used to stay
+      // silent when this file carried its own local copy of the predicate,
+      // which returned `false` for that shape. Toasting it is intentional —
+      // the alternative is a failed add nobody is ever told about — but it is
+      // a behavior change from before the shared extraction.
       if (isUnmessagedHttpError(err)) {
         toast.error("Failed to add genre");
       }

--- a/src/components/experiences/modern/admin/catalog/GenreAdmin.tsx
+++ b/src/components/experiences/modern/admin/catalog/GenreAdmin.tsx
@@ -15,22 +15,7 @@ import {
 } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
 import { useAddGenreMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
-
-/**
- * True when `err` is a genuine HTTP error response (fetchBaseQuery's numeric
- * `status`) whose body carries no `message`. This is the one rejection shape
- * the global `rtkQueryErrorLogger` middleware leaves untoasted — it only
- * toasts `data.message`, `FETCH_ERROR`, `TIMEOUT_ERROR`, or a top-level
- * `error` string, none of which this shape has.
- */
-function isUnmessagedHttpError(err: unknown): boolean {
-  if (!err || typeof err !== "object" || !("status" in err)) return false;
-  const { status, data } = err as { status?: unknown; data?: unknown };
-  if (typeof status !== "number") return false;
-  const message =
-    data && typeof data === "object" ? (data as { message?: unknown }).message : undefined;
-  return !(typeof message === "string" && message.trim().length > 0);
-}
+import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 
 function GenreAdmin() {
   const { data: genres } = useGetGenresQuery();

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -76,7 +76,17 @@ export interface ArtistSearchTypeaheadProps {
   disabled?: boolean;
 }
 
-function ArtistSearchTypeaheadInner({
+/**
+ * Ungated variant for a caller that already wraps its own mount point in
+ * `RequireMD` (or an equivalent authority check). `AuthorizedView` re-resolves
+ * from scratch on every mount — it has no cache of an authority a parent
+ * already established — so nesting the gated default export inside an
+ * already-MD-gated form re-runs that resolution for no reason and renders a
+ * blank field until it settles, on every remount (`key={album.id}`-keyed
+ * forms remount on every navigation). Use the default export for any other
+ * caller; this one skips the gate, not the auth check.
+ */
+export function ArtistSearchTypeaheadInner({
   genreId,
   value,
   onChange,

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -76,17 +76,7 @@ export interface ArtistSearchTypeaheadProps {
   disabled?: boolean;
 }
 
-/**
- * Ungated variant for a caller that already wraps its own mount point in
- * `RequireMD` (or an equivalent authority check). `AuthorizedView` re-resolves
- * from scratch on every mount — it has no cache of an authority a parent
- * already established — so nesting the gated default export inside an
- * already-MD-gated form re-runs that resolution for no reason and renders a
- * blank field until it settles, on every remount (`key={album.id}`-keyed
- * forms remount on every navigation). Use the default export for any other
- * caller; this one skips the gate, not the auth check.
- */
-export function ArtistSearchTypeaheadInner({
+function ArtistSearchTypeaheadInner({
   genreId,
   value,
   onChange,

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
@@ -43,6 +43,8 @@ import { toast } from "sonner";
 const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
 const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof vi.fn>;
 const mockToastError = toast.error as ReturnType<typeof vi.fn>;
+const mockToastSuccess = toast.success as ReturnType<typeof vi.fn>;
+const mockToastInfo = toast.info as ReturnType<typeof vi.fn>;
 
 function sessionWithRole() {
   return {
@@ -119,37 +121,84 @@ function mockArtistSearch(artists: { id: number; artist_name: string; code_lette
   return requests;
 }
 
+const GENRE_NAMES: Record<number, string> = {
+  [ROCK_GENRE_ID]: "Rock",
+  [JAZZ_GENRE_ID]: "Jazz",
+};
+const FORMAT_NAMES: Record<number, string> = {
+  [CD_FORMAT_ID]: "CD",
+  [VINYL_FORMAT_ID]: "Vinyl",
+};
+const ARTIST_NAMES: Record<number, string> = {
+  [JUANA_ARTIST_ID]: "Juana Molina",
+  [JUANA_JAZZ_ARTIST_ID]: "Juana Molina",
+  [JESSICA_ARTIST_ID]: "Jessica Pratt",
+};
+
 /**
+ * Answers with the row as the server would leave it: seeded from the album
+ * under test, then the received partial applied on top. The response is what
+ * reseeds the form, so a fake that echoed fixed defaults instead of the row's
+ * own values would let a reseed bug pass unseen — and would answer a
+ * `label_id: null` clear with the label still set, which the server never does.
+ * Omitting a field is a no-op, matching true-partial-update semantics.
+ *
  * `gate`, when supplied, holds the response open until it settles — the window
  * in which Backend-Service awaits its post-update enrichment (a streaming check
  * plus a metadata lookup) before answering, which is measured in seconds for
  * exactly the fields this form edits.
  */
-function mockPatch({ gate }: { gate?: Promise<unknown> } = {}) {
+function mockPatch({
+  gate,
+  album = juanaMolinaAlbum(),
+}: { gate?: Promise<unknown>; album?: ReturnType<typeof juanaMolinaAlbum> } = {}) {
   let receivedBody: Record<string, unknown> | undefined;
   let callCount = 0;
+  const row: Record<string, unknown> = {
+    id: album.id,
+    album_title: album.title,
+    artist_name: album.artist.name,
+    artist_id: album.artist_id,
+    code_letters: album.artist.lettercode,
+    code_number: album.entry,
+    code_artist_number: album.artist.numbercode,
+    format_name: album.format,
+    format_id: album.format_id,
+    genre_name: album.artist.genre,
+    genre_id: album.genre_id,
+    label: album.label,
+    disc_quantity: album.disc_quantity,
+    alternate_artist_name: album.alternate_artist || null,
+    album_artist: album.album_artist,
+  };
+
   server.use(
     http.patch(`${TEST_BACKEND_URL}/library/:id`, async ({ request }) => {
       callCount++;
       receivedBody = (await request.json()) as Record<string, unknown>;
+
+      if ("album_title" in receivedBody) row.album_title = receivedBody.album_title;
+      if ("label" in receivedBody) row.label = receivedBody.label;
+      // The server treats label_id: null as clearing both columns together.
+      if (receivedBody.label_id === null) row.label = null;
+      if ("alternate_artist_name" in receivedBody)
+        row.alternate_artist_name = receivedBody.alternate_artist_name;
+      if ("disc_quantity" in receivedBody) row.disc_quantity = receivedBody.disc_quantity;
+      if (typeof receivedBody.genre_id === "number") {
+        row.genre_id = receivedBody.genre_id;
+        row.genre_name = GENRE_NAMES[receivedBody.genre_id];
+      }
+      if (typeof receivedBody.format_id === "number") {
+        row.format_id = receivedBody.format_id;
+        row.format_name = FORMAT_NAMES[receivedBody.format_id];
+      }
+      if (typeof receivedBody.artist_id === "number") {
+        row.artist_id = receivedBody.artist_id;
+        row.artist_name = ARTIST_NAMES[receivedBody.artist_id];
+      }
+
       if (gate) await gate;
-      return HttpResponse.json({
-        id: 4242,
-        album_title: receivedBody.album_title ?? "DOGA",
-        artist_name: "Juana Molina",
-        artist_id: receivedBody.artist_id ?? JUANA_ARTIST_ID,
-        code_letters: "MO",
-        code_number: 1,
-        code_artist_number: 12,
-        format_name: "CD",
-        format_id: receivedBody.format_id ?? CD_FORMAT_ID,
-        genre_name: receivedBody.genre_id === JAZZ_GENRE_ID ? "Jazz" : "Rock",
-        genre_id: receivedBody.genre_id ?? ROCK_GENRE_ID,
-        label: receivedBody.label ?? "Sonamos",
-        disc_quantity: receivedBody.disc_quantity ?? 1,
-        alternate_artist_name:
-          "alternate_artist_name" in receivedBody ? receivedBody.alternate_artist_name : null,
-      });
+      return HttpResponse.json({ ...row });
     }),
   );
   return {
@@ -298,10 +347,9 @@ describe("AlbumEditForm", () => {
       });
 
       it("never includes album_artist in the outgoing body", async () => {
-        const { getReceivedBody } = mockPatch();
-        const { user } = renderWithProviders(
-          <AlbumEditForm album={juanaMolinaAlbum({ album_artist: "Various Artists" })} />,
-        );
+        const album = juanaMolinaAlbum({ album_artist: "Various Artists" });
+        const { getReceivedBody } = mockPatch({ album });
+        const { user } = renderWithProviders(<AlbumEditForm album={album} />);
 
         const title = await screen.findByLabelText("Title");
         await user.clear(title);
@@ -312,19 +360,67 @@ describe("AlbumEditForm", () => {
         expect(getReceivedBody()).not.toHaveProperty("album_artist");
       });
 
+      // Save is disabled the instant the click dispatches (the button is in its
+      // loading state), so asserting that alone would pass on the in-flight
+      // render and never observe the response. The baseline reset is only
+      // visible once the save has settled: the fields must hold the saved
+      // values, and Save must be disabled because they now match the baseline,
+      // not because a request is open.
       it("disables Save again and resets the baseline after a successful save", async () => {
-        mockPatch();
+        const { getReceivedBody } = mockPatch();
         const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
 
         const title = await screen.findByLabelText("Title");
         await user.clear(title);
         await user.type(title, "New Title");
+        const label = screen.getByLabelText("Label");
+        await user.clear(label);
         expect(screen.getByRole("button", SAVE_BUTTON)).toBeEnabled();
 
         await user.click(screen.getByRole("button", SAVE_BUTTON));
 
         await waitFor(() =>
-          expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled(),
+          expect(mockToastSuccess).toHaveBeenCalledWith("Album updated"),
+        );
+        expect(getReceivedBody()).toEqual({
+          album_title: "New Title",
+          label_id: null,
+        });
+        expect(title).toHaveValue("New Title");
+        expect(label).toHaveValue("");
+        expect(title).toBeEnabled();
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
+      });
+
+      // Every field is reseeded from the response, so a value the server
+      // normalised or filled in on its own must land back in the form — and a
+      // second save must then diff against that, not against what was typed.
+      it("reseeds from the response and diffs the next save against it", async () => {
+        const { getReceivedBody } = mockPatch();
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        await screen.findByLabelText("Title");
+        await user.click(screen.getByRole("combobox", { name: "Format" }));
+        await user.click(await screen.findByRole("option", { name: "Vinyl" }));
+        await user.click(screen.getByRole("button", SAVE_BUTTON));
+
+        await waitFor(() =>
+          expect(mockToastSuccess).toHaveBeenCalledWith("Album updated"),
+        );
+        await waitFor(() =>
+          expect(screen.getByRole("combobox", { name: "Format" })).toHaveTextContent(
+            "Vinyl",
+          ),
+        );
+
+        const title = screen.getByLabelText("Title");
+        await user.clear(title);
+        await user.type(title, "DOGA (Reissue)");
+        await user.click(screen.getByRole("button", SAVE_BUTTON));
+
+        // The format is no longer a change: the baseline moved with the save.
+        await waitFor(() =>
+          expect(getReceivedBody()).toEqual({ album_title: "DOGA (Reissue)" }),
         );
       });
 
@@ -429,10 +525,9 @@ describe("AlbumEditForm", () => {
       });
 
       it("sends alternate_artist_name: null when the field is cleared", async () => {
-        const { getReceivedBody } = mockPatch();
-        const { user } = renderWithProviders(
-          <AlbumEditForm album={juanaMolinaAlbum({ alternate_artist: "Various" })} />,
-        );
+        const album = juanaMolinaAlbum({ alternate_artist: "Various" });
+        const { getReceivedBody } = mockPatch({ album });
+        const { user } = renderWithProviders(<AlbumEditForm album={album} />);
 
         const field = await screen.findByLabelText("Alternate Artist Name");
         await user.clear(field);
@@ -537,10 +632,9 @@ describe("AlbumEditForm", () => {
         ["below the minimum", DISC_QUANTITY_MIN - 1],
         ["above the maximum", DISC_QUANTITY_MAX + 1],
       ])("still saves an unrelated edit when the stored value is %s", async (_case, stored) => {
-        const { getReceivedBody, getCallCount } = mockPatch();
-        const { user } = renderWithProviders(
-          <AlbumEditForm album={juanaMolinaAlbum({ disc_quantity: stored })} />,
-        );
+        const album = juanaMolinaAlbum({ disc_quantity: stored });
+        const { getReceivedBody, getCallCount } = mockPatch({ album });
+        const { user } = renderWithProviders(<AlbumEditForm album={album} />);
 
         const title = await screen.findByLabelText("Title");
         expect(screen.getByLabelText("Disc Quantity")).toHaveValue(stored);
@@ -562,10 +656,9 @@ describe("AlbumEditForm", () => {
       });
 
       it("still blocks Save once the MD types a fresh out-of-range value", async () => {
-        const { getCallCount } = mockPatch();
-        const { user } = renderWithProviders(
-          <AlbumEditForm album={juanaMolinaAlbum({ disc_quantity: DISC_QUANTITY_MIN - 1 })} />,
-        );
+        const album = juanaMolinaAlbum({ disc_quantity: DISC_QUANTITY_MIN - 1 });
+        const { getCallCount } = mockPatch({ album });
+        const { user } = renderWithProviders(<AlbumEditForm album={album} />);
 
         const discQuantity = await screen.findByLabelText("Disc Quantity");
         await user.clear(discQuantity);
@@ -690,6 +783,26 @@ describe("AlbumEditForm", () => {
           expect(getReceivedBody()).toEqual({ album_title: "DOGA (Reissue)" }),
         );
       });
+    });
+
+    // The typeahead always offers its create-new row. This form can't honour
+    // it and has nowhere to send the MD, so the message must describe what is
+    // actually possible instead of naming a flow that doesn't exist.
+    it("explains that a new artist can't be created from here", async () => {
+      const { getCallCount } = mockPatch();
+      mockArtistSearch([]);
+      const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+      const artistInput = await screen.findByLabelText("Search artists");
+      await user.clear(artistInput);
+      await user.type(artistInput, "Csillagrablók");
+      await user.click(await screen.findByText(/Create new artist/));
+
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        expect.stringContaining("Csillagrablók"),
+      );
+      expect(mockToastInfo.mock.calls[0][0]).not.toMatch(/artist-add flow/);
+      expect(getCallCount()).toBe(0);
     });
 
     // The typeahead retracts only the selections it reported through its own
@@ -822,8 +935,8 @@ describe("AlbumEditForm", () => {
 
     describe("alongside the Discogs-unavailable toggle", () => {
       it("keeps both controls independently operable in the same panel", async () => {
-        const { getReceivedBody, getCallCount } = mockPatch();
         const album = juanaMolinaAlbum({ discogsUnavailable: true });
+        const { getReceivedBody, getCallCount } = mockPatch({ album });
         const { user } = renderWithProviders(
           <>
             <DiscogsUnavailableControl album={album} />

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
@@ -233,6 +233,20 @@ describe("AlbumEditForm", () => {
 
       expect(await screen.findByLabelText("Title")).toBeInTheDocument();
     });
+
+    // AuthorizedView (RequireMD) re-resolves authority from scratch on every
+    // mount — it has no cache of an authority a parent already established.
+    // The artist field must use the ungated typeahead variant so this form's
+    // own RequireMD is the only resolution in the tree; the self-gated
+    // default export would open a second, redundant one on every mount.
+    it("resolves organization authority once, not once per nested field", async () => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+      expect(await screen.findByLabelText("Search artists")).toBeInTheDocument();
+      expect(mockFetchOrgRole).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("as a Music Director", () => {

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
@@ -351,6 +351,11 @@ describe("AlbumEditForm", () => {
         expect(screen.getByLabelText("Alternate Artist Name")).toBeDisabled();
         expect(screen.getByLabelText("Disc Quantity")).toBeDisabled();
         expect(screen.getByLabelText("Search artists")).toBeDisabled();
+        // Genre is the field the artist-link invariant turns on: a genre moved
+        // inside the request window would be reseeded away by the response
+        // while the artist link it invalidated had no chance to be re-picked.
+        expect(screen.getByRole("combobox", { name: "Genre" })).toBeDisabled();
+        expect(screen.getByRole("combobox", { name: "Format" })).toBeDisabled();
 
         await user.type(label, " Discos");
         expect(label).toHaveValue("Sonamos");
@@ -510,6 +515,61 @@ describe("AlbumEditForm", () => {
         const discQuantity = await screen.findByLabelText("Disc Quantity");
         await user.clear(discQuantity);
         await user.type(discQuantity, value);
+
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
+        expect(
+          screen.getByText(
+            `Disc quantity must be a whole number between ${DISC_QUANTITY_MIN} and ${DISC_QUANTITY_MAX}.`,
+          ),
+        ).toBeInTheDocument();
+        expect(getCallCount()).toBe(0);
+      });
+    });
+
+    // `library.disc_quantity` is a plain smallint with no CHECK behind it, and
+    // neither the API's insert path nor the tubafrenzy ETL bounds it, so rows
+    // outside 1-99 are already on the shelf. The range is a rule about the
+    // value being written, not about the row: holding an untouched stored value
+    // to it would make the album permanently uneditable, since every unrelated
+    // edit would be blocked until someone invented a disc count for it.
+    describe("an album stored outside the disc-quantity range", () => {
+      it.each([
+        ["below the minimum", DISC_QUANTITY_MIN - 1],
+        ["above the maximum", DISC_QUANTITY_MAX + 1],
+      ])("still saves an unrelated edit when the stored value is %s", async (_case, stored) => {
+        const { getReceivedBody, getCallCount } = mockPatch();
+        const { user } = renderWithProviders(
+          <AlbumEditForm album={juanaMolinaAlbum({ disc_quantity: stored })} />,
+        );
+
+        const title = await screen.findByLabelText("Title");
+        expect(screen.getByLabelText("Disc Quantity")).toHaveValue(stored);
+        await user.clear(title);
+        await user.type(title, "DOGA (Reissue)");
+
+        expect(
+          screen.queryByText(
+            `Disc quantity must be a whole number between ${DISC_QUANTITY_MIN} and ${DISC_QUANTITY_MAX}.`,
+          ),
+        ).not.toBeInTheDocument();
+
+        const saveButton = screen.getByRole("button", SAVE_BUTTON);
+        expect(saveButton).toBeEnabled();
+        await user.click(saveButton);
+
+        await waitFor(() => expect(getCallCount()).toBe(1));
+        expect(getReceivedBody()).toEqual({ album_title: "DOGA (Reissue)" });
+      });
+
+      it("still blocks Save once the MD types a fresh out-of-range value", async () => {
+        const { getCallCount } = mockPatch();
+        const { user } = renderWithProviders(
+          <AlbumEditForm album={juanaMolinaAlbum({ disc_quantity: DISC_QUANTITY_MIN - 1 })} />,
+        );
+
+        const discQuantity = await screen.findByLabelText("Disc Quantity");
+        await user.clear(discQuantity);
+        await user.type(discQuantity, String(DISC_QUANTITY_MAX + 1));
 
         expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
         expect(

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import {
+  renderWithProviders,
+  createTestAlbum,
+  createTestArtist,
+  server,
+  TEST_BACKEND_URL,
+} from "@/tests/helpers";
+import AlbumEditForm from "@/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+// No organization configured (the real production shape): the WXYC tier
+// resolves via fetchOrganizationRoleForUserClient's JWT decode, not the raw
+// session role, so every test drives that mock and awaits resolution.
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof vi.fn>;
+
+function sessionWithRole() {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role: null,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+    error: null,
+  };
+}
+
+const ROCK_GENRE_ID = 7;
+const JAZZ_GENRE_ID = 9;
+const CD_FORMAT_ID = 3;
+const VINYL_FORMAT_ID = 4;
+const JUANA_ARTIST_ID = 501;
+const JUANA_JAZZ_ARTIST_ID = 777;
+
+const juanaMolinaAlbum = (overrides: Parameters<typeof createTestAlbum>[0] = {}) =>
+  createTestAlbum({
+    id: 4242,
+    title: "DOGA",
+    artist: createTestArtist({
+      name: "Juana Molina",
+      lettercode: "MO",
+      numbercode: 12,
+      genre: "Rock",
+    }),
+    label: "Sonamos",
+    artist_id: JUANA_ARTIST_ID,
+    genre_id: ROCK_GENRE_ID,
+    format_id: CD_FORMAT_ID,
+    disc_quantity: 1,
+    alternate_artist: "",
+    ...overrides,
+  });
+
+function mockGenresAndFormats() {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
+      HttpResponse.json([
+        { id: ROCK_GENRE_ID, genre_name: "Rock" },
+        { id: JAZZ_GENRE_ID, genre_name: "Jazz" },
+      ]),
+    ),
+    http.get(`${TEST_BACKEND_URL}/library/formats`, () =>
+      HttpResponse.json([
+        { id: CD_FORMAT_ID, format_name: "CD" },
+        { id: VINYL_FORMAT_ID, format_name: "Vinyl" },
+      ]),
+    ),
+  );
+}
+
+function mockArtistSearch(artists: { id: number; artist_name: string; code_letters: string; code_number: number }[]) {
+  const requests: URL[] = [];
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/artists/search`, ({ request }) => {
+      requests.push(new URL(request.url));
+      return HttpResponse.json({ artists });
+    }),
+  );
+  return requests;
+}
+
+function mockPatch() {
+  let receivedBody: Record<string, unknown> | undefined;
+  let callCount = 0;
+  server.use(
+    http.patch(`${TEST_BACKEND_URL}/library/:id`, async ({ request }) => {
+      callCount++;
+      receivedBody = (await request.json()) as Record<string, unknown>;
+      return HttpResponse.json({
+        id: 4242,
+        album_title: receivedBody.album_title ?? "DOGA",
+        artist_name: "Juana Molina",
+        artist_id: receivedBody.artist_id ?? JUANA_ARTIST_ID,
+        code_letters: "MO",
+        code_number: 1,
+        code_artist_number: 12,
+        format_name: "CD",
+        format_id: receivedBody.format_id ?? CD_FORMAT_ID,
+        genre_name: receivedBody.genre_id === JAZZ_GENRE_ID ? "Jazz" : "Rock",
+        genre_id: receivedBody.genre_id ?? ROCK_GENRE_ID,
+        label: receivedBody.label ?? "Sonamos",
+        disc_quantity: receivedBody.disc_quantity ?? 1,
+        alternate_artist_name:
+          "alternate_artist_name" in receivedBody ? receivedBody.alternate_artist_name : null,
+      });
+    }),
+  );
+  return {
+    getReceivedBody: () => receivedBody,
+    getCallCount: () => callCount,
+  };
+}
+
+describe("AlbumEditForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGenresAndFormats();
+  });
+
+  describe("permission gating", () => {
+    it("renders nothing for a DJ", async () => {
+      mockFetchOrgRole.mockResolvedValue("dj");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+      await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
+      await mockFetchOrgRole.mock.results[0].value;
+      await waitFor(() =>
+        expect(screen.queryByLabelText("Title")).not.toBeInTheDocument(),
+      );
+    });
+
+    it("renders the form for a Music Director", async () => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+      expect(await screen.findByLabelText("Title")).toBeInTheDocument();
+    });
+  });
+
+  describe("as a Music Director", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    describe("initial state", () => {
+      it("seeds every field from the album", async () => {
+        renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        expect(await screen.findByLabelText("Title")).toHaveValue("DOGA");
+        expect(screen.getByLabelText("Label")).toHaveValue("Sonamos");
+        await waitFor(() =>
+          expect(screen.getByRole("combobox", { name: "Genre" })).toHaveTextContent("Rock"),
+        );
+        await waitFor(() =>
+          expect(screen.getByRole("combobox", { name: "Format" })).toHaveTextContent("CD"),
+        );
+        expect(screen.getByLabelText("Search artists")).toHaveValue("Juana Molina");
+        expect(screen.getByLabelText("Disc Quantity")).toHaveValue(1);
+      });
+
+      it("renders album_artist read-only with an explanatory note", async () => {
+        renderWithProviders(
+          <AlbumEditForm album={juanaMolinaAlbum({ album_artist: "Various Artists" })} />,
+        );
+
+        const field = await screen.findByLabelText("Album Artist");
+        expect(field).toHaveValue("Various Artists");
+        expect(field).toBeDisabled();
+        expect(screen.getByText(/isn't supported yet/)).toBeInTheDocument();
+      });
+
+      it("disables Save until a field changes", async () => {
+        renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        await screen.findByLabelText("Title");
+        expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+      });
+    });
+
+    describe("saving", () => {
+      it("sends exactly one PATCH containing only the changed fields", async () => {
+        const { getReceivedBody, getCallCount } = mockPatch();
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const title = await screen.findByLabelText("Title");
+        await user.clear(title);
+        await user.type(title, "DOGA (Reissue)");
+
+        const label = screen.getByLabelText("Label");
+        await user.clear(label);
+        await user.type(label, "Sonamos Discos");
+
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        await waitFor(() => expect(getCallCount()).toBe(1));
+        expect(getReceivedBody()).toEqual({
+          album_title: "DOGA (Reissue)",
+          label: "Sonamos Discos",
+        });
+      });
+
+      it("never includes album_artist in the outgoing body", async () => {
+        const { getReceivedBody } = mockPatch();
+        const { user } = renderWithProviders(
+          <AlbumEditForm album={juanaMolinaAlbum({ album_artist: "Various Artists" })} />,
+        );
+
+        const title = await screen.findByLabelText("Title");
+        await user.clear(title);
+        await user.type(title, "New Title");
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        await waitFor(() => expect(getReceivedBody()).toBeDefined());
+        expect(getReceivedBody()).not.toHaveProperty("album_artist");
+      });
+
+      it("re-hides Save and resets the baseline after a successful save", async () => {
+        mockPatch();
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const title = await screen.findByLabelText("Title");
+        await user.clear(title);
+        await user.type(title, "New Title");
+        expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        await waitFor(() =>
+          expect(screen.getByRole("button", { name: "Save" })).toBeDisabled(),
+        );
+      });
+    });
+
+    describe("clearing nullable fields", () => {
+      it("sends alternate_artist_name: null when the field is cleared", async () => {
+        const { getReceivedBody } = mockPatch();
+        const { user } = renderWithProviders(
+          <AlbumEditForm album={juanaMolinaAlbum({ alternate_artist: "Various" })} />,
+        );
+
+        const field = await screen.findByLabelText("Alternate Artist Name");
+        await user.clear(field);
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        await waitFor(() =>
+          expect(getReceivedBody()).toEqual({ alternate_artist_name: null }),
+        );
+      });
+
+      it("sends label_id: null when 'Clear linked label record' is toggled", async () => {
+        const { getReceivedBody } = mockPatch();
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const clearSwitch = await screen.findByLabelText("Clear linked label record");
+        await user.click(clearSwitch);
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        await waitFor(() => expect(getReceivedBody()).toEqual({ label_id: null }));
+      });
+    });
+
+    describe("genre change invalidates a seeded artist link", () => {
+      it("drops the seeded artist_id and blocks Save until a fresh pick is made", async () => {
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const artistInput = await screen.findByLabelText("Search artists");
+        expect(artistInput).toHaveValue("Juana Molina");
+
+        const genreSelect = screen.getByRole("combobox", { name: "Genre" });
+        await user.click(genreSelect);
+        await user.click(await screen.findByRole("option", { name: "Jazz" }));
+
+        // Text is left standing (the MD still needs it to re-pick under Jazz)
+        // but the seeded id must no longer be submittable.
+        expect(artistInput).toHaveValue("Juana Molina");
+        expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+        expect(
+          screen.getByText(/select an artist to continue/i),
+        ).toBeInTheDocument();
+      });
+
+      it("never PATCHes a genre_id/artist_id pair resolved under different genres", async () => {
+        const { getReceivedBody, getCallCount } = mockPatch();
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        await screen.findByLabelText("Title");
+        const genreSelect = screen.getByRole("combobox", { name: "Genre" });
+        await user.click(genreSelect);
+        await user.click(await screen.findByRole("option", { name: "Jazz" }));
+
+        // Save is disabled by the invalid artist link, so it cannot be
+        // clicked at all (pointer-events are suppressed on disabled
+        // controls) — the important assertion is that no PATCH ever fires.
+        const saveButton = screen.getByRole("button", { name: "Save" });
+        expect(saveButton).toBeDisabled();
+
+        expect(getCallCount()).toBe(0);
+        expect(getReceivedBody()).toBeUndefined();
+      });
+
+      it("re-enables Save once the artist is re-picked under the new genre", async () => {
+        const { getReceivedBody } = mockPatch();
+        mockArtistSearch([
+          {
+            id: JUANA_JAZZ_ARTIST_ID,
+            artist_name: "Juana Molina",
+            code_letters: "MO",
+            code_number: 4,
+          },
+        ]);
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        await screen.findByLabelText("Title");
+        await user.click(screen.getByRole("combobox", { name: "Genre" }));
+        await user.click(await screen.findByRole("option", { name: "Jazz" }));
+
+        const artistInput = screen.getByLabelText("Search artists");
+        await user.click(artistInput);
+        await user.click(await screen.findByText("Juana Molina"));
+
+        const saveButton = screen.getByRole("button", { name: "Save" });
+        await waitFor(() => expect(saveButton).toBeEnabled());
+        await user.click(saveButton);
+
+        await waitFor(() =>
+          expect(getReceivedBody()).toEqual({
+            genre_id: JAZZ_GENRE_ID,
+            artist_id: JUANA_JAZZ_ARTIST_ID,
+          }),
+        );
+      });
+    });
+  });
+});

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
@@ -68,6 +68,7 @@ const CD_FORMAT_ID = 3;
 const VINYL_FORMAT_ID = 4;
 const JUANA_ARTIST_ID = 501;
 const JUANA_JAZZ_ARTIST_ID = 777;
+const JESSICA_ARTIST_ID = 600;
 
 const SAVE_BUTTON = { name: "Save Release" };
 
@@ -710,6 +711,52 @@ describe("AlbumEditForm", () => {
         await waitFor(() =>
           expect(getReceivedBody()).toEqual({ album_title: "DOGA (Reissue)" }),
         );
+      });
+
+      // The typeahead retracts at most once per selection and stops tracking
+      // that selection afterwards, so a link restored by a genre round trip has
+      // nothing left to announce a later text edit. The form has to judge the
+      // link against the field itself — otherwise Save re-attributes the album
+      // to an artist the field visibly does not name, and the server can burn a
+      // fresh call number doing it.
+      it("blocks Save when a restored link's artist text is edited without a fresh pick", async () => {
+        const { getCallCount } = mockPatch();
+        mockArtistSearch([
+          {
+            id: JESSICA_ARTIST_ID,
+            artist_name: "Jessica Pratt",
+            code_letters: "PR",
+            code_number: 3,
+          },
+        ]);
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const artistInput = await screen.findByLabelText("Search artists");
+        await user.clear(artistInput);
+        await user.type(artistInput, "Jessica");
+        await user.click(await screen.findByText("Jessica Pratt"));
+
+        const saveButton = screen.getByRole("button", SAVE_BUTTON);
+        await waitFor(() => expect(saveButton).toBeEnabled());
+
+        await user.click(screen.getByRole("combobox", { name: "Genre" }));
+        await user.click(await screen.findByRole("option", { name: "Jazz" }));
+        expect(saveButton).toBeDisabled();
+
+        await user.click(screen.getByRole("combobox", { name: "Genre" }));
+        await user.click(await screen.findByRole("option", { name: "Rock" }));
+        await waitFor(() => expect(saveButton).toBeEnabled());
+
+        // Retyping the album's original artist without picking a row: the field
+        // reads "Juana Molina" while the held id is Jessica Pratt's.
+        await user.clear(artistInput);
+        await user.type(artistInput, "Juana Molina");
+
+        await waitFor(() => expect(saveButton).toBeDisabled());
+        expect(
+          screen.getByText("Search and select an artist to continue."),
+        ).toBeInTheDocument();
+        expect(getCallCount()).toBe(0);
       });
     });
 

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
@@ -407,6 +407,21 @@ describe("AlbumEditForm", () => {
     });
 
     describe("clearing nullable fields", () => {
+      it("sends the typed alternate_artist_name when the field is set", async () => {
+        const { getReceivedBody } = mockPatch();
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const field = await screen.findByLabelText("Alternate Artist Name");
+        await user.type(field, "Juana Molina y Los Hermanos");
+        await user.click(screen.getByRole("button", SAVE_BUTTON));
+
+        await waitFor(() =>
+          expect(getReceivedBody()).toEqual({
+            alternate_artist_name: "Juana Molina y Los Hermanos",
+          }),
+        );
+      });
+
       it("sends alternate_artist_name: null when the field is cleared", async () => {
         const { getReceivedBody } = mockPatch();
         const { user } = renderWithProviders(
@@ -546,7 +561,7 @@ describe("AlbumEditForm", () => {
 
       it("re-enables Save once the artist is re-picked under the new genre", async () => {
         const { getReceivedBody } = mockPatch();
-        mockArtistSearch([
+        const searchRequests = mockArtistSearch([
           {
             id: JUANA_JAZZ_ARTIST_ID,
             artist_name: "Juana Molina",
@@ -563,6 +578,14 @@ describe("AlbumEditForm", () => {
         const artistInput = screen.getByLabelText("Search artists");
         await user.click(artistInput);
         await user.click(await screen.findByText("Juana Molina"));
+
+        // The rows offered must come from the genre now selected, not the one
+        // the album arrived under — picking a Rock-only artist while filing
+        // under Jazz is the 400 this whole invalidation design exists to avoid.
+        expect(searchRequests.length).toBeGreaterThan(0);
+        expect(searchRequests.at(-1)?.searchParams.get("genre_id")).toBe(
+          String(JAZZ_GENRE_ID),
+        );
 
         const saveButton = screen.getByRole("button", SAVE_BUTTON);
         await waitFor(() => expect(saveButton).toBeEnabled());
@@ -642,6 +665,51 @@ describe("AlbumEditForm", () => {
           screen.getByText("Search and select an artist to continue."),
         ).toBeInTheDocument();
         expect(getCallCount()).toBe(0);
+      });
+
+      // The typeahead reports a genre move through the same callback as a text
+      // edit, but only the text edit unmakes the pick — so a picked link has to
+      // survive a genre round trip exactly as a seeded one does, and say so.
+      it("restores a picked link when the genre returns to the one it was picked under", async () => {
+        const { getReceivedBody } = mockPatch();
+        mockArtistSearch([
+          {
+            id: JUANA_ARTIST_ID,
+            artist_name: "Juana Molina",
+            code_letters: "MO",
+            code_number: 12,
+          },
+        ]);
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const title = await screen.findByLabelText("Title");
+        await user.clear(title);
+        await user.type(title, "DOGA (Reissue)");
+
+        const artistInput = screen.getByLabelText("Search artists");
+        await user.click(artistInput);
+        await user.click(await screen.findByText("Juana Molina"));
+
+        await user.click(screen.getByRole("combobox", { name: "Genre" }));
+        await user.click(await screen.findByRole("option", { name: "Jazz" }));
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
+        expect(
+          screen.getByText(/the previous link no longer applies under this genre/i),
+        ).toBeInTheDocument();
+
+        await user.click(screen.getByRole("combobox", { name: "Genre" }));
+        await user.click(await screen.findByRole("option", { name: "Rock" }));
+
+        expect(
+          screen.queryByText(/select an artist to continue/i),
+        ).not.toBeInTheDocument();
+        const saveButton = screen.getByRole("button", SAVE_BUTTON);
+        await waitFor(() => expect(saveButton).toBeEnabled());
+        await user.click(saveButton);
+
+        await waitFor(() =>
+          expect(getReceivedBody()).toEqual({ album_title: "DOGA (Reissue)" }),
+        );
       });
     });
 

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
@@ -8,7 +8,13 @@ import {
   server,
   TEST_BACKEND_URL,
 } from "@/tests/helpers";
+import {
+  ALBUM_TEXT_MAX_LENGTH,
+  DISC_QUANTITY_MAX,
+  DISC_QUANTITY_MIN,
+} from "@/lib/features/catalog/constants";
 import AlbumEditForm from "@/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm";
+import DiscogsUnavailableControl from "@/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl";
 
 vi.mock("@/lib/features/authentication/client", () => ({
   authClient: { useSession: vi.fn() },
@@ -32,9 +38,11 @@ vi.mock("sonner", () => ({
 
 import { authClient } from "@/lib/features/authentication/client";
 import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+import { toast } from "sonner";
 
 const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
 const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof vi.fn>;
+const mockToastError = toast.error as ReturnType<typeof vi.fn>;
 
 function sessionWithRole() {
   return {
@@ -60,6 +68,8 @@ const CD_FORMAT_ID = 3;
 const VINYL_FORMAT_ID = 4;
 const JUANA_ARTIST_ID = 501;
 const JUANA_JAZZ_ARTIST_ID = 777;
+
+const SAVE_BUTTON = { name: "Save Release" };
 
 const juanaMolinaAlbum = (overrides: Parameters<typeof createTestAlbum>[0] = {}) =>
   createTestAlbum({
@@ -108,13 +118,20 @@ function mockArtistSearch(artists: { id: number; artist_name: string; code_lette
   return requests;
 }
 
-function mockPatch() {
+/**
+ * `gate`, when supplied, holds the response open until it settles — the window
+ * in which Backend-Service awaits its post-update enrichment (a streaming check
+ * plus a metadata lookup) before answering, which is measured in seconds for
+ * exactly the fields this form edits.
+ */
+function mockPatch({ gate }: { gate?: Promise<unknown> } = {}) {
   let receivedBody: Record<string, unknown> | undefined;
   let callCount = 0;
   server.use(
     http.patch(`${TEST_BACKEND_URL}/library/:id`, async ({ request }) => {
       callCount++;
       receivedBody = (await request.json()) as Record<string, unknown>;
+      if (gate) await gate;
       return HttpResponse.json({
         id: 4242,
         album_title: receivedBody.album_title ?? "DOGA",
@@ -205,13 +222,41 @@ describe("AlbumEditForm", () => {
         renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
 
         await screen.findByLabelText("Title");
-        expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
+      });
+
+      // Rows predating the write path's trimming can carry padding; comparing a
+      // trimmed draft against an untrimmed baseline would arm Save with no user
+      // edit, and a trim-only PATCH still moves the catalog watermark.
+      it("treats whitespace-padded stored values as unchanged", async () => {
+        renderWithProviders(
+          <AlbumEditForm
+            album={juanaMolinaAlbum({
+              title: "DOGA ",
+              label: " Sonamos",
+              alternate_artist: " ",
+            })}
+          />,
+        );
+
+        expect(await screen.findByLabelText("Title")).toHaveValue("DOGA");
+        expect(screen.getByLabelText("Label")).toHaveValue("Sonamos");
+        expect(screen.getByLabelText("Alternate Artist Name")).toHaveValue("");
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
       });
     });
 
     describe("saving", () => {
       it("sends exactly one PATCH containing only the changed fields", async () => {
         const { getReceivedBody, getCallCount } = mockPatch();
+        mockArtistSearch([
+          {
+            id: JUANA_JAZZ_ARTIST_ID,
+            artist_name: "Juana Molina",
+            code_letters: "MO",
+            code_number: 4,
+          },
+        ]);
         const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
 
         const title = await screen.findByLabelText("Title");
@@ -222,12 +267,32 @@ describe("AlbumEditForm", () => {
         await user.clear(label);
         await user.type(label, "Sonamos Discos");
 
-        await user.click(screen.getByRole("button", { name: "Save" }));
+        await user.click(screen.getByRole("combobox", { name: "Format" }));
+        await user.click(await screen.findByRole("option", { name: "Vinyl" }));
+
+        const discQuantity = screen.getByLabelText("Disc Quantity");
+        await user.clear(discQuantity);
+        await user.type(discQuantity, "2");
+
+        await user.click(screen.getByRole("combobox", { name: "Genre" }));
+        await user.click(await screen.findByRole("option", { name: "Jazz" }));
+
+        const artistInput = screen.getByLabelText("Search artists");
+        await user.click(artistInput);
+        await user.click(await screen.findByText("Juana Molina"));
+
+        const saveButton = screen.getByRole("button", SAVE_BUTTON);
+        await waitFor(() => expect(saveButton).toBeEnabled());
+        await user.click(saveButton);
 
         await waitFor(() => expect(getCallCount()).toBe(1));
         expect(getReceivedBody()).toEqual({
           album_title: "DOGA (Reissue)",
           label: "Sonamos Discos",
+          genre_id: JAZZ_GENRE_ID,
+          format_id: VINYL_FORMAT_ID,
+          artist_id: JUANA_JAZZ_ARTIST_ID,
+          disc_quantity: 2,
         });
       });
 
@@ -240,7 +305,7 @@ describe("AlbumEditForm", () => {
         const title = await screen.findByLabelText("Title");
         await user.clear(title);
         await user.type(title, "New Title");
-        await user.click(screen.getByRole("button", { name: "Save" }));
+        await user.click(screen.getByRole("button", SAVE_BUTTON));
 
         await waitFor(() => expect(getReceivedBody()).toBeDefined());
         expect(getReceivedBody()).not.toHaveProperty("album_artist");
@@ -253,12 +318,90 @@ describe("AlbumEditForm", () => {
         const title = await screen.findByLabelText("Title");
         await user.clear(title);
         await user.type(title, "New Title");
-        expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeEnabled();
 
-        await user.click(screen.getByRole("button", { name: "Save" }));
+        await user.click(screen.getByRole("button", SAVE_BUTTON));
 
         await waitFor(() =>
-          expect(screen.getByRole("button", { name: "Save" })).toBeDisabled(),
+          expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled(),
+        );
+      });
+
+      // The response reseeds every field, so a draft typed while the request is
+      // open would be overwritten without a toast, a dirty marker, or any other
+      // trace. Locking the fields for the duration is what makes that
+      // unreachable.
+      it("locks every field while the save is in flight so an edit can't be discarded", async () => {
+        let releaseResponse: (() => void) | undefined;
+        const gate = new Promise<void>((resolve) => {
+          releaseResponse = resolve;
+        });
+        mockPatch({ gate });
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const title = await screen.findByLabelText("Title");
+        await user.clear(title);
+        await user.type(title, "DOGA (Reissue)");
+        await user.click(screen.getByRole("button", SAVE_BUTTON));
+
+        const label = screen.getByLabelText("Label");
+        await waitFor(() => expect(label).toBeDisabled());
+        expect(title).toBeDisabled();
+        expect(screen.getByLabelText("Alternate Artist Name")).toBeDisabled();
+        expect(screen.getByLabelText("Disc Quantity")).toBeDisabled();
+        expect(screen.getByLabelText("Search artists")).toBeDisabled();
+
+        await user.type(label, " Discos");
+        expect(label).toHaveValue("Sonamos");
+
+        releaseResponse?.();
+        await waitFor(() => expect(title).toBeEnabled());
+        expect(title).toHaveValue("DOGA (Reissue)");
+        expect(label).toHaveValue("Sonamos");
+      });
+
+      // Backend-Service answers every rejection with a specific reason and the
+      // global RTK Query error middleware toasts it; a second unconditional
+      // toast from this form would bury it.
+      it("lets the server's own rejection reason through instead of a generic toast", async () => {
+        server.use(
+          http.patch(`${TEST_BACKEND_URL}/library/:id`, () =>
+            HttpResponse.json(
+              { message: "Artist is not catalogued in the selected genre" },
+              { status: 400 },
+            ),
+          ),
+        );
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const title = await screen.findByLabelText("Title");
+        await user.clear(title);
+        await user.type(title, "New Title");
+        await user.click(screen.getByRole("button", SAVE_BUTTON));
+
+        await waitFor(() =>
+          expect(mockToastError).toHaveBeenCalledWith(
+            "Artist is not catalogued in the selected genre",
+          ),
+        );
+        expect(mockToastError).not.toHaveBeenCalledWith("Failed to update album");
+      });
+
+      it("falls back to a generic toast when the rejection carries no message", async () => {
+        server.use(
+          http.patch(`${TEST_BACKEND_URL}/library/:id`, () =>
+            HttpResponse.json({}, { status: 500 }),
+          ),
+        );
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const title = await screen.findByLabelText("Title");
+        await user.clear(title);
+        await user.type(title, "New Title");
+        await user.click(screen.getByRole("button", SAVE_BUTTON));
+
+        await waitFor(() =>
+          expect(mockToastError).toHaveBeenCalledWith("Failed to update album"),
         );
       });
     });
@@ -272,7 +415,7 @@ describe("AlbumEditForm", () => {
 
         const field = await screen.findByLabelText("Alternate Artist Name");
         await user.clear(field);
-        await user.click(screen.getByRole("button", { name: "Save" }));
+        await user.click(screen.getByRole("button", SAVE_BUTTON));
 
         await waitFor(() =>
           expect(getReceivedBody()).toEqual({ alternate_artist_name: null }),
@@ -285,7 +428,7 @@ describe("AlbumEditForm", () => {
 
         const field = await screen.findByLabelText("Label");
         await user.clear(field);
-        await user.click(screen.getByRole("button", { name: "Save" }));
+        await user.click(screen.getByRole("button", SAVE_BUTTON));
 
         await waitFor(() => expect(getReceivedBody()).toEqual({ label_id: null }));
       });
@@ -299,7 +442,7 @@ describe("AlbumEditForm", () => {
         const title = await screen.findByLabelText("Title");
         await user.clear(title);
 
-        expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
         expect(screen.getByText("Title can't be empty.")).toBeInTheDocument();
         expect(getCallCount()).toBe(0);
       });
@@ -311,7 +454,53 @@ describe("AlbumEditForm", () => {
         const discQuantity = await screen.findByLabelText("Disc Quantity");
         await user.clear(discQuantity);
 
-        expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
+        expect(getCallCount()).toBe(0);
+      });
+    });
+
+    // Backend-Service rejects each of these with its own 400; enforcing them
+    // here keeps a round trip from being spent on a value the form can already
+    // see is out of range.
+    describe("server-side limits enforced before the request", () => {
+      it.each([
+        ["Title", "Title"],
+        ["Label", "Label"],
+        ["Alternate Artist Name", "Alternate artist name"],
+      ])("blocks Save when %s exceeds the column length", async (fieldLabel, message) => {
+        const { getCallCount } = mockPatch();
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const field = await screen.findByLabelText(fieldLabel);
+        await user.clear(field);
+        await user.paste("D".repeat(ALBUM_TEXT_MAX_LENGTH + 1));
+
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
+        expect(
+          screen.getByText(
+            `${message} must be ${ALBUM_TEXT_MAX_LENGTH} characters or fewer.`,
+          ),
+        ).toBeInTheDocument();
+        expect(getCallCount()).toBe(0);
+      });
+
+      it.each([
+        ["below the minimum", String(DISC_QUANTITY_MIN - 1)],
+        ["above the maximum", String(DISC_QUANTITY_MAX + 1)],
+      ])("blocks Save when disc quantity is %s", async (_case, value) => {
+        const { getCallCount } = mockPatch();
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const discQuantity = await screen.findByLabelText("Disc Quantity");
+        await user.clear(discQuantity);
+        await user.type(discQuantity, value);
+
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
+        expect(
+          screen.getByText(
+            `Disc quantity must be a whole number between ${DISC_QUANTITY_MIN} and ${DISC_QUANTITY_MAX}.`,
+          ),
+        ).toBeInTheDocument();
         expect(getCallCount()).toBe(0);
       });
     });
@@ -330,9 +519,9 @@ describe("AlbumEditForm", () => {
         // Text is left standing (the MD still needs it to re-pick under Jazz)
         // but the seeded id must no longer be submittable.
         expect(artistInput).toHaveValue("Juana Molina");
-        expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
         expect(
-          screen.getByText(/select an artist to continue/i),
+          screen.getByText(/the previous link no longer applies under this genre/i),
         ).toBeInTheDocument();
       });
 
@@ -348,7 +537,7 @@ describe("AlbumEditForm", () => {
         // Save is disabled by the invalid artist link, so it cannot be
         // clicked at all (pointer-events are suppressed on disabled
         // controls) — the important assertion is that no PATCH ever fires.
-        const saveButton = screen.getByRole("button", { name: "Save" });
+        const saveButton = screen.getByRole("button", SAVE_BUTTON);
         expect(saveButton).toBeDisabled();
 
         expect(getCallCount()).toBe(0);
@@ -375,7 +564,7 @@ describe("AlbumEditForm", () => {
         await user.click(artistInput);
         await user.click(await screen.findByText("Juana Molina"));
 
-        const saveButton = screen.getByRole("button", { name: "Save" });
+        const saveButton = screen.getByRole("button", SAVE_BUTTON);
         await waitFor(() => expect(saveButton).toBeEnabled());
         await user.click(saveButton);
 
@@ -385,6 +574,106 @@ describe("AlbumEditForm", () => {
             artist_id: JUANA_JAZZ_ARTIST_ID,
           }),
         );
+      });
+
+      // The invalidation is a comparison against the genre the link was
+      // resolved under, not an erasure — otherwise returning the genre to where
+      // it started leaves an album whose every field reads its original value
+      // with Save permanently blocked and nothing explaining why.
+      it("restores the seeded link when the genre returns to the one it was resolved under", async () => {
+        const { getReceivedBody } = mockPatch();
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const title = await screen.findByLabelText("Title");
+        await user.clear(title);
+        await user.type(title, "DOGA (Reissue)");
+
+        await user.click(screen.getByRole("combobox", { name: "Genre" }));
+        await user.click(await screen.findByRole("option", { name: "Jazz" }));
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
+
+        await user.click(screen.getByRole("combobox", { name: "Genre" }));
+        await user.click(await screen.findByRole("option", { name: "Rock" }));
+
+        expect(
+          screen.queryByText(/select an artist to continue/i),
+        ).not.toBeInTheDocument();
+        const saveButton = screen.getByRole("button", SAVE_BUTTON);
+        await waitFor(() => expect(saveButton).toBeEnabled());
+        await user.click(saveButton);
+
+        await waitFor(() =>
+          expect(getReceivedBody()).toEqual({ album_title: "DOGA (Reissue)" }),
+        );
+      });
+    });
+
+    // The typeahead retracts only the selections it reported through its own
+    // `onSelect`, and this form has to drop the id when it does — otherwise a
+    // picked link outlives the text that produced it.
+    describe("typeahead retraction of a picked artist", () => {
+      it("blocks Save once the artist text is edited away from the picked artist", async () => {
+        const { getCallCount } = mockPatch();
+        mockArtistSearch([
+          {
+            id: JUANA_ARTIST_ID,
+            artist_name: "Juana Molina",
+            code_letters: "MO",
+            code_number: 12,
+          },
+        ]);
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const title = await screen.findByLabelText("Title");
+        await user.clear(title);
+        await user.type(title, "DOGA (Reissue)");
+
+        const artistInput = screen.getByLabelText("Search artists");
+        await user.click(artistInput);
+        await user.click(await screen.findByText("Juana Molina"));
+
+        const saveButton = screen.getByRole("button", SAVE_BUTTON);
+        await waitFor(() => expect(saveButton).toBeEnabled());
+
+        await user.type(artistInput, " Trio");
+
+        await waitFor(() => expect(saveButton).toBeDisabled());
+        expect(
+          screen.getByText("Search and select an artist to continue."),
+        ).toBeInTheDocument();
+        expect(getCallCount()).toBe(0);
+      });
+    });
+
+    describe("alongside the Discogs-unavailable toggle", () => {
+      it("keeps both controls independently operable in the same panel", async () => {
+        const { getReceivedBody, getCallCount } = mockPatch();
+        const album = juanaMolinaAlbum({ discogsUnavailable: true });
+        const { user } = renderWithProviders(
+          <>
+            <DiscogsUnavailableControl album={album} />
+            <AlbumEditForm album={album} />
+          </>,
+        );
+
+        const title = await screen.findByLabelText("Title");
+        await user.type(screen.getByLabelText("Reason (optional)"), "embargoed promo");
+
+        // Two Save affordances share the panel; each must name its own scope.
+        expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        await waitFor(() => expect(getCallCount()).toBe(1));
+        expect(getReceivedBody()).toEqual({
+          discogsUnavailable: true,
+          discogsUnavailableNote: "embargoed promo",
+        });
+        // The note save is scoped to the toggle: it leaves the edit form's
+        // draft alone and does not arm its Save.
+        expect(title).toHaveValue("DOGA");
+        expect(screen.getByRole("button", SAVE_BUTTON)).toBeDisabled();
       });
     });
   });

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
@@ -234,18 +234,21 @@ describe("AlbumEditForm", () => {
       expect(await screen.findByLabelText("Title")).toBeInTheDocument();
     });
 
-    // AuthorizedView (RequireMD) re-resolves authority from scratch on every
-    // mount — it has no cache of an authority a parent already established.
-    // The artist field must use the ungated typeahead variant so this form's
-    // own RequireMD is the only resolution in the tree; the self-gated
-    // default export would open a second, redundant one on every mount.
-    it("resolves organization authority once, not once per nested field", async () => {
+    // The artist field uses the same self-gated typeahead every other caller
+    // does, rather than an ungated variant reserved for this form — an
+    // ungated export left in the module's public surface is an authorization
+    // hole waiting for a future importer that skips the gate entirely. That
+    // costs a second AuthorizedView resolution alongside this form's own
+    // RequireMD, but AuthorizedView's role fetch already caches its token and
+    // coalesces concurrent lookups, so the real cost is a second cheap
+    // synchronous JWT decode, not a second network round trip.
+    it("resolves organization authority for both this form's gate and the artist field's own gate", async () => {
       mockFetchOrgRole.mockResolvedValue("musicDirector");
       mockUseSession.mockReturnValue(sessionWithRole());
       renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
 
       expect(await screen.findByLabelText("Search artists")).toBeInTheDocument();
-      expect(mockFetchOrgRole).toHaveBeenCalledTimes(1);
+      expect(mockFetchOrgRole).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
@@ -753,6 +753,42 @@ describe("AlbumEditForm", () => {
         );
       });
 
+      // Artists can be catalogued in multiple genres (genre_artist_crossreference),
+      // so re-picking the identical artist id under the new genre is a real,
+      // reachable flow. `artistId === saved.artistId` then suppresses
+      // `changes.artist_id`, leaving `genre_id` as the only changed field —
+      // the one body shape whose safety rests entirely on Backend-Service
+      // re-validating the pair against `existing.artist_id` rather than on
+      // this form's own invariant.
+      it("PATCHes only genre_id when the MD re-picks the same artist row under the new genre", async () => {
+        const { getReceivedBody } = mockPatch();
+        mockArtistSearch([
+          {
+            id: JUANA_ARTIST_ID,
+            artist_name: "Juana Molina",
+            code_letters: "MO",
+            code_number: 12,
+          },
+        ]);
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        await screen.findByLabelText("Title");
+        await user.click(screen.getByRole("combobox", { name: "Genre" }));
+        await user.click(await screen.findByRole("option", { name: "Jazz" }));
+
+        const artistInput = screen.getByLabelText("Search artists");
+        await user.click(artistInput);
+        await user.click(await screen.findByText("Juana Molina"));
+
+        const saveButton = screen.getByRole("button", SAVE_BUTTON);
+        await waitFor(() => expect(saveButton).toBeEnabled());
+        await user.click(saveButton);
+
+        await waitFor(() =>
+          expect(getReceivedBody()).toEqual({ genre_id: JAZZ_GENRE_ID }),
+        );
+      });
+
       // The invalidation is a comparison against the genre the link was
       // resolved under, not an erasure — otherwise returning the genre to where
       // it started leaves an album whose every field reads its original value

--- a/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/AlbumEditForm.test.tsx
@@ -246,7 +246,7 @@ describe("AlbumEditForm", () => {
         expect(getReceivedBody()).not.toHaveProperty("album_artist");
       });
 
-      it("re-hides Save and resets the baseline after a successful save", async () => {
+      it("disables Save again and resets the baseline after a successful save", async () => {
         mockPatch();
         const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
 
@@ -279,15 +279,40 @@ describe("AlbumEditForm", () => {
         );
       });
 
-      it("sends label_id: null when 'Clear linked label record' is toggled", async () => {
+      it("sends label_id: null (not an empty label string) when the Label field is cleared", async () => {
         const { getReceivedBody } = mockPatch();
         const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
 
-        const clearSwitch = await screen.findByLabelText("Clear linked label record");
-        await user.click(clearSwitch);
+        const field = await screen.findByLabelText("Label");
+        await user.clear(field);
         await user.click(screen.getByRole("button", { name: "Save" }));
 
         await waitFor(() => expect(getReceivedBody()).toEqual({ label_id: null }));
+      });
+    });
+
+    describe("required fields", () => {
+      it("blocks Save and never sends an empty title", async () => {
+        const { getCallCount } = mockPatch();
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const title = await screen.findByLabelText("Title");
+        await user.clear(title);
+
+        expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+        expect(screen.getByText("Title can't be empty.")).toBeInTheDocument();
+        expect(getCallCount()).toBe(0);
+      });
+
+      it("blocks Save when a previously-set disc quantity is cleared", async () => {
+        const { getCallCount } = mockPatch();
+        const { user } = renderWithProviders(<AlbumEditForm album={juanaMolinaAlbum()} />);
+
+        const discQuantity = await screen.findByLabelText("Disc Quantity");
+        await user.clear(discQuantity);
+
+        expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+        expect(getCallCount()).toBe(0);
       });
     });
 

--- a/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
@@ -248,12 +248,11 @@ describe("DiscogsUnavailableControl", () => {
     });
   });
 
-  // The global RTK Query middleware re-toasts a server-supplied reason, so this
-  // control stays quiet for that one shape. For every other shape the
-  // middleware raises a raw parse failure, a bare transport line, or nothing at
-  // all — none of which say which control failed — so the fallback here is the
-  // only message naming the failure and must survive.
-  describe("every rejection shape leaves the MD a readable message", () => {
+  // The global RTK Query middleware owns the wording for every shape it can
+  // describe — a server-supplied reason, a transport failure, a body that
+  // wasn't JSON — and this control stays out of those. What it must cover is
+  // the shapes the middleware says nothing for, or the failure is silent.
+  describe("every rejection shape leaves the MD exactly one message", () => {
     beforeEach(() => {
       mockFetchOrgRole.mockResolvedValue("musicDirector");
       mockUseSession.mockReturnValue(sessionWithRole());
@@ -283,9 +282,16 @@ describe("DiscogsUnavailableControl", () => {
       expect(messages).toEqual(["Album is not catalogued"]);
     });
 
-    // A route that answers a mutation with HTML (an Express 404 page, a gateway
-    // 502) leaves the middleware toasting only the JSON parse failure.
-    it("speaks alongside the raw parse failure when the body is not JSON", async () => {
+    it("speaks when the server rejects with no reason at all", async () => {
+      const messages = await toggleWith(() => HttpResponse.json({}, { status: 500 }));
+
+      expect(messages).toEqual(["Failed to update Discogs availability"]);
+    });
+
+    // A route answering a mutation with HTML (an Express 404 page, a gateway
+    // 502) is the middleware's to word — asserted as "something, but not a
+    // second toast from here", so improving that wording doesn't break this.
+    it("leaves a non-JSON body to the middleware", async () => {
       const messages = await toggleWith(
         () =>
           new HttpResponse(
@@ -294,13 +300,14 @@ describe("DiscogsUnavailableControl", () => {
           ),
       );
 
-      expect(messages).toContain("Failed to update Discogs availability");
+      expect(messages).toHaveLength(1);
+      expect(messages).not.toContain("Failed to update Discogs availability");
     });
 
-    it("speaks alongside the generic network toast when the request never lands", async () => {
+    it("leaves a request that never lands to the middleware", async () => {
       const messages = await toggleWith(() => HttpResponse.error());
 
-      expect(messages).toContain("Failed to update Discogs availability");
+      expect(messages).toEqual(["Network error — please check your connection."]);
     });
 
     // A 200 whose body the response transform can't read rejects the thunk

--- a/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
@@ -248,6 +248,71 @@ describe("DiscogsUnavailableControl", () => {
     });
   });
 
+  // The global RTK Query middleware re-toasts a server-supplied reason, so this
+  // control stays quiet for that one shape. For every other shape the
+  // middleware raises a raw parse failure, a bare transport line, or nothing at
+  // all — none of which say which control failed — so the fallback here is the
+  // only message naming the failure and must survive.
+  describe("every rejection shape leaves the MD a readable message", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    async function toggleWith(respond: Parameters<typeof http.patch>[1]) {
+      server.use(http.patch(`${TEST_BACKEND_URL}/library/:id`, respond));
+      const { user } = renderWithProviders(
+        <DiscogsUnavailableControl album={juanaMolinaAlbum()} />,
+      );
+      const toggle = await screen.findByLabelText("Not on Discogs");
+      await user.click(toggle);
+      await waitFor(() => expect(toggle).not.toBeChecked());
+      return (toast.error as ReturnType<typeof vi.fn>).mock.calls.map(
+        ([message]) => message,
+      );
+    }
+
+    it("stays quiet when the server supplied its own reason", async () => {
+      const messages = await toggleWith(() =>
+        HttpResponse.json(
+          { message: "Album is not catalogued" },
+          { status: 400 },
+        ),
+      );
+
+      expect(messages).toEqual(["Album is not catalogued"]);
+    });
+
+    // A route that answers a mutation with HTML (an Express 404 page, a gateway
+    // 502) leaves the middleware toasting only the JSON parse failure.
+    it("speaks alongside the raw parse failure when the body is not JSON", async () => {
+      const messages = await toggleWith(
+        () =>
+          new HttpResponse(
+            "<!DOCTYPE html><html><body>Cannot PATCH /library/4242</body></html>",
+            { status: 404, headers: { "Content-Type": "text/html" } },
+          ),
+      );
+
+      expect(messages).toContain("Failed to update Discogs availability");
+    });
+
+    it("speaks alongside the generic network toast when the request never lands", async () => {
+      const messages = await toggleWith(() => HttpResponse.error());
+
+      expect(messages).toContain("Failed to update Discogs availability");
+    });
+
+    // A 200 whose body the response transform can't read rejects the thunk
+    // without a value, so the middleware never sees it and toasts nothing —
+    // this fallback is all the MD gets.
+    it("is the only message when the response transform throws", async () => {
+      const messages = await toggleWith(() => HttpResponse.json(null));
+
+      expect(messages).toEqual(["Failed to update Discogs availability"]);
+    });
+  });
+
   describe("editing the note", () => {
     beforeEach(() => {
       mockFetchOrgRole.mockResolvedValue("musicDirector");

--- a/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
@@ -312,10 +312,12 @@ describe("DiscogsUnavailableControl", () => {
       expect(messages).toEqual(["Network error — please check your connection."]);
     });
 
-    // A 200 whose body the response transform can't read rejects the thunk
-    // without a value, so the middleware never sees it and toasts nothing —
-    // this fallback is all the MD gets.
-    it("is the only message when the response transform throws", async () => {
+    // A 200 with a JSON `null` body (a malformed response updateAlbum should
+    // never legitimately produce) is guarded in transformResponse rather than
+    // left to crash; the guard's rejection still carries no value, so the
+    // middleware never sees it and toasts nothing — this fallback is all the
+    // MD gets.
+    it("is the only message when the response transform guards against an empty body", async () => {
       const messages = await toggleWith(() => HttpResponse.json(null));
 
       expect(messages).toEqual(["Failed to update Discogs availability"]);

--- a/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/DiscogsUnavailableControl.test.tsx
@@ -289,8 +289,9 @@ describe("DiscogsUnavailableControl", () => {
     });
 
     // A route answering a mutation with HTML (an Express 404 page, a gateway
-    // 502) is the middleware's to word — asserted as "something, but not a
-    // second toast from here", so improving that wording doesn't break this.
+    // 502) is the middleware's to word: it toasts its own plain-language
+    // PARSING_ERROR line, and this control must not stack a second, vaguer
+    // toast on top of it.
     it("leaves a non-JSON body to the middleware", async () => {
       const messages = await toggleWith(
         () =>
@@ -300,8 +301,9 @@ describe("DiscogsUnavailableControl", () => {
           ),
       );
 
-      expect(messages).toHaveLength(1);
-      expect(messages).not.toContain("Failed to update Discogs availability");
+      expect(messages).toEqual([
+        "Server returned an unexpected response — please try again.",
+      ]);
     });
 
     it("leaves a request that never lands to the middleware", async () => {

--- a/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
@@ -372,6 +372,35 @@ describe("RotationClassifyControl", () => {
         await screen.findByRole("radiogroup", { name: "Rotation bin" }),
       ).toBeInTheDocument();
     });
+
+    // A route answering a mutation with HTML (an Express 404 page, a gateway
+    // 502) leaves the global middleware toasting only the raw JSON parse
+    // failure, so this control's own message is the only one naming what
+    // failed and must still fire.
+    it("shows an error toast when the POST comes back as HTML", async () => {
+      fakeRotationEndpoints();
+      server.use(
+        http.post(
+          `${TEST_BACKEND_URL}/library/rotation`,
+          () =>
+            new HttpResponse(
+              "<!DOCTYPE html><html><body>Cannot POST /library/rotation</body></html>",
+              { status: 404, headers: { "Content-Type": "text/html" } },
+            ),
+        ),
+      );
+      const { user } = renderWithProviders(
+        inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
+      );
+
+      await screen.findByRole("radiogroup", { name: "Rotation bin" });
+      await user.click(screen.getByRole("radio", { name: "M" }));
+      await user.click(screen.getByRole("button", { name: "Add to Rotation" }));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith("Failed to add to rotation"),
+      );
+    });
   });
 
   describe("kill-rotation flow", () => {

--- a/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
@@ -374,10 +374,10 @@ describe("RotationClassifyControl", () => {
     });
 
     // A route answering a mutation with HTML (an Express 404 page, a gateway
-    // 502) leaves the global middleware toasting only the raw JSON parse
-    // failure, so this control's own message is the only one naming what
-    // failed and must still fire.
-    it("shows an error toast when the POST comes back as HTML", async () => {
+    // 502) is the global middleware's to word; this control must not stack a
+    // vaguer second toast on top of it. Asserted as "something, but not our
+    // message", so improving that wording doesn't break this.
+    it("leaves a non-JSON POST response to the middleware", async () => {
       fakeRotationEndpoints();
       server.use(
         http.post(
@@ -397,9 +397,8 @@ describe("RotationClassifyControl", () => {
       await user.click(screen.getByRole("radio", { name: "M" }));
       await user.click(screen.getByRole("button", { name: "Add to Rotation" }));
 
-      await waitFor(() =>
-        expect(toast.error).toHaveBeenCalledWith("Failed to add to rotation"),
-      );
+      await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
+      expect(toast.error).not.toHaveBeenCalledWith("Failed to add to rotation");
     });
   });
 

--- a/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
+++ b/tests/integration/components/modern/Rightbar/panels/album/RotationClassifyControl.test.tsx
@@ -374,9 +374,9 @@ describe("RotationClassifyControl", () => {
     });
 
     // A route answering a mutation with HTML (an Express 404 page, a gateway
-    // 502) is the global middleware's to word; this control must not stack a
-    // vaguer second toast on top of it. Asserted as "something, but not our
-    // message", so improving that wording doesn't break this.
+    // 502) is the global middleware's to word: it toasts its own
+    // plain-language PARSING_ERROR line, and this control must not stack a
+    // vaguer second toast on top of it.
     it("leaves a non-JSON POST response to the middleware", async () => {
       fakeRotationEndpoints();
       server.use(
@@ -397,8 +397,12 @@ describe("RotationClassifyControl", () => {
       await user.click(screen.getByRole("radio", { name: "M" }));
       await user.click(screen.getByRole("button", { name: "Add to Rotation" }));
 
-      await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
-      expect(toast.error).not.toHaveBeenCalledWith("Failed to add to rotation");
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith(
+          "Server returned an unexpected response — please try again.",
+        ),
+      );
+      expect(toast.error).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/tests/unit/lib/features/catalog/patchSearchResult.test.ts
+++ b/tests/unit/lib/features/catalog/patchSearchResult.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createTestAlbum } from "@/tests/helpers";
+import { createTestAlbum, createTestArtist } from "@/tests/helpers";
 import type { AlbumEntry } from "@/lib/features/catalog/types";
 import { mergeAlbumIntoSearchResult } from "@/lib/features/catalog/patchSearchResult";
 
@@ -30,11 +30,50 @@ describe("mergeAlbumIntoSearchResult", () => {
 
     expect(merged.title).toBe("New Title");
     expect(merged.label).toBe("New Label");
-    expect(merged.entry).toBe(3);
+    // A nonzero entry from the response is the server's authoritative call
+    // number and must win over the cached one — see the reattribution test
+    // below for why.
+    expect(merged.entry).toBe(99);
     expect(merged.plays).toBe(12);
     expect(merged.matched_via).toEqual(existing.matched_via);
     expect(merged.artwork_url).toBe("https://example.com/art.jpg");
     expect(merged.rotation_id).toBe(99);
+  });
+
+  it("carries the server's reissued call number when re-attribution changes it", () => {
+    // updateAlbum can move an album onto a fresh call number when the newly
+    // linked artist already owns the album's current one (Backend-Service
+    // burns a new code_number). The cached search row must pick up both the
+    // new entry number and the new artist prefix, or it renders a call
+    // number that doesn't exist on the shelf.
+    const existing = createTestAlbum({
+      id: 42,
+      entry: 3,
+      artist: createTestArtist({ name: "Juana Molina", lettercode: "MO", numbercode: 12 }),
+    });
+    const updated = createTestAlbum({
+      id: 42,
+      entry: 47,
+      artist: createTestArtist({ name: "Jessica Pratt", lettercode: "PR", numbercode: 3 }),
+    });
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.entry).toBe(47);
+    expect(merged.artist.lettercode).toBe("PR");
+    expect(merged.artist.numbercode).toBe(3);
+  });
+
+  it("falls back to the cached entry when the response's code_number is the LML-only sentinel", () => {
+    // `entry: 0` isn't a real call number — it's convertToAlbumEntry's
+    // fallback for a row with no code_number at all — so it must not
+    // overwrite a cached row that does have one.
+    const existing = createTestAlbum({ id: 42, entry: 5 });
+    const updated = createTestAlbum({ id: 42, entry: 0 });
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.entry).toBe(5);
   });
 
   it("clears date_lost and date_found when mutation returns null", () => {

--- a/tests/unit/lib/features/catalog/patchSearchResult.test.ts
+++ b/tests/unit/lib/features/catalog/patchSearchResult.test.ts
@@ -67,13 +67,27 @@ describe("mergeAlbumIntoSearchResult", () => {
   it("falls back to the cached entry when the response's code_number is the LML-only sentinel", () => {
     // `entry: 0` isn't a real call number — it's convertToAlbumEntry's
     // fallback for a row with no code_number at all — so it must not
-    // overwrite a cached row that does have one.
-    const existing = createTestAlbum({ id: 42, entry: 5 });
-    const updated = createTestAlbum({ id: 42, entry: 0 });
+    // overwrite a cached row that does have one. The call number's three
+    // parts (lettercode, numbercode, entry) have to come from the same row:
+    // pairing the response's artist prefix with the cached entry digit would
+    // print a call number that belongs to neither row, so the fallback must
+    // carry the cached artist along with the cached entry, not just the entry.
+    const existing = createTestAlbum({
+      id: 42,
+      entry: 5,
+      artist: createTestArtist({ name: "Jessica Pratt", lettercode: "PR", numbercode: 3 }),
+    });
+    const updated = createTestAlbum({
+      id: 42,
+      entry: 0,
+      artist: createTestArtist({ name: "Juana Molina", lettercode: "MO", numbercode: 12 }),
+    });
 
     const merged = mergeAlbumIntoSearchResult(existing, updated);
 
     expect(merged.entry).toBe(5);
+    expect(merged.artist.lettercode).toBe("PR");
+    expect(merged.artist.numbercode).toBe(3);
   });
 
   it("clears date_lost and date_found when mutation returns null", () => {

--- a/tests/unit/lib/rtk-query-error-logger.test.ts
+++ b/tests/unit/lib/rtk-query-error-logger.test.ts
@@ -6,7 +6,6 @@ vi.mock("sonner", () => ({
 
 import {
   isUnmessagedHttpError,
-  isUnmessagedRejection,
   rtkQueryErrorLogger,
 } from "@/lib/rtk-query-error-logger";
 import { toast } from "sonner";
@@ -17,8 +16,6 @@ const mockToastError = toast.error as ReturnType<typeof vi.fn>;
 const FALLBACK = "Failed to update album";
 
 const SERVER_MESSAGE = "Artist is not catalogued in the selected genre";
-const PARSE_FAILURE =
-  "SyntaxError: Unexpected token '<', \"<html><bod\"... is not valid JSON";
 
 function rejectedAction(payload: unknown, { withValue = true } = {}) {
   return {
@@ -37,68 +34,49 @@ function rejectedAction(payload: unknown, { withValue = true } = {}) {
 }
 
 /**
- * Every shape `.unwrap()` can throw, and what a user is shown for it. `err` is
- * the value the caller's `catch` receives; `reachesMiddleware` is whether RTK
- * flags the action `rejectedWithValue` (a `SerializedError` — thrown when a
- * `transformResponse` throws or the request aborts — is not flagged, so the
- * middleware never runs for it); `toasts` is every message raised for a caller
- * that gates its fallback on `isUnmessagedRejection`, in order.
+ * Every shape `.unwrap()` can throw. `err` is the value the caller's `catch`
+ * receives; `reachesMiddleware` is whether RTK flags the action
+ * `rejectedWithValue` (a `SerializedError` — thrown when a `transformResponse`
+ * throws or the request aborts — is not flagged, so the middleware never runs
+ * for it); `toastCount` is how many messages the middleware raises on its own;
+ * `callerSpeaks` is whether a caller gating on `isUnmessagedHttpError` adds
+ * one. Exactly one of the two must be non-zero: a shape the middleware can
+ * describe must not be talked over, and a shape it cannot must not be silent.
  */
 const SHAPES: {
   name: string;
   err: unknown;
   reachesMiddleware: boolean;
-  toasts: string[];
-  unmessagedRejection: boolean;
-  unmessagedHttpError: boolean;
+  middlewareToasts: string[];
+  callerSpeaks: boolean;
 }[] = [
   {
     name: "HTTP error carrying the server's own reason",
     err: { status: 400, data: { message: SERVER_MESSAGE } },
     reachesMiddleware: true,
-    // The caller stays quiet: a generic second toast would bury the reason.
-    toasts: [SERVER_MESSAGE],
-    unmessagedRejection: false,
-    unmessagedHttpError: false,
+    middlewareToasts: [SERVER_MESSAGE],
+    callerSpeaks: false,
   },
   {
     name: "HTTP error with no message in the body",
     err: { status: 500, data: { error: "rejected" } },
     reachesMiddleware: true,
-    toasts: [FALLBACK],
-    unmessagedRejection: true,
-    unmessagedHttpError: true,
-  },
-  {
-    name: "PARSING_ERROR from an HTML body",
-    err: {
-      status: "PARSING_ERROR",
-      originalStatus: 404,
-      data: "<!DOCTYPE html><html><body>Cannot PATCH /library/4242</body></html>",
-      error: PARSE_FAILURE,
-    },
-    reachesMiddleware: true,
-    // The middleware's own toast is the raw parse failure, which names neither
-    // the operation nor anything the user can act on.
-    toasts: [PARSE_FAILURE, FALLBACK],
-    unmessagedRejection: true,
-    unmessagedHttpError: false,
+    middlewareToasts: [],
+    callerSpeaks: true,
   },
   {
     name: "FETCH_ERROR",
     err: { status: "FETCH_ERROR", error: "TypeError: Failed to fetch" },
     reachesMiddleware: true,
-    toasts: ["Network error — please check your connection.", FALLBACK],
-    unmessagedRejection: true,
-    unmessagedHttpError: false,
+    middlewareToasts: ["Network error — please check your connection."],
+    callerSpeaks: false,
   },
   {
     name: "TIMEOUT_ERROR",
     err: { status: "TIMEOUT_ERROR", error: "AbortError: The user aborted a request." },
     reachesMiddleware: true,
-    toasts: ["Request timed out — please try again.", FALLBACK],
-    unmessagedRejection: true,
-    unmessagedHttpError: false,
+    middlewareToasts: ["Request timed out — please try again."],
+    callerSpeaks: false,
   },
   {
     name: "SerializedError thrown by a transformResponse",
@@ -108,13 +86,12 @@ const SHAPES: {
       stack: "TypeError: Cannot use 'in' operator…",
     },
     reachesMiddleware: false,
-    toasts: [FALLBACK],
-    unmessagedRejection: true,
-    unmessagedHttpError: false,
+    middlewareToasts: [],
+    callerSpeaks: true,
   },
 ];
 
-describe("rejection-shape gates", () => {
+describe("rejection-shape gate", () => {
   const next = vi.fn((action: unknown) => action);
   const api = { dispatch: vi.fn(), getState: vi.fn() };
   const middleware = rtkQueryErrorLogger(api)(next);
@@ -123,28 +100,42 @@ describe("rejection-shape gates", () => {
     vi.clearAllMocks();
   });
 
-  // A control whose fallback is the only message naming what failed must end up
-  // with at least one plain-language toast in every shape, and must never add a
-  // vaguer one on top of a reason the server supplied.
-  it.each(SHAPES)("$name", ({ err, reachesMiddleware, toasts }) => {
-    middleware(rejectedAction(err, { withValue: reachesMiddleware }));
-    if (isUnmessagedRejection(err)) {
-      toast.error(FALLBACK);
-    }
+  it.each(SHAPES)(
+    "$name leaves the user exactly one message",
+    ({ err, reachesMiddleware, middlewareToasts, callerSpeaks }) => {
+      middleware(rejectedAction(err, { withValue: reachesMiddleware }));
+      expect(mockToastError.mock.calls.map(([message]) => message)).toEqual(
+        middlewareToasts,
+      );
 
-    expect(mockToastError.mock.calls.map(([message]) => message)).toEqual(toasts);
+      if (isUnmessagedHttpError(err)) {
+        toast.error(FALLBACK);
+      }
+
+      expect(mockToastError.mock.calls.map(([message]) => message)).toEqual(
+        callerSpeaks ? [...middlewareToasts, FALLBACK] : middlewareToasts,
+      );
+    },
+  );
+
+  it.each(SHAPES)("$name — gate", ({ err, callerSpeaks }) => {
+    expect(isUnmessagedHttpError(err)).toBe(callerSpeaks);
   });
 
-  it.each(SHAPES)("$name — isUnmessagedRejection", ({ err, unmessagedRejection }) => {
-    expect(isUnmessagedRejection(err)).toBe(unmessagedRejection);
-  });
-
-  // The narrow gate answers only "HTTP error with no body message", so it is
-  // false for every transport-level and non-HTTP rejection. A caller gating a
-  // sole fallback on it goes silent exactly where the middleware's own toast is
-  // unusable or absent.
-  it.each(SHAPES)("$name — isUnmessagedHttpError", ({ err, unmessagedHttpError }) => {
-    expect(isUnmessagedHttpError(err)).toBe(unmessagedHttpError);
+  // A `PARSING_ERROR` is a mutation answered with a body that isn't JSON — a
+  // gateway's HTML error page, or a route that isn't there. It carries a
+  // string status, so the middleware owns the wording and the caller keeps out
+  // of it; the raw parser complaint it falls through to today is a middleware
+  // concern, not a reason for a second toast here.
+  it("leaves a PARSING_ERROR to the middleware", () => {
+    expect(
+      isUnmessagedHttpError({
+        status: "PARSING_ERROR",
+        originalStatus: 404,
+        data: "<!DOCTYPE html><html><body>Cannot PATCH /library/4242</body></html>",
+        error: "SyntaxError: Unexpected token '<'",
+      }),
+    ).toBe(false);
   });
 
   it.each([
@@ -152,16 +143,9 @@ describe("rejection-shape gates", () => {
     ["a non-string server message", { status: 409, data: { message: 42 } }],
     ["a string body", { status: 502, data: "Bad Gateway" }],
     ["no body at all", { status: 503 }],
-  ])("treats %s as unmessaged", (_case, err) => {
-    expect(isUnmessagedRejection(err)).toBe(true);
-    expect(isUnmessagedHttpError(err)).toBe(true);
-  });
-
-  it.each([
     ["a thrown string", "boom"],
     ["undefined", undefined],
-  ])("treats %s as unmessaged but not as an HTTP error", (_case, err) => {
-    expect(isUnmessagedRejection(err)).toBe(true);
-    expect(isUnmessagedHttpError(err)).toBe(false);
+  ])("makes the caller speak for %s", (_case, err) => {
+    expect(isUnmessagedHttpError(err)).toBe(true);
   });
 });

--- a/tests/unit/lib/rtk-query-error-logger.test.ts
+++ b/tests/unit/lib/rtk-query-error-logger.test.ts
@@ -89,6 +89,18 @@ const SHAPES: {
     middlewareToasts: [],
     callerSpeaks: true,
   },
+  {
+    // RTK's own documented `rejectWithValue(payload)` shape for a bare
+    // string error — no `status` at all, unlike every other shape above.
+    // The middleware's `error`-string branch fires on this regardless of
+    // `status`, so a predicate that reads "no `status`" as "middleware said
+    // nothing" doubles the toast.
+    name: "no-status rejectWithValue payload carrying only `error`",
+    err: { error: "Oh no!" },
+    reachesMiddleware: true,
+    middlewareToasts: ["Oh no!"],
+    callerSpeaks: false,
+  },
 ];
 
 describe("rejection-shape gate", () => {
@@ -123,10 +135,8 @@ describe("rejection-shape gate", () => {
   });
 
   // A `PARSING_ERROR` is a mutation answered with a body that isn't JSON — a
-  // gateway's HTML error page, or a route that isn't there. It carries a
-  // string status, so the middleware owns the wording and the caller keeps out
-  // of it; the raw parser complaint it falls through to today is a middleware
-  // concern, not a reason for a second toast here.
+  // gateway's HTML error page, or a route that isn't there. The middleware
+  // owns a plain-language line for it, so the caller keeps out of it.
   it("leaves a PARSING_ERROR to the middleware", () => {
     expect(
       isUnmessagedHttpError({

--- a/tests/unit/lib/rtk-query-error-logger.test.ts
+++ b/tests/unit/lib/rtk-query-error-logger.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import {
+  isUnmessagedHttpError,
+  isUnmessagedRejection,
+  rtkQueryErrorLogger,
+} from "@/lib/rtk-query-error-logger";
+import { toast } from "sonner";
+
+const mockToastError = toast.error as ReturnType<typeof vi.fn>;
+
+/** The generic message a caller raises when nothing else names the failure. */
+const FALLBACK = "Failed to update album";
+
+const SERVER_MESSAGE = "Artist is not catalogued in the selected genre";
+const PARSE_FAILURE =
+  "SyntaxError: Unexpected token '<', \"<html><bod\"... is not valid JSON";
+
+function rejectedAction(payload: unknown, { withValue = true } = {}) {
+  return {
+    type: "catalogApi/executeMutation/rejected",
+    payload: withValue ? payload : undefined,
+    error: withValue ? undefined : payload,
+    meta: {
+      rejectedWithValue: withValue,
+      requestId: "test-req",
+      requestStatus: "rejected" as const,
+      aborted: false,
+      condition: false,
+      arg: { endpointName: "updateAlbum" },
+    },
+  };
+}
+
+/**
+ * Every shape `.unwrap()` can throw, and what a user is shown for it. `err` is
+ * the value the caller's `catch` receives; `reachesMiddleware` is whether RTK
+ * flags the action `rejectedWithValue` (a `SerializedError` — thrown when a
+ * `transformResponse` throws or the request aborts — is not flagged, so the
+ * middleware never runs for it); `toasts` is every message raised for a caller
+ * that gates its fallback on `isUnmessagedRejection`, in order.
+ */
+const SHAPES: {
+  name: string;
+  err: unknown;
+  reachesMiddleware: boolean;
+  toasts: string[];
+  unmessagedRejection: boolean;
+  unmessagedHttpError: boolean;
+}[] = [
+  {
+    name: "HTTP error carrying the server's own reason",
+    err: { status: 400, data: { message: SERVER_MESSAGE } },
+    reachesMiddleware: true,
+    // The caller stays quiet: a generic second toast would bury the reason.
+    toasts: [SERVER_MESSAGE],
+    unmessagedRejection: false,
+    unmessagedHttpError: false,
+  },
+  {
+    name: "HTTP error with no message in the body",
+    err: { status: 500, data: { error: "rejected" } },
+    reachesMiddleware: true,
+    toasts: [FALLBACK],
+    unmessagedRejection: true,
+    unmessagedHttpError: true,
+  },
+  {
+    name: "PARSING_ERROR from an HTML body",
+    err: {
+      status: "PARSING_ERROR",
+      originalStatus: 404,
+      data: "<!DOCTYPE html><html><body>Cannot PATCH /library/4242</body></html>",
+      error: PARSE_FAILURE,
+    },
+    reachesMiddleware: true,
+    // The middleware's own toast is the raw parse failure, which names neither
+    // the operation nor anything the user can act on.
+    toasts: [PARSE_FAILURE, FALLBACK],
+    unmessagedRejection: true,
+    unmessagedHttpError: false,
+  },
+  {
+    name: "FETCH_ERROR",
+    err: { status: "FETCH_ERROR", error: "TypeError: Failed to fetch" },
+    reachesMiddleware: true,
+    toasts: ["Network error — please check your connection.", FALLBACK],
+    unmessagedRejection: true,
+    unmessagedHttpError: false,
+  },
+  {
+    name: "TIMEOUT_ERROR",
+    err: { status: "TIMEOUT_ERROR", error: "AbortError: The user aborted a request." },
+    reachesMiddleware: true,
+    toasts: ["Request timed out — please try again.", FALLBACK],
+    unmessagedRejection: true,
+    unmessagedHttpError: false,
+  },
+  {
+    name: "SerializedError thrown by a transformResponse",
+    err: {
+      name: "TypeError",
+      message: "Cannot use 'in' operator to search for 'id' in null",
+      stack: "TypeError: Cannot use 'in' operator…",
+    },
+    reachesMiddleware: false,
+    toasts: [FALLBACK],
+    unmessagedRejection: true,
+    unmessagedHttpError: false,
+  },
+];
+
+describe("rejection-shape gates", () => {
+  const next = vi.fn((action: unknown) => action);
+  const api = { dispatch: vi.fn(), getState: vi.fn() };
+  const middleware = rtkQueryErrorLogger(api)(next);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // A control whose fallback is the only message naming what failed must end up
+  // with at least one plain-language toast in every shape, and must never add a
+  // vaguer one on top of a reason the server supplied.
+  it.each(SHAPES)("$name", ({ err, reachesMiddleware, toasts }) => {
+    middleware(rejectedAction(err, { withValue: reachesMiddleware }));
+    if (isUnmessagedRejection(err)) {
+      toast.error(FALLBACK);
+    }
+
+    expect(mockToastError.mock.calls.map(([message]) => message)).toEqual(toasts);
+  });
+
+  it.each(SHAPES)("$name — isUnmessagedRejection", ({ err, unmessagedRejection }) => {
+    expect(isUnmessagedRejection(err)).toBe(unmessagedRejection);
+  });
+
+  // The narrow gate answers only "HTTP error with no body message", so it is
+  // false for every transport-level and non-HTTP rejection. A caller gating a
+  // sole fallback on it goes silent exactly where the middleware's own toast is
+  // unusable or absent.
+  it.each(SHAPES)("$name — isUnmessagedHttpError", ({ err, unmessagedHttpError }) => {
+    expect(isUnmessagedHttpError(err)).toBe(unmessagedHttpError);
+  });
+
+  it.each([
+    ["a whitespace-only server message", { status: 409, data: { message: "   " } }],
+    ["a non-string server message", { status: 409, data: { message: 42 } }],
+    ["a string body", { status: 502, data: "Bad Gateway" }],
+    ["no body at all", { status: 503 }],
+  ])("treats %s as unmessaged", (_case, err) => {
+    expect(isUnmessagedRejection(err)).toBe(true);
+    expect(isUnmessagedHttpError(err)).toBe(true);
+  });
+
+  it.each([
+    ["a thrown string", "boom"],
+    ["undefined", undefined],
+  ])("treats %s as unmessaged but not as an HTTP error", (_case, err) => {
+    expect(isUnmessagedRejection(err)).toBe(true);
+    expect(isUnmessagedHttpError(err)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `AlbumEditForm`, mounted inline in the album Rightbar panel's `AlbumCard` beside the existing `DiscogsUnavailableControl` (not a modal), MD-gated via `RequireMD`.
- One Save button batches title/label/genre/format/artist-link/alternate-artist-name/disc-quantity edits into exactly one `PATCH /library/:id`, carrying only the fields that changed.
- Reuses the shared `ArtistSearchTypeahead` for the artist link and wires its required `onSelectionCleared`. That component only retracts selections it confirmed via its own `onSelect`, so it can't see a link this form seeded straight from `album.artist_id`. This form additionally invalidates that seeded link itself when `genre_id` changes (artist rows are genre-scoped), and blocks Save until a fresh pick resolves the artist under the new genre — so no PATCH can ever carry a genre_id/artist_id pair resolved under different genres.
- Widens the local `UpdateAlbumRequestBody` (`lib/features/catalog/types.ts`) so `alternate_artist_name` and `label_id` accept `null`, matching the published contract and Backend-Service's accepted fields, and lets the form send explicit `null` to clear either. Clearing Label routes through `label_id: null` (Backend-Service rejects an empty `label` string, and rejects `label` combined with `label_id: null` in the same request). An empty Title, and clearing a previously-set Disc Quantity, block Save instead of reaching the request.
- `album_artist` renders read-only with a short explanatory note and is never included in the outgoing PATCH body.

## Test plan

- [x] `npx vitest run tests/integration/components/modern/Rightbar/panels/album/` — 76/76 passing, including the new `AlbumEditForm.test.tsx` (permission gating, seeded initial state, partial-update PATCH body, album_artist exclusion, null-clearing for `alternate_artist_name`/label via `label_id`, required-field guards for Title/Disc Quantity, and the genre-change/seeded-artist invalidation scenarios) and the existing `DiscogsUnavailableControl`/`AlbumCard` tests (unaffected).
- [x] `npx vitest run` — full suite green, 298 files / 4027 tests.
- [x] `npx tsc --noEmit -p .` — clean.
- [x] `npm run lint` — 0 errors, no new warnings.

Closes #1076