### PR TITLE
fix(flowsheet): refuse a compilation credit in the artist field

### DIFF
--- a/lib/features/flowsheet/various-artists-guard.ts
+++ b/lib/features/flowsheet/various-artists-guard.ts
@@ -1,0 +1,42 @@
+import { isCompilationReleaseArtistName } from "@/lib/features/catalog/is-compilation-artist";
+
+/**
+ * Compilation credits the flowsheet refuses on top of the shared release-artist
+ * set. Both are deliberately absent from COMPILATION_ARTIST_PATTERNS, where a
+ * false positive would push a real single artist into the catalog's per-track
+ * capture step; in the artist field of a flowsheet entry they are only ever
+ * shorthand for the compilation credit. Mirrors tubafrenzy's `isVariousArtists`
+ * (flowsheet-form-controller.ts), which has refused both for years.
+ */
+const ABBREVIATED_COMPILATION_CREDITS: readonly RegExp[] = [
+  /^v[\s./]*a\.?$/, //      "VA", "V A", "V/A", "V.A."
+  /^var\.?\s+artists?$/, // "Var. Artists", "Var Artist"
+];
+
+/**
+ * Copy for every refusal, in both experiences. Names the fix rather than the
+ * rule: the DJ needs to know what to type, not which predicate matched.
+ */
+export const VARIOUS_ARTISTS_REJECTION_MESSAGE =
+  'Use the artist who performed the track, not "Various Artists".';
+
+/**
+ * Whole-name predicate for the flowsheet submit block: true when the artist
+ * field holds a compilation credit instead of a performer.
+ *
+ * Stricter than `isCompilationReleaseArtistName` by the two abbreviations
+ * above, and applied at a different moment — that predicate classifies a
+ * release the catalog already holds, this one refuses a value a DJ is trying
+ * to write. Emptiness is not this predicate's business: a blank artist is a
+ * separate check each caller already makes.
+ */
+export function isVariousArtistsEntry(
+  artist: string | null | undefined
+): boolean {
+  if (!artist) return false;
+  if (isCompilationReleaseArtistName(artist)) return true;
+  const normalized = artist.trim().toLowerCase().replace(/\s+/g, " ");
+  return ABBREVIATED_COMPILATION_CREDITS.some((pattern) =>
+    pattern.test(normalized)
+  );
+}

--- a/lib/features/flowsheet/various-artists-guard.ts
+++ b/lib/features/flowsheet/various-artists-guard.ts
@@ -40,3 +40,34 @@ export function isVariousArtistsEntry(
     pattern.test(normalized)
   );
 }
+
+type ReleaseCredit = { artist?: { name?: string | null } | null } | null;
+
+/**
+ * True when a release cannot supply its own performing artist, because its
+ * credit is one submission refuses.
+ *
+ * This — not `isCompilationRelease` — is what drives the rotation artist field
+ * and the freeform submission routing. The two differ in both directions and
+ * each gap is a live bug: a release credited "VA" is refused by the guard but
+ * is not an `isCompilationRelease`, so keying on that predicate blanks the
+ * field with nothing to refill it; a compilation filed under a credited album
+ * artist is an `isCompilationRelease` whose name the guard never refuses, so
+ * keying on it strips linkage from an entry that was never in trouble.
+ *
+ * `isCompilationRelease` stays the right question for per-track credit
+ * auto-fill, which is about whether the credits are performers.
+ */
+export function releaseCreditIsRefused(release: ReleaseCredit): boolean {
+  return isVariousArtistsEntry(release?.artist?.name);
+}
+
+/**
+ * The artist value to seed from a release, or "" when its credit is refused.
+ * Never auto-filling a value the form then rejects is what keeps the guard
+ * from reading as a bug.
+ */
+export function seedableArtistName(release: ReleaseCredit): string {
+  const name = release?.artist?.name ?? "";
+  return isVariousArtistsEntry(name) ? "" : name;
+}

--- a/src/components/experiences/classic/flowsheet/EntryForm.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryForm.tsx
@@ -7,9 +7,10 @@ import { useAddToFlowsheetMutation } from "@/lib/features/flowsheet/api";
 import { useGetRotationQuery } from "@/lib/features/rotation/api";
 import { sortRotationReleases } from "@/lib/features/rotation/sort";
 import { Rotation } from "@/lib/features/rotation/types";
-import { isCompilationRelease } from "@/lib/features/catalog/is-compilation-artist";
 import {
   isVariousArtistsEntry,
+  releaseCreditIsRefused,
+  seedableArtistName,
   VARIOUS_ARTISTS_REJECTION_MESSAGE,
 } from "@/lib/features/flowsheet/various-artists-guard";
 import { FlowsheetEntryType } from "@wxyc/shared/dtos";
