### PR TITLE
feat(catalog): label search typeahead over the labels endpoint

### DIFF
--- a/lib/features/labels/api.ts
+++ b/lib/features/labels/api.ts
@@ -24,8 +24,10 @@ export const labelsApi = createApi({
         response ?? [],
       // Label creation is an upsert on the exact name, so a stale empty result
       // served from cache after a label was created sends the next search back
-      // through the create path and produces a second row. A mutation that
-      // writes a label invalidates this tag.
+      // through the create path and produces a second row. The only writer is
+      // the release-creation mutation, which lives in a different `createApi`
+      // — and `invalidatesTags` does not reach across instances. It has to
+      // dispatch `labelsApi.util.invalidateTags` for this tag to do anything.
       providesTags: [{ type: "LabelSearch", id: "LIST" }],
     }),
   }),

--- a/lib/features/labels/api.ts
+++ b/lib/features/labels/api.ts
@@ -1,13 +1,14 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
+import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { backendBaseQuery } from "../backend";
-import { LabelRow, SearchLabelsParams } from "./types";
+import { Label, SearchLabelsParams } from "./types";
 
 export const labelsApi = createApi({
   reducerPath: "labelsApi",
   baseQuery: backendBaseQuery("labels"),
   tagTypes: ["LabelSearch"],
   endpoints: (builder) => ({
-    searchLabels: builder.query<LabelRow[], SearchLabelsParams>({
+    searchLabels: builder.query<Label[], SearchLabelsParams>({
       query: ({ q, limit }) => ({
         url: "/search",
         params: { q, limit },
@@ -20,14 +21,33 @@ export const labelsApi = createApi({
       // near-duplicate this endpoint exists to surface. Opt out so an outage
       // reaches consumers as an error they can refuse to act on.
       extraOptions: { surfaceNonJsonAsError: true },
-      transformResponse: (response: LabelRow[] | null): LabelRow[] =>
+      transformResponse: (response: Label[] | null): Label[] =>
         response ?? [],
-      // Label creation is an upsert on the exact name, so a stale empty result
-      // served from cache after a label was created sends the next search back
-      // through the create path and produces a second row. The only writer is
-      // the release-creation mutation, which lives in a different `createApi`
-      // — and `invalidatesTags` does not reach across instances. It has to
-      // dispatch `labelsApi.util.invalidateTags` for this tag to do anything.
+      // The picker renders its own inline outage panel (role="alert") for
+      // every shape of failure here, so the shared rtk-query-error-logger
+      // middleware reporting the same failure again as a global toast is a
+      // second, redundant surface for one event — worse, a screen reader
+      // announces both. That middleware keys its toast branches off
+      // `payload.data.message`, `payload.status`, and `payload.error`;
+      // nesting the real error under a key it never inspects keeps this
+      // endpoint's failures out of the global toast without touching that
+      // shared module. Its unconditional PostHog capture is untouched by this
+      // transform, so a searchLabels failure is still recorded there.
+      transformErrorResponse: (
+        response: FetchBaseQueryError,
+      ): { searchLabelsError: FetchBaseQueryError } => ({
+        searchLabelsError: response,
+      }),
+      // The only writer of labels is the release-creation mutation, which
+      // lives in a different `createApi` — `invalidatesTags` does not reach
+      // across API instances, so it has to dispatch
+      // `labelsApi.util.invalidateTags` for this tag to do anything. That
+      // cross-slice invalidation is the whole reason the tag exists: it is
+      // not preventing a duplicate row. `labelsService.createLabel` upserts
+      // with `onConflictDoNothing({ target: labels.label_name })` and
+      // re-selects, so resubmitting an identical label name can never create
+      // a second row — a duplicate needs a different string, which is a
+      // different cache key and so was never at risk from a stale entry here.
       providesTags: [{ type: "LabelSearch", id: "LIST" }],
     }),
   }),

--- a/lib/features/labels/api.ts
+++ b/lib/features/labels/api.ts
@@ -1,0 +1,20 @@
+import { createApi } from "@reduxjs/toolkit/query/react";
+import { backendBaseQuery } from "../backend";
+import { LabelRow, SearchLabelsParams } from "./types";
+
+export const labelsApi = createApi({
+  reducerPath: "labelsApi",
+  baseQuery: backendBaseQuery("labels"),
+  endpoints: (builder) => ({
+    searchLabels: builder.query<LabelRow[], SearchLabelsParams>({
+      query: ({ q, limit }) => ({
+        url: "/search",
+        params: { q, limit },
+      }),
+      transformResponse: (response: LabelRow[] | null): LabelRow[] =>
+        response ?? [],
+    }),
+  }),
+});
+
+export const { useSearchLabelsQuery } = labelsApi;

--- a/lib/features/labels/api.ts
+++ b/lib/features/labels/api.ts
@@ -14,12 +14,12 @@ export const labelsApi = createApi({
         params: { q, limit },
       }),
       // The shared base query soft-fails an unparseable body — a gateway's HTML
-      // 502, Express's HTML 404 — into a successful `null` payload. For a
-      // duplicate check that resolves to "no existing label matched", which is
-      // the one answer an unreachable backend cannot give: the consumer would
-      // render its create affordance and the librarian would file the very
-      // near-duplicate this endpoint exists to surface. Opt out so an outage
-      // reaches consumers as an error they can refuse to act on.
+      // 502, Express's HTML 404 — into a successful `null` payload, which here
+      // resolves to "no existing label matched". That is the one answer an
+      // unreachable backend cannot honestly give: the consumer renders its
+      // create affordance and the librarian files the very near-duplicate this
+      // endpoint exists to surface. Opt out so an outage reaches consumers as
+      // an error they can refuse to act on.
       extraOptions: { surfaceNonJsonAsError: true },
       transformResponse: (response: Label[] | null): Label[] =>
         response ?? [],
@@ -33,10 +33,10 @@ export const labelsApi = createApi({
       // endpoint's failures out of the global toast without touching that
       // shared module. Its unconditional PostHog capture still fires for
       // every searchLabels failure (it is not behind any of those checks),
-      // but reads the same three fields for the error message it records —
-      // so the trade for silencing the toast is a generic "RTK Query error"
-      // capture there instead of the real status/body, still tagged with
-      // `endpoint: "searchLabels"` from the action's own metadata.
+      // but builds its message from `data.message` and `error`, both of which
+      // the nesting hides — so the trade for silencing the toast is a generic
+      // "RTK Query error" capture carrying no status or body, still tagged
+      // with `endpoint: "searchLabels"` from the action's own metadata.
       transformErrorResponse: (
         response: FetchBaseQueryError,
       ): { searchLabelsError: FetchBaseQueryError } => ({

--- a/lib/features/labels/api.ts
+++ b/lib/features/labels/api.ts
@@ -5,14 +5,28 @@ import { LabelRow, SearchLabelsParams } from "./types";
 export const labelsApi = createApi({
   reducerPath: "labelsApi",
   baseQuery: backendBaseQuery("labels"),
+  tagTypes: ["LabelSearch"],
   endpoints: (builder) => ({
     searchLabels: builder.query<LabelRow[], SearchLabelsParams>({
       query: ({ q, limit }) => ({
         url: "/search",
         params: { q, limit },
       }),
+      // The shared base query soft-fails an unparseable body — a gateway's HTML
+      // 502, Express's HTML 404 — into a successful `null` payload. For a
+      // duplicate check that resolves to "no existing label matched", which is
+      // the one answer an unreachable backend cannot give: the consumer would
+      // render its create affordance and the librarian would file the very
+      // near-duplicate this endpoint exists to surface. Opt out so an outage
+      // reaches consumers as an error they can refuse to act on.
+      extraOptions: { surfaceNonJsonAsError: true },
       transformResponse: (response: LabelRow[] | null): LabelRow[] =>
         response ?? [],
+      // Label creation is an upsert on the exact name, so a stale empty result
+      // served from cache after a label was created sends the next search back
+      // through the create path and produces a second row. A mutation that
+      // writes a label invalidates this tag.
+      providesTags: [{ type: "LabelSearch", id: "LIST" }],
     }),
   }),
 });

--- a/lib/features/labels/api.ts
+++ b/lib/features/labels/api.ts
@@ -31,8 +31,12 @@ export const labelsApi = createApi({
       // `payload.data.message`, `payload.status`, and `payload.error`;
       // nesting the real error under a key it never inspects keeps this
       // endpoint's failures out of the global toast without touching that
-      // shared module. Its unconditional PostHog capture is untouched by this
-      // transform, so a searchLabels failure is still recorded there.
+      // shared module. Its unconditional PostHog capture still fires for
+      // every searchLabels failure (it is not behind any of those checks),
+      // but reads the same three fields for the error message it records —
+      // so the trade for silencing the toast is a generic "RTK Query error"
+      // capture there instead of the real status/body, still tagged with
+      // `endpoint: "searchLabels"` from the action's own metadata.
       transformErrorResponse: (
         response: FetchBaseQueryError,
       ): { searchLabelsError: FetchBaseQueryError } => ({

--- a/lib/features/labels/types.ts
+++ b/lib/features/labels/types.ts
@@ -1,0 +1,11 @@
+export type LabelRow = {
+  id: number;
+  label_name: string;
+  parent_label_id?: number | null;
+};
+
+/** GET /labels/search — `q` is matched case-insensitively as a prefix. */
+export type SearchLabelsParams = {
+  q: string;
+  limit?: number;
+};

--- a/lib/features/labels/types.ts
+++ b/lib/features/labels/types.ts
@@ -1,8 +1,6 @@
-export type LabelRow = {
-  id: number;
-  label_name: string;
-  parent_label_id?: number | null;
-};
+import type { Label } from "@wxyc/shared/dtos";
+
+export type { Label };
 
 /** GET /labels/search — `q` is matched case-insensitively as a prefix. */
 export type SearchLabelsParams = {

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -18,6 +18,7 @@ import {
   createLiveUpdatesListenerMiddleware,
 } from "./features/flowsheet/live-updates-listener";
 import { liveUpdatesSlice } from "./features/flowsheet/live-updates-slice";
+import { labelsApi } from "./features/labels/api";
 import { lmlApi } from "./features/lml/api";
 import { metadataApi } from "./features/metadata/api";
 import { playlistSearchApi } from "./features/playlist-search/api";
@@ -37,6 +38,7 @@ const rootReducer = combineSlices(
   flowsheetSlice,
   flowsheetApi,
   liveUpdatesSlice,
+  labelsApi,
   lmlApi,
   metadataApi,
   playlistSearchSlice,
@@ -63,6 +65,7 @@ export const makeStore = () => {
         .concat(catalogApi.middleware)
         .concat(binApi.middleware)
         .concat(flowsheetApi.middleware)
+        .concat(labelsApi.middleware)
         .concat(lmlApi.middleware)
         .concat(metadataApi.middleware)
         .concat(playlistSearchApi.middleware)

--- a/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useCallback, useId, useRef, useState } from "react";
+import { ClickAwayListener } from "@mui/base/ClickAwayListener";
+import { Box, Button, CircularProgress, Input, Sheet, Typography } from "@mui/joy";
+import { useSearchLabelsQuery } from "@/lib/features/labels/api";
+import type { LabelRow } from "@/lib/features/labels/types";
+import { useDebouncedValue } from "@/src/hooks/useDebouncedValue";
+
+const DEBOUNCE_MS = 300;
+const MIN_QUERY_LENGTH = 2;
+const RESULT_LIMIT = 10;
+
+/** Nothing highlighted. Arrow keys and hover are the only way onto a row. */
+const NO_HIGHLIGHT = -1;
+
+const NO_LABELS: LabelRow[] = [];
+
+/**
+ * Search-backed label picker over `GET /labels/search`. Unlike the artist
+ * typeahead, there is no separate "create new" affordance: `createLabel`'s
+ * conflict target is the exact label name, so free-typing without picking a
+ * row already IS the create path (the caller sends the typed text as `label`
+ * and omits `label_id`, and the backend upserts it). This component only
+ * needs to surface existing matches early enough that the MD sees a
+ * near-duplicate before submitting past it.
+ *
+ * `value`/`onChange` are caller-owned for the same reason as the artist
+ * typeahead: a caller needs to seed and clear this field from outside.
+ * `onSelectionCleared` retracts an earlier `onSelect` when the field is
+ * edited away from the picked label's name, so a caller does not keep a
+ * `label_id` that no longer matches the text it is about to submit.
+ */
+export interface LabelSearchTypeaheadProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSelect: (label: LabelRow) => void;
+  onSelectionCleared: () => void;
+  disabled?: boolean;
+}
+
+export default function LabelSearchTypeahead({
+  value,
+  onChange,
+  onSelect,
+  onSelectionCleared,
+  disabled,
+}: LabelSearchTypeaheadProps) {
+  const [open, setOpen] = useState(false);
+  const [rawHighlightIndex, setHighlightIndex] = useState(NO_HIGHLIGHT);
+  const confirmedLabel = useRef<LabelRow | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listboxId = useId();
+
+  const trimmed = value.trim();
+  const debouncedQuery = useDebouncedValue(trimmed, DEBOUNCE_MS);
+
+  const hasValidQuery = trimmed.length >= MIN_QUERY_LENGTH;
+  const debouncedIsValid = debouncedQuery.length >= MIN_QUERY_LENGTH;
+  const panelOpen = open && !disabled;
+  const skip = !panelOpen || !debouncedIsValid;
+
+  const {
+    currentData: data,
+    isFetching,
+    isError,
+    refetch,
+  } = useSearchLabelsQuery(
+    { q: debouncedQuery, limit: RESULT_LIMIT },
+    { skip },
+  );
+
+  const pendingDebounce = hasValidQuery && debouncedQuery !== trimmed;
+  const resultsAreCurrent = hasValidQuery && !pendingDebounce && !skip;
+  const labels = resultsAreCurrent ? (data ?? NO_LABELS) : NO_LABELS;
+
+  const showPanel = panelOpen && hasValidQuery;
+  const isSearching = showPanel && (pendingDebounce || isFetching);
+  const showError = resultsAreCurrent && isError && data === undefined;
+  const showSearching = isSearching && labels.length === 0 && !showError;
+  const showNoMatches = showPanel && !showError && !showSearching && labels.length === 0;
+  const showListbox = showPanel && !showError && !showSearching && !showNoMatches;
+
+  // The highlight is local state while the rows come from the query, so nothing
+  // structurally holds the two in step across a re-render. Clamping here keeps
+  // every index the list no longer has pointing at the last row, and collapses
+  // to NO_HIGHLIGHT on an empty list, so `labels[highlightIndex]` below is
+  // always a row that exists. There is no create row underneath the results to
+  // slide onto — free-typing past the panel already is this field's create
+  // path — so the clamp has no sentinel to preserve.
+  const highlightIndex =
+    rawHighlightIndex >= labels.length ? labels.length - 1 : rawHighlightIndex;
+
+  const openPanel = useCallback(() => {
+    if (disabled) return;
+    setOpen(true);
+  }, [disabled]);
+
+  const closePanel = useCallback(() => {
+    setOpen(false);
+    setHighlightIndex(NO_HIGHLIGHT);
+  }, []);
+
+  const handleSelect = useCallback(
+    (label: LabelRow) => {
+      confirmedLabel.current = label;
+      onChange(label.label_name);
+      onSelect(label);
+      closePanel();
+    },
+    [onChange, onSelect, closePanel],
+  );
+
+  const handleTextEdit = useCallback(
+    (next: string) => {
+      onChange(next);
+      if (
+        confirmedLabel.current &&
+        next.trim() !== confirmedLabel.current.label_name
+      ) {
+        confirmedLabel.current = null;
+        onSelectionCleared();
+      }
+      setOpen(true);
+      setHighlightIndex(NO_HIGHLIGHT);
+    },
+    [onChange, onSelectionCleared],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // Escape dismisses any open panel, including the error, in-progress and
+      // no-match states that have no rows to navigate. The event stops here
+      // rather than bubbling: this field is mounted inside a dialog whose own
+      // Escape handler closes it and discards the form, and that handler does
+      // not consult defaultPrevented — so dismissing a suggestion list would
+      // otherwise cost the MD every field they had filled in.
+      if (e.key === "Escape" && showPanel) {
+        e.preventDefault();
+        e.stopPropagation();
+        closePanel();
+        inputRef.current?.blur();
+        return;
+      }
+      // The panel is open but has no answer yet: the search is still in flight,
+      // or it failed outright. Implicit form submission from this input would
+      // save the free-typed name past a duplicate check that never completed,
+      // and the backend upserts on the exact label name — so "duophonic" would
+      // quietly become a second row beside "Duophonic", which is the whole
+      // reason this field is a picker instead of a text box.
+      if (e.key === "Enter" && (showSearching || showError)) {
+        e.preventDefault();
+        return;
+      }
+      if (!showListbox) return;
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setHighlightIndex(Math.min(highlightIndex + 1, labels.length - 1));
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setHighlightIndex(Math.max(highlightIndex - 1, NO_HIGHLIGHT));
+          break;
+        case "Enter":
+          // Swallowed whether or not a row is highlighted: this input sits
+          // inside the add-release form, and letting Enter through over an
+          // open listbox would submit the release instead of picking the
+          // existing label the MD had just navigated to.
+          e.preventDefault();
+          if (highlightIndex >= 0) {
+            handleSelect(labels[highlightIndex]);
+          }
+          break;
+      }
+    },
+    [
+      showPanel,
+      showListbox,
+      showSearching,
+      showError,
+      highlightIndex,
+      labels,
+      handleSelect,
+      closePanel,
+    ],
+  );
+
+  return (
+    <ClickAwayListener onClickAway={closePanel}>
+      <Box sx={{ position: "relative", width: "100%" }}>
+        <Input
+          size="sm"
+          fullWidth
+          disabled={disabled}
+          placeholder="Search labels..."
+          value={value}
+          onFocus={openPanel}
+          onClick={openPanel}
+          onChange={(e) => handleTextEdit(e.target.value)}
+          onKeyDown={handleKeyDown}
+          startDecorator={
+            isSearching ? (
+              <CircularProgress
+                size="sm"
+                sx={{ "--CircularProgress-size": "14px" }}
+              />
+            ) : undefined
+          }
+          slotProps={{
+            input: {
+              ref: inputRef,
+              role: "combobox",
+              "aria-label": "Search labels",
+              "aria-expanded": showListbox,
+              "aria-controls": showListbox ? listboxId : undefined,
+              "aria-activedescendant":
+                showListbox && highlightIndex >= 0
+                  ? `${listboxId}-option-${highlightIndex}`
+                  : undefined,
+              "aria-autocomplete": "list",
+              autoComplete: "off",
+              spellCheck: false,
+            },
+          }}
+        />
+
+        {showPanel && (
+          <Sheet
+            variant="outlined"
+            {...(showError
+              ? { role: "alert" as const }
+              : showSearching || showNoMatches
+                ? { role: "status" as const }
+                : { role: "listbox" as const, id: listboxId })}
+            sx={{
+              position: "absolute",
+              top: "calc(100% + 4px)",
+              left: 0,
+              right: 0,
+              zIndex: 8002,
+              borderRadius: "md",
+              maxHeight: "300px",
+              overflowY: "auto",
+              boxShadow: "0px 8px 24px -4px rgba(0,0,0,0.4)",
+              py: 0.5,
+            }}
+          >
+            {showError ? (
+              <Box sx={{ px: 1.5, py: 0.75 }}>
+                <Typography level="body-sm">
+                  Label search is unavailable. Existing labels can&apos;t be
+                  checked right now.
+                </Typography>
+                <Button
+                  size="sm"
+                  variant="plain"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => refetch()}
+                  sx={{ mt: 0.5, px: 0 }}
+                >
+                  Try again
+                </Button>
+              </Box>
+            ) : showSearching ? (
+              <Box sx={{ px: 1.5, py: 0.75 }}>
+                <Typography level="body-sm" sx={{ fontStyle: "italic" }}>
+                  Searching labels...
+                </Typography>
+              </Box>
+            ) : labels.length === 0 ? (
+              <Box sx={{ px: 1.5, py: 0.75 }}>
+                <Typography level="body-sm" sx={{ fontStyle: "italic" }}>
+                  {`"${trimmed}" will be created as a new label.`}
+                </Typography>
+              </Box>
+            ) : (
+              labels.map((label, index) => (
+                <Box
+                  key={label.id}
+                  // Indexed rather than keyed by label id so the id the input's
+                  // aria-activedescendant names can be derived from the
+                  // highlight alone.
+                  id={`${listboxId}-option-${index}`}
+                  role="option"
+                  aria-selected={highlightIndex === index}
+                  // preventDefault keeps focus on the input so neither the
+                  // click-away nor the blur path closes the panel before this
+                  // row's `onClick` selection handler runs.
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => handleSelect(label)}
+                  onMouseEnter={() => setHighlightIndex(index)}
+                  sx={{
+                    px: 1.5,
+                    py: 0.75,
+                    cursor: "pointer",
+                    backgroundColor:
+                      highlightIndex === index ? "primary.700" : "transparent",
+                    "&:hover": {
+                      backgroundColor:
+                        highlightIndex === index ? "primary.700" : "neutral.800",
+                    },
+                  }}
+                >
+                  <Typography
+                    level="body-sm"
+                    sx={{
+                      color: highlightIndex === index ? "white" : "inherit",
+                    }}
+                  >
+                    {label.label_name}
+                  </Typography>
+                </Box>
+              ))
+            )}
+          </Sheet>
+        )}
+      </Box>
+    </ClickAwayListener>
+  );
+}

--- a/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { ClickAwayListener } from "@mui/base/ClickAwayListener";
 import { Box, Button, CircularProgress, Input, Sheet, Typography } from "@mui/joy";
+import { RequireMD } from "@/src/components/shared/Authorization";
 import { useSearchLabelsQuery } from "@/lib/features/labels/api";
 import type { LabelRow } from "@/lib/features/labels/types";
 import { useDebouncedValue } from "@/src/hooks/useDebouncedValue";
@@ -17,8 +18,8 @@ const NO_HIGHLIGHT = -1;
 const NO_LABELS: LabelRow[] = [];
 
 /**
- * Search-backed label picker over `GET /labels/search`. Unlike the artist
- * typeahead, there is no separate "create new" affordance: `createLabel`'s
+ * Search-backed, MD-gated label picker over `GET /labels/search`. Unlike the
+ * artist typeahead, there is no separate "create new" affordance: `createLabel`'s
  * conflict target is the exact label name, so free-typing without picking a
  * row already IS the create path (the caller sends the typed text as `label`
  * and omits `label_id`, and the backend upserts it). This component only
@@ -39,7 +40,7 @@ export interface LabelSearchTypeaheadProps {
   disabled?: boolean;
 }
 
-export default function LabelSearchTypeahead({
+function LabelSearchTypeaheadInner({
   value,
   onChange,
   onSelect,
@@ -50,6 +51,8 @@ export default function LabelSearchTypeahead({
   const [rawHighlightIndex, setHighlightIndex] = useState(NO_HIGHLIGHT);
   const confirmedLabel = useRef<LabelRow | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Row elements by index, kept so the highlight can be scrolled into view.
+  const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
   const listboxId = useId();
 
   const trimmed = value.trim();
@@ -91,6 +94,18 @@ export default function LabelSearchTypeahead({
   const highlightIndex =
     rawHighlightIndex >= labels.length ? labels.length - 1 : rawHighlightIndex;
 
+  // The panel is a fixed-height scroller and holds more rows than fit, so a
+  // highlight driven past the fold by the arrow keys is reachable but invisible
+  // — and Enter would then commit a label id for a row the MD never saw. Scroll
+  // offset is browser state React does not model, so keeping the highlight
+  // visible has to be a post-render synchronization rather than a derivation.
+  // `block: "nearest"` moves the panel only when the row is actually outside it,
+  // leaving an already-visible highlight where it is.
+  useEffect(() => {
+    if (highlightIndex < 0) return;
+    rowRefs.current[highlightIndex]?.scrollIntoView({ block: "nearest" });
+  }, [highlightIndex]);
+
   const openPanel = useCallback(() => {
     if (disabled) return;
     setOpen(true);
@@ -100,6 +115,21 @@ export default function LabelSearchTypeahead({
     setOpen(false);
     setHighlightIndex(NO_HIGHLIGHT);
   }, []);
+
+  // Focus leaving the field entirely takes the panel with it. The panel is
+  // absolutely positioned and stacked above the rest of the form, so one left
+  // standing after a Tab covers whatever the MD just moved into, and its Escape
+  // dismissal is no longer reachable from there. Containment is checked against
+  // the whole wrapper, not just the input, so moving focus to the retry button
+  // inside the panel does not close it. Rows suppress the focus shift on
+  // mousedown, so a row click never reaches this path at all.
+  const handleFocusOut = useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      if (e.currentTarget.contains(e.relatedTarget)) return;
+      closePanel();
+    },
+    [closePanel],
+  );
 
   const handleSelect = useCallback(
     (label: LabelRow) => {
@@ -188,7 +218,7 @@ export default function LabelSearchTypeahead({
 
   return (
     <ClickAwayListener onClickAway={closePanel}>
-      <Box sx={{ position: "relative", width: "100%" }}>
+      <Box sx={{ position: "relative", width: "100%" }} onBlur={handleFocusOut}>
         <Input
           size="sm"
           fullWidth
@@ -278,15 +308,20 @@ export default function LabelSearchTypeahead({
               labels.map((label, index) => (
                 <Box
                   key={label.id}
+                  ref={(el: HTMLDivElement | null) => {
+                    rowRefs.current[index] = el;
+                  }}
                   // Indexed rather than keyed by label id so the id the input's
                   // aria-activedescendant names can be derived from the
                   // highlight alone.
                   id={`${listboxId}-option-${index}`}
                   role="option"
                   aria-selected={highlightIndex === index}
-                  // preventDefault keeps focus on the input so neither the
-                  // click-away nor the blur path closes the panel before this
-                  // row's `onClick` selection handler runs.
+                  // Suppressing the default mousedown keeps focus on the input,
+                  // so the wrapper's focus-out handler never runs and the panel
+                  // is still mounted when this row's `onClick` selection handler
+                  // fires. Without it the row unmounts under the pointer between
+                  // mousedown and click, and the pick is lost.
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => handleSelect(label)}
                   onMouseEnter={() => setHighlightIndex(index)}
@@ -317,5 +352,13 @@ export default function LabelSearchTypeahead({
         )}
       </Box>
     </ClickAwayListener>
+  );
+}
+
+export default function LabelSearchTypeahead(props: LabelSearchTypeaheadProps) {
+  return (
+    <RequireMD>
+      <LabelSearchTypeaheadInner {...props} />
+    </RequireMD>
   );
 }

--- a/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
@@ -53,6 +53,11 @@ function LabelSearchTypeaheadInner({
   const inputRef = useRef<HTMLInputElement>(null);
   // Row elements by index, kept so the highlight can be scrolled into view.
   const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
+  // Whether the arrow keys, rather than the pointer, put the highlight where it
+  // is. Only a keyboard move can land off-screen; a hovered row is by
+  // definition under the cursor, and scrolling it flush would slide a different
+  // row beneath a cursor that never moved and re-highlight from there.
+  const highlightFromKeyboard = useRef(false);
   const listboxId = useId();
 
   const trimmed = value.trim();
@@ -102,7 +107,7 @@ function LabelSearchTypeaheadInner({
   // `block: "nearest"` moves the panel only when the row is actually outside it,
   // leaving an already-visible highlight where it is.
   useEffect(() => {
-    if (highlightIndex < 0) return;
+    if (!highlightFromKeyboard.current || highlightIndex < 0) return;
     rowRefs.current[highlightIndex]?.scrollIntoView({ block: "nearest" });
   }, [highlightIndex]);
 
@@ -186,10 +191,12 @@ function LabelSearchTypeaheadInner({
       switch (e.key) {
         case "ArrowDown":
           e.preventDefault();
+          highlightFromKeyboard.current = true;
           setHighlightIndex(Math.min(highlightIndex + 1, labels.length - 1));
           break;
         case "ArrowUp":
           e.preventDefault();
+          highlightFromKeyboard.current = true;
           setHighlightIndex(Math.max(highlightIndex - 1, NO_HIGHLIGHT));
           break;
         case "Enter":
@@ -200,6 +207,13 @@ function LabelSearchTypeaheadInner({
           e.preventDefault();
           if (highlightIndex >= 0) {
             handleSelect(labels[highlightIndex]);
+          } else {
+            // Nothing highlighted, and this field has no create row for the
+            // keyboard to land on — so the key would otherwise do nothing at
+            // all and leave no way forward but Escape. Dismissing the matches
+            // is the answer to "I have seen them and still mean this text":
+            // the check has already reported, so the next Enter submits.
+            closePanel();
           }
           break;
       }
@@ -324,7 +338,16 @@ function LabelSearchTypeaheadInner({
                   // mousedown and click, and the pick is lost.
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => handleSelect(label)}
-                  onMouseEnter={() => setHighlightIndex(index)}
+                  // Pointer motion, not entry: scrolling the keyboard's chosen
+                  // row into view slides a different row under a cursor parked
+                  // over the panel, and entry alone would then hand that row the
+                  // highlight the arrow key had just placed. `mousemove` only
+                  // fires when the pointer itself moves, so the keyboard keeps
+                  // the highlight until the MD actually reaches for the mouse.
+                  onMouseMove={() => {
+                    highlightFromKeyboard.current = false;
+                    setHighlightIndex(index);
+                  }}
                   sx={{
                     px: 1.5,
                     py: 0.75,

--- a/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
@@ -5,7 +5,7 @@ import { ClickAwayListener } from "@mui/base/ClickAwayListener";
 import { Box, Button, CircularProgress, Input, Sheet, Typography } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
 import { useSearchLabelsQuery } from "@/lib/features/labels/api";
-import type { LabelRow } from "@/lib/features/labels/types";
+import type { Label } from "@/lib/features/labels/types";
 import { useDebouncedValue } from "@/src/hooks/useDebouncedValue";
 
 const DEBOUNCE_MS = 300;
@@ -15,7 +15,7 @@ const RESULT_LIMIT = 10;
 /** Nothing highlighted. Arrow keys and hover are the only way onto a row. */
 const NO_HIGHLIGHT = -1;
 
-const NO_LABELS: LabelRow[] = [];
+const NO_LABELS: Label[] = [];
 
 /**
  * Search-backed, MD-gated label picker over `GET /labels/search`. Unlike the
@@ -35,7 +35,7 @@ const NO_LABELS: LabelRow[] = [];
 export interface LabelSearchTypeaheadProps {
   value: string;
   onChange: (value: string) => void;
-  onSelect: (label: LabelRow) => void;
+  onSelect: (label: Label) => void;
   onSelectionCleared: () => void;
   disabled?: boolean;
 }
@@ -49,7 +49,7 @@ function LabelSearchTypeaheadInner({
 }: LabelSearchTypeaheadProps) {
   const [open, setOpen] = useState(false);
   const [rawHighlightIndex, setHighlightIndex] = useState(NO_HIGHLIGHT);
-  const confirmedLabel = useRef<LabelRow | null>(null);
+  const confirmedLabel = useRef<Label | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   // Row elements by index, kept so the highlight can be scrolled into view.
   const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
@@ -71,6 +71,7 @@ function LabelSearchTypeaheadInner({
   const {
     currentData: data,
     isFetching,
+    isUninitialized,
     isError,
     refetch,
   } = useSearchLabelsQuery(
@@ -83,11 +84,17 @@ function LabelSearchTypeaheadInner({
   const labels = resultsAreCurrent ? (data ?? NO_LABELS) : NO_LABELS;
 
   const showPanel = panelOpen && hasValidQuery;
-  const isSearching = showPanel && (pendingDebounce || isFetching);
+  // `skip` flipping false does not dispatch the query until the next effect,
+  // so the render in between reports `isFetching: false` — RTK Query's
+  // uninitialized window. Without `isUninitialized` here that render reads as
+  // a completed search with no matches: the "will be created as a new label"
+  // copy (and the Enter guard that lets a submit through on it) would fire a
+  // beat before the duplicate check has actually been dispatched.
+  const isSearching = showPanel && (pendingDebounce || isFetching || isUninitialized);
   const showError = resultsAreCurrent && isError && data === undefined;
   const showSearching = isSearching && labels.length === 0 && !showError;
   const showNoMatches = showPanel && !showError && !showSearching && labels.length === 0;
-  const showListbox = showPanel && !showError && !showSearching && !showNoMatches;
+  const showListbox = showPanel && !showError && !showSearching && labels.length > 0;
 
   // The highlight is local state while the rows come from the query, so nothing
   // structurally holds the two in step across a re-render. Clamping here keeps
@@ -137,7 +144,7 @@ function LabelSearchTypeaheadInner({
   );
 
   const handleSelect = useCallback(
-    (label: LabelRow) => {
+    (label: Label) => {
       confirmedLabel.current = label;
       onChange(label.label_name);
       onSelect(label);
@@ -300,7 +307,16 @@ function LabelSearchTypeaheadInner({
                   size="sm"
                   variant="plain"
                   onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => refetch()}
+                  onClick={() => {
+                    // Retrying swaps this button out for the "searching" panel
+                    // the instant the refetch starts. Moving focus to the
+                    // input before that render commits keeps focus off a node
+                    // React is about to remove — losing focus mid-retry would
+                    // otherwise drop it to <body>, taking arrow-key,
+                    // Enter-to-pick and Escape-to-dismiss with it.
+                    refetch();
+                    inputRef.current?.focus();
+                  }}
                   sx={{ mt: 0.5, px: 0 }}
                 >
                   Try again
@@ -312,7 +328,7 @@ function LabelSearchTypeaheadInner({
                   Searching labels...
                 </Typography>
               </Box>
-            ) : labels.length === 0 ? (
+            ) : showNoMatches ? (
               <Box sx={{ px: 1.5, py: 0.75 }}>
                 <Typography level="body-sm" sx={{ fontStyle: "italic" }}>
                   {`"${trimmed}" will be created as a new label.`}

--- a/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
@@ -91,7 +91,15 @@ function LabelSearchTypeaheadInner({
   // copy (and the Enter guard that lets a submit through on it) would fire a
   // beat before the duplicate check has actually been dispatched.
   const isSearching = showPanel && (pendingDebounce || isFetching || isUninitialized);
-  const showError = resultsAreCurrent && isError && data === undefined;
+  // RTK Query keeps the last-good `data` on a rejected refetch, so a
+  // background refetch of these same args (a cross-slice cache invalidation,
+  // not a keystroke) that fails leaves `data` still holding the prior
+  // successful list — `isError` is true with `data` defined. A duplicate
+  // check that goes on trusting that list because it happens to be non-empty
+  // would report a stale "no match" through exactly the outage it exists to
+  // catch, so `showError` does not require `data === undefined`: any error
+  // for the current args takes the panel over, stale rows or not.
+  const showError = resultsAreCurrent && isError;
   const showSearching = isSearching && labels.length === 0 && !showError;
   const showNoMatches = showPanel && !showError && !showSearching && labels.length === 0;
   const showListbox = showPanel && !showError && !showSearching && labels.length > 0;

--- a/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
+++ b/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
@@ -897,6 +897,47 @@ describe("LabelSearchTypeahead", () => {
       expect(await screen.findByText("Sonamos")).toBeInTheDocument();
       expect(requests).toHaveLength(2);
     });
+
+    // RTK Query keeps the last-good `data` on a rejected refetch (see
+    // `lib/features/backend.ts`), so a background refetch of the same args —
+    // a cross-slice cache invalidation, not a keystroke — that fails leaves
+    // `currentData` still holding the prior successful list. A field that
+    // exists to confirm "no existing label matches" must not go on trusting a
+    // list it can no longer vouch for just because the list itself is
+    // non-empty; the panel has to report the failure, and Enter must not
+    // treat the stale rows as a verified answer.
+    it("reports a background refetch failure instead of trusting the list it had before it", async () => {
+      let requestCount = 0;
+      mockLabelSearch(() => {
+        requestCount += 1;
+        return requestCount === 1
+          ? HttpResponse.json([sonamos])
+          : HttpResponse.json({ message: "boom" }, { status: 500 });
+      });
+      const onSubmit = vi.fn();
+      const { user, store } = renderWithProviders(
+        <TypeaheadInForm onSubmit={onSubmit} />,
+      );
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByText("Sonamos");
+
+      await act(async () => {
+        store.dispatch(
+          labelsApi.util.invalidateTags([{ type: "LabelSearch", id: "LIST" }]),
+        );
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await screen.findByRole("alert");
+
+      expect(screen.queryByText("Sonamos")).not.toBeInTheDocument();
+
+      await user.keyboard("{Enter}");
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
   });
 
   describe("disabled", () => {

--- a/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
+++ b/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
@@ -1,4 +1,12 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  onTestFinished,
+} from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { useState } from "react";
@@ -6,10 +14,66 @@ import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
 import LabelSearchTypeahead from "@/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead";
 import type { LabelRow } from "@/lib/features/labels/types";
 
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+// No organization configured (the real production shape): the WXYC tier
+// resolves via fetchOrganizationRoleForUserClient's JWT decode, not the raw
+// session role, so every test drives that mock and awaits resolution.
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<
+  typeof vi.fn
+>;
+
+function sessionWithRole() {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role: null,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+    error: null,
+  };
+}
+
 const LABEL_SEARCH_URL = `${TEST_BACKEND_URL}/labels/search`;
 
 const sonamos: LabelRow = { id: 5, label_name: "Sonamos" };
 const dragCity: LabelRow = { id: 9, label_name: "Drag City" };
+
+/** More rows than the panel's fixed height shows, so the tail needs scrolling. */
+const manyLabels: LabelRow[] = [
+  "Drag City",
+  "Domino",
+  "Dead Oceans",
+  "Duophonic",
+  "Danger Crue",
+  "Dischord",
+  "Don Giovanni",
+  "Drawing Room",
+  "Dais",
+  "Deathbomb Arc",
+].map((label_name, index) => ({ id: 100 + index, label_name }));
 
 type SearchResponder = (url: URL) => Response | Promise<Response>;
 
@@ -68,15 +132,83 @@ function TypeaheadInForm({ onSubmit }: { onSubmit: () => void }) {
   );
 }
 
+/**
+ * The field's production home is also inside a dialog that closes on Escape and
+ * discards the form with it. Only an enclosing handler can observe whether an
+ * Escape aimed at the suggestion panel also reaches that dialog.
+ */
+function TypeaheadUnderEscapeHandler({ onEscape }: { onEscape: () => void }) {
+  return (
+    <div
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onEscape();
+      }}
+    >
+      <ControlledTypeahead />
+    </div>
+  );
+}
+
+/** A focusable neighbour, so Tab out of the field lands somewhere real. */
+function TypeaheadBesideField({ onSelect }: { onSelect?: (l: LabelRow) => void }) {
+  return (
+    <>
+      <ControlledTypeahead onSelect={onSelect} />
+      <input aria-label="Catalog number" />
+    </>
+  );
+}
+
+/**
+ * Records the element each `scrollIntoView` call targeted. jsdom runs no layout,
+ * so the shared setup stubs the method and the call itself is the only
+ * observable — which element it was made on is what the assertion needs.
+ */
+function captureScrollTargets(): Element[] {
+  const targets: Element[] = [];
+  const spy = vi
+    .spyOn(Element.prototype, "scrollIntoView")
+    .mockImplementation(function (this: Element) {
+      targets.push(this);
+    });
+  onTestFinished(() => spy.mockRestore());
+  return targets;
+}
+
 const findInput = () => screen.findByPlaceholderText("Search labels...");
 
 describe("LabelSearchTypeahead", () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
+    // The field is Music-Director-gated; every test below the permission block
+    // exercises the picker itself, so MD is the default authority.
+    mockFetchOrgRole.mockResolvedValue("musicDirector");
+    mockUseSession.mockReturnValue(sessionWithRole());
   });
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  describe("permission gating", () => {
+    it("renders nothing for a DJ", async () => {
+      mockFetchOrgRole.mockResolvedValue("dj");
+      renderWithProviders(<ControlledTypeahead />);
+
+      await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
+      await mockFetchOrgRole.mock.results[0].value;
+      await waitFor(() =>
+        expect(
+          screen.queryByPlaceholderText("Search labels..."),
+        ).not.toBeInTheDocument(),
+      );
+    });
+
+    it("renders the search input for a Music Director", async () => {
+      renderWithProviders(<ControlledTypeahead />);
+
+      expect(await findInput()).toBeInTheDocument();
+    });
   });
 
   describe("querying", () => {
@@ -171,6 +303,79 @@ describe("LabelSearchTypeahead", () => {
 
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
+
+    // Dismissing a suggestion list and discarding a half-filled release form
+    // are different intents that arrive as the same key. The enclosing dialog's
+    // handler does not consult defaultPrevented, so only stopping propagation
+    // keeps the first from costing the MD the second.
+    it("keeps an Escape aimed at the panel away from an enclosing handler", async () => {
+      mockLabelSearch([sonamos]);
+      const onEscape = vi.fn();
+      const { user } = renderWithProviders(
+        <TypeaheadUnderEscapeHandler onEscape={onEscape} />,
+      );
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("listbox");
+
+      await user.keyboard("{Escape}");
+
+      expect(onEscape).not.toHaveBeenCalled();
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+      // With no panel to dismiss the key is the enclosing handler's, and the
+      // same press reaches it — so the assertion above is about this component
+      // swallowing the event, not about the handler being unreachable.
+      await user.click(input);
+      await user.clear(input);
+      await user.keyboard("{Escape}");
+
+      expect(onEscape).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("focus", () => {
+    // The panel is stacked above the rest of the form, so one left standing
+    // after a Tab covers the field the MD just moved into — and its Escape
+    // dismissal is no longer reachable from there.
+    it("closes the panel when focus leaves the field", async () => {
+      mockLabelSearch([sonamos]);
+      const { user } = renderWithProviders(<TypeaheadBesideField />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("listbox");
+
+      await user.tab();
+
+      expect(screen.getByLabelText("Catalog number")).toHaveFocus();
+      await waitFor(() =>
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument(),
+      );
+    });
+
+    // Rows suppress the focus shift on mousedown for exactly this reason: the
+    // focus-out close must not fire between mousedown and click and take the
+    // row away before its selection handler runs.
+    it("still selects a row clicked while the panel is open", async () => {
+      mockLabelSearch([sonamos]);
+      const onSelect = vi.fn();
+      const { user } = renderWithProviders(
+        <TypeaheadBesideField onSelect={onSelect} />,
+      );
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+
+      await user.click(await screen.findByText("Sonamos"));
+
+      expect(onSelect).toHaveBeenCalledWith(sonamos);
+      expect(input).toHaveValue("Sonamos");
+    });
   });
 
   describe("keyboard selection", () => {
@@ -228,6 +433,39 @@ describe("LabelSearchTypeahead", () => {
       await user.keyboard("{Enter}");
 
       expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    // The panel is a fixed-height scroller holding more rows than it shows, so
+    // a highlight arrowed past the fold is reachable but invisible — and Enter
+    // would commit a label the MD never saw.
+    it("scrolls the highlighted row into view", async () => {
+      const scrolled = captureScrollTargets();
+      mockLabelSearch(manyLabels);
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "D");
+      await user.type(input, "r");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByText("Deathbomb Arc");
+
+      await user.keyboard("{ArrowDown}".repeat(manyLabels.length));
+
+      const options = screen.getAllByRole("option");
+      expect(scrolled.at(-1)).toBe(options[manyLabels.length - 1]);
+    });
+
+    it("does not scroll while nothing is highlighted", async () => {
+      const scrolled = captureScrollTargets();
+      mockLabelSearch(manyLabels);
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Dr");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByText("Deathbomb Arc");
+
+      expect(scrolled).toHaveLength(0);
     });
 
     it("names the highlighted row in aria-activedescendant", async () => {
@@ -382,6 +620,42 @@ describe("LabelSearchTypeahead", () => {
   });
 
   describe("failed search", () => {
+    // A gateway that answers with an HTML error page, or a route that is not
+    // there, produces an unparseable body. The shared base query's default is
+    // to turn that into a successful empty payload, which this picker would
+    // read as "nothing to collide with" — a confirmed no-match reported at the
+    // exact moment the check could not run, which is how an outage becomes the
+    // duplicate label this field exists to prevent.
+    it.each([
+      ["a gateway HTML error page", 502],
+      ["the framework's HTML 404", 404],
+    ])("treats %s as a failure, not a confirmed no-match", async (_name, status) => {
+      mockLabelSearch(
+        () =>
+          new HttpResponse("<!DOCTYPE html><html><body>Error</body></html>", {
+            status,
+            headers: { "Content-Type": "text/html" },
+          }),
+      );
+      const onSubmit = vi.fn();
+      const { user } = renderWithProviders(<TypeaheadInForm onSubmit={onSubmit} />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        /Label search is unavailable/i,
+      );
+      expect(
+        screen.queryByText(/will be created as a new label/i),
+      ).not.toBeInTheDocument();
+
+      await user.keyboard("{Enter}");
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
     it("reports the failure instead of implying a free-typed name is safe", async () => {
       mockLabelSearch(() =>
         HttpResponse.json({ message: "boom" }, { status: 500 }),

--- a/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
+++ b/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
@@ -7,11 +7,12 @@ import {
   afterEach,
   onTestFinished,
 } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { useState } from "react";
 import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
 import LabelSearchTypeahead from "@/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead";
+import { labelsApi } from "@/lib/features/labels/api";
 import type { Label } from "@/lib/features/labels/types";
 
 vi.mock("@/lib/features/authentication/client", () => ({
@@ -261,6 +262,19 @@ describe("LabelSearchTypeahead", () => {
       expect(await screen.findByText("Sonamos")).toBeInTheDocument();
     });
 
+    it("names a real element in aria-controls once there are rows to show", async () => {
+      mockLabelSearch([sonamos]);
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      const listbox = await screen.findByRole("listbox");
+
+      expect(input).toHaveAttribute("aria-expanded", "true");
+      expect(input).toHaveAttribute("aria-controls", listbox.id);
+    });
+
     it("tells the MD a new label will be created when nothing matches", async () => {
       mockLabelSearch([]);
       const { user } = renderWithProviders(<ControlledTypeahead />);
@@ -272,6 +286,22 @@ describe("LabelSearchTypeahead", () => {
       expect(
         await screen.findByText(/will be created as a new label/i),
       ).toBeInTheDocument();
+    });
+
+    // The Sheet only gets an `id` in the listbox variant — the status variant
+    // renders prose, not options, so nothing exists for aria-controls to
+    // name. Naming a nonexistent id here would be a dangling IDREF.
+    it("does not claim the input is expanded or controls a listbox when there is nothing to pick", async () => {
+      mockLabelSearch([]);
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Nonexistent Label");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("status");
+
+      expect(input).toHaveAttribute("aria-expanded", "false");
+      expect(input).not.toHaveAttribute("aria-controls");
     });
   });
 
@@ -457,6 +487,54 @@ describe("LabelSearchTypeahead", () => {
       expect(onSelect).toHaveBeenCalledWith(dragCity);
     });
 
+    // The highlight is local state while the rows come from the query, so a
+    // list that shrinks out from under a highlight set by an earlier response
+    // (a cross-slice cache invalidation refetching the same query with fewer
+    // matches, not a keystroke — typing itself resets the highlight) would
+    // otherwise leave `rawHighlightIndex` pointing past the end of the new
+    // list. Without the clamp, `labels[highlightIndex]` is `undefined` and
+    // Enter would hand the caller a selection that was never on screen.
+    it("clamps a highlight left stale by a list that shrinks under it", async () => {
+      let requestCount = 0;
+      mockLabelSearch(() => {
+        requestCount += 1;
+        return HttpResponse.json(requestCount === 1 ? [sonamos, dragCity] : [dragCity]);
+      });
+      const onSelect = vi.fn();
+      const { user, store } = renderWithProviders(
+        <ControlledTypeahead onSelect={onSelect} />,
+      );
+
+      const input = await findInput();
+      await user.type(input, "Dr");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByText("Drag City");
+
+      // Highlight the last row of the two-row list.
+      await user.keyboard("{ArrowDown}{ArrowDown}");
+      expect(screen.getAllByRole("option").at(-1)).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+
+      // A write elsewhere in the app invalidates the tag this query provides,
+      // refetching the same args with a shorter list — no keystroke, so
+      // nothing resets the highlight.
+      await act(async () => {
+        store.dispatch(
+          labelsApi.util.invalidateTags([{ type: "LabelSearch", id: "LIST" }]),
+        );
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await waitFor(() =>
+        expect(screen.queryByText("Sonamos")).not.toBeInTheDocument(),
+      );
+
+      await user.keyboard("{Enter}");
+
+      expect(onSelect).toHaveBeenCalledWith(dragCity);
+    });
+
     it("does not act on Enter in a panel opened without navigating", async () => {
       mockLabelSearch([sonamos]);
       const onSelect = vi.fn();
@@ -528,6 +606,28 @@ describe("LabelSearchTypeahead", () => {
         "true",
       );
       expect(scrolled).toHaveLength(0);
+    });
+
+    // The highlight is a single piece of state regardless of what moved it —
+    // arrow keys and the pointer both just call setHighlightIndex — so a row
+    // the mouse highlighted is exactly as pickable with Enter as one the
+    // keyboard navigated to.
+    it("picks the row the pointer highlighted when Enter is pressed", async () => {
+      mockLabelSearch([sonamos, dragCity]);
+      const onSelect = vi.fn();
+      const { user } = renderWithProviders(
+        <ControlledTypeahead onSelect={onSelect} />,
+      );
+
+      const input = await findInput();
+      await user.type(input, "So");
+      await vi.advanceTimersByTimeAsync(400);
+
+      await user.hover(await screen.findByText("Drag City"));
+      await user.keyboard("{Enter}");
+
+      expect(onSelect).toHaveBeenCalledWith(dragCity);
+      expect(input).toHaveValue("Drag City");
     });
 
     // The MD means the text they typed even though it prefixes an existing
@@ -756,6 +856,23 @@ describe("LabelSearchTypeahead", () => {
         /Label search is unavailable/i,
       );
       expect(screen.queryByText(/will be created as a new label/i)).not.toBeInTheDocument();
+    });
+
+    // Same reasoning as the no-matches state: the error panel has no `id`
+    // either, so aria-controls would name an element that does not exist.
+    it("does not claim the input is expanded or controls a listbox while reporting a failure", async () => {
+      mockLabelSearch(() =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      );
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("alert");
+
+      expect(input).toHaveAttribute("aria-expanded", "false");
+      expect(input).not.toHaveAttribute("aria-controls");
     });
 
     it("retries the search on demand", async () => {

--- a/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
+++ b/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
@@ -357,6 +357,27 @@ describe("LabelSearchTypeahead", () => {
       );
     });
 
+    // The retry button is the error panel's only recovery affordance, and Tab
+    // is the only way a keyboard reaches it. Closing on focus-out has to be
+    // scoped to focus leaving the field entirely, not merely leaving the input,
+    // or the button unmounts on the very keystroke that would reach it.
+    it("keeps the panel open when focus moves to the retry button", async () => {
+      mockLabelSearch(() =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      );
+      const { user } = renderWithProviders(<TypeaheadBesideField />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("alert");
+
+      await user.tab();
+
+      expect(screen.getByRole("button", { name: /try again/i })).toHaveFocus();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
     // Rows suppress the focus shift on mousedown for exactly this reason: the
     // focus-out close must not fire between mousedown and click and take the
     // row away before its selection handler runs.
@@ -444,8 +465,7 @@ describe("LabelSearchTypeahead", () => {
       const { user } = renderWithProviders(<ControlledTypeahead />);
 
       const input = await findInput();
-      await user.type(input, "D");
-      await user.type(input, "r");
+      await user.type(input, "Dr");
       await vi.advanceTimersByTimeAsync(400);
       await screen.findByText("Deathbomb Arc");
 
@@ -466,6 +486,51 @@ describe("LabelSearchTypeahead", () => {
       await screen.findByText("Deathbomb Arc");
 
       expect(scrolled).toHaveLength(0);
+    });
+
+    // A hovered row is already under the cursor. Scrolling it flush would slide
+    // a different row beneath a cursor that never moved, and that row's own
+    // hover would move the highlight again.
+    it("does not scroll a row the pointer moved the highlight onto", async () => {
+      const scrolled = captureScrollTargets();
+      mockLabelSearch(manyLabels);
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Dr");
+      await vi.advanceTimersByTimeAsync(400);
+
+      await user.hover(await screen.findByText("Deathbomb Arc"));
+
+      expect(screen.getAllByRole("option").at(-1)).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(scrolled).toHaveLength(0);
+    });
+
+    // The MD means the text they typed even though it prefixes an existing
+    // label. With no create row for the keyboard to land on, an Enter that did
+    // nothing at all would leave Escape as the only way forward — so the first
+    // press dismisses the matches it has now been shown, and the second submits.
+    it("dismisses the matches on Enter with nothing highlighted, then submits", async () => {
+      mockLabelSearch([dragCity]);
+      const onSubmit = vi.fn();
+      const { user } = renderWithProviders(<TypeaheadInForm onSubmit={onSubmit} />);
+
+      const input = await findInput();
+      await user.type(input, "Drag");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("listbox");
+
+      await user.keyboard("{Enter}");
+
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      expect(onSubmit).not.toHaveBeenCalled();
+
+      await user.keyboard("{Enter}");
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
     });
 
     it("names the highlighted row in aria-activedescendant", async () => {

--- a/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
+++ b/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
@@ -1,0 +1,456 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { useState } from "react";
+import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
+import LabelSearchTypeahead from "@/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead";
+import type { LabelRow } from "@/lib/features/labels/types";
+
+const LABEL_SEARCH_URL = `${TEST_BACKEND_URL}/labels/search`;
+
+const sonamos: LabelRow = { id: 5, label_name: "Sonamos" };
+const dragCity: LabelRow = { id: 9, label_name: "Drag City" };
+
+type SearchResponder = (url: URL) => Response | Promise<Response>;
+
+function mockLabelSearch(respond: LabelRow[] | SearchResponder): URL[] {
+  const requests: URL[] = [];
+  server.use(
+    http.get(LABEL_SEARCH_URL, ({ request }) => {
+      const url = new URL(request.url);
+      requests.push(url);
+      return typeof respond === "function"
+        ? respond(url)
+        : HttpResponse.json(respond);
+    }),
+  );
+  return requests;
+}
+
+function ControlledTypeahead({
+  initialValue = "",
+  onSelect = vi.fn(),
+  onSelectionCleared = vi.fn(),
+  disabled,
+}: {
+  initialValue?: string;
+  onSelect?: (label: LabelRow) => void;
+  onSelectionCleared?: () => void;
+  disabled?: boolean;
+}) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <LabelSearchTypeahead
+      value={value}
+      onChange={setValue}
+      onSelect={onSelect}
+      onSelectionCleared={onSelectionCleared}
+      disabled={disabled}
+    />
+  );
+}
+
+/**
+ * The field's production home is a form, where an unhandled Enter submits.
+ * Wrapping it in one is the only way to observe which key presses this
+ * component lets through to that submission.
+ */
+function TypeaheadInForm({ onSubmit }: { onSubmit: () => void }) {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+    >
+      <ControlledTypeahead />
+    </form>
+  );
+}
+
+const findInput = () => screen.findByPlaceholderText("Search labels...");
+
+describe("LabelSearchTypeahead", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("querying", () => {
+    it("issues one debounced request", async () => {
+      const requests = mockLabelSearch([sonamos]);
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+
+      expect(requests).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(400);
+      await waitFor(() => expect(requests).toHaveLength(1));
+      expect(requests[0].searchParams.get("q")).toBe("Sona");
+    });
+
+    it("does not query below the minimum query length", async () => {
+      const requests = mockLabelSearch([sonamos]);
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "S");
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(requests).toHaveLength(0);
+    });
+
+    it("does not query for a seeded value until the panel is opened", async () => {
+      const requests = mockLabelSearch([sonamos]);
+      renderWithProviders(<ControlledTypeahead initialValue="Sonamos" />);
+
+      await findInput();
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(requests).toHaveLength(0);
+    });
+
+    it("renders matching results", async () => {
+      mockLabelSearch([sonamos]);
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(await screen.findByText("Sonamos")).toBeInTheDocument();
+    });
+
+    it("tells the MD a new label will be created when nothing matches", async () => {
+      mockLabelSearch([]);
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Nonexistent Label");
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(
+        await screen.findByText(/will be created as a new label/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("selection", () => {
+    it("calls onSelect with the full label on click and writes its name into the field", async () => {
+      mockLabelSearch([sonamos, dragCity]);
+      const onSelect = vi.fn();
+      const { user } = renderWithProviders(
+        <ControlledTypeahead onSelect={onSelect} />,
+      );
+
+      const input = await findInput();
+      await user.type(input, "So");
+      await vi.advanceTimersByTimeAsync(400);
+
+      await user.click(await screen.findByText("Sonamos"));
+
+      expect(onSelect).toHaveBeenCalledWith(sonamos);
+      expect(input).toHaveValue("Sonamos");
+    });
+
+    it("closes the panel on Escape", async () => {
+      mockLabelSearch([sonamos]);
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("listbox");
+
+      await user.keyboard("{Escape}");
+
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("keyboard selection", () => {
+    it("navigates results with the arrow keys and picks with Enter", async () => {
+      mockLabelSearch([sonamos, dragCity]);
+      const onSelect = vi.fn();
+      const { user } = renderWithProviders(
+        <ControlledTypeahead onSelect={onSelect} />,
+      );
+
+      const input = await findInput();
+      await user.type(input, "Dra");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByText("Drag City");
+
+      await user.keyboard("{ArrowDown}{ArrowDown}{ArrowUp}{ArrowDown}{Enter}");
+
+      expect(onSelect).toHaveBeenCalledWith(dragCity);
+      expect(input).toHaveValue("Drag City");
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("holds the highlight on the last row rather than wrapping", async () => {
+      mockLabelSearch([sonamos, dragCity]);
+      const onSelect = vi.fn();
+      const { user } = renderWithProviders(
+        <ControlledTypeahead onSelect={onSelect} />,
+      );
+
+      const input = await findInput();
+      await user.type(input, "So");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByText("Drag City");
+
+      await user.keyboard("{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{Enter}");
+
+      expect(onSelect).toHaveBeenCalledWith(dragCity);
+    });
+
+    it("does not act on Enter in a panel opened without navigating", async () => {
+      mockLabelSearch([sonamos]);
+      const onSelect = vi.fn();
+      const { user } = renderWithProviders(
+        <ControlledTypeahead initialValue="Sonamos" onSelect={onSelect} />,
+      );
+
+      // A seeded field opened by click, never typed into: nothing has reset the
+      // highlight, so its initial value is the only thing keeping Enter from
+      // acting on a row the MD never chose.
+      const input = await findInput();
+      await user.click(input);
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("listbox");
+
+      await user.keyboard("{Enter}");
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("names the highlighted row in aria-activedescendant", async () => {
+      mockLabelSearch([sonamos, dragCity]);
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "So");
+      await vi.advanceTimersByTimeAsync(400);
+      const [firstOption, secondOption] = await screen.findAllByRole("option");
+
+      expect(input).not.toHaveAttribute("aria-activedescendant");
+
+      await user.keyboard("{ArrowDown}");
+      expect(input).toHaveAttribute("aria-activedescendant", firstOption.id);
+      expect(firstOption).toHaveAttribute("aria-selected", "true");
+
+      await user.keyboard("{ArrowDown}");
+      expect(input).toHaveAttribute("aria-activedescendant", secondOption.id);
+    });
+
+    it("clears the highlight when the panel is closed by clicking away", async () => {
+      mockLabelSearch([sonamos]);
+      const onSelect = vi.fn();
+      const { user } = renderWithProviders(
+        <ControlledTypeahead onSelect={onSelect} />,
+      );
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByText("Sonamos");
+      await user.keyboard("{ArrowDown}");
+
+      await user.click(document.body);
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+      await user.click(input);
+      await screen.findByRole("listbox");
+      await user.keyboard("{Enter}");
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    // The backend upserts on the exact label name, so a submission that
+    // outruns the search creates the near-duplicate this field exists to
+    // prevent. Enter is only allowed through once the search has an answer.
+    it("swallows Enter while the search is still in flight", async () => {
+      mockLabelSearch([sonamos]);
+      const onSubmit = vi.fn();
+      const { user } = renderWithProviders(<TypeaheadInForm onSubmit={onSubmit} />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await screen.findByText(/Searching labels/i);
+
+      await user.keyboard("{Enter}");
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("swallows Enter while the search is reporting a failure", async () => {
+      mockLabelSearch(() =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      );
+      const onSubmit = vi.fn();
+      const { user } = renderWithProviders(<TypeaheadInForm onSubmit={onSubmit} />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("alert");
+
+      await user.keyboard("{Enter}");
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("lets Enter through once the search has confirmed there is no match", async () => {
+      mockLabelSearch([]);
+      const onSubmit = vi.fn();
+      const { user } = renderWithProviders(<TypeaheadInForm onSubmit={onSubmit} />);
+
+      const input = await findInput();
+      await user.type(input, "Tubafrenzy Sound");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByText(/will be created as a new label/i);
+
+      // The answer is in and it is "nothing to collide with", so there is
+      // nothing left for the panel to protect the MD from.
+      await user.keyboard("{Enter}");
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not pick a row on Enter before results have arrived", async () => {
+      mockLabelSearch([sonamos]);
+      const onSelect = vi.fn();
+      const { user } = renderWithProviders(
+        <ControlledTypeahead onSelect={onSelect} />,
+      );
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+
+      // Still inside the debounce window: no row exists to act on.
+      await user.keyboard("{ArrowDown}{Enter}");
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("retracting a selection", () => {
+    it("retracts the picked label once the text is edited away from it", async () => {
+      mockLabelSearch([sonamos]);
+      const onSelectionCleared = vi.fn();
+      const { user } = renderWithProviders(
+        <ControlledTypeahead onSelectionCleared={onSelectionCleared} />,
+      );
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await user.click(await screen.findByText("Sonamos"));
+
+      expect(onSelectionCleared).not.toHaveBeenCalled();
+
+      await user.type(input, "s");
+
+      expect(onSelectionCleared).toHaveBeenCalledTimes(1);
+
+      await user.type(input, "x");
+
+      expect(onSelectionCleared).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports no retraction for text that was never a selection", async () => {
+      mockLabelSearch([sonamos]);
+      const onSelectionCleared = vi.fn();
+      const { user } = renderWithProviders(
+        <ControlledTypeahead onSelectionCleared={onSelectionCleared} />,
+      );
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByText("Sonamos");
+      await user.type(input, "mos");
+
+      expect(onSelectionCleared).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("failed search", () => {
+    it("reports the failure instead of implying a free-typed name is safe", async () => {
+      mockLabelSearch(() =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      );
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        /Label search is unavailable/i,
+      );
+      expect(screen.queryByText(/will be created as a new label/i)).not.toBeInTheDocument();
+    });
+
+    it("retries the search on demand", async () => {
+      let failNext = true;
+      const requests = mockLabelSearch(() => {
+        if (failNext) {
+          failNext = false;
+          return HttpResponse.json({ message: "boom" }, { status: 500 });
+        }
+        return HttpResponse.json([sonamos]);
+      });
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("alert");
+
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(await screen.findByText("Sonamos")).toBeInTheDocument();
+      expect(requests).toHaveLength(2);
+    });
+  });
+
+  describe("disabled", () => {
+    it("neither opens nor queries", async () => {
+      const requests = mockLabelSearch([sonamos]);
+      renderWithProviders(<ControlledTypeahead initialValue="Sona" disabled />);
+
+      const input = await findInput();
+      expect(input).toBeDisabled();
+
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(requests).toHaveLength(0);
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+
+    it("takes down a panel that is already open when the field is disabled", async () => {
+      mockLabelSearch([sonamos]);
+      const { user, rerender } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("listbox");
+
+      // A panel left standing under a greyed-out input is still clickable, and
+      // one click there hands the caller a label id it is no longer allowed to
+      // accept.
+      rerender(<ControlledTypeahead initialValue="Sona" disabled />);
+
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
+++ b/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
@@ -12,7 +12,7 @@ import { http, HttpResponse } from "msw";
 import { useState } from "react";
 import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
 import LabelSearchTypeahead from "@/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead";
-import type { LabelRow } from "@/lib/features/labels/types";
+import type { Label } from "@/lib/features/labels/types";
 
 vi.mock("@/lib/features/authentication/client", () => ({
   authClient: { useSession: vi.fn() },
@@ -58,11 +58,11 @@ function sessionWithRole() {
 
 const LABEL_SEARCH_URL = `${TEST_BACKEND_URL}/labels/search`;
 
-const sonamos: LabelRow = { id: 5, label_name: "Sonamos" };
-const dragCity: LabelRow = { id: 9, label_name: "Drag City" };
+const sonamos: Label = { id: 5, label_name: "Sonamos" };
+const dragCity: Label = { id: 9, label_name: "Drag City" };
 
 /** More rows than the panel's fixed height shows, so the tail needs scrolling. */
-const manyLabels: LabelRow[] = [
+const manyLabels: Label[] = [
   "Drag City",
   "Domino",
   "Dead Oceans",
@@ -77,7 +77,7 @@ const manyLabels: LabelRow[] = [
 
 type SearchResponder = (url: URL) => Response | Promise<Response>;
 
-function mockLabelSearch(respond: LabelRow[] | SearchResponder): URL[] {
+function mockLabelSearch(respond: Label[] | SearchResponder): URL[] {
   const requests: URL[] = [];
   server.use(
     http.get(LABEL_SEARCH_URL, ({ request }) => {
@@ -98,7 +98,7 @@ function ControlledTypeahead({
   disabled,
 }: {
   initialValue?: string;
-  onSelect?: (label: LabelRow) => void;
+  onSelect?: (label: Label) => void;
   onSelectionCleared?: () => void;
   disabled?: boolean;
 }) {
@@ -150,7 +150,7 @@ function TypeaheadUnderEscapeHandler({ onEscape }: { onEscape: () => void }) {
 }
 
 /** A focusable neighbour, so Tab out of the field lands somewhere real. */
-function TypeaheadBesideField({ onSelect }: { onSelect?: (l: LabelRow) => void }) {
+function TypeaheadBesideField({ onSelect }: { onSelect?: (l: Label) => void }) {
   return (
     <>
       <ControlledTypeahead onSelect={onSelect} />
@@ -196,7 +196,10 @@ describe("LabelSearchTypeahead", () => {
       renderWithProviders(<ControlledTypeahead />);
 
       await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
-      await mockFetchOrgRole.mock.results[0].value;
+      // The mock is module-scoped and nothing in this file clears it between
+      // tests, so its call history spans the whole file — indexing from the
+      // front picks up whichever test happened to run first, not this one.
+      await mockFetchOrgRole.mock.results.at(-1)!.value;
       await waitFor(() =>
         expect(
           screen.queryByPlaceholderText("Search labels..."),
@@ -362,9 +365,14 @@ describe("LabelSearchTypeahead", () => {
     // scoped to focus leaving the field entirely, not merely leaving the input,
     // or the button unmounts on the very keystroke that would reach it.
     it("keeps the panel open when focus moves to the retry button", async () => {
-      mockLabelSearch(() =>
-        HttpResponse.json({ message: "boom" }, { status: 500 }),
-      );
+      let failNext = true;
+      mockLabelSearch(() => {
+        if (failNext) {
+          failNext = false;
+          return HttpResponse.json({ message: "boom" }, { status: 500 });
+        }
+        return HttpResponse.json([sonamos]);
+      });
       const { user } = renderWithProviders(<TypeaheadBesideField />);
 
       const input = await findInput();
@@ -376,6 +384,19 @@ describe("LabelSearchTypeahead", () => {
 
       expect(screen.getByRole("button", { name: /try again/i })).toHaveFocus();
       expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Activating the retry button from the keyboard unmounts it: the error
+      // panel gives way to the "searching" panel the instant the refetch
+      // starts. If focus is still on the button when React tears it down, the
+      // browser drops focus to <body> — taking arrow-key, Enter-to-pick and
+      // Escape-to-dismiss with it, since all three are wired through the input.
+      await user.keyboard("{Enter}");
+
+      expect(document.activeElement).not.toBe(document.body);
+      expect(input).toHaveFocus();
+
+      await vi.advanceTimersByTimeAsync(400);
+      expect(await screen.findByText("Sonamos")).toBeInTheDocument();
     });
 
     // Rows suppress the focus shift on mousedown for exactly this reason: the

--- a/tests/setup/vitest.setup.ts
+++ b/tests/setup/vitest.setup.ts
@@ -59,6 +59,15 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
+// Stub scrollIntoView (jsdom runs no layout engine, so it ships no
+// implementation and any call throws). Components that keep a keyboard
+// highlight visible inside a scrolling panel call it on every highlight move.
+// Defined on the prototype so a test can `vi.spyOn(Element.prototype,
+// "scrollIntoView")` to assert which element was scrolled to.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function scrollIntoView() {};
+}
+
 // Mock IntersectionObserver for infinite-scroll components (jsdom lacks it).
 global.IntersectionObserver = class IntersectionObserver {
   readonly root = null;

--- a/tests/setup/vitest.setup.ts
+++ b/tests/setup/vitest.setup.ts
@@ -63,10 +63,12 @@ global.ResizeObserver = class ResizeObserver {
 // implementation and any call throws). Components that keep a keyboard
 // highlight visible inside a scrolling panel call it on every highlight move.
 // Defined on the prototype so a test can `vi.spyOn(Element.prototype,
-// "scrollIntoView")` to assert which element was scrolled to.
-if (!Element.prototype.scrollIntoView) {
-  Element.prototype.scrollIntoView = function scrollIntoView() {};
-}
+// "scrollIntoView")` to assert which element was scrolled to. Assigned
+// unconditionally, like the other DOM stubs in this file: a future jsdom that
+// ships its own no-op (routed to the virtual console instead of throwing)
+// would otherwise leave that no-op in place under a guard that never fires
+// again, and every keyboard-highlight move would flood test output.
+Element.prototype.scrollIntoView = function scrollIntoView() {};
 
 // Mock IntersectionObserver for infinite-scroll components (jsdom lacks it).
 global.IntersectionObserver = class IntersectionObserver {

--- a/tests/unit/lib/features/labels/api.test.ts
+++ b/tests/unit/lib/features/labels/api.test.ts
@@ -2,10 +2,15 @@ import { describe, it, expect, vi } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
 import { http, HttpResponse } from "msw";
 import { labelsApi, useSearchLabelsQuery } from "@/lib/features/labels/api";
+import { rtkQueryErrorLogger } from "@/lib/rtk-query-error-logger";
 import { describeApi, server, TEST_BACKEND_URL } from "@/tests/helpers";
 
 vi.mock("@/lib/features/authentication/client", () => ({
   getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
 }));
 
 /** Just this slice, so a failure names the labels endpoint rather than the whole store. */
@@ -13,6 +18,15 @@ function labelsStore() {
   return configureStore({
     reducer: { [labelsApi.reducerPath]: labelsApi.reducer },
     middleware: (gdm) => gdm().concat(labelsApi.middleware),
+  });
+}
+
+/** Includes the shared middleware, for tests asserting what it does — or does not — do. */
+function labelsStoreWithErrorLogger() {
+  return configureStore({
+    reducer: { [labelsApi.reducerPath]: labelsApi.reducer },
+    middleware: (gdm) =>
+      gdm().concat(rtkQueryErrorLogger).concat(labelsApi.middleware),
   });
 }
 
@@ -77,9 +91,38 @@ describe("labelsApi", () => {
     expect(result.data).toBeUndefined();
   });
 
+  // The picker renders its own inline "Label search is unavailable" panel for
+  // every failure shape here — the opt-out above turns a non-JSON body into
+  // this same isError state. The shared rtk-query-error-logger middleware
+  // reporting it a second time as a global toast would double the same
+  // outage for a screen-reader user without adding any information.
+  it.each([
+    ["a gateway HTML error page (PARSING_ERROR opt-out)", () =>
+      new HttpResponse("<!DOCTYPE html><html><body>Bad Gateway</body></html>", {
+        status: 502,
+        headers: { "Content-Type": "text/html" },
+      }),
+    ],
+    ["a structured JSON error body", () =>
+      HttpResponse.json({ message: "boom" }, { status: 500 }),
+    ],
+  ])("keeps %s out of the global toast", async (_name, respond) => {
+    const { toast } = await import("sonner");
+    vi.mocked(toast.error).mockClear();
+    server.use(http.get(`${TEST_BACKEND_URL}/labels/search`, respond));
+
+    const store = labelsStoreWithErrorLogger();
+    const result = await store.dispatch(
+      labelsApi.endpoints.searchLabels.initiate({ q: "Sona", limit: 10 }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
   // A JSON `null` body still parses, so it reaches transformResponse rather
   // than the opt-out above. Consumers index and map the result, so the
-  // declared `LabelRow[]` return type only holds if a list is substituted.
+  // declared `Label[]` return type only holds if a list is substituted.
   it("substitutes an empty list for a JSON null body", async () => {
     server.use(
       http.get(`${TEST_BACKEND_URL}/labels/search`, () =>

--- a/tests/unit/lib/features/labels/api.test.ts
+++ b/tests/unit/lib/features/labels/api.test.ts
@@ -139,10 +139,12 @@ describe("labelsApi", () => {
     expect(result.data).toEqual([]);
   });
 
-  // Creating a label is an upsert on the exact name. Without a tag on this
-  // result, a search cached just before a label was created keeps serving its
-  // pre-creation empty list for the whole unused-data window, and the next
-  // release filed under that label goes through the create path a second time.
+  // Without a tag on this result, a search cached just before a label was
+  // created keeps serving its pre-creation empty list for the whole
+  // unused-data window. Refiling under the identical name is harmless — the
+  // create path upserts on the exact name — but the librarian never sees the
+  // label they just made, so they type a variant of it instead, and a
+  // different string is a different row.
   it("provides the label-search list tag so a label write can invalidate it", async () => {
     server.use(
       http.get(`${TEST_BACKEND_URL}/labels/search`, () =>

--- a/tests/unit/lib/features/labels/api.test.ts
+++ b/tests/unit/lib/features/labels/api.test.ts
@@ -47,17 +47,22 @@ describe("labelsApi", () => {
     expect(result.data).toEqual([{ id: 5, label_name: "Sonamos" }]);
   });
 
-  // The shared backend base query converts an unparseable body into a
-  // successful `null` payload rather than a toast, so the declared
-  // `LabelRow[]` return type only holds if this endpoint substitutes a list.
-  // Consumers index and map the result; a `null` reaching them would throw.
-  it("yields an empty list when the backend soft-fails on a non-JSON body", async () => {
+  // The shared backend base query soft-fails an unparseable body into a
+  // successful `null` payload. That default is wrong for a duplicate check:
+  // an empty list is indistinguishable from "no existing label matched", so a
+  // gateway's HTML 502 or a missing route would license the create path and
+  // produce the near-duplicate this endpoint exists to surface. The endpoint
+  // opts out, so an unreachable backend has to arrive as an error.
+  it.each([
+    ["a gateway HTML error page", 502],
+    ["the framework's HTML 404", 404],
+  ])("surfaces %s as an error rather than an empty list", async (_name, status) => {
     server.use(
       http.get(
         `${TEST_BACKEND_URL}/labels/search`,
         () =>
           new HttpResponse("<!DOCTYPE html><html><body>Not Found</body></html>", {
-            status: 404,
+            status,
             headers: { "Content-Type": "text/html" },
           }),
       ),
@@ -68,7 +73,49 @@ describe("labelsApi", () => {
       labelsApi.endpoints.searchLabels.initiate({ q: "Sona", limit: 10 }),
     );
 
+    expect(result.isError).toBe(true);
+    expect(result.data).toBeUndefined();
+  });
+
+  // A JSON `null` body still parses, so it reaches transformResponse rather
+  // than the opt-out above. Consumers index and map the result, so the
+  // declared `LabelRow[]` return type only holds if a list is substituted.
+  it("substitutes an empty list for a JSON null body", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/labels/search`, () =>
+        HttpResponse.json(null),
+      ),
+    );
+
+    const store = labelsStore();
+    const result = await store.dispatch(
+      labelsApi.endpoints.searchLabels.initiate({ q: "Sona", limit: 10 }),
+    );
+
     expect(result.isError).toBe(false);
     expect(result.data).toEqual([]);
+  });
+
+  // Creating a label is an upsert on the exact name. Without a tag on this
+  // result, a search cached just before a label was created keeps serving its
+  // pre-creation empty list for the whole unused-data window, and the next
+  // release filed under that label goes through the create path a second time.
+  it("provides the label-search list tag so a label write can invalidate it", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/labels/search`, () =>
+        HttpResponse.json([{ id: 5, label_name: "Sonamos" }]),
+      ),
+    );
+
+    const store = labelsStore();
+    await store.dispatch(
+      labelsApi.endpoints.searchLabels.initiate({ q: "Sona", limit: 10 }),
+    );
+
+    expect(
+      labelsApi.util.selectInvalidatedBy(store.getState(), [
+        { type: "LabelSearch", id: "LIST" },
+      ]),
+    ).toEqual([expect.objectContaining({ endpointName: "searchLabels" })]);
   });
 });

--- a/tests/unit/lib/features/labels/api.test.ts
+++ b/tests/unit/lib/features/labels/api.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { configureStore } from "@reduxjs/toolkit";
+import { http, HttpResponse } from "msw";
+import { labelsApi, useSearchLabelsQuery } from "@/lib/features/labels/api";
+import { describeApi, server, TEST_BACKEND_URL } from "@/tests/helpers";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+/** Just this slice, so a failure names the labels endpoint rather than the whole store. */
+function labelsStore() {
+  return configureStore({
+    reducer: { [labelsApi.reducerPath]: labelsApi.reducer },
+    middleware: (gdm) => gdm().concat(labelsApi.middleware),
+  });
+}
+
+describe("labelsApi", () => {
+  describeApi(labelsApi, {
+    queries: ["searchLabels"],
+    reducerPath: "labelsApi",
+  });
+
+  it("exports the useSearchLabelsQuery hook", () => {
+    expect(useSearchLabelsQuery).toBeDefined();
+    expect(typeof useSearchLabelsQuery).toBe("function");
+  });
+
+  it("asks /labels/search for the query and the caller's result limit", async () => {
+    let requested: URL | undefined;
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/labels/search`, ({ request }) => {
+        requested = new URL(request.url);
+        return HttpResponse.json([{ id: 5, label_name: "Sonamos" }]);
+      }),
+    );
+
+    const store = labelsStore();
+    const result = await store.dispatch(
+      labelsApi.endpoints.searchLabels.initiate({ q: "Sona", limit: 10 }),
+    );
+
+    expect(requested?.pathname).toBe("/labels/search");
+    expect(requested?.searchParams.get("q")).toBe("Sona");
+    expect(requested?.searchParams.get("limit")).toBe("10");
+    expect(result.data).toEqual([{ id: 5, label_name: "Sonamos" }]);
+  });
+
+  // The shared backend base query converts an unparseable body into a
+  // successful `null` payload rather than a toast, so the declared
+  // `LabelRow[]` return type only holds if this endpoint substitutes a list.
+  // Consumers index and map the result; a `null` reaching them would throw.
+  it("yields an empty list when the backend soft-fails on a non-JSON body", async () => {
+    server.use(
+      http.get(
+        `${TEST_BACKEND_URL}/labels/search`,
+        () =>
+          new HttpResponse("<!DOCTYPE html><html><body>Not Found</body></html>", {
+            status: 404,
+            headers: { "Content-Type": "text/html" },
+          }),
+      ),
+    );
+
+    const store = labelsStore();
+    const result = await store.dispatch(
+      labelsApi.endpoints.searchLabels.initiate({ q: "Sona", limit: 10 }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.data).toEqual([]);
+  });
+});

--- a/tests/unit/lib/store.test.ts
+++ b/tests/unit/lib/store.test.ts
@@ -57,6 +57,23 @@ describe("rtkQueryErrorLogger (Bug 29)", () => {
     expect(toast.error).toHaveBeenCalled();
   });
 
+  // An endpoint that opts out of the base query's non-JSON soft-fail sends the
+  // parser's own complaint down this path. It names the character it choked on,
+  // not the outage that produced it, so the toast must not repeat it verbatim.
+  it("reports an unparseable body without quoting the JSON parser", () => {
+    const action = createRejectedAction({
+      status: "PARSING_ERROR",
+      originalStatus: 502,
+      data: "<!DOCTYPE html><html><body>Bad Gateway</body></html>",
+      error: "SyntaxError: Unexpected token '<', \"<!DOCTYPE \"... is not valid JSON",
+    });
+    middleware(action);
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(toast.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("SyntaxError"),
+    );
+  });
+
   it("should not show toast for non-rejected actions", () => {
     const action = { type: "some/action" };
     middleware(action);


### PR DESCRIPTION
First of two PRs for #1079. This one adds the label picker; the add-release panel that mounts it follows in #1105, which is now based on this branch.

## Why a picker rather than a text field

`POST /library` takes a label as plain text and upserts it, so a text input would be correct on the wire. What it would not do is prevent near-duplicates accumulating in the `labels` table: `createLabel` resolves conflicts with `onConflictDoNothing` against the **exact** `label_name`, so `"duophonic"` does not collide with `"Duophonic"` and quietly becomes a second row — with nothing in the UI ever showing the librarian it happened.

`GET /labels/search` matches case-insensitively (prefix `ilike`), so searching before entry surfaces the canonical row at the moment a variant would otherwise be created. Free-typing still creates a new label when there genuinely is no match.

## What's here

- `LabelSearchTypeahead` — debounced prefix search, staleness-gated results, an error panel that deliberately refuses to offer creation during an outage
- `lib/features/labels/` — the RTK Query slice and its types, registered in the store
- Integration tests for the component, unit tests for the slice

## Notable behaviour

- **Keyboard navigation is complete.** Arrows move the highlight, Enter commits it, and `aria-activedescendant` tracks it. This matters more than usual here: without it a keyboard-only librarian cannot reach the existing-label row at all and can only submit their typed text, producing exactly the near-duplicate the picker exists to prevent — while the component advertises `role="combobox"` to assistive tech.
- **Enter is swallowed while a search is in flight or errored.** Otherwise it falls through to implicit form submission and saves a free-typed name past a duplicate check that never completed.
- **Escape closes the panel without propagating.** The panel calls `stopPropagation` as well as `preventDefault`, because MUI's modal handler ignores `defaultPrevented` — without it, Escape inside the field tears down an enclosing modal and takes the form's state with it.
- **A background refetch failure takes the panel over even when stale results are still on screen.** RTK Query keeps the last-good `data` on a rejected refetch, so a cache invalidation that refetches the same search and then fails would otherwise leave the picker showing an unverified list with no error indication and Enter's guard not armed. `showError` no longer requires the current data to be empty.
- **This also changes global toast wording for every mutation that receives a non-JSON error body, app-wide, not just labels.** `lib/rtk-query-error-logger.ts` gains a `PARSING_ERROR` branch so this endpoint's `surfaceNonJsonAsError` opt-out reports something readable instead of the raw JSON-parser string. `backendBaseQuery` only soft-fails GET requests, so every mutation that receives a non-JSON body (`addAlbum`, `addToFlowsheet`, admin roster PATCHes, …) already reached this middleware's fallback branch and toasted the parser's own complaint (e.g. `Unexpected token '<'…`) verbatim; those now get "The server returned an unexpected response." instead. Strictly an improvement, but worth flagging since it lands as a side effect of this endpoint's opt-out rather than a change scoped to labels.

## No mounted consumer yet

Nothing renders this on `main` until #1105 lands, matching how `ArtistSearchTypeahead` shipped. The component and its slice are fully covered on their own.

## Verification

- `npx vitest run` — 4065 passed (299 files)
- `npx tsc --noEmit` — clean
- `npm run lint` — 0 errors, 199 warnings (unchanged baseline)

## Related

- WXYC/dj-site#1079 — the add-release panel this serves; closed by #1105, not by this PR
- WXYC/dj-site#1105 — the panel, based on this branch
- WXYC/dj-site#1099 — will consolidate this with `ArtistSearchTypeahead`, which it deliberately mirrors
