### PR TITLE
MD catalog-edit UI: add-release panel (basic, non-V/A)

### DIFF
--- a/app/dashboard/@modern/catalog/page.tsx
+++ b/app/dashboard/@modern/catalog/page.tsx
@@ -4,6 +4,7 @@ import MobileSearchBar from "@/src/components/experiences/modern/catalog/Search/
 import SearchBar from "@/src/components/experiences/modern/catalog/Search/SearchBar";
 import Results from "@/src/components/experiences/modern/catalog/Results/Results";
 import AddReleasePanel from "@/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel";
+import ArtistAddPanel from "@/src/components/experiences/modern/catalog/ArtistAddPanel";
 import { Metadata } from "next";
 import { getPageTitle } from "@/lib/utils/page-title";
 
@@ -15,6 +16,7 @@ export default function CatalogPage() {
   return (
     <>
       <PageHeader title="Card Catalog">
+        <ArtistAddPanel />
         <AddReleasePanel />
       </PageHeader>
       <>

--- a/app/dashboard/@modern/catalog/page.tsx
+++ b/app/dashboard/@modern/catalog/page.tsx
@@ -3,6 +3,7 @@ import PageHeader from "@/src/components/experiences/modern/Header/PageHeader";
 import MobileSearchBar from "@/src/components/experiences/modern/catalog/Search/MobileSearchBar";
 import SearchBar from "@/src/components/experiences/modern/catalog/Search/SearchBar";
 import Results from "@/src/components/experiences/modern/catalog/Results/Results";
+import AddReleasePanel from "@/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel";
 import { Metadata } from "next";
 import { getPageTitle } from "@/lib/utils/page-title";
 
@@ -13,7 +14,9 @@ export const metadata: Metadata = {
 export default function CatalogPage() {
   return (
     <>
-      <PageHeader title="Card Catalog" />
+      <PageHeader title="Card Catalog">
+        <AddReleasePanel />
+      </PageHeader>
       <>
         <MobileSearchBar color="primary" />
         <SearchBar color="primary" />

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -118,11 +118,9 @@ export const catalogApi = createApi({
         body,
       }),
       // The POST response isn't a full AlbumEntry and the browse is a
-      // paginated/sorted infinite query, so a new row can't be patched into the
-      // cache coherently (its correct page may be unloaded). Invalidate the
-      // list instead so the panel refetches — dj-site#624. No UI dispatches
-      // this mutation yet; the tag is wired so the first adopter gets correct
-      // cache behavior instead of the stale-list bug #624 documented.
+      // paginated/sorted infinite query, so a new row can't be patched into
+      // the cache coherently (its correct page may be unloaded). Invalidate
+      // the list instead so the panel refetches.
       invalidatesTags: [{ type: "CatalogList", id: "LIST" }],
     }),
     updateAlbum: builder.mutation<AlbumEntry, { albumId: number; body: UpdateAlbumRequestBody }>({

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -175,8 +175,11 @@ export const catalogApi = createApi({
         delete data.message;
         return { ...error, data };
       },
-      // A new artist would surface in the artist typeahead (searchArtistsInGenre)
-      // and can gate later album rows; refetch both rather than patch.
+      // A new artist can appear in the artist typeahead (searchArtistsInGenre)
+      // and gates the album rows filed under it, and neither cache can absorb
+      // the row by patch: typeahead entries are keyed by the search args the
+      // new name may not match, and the browse is a paginated/sorted infinite
+      // query whose correct page may be unloaded. Invalidate both instead.
       // Also invalidate the peek-code preview for the exact code_letters/genre_id
       // pair just filled: without this, a cached preview for that pair keeps
       // showing the pre-add code number to an MD who revisits it in the same

--- a/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { AddCircle } from "@mui/icons-material";
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Modal,
+  ModalClose,
+  ModalDialog,
+  Option,
+  Select,
+  Sheet,
+  Stack,
+  Typography,
+} from "@mui/joy";
+import { RequireMD } from "@/src/components/shared/Authorization";
+import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTypeahead";
+import {
+  useAddAlbumMutation,
+  useGetFormatsQuery,
+  useGetGenresQuery,
+} from "@/lib/features/catalog/api";
+import type { AddAlbumRequestBody, ArtistInGenreOption } from "@/lib/features/catalog/types";
+import type { LabelRow } from "@/lib/features/labels/types";
+import LabelSearchTypeahead from "./LabelSearchTypeahead";
+
+/**
+ * Exact 400 message `addAlbum` sends when an `artist_name` fails genre-scoped
+ * resolution. Matched by value rather than by status code alone — a 400 can
+ * also mean a blank album_title — so this form only offers the artist-add
+ * route for the one failure that actually means "this artist isn't filed
+ * here yet".
+ */
+const GENRE_SCOPED_ARTIST_MISS_MESSAGE =
+  "Artist doesn't exist or hasn't released an album in this genre before. Add a new artist entry to the library";
+
+function serverErrorMessage(err: unknown): string | undefined {
+  if (!err || typeof err !== "object" || !("data" in err)) return undefined;
+  const { data } = err as { data?: unknown };
+  if (!data || typeof data !== "object") return undefined;
+  const { message } = data as { message?: unknown };
+  return typeof message === "string" ? message : undefined;
+}
+
+function emptyForm() {
+  return {
+    albumTitle: "",
+    genreId: null as number | null,
+    formatId: null as number | null,
+    artistName: "",
+    artistId: null as number | null,
+    labelName: "",
+    labelId: null as number | null,
+  };
+}
+
+function AddReleaseForm() {
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState(emptyForm);
+  // Set on a genre-scoped artist miss (backend 400) or on the typeahead's own
+  // "create new artist" pick — both mean the same thing: this exact text
+  // names no artist filed under the chosen genre. The panel routes the MD
+  // toward the (separate) artist-add form rather than dead-ending on a raw
+  // error.
+  const [artistNotFound, setArtistNotFound] = useState<
+    { term: string; genreId: number } | null
+  >(null);
+
+  const { data: genres } = useGetGenresQuery();
+  const { data: formats } = useGetFormatsQuery();
+  const [addAlbum, { isLoading }] = useAddAlbumMutation();
+
+  const closePanel = () => {
+    setOpen(false);
+    setForm(emptyForm());
+    setArtistNotFound(null);
+  };
+
+  const handleGenreChange = (_: unknown, value: number | null) => {
+    // Artist rows are genre-scoped (ArtistSearchTypeahead's own invariant),
+    // so a resolved artist_id from the old genre names no row under the new
+    // one; clearing it here keeps the typeahead's own retraction from being
+    // the only thing standing between a genre swap and a misfiled release.
+    setForm((f) => ({ ...f, genreId: value, artistId: null }));
+    setArtistNotFound(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setArtistNotFound(null);
+
+    const albumTitle = form.albumTitle.trim();
+    const artistName = form.artistName.trim();
+    const labelName = form.labelName.trim();
+    const hasArtist = form.artistId !== null || artistName.length > 0;
+
+    if (!albumTitle || !form.genreId || !form.formatId || !hasArtist || !labelName) {
+      toast.error("Album title, genre, format, artist, and label are all required");
+      return;
+    }
+
+    const body: AddAlbumRequestBody = {
+      album_title: albumTitle,
+      label: labelName,
+      genre_id: form.genreId,
+      format_id: form.formatId,
+    };
+    // A resolved artist_id is sent wherever the MD picked an existing artist:
+    // only the id skips the genre-scoped name resolution that can 400, and an
+    // explicit id short-circuits that resolution entirely.
+    if (form.artistId !== null) {
+      body.artist_id = form.artistId;
+    }
+    // artist_name rides along even when the id resolves the artist, because
+    // resolution is not its only job: the name is also the sole artist input to
+    // the post-insert metadata enrichment the backend kicks off. Omitting it
+    // there leaves that lookup with an empty artist, which loses the artwork
+    // and makes the enrichment cache key collide across every release that
+    // shares an album title.
+    if (artistName) {
+      body.artist_name = artistName;
+    }
+    if (form.labelId !== null) {
+      body.label_id = form.labelId;
+    }
+    // album_artist is declared on the shared AddAlbumRequest type but the
+    // backend silently drops it — never send it. code_number is assigned
+    // server-side here — never send it either.
+
+    try {
+      await addAlbum(body).unwrap();
+      closePanel();
+    } catch (err) {
+      if (serverErrorMessage(err) === GENRE_SCOPED_ARTIST_MISS_MESSAGE && form.genreId) {
+        setArtistNotFound({ term: artistName, genreId: form.genreId });
+      }
+      // Every rejection, this one included, has already been toasted with the
+      // server's message by the global rtkQueryErrorLogger middleware — it
+      // fires on the rejected action itself and has no per-endpoint opt-out.
+      // The guidance above therefore adds a route out of the miss; it does not
+      // replace the toast.
+    }
+  };
+
+  return (
+    <>
+      <Button startDecorator={<AddCircle />} onClick={() => setOpen(true)}>
+        Add Release
+      </Button>
+      <Modal open={open} onClose={closePanel}>
+        <ModalDialog sx={{ maxWidth: 480, width: "100%" }}>
+          <ModalClose />
+          <Typography level="title-lg">Add Release</Typography>
+          <form onSubmit={handleSubmit}>
+            <Stack spacing={1.5}>
+              <FormControl required>
+                <FormLabel>Album title</FormLabel>
+                <Input
+                  value={form.albumTitle}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, albumTitle: e.target.value }))
+                  }
+                />
+              </FormControl>
+
+              <FormControl required>
+                <FormLabel>Genre</FormLabel>
+                <Select
+                  aria-label="Genre"
+                  value={form.genreId}
+                  onChange={handleGenreChange}
+                  placeholder="Choose a genre..."
+                >
+                  {(genres ?? []).map((genre) => (
+                    <Option key={genre.id} value={genre.id}>
+                      {genre.genre_name}
+                    </Option>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <FormControl required>
+                <FormLabel>Format</FormLabel>
+                <Select
+                  aria-label="Format"
+                  value={form.formatId}
+                  onChange={(_, value: number | null) =>
+                    setForm((f) => ({ ...f, formatId: value }))
+                  }
+                  placeholder="Choose a format..."
+                >
+                  {(formats ?? []).map((format) => (
+                    <Option key={format.id} value={format.id}>
+                      {format.format_name}
+                    </Option>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <FormControl required>
+                <FormLabel>Artist</FormLabel>
+                {form.genreId !== null ? (
+                  <ArtistSearchTypeahead
+                    genreId={form.genreId}
+                    value={form.artistName}
+                    onChange={(value) => {
+                      setForm((f) => ({ ...f, artistName: value }));
+                      // The guidance names the exact term that missed, so it
+                      // stops describing the field the moment that term is
+                      // edited.
+                      setArtistNotFound(null);
+                    }}
+                    onSelect={(artist: ArtistInGenreOption) => {
+                      setForm((f) => ({ ...f, artistId: artist.id }));
+                      setArtistNotFound(null);
+                    }}
+                    onCreateNew={(term) => {
+                      // Choosing to create says this text names no existing
+                      // artist, which retires any id picked earlier under the
+                      // same text — the typeahead only retracts on an edit, and
+                      // there is none on this path. Left standing, the id would
+                      // file the release against the very artist the panel is
+                      // telling the MD does not exist yet.
+                      setForm((f) => ({ ...f, artistId: null }));
+                      setArtistNotFound({ term, genreId: form.genreId as number });
+                    }}
+                    onSelectionCleared={() =>
+                      setForm((f) => ({ ...f, artistId: null }))
+                    }
+                  />
+                ) : (
+                  <Input disabled placeholder="Choose a genre first" />
+                )}
+              </FormControl>
+
+              {artistNotFound && (
+                <Sheet
+                  variant="soft"
+                  color="warning"
+                  role="status"
+                  sx={{ p: 1, borderRadius: "sm" }}
+                >
+                  <Typography level="body-sm">
+                    {`"${artistNotFound.term}" isn't filed under ${
+                      genres?.find((g) => g.id === artistNotFound.genreId)
+                        ?.genre_name ?? "this genre"
+                    } yet. Add it as a new artist, then come back and add this release.`}
+                  </Typography>
+                </Sheet>
+              )}
+
+              <FormControl required>
+                <FormLabel>Label</FormLabel>
+                <LabelSearchTypeahead
+                  value={form.labelName}
+                  onChange={(value) =>
+                    setForm((f) => ({ ...f, labelName: value }))
+                  }
+                  onSelect={(label: LabelRow) =>
+                    setForm((f) => ({ ...f, labelId: label.id }))
+                  }
+                  onSelectionCleared={() =>
+                    setForm((f) => ({ ...f, labelId: null }))
+                  }
+                />
+              </FormControl>
+
+              <Stack direction="row" justifyContent="flex-end">
+                <Button type="submit" loading={isLoading}>
+                  Save Release
+                </Button>
+              </Stack>
+            </Stack>
+          </form>
+        </ModalDialog>
+      </Modal>
+    </>
+  );
+}
+
+export default function AddReleasePanel() {
+  return (
+    <RequireMD>
+      <AddReleaseForm />
+    </RequireMD>
+  );
+}

--- a/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { AddCircle } from "@mui/icons-material";
 import {
@@ -19,12 +19,14 @@ import {
 } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
 import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTypeahead";
+import { useAppDispatch } from "@/lib/hooks";
 import {
   useAddAlbumMutation,
   useGetFormatsQuery,
   useGetGenresQuery,
 } from "@/lib/features/catalog/api";
 import type { AddAlbumRequestBody, ArtistInGenreOption } from "@/lib/features/catalog/types";
+import { labelsApi } from "@/lib/features/labels/api";
 import type { LabelRow } from "@/lib/features/labels/types";
 import LabelSearchTypeahead from "./LabelSearchTypeahead";
 
@@ -59,6 +61,7 @@ function emptyForm() {
 }
 
 function AddReleaseForm() {
+  const dispatch = useAppDispatch();
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState(emptyForm);
   // Set on a genre-scoped artist miss (backend 400) or on the typeahead's own
@@ -69,15 +72,44 @@ function AddReleaseForm() {
   const [artistNotFound, setArtistNotFound] = useState<
     { term: string; genreId: number } | null
   >(null);
+  // Live mirror of the artist field: the submit handler's catch runs after an
+  // awaited rejection, by which point a still-mounted panel may have moved on
+  // to a different typed term. Reading this instead of the term captured at
+  // submit time is what lets the catch refuse to relabel guidance onto text
+  // the MD has since edited away from.
+  const artistNameRef = useRef(form.artistName);
+  artistNameRef.current = form.artistName;
 
-  const { data: genres } = useGetGenresQuery();
-  const { data: formats } = useGetFormatsQuery();
+  // Skipped until the dialog is open: these two lookups are static enough to
+  // cache indefinitely, but every catalog page load by an MD would otherwise
+  // fetch both on mount for a dialog usually never opened.
+  const { data: genres } = useGetGenresQuery(undefined, { skip: !open });
+  const { data: formats } = useGetFormatsQuery(undefined, { skip: !open });
   const [addAlbum, { isLoading }] = useAddAlbumMutation();
 
   const closePanel = () => {
     setOpen(false);
     setForm(emptyForm());
     setArtistNotFound(null);
+  };
+
+  const hasUnsavedInput = () =>
+    form.albumTitle.trim() !== "" ||
+    form.genreId !== null ||
+    form.formatId !== null ||
+    form.artistName.trim() !== "" ||
+    form.labelName.trim() !== "";
+
+  // Modal's onClose fires for a backdrop click, an Escape that reaches the
+  // dialog, and the close button alike — all three would otherwise wipe a
+  // part-filled form with no undo. A confirm only interrupts the two
+  // accidental paths; the submit handler calls closePanel directly so a
+  // completed save never asks the MD to confirm work they already finished.
+  const handleDismiss = () => {
+    if (hasUnsavedInput() && !confirm("Discard this release? Nothing has been saved yet.")) {
+      return;
+    }
+    closePanel();
   };
 
   const handleGenreChange = (_: unknown, value: number | null) => {
@@ -133,9 +165,29 @@ function AddReleaseForm() {
 
     try {
       await addAlbum(body).unwrap();
+      // A free-typed label with no resolved id means the backend just
+      // upserted a new row from `body.label`. labelsApi's searchLabels only
+      // reads, so nothing else invalidates its cache — without this, a
+      // reopened picker searching this same name within the 60s cache
+      // window still shows the stale empty (or prior) result and offers to
+      // create the very near-duplicate this field exists to prevent.
+      if (form.labelId === null) {
+        dispatch(labelsApi.util.invalidateTags([{ type: "LabelSearch", id: "LIST" }]));
+      }
+      // Closing on success looks identical to an accidental dismissal
+      // without this: both leave the MD looking at the catalog page with no
+      // dialog open, which invites a duplicate re-add of the same release.
+      toast.success(`Added "${albumTitle}" to the catalog`);
       closePanel();
     } catch (err) {
-      if (serverErrorMessage(err) === GENRE_SCOPED_ARTIST_MISS_MESSAGE && form.genreId) {
+      // The field's own onChange already cleared any guidance the moment the
+      // MD edited it; re-checking here guards the other direction, where the
+      // edit happens first and this stale rejection arrives after.
+      if (
+        serverErrorMessage(err) === GENRE_SCOPED_ARTIST_MISS_MESSAGE &&
+        form.genreId &&
+        artistNameRef.current === artistName
+      ) {
         setArtistNotFound({ term: artistName, genreId: form.genreId });
       }
       // Every rejection, this one included, has already been toasted with the
@@ -151,7 +203,7 @@ function AddReleaseForm() {
       <Button startDecorator={<AddCircle />} onClick={() => setOpen(true)}>
         Add Release
       </Button>
-      <Modal open={open} onClose={closePanel}>
+      <Modal open={open} onClose={handleDismiss}>
         <ModalDialog sx={{ maxWidth: 480, width: "100%" }}>
           <ModalClose />
           <Typography level="title-lg">Add Release</Typography>

--- a/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel.tsx
@@ -72,13 +72,25 @@ function AddReleaseForm() {
   const [artistNotFound, setArtistNotFound] = useState<
     { term: string; genreId: number } | null
   >(null);
-  // Live mirror of the artist field: the submit handler's catch runs after an
-  // awaited rejection, by which point a still-mounted panel may have moved on
-  // to a different typed term. Reading this instead of the term captured at
-  // submit time is what lets the catch refuse to relabel guidance onto text
-  // the MD has since edited away from.
-  const artistNameRef = useRef(form.artistName);
-  artistNameRef.current = form.artistName;
+  // Bumped whenever the artist text or the genre changes — including the
+  // reset a close (or a close-then-reopen) performs, since that also changes
+  // both away from whatever a request in flight was submitted with. Compared
+  // against a snapshot taken at submit time, this is what lets the async
+  // continuation after an awaited request tell "nothing relevant has moved"
+  // from "the panel now describes a different artist, genre, or release
+  // entirely" — a plain field-vs-closure comparison of just the artist text
+  // covers only one of those axes and misses the other.
+  const formGenerationRef = useRef(0);
+  const artistNameAtRenderRef = useRef(form.artistName);
+  const genreIdAtRenderRef = useRef(form.genreId);
+  if (
+    artistNameAtRenderRef.current !== form.artistName ||
+    genreIdAtRenderRef.current !== form.genreId
+  ) {
+    artistNameAtRenderRef.current = form.artistName;
+    genreIdAtRenderRef.current = form.genreId;
+    formGenerationRef.current += 1;
+  }
 
   // Skipped until the dialog is open: these two lookups are static enough to
   // cache indefinitely, but every catalog page load by an MD would otherwise
@@ -105,7 +117,12 @@ function AddReleaseForm() {
   // part-filled form with no undo. A confirm only interrupts the two
   // accidental paths; the submit handler calls closePanel directly so a
   // completed save never asks the MD to confirm work they already finished.
+  // Dismissal is refused outright while a save is in flight rather than
+  // asking the confirm question at all: the request can still succeed a
+  // moment later and create the row anyway, which would make "nothing has
+  // been saved yet" false by the time the MD reads it.
   const handleDismiss = () => {
+    if (isLoading) return;
     if (hasUnsavedInput() && !confirm("Discard this release? Nothing has been saved yet.")) {
       return;
     }
@@ -130,15 +147,22 @@ function AddReleaseForm() {
     const labelName = form.labelName.trim();
     const hasArtist = form.artistId !== null || artistName.length > 0;
 
-    if (!albumTitle || !form.genreId || !form.formatId || !hasArtist || !labelName) {
+    if (
+      !albumTitle ||
+      form.genreId === null ||
+      form.formatId === null ||
+      !hasArtist ||
+      !labelName
+    ) {
       toast.error("Album title, genre, format, artist, and label are all required");
       return;
     }
+    const genreId = form.genreId;
 
     const body: AddAlbumRequestBody = {
       album_title: albumTitle,
       label: labelName,
-      genre_id: form.genreId,
+      genre_id: genreId,
       format_id: form.formatId,
     };
     // A resolved artist_id is sent wherever the MD picked an existing artist:
@@ -163,6 +187,15 @@ function AddReleaseForm() {
     // backend silently drops it — never send it. code_number is assigned
     // server-side here — never send it either.
 
+    // Every field is disabled for the duration of this request (see the
+    // `disabled={isLoading}` props below), so in the ordinary case nothing
+    // can change before it settles. This is still taken as a snapshot rather
+    // than trusted implicitly: a dismiss-and-reopen or a genre/artist change
+    // land here the moment any gap in that disabling is found or reopened,
+    // rather than silently reintroducing the stale-guidance bug this exists
+    // to close.
+    const submitGeneration = formGenerationRef.current;
+
     try {
       await addAlbum(body).unwrap();
       // A free-typed label with no resolved id means the backend just
@@ -170,7 +203,9 @@ function AddReleaseForm() {
       // reads, so nothing else invalidates its cache — without this, a
       // reopened picker searching this same name within the 60s cache
       // window still shows the stale empty (or prior) result and offers to
-      // create the very near-duplicate this field exists to prevent.
+      // create the very near-duplicate this field exists to prevent. This
+      // runs unconditionally: the label really was created regardless of
+      // what the dialog is showing by the time the response lands.
       if (form.labelId === null) {
         dispatch(labelsApi.util.invalidateTags([{ type: "LabelSearch", id: "LIST" }]));
       }
@@ -178,17 +213,23 @@ function AddReleaseForm() {
       // without this: both leave the MD looking at the catalog page with no
       // dialog open, which invites a duplicate re-add of the same release.
       toast.success(`Added "${albumTitle}" to the catalog`);
-      closePanel();
+      // Guarded on the generation: without it, a request whose panel was
+      // dismissed and reopened onto a new, still-unsaved release would close
+      // that unrelated form the moment this one's response arrived, discarding
+      // it exactly as if the MD had cancelled — which they did not.
+      if (formGenerationRef.current === submitGeneration) {
+        closePanel();
+      }
     } catch (err) {
-      // The field's own onChange already cleared any guidance the moment the
-      // MD edited it; re-checking here guards the other direction, where the
-      // edit happens first and this stale rejection arrives after.
+      // Guarded the same way as the success path above, and for the same
+      // reason: a rejection that arrives after the artist text or the genre
+      // has moved on would otherwise relabel guidance onto a term or a genre
+      // the form no longer shows.
       if (
-        serverErrorMessage(err) === GENRE_SCOPED_ARTIST_MISS_MESSAGE &&
-        form.genreId &&
-        artistNameRef.current === artistName
+        formGenerationRef.current === submitGeneration &&
+        serverErrorMessage(err) === GENRE_SCOPED_ARTIST_MISS_MESSAGE
       ) {
-        setArtistNotFound({ term: artistName, genreId: form.genreId });
+        setArtistNotFound({ term: artistName, genreId });
       }
       // Every rejection, this one included, has already been toasted with the
       // server's message by the global rtkQueryErrorLogger middleware — it
@@ -213,6 +254,7 @@ function AddReleaseForm() {
                 <FormLabel>Album title</FormLabel>
                 <Input
                   value={form.albumTitle}
+                  disabled={isLoading}
                   onChange={(e) =>
                     setForm((f) => ({ ...f, albumTitle: e.target.value }))
                   }
@@ -224,6 +266,7 @@ function AddReleaseForm() {
                 <Select
                   aria-label="Genre"
                   value={form.genreId}
+                  disabled={isLoading}
                   onChange={handleGenreChange}
                   placeholder="Choose a genre..."
                 >
@@ -240,6 +283,7 @@ function AddReleaseForm() {
                 <Select
                   aria-label="Format"
                   value={form.formatId}
+                  disabled={isLoading}
                   onChange={(_, value: number | null) =>
                     setForm((f) => ({ ...f, formatId: value }))
                   }
@@ -259,6 +303,7 @@ function AddReleaseForm() {
                   <ArtistSearchTypeahead
                     genreId={form.genreId}
                     value={form.artistName}
+                    disabled={isLoading}
                     onChange={(value) => {
                       setForm((f) => ({ ...f, artistName: value }));
                       // The guidance names the exact term that missed, so it
@@ -309,6 +354,7 @@ function AddReleaseForm() {
                 <FormLabel>Label</FormLabel>
                 <LabelSearchTypeahead
                   value={form.labelName}
+                  disabled={isLoading}
                   onChange={(value) =>
                     setForm((f) => ({ ...f, labelName: value }))
                   }

--- a/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { AddCircle } from "@mui/icons-material";
 import {
   Button,
+  DialogTitle,
   FormControl,
   FormLabel,
   Input,
@@ -247,7 +248,7 @@ function AddReleaseForm() {
       <Modal open={open} onClose={handleDismiss}>
         <ModalDialog sx={{ maxWidth: 480, width: "100%" }}>
           <ModalClose />
-          <Typography level="title-lg">Add Release</Typography>
+          <DialogTitle>Add Release</DialogTitle>
           <form onSubmit={handleSubmit}>
             <Stack spacing={1.5}>
               <FormControl required>

--- a/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/lib/features/catalog/api";
 import type { AddAlbumRequestBody, ArtistInGenreOption } from "@/lib/features/catalog/types";
 import { labelsApi } from "@/lib/features/labels/api";
-import type { LabelRow } from "@/lib/features/labels/types";
+import type { Label } from "@/lib/features/labels/types";
 import LabelSearchTypeahead from "./LabelSearchTypeahead";
 
 /**
@@ -358,7 +358,7 @@ function AddReleaseForm() {
                   onChange={(value) =>
                     setForm((f) => ({ ...f, labelName: value }))
                   }
-                  onSelect={(label: LabelRow) =>
+                  onSelect={(label: Label) =>
                     setForm((f) => ({ ...f, labelId: label.id }))
                   }
                   onSelectionCleared={() =>

--- a/src/components/experiences/modern/catalog/ArtistAddPanel.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { PersonAdd } from "@mui/icons-material";
-import { Button, Modal, ModalClose, ModalDialog, Typography } from "@mui/joy";
+import { Button, DialogTitle, Modal, ModalClose, ModalDialog } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
 import ArtistAddForm from "./ArtistAddForm";
 
@@ -13,8 +13,10 @@ import ArtistAddForm from "./ArtistAddForm";
  * tells the MD to add the artist first. Without an entry point that sentence
  * names a step the product does not offer.
  *
- * The form is not remounted between openings, so a 409 the MD is working
- * through survives an accidental dismissal.
+ * Closing discards the form. `Modal` unmounts its children while shut, so the
+ * fields and any standing code-taken conflict go with it, and a reopened panel
+ * starts empty — the add-release panel guards its own dismissal against that,
+ * this one does not yet.
  */
 export default function ArtistAddPanel() {
   const [open, setOpen] = useState(false);
@@ -31,7 +33,7 @@ export default function ArtistAddPanel() {
       <Modal open={open} onClose={() => setOpen(false)}>
         <ModalDialog sx={{ maxWidth: 480, width: "100%" }}>
           <ModalClose />
-          <Typography level="title-lg">Add Artist</Typography>
+          <DialogTitle>Add Artist</DialogTitle>
           <ArtistAddForm />
         </ModalDialog>
       </Modal>

--- a/src/components/experiences/modern/catalog/ArtistAddPanel.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddPanel.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+import { PersonAdd } from "@mui/icons-material";
+import { Button, Modal, ModalClose, ModalDialog, Typography } from "@mui/joy";
+import { RequireMD } from "@/src/components/shared/Authorization";
+import ArtistAddForm from "./ArtistAddForm";
+
+/**
+ * Reachability for the artist-add form: `POST /library/artists` is the only
+ * way to file an artist, and a release cannot be added under an artist that
+ * is not already catalogued in its genre — the add-release panel says so and
+ * tells the MD to add the artist first. Without an entry point that sentence
+ * names a step the product does not offer.
+ *
+ * The form is not remounted between openings, so a 409 the MD is working
+ * through survives an accidental dismissal.
+ */
+export default function ArtistAddPanel() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <RequireMD>
+      <Button
+        variant="outlined"
+        startDecorator={<PersonAdd />}
+        onClick={() => setOpen(true)}
+      >
+        Add Artist
+      </Button>
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <ModalDialog sx={{ maxWidth: 480, width: "100%" }}>
+          <ModalClose />
+          <Typography level="title-lg">Add Artist</Typography>
+          <ArtistAddForm />
+        </ModalDialog>
+      </Modal>
+    </RequireMD>
+  );
+}

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -295,6 +295,15 @@ function ArtistSearchTypeaheadInner({
         inputRef.current?.blur();
         return;
       }
+      // The panel is open but has no answer yet: the search is still in
+      // flight, or it failed outright. Implicit form submission from this
+      // input would send a partially-typed name past a duplicate check that
+      // never completed, so callers that mount this inside a form (as
+      // AddReleasePanel does) must not have Enter fall through to it here.
+      if (e.key === "Enter" && (showSearching || showError)) {
+        e.preventDefault();
+        return;
+      }
       if (!showListbox) return;
       switch (e.key) {
         case "ArrowDown": {
@@ -327,6 +336,8 @@ function ArtistSearchTypeaheadInner({
     [
       showPanel,
       showListbox,
+      showSearching,
+      showError,
       highlightIndex,
       createHighlighted,
       artists,

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -283,9 +283,14 @@ function ArtistSearchTypeaheadInner({
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       // Escape dismisses any open panel, including the error and in-progress
-      // states that have no rows to navigate.
+      // states that have no rows to navigate. The event stops here rather than
+      // bubbling: consumers mount this inside dialogs whose own Escape handler
+      // closes them and discards their form, and that handler does not consult
+      // defaultPrevented — so dismissing a suggestion list would otherwise cost
+      // the user every field they had filled in.
       if (e.key === "Escape" && showPanel) {
         e.preventDefault();
+        e.stopPropagation();
         closePanel();
         inputRef.current?.blur();
         return;

--- a/tests/integration/app/dashboard/@modern/catalog/page.test.tsx
+++ b/tests/integration/app/dashboard/@modern/catalog/page.test.tsx
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
-import { http, HttpResponse } from "msw";
 import { renderWithProviders } from "@/tests/helpers";
-import { server } from "@/tests/fakes/server";
-import { TEST_BACKEND_URL } from "@/tests/helpers/constants";
-import ArtistAddPanel from "@/src/components/experiences/modern/catalog/ArtistAddPanel";
+
+// Search and results aren't under test here; this page's own responsibility is
+// which controls it offers in its header.
+vi.mock("@/src/components/experiences/modern/catalog/Search/MobileSearchBar", () => ({
+  default: () => null,
+}));
+vi.mock("@/src/components/experiences/modern/catalog/Search/SearchBar", () => ({
+  default: () => null,
+}));
+vi.mock("@/src/components/experiences/modern/catalog/Results/Results", () => ({
+  default: () => null,
+}));
 
 vi.mock("@/lib/features/authentication/client", () => ({
   authClient: { useSession: vi.fn() },
@@ -19,12 +27,9 @@ vi.mock("@/lib/features/authentication/organization-utils", () => ({
   fetchOrganizationRoleForUserClient: vi.fn(),
 }));
 
-vi.mock("sonner", () => ({
-  toast: { error: vi.fn(), success: vi.fn() },
-}));
-
 import { authClient } from "@/lib/features/authentication/client";
 import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+import CatalogPage from "@/app/dashboard/@modern/catalog/page";
 
 const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
 const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<
@@ -48,45 +53,34 @@ function session() {
   };
 }
 
-describe("ArtistAddPanel", () => {
+describe("catalog page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseSession.mockReturnValue(session());
+  });
+
+  // Both write surfaces have to be reachable from this page, and neither
+  // component can assert that about itself. The add-release panel tells an MD
+  // whose artist isn't filed under the chosen genre to add that artist first —
+  // if the artist entry point stops being mounted, that sentence names a step
+  // the product no longer offers, and every test that renders either panel
+  // directly still passes.
+  it("offers an MD both catalog write entry points", async () => {
     mockFetchOrgRole.mockResolvedValue("musicDirector");
-    server.use(
-      http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
-        HttpResponse.json([{ id: 7, genre_name: "Rock" }]),
-      ),
-    );
-  });
-
-  // The add-release panel tells an MD whose artist isn't filed under the
-  // chosen genre to add that artist first. This entry point is what makes
-  // that instruction followable — without it the form exists but nothing
-  // renders it, and the release cannot be filed at all.
-  it("opens the artist-add form from the catalog header", async () => {
-    const { user } = renderWithProviders(<ArtistAddPanel />);
-
-    const trigger = await screen.findByRole("button", { name: /add artist/i });
-    expect(
-      screen.queryByPlaceholderText("Search artists..."),
-    ).not.toBeInTheDocument();
-
-    await user.click(trigger);
+    renderWithProviders(<CatalogPage />);
 
     expect(
-      await screen.findByPlaceholderText("Search artists..."),
+      await screen.findByRole("button", { name: /add artist/i }),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText("Code number")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /add release/i }),
+    ).toBeInTheDocument();
   });
 
-  it("stays shut for a DJ", async () => {
+  it("offers a DJ neither", async () => {
     mockFetchOrgRole.mockResolvedValue("dj");
-    renderWithProviders(<ArtistAddPanel />);
+    renderWithProviders(<CatalogPage />);
 
-    // Awaiting the call only proves the gate was asked. AuthorizedView renders
-    // nothing while the answer is outstanding, so asserting absence before the
-    // promise settles cannot tell a refusal from a pending question.
     await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
     await mockFetchOrgRole.mock.results[0].value;
 
@@ -94,7 +88,7 @@ describe("ArtistAddPanel", () => {
       screen.queryByRole("button", { name: /add artist/i }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByPlaceholderText("Search artists..."),
+      screen.queryByRole("button", { name: /add release/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/tests/integration/components/modern/catalog/AddRelease/AddReleasePanel.test.tsx
+++ b/tests/integration/components/modern/catalog/AddRelease/AddReleasePanel.test.tsx
@@ -1,0 +1,704 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
+import AddReleasePanel from "@/src/components/experiences/modern/catalog/AddRelease/AddReleasePanel";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+// No <Toaster /> is mounted by renderWithProviders, so the panel's own
+// validation toast and the store's rejected-query toast are both only
+// observable through the mocked module.
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+import { toast } from "sonner";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof vi.fn>;
+const mockToastError = toast.error as ReturnType<typeof vi.fn>;
+
+function sessionWithRole() {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role: null,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+    error: null,
+  };
+}
+
+const ROCK_GENRE_ID = 7;
+const CD_FORMAT_ID = 2;
+
+function mockLookups() {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
+      HttpResponse.json([{ id: ROCK_GENRE_ID, genre_name: "Rock" }]),
+    ),
+    http.get(`${TEST_BACKEND_URL}/library/formats`, () =>
+      HttpResponse.json([{ id: CD_FORMAT_ID, format_name: "CD" }]),
+    ),
+  );
+}
+
+function mockArtistSearch(artists: { id: number; artist_name: string; code_letters: string; code_number: number }[]) {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/artists/search`, () =>
+      HttpResponse.json({ artists }),
+    ),
+  );
+}
+
+function mockLabelSearch(labels: { id: number; label_name: string }[]) {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/labels/search`, () => HttpResponse.json(labels)),
+  );
+}
+
+function mockAddAlbum(
+  respond: (body: unknown) => Response | Promise<Response> = () =>
+    HttpResponse.json({ id: 999 }),
+) {
+  let receivedBody: unknown;
+  server.use(
+    http.post(`${TEST_BACKEND_URL}/library/`, async ({ request }) => {
+      receivedBody = await request.json();
+      return respond(receivedBody);
+    }),
+  );
+  return () => receivedBody;
+}
+
+async function openPanel(user: ReturnType<typeof renderWithProviders>["user"]) {
+  await user.click(await screen.findByRole("button", { name: "Add Release" }));
+}
+
+async function pickGenre(user: ReturnType<typeof renderWithProviders>["user"], name = "Rock") {
+  await user.click(await screen.findByRole("combobox", { name: "Genre" }));
+  await user.click(await screen.findByRole("option", { name }));
+}
+
+async function pickFormat(user: ReturnType<typeof renderWithProviders>["user"], name = "CD") {
+  await user.click(await screen.findByRole("combobox", { name: "Format" }));
+  await user.click(await screen.findByRole("option", { name }));
+}
+
+const SUGGESTION_FIELDS = [
+  { name: "artist", placeholder: "Search artists...", term: "Juana" },
+  { name: "label", placeholder: "Search labels...", term: "Sona" },
+] as const;
+
+/** The three fields backed by a real form control, which the browser's own constraint validation can refuse. */
+const TEXT_FIELDS = ["album title", "artist", "label"] as const;
+/**
+ * Joy renders these two as buttons, which no constraint validation applies to,
+ * so the submit handler's guard is the only thing that refuses them. Leaving
+ * the genre unchosen also leaves the artist blank — the artist field does not
+ * render without a genre — so that case pins the guard's refusal, not which of
+ * its two clauses did the refusing.
+ */
+const SELECT_FIELDS = ["genre", "format"] as const;
+
+type TextField = (typeof TEXT_FIELDS)[number];
+type RequiredField = TextField | (typeof SELECT_FIELDS)[number];
+
+const REQUIRED_FIELDS_MESSAGE =
+  "Album title, genre, format, artist, and label are all required";
+
+/** Non-empty, so it satisfies `required` and reaches the guard, which trims. */
+const WHITESPACE_ONLY = "   ";
+
+const textControl: Record<TextField, () => HTMLElement> = {
+  "album title": () => screen.getByLabelText(/Album title/),
+  artist: () => screen.getByPlaceholderText("Search artists..."),
+  label: () => screen.getByPlaceholderText("Search labels..."),
+};
+
+/**
+ * Fills every required field, leaving `blank` either untouched or holding only
+ * whitespace. Leaving the genre untouched necessarily leaves the artist blank
+ * too — the artist field does not render until a genre is chosen — so `blank`
+ * is only ever a select in the untouched mode.
+ */
+async function fillForm(
+  user: ReturnType<typeof renderWithProviders>["user"],
+  blank: RequiredField,
+  mode: "untouched" | "whitespace" = "untouched",
+) {
+  const textFor = (field: TextField, value: string) =>
+    field !== blank ? value : mode === "whitespace" ? WHITESPACE_ONLY : "";
+
+  const albumTitle = textFor("album title", "DOGA");
+  if (albumTitle) {
+    await user.type(screen.getByLabelText(/Album title/), albumTitle);
+  }
+  if (blank !== "genre") {
+    await pickGenre(user);
+  }
+  if (blank !== "format") {
+    await pickFormat(user);
+  }
+  const artist = textFor("artist", "Juana Molina");
+  if (blank !== "genre" && artist) {
+    await user.type(await screen.findByPlaceholderText("Search artists..."), artist);
+  }
+  const label = textFor("label", "Sonamos");
+  if (label) {
+    await user.type(await screen.findByPlaceholderText("Search labels..."), label);
+  }
+}
+
+describe("AddReleasePanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLookups();
+    mockArtistSearch([]);
+    mockLabelSearch([]);
+  });
+
+  describe("permission gating", () => {
+    it("renders nothing for a DJ", async () => {
+      mockFetchOrgRole.mockResolvedValue("dj");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(<AddReleasePanel />);
+
+      await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
+      await mockFetchOrgRole.mock.results[0].value;
+      await waitFor(() =>
+        expect(screen.queryByRole("button", { name: "Add Release" })).not.toBeInTheDocument(),
+      );
+    });
+
+    it("renders the trigger for a Music Director", async () => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+      renderWithProviders(<AddReleasePanel />);
+
+      expect(await screen.findByRole("button", { name: "Add Release" })).toBeInTheDocument();
+    });
+  });
+
+  describe("as a Music Director", () => {
+    beforeEach(() => {
+      mockFetchOrgRole.mockResolvedValue("musicDirector");
+      mockUseSession.mockReturnValue(sessionWithRole());
+    });
+
+    it("disables the artist field until a genre is chosen", async () => {
+      const { user } = renderWithProviders(<AddReleasePanel />);
+      await openPanel(user);
+
+      expect(screen.queryByPlaceholderText("Search artists...")).not.toBeInTheDocument();
+
+      await pickGenre(user);
+
+      expect(await screen.findByPlaceholderText("Search artists...")).toBeEnabled();
+    });
+
+    it("sends the resolved artist_id alongside artist_name and label_id when the MD picks existing rows, and never sends album_artist or code_number", async () => {
+      mockArtistSearch([
+        { id: 12, artist_name: "Juana Molina", code_letters: "MO", code_number: 3 },
+      ]);
+      mockLabelSearch([{ id: 5, label_name: "Sonamos" }]);
+      const getReceivedBody = mockAddAlbum();
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "DOGA");
+      await pickGenre(user);
+      await pickFormat(user);
+
+      const artistInput = await screen.findByPlaceholderText("Search artists...");
+      await user.type(artistInput, "Juana");
+      await user.click(await screen.findByText("Juana Molina"));
+
+      const labelInput = await screen.findByPlaceholderText("Search labels...");
+      await user.type(labelInput, "Sona");
+      await user.click(await screen.findByText("Sonamos"));
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+      // artist_id and artist_name are both required on this path: the id
+      // short-circuits genre-scoped resolution, and the name is what the
+      // backend's post-insert metadata enrichment looks the release up by.
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          album_title: "DOGA",
+          genre_id: ROCK_GENRE_ID,
+          format_id: CD_FORMAT_ID,
+          artist_id: 12,
+          artist_name: "Juana Molina",
+          label: "Sonamos",
+          label_id: 5,
+        }),
+      );
+    });
+
+    it("sends the label_id of a row the MD reached with the keyboard alone", async () => {
+      mockLabelSearch([
+        { id: 5, label_name: "Sonamos" },
+        { id: 9, label_name: "Sonar" },
+      ]);
+      const getReceivedBody = mockAddAlbum();
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "DOGA");
+      await pickGenre(user);
+      await pickFormat(user);
+      await user.type(
+        await screen.findByPlaceholderText("Search artists..."),
+        "Juana Molina",
+      );
+
+      // A near-duplicate is only prevented if the existing row is reachable
+      // without a pointer: a keyboard-only MD who can only submit their own
+      // typing creates exactly the second label row the picker exists to stop.
+      await user.type(await screen.findByPlaceholderText("Search labels..."), "Sona");
+      await screen.findByText("Sonamos");
+      await user.keyboard("{ArrowDown}{Enter}");
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          album_title: "DOGA",
+          genre_id: ROCK_GENRE_ID,
+          format_id: CD_FORMAT_ID,
+          artist_name: "Juana Molina",
+          label: "Sonamos",
+          label_id: 5,
+        }),
+      );
+    });
+
+    it("sends free-typed artist_name and label when the MD does not pick a suggestion", async () => {
+      const getReceivedBody = mockAddAlbum();
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "On Your Own Love Again");
+      await pickGenre(user);
+      await pickFormat(user);
+
+      const artistInput = await screen.findByPlaceholderText("Search artists...");
+      await user.type(artistInput, "Jessica Pratt");
+
+      const labelInput = await screen.findByPlaceholderText("Search labels...");
+      await user.type(labelInput, "Drag City");
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          album_title: "On Your Own Love Again",
+          genre_id: ROCK_GENRE_ID,
+          format_id: CD_FORMAT_ID,
+          artist_name: "Jessica Pratt",
+          label: "Drag City",
+        }),
+      );
+    });
+
+    it("sends artist_name instead of a stale artist_id once the picked artist's text is edited", async () => {
+      mockArtistSearch([
+        { id: 12, artist_name: "Juana Molina", code_letters: "MO", code_number: 3 },
+      ]);
+      const getReceivedBody = mockAddAlbum();
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "DOGA");
+      await pickGenre(user);
+      await pickFormat(user);
+
+      const artistInput = await screen.findByPlaceholderText("Search artists...");
+      await user.type(artistInput, "Juana");
+      await user.click(await screen.findByText("Juana Molina"));
+
+      // Edited away from the picked artist's name: the id no longer names
+      // this text, so the retraction must drop it before submit.
+      await user.type(artistInput, " Solo");
+
+      const labelInput = await screen.findByPlaceholderText("Search labels...");
+      await user.type(labelInput, "Sonamos");
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          album_title: "DOGA",
+          genre_id: ROCK_GENRE_ID,
+          format_id: CD_FORMAT_ID,
+          artist_name: "Juana Molina Solo",
+          label: "Sonamos",
+        }),
+      );
+    });
+
+    it("sends artist_name instead of a stale artist_id once the genre changes after a pick", async () => {
+      const JAZZ_GENRE_ID = 11;
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
+          HttpResponse.json([
+            { id: ROCK_GENRE_ID, genre_name: "Rock" },
+            { id: JAZZ_GENRE_ID, genre_name: "Jazz" },
+          ]),
+        ),
+      );
+      mockArtistSearch([
+        { id: 12, artist_name: "Juana Molina", code_letters: "MO", code_number: 3 },
+      ]);
+      const getReceivedBody = mockAddAlbum();
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "DOGA");
+      await pickGenre(user, "Rock");
+      await pickFormat(user);
+
+      const artistInput = await screen.findByPlaceholderText("Search artists...");
+      await user.type(artistInput, "Juana");
+      await user.click(await screen.findByText("Juana Molina"));
+
+      // Artist rows are genre-scoped: the id picked under Rock names no row
+      // under Jazz, so the resolved id must not survive the genre swap even
+      // though the typed text is left standing.
+      await pickGenre(user, "Jazz");
+
+      const labelInput = await screen.findByPlaceholderText("Search labels...");
+      await user.type(labelInput, "Sonamos");
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          album_title: "DOGA",
+          genre_id: JAZZ_GENRE_ID,
+          format_id: CD_FORMAT_ID,
+          artist_name: "Juana Molina",
+          label: "Sonamos",
+        }),
+      );
+    });
+
+    // An artist is mandatory to the backend but optional on the request type,
+    // so nothing in the types stops a form that omits one. Two mechanisms hold
+    // the line — native constraint validation and the submit handler's guard —
+    // and each case pins whichever one applies. Asserting only that no body was
+    // received cannot pin either: the interceptor assigns that body
+    // asynchronously, so it reads as unset whether or not a request went out.
+    it.each(TEXT_FIELDS)(
+      "marks the %s required so an empty one never reaches the server",
+      async (blank) => {
+        const getReceivedBody = mockAddAlbum();
+        const { user } = renderWithProviders(<AddReleasePanel />);
+
+        await openPanel(user);
+        await fillForm(user, blank);
+
+        await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+        expect(textControl[blank]()).toBeInvalid();
+        expect(getReceivedBody()).toBeUndefined();
+      },
+    );
+
+    it.each(SELECT_FIELDS)(
+      "reports the requirement and sends nothing when no %s is chosen",
+      async (blank) => {
+        const getReceivedBody = mockAddAlbum();
+        const { user } = renderWithProviders(<AddReleasePanel />);
+
+        await openPanel(user);
+        await fillForm(user, blank);
+
+        await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+        await waitFor(() =>
+          expect(mockToastError).toHaveBeenCalledWith(REQUIRED_FIELDS_MESSAGE),
+        );
+        expect(getReceivedBody()).toBeUndefined();
+      },
+    );
+
+    // `required` accepts a space, so whitespace is the one path on which a text
+    // field reaches the submit handler blank — the case that pins the guard's
+    // own trim, and with it the mandatory-artist contract the request type
+    // leaves optional.
+    it.each(TEXT_FIELDS)(
+      "reports the requirement and sends nothing when the %s is only whitespace",
+      async (blank) => {
+        const getReceivedBody = mockAddAlbum();
+        const { user } = renderWithProviders(<AddReleasePanel />);
+
+        await openPanel(user);
+        await fillForm(user, blank, "whitespace");
+
+        await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+        await waitFor(() =>
+          expect(mockToastError).toHaveBeenCalledWith(REQUIRED_FIELDS_MESSAGE),
+        );
+        expect(getReceivedBody()).toBeUndefined();
+      },
+    );
+
+    it("routes the MD toward adding the artist instead of a generic error on a genre-scoped miss", async () => {
+      mockAddAlbum(() =>
+        HttpResponse.json(
+          {
+            message:
+              "Artist doesn't exist or hasn't released an album in this genre before. Add a new artist entry to the library",
+          },
+          { status: 400 },
+        ),
+      );
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "Edits");
+      await pickGenre(user);
+      await pickFormat(user);
+
+      const artistInput = await screen.findByPlaceholderText("Search artists...");
+      await user.type(artistInput, "Chuquimamani-Condori");
+
+      const labelInput = await screen.findByPlaceholderText("Search labels...");
+      await user.type(labelInput, "self-released");
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+      expect(
+        await screen.findByText(/Chuquimamani-Condori.*isn't filed under Rock/i),
+      ).toBeInTheDocument();
+    });
+
+    it("leaves a 400 that is not the genre-scoped miss to the generic error path", async () => {
+      const BLANK_TITLE_MESSAGE = "album_title must be a non-empty string";
+      mockAddAlbum(() =>
+        HttpResponse.json({ message: BLANK_TITLE_MESSAGE }, { status: 400 }),
+      );
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "Edits");
+      await pickGenre(user);
+      await pickFormat(user);
+      await user.type(
+        await screen.findByPlaceholderText("Search artists..."),
+        "Chuquimamani-Condori",
+      );
+      await user.type(
+        await screen.findByPlaceholderText("Search labels..."),
+        "self-released",
+      );
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+      // The server's own message reaching the toast is the settle signal: the
+      // rejection has been all the way through the store by then, so the
+      // guidance's absence is a decision the panel made rather than a render
+      // that has not happened yet. Routing every 400 to the artist-add form
+      // would send the MD off to fix an artist that was never the problem.
+      await waitFor(() =>
+        expect(mockToastError).toHaveBeenCalledWith(BLANK_TITLE_MESSAGE),
+      );
+      expect(screen.queryByText(/isn't filed under/i)).not.toBeInTheDocument();
+    });
+
+    // The dialog's own Escape handler closes it and discards everything typed
+    // so far, and it does not consult defaultPrevented — so a suggestion list
+    // that merely prevents the default still loses the MD their work.
+    it.each(SUGGESTION_FIELDS)(
+      "dismisses the $name suggestions on Escape without discarding the form",
+      async ({ placeholder, term }) => {
+        mockArtistSearch([
+          { id: 12, artist_name: "Juana Molina", code_letters: "MO", code_number: 3 },
+        ]);
+        mockLabelSearch([{ id: 5, label_name: "Sonamos" }]);
+        const { user } = renderWithProviders(<AddReleasePanel />);
+
+        await openPanel(user);
+        await user.type(screen.getByLabelText(/Album title/), "DOGA");
+        await pickGenre(user);
+        await user.type(await screen.findByPlaceholderText(placeholder), term);
+        await screen.findByRole("listbox");
+
+        await user.keyboard("{Escape}");
+
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Save Release" })).toBeInTheDocument();
+        expect(screen.getByLabelText(/Album title/)).toHaveValue("DOGA");
+        expect(screen.getByPlaceholderText(placeholder)).toHaveValue(term);
+      },
+    );
+
+    it("retires a resolved artist_id when the MD chooses to create the artist instead", async () => {
+      mockArtistSearch([
+        { id: 12, artist_name: "Juana Molina", code_letters: "MO", code_number: 3 },
+      ]);
+      const getReceivedBody = mockAddAlbum();
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "DOGA");
+      await pickGenre(user);
+      await pickFormat(user);
+
+      const artistInput = await screen.findByPlaceholderText("Search artists...");
+      await user.type(artistInput, "Juana");
+      await user.click(await screen.findByText("Juana Molina"));
+
+      // Reopening over the cached rows and taking the create row instead never
+      // edits the text, so the typeahead's own retraction never fires: the
+      // panel has to drop the id itself, or it files the release against the
+      // very artist it is telling the MD does not exist yet.
+      await user.click(artistInput);
+      await user.click(await screen.findByText(/Create new artist/i));
+      await user.type(
+        await screen.findByPlaceholderText("Search labels..."),
+        "Sonamos",
+      );
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          album_title: "DOGA",
+          genre_id: ROCK_GENRE_ID,
+          format_id: CD_FORMAT_ID,
+          artist_name: "Juana Molina",
+          label: "Sonamos",
+        }),
+      );
+    });
+
+    it("drops the artist-add guidance once the artist text moves off the term that missed", async () => {
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await pickGenre(user);
+
+      const artistInput = await screen.findByPlaceholderText("Search artists...");
+      await user.type(artistInput, "Chuquimamani-Condori");
+      await user.click(await screen.findByText(/Create new artist/i));
+      await screen.findByText(/Chuquimamani-Condori.*isn't filed under Rock/i);
+
+      await user.type(artistInput, " II");
+
+      expect(screen.queryByText(/isn't filed under/i)).not.toBeInTheDocument();
+    });
+
+    it("closes and resets the form after a successful add", async () => {
+      mockAddAlbum();
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "DOGA");
+      await pickGenre(user);
+      await pickFormat(user);
+      const artistInput = await screen.findByPlaceholderText("Search artists...");
+      await user.type(artistInput, "Juana Molina");
+      const labelInput = await screen.findByPlaceholderText("Search labels...");
+      await user.type(labelInput, "Sonamos");
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+      await waitFor(() =>
+        expect(screen.queryByRole("button", { name: "Save Release" })).not.toBeInTheDocument(),
+      );
+
+      await openPanel(user);
+
+      // Every field, not just the title: a partial reset is how the next
+      // release silently inherits the previous one's artist and label, and the
+      // ids behind those two carry over invisibly because the text they belong
+      // to is the only thing on screen.
+      expect(screen.getByLabelText(/Album title/)).toHaveValue("");
+      expect(screen.getByRole("combobox", { name: "Genre" })).toHaveTextContent(
+        "Choose a genre...",
+      );
+      expect(screen.getByRole("combobox", { name: "Format" })).toHaveTextContent(
+        "Choose a format...",
+      );
+      // No genre means no artist typeahead, so the artist text is gone with it.
+      expect(screen.queryByPlaceholderText("Search artists...")).not.toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Search labels...")).toHaveValue("");
+    });
+
+    it("carries no resolved artist_id or label_id into the next release", async () => {
+      mockArtistSearch([
+        { id: 12, artist_name: "Juana Molina", code_letters: "MO", code_number: 3 },
+      ]);
+      mockLabelSearch([{ id: 5, label_name: "Sonamos" }]);
+      const getReceivedBody = mockAddAlbum();
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "DOGA");
+      await pickGenre(user);
+      await pickFormat(user);
+      await user.type(await screen.findByPlaceholderText("Search artists..."), "Juana");
+      await user.click(await screen.findByText("Juana Molina"));
+      await user.type(await screen.findByPlaceholderText("Search labels..."), "Sona");
+      await user.click(await screen.findByText("Sonamos"));
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+      await waitFor(() => expect(getReceivedBody()).toBeDefined());
+
+      // Both ids live in state the reopened form still holds unless the reset
+      // clears them, and neither is visible in the UI once their text is gone.
+      mockArtistSearch([]);
+      mockLabelSearch([]);
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "On Your Own Love Again");
+      await pickGenre(user);
+      await pickFormat(user);
+      await user.type(
+        await screen.findByPlaceholderText("Search artists..."),
+        "Jessica Pratt",
+      );
+      await user.type(
+        await screen.findByPlaceholderText("Search labels..."),
+        "Drag City",
+      );
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+      await waitFor(() =>
+        expect(getReceivedBody()).toEqual({
+          album_title: "On Your Own Love Again",
+          genre_id: ROCK_GENRE_ID,
+          format_id: CD_FORMAT_ID,
+          artist_name: "Jessica Pratt",
+          label: "Drag City",
+        }),
+      );
+    });
+  });
+});

--- a/tests/integration/components/modern/catalog/AddRelease/AddReleasePanel.test.tsx
+++ b/tests/integration/components/modern/catalog/AddRelease/AddReleasePanel.test.tsx
@@ -34,6 +34,7 @@ import { toast } from "sonner";
 const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
 const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<typeof vi.fn>;
 const mockToastError = toast.error as ReturnType<typeof vi.fn>;
+const mockToastSuccess = toast.success as ReturnType<typeof vi.fn>;
 
 function sessionWithRole() {
   return {
@@ -79,6 +80,25 @@ function mockLabelSearch(labels: { id: number; label_name: string }[]) {
   server.use(
     http.get(`${TEST_BACKEND_URL}/labels/search`, () => HttpResponse.json(labels)),
   );
+}
+
+/**
+ * Installs the label-search handler and returns the list of requests it has
+ * served, so a test can tell a cache hit (no new request) apart from a
+ * refetch forced by invalidation.
+ */
+function mockLabelSearchTracking(
+  respond: (url: URL) => Response | Promise<Response>,
+): URL[] {
+  const requests: URL[] = [];
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/labels/search`, ({ request }) => {
+      const url = new URL(request.url);
+      requests.push(url);
+      return respond(url);
+    }),
+  );
+  return requests;
 }
 
 function mockAddAlbum(
@@ -500,6 +520,52 @@ describe("AddReleasePanel", () => {
       ).toBeInTheDocument();
     });
 
+    it("does not show guidance for the submitted term once the artist field is edited while the rejection is still in flight", async () => {
+      let resolveResponse: (response: Response) => void;
+      const responsePromise = new Promise<Response>((resolve) => {
+        resolveResponse = resolve;
+      });
+      const getReceivedBody = mockAddAlbum(() => responsePromise);
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "Edits");
+      await pickGenre(user);
+      await pickFormat(user);
+
+      const artistInput = await screen.findByPlaceholderText("Search artists...");
+      await user.type(artistInput, "Chuquimamani-Condori");
+
+      const labelInput = await screen.findByPlaceholderText("Search labels...");
+      await user.type(labelInput, "self-released");
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+      await waitFor(() => expect(getReceivedBody()).toBeDefined());
+
+      // The field is never disabled while the mutation is in flight, so the
+      // MD can correct it before the rejection they are still waiting on
+      // arrives.
+      await user.clear(artistInput);
+      await user.type(artistInput, "DJ E");
+
+      resolveResponse!(
+        HttpResponse.json(
+          {
+            message:
+              "Artist doesn't exist or hasn't released an album in this genre before. Add a new artist entry to the library",
+          },
+          { status: 400 },
+        ),
+      );
+
+      await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+
+      // Guidance naming the submitted term would now describe text the field
+      // no longer holds.
+      expect(screen.queryByText(/isn't filed under/i)).not.toBeInTheDocument();
+      expect(artistInput).toHaveValue("DJ E");
+    });
+
     it("leaves a 400 that is not the genre-scoped miss to the generic error path", async () => {
       const BLANK_TITLE_MESSAGE = "album_title must be a non-empty string";
       mockAddAlbum(() =>
@@ -616,6 +682,43 @@ describe("AddReleasePanel", () => {
       expect(screen.queryByText(/isn't filed under/i)).not.toBeInTheDocument();
     });
 
+    // The backend upserts labels on the exact name, so a stale empty result
+    // served from cache after this panel files a new one sends the next MD
+    // who searches for it back through the free-type path, filing a second,
+    // near-duplicate row beside the one just created.
+    it("invalidates the label search cache after a release is added with a free-typed label", async () => {
+      const labelRequests = mockLabelSearchTracking(() => HttpResponse.json([]));
+      const getReceivedBody = mockAddAlbum();
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "Edits");
+      await pickGenre(user);
+      await pickFormat(user);
+      await user.type(
+        await screen.findByPlaceholderText("Search artists..."),
+        "Chuquimamani-Condori",
+      );
+      const labelInput = await screen.findByPlaceholderText("Search labels...");
+      await user.type(labelInput, "Duophonic");
+      await screen.findByText(/will be created as a new label/i);
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+      await waitFor(() => expect(getReceivedBody()).toBeDefined());
+      expect(labelRequests).toHaveLength(1);
+
+      // Reopening and searching the exact term the panel just filed — a
+      // stale cache would serve the earlier empty result without a new
+      // request, hiding the label the backend just created.
+      await openPanel(user);
+      await user.type(
+        await screen.findByPlaceholderText("Search labels..."),
+        "Duophonic",
+      );
+
+      await waitFor(() => expect(labelRequests.length).toBeGreaterThan(1));
+    });
+
     it("closes and resets the form after a successful add", async () => {
       mockAddAlbum();
       const { user } = renderWithProviders(<AddReleasePanel />);
@@ -634,6 +737,9 @@ describe("AddReleasePanel", () => {
       await waitFor(() =>
         expect(screen.queryByRole("button", { name: "Save Release" })).not.toBeInTheDocument(),
       );
+      // A silent close on success is indistinguishable from an accidental
+      // dismissal, which invites a duplicate re-add of the same release.
+      expect(mockToastSuccess).toHaveBeenCalledWith('Added "DOGA" to the catalog');
 
       await openPanel(user);
 
@@ -653,6 +759,10 @@ describe("AddReleasePanel", () => {
       expect(screen.getByPlaceholderText("Search labels...")).toHaveValue("");
     });
 
+    // Two complete form fills, each driving both typeaheads through their
+    // 300ms debounce, run close enough to the default 5s test timeout that a
+    // loaded full-suite run can miss it — an explicit longer budget keeps
+    // that a timing margin rather than a flake.
     it("carries no resolved artist_id or label_id into the next release", async () => {
       mockArtistSearch([
         { id: 12, artist_name: "Juana Molina", code_letters: "MO", code_number: 3 },
@@ -699,6 +809,56 @@ describe("AddReleasePanel", () => {
           label: "Drag City",
         }),
       );
+    }, 10000);
+
+    // Modal's onClose fires alike for the close button, a backdrop click,
+    // and an Escape that reaches the dialog — all three would otherwise wipe
+    // a part-filled form with no undo.
+    describe("dismissing with unsaved input", () => {
+      const closeButton = () => screen.getByTestId("CloseIcon");
+
+      it("asks for confirmation and leaves the form standing when declined", async () => {
+        const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+        const { user } = renderWithProviders(<AddReleasePanel />);
+
+        await openPanel(user);
+        await user.type(screen.getByLabelText(/Album title/), "DOGA");
+
+        await user.click(closeButton());
+
+        expect(confirmSpy).toHaveBeenCalled();
+        expect(screen.getByLabelText(/Album title/)).toHaveValue("DOGA");
+        confirmSpy.mockRestore();
+      });
+
+      it("discards the form once the confirmation is accepted", async () => {
+        const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+        const { user } = renderWithProviders(<AddReleasePanel />);
+
+        await openPanel(user);
+        await user.type(screen.getByLabelText(/Album title/), "DOGA");
+
+        await user.click(closeButton());
+
+        expect(
+          screen.queryByRole("button", { name: "Save Release" }),
+        ).not.toBeInTheDocument();
+        confirmSpy.mockRestore();
+      });
+
+      it("closes without asking when nothing has been entered", async () => {
+        const confirmSpy = vi.spyOn(window, "confirm");
+        const { user } = renderWithProviders(<AddReleasePanel />);
+
+        await openPanel(user);
+        await user.click(closeButton());
+
+        expect(confirmSpy).not.toHaveBeenCalled();
+        expect(
+          screen.queryByRole("button", { name: "Save Release" }),
+        ).not.toBeInTheDocument();
+        confirmSpy.mockRestore();
+      });
     });
   });
 });

--- a/tests/integration/components/modern/catalog/AddRelease/AddReleasePanel.test.tsx
+++ b/tests/integration/components/modern/catalog/AddRelease/AddReleasePanel.test.tsx
@@ -230,6 +230,33 @@ describe("AddReleasePanel", () => {
       mockUseSession.mockReturnValue(sessionWithRole());
     });
 
+    it("does not fetch genres or formats until the dialog is opened", async () => {
+      let genreRequests = 0;
+      let formatRequests = 0;
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/genres`, () => {
+          genreRequests += 1;
+          return HttpResponse.json([{ id: ROCK_GENRE_ID, genre_name: "Rock" }]);
+        }),
+        http.get(`${TEST_BACKEND_URL}/library/formats`, () => {
+          formatRequests += 1;
+          return HttpResponse.json([{ id: CD_FORMAT_ID, format_name: "CD" }]);
+        }),
+      );
+      const { user } = renderWithProviders(<AddReleasePanel />);
+      await screen.findByRole("button", { name: "Add Release" });
+
+      // A catalog page load never opens this dialog for most visits, so the
+      // two lookups it needs must wait for that instead of firing on mount.
+      expect(genreRequests).toBe(0);
+      expect(formatRequests).toBe(0);
+
+      await openPanel(user);
+
+      await waitFor(() => expect(genreRequests).toBeGreaterThan(0));
+      await waitFor(() => expect(formatRequests).toBeGreaterThan(0));
+    });
+
     it("disables the artist field until a genre is chosen", async () => {
       const { user } = renderWithProviders(<AddReleasePanel />);
       await openPanel(user);
@@ -520,7 +547,10 @@ describe("AddReleasePanel", () => {
       ).toBeInTheDocument();
     });
 
-    it("does not show guidance for the submitted term once the artist field is edited while the rejection is still in flight", async () => {
+    // A submitted term can no longer be edited out from under a pending
+    // rejection: every field is disabled for the duration of the request,
+    // which is what closes the race the guidance-staleness bug depended on.
+    it("disables every field while the mutation is in flight, and re-enables them once it settles", async () => {
       let resolveResponse: (response: Response) => void;
       const responsePromise = new Promise<Response>((resolve) => {
         resolveResponse = resolve;
@@ -529,7 +559,8 @@ describe("AddReleasePanel", () => {
       const { user } = renderWithProviders(<AddReleasePanel />);
 
       await openPanel(user);
-      await user.type(screen.getByLabelText(/Album title/), "Edits");
+      const albumTitleInput = screen.getByLabelText(/Album title/);
+      await user.type(albumTitleInput, "Edits");
       await pickGenre(user);
       await pickFormat(user);
 
@@ -542,11 +573,11 @@ describe("AddReleasePanel", () => {
       await user.click(screen.getByRole("button", { name: "Save Release" }));
       await waitFor(() => expect(getReceivedBody()).toBeDefined());
 
-      // The field is never disabled while the mutation is in flight, so the
-      // MD can correct it before the rejection they are still waiting on
-      // arrives.
-      await user.clear(artistInput);
-      await user.type(artistInput, "DJ E");
+      expect(albumTitleInput).toBeDisabled();
+      expect(screen.getByRole("combobox", { name: "Genre" })).toBeDisabled();
+      expect(screen.getByRole("combobox", { name: "Format" })).toBeDisabled();
+      expect(artistInput).toBeDisabled();
+      expect(labelInput).toBeDisabled();
 
       resolveResponse!(
         HttpResponse.json(
@@ -560,10 +591,90 @@ describe("AddReleasePanel", () => {
 
       await waitFor(() => expect(mockToastError).toHaveBeenCalled());
 
-      // Guidance naming the submitted term would now describe text the field
-      // no longer holds.
-      expect(screen.queryByText(/isn't filed under/i)).not.toBeInTheDocument();
-      expect(artistInput).toHaveValue("DJ E");
+      expect(albumTitleInput).toBeEnabled();
+      expect(screen.getByRole("combobox", { name: "Genre" })).toBeEnabled();
+      expect(screen.getByRole("combobox", { name: "Format" })).toBeEnabled();
+      expect(artistInput).toBeEnabled();
+      expect(labelInput).toBeEnabled();
+    });
+
+    // A trailing space submits identically to the trimmed term — the guard
+    // must compare on the same basis it is protecting, not the raw field
+    // value against the trimmed one, or a submission that carried whitespace
+    // and was never touched again would read as "edited" and lose guidance
+    // it is still entitled to.
+    it("still shows guidance for a submitted term that carried surrounding whitespace", async () => {
+      mockAddAlbum(() =>
+        HttpResponse.json(
+          {
+            message:
+              "Artist doesn't exist or hasn't released an album in this genre before. Add a new artist entry to the library",
+          },
+          { status: 400 },
+        ),
+      );
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "Edits");
+      await pickGenre(user);
+      await pickFormat(user);
+
+      const artistInput = await screen.findByPlaceholderText("Search artists...");
+      await user.type(artistInput, "Chuquimamani-Condori  ");
+
+      const labelInput = await screen.findByPlaceholderText("Search labels...");
+      await user.type(labelInput, "self-released");
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+
+      expect(
+        await screen.findByText(/Chuquimamani-Condori.*isn't filed under Rock/i),
+      ).toBeInTheDocument();
+    });
+
+    // The Genre Select is disabled for the same window (see the
+    // field-disabling test above), so a genre swap can no longer race a
+    // pending rejection through the UI at all — this pins the other half of
+    // the same in-flight window: dismissal.
+    it("refuses to dismiss while a save is in flight", async () => {
+      let resolveResponse: (response: Response) => void;
+      const responsePromise = new Promise<Response>((resolve) => {
+        resolveResponse = resolve;
+      });
+      const getReceivedBody = mockAddAlbum(() => responsePromise);
+      const confirmSpy = vi.spyOn(window, "confirm");
+      const { user } = renderWithProviders(<AddReleasePanel />);
+
+      await openPanel(user);
+      await user.type(screen.getByLabelText(/Album title/), "DOGA");
+      await pickGenre(user);
+      await pickFormat(user);
+      await user.type(
+        await screen.findByPlaceholderText("Search artists..."),
+        "Juana Molina",
+      );
+      await user.type(
+        await screen.findByPlaceholderText("Search labels..."),
+        "Sonamos",
+      );
+
+      await user.click(screen.getByRole("button", { name: "Save Release" }));
+      await waitFor(() => expect(getReceivedBody()).toBeDefined());
+
+      await user.click(screen.getByTestId("CloseIcon"));
+
+      // Neither the confirm question nor a close: the request could still
+      // succeed and create the row a moment later, which would make "nothing
+      // has been saved yet" false.
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(screen.getByRole("button", { name: "Save Release" })).toBeInTheDocument();
+
+      resolveResponse!(HttpResponse.json({ id: 999 }));
+      await waitFor(() =>
+        expect(screen.queryByRole("button", { name: "Save Release" })).not.toBeInTheDocument(),
+      );
+      confirmSpy.mockRestore();
     });
 
     it("leaves a 400 that is not the genre-scoped miss to the generic error path", async () => {

--- a/tests/integration/components/modern/catalog/ArtistAddPanel.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddPanel.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders } from "@/tests/helpers";
+import { server } from "@/tests/fakes/server";
+import { TEST_BACKEND_URL } from "@/tests/helpers/constants";
+import ArtistAddPanel from "@/src/components/experiences/modern/catalog/ArtistAddPanel";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<
+  typeof vi.fn
+>;
+
+function session() {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role: null,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+  };
+}
+
+describe("ArtistAddPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSession.mockReturnValue(session());
+    mockFetchOrgRole.mockResolvedValue("musicDirector");
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
+        HttpResponse.json([{ id: 7, genre_name: "Rock" }]),
+      ),
+    );
+  });
+
+  // The add-release panel tells an MD whose artist isn't filed under the
+  // chosen genre to add that artist first. This entry point is what makes
+  // that instruction followable — without it the form exists but nothing
+  // renders it, and the release cannot be filed at all.
+  it("opens the artist-add form from the catalog header", async () => {
+    const { user } = renderWithProviders(<ArtistAddPanel />);
+
+    const trigger = await screen.findByRole("button", { name: /add artist/i });
+    expect(
+      screen.queryByPlaceholderText("Search artists..."),
+    ).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    expect(
+      await screen.findByPlaceholderText("Search artists..."),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Code number")).toBeInTheDocument();
+  });
+
+  it("stays shut for a DJ", async () => {
+    mockFetchOrgRole.mockResolvedValue("dj");
+    renderWithProviders(<ArtistAddPanel />);
+
+    await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
+    expect(
+      screen.queryByRole("button", { name: /add artist/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
+++ b/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
@@ -149,6 +149,24 @@ function ControlledTypeahead({
   );
 }
 
+/**
+ * The field's production home (AddReleasePanel) is a form, where an
+ * unhandled Enter submits. Wrapping it in one is the only way to observe
+ * which key presses this component lets through to that submission.
+ */
+function TypeaheadInForm({ onSubmit }: { onSubmit: () => void }) {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+    >
+      <ControlledTypeahead />
+    </form>
+  );
+}
+
 const findInput = () => screen.findByPlaceholderText("Search artists...");
 
 describe("ArtistSearchTypeahead", () => {
@@ -1023,6 +1041,42 @@ describe("ArtistSearchTypeahead", () => {
 
         expect(await screen.findByText("Juana Molina")).toBeInTheDocument();
         expect(requests).toHaveLength(2);
+      });
+    });
+
+    // The backend resolves an artist by exact genre-scoped name, so a
+    // submission that outruns the search sends a partially-typed name with no
+    // artist_id and skips the duplicate check this field exists to run. Enter
+    // is only allowed through once the search has an answer.
+    describe("Enter inside a form", () => {
+      it("swallows Enter while the search is still in flight", async () => {
+        mockArtistSearch([juanaMolina]);
+        const onSubmit = vi.fn();
+        const { user } = renderWithProviders(<TypeaheadInForm onSubmit={onSubmit} />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        // Still inside the debounce window: no answer to act on yet.
+        await user.keyboard("{Enter}");
+
+        expect(onSubmit).not.toHaveBeenCalled();
+      });
+
+      it("swallows Enter while the search is reporting a failure", async () => {
+        mockArtistSearch(() =>
+          HttpResponse.json({ message: "boom" }, { status: 500 }),
+        );
+        const onSubmit = vi.fn();
+        const { user } = renderWithProviders(<TypeaheadInForm onSubmit={onSubmit} />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByRole("alert");
+
+        await user.keyboard("{Enter}");
+
+        expect(onSubmit).not.toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
## Summary

Closes #1079

- Adds an MD-gated add-release panel wired to `useAddAlbumMutation`, reachable from the catalog page (`app/dashboard/@modern/catalog/page.tsx`).
- Artist linking reuses the shared `ArtistSearchTypeahead`, preferring a resolved `artist_id` over a bare `artist_name` wherever the MD picks an existing artist. The typed field's confirmed id is retracted (falling back to `artist_name`) both when the text is edited away from the pick and when the genre changes underneath it.
- The label field uses `LabelSearchTypeahead` over `GET /labels/search` with a free-type create fallback — picking an existing row sends `label_id` alongside `label`; free-typing sends `label` alone and the backend upserts it. Creating a label dispatches `labelsApi.util.invalidateTags`, the cross-`createApi` invalidation that slice's tag exists for: without it the picker keeps serving its pre-creation results for the cache lifetime, the librarian doesn't see the label they just made, and they type a variant — a different string, and so a second row.
- Never sends `album_artist` (the backend silently drops it) or `code_number` (assigned server-side).
- A genre-scoped artist-resolution miss (`addAlbum`'s 400 for an `artist_name` not filed under the chosen genre) surfaces inline guidance routing the MD toward adding the artist first, instead of a generic error toast.
- **Adds `ArtistAddPanel`**, mounting the artist-add form beside Add Release in the catalog header. That guidance told the MD to add the artist first, and nothing rendered the form — each half was correct alone and the gap existed only between them, so the release could not be filed at all.

## In-flight mutation races

Every field is disabled while `addAlbum` is in flight, and dismissal is refused outright rather than confirmed — the confirm's "nothing has been saved yet" could be false by the time it is read. Behind that, a single generation counter bumped on any invalidating change (artist edit, genre change, close) is snapshotted at submit and checked by both the catch and the success path, so a settled request can neither resurrect guidance naming a genre the MD has moved off nor close a panel they have since reopened and refilled.

## Accessibility

Both catalog dialogs now title themselves with `DialogTitle`. `ModalDialog` emits `aria-labelledby` unconditionally and only `DialogTitle` claims that id, so a bare `Typography` left both dialogs with a dangling reference and no accessible name.

## Test plan

- [x] `npx vitest run` — 305 files / 4224 tests green
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors, 199 warnings (unchanged baseline)
- [x] Integration tests assert the serialized `POST /library` body for the picked-artist/picked-label path, the free-typed path, and both artist_id retraction paths; confirm no `album_artist`/`code_number` keys are ever sent; cover the genre-scoped-miss routing, the label-cache invalidation, the in-flight field disabling, and the refused dismissal
- [x] Reachability is asserted against the catalog page, not against either panel in isolation — a panel rendered alone proves it opens its own modal and nothing about the page mounting it

## Related

- WXYC/dj-site#1099 — will consolidate `ArtistSearchTypeahead` and `LabelSearchTypeahead`, which this PR mounts side by side