@@ -88,13 +89,14 @@ export default function EntryForm({
   const selectedRotationRelease = rotationData?.find(
     (r) => r.rotation_id === selectedRotationId
   );
-  // On a compilation the release-level artist is the compilation credit, so
-  // rotation mode has to expose the Artist field it normally hides — otherwise
-  // the submit refusal below has no field to satisfy it.
+  // Rotation mode hides the Artist field and submits the release-level artist.
+  // When that artist is a credit submission refuses, the field has to come back
+  // or the refusal has nothing that can satisfy it. Keyed on the refused credit
+  // rather than on `isCompilationRelease`: a compilation filed under a credited
+  // album artist is submittable as-is and must keep its library linkage.
   const rotationNeedsArtist =
     releaseType === "rotationRelease" &&
-    !!selectedRotationRelease &&
-    isCompilationRelease(selectedRotationRelease);
+    releaseCreditIsRefused(selectedRotationRelease ?? null);
   const showArtistField =
     releaseType !== "rotationRelease" || rotationNeedsArtist;
   const artistRefused = showArtistField && isVariousArtistsEntry(artistName);
@@ -103,9 +105,7 @@ export default function EntryForm({
     setSelectedRotationId(rotationId);
     const release = rotationData?.find((r) => r.rotation_id === rotationId);
     if (release) {
-      // Never seed a value the form then refuses.
-      const seeded = release.artist?.name ?? "";
-      setArtistName(isVariousArtistsEntry(seeded) ? "" : seeded);
+      setArtistName(seedableArtistName(release));
       setReleaseTitle(release.title);
       setLabelName(release.label);
     }
@@ -352,7 +352,8 @@ export default function EntryForm({
                       {artistRefused && (
                         <div
                           id="artistNameError"
-                          className="artist-error-message visible"
+                          role="alert"
+                          className="artist-error-message"
                         >
                           {VARIOUS_ARTISTS_REJECTION_MESSAGE}
                         </div>

--- a/src/components/experiences/classic/flowsheet/EntryForm.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryForm.tsx
@@ -7,6 +7,11 @@ import { useAddToFlowsheetMutation } from "@/lib/features/flowsheet/api";
 import { useGetRotationQuery } from "@/lib/features/rotation/api";
 import { sortRotationReleases } from "@/lib/features/rotation/sort";
 import { Rotation } from "@/lib/features/rotation/types";
+import { isCompilationRelease } from "@/lib/features/catalog/is-compilation-artist";
+import {
+  isVariousArtistsEntry,
+  VARIOUS_ARTISTS_REJECTION_MESSAGE,
+} from "@/lib/features/flowsheet/various-artists-guard";
 import { FlowsheetEntryType } from "@wxyc/shared/dtos";
 import {
   stationBreakpointMessage,
@@ -80,11 +85,27 @@ export default function EntryForm({
     ),
   };
 
+  const selectedRotationRelease = rotationData?.find(
+    (r) => r.rotation_id === selectedRotationId
+  );
+  // On a compilation the release-level artist is the compilation credit, so
+  // rotation mode has to expose the Artist field it normally hides — otherwise
+  // the submit refusal below has no field to satisfy it.
+  const rotationNeedsArtist =
+    releaseType === "rotationRelease" &&
+    !!selectedRotationRelease &&
+    isCompilationRelease(selectedRotationRelease);
+  const showArtistField =
+    releaseType !== "rotationRelease" || rotationNeedsArtist;
+  const artistRefused = showArtistField && isVariousArtistsEntry(artistName);
+
   const handleRotationSelect = (rotationId: number) => {
     setSelectedRotationId(rotationId);
     const release = rotationData?.find((r) => r.rotation_id === rotationId);
     if (release) {
-      setArtistName(release.artist?.name ?? "");
+      // Never seed a value the form then refuses.
+      const seeded = release.artist?.name ?? "";
+      setArtistName(isVariousArtistsEntry(seeded) ? "" : seeded);
       setReleaseTitle(release.title);
       setLabelName(release.label);
     }
@@ -107,8 +128,10 @@ export default function EntryForm({
   // Breakpoint modes have no track to gate on, so they're always enabled.
   const canSubmitTrack =
     songTitle.trim().length > 0 &&
+    !artistRefused &&
     (releaseType === "rotationRelease"
-      ? selectedRotationId > 0
+      ? selectedRotationId > 0 &&
+        (!rotationNeedsArtist || artistName.trim().length > 0)
       : artistName.trim().length > 0);
   const canSubmit = entryType === "track" ? canSubmitTrack : true;
 
@@ -142,7 +165,22 @@ export default function EntryForm({
       // a non-error submit; recovering the linkage requires BS to accept
       // `rotation_id` without `album_id` (Option C, BS-side schema work).
       // Aligned with sibling dj-site#608's fix shape.
-      if (typeof release.id === "number" && release.id > 0) {
+      if (rotationNeedsArtist) {
+        // The catalog-linked variant carries no `artist_name` — BS resolves it
+        // from `album_id`, which on a compilation resolves straight back to the
+        // credit the DJ just replaced. Only the freeform variant preserves the
+        // performer they typed. `rotation_id` rides that variant, so the
+        // rotation badge survives the trade.
+        submissionData = {
+          artist_name: artistName,
+          album_title: release.title,
+          track_title: songTitle,
+          rotation_id: release.rotation_id,
+          request_flag: requestFlag,
+          segue,
+          record_label: labelName || release.label,
+        };
+      } else if (typeof release.id === "number" && release.id > 0) {
         submissionData = {
           album_id: release.id,
           track_title: songTitle,
@@ -287,7 +325,7 @@ export default function EntryForm({
 
             <table className="flowsheet-entry-form">
               <tbody>
-                {releaseType !== "rotationRelease" && (
+                {showArtistField && (
                   <tr id="artistTextboxRow">
                     <td>
                       <label htmlFor="artistName">Artist</label>
@@ -301,7 +339,24 @@ export default function EntryForm({
                         value={artistName}
                         onChange={(e) => setArtistName(e.target.value)}
                         disabled={!isLive}
+                        aria-invalid={artistRefused}
+                        aria-describedby={
+                          artistRefused ? "artistNameError" : undefined
+                        }
                       />
+                      {rotationNeedsArtist && !artistRefused && (
+                        <div className="field-hint">
+                          Compilation — name the artist on this track
+                        </div>
+                      )}
+                      {artistRefused && (
+                        <div
+                          id="artistNameError"
+                          className="artist-error-message visible"
+                        >
+                          {VARIOUS_ARTISTS_REJECTION_MESSAGE}
+                        </div>
+                      )}
                     </td>
                   </tr>
                 )}

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -3,7 +3,10 @@
 import { isCompilationRelease } from "@/lib/features/catalog/is-compilation-artist";
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
-import { isVariousArtistsEntry } from "@/lib/features/flowsheet/various-artists-guard";
+import {
+  releaseCreditIsRefused,
+  seedableArtistName,
+} from "@/lib/features/flowsheet/various-artists-guard";
 import { Rotation } from "@/lib/features/rotation/types";
 import { normalizeTrackArtists } from "@/lib/features/rotation/normalize-track-artists";
 import {
@@ -18,18 +21,6 @@ import FlowsheetSearchInput from "./FlowsheetSearchInput";
 import RotationBinSelector from "./RotationBinSelector";
 import RotationReleaseDropdown from "./RotationReleaseDropdown";
 import TrackPickerDropdown from "./TrackPickerDropdown";
-
-/**
- * The artist value to seed from a release, or "" when the release-level artist
- * is a compilation credit submission would refuse. Never auto-filling a value
- * the form then rejects is what keeps the guard from reading as a bug; a
- * compilation filed under a credited album artist keeps that name, because the
- * guard has no quarrel with it.
- */
-function seedableArtistName(release: AlbumEntry | null): string {
-  const name = release?.artist?.name ?? "";
-  return isVariousArtistsEntry(name) ? "" : name;
-}
 
 export default function RotationEntryFields({ disabled }: { disabled: boolean }) {
   const dispatch = useAppDispatch();
@@ -101,7 +92,11 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
       dispatch(flowsheetSlice.actions.setSearchProperty({ name: "label", value: release.label ?? "" }));
       dispatch(
         flowsheetSlice.actions.setRotationMetadata({
-          album_id: release.id,
+          // Withheld when the credit is refused: BS's album_id branch spreads
+          // the library row's artist_name over the request's, so keeping the
+          // linkage would hand back the very credit the DJ just replaced.
+          // Classic makes the same trade by switching submission variants.
+          album_id: releaseCreditIsRefused(release) ? undefined : release.id,
           rotation_id: release.rotation_id,
           rotation_bin: release.rotation_bin,
         })
@@ -120,6 +115,10 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
   // name keep the release-level artist.
   const trackCreditsAreDisambiguating =
     !!selectedRelease && isCompilationRelease(selectedRelease);
+
+  // Distinct from the above on purpose — see releaseCreditIsRefused.
+  const needsPerformerName =
+    !!selectedRelease && releaseCreditIsRefused(selectedRelease);
 
   const handleSelectTrack = useCallback(
     (track: RotationTrack) => {
@@ -210,16 +209,15 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
           />
         )}
       </Box>
-      {/* On a compilation the performing artist is per-track, so the DJ needs
-          somewhere to supply or correct it — without this the submit guard
-          would refuse a V/A release with no field to fix. Normally-credited
-          releases keep the read-only behavior: their release artist is the
-          answer. */}
-      {trackCreditsAreDisambiguating && (
+      {/* Shown exactly when the release cannot supply its own artist, so the
+          submit guard always has a field that can satisfy it. Releases whose
+          credit is a real name keep the read-only behavior — including
+          compilations filed under a credited album artist. */}
+      {needsPerformerName && (
         <FlowsheetSearchInput
           name="artist"
           value={artistValue}
-          disabled={disabled || !selectedRelease}
+          disabled={disabled}
           required
           suppressHydrationWarning
         />

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -3,6 +3,7 @@
 import { isCompilationRelease } from "@/lib/features/catalog/is-compilation-artist";
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { isVariousArtistsEntry } from "@/lib/features/flowsheet/various-artists-guard";
 import { Rotation } from "@/lib/features/rotation/types";
 import { normalizeTrackArtists } from "@/lib/features/rotation/normalize-track-artists";
 import {
@@ -18,11 +19,26 @@ import RotationBinSelector from "./RotationBinSelector";
 import RotationReleaseDropdown from "./RotationReleaseDropdown";
 import TrackPickerDropdown from "./TrackPickerDropdown";
 
+/**
+ * The artist value to seed from a release, or "" when the release-level artist
+ * is a compilation credit submission would refuse. Never auto-filling a value
+ * the form then rejects is what keeps the guard from reading as a bug; a
+ * compilation filed under a credited album artist keeps that name, because the
+ * guard has no quarrel with it.
+ */
+function seedableArtistName(release: AlbumEntry | null): string {
+  const name = release?.artist?.name ?? "";
+  return isVariousArtistsEntry(name) ? "" : name;
+}
+
 export default function RotationEntryFields({ disabled }: { disabled: boolean }) {
   const dispatch = useAppDispatch();
   const store = useAppStore();
   const songValue = useAppSelector(
     (state) => flowsheetSlice.selectors.getSearchQuery(state).song as string
+  );
+  const artistValue = useAppSelector(
+    (state) => flowsheetSlice.selectors.getSearchQuery(state).artist as string
   );
   const labelValue = useAppSelector(
     (state) => flowsheetSlice.selectors.getSearchQuery(state).label as string
@@ -80,7 +96,7 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
       setManualEntry(false);
       dispatch(flowsheetSlice.actions.setSearchOpen(true));
       dispatch(flowsheetSlice.actions.setSearchProperty({ name: "song", value: "" }));
-      dispatch(flowsheetSlice.actions.setSearchProperty({ name: "artist", value: release.artist?.name ?? "" }));
+      dispatch(flowsheetSlice.actions.setSearchProperty({ name: "artist", value: seedableArtistName(release) }));
       dispatch(flowsheetSlice.actions.setSearchProperty({ name: "album", value: release.title }));
       dispatch(flowsheetSlice.actions.setSearchProperty({ name: "label", value: release.label ?? "" }));
       dispatch(
@@ -126,8 +142,10 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
       }
       // No usable per-track credits: fall back to the release-level artist,
       // dispatching only when it differs from the live value so re-selecting a
-      // release does not re-write it.
-      const releaseArtist = selectedRelease?.artist?.name ?? "";
+      // release does not re-write it. On a V/A comp that fallback is empty
+      // rather than the compilation credit — clearing still prevents the
+      // previous track's performer from lingering, which is the point.
+      const releaseArtist = seedableArtistName(selectedRelease);
       const currentArtist = flowsheetSlice.selectors.getSearchQuery(
         store.getState()
       ).artist;
@@ -192,6 +210,20 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
           />
         )}
       </Box>
+      {/* On a compilation the performing artist is per-track, so the DJ needs
+          somewhere to supply or correct it — without this the submit guard
+          would refuse a V/A release with no field to fix. Normally-credited
+          releases keep the read-only behavior: their release artist is the
+          answer. */}
+      {trackCreditsAreDisambiguating && (
+        <FlowsheetSearchInput
+          name="artist"
+          value={artistValue}
+          disabled={disabled || !selectedRelease}
+          required
+          suppressHydrationWarning
+        />
+      )}
       {/* Editable label: some rotation albums carry no label upstream and the
           DJ is the only source for it */}
       <FlowsheetSearchInput

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -707,15 +707,16 @@ export const useFlowsheetSubmit = () => {
         toast.error("Song title is required");
         return;
       }
-      // A compilation credit reaches this field two ways the DJ never typed:
-      // a clicked result row, and the rotation picker's release-artist
-      // fallback when Discogs lists no performer for the track.
-      if (isVariousArtistsEntry(selectedResultData.artist)) {
-        toast.error(VARIOUS_ARTISTS_REJECTION_MESSAGE);
-        return;
-      }
       if (queueModifierRef.current) {
         submitToQueue();
+        return;
+      }
+      // A compilation credit reaches this field two ways the DJ never typed:
+      // a clicked result row, and the rotation picker's release-artist
+      // fallback when Discogs lists no performer for the track. The queue
+      // path above carries its own copy; this one covers the rest.
+      if (isVariousArtistsEntry(selectedResultData.artist)) {
+        toast.error(VARIOUS_ARTISTS_REJECTION_MESSAGE);
         return;
       }
       if (isRotationPick && selectedEntry) {

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -14,6 +14,10 @@ import {
 import { convertQueryToSubmission } from "@/lib/features/flowsheet/conversions";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import {
+  isVariousArtistsEntry,
+  VARIOUS_ARTISTS_REJECTION_MESSAGE,
+} from "@/lib/features/flowsheet/various-artists-guard";
+import {
   compareEntriesNewestFirst,
   primaryShowId,
 } from "@/lib/features/flowsheet/infinite-cache";
@@ -685,6 +689,10 @@ export const useFlowsheetSubmit = () => {
       toast.error("Song title is required");
       return;
     }
+    if (isVariousArtistsEntry(selectedResultData.artist)) {
+      toast.error(VARIOUS_ARTISTS_REJECTION_MESSAGE);
+      return;
+    }
     addToQueue(selectedResultData);
     dispatch(flowsheetSlice.actions.resetSearch());
   }, [addToQueue, selectedResultData, dispatch]);
@@ -697,6 +705,13 @@ export const useFlowsheetSubmit = () => {
       // calls handleSubmit directly instead of submitting the form).
       if (!(selectedResultData.song ?? "").trim()) {
         toast.error("Song title is required");
+        return;
+      }
+      // A compilation credit reaches this field two ways the DJ never typed:
+      // a clicked result row, and the rotation picker's release-artist
+      // fallback when Discogs lists no performer for the track.
+      if (isVariousArtistsEntry(selectedResultData.artist)) {
+        toast.error(VARIOUS_ARTISTS_REJECTION_MESSAGE);
         return;
       }
       if (queueModifierRef.current) {

--- a/src/styles/classic/flowsheet.css
+++ b/src/styles/classic/flowsheet.css
@@ -99,13 +99,9 @@
 	box-sizing: border-box;
 }
 
-.optional-hint {
-	font-size: x-small;
-	color: #888;
-}
-
-/* Same weight as .optional-hint, opposite meaning: names a constraint on a
-   field the form requires. */
+/* .optional-hint marks a field the form will accept blank; .field-hint names a
+   constraint on one it won't. Same treatment, opposite meanings. */
+.optional-hint,
 .field-hint {
 	font-size: x-small;
 	color: #888;

--- a/src/styles/classic/flowsheet.css
+++ b/src/styles/classic/flowsheet.css
@@ -104,6 +104,13 @@
 	color: #888;
 }
 
+/* Same weight as .optional-hint, opposite meaning: names a constraint on a
+   field the form requires. */
+.field-hint {
+	font-size: x-small;
+	color: #888;
+}
+
 /* Autocomplete dropdown styles */
 .ac_results {
 	background-color: #FFFFFF;

--- a/src/styles/classic/wxyc.css
+++ b/src/styles/classic/wxyc.css
@@ -527,9 +527,9 @@ html[data-experience="classic"] body {
 }
 
 /* Field-scoped variant: sits directly under the offending input rather than
-   centered under the form, and is sized to the 300px text inputs. */
+   centered under the form, and is sized to the 300px text inputs. Rendered
+   only while the value is refused, so it needs no hidden state. */
 .artist-error-message {
-	display: none;
 	color: #FF0000;
 	font-size: 11px;
 	font-weight: bold;
@@ -542,8 +542,10 @@ html[data-experience="classic"] body {
 	box-sizing: border-box;
 }
 
-.artist-error-message.visible {
-	display: block;
+html[data-experience="classic"][data-joy-color-scheme="dark"] .artist-error-message {
+	color: #FF8A8A;
+	background-color: #3A1D1D;
+	border-color: #A33;
 }
 
 /* ========== wxycdb page bits ========== */

--- a/src/styles/classic/wxyc.css
+++ b/src/styles/classic/wxyc.css
@@ -526,6 +526,26 @@ html[data-experience="classic"] body {
 	display: block;
 }
 
+/* Field-scoped variant: sits directly under the offending input rather than
+   centered under the form, and is sized to the 300px text inputs. */
+.artist-error-message {
+	display: none;
+	color: #FF0000;
+	font-size: 11px;
+	font-weight: bold;
+	margin-top: 4px;
+	padding: 4px 8px;
+	background-color: #FFF0F0;
+	border: 1px solid #FF0000;
+	border-radius: 3px;
+	max-width: 300px;
+	box-sizing: border-box;
+}
+
+.artist-error-message.visible {
+	display: block;
+}
+
 /* ========== wxycdb page bits ========== */
 
 ul {

--- a/tests/integration/components/classic/flowsheet/EntryForm.test.tsx
+++ b/tests/integration/components/classic/flowsheet/EntryForm.test.tsx
@@ -753,6 +753,64 @@ describe("Classic EntryForm — Various Artists refusal", () => {
       expect("album_id" in payload).toBe(false);
     });
 
+    // A compilation filed under a credited album artist is submittable as-is:
+    // it must keep its linkage and gain no field. Keying the escape hatch on
+    // isCompilationRelease stripped album_id from entries never in trouble.
+    it("keeps the catalog-linked variant for a credited album artist", async () => {
+      rotationDataMock = [
+        createTestRotationAlbum(Rotation.H, {
+          id: 6301,
+          rotation_id: 6302,
+          title: "DJ-Kicks",
+          label: "!K7",
+          album_artist: "Kruder & Dorfmeister",
+          artist: createTestArtist({
+            name: "Kruder & Dorfmeister",
+            lettercode: "KR",
+            numbercode: 3,
+          }),
+        }),
+      ];
+      const { user } = renderWithProviders(<EntryForm />);
+      await pickRotation(user, "DJ-Kicks");
+
+      expect(
+        document.querySelector('input[name="artistName"]')
+      ).not.toBeInTheDocument();
+
+      await user.type(getNamedInput("songTitle"), "Donaueschingen");
+      await user.click(addButton());
+
+      await waitFor(() => {
+        expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+      });
+      expect(addToFlowsheetMock.mock.calls[0][0].album_id).toBe(6301);
+    });
+
+    // "VA" is refused by the guard but is not an isCompilationRelease, so
+    // keying the field on that predicate submitted the credit verbatim.
+    it("reveals the Artist row for a release credited VA", async () => {
+      rotationDataMock = [
+        createTestRotationAlbum(Rotation.H, {
+          id: 6401,
+          rotation_id: 6402,
+          title: "Habibi Funk 015",
+          label: "Habibi Funk",
+          artist: createTestArtist({
+            name: "VA",
+            lettercode: "ZH",
+            numbercode: 9,
+          }),
+        }),
+      ];
+      const { user } = renderWithProviders(<EntryForm />);
+      await pickRotation(user, "Habibi Funk");
+
+      expect(getNamedInput("artistName")).toBeInTheDocument();
+      expect(getNamedInput("artistName").value).toBe("");
+      expect(addButton().disabled).toBe(true);
+    });
+
     it("still submits a normally-credited release through the catalog-linked variant", async () => {
       rotationDataMock = [credited()];
       const { user } = renderWithProviders(<EntryForm />);

--- a/tests/integration/components/classic/flowsheet/EntryForm.test.tsx
+++ b/tests/integration/components/classic/flowsheet/EntryForm.test.tsx
@@ -602,3 +602,170 @@ describe("Classic EntryForm — Enter-key submission guard", () => {
     expect(addToFlowsheetMock.mock.calls[0][0].artist_name).toBe("Cat Power");
   });
 });
+
+describe("Classic EntryForm — Various Artists refusal", () => {
+  async function selectByText(
+    user: ReturnType<typeof renderWithProviders>["user"],
+    select: HTMLSelectElement,
+    textContains: string
+  ): Promise<void> {
+    const option = Array.from(select.options).find((o) =>
+      o.text.includes(textContains)
+    );
+    if (!option) throw new Error(`No option text contains: ${textContains}`);
+    await user.selectOptions(select, option);
+  }
+
+  const addButton = () =>
+    screen.getByRole("button", { name: /^add$/i }) as HTMLButtonElement;
+
+  it.each([
+    "Various Artists",
+    "various artists",
+    "V/A",
+    "VA",
+    "Var. Artists",
+    "Soundtrack",
+  ])("disables Add when the artist field holds %s", async (artist) => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("releaseType"), "otherRelease");
+    await user.type(getNamedInput("artistName"), artist);
+    await user.type(getNamedInput("songTitle"), "Call Your Name");
+
+    expect(addButton().disabled).toBe(true);
+    expect(screen.getByText(/not "various artists"/i)).toBeInTheDocument();
+  });
+
+  it("keeps Add live for a performing artist whose name embeds a keyword", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("releaseType"), "otherRelease");
+    await user.type(getNamedInput("artistName"), "Various Production");
+    await user.type(getNamedInput("songTitle"), "Hater");
+
+    expect(addButton().disabled).toBe(false);
+    expect(screen.queryByText(/not "various artists"/i)).not.toBeInTheDocument();
+  });
+
+  it("re-enables Add once a performing artist replaces the compilation credit", async () => {
+    const { user } = renderWithProviders(<EntryForm />);
+    await user.selectOptions(getNamedSelect("releaseType"), "otherRelease");
+    await user.type(getNamedInput("artistName"), "Various Artists");
+    await user.type(getNamedInput("songTitle"), "Call Your Name");
+    expect(addButton().disabled).toBe(true);
+
+    await user.clear(getNamedInput("artistName"));
+    await user.type(getNamedInput("artistName"), "Chuquimamani-Condori");
+
+    expect(addButton().disabled).toBe(false);
+    expect(screen.queryByText(/not "various artists"/i)).not.toBeInTheDocument();
+  });
+
+  describe("rotation releases", () => {
+    const compilation = () =>
+      createTestRotationAlbum(Rotation.H, {
+        id: 6101,
+        rotation_id: 6102,
+        title: "In-Correcto 15-25",
+        label: "self-released",
+        artist: createTestArtist({
+          name: "Various Artists",
+          lettercode: "ZC",
+          numbercode: 4,
+        }),
+      });
+
+    const credited = () =>
+      createTestRotationAlbum(Rotation.H, {
+        id: 6201,
+        rotation_id: 6202,
+        title: "Aluminum Tunes",
+        label: "Duophonic",
+        artist: createTestArtist({
+          name: "Stereolab",
+          lettercode: "RO",
+          numbercode: 87,
+        }),
+      });
+
+    async function pickRotation(
+      user: ReturnType<typeof renderWithProviders>["user"],
+      titleContains: string
+    ) {
+      await user.selectOptions(getNamedSelect("releaseType"), "rotationRelease");
+      await user.selectOptions(getNamedSelect("rotationType"), "heavy");
+      await selectByText(user, getNamedSelect("heavyRelease"), titleContains);
+    }
+
+    // Rotation mode normally submits the release-level artist with no Artist
+    // field at all. On a compilation that artist IS the credit submission
+    // refuses, so the field has to appear or the refusal is unescapable.
+    it("reveals the Artist row for a compilation release", async () => {
+      rotationDataMock = [compilation()];
+      const { user } = renderWithProviders(<EntryForm />);
+      await pickRotation(user, "In-Correcto");
+
+      expect(getNamedInput("artistName")).toBeInTheDocument();
+      expect(getNamedInput("artistName").value).toBe("");
+    });
+
+    it("keeps the Artist row hidden for a normally-credited release", async () => {
+      rotationDataMock = [credited()];
+      const { user } = renderWithProviders(<EntryForm />);
+      await pickRotation(user, "Aluminum Tunes");
+
+      expect(
+        document.querySelector('input[name="artistName"]')
+      ).not.toBeInTheDocument();
+    });
+
+    it("holds Add until the DJ names the performer on a compilation", async () => {
+      rotationDataMock = [compilation()];
+      const { user } = renderWithProviders(<EntryForm />);
+      await pickRotation(user, "In-Correcto");
+      await user.type(getNamedInput("songTitle"), "Call Your Name");
+
+      expect(addButton().disabled).toBe(true);
+
+      await user.type(getNamedInput("artistName"), "Chuquimamani-Condori");
+
+      expect(addButton().disabled).toBe(false);
+    });
+
+    it("submits the typed artist freeform, keeping the rotation linkage", async () => {
+      rotationDataMock = [compilation()];
+      const { user } = renderWithProviders(<EntryForm />);
+      await pickRotation(user, "In-Correcto");
+      await user.type(getNamedInput("songTitle"), "Call Your Name");
+      await user.type(getNamedInput("artistName"), "Chuquimamani-Condori");
+      await user.click(addButton());
+
+      await waitFor(() => {
+        expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+      });
+      const payload = addToFlowsheetMock.mock.calls[0][0];
+      // The catalog-linked variant resolves the artist from `album_id`, which
+      // on a compilation resolves straight back to "Various Artists" — so the
+      // typed name only survives on the freeform variant.
+      expect(payload.artist_name).toBe("Chuquimamani-Condori");
+      expect(payload.album_title).toBe("In-Correcto 15-25");
+      expect(payload.track_title).toBe("Call Your Name");
+      expect(payload.rotation_id).toBe(6102);
+      expect("album_id" in payload).toBe(false);
+    });
+
+    it("still submits a normally-credited release through the catalog-linked variant", async () => {
+      rotationDataMock = [credited()];
+      const { user } = renderWithProviders(<EntryForm />);
+      await pickRotation(user, "Aluminum Tunes");
+      await user.type(getNamedInput("songTitle"), "Tone Burst");
+      await user.click(addButton());
+
+      await waitFor(() => {
+        expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+      });
+      const payload = addToFlowsheetMock.mock.calls[0][0];
+      expect(payload.album_id).toBe(6201);
+      expect(payload.rotation_id).toBe(6202);
+    });
+  });
+});

--- a/tests/integration/components/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -217,6 +217,85 @@ describe("RotationEntryFields", () => {
     ).not.toBeInTheDocument();
   });
 
+  // The artist field is worthless on a linked release: BS's album_id branch
+  // spreads the library row's artist_name over the request's, so the typed
+  // performer is discarded and the credit lands anyway. Withholding album_id
+  // is what makes the field mean something.
+  it("withholds album_id for a release whose credit is refused", () => {
+    const { store } = renderWithProviders(
+      inModernTheme(<RotationEntryFields disabled={false} />)
+    );
+
+    selectBinAndRelease(tobaccoAGoGo);
+
+    const query = flowsheetSlice.selectors.getSearchQuery(store.getState());
+    expect(query.album_id).toBeUndefined();
+    expect(query.rotation_id).toBe(44);
+  });
+
+  it("keeps album_id for a normally-credited release", () => {
+    const { store } = renderWithProviders(
+      inModernTheme(<RotationEntryFields disabled={false} />)
+    );
+
+    selectBinAndRelease(lightningBoltOoioo);
+
+    expect(
+      flowsheetSlice.selectors.getSearchQuery(store.getState()).album_id
+    ).toBe(7);
+  });
+
+  // A compilation filed under a credited album artist is submittable as-is:
+  // it must not lose its linkage or gain a field it does not need.
+  it("keeps album_id and renders no artist input for a credited album artist", () => {
+    const djKicks = createTestAlbum({
+      id: 13,
+      title: "DJ-Kicks",
+      artist: createTestArtist({ name: "Kruder & Dorfmeister" }),
+      album_artist: "Kruder & Dorfmeister",
+      rotation_id: 47,
+      rotation_bin: "H",
+    });
+    mockRotationData = [djKicks];
+
+    const { store } = renderWithProviders(
+      inModernTheme(<RotationEntryFields disabled={false} />)
+    );
+
+    selectBinAndRelease(djKicks);
+
+    expect(
+      flowsheetSlice.selectors.getSearchQuery(store.getState()).album_id
+    ).toBe(13);
+    expect(
+      screen.queryByTestId("flowsheet-search-artist")
+    ).not.toBeInTheDocument();
+  });
+
+  // "VA" is refused by the guard but is not an isCompilationRelease. Keying
+  // the field on that predicate blanked the artist with nothing to refill it.
+  it("reveals the artist input for a release credited VA", () => {
+    const vaRelease = createTestAlbum({
+      id: 14,
+      title: "Habibi Funk 015",
+      artist: createTestArtist({ name: "VA" }),
+      rotation_id: 48,
+      rotation_bin: "H",
+    });
+    mockRotationData = [vaRelease];
+
+    const { store } = renderWithProviders(
+      inModernTheme(<RotationEntryFields disabled={false} />)
+    );
+
+    selectBinAndRelease(vaRelease);
+
+    expect(screen.getByTestId("flowsheet-search-artist")).toBeInTheDocument();
+    const query = flowsheetSlice.selectors.getSearchQuery(store.getState());
+    expect(query.artist).toBe("");
+    expect(query.album_id).toBeUndefined();
+  });
+
   it("leaves the compilation artist field empty rather than seeding the V/A credit", () => {
     const { store } = renderWithProviders(
       inModernTheme(<RotationEntryFields disabled={false} />)
@@ -233,9 +312,9 @@ describe("RotationEntryFields", () => {
   });
 
   it("seeds the artist into the search query on release selection", () => {
-    // The artist is no longer rendered as an input, but the value still has
-    // to flow into Redux so form submission carries the release's primary
-    // artist. Assert against the real action creator to catch slice drift.
+    // A credited release renders no artist input, but the value still has to
+    // flow into Redux so form submission carries the release's primary artist.
+    // Assert against the real action creator to catch slice drift.
     const { store } = renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
     const dispatchSpy = vi.spyOn(store, "dispatch");
 

--- a/tests/integration/components/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -177,7 +177,7 @@ describe("RotationEntryFields", () => {
     );
   });
 
-  it("never renders an artist input — rotation mode has no override UI", () => {
+  it("renders no artist input for a normally-credited release", () => {
     renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
     expect(
       screen.queryByTestId("flowsheet-search-artist")
@@ -188,6 +188,48 @@ describe("RotationEntryFields", () => {
     expect(
       screen.queryByTestId("flowsheet-search-artist")
     ).not.toBeInTheDocument();
+  });
+
+  // Submission refuses a compilation credit in the artist field, and the
+  // release-level artist on a V/A comp IS that credit — so rotation mode has
+  // to offer somewhere to correct it, or the refusal is a dead end.
+  it("renders an artist input once a compilation release is selected", () => {
+    renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
+
+    expect(
+      screen.queryByTestId("flowsheet-search-artist")
+    ).not.toBeInTheDocument();
+
+    selectBinAndRelease(tobaccoAGoGo);
+
+    expect(screen.getByTestId("flowsheet-search-artist")).toBeInTheDocument();
+  });
+
+  it("drops the artist input again when the DJ switches to a credited release", () => {
+    renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
+
+    selectBinAndRelease(tobaccoAGoGo);
+    expect(screen.getByTestId("flowsheet-search-artist")).toBeInTheDocument();
+
+    selectBinAndRelease(foxbaseAlpha);
+    expect(
+      screen.queryByTestId("flowsheet-search-artist")
+    ).not.toBeInTheDocument();
+  });
+
+  it("leaves the compilation artist field empty rather than seeding the V/A credit", () => {
+    const { store } = renderWithProviders(
+      inModernTheme(<RotationEntryFields disabled={false} />)
+    );
+
+    selectBinAndRelease(tobaccoAGoGo);
+
+    expect(
+      flowsheetSlice.selectors.getSearchQuery(store.getState()).artist
+    ).toBe("");
+    expect(
+      (screen.getByTestId("flowsheet-search-artist") as HTMLInputElement).value
+    ).toBe("");
   });
 
   it("seeds the artist into the search query on release selection", () => {
@@ -302,10 +344,11 @@ describe("RotationEntryFields", () => {
       selectBinAndRelease(tobaccoAGoGo);
       selectTrack(0);
 
-      // Release select dispatches artist=Various Artists; track select with
-      // empty credits must not dispatch any further artist value even though
-      // the release qualifies for the override.
-      expect(artistValues(dispatchSpy)).toEqual(["Various Artists"]);
+      // Release select dispatches an empty artist — the V/A credit is a value
+      // submission refuses, so it is never seeded. Track select with empty
+      // credits must not dispatch any further artist value even though the
+      // release qualifies for the override.
+      expect(artistValues(dispatchSpy)).toEqual([""]);
     });
 
     it("sets artist to track's single per-track credit on V/A releases", () => {
@@ -462,7 +505,7 @@ describe("RotationEntryFields", () => {
       selectBinAndRelease(tobaccoAGoGo);
       selectTrack(0);
 
-      expect(artistValues(dispatchSpy)).toEqual(["Various Artists", "Warrior"]);
+      expect(artistValues(dispatchSpy)).toEqual(["", "Warrior"]);
     });
 
     it("strips Discogs (N) disambig before writing to the artist field", () => {
@@ -483,7 +526,7 @@ describe("RotationEntryFields", () => {
       selectBinAndRelease(tobaccoAGoGo);
       selectTrack(0);
 
-      expect(artistValues(dispatchSpy)).toEqual(["Various Artists", "M.I.A."]);
+      expect(artistValues(dispatchSpy)).toEqual(["", "M.I.A."]);
     });
 
     it("reverts to the release artist when switching from a credited to an uncredited track in one release", () => {
@@ -508,11 +551,10 @@ describe("RotationEntryFields", () => {
       selectTrack(0);
       selectTrack(1);
 
-      expect(artistValues(dispatchSpy)).toEqual([
-        "Various Artists",
-        "Skull Mitten",
-        "Various Artists",
-      ]);
+      // Reverting to an empty artist still clears the previous track's
+      // performer, which is what this guards; on a V/A comp the release-level
+      // value it reverts *to* is empty rather than the compilation credit.
+      expect(artistValues(dispatchSpy)).toEqual(["", "Skull Mitten", ""]);
     });
 
     it("falls back to the release-level artist when every per-track credit is malformed", () => {
@@ -520,6 +562,19 @@ describe("RotationEntryFields", () => {
       // normalizeTrackArtists returns [] for that shape; the auto-fill must
       // be a no-op so the release-level artist (seeded by handleSelectRelease)
       // stays in the field rather than being clobbered with an empty string.
+      //
+      // Uses a compilation filed under a credited album artist: on a V/A comp
+      // the seed is empty by design, which would make a clobber and a no-op
+      // indistinguishable.
+      const djKicks = createTestAlbum({
+        id: 12,
+        title: "DJ-Kicks",
+        artist: createTestArtist({ name: "Kruder & Dorfmeister" }),
+        album_artist: "Kruder & Dorfmeister",
+        rotation_id: 46,
+        rotation_bin: "H",
+      });
+      mockRotationData = [djKicks];
       mockTracksData = [
         {
           position: "A1",
@@ -531,10 +586,10 @@ describe("RotationEntryFields", () => {
 
       const { store } = renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
       const dispatchSpy = vi.spyOn(store, "dispatch");
-      selectBinAndRelease(tobaccoAGoGo);
+      selectBinAndRelease(djKicks);
       selectTrack(0);
 
-      expect(artistValues(dispatchSpy)).toEqual(["Various Artists"]);
+      expect(artistValues(dispatchSpy)).toEqual(["Kruder & Dorfmeister"]);
     });
   });
 });

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -1361,6 +1361,25 @@ describe("flowsheetHooks", () => {
         expect(result.current.search.searchQuery.artist).toBe("Stereolab");
       });
 
+      // The queue is a staging area for the flowsheet, so it takes the same
+      // refusal — otherwise ⌘-Enter becomes the way around the guard.
+      it("rejects a various-artists entry and leaves the search intact", () => {
+        const { result } = renderCombined();
+
+        act(() => {
+          result.current.search.setSearchProperty("artist", "Various Artists");
+          result.current.search.setSearchProperty("song", "Call Your Name");
+        });
+        act(() => {
+          result.current.submit.submitToQueue();
+        });
+
+        expect(result.current.queue.queue.length).toBe(0);
+        expect(result.current.search.searchQuery.artist).toBe(
+          "Various Artists"
+        );
+      });
+
       it("queues the typed entry and resets the search", () => {
         const { result } = renderCombined();
 
@@ -1926,6 +1945,104 @@ describe("flowsheetHooks", () => {
 
         expect(mockAddToFlowsheet).toHaveBeenCalledTimes(1);
         expect(mockToastError).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("handleSubmit various-artists validation", () => {
+      // Every submission path converges here, including the result-row click
+      // that never touches an input, so the artist check has to live beside
+      // the song check rather than in the markup.
+      const mkPreloaded = (artist: string) => ({
+        flowsheet: {
+          ...flowsheetSlice.getInitialState(),
+          search: {
+            ...flowsheetSlice.getInitialState().search,
+            selectedResult: 0,
+            query: {
+              song: "Call Your Name",
+              artist,
+              album: "In-Correcto 15-25",
+              label: "self-released",
+              request: false,
+            },
+          },
+        },
+      });
+
+      const submitWith = async (artist: string) => {
+        const { result } = renderHook(() => useFlowsheetSubmit(), {
+          wrapper: createHookWrapper(
+            { flowsheet: flowsheetSlice, liveUpdates: liveUpdatesSlice },
+            mkPreloaded(artist)
+          ),
+        });
+
+        await act(async () => {
+          await result.current.handleSubmit({
+            preventDefault: vi.fn(),
+          } as unknown as FormEvent);
+        });
+      };
+
+      it.each([
+        "Various Artists",
+        "various artists",
+        "V/A",
+        "VA",
+        "Var. Artists",
+        "Soundtrack",
+      ])("refuses %s and does not call addToFlowsheet", async (artist) => {
+        await submitWith(artist);
+
+        expect(mockAddToFlowsheet).not.toHaveBeenCalled();
+        expect(mockToastError).toHaveBeenCalledWith(
+          expect.stringMatching(/not "various artists"/i)
+        );
+      });
+
+      it.each(["Chuquimamani-Condori", "Various Production", "Van Morrison"])(
+        "submits normally for the performing artist %s",
+        async (artist) => {
+          await submitWith(artist);
+
+          expect(mockAddToFlowsheet).toHaveBeenCalledTimes(1);
+          expect(mockToastError).not.toHaveBeenCalled();
+        }
+      );
+
+      it("checks the song title before the artist so a blank entry names the first problem", async () => {
+        const { result } = renderHook(() => useFlowsheetSubmit(), {
+          wrapper: createHookWrapper(
+            { flowsheet: flowsheetSlice, liveUpdates: liveUpdatesSlice },
+            {
+              flowsheet: {
+                ...flowsheetSlice.getInitialState(),
+                search: {
+                  ...flowsheetSlice.getInitialState().search,
+                  selectedResult: 0,
+                  query: {
+                    song: "",
+                    artist: "Various Artists",
+                    album: "",
+                    label: "",
+                    request: false,
+                  },
+                },
+              },
+            }
+          ),
+        });
+
+        await act(async () => {
+          await result.current.handleSubmit({
+            preventDefault: vi.fn(),
+          } as unknown as FormEvent);
+        });
+
+        expect(mockAddToFlowsheet).not.toHaveBeenCalled();
+        expect(mockToastError).toHaveBeenCalledWith(
+          expect.stringMatching(/song title is required/i)
+        );
       });
     });
 

--- a/tests/unit/lib/features/flowsheet/various-artists-guard.test.ts
+++ b/tests/unit/lib/features/flowsheet/various-artists-guard.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 
-import { isVariousArtistsEntry } from "@/lib/features/flowsheet/various-artists-guard";
+import {
+  isVariousArtistsEntry,
+  releaseCreditIsRefused,
+  seedableArtistName,
+} from "@/lib/features/flowsheet/various-artists-guard";
 
 describe("isVariousArtistsEntry", () => {
   it.each([
@@ -63,4 +67,50 @@ describe("isVariousArtistsEntry", () => {
       expect(isVariousArtistsEntry(input)).toBe(false);
     }
   );
+});
+
+describe("releaseCreditIsRefused", () => {
+  // This is what drives the rotation artist field and the freeform routing.
+  // Keying either on `isCompilationRelease` instead leaves a hole in both
+  // directions, so the divergent cases are pinned here.
+  it.each(["Various Artists", "V/A", "VA", "Var. Artists", "Soundtrack"])(
+    "is true for a release credited %s",
+    (name) => {
+      expect(releaseCreditIsRefused({ artist: { name } })).toBe(true);
+    }
+  );
+
+  it("is false for a compilation filed under a credited album artist", () => {
+    // An isCompilationRelease whose name the guard never refuses: it is
+    // submittable as-is and must keep its library linkage.
+    expect(
+      releaseCreditIsRefused({ artist: { name: "Kruder & Dorfmeister" } })
+    ).toBe(false);
+  });
+
+  it.each([null, { artist: null }, { artist: { name: null } }])(
+    "is false for a release with no credit (%s)",
+    (release) => {
+      expect(releaseCreditIsRefused(release)).toBe(false);
+    }
+  );
+});
+
+describe("seedableArtistName", () => {
+  it("passes through a performing artist", () => {
+    expect(seedableArtistName({ artist: { name: "Jessica Pratt" } })).toBe(
+      "Jessica Pratt"
+    );
+  });
+
+  it.each(["Various Artists", "VA", "Var. Artists"])(
+    "blanks the refused credit %s rather than seeding it",
+    (name) => {
+      expect(seedableArtistName({ artist: { name } })).toBe("");
+    }
+  );
+
+  it("returns an empty string for a null-artist release", () => {
+    expect(seedableArtistName({ artist: null })).toBe("");
+  });
 });

--- a/tests/unit/lib/features/flowsheet/various-artists-guard.test.ts
+++ b/tests/unit/lib/features/flowsheet/various-artists-guard.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+
+import { isVariousArtistsEntry } from "@/lib/features/flowsheet/various-artists-guard";
+
+describe("isVariousArtistsEntry", () => {
+  it.each([
+    "Various Artists",
+    "various artists",
+    "VARIOUS ARTISTS",
+    "Various Artist",
+    "Various",
+    "  Various   Artists  ",
+    "V/A",
+    "v/a",
+    "V / A",
+    "V.A.",
+    "v.a.",
+    "Soundtrack",
+    "Original Soundtrack",
+    "Original Motion Picture Soundtrack",
+    "OST",
+    "Compilation",
+  ])("refuses the compilation designation %s", (input) => {
+    expect(isVariousArtistsEntry(input)).toBe(true);
+  });
+
+  // The two spellings the shared release-artist predicate deliberately allows.
+  // In the artist field of a flowsheet entry they are only ever shorthand for
+  // the compilation credit, and tubafrenzy has refused both for years.
+  it.each(["VA", "va", "V A", "v a", "Var. Artists", "Var Artists", "var. artist"])(
+    "refuses the abbreviated compilation credit %s",
+    (input) => {
+      expect(isVariousArtistsEntry(input)).toBe(true);
+    }
+  );
+
+  it.each([
+    "Juana Molina",
+    "Stereolab",
+    "Cat Power",
+    "Jessica Pratt",
+    "Chuquimamani-Condori",
+    "Duke Ellington & John Coltrane",
+    "Nilüfer Yanya",
+    // Real artists whose names embed a keyword — the whole-name anchoring is
+    // what keeps these submittable.
+    "Various Production",
+    "The Soundtrack of Our Lives",
+    "Death By Compilation",
+    "Vamping In Vegas",
+    "Variant Configuration",
+    // "Van" and "Vast" start with the same two letters as the "v...a" arm
+    // without being an abbreviation of it.
+    "Van Morrison",
+    "Vashti Bunyan",
+  ])("allows the performing artist %s", (input) => {
+    expect(isVariousArtistsEntry(input)).toBe(false);
+  });
+
+  it.each([null, undefined, "", "   "])(
+    "allows empty input %s — emptiness is a separate check",
+    (input) => {
+      expect(isVariousArtistsEntry(input)).toBe(false);
+    }
+  );
+});


### PR DESCRIPTION
Closes #1120

"Various Artists" submitted cleanly on every dj-site path. Tubafrenzy has refused it since the JSP form; dj-site refused it nowhere.

## The refusal

`useFlowsheetSubmit` gains the check in both `handleSubmit` and `submitToQueue` — beside the existing song-title check and for the same reason: a clicked result row calls `handleSubmit` directly and never touches an input, so markup-level validation can't see it. Classic gates `canSubmitTrack` and renders the message under the field, matching the legacy form's `.artist-error-message`.

`isVariousArtistsEntry` (new, `lib/features/flowsheet/various-artists-guard.ts`) composes the strict release-artist predicate with two spellings it deliberately allows — bare `VA` and `Var. Artists`. Widening `COMPILATION_ARTIST_PATTERNS` itself would have changed the catalog's per-track capture gate, where a false positive drags a real single artist into a step that makes no sense for them. In the artist field of a flowsheet entry both spellings are only ever the compilation credit. That predicate and its tests are untouched.

## Making the refusal escapable

Blocking alone would have dead-ended rotation mode: neither experience renders an artist field there, and on a V/A comp the release-level artist *is* the refused credit. Both now surface the field for compilation releases only, seeded empty rather than auto-filled with a value the form then rejects.

Classic additionally routes those submissions through the freeform variant. The catalog-linked variant carries no `artist_name` and resolves it from `album_id` — straight back to the credit the DJ just replaced. `rotation_id` rides the freeform variant, so the rotation badge survives the trade.

A compilation filed under a credited album artist keeps that name; normally-credited releases keep their current behavior and their catalog-linked submission.

## Tests

Five existing rotation assertions changed from `"Various Artists"` to `""` — they pinned the seed this PR removes. One (`falls back to the release-level artist when every per-track credit is malformed`) was re-pointed at a compilation with a credited album artist: with a V/A seed now empty, a no-op and a clobber were no longer distinguishable, and the test would have passed without testing anything.

`renders no artist input for a normally-credited release` is the narrowed survivor of `never renders an artist input — rotation mode has no override UI`.

Full suite: 308 files / 4347 tests pass. Lint 0 errors, no new warnings. `tsc --noEmit` clean.

## Review round

Code review caught that the field-reveal and submission routing were keyed on `isCompilationRelease` while the seed suppression and the refusal itself were keyed on `isVariousArtistsEntry`. Both gaps between them were live bugs, now closed by a single `releaseCreditIsRefused` trigger — see the second commit. It also caught that Modern's artist field was cosmetic on library-linked compilations, because BS's `album_id` branch spreads the library row over the request and discards `artist_name`; compilation picks now withhold `album_id`.

## Not included

- The Modern inline strip and danger-tinted artist cell. Modern reports the refusal as a toast; a disabled button with no explanation would be worse, and the full strip needs its own layout pass against the results panel.
- A server-side equivalent — tubafrenzy also refuses in the servlet, so this guard is client-side only until Backend-Service has one.
- The mail-bin Play Now / Add to Queue paths and queue replay, which reach the flowsheet without passing through `useFlowsheetSubmit`, plus the blank-artist queue gap in Modern rotation mode. Filed as #1122 — the fix wants a shared chokepoint rather than a fourth copy of the check.

Mockups behind the design: https://claude.ai/code/artifact/442bf076-12d3-4051-b56a-3c39ae0a5071


