### PR TITLE
fix(flowsheet): close the bin, queue, and replay gaps around the artist guard

### DIFF
--- a/lib/features/bin/conversions.ts
+++ b/lib/features/bin/conversions.ts
@@ -1,10 +1,22 @@
 import { AlbumEntry } from "../catalog/types";
 import { hasLinkedAlbumId } from "../flowsheet/linkage";
+import { releaseCreditIsRefused, seedableArtistName } from "../flowsheet/various-artists-guard";
 import { FlowsheetQuery, FlowsheetSubmissionParams } from "../flowsheet/types";
 
+/**
+ * `null` means Play Now must refuse the entry outright: a compilation credit
+ * is invisible on the linked (`album_id`-only) submission shape, so the
+ * check runs against the `AlbumEntry` here, before the linked/unlinked
+ * branch below can hide it. Play Now has no artist field to satisfy the
+ * refusal in place — the caller (useBinEntryActions) redirects the DJ to
+ * Add to Queue, whose conversion below seeds a blank, editable artist
+ * instead of refusing.
+ */
 export function convertBinToFlowsheet(
   binEntry: AlbumEntry
-): FlowsheetSubmissionParams {
+): FlowsheetSubmissionParams | null {
+  if (releaseCreditIsRefused(binEntry)) return null;
+
   // #608: gate album_id on `> 0` to drop the synthesized negative id that
   // `synthesizeAlbumId` produces for library-unlinked bin rows. Bypassed
   // `convertQueryToSubmission`'s chokepoint gate (04f027a) because
@@ -38,11 +50,17 @@ export function convertBinToFlowsheet(
 }
 
 export function convertBinToQueue(binEntry: AlbumEntry): FlowsheetQuery {
+  const refused = releaseCreditIsRefused(binEntry);
   return {
-    album_id: binEntry.id,
+    // Withheld together with the artist when refused: BS's album_id branch
+    // spreads the library row's artist over the request's, so keeping the
+    // linkage would hand the credit right back once the DJ types a real
+    // performer into the queued row (mirrors
+    // RotationEntryFields.handleSelectRelease's withholding trade).
+    album_id: refused ? undefined : binEntry.id,
     song: "",
     album: binEntry.title,
-    artist: binEntry.artist.name,
+    artist: seedableArtistName(binEntry),
     label: binEntry.label,
     rotation_id: binEntry.rotation_id,
     rotation_bin: binEntry.rotation_bin,

--- a/lib/features/bin/conversions.ts
+++ b/lib/features/bin/conversions.ts
@@ -1,21 +1,22 @@
 import { AlbumEntry } from "../catalog/types";
 import { hasLinkedAlbumId } from "../flowsheet/linkage";
-import { releaseCreditIsRefused, seedableArtistName } from "../flowsheet/various-artists-guard";
+import { releaseCannotSupplyArtist, seedableArtistName } from "../flowsheet/various-artists-guard";
 import { FlowsheetQuery, FlowsheetSubmissionParams } from "../flowsheet/types";
 
 /**
- * `null` means Play Now must refuse the entry outright: a compilation credit
- * is invisible on the linked (`album_id`-only) submission shape, so the
- * check runs against the `AlbumEntry` here, before the linked/unlinked
- * branch below can hide it. Play Now has no artist field to satisfy the
- * refusal in place — the caller (useBinEntryActions) redirects the DJ to
- * Add to Queue, whose conversion below seeds a blank, editable artist
- * instead of refusing.
+ * `null` means Play Now must refuse the entry outright: the release leaves
+ * the artist blank, either because its credit is refused or because it
+ * carries none, and the flowsheet is the permanent record. Neither is
+ * visible on the linked (`album_id`-only) submission shape, so the check
+ * runs against the `AlbumEntry` here, before the linked/unlinked branch
+ * below can hide it. Play Now has no artist field to satisfy the refusal in
+ * place — the caller (useBinEntryActions) redirects the DJ to Add to Queue,
+ * whose conversion below seeds a blank, editable artist instead of refusing.
  */
 export function convertBinToFlowsheet(
   binEntry: AlbumEntry
 ): FlowsheetSubmissionParams | null {
-  if (releaseCreditIsRefused(binEntry)) return null;
+  if (releaseCannotSupplyArtist(binEntry)) return null;
 
   // #608: gate album_id on `> 0` to drop the synthesized negative id that
   // `synthesizeAlbumId` produces for library-unlinked bin rows. Bypassed
@@ -60,14 +61,15 @@ export function convertBinToFlowsheet(
  * flowsheet boundary until they do.
  */
 export function convertBinToQueue(binEntry: AlbumEntry): FlowsheetQuery {
-  const refused = releaseCreditIsRefused(binEntry);
+  const cannotSupplyArtist = releaseCannotSupplyArtist(binEntry);
   return {
-    // Withheld together with the artist when refused: BS's album_id branch
-    // spreads the library row's artist over the request's, so keeping the
-    // linkage would hand the credit right back once the DJ types a real
-    // performer into the queued row (mirrors
-    // RotationEntryFields.handleSelectRelease's withholding trade).
-    album_id: refused ? undefined : binEntry.id,
+    // Withheld together with the artist whenever the release leaves it
+    // blank: BS's album_id branch spreads the library row's artist over the
+    // request's, so keeping the linkage would hand the credit — or the
+    // blank — right back once the DJ types a real performer into the queued
+    // row (mirrors RotationEntryFields.handleSelectRelease's withholding
+    // trade).
+    album_id: cannotSupplyArtist ? undefined : binEntry.id,
     song: "",
     album: binEntry.title,
     artist: seedableArtistName(binEntry),

--- a/lib/features/bin/conversions.ts
+++ b/lib/features/bin/conversions.ts
@@ -49,6 +49,16 @@ export function convertBinToFlowsheet(
   };
 }
 
+/**
+ * Also the catalog search results' Add-to-Queue conversion (modern
+ * `Result` / `MobileResult`), not the mail bin's alone — the name predates
+ * that second caller. Any behavior change here reaches both surfaces.
+ *
+ * A refused credit is queued blank rather than refused outright: unlike Play
+ * Now, the queue row's artist cell is editable, so it is the surface where
+ * the DJ can name the performer. `usePlayNow` refuses the blank at the
+ * flowsheet boundary until they do.
+ */
 export function convertBinToQueue(binEntry: AlbumEntry): FlowsheetQuery {
   const refused = releaseCreditIsRefused(binEntry);
   return {

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -35,6 +35,14 @@ export function entryToFreezePayload(entry: {
     // the form never autofills a value it then rejects. The DJ types the
     // performer into the field the freeze leaves blank.
     artist: seedableArtistName(entry),
+    // Whether the release supplied an artist at all, which a withheld seed
+    // can no longer be read off the seeded string to answer. The deviation
+    // rule needs the release's answer, not the seed's: typing a performer
+    // over a withheld credit departs from the linked row and must strip the
+    // linkage, or BS's album_id branch spreads the refused credit back over
+    // the request. Filling a field the release genuinely left empty is added
+    // data, and still keeps the selection.
+    artistProvided: Boolean(entry.artist?.name),
     album: entry.title ?? "",
     label: entry.label ?? "",
     album_id: entry.id ?? undefined,

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -2,6 +2,7 @@ import { Rotation } from "../rotation/types";
 import { formatStationDateTime } from "@/src/utilities/stationTime";
 import { OFF_AIR_LABEL } from "./constants";
 import { hasLinkedAlbumId } from "./linkage";
+import { seedableArtistName } from "./various-artists-guard";
 import {
   FlowsheetEntry,
   FlowsheetQuery,
@@ -30,7 +31,10 @@ export function entryToFreezePayload(entry: {
   rotation_bin?: Rotation | null;
 }) {
   return {
-    artist: entry.artist?.name ?? "",
+    // Seeded empty when the release's credit is one submission refuses, so
+    // the form never autofills a value it then rejects. The DJ types the
+    // performer into the field the freeze leaves blank.
+    artist: seedableArtistName(entry),
     album: entry.title ?? "",
     label: entry.label ?? "",
     album_id: entry.id ?? undefined,

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -35,14 +35,16 @@ export function entryToFreezePayload(entry: {
     // the form never autofills a value it then rejects. The DJ types the
     // performer into the field the freeze leaves blank.
     artist: seedableArtistName(entry),
-    // Whether the release supplied an artist at all, which a withheld seed
-    // can no longer be read off the seeded string to answer. The deviation
-    // rule needs the release's answer, not the seed's: typing a performer
-    // over a withheld credit departs from the linked row and must strip the
-    // linkage, or BS's album_id branch spreads the refused credit back over
-    // the request. Filling a field the release genuinely left empty is added
-    // data, and still keeps the selection.
-    artistProvided: Boolean(entry.artist?.name),
+    // Whether an artist typed into the field departs from this release,
+    // which the seeded string can no longer answer once a credit is withheld
+    // from it. True for every linked release, whatever its credit column
+    // holds: BS's album_id branch spreads that column over the request, so a
+    // performer typed over a withheld credit — or over a blank — is handed
+    // straight back unless the edit strips the linkage first. Without a
+    // linked row there is no linkage to strip and the deviation rule never
+    // runs, so the release's own credit is the only answer left to give.
+    artistProvided:
+      hasLinkedAlbumId(entry.id ?? undefined) || Boolean(entry.artist?.name),
     album: entry.title ?? "",
     label: entry.label ?? "",
     album_id: entry.id ?? undefined,

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -19,15 +19,6 @@ import { clearQueueFromStorage, loadQueueFromStorage, saveQueueToStorage } from 
 // queued, dropping the badge on dj-site/iOS and failing to propagate as
 // rotation to the wxyc.info archive. (Mirrors convertQueryToSubmission /
 // convertBinToFlowsheet, which forward rotation_id independent of album_id.)
-// The fields a linked library row supplies. Editing one of these on a queued
-// entry deviates from that row; editing anything else (track title, request,
-// segue) does not, since the row never claimed to describe them.
-const ALBUM_SCOPED_QUEUE_FIELDS: readonly (keyof FlowsheetSongEntry)[] = [
-  "artist_name",
-  "album_title",
-  "record_label",
-];
-
 function withSanitizedAlbumLinkage<
   T extends {
     album_id?: number;
@@ -43,6 +34,15 @@ function withSanitizedAlbumLinkage<
     album_id: undefined,
   };
 }
+
+// The fields a linked library row supplies. Editing one of these on a queued
+// entry deviates from that row; editing anything else (track title, request,
+// segue) does not, since the row never claimed to describe them.
+const ALBUM_SCOPED_QUEUE_FIELDS: readonly (keyof FlowsheetSongEntry)[] = [
+  "artist_name",
+  "album_title",
+  "record_label",
+];
 
 export const defaultFlowsheetFrontendState: FlowsheetFrontendState = {
   autoplay: false,
@@ -169,6 +169,11 @@ export const flowsheetSlice = createAppSlice({
         artist: string;
         album: string;
         label: string;
+        // Whether the release supplied an artist, for the case where the
+        // seeded string cannot say: a refused credit is withheld from the
+        // seed but was still supplied, and the deviation rule below must
+        // treat a performer typed over it as a departure from the release.
+        artistProvided?: boolean;
         album_id?: number;
         rotation_id?: number;
         rotation_bin?: Rotation;
@@ -183,7 +188,7 @@ export const flowsheetSlice = createAppSlice({
       state.search.query.track_position = undefined;
       state.search.selectedResult = 0;
       state.search.selectionProvided = {
-        artist: action.payload.artist !== "",
+        artist: action.payload.artistProvided ?? action.payload.artist !== "",
         album: action.payload.album !== "",
         label: action.payload.label !== "",
       };

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -249,11 +249,16 @@ export const flowsheetSlice = createAppSlice({
         //
         // Filling a field the row left EMPTY is added data, not a deviation
         // — the linkage still describes the entry and survives, exactly as
-        // it does in the searchbar.
+        // it does in the searchbar. The artist is the exception: a linked
+        // row always carries a credit, so a blank artist there means the
+        // conversion withheld one, and naming the performer corrects that
+        // row rather than adding to it.
+        const supplied =
+          action.payload.field === "artist_name" ||
+          (previous !== "" && previous !== undefined);
         if (
           ALBUM_SCOPED_QUEUE_FIELDS.includes(action.payload.field) &&
-          previous !== "" &&
-          previous !== undefined &&
+          supplied &&
           previous !== action.payload.value
         ) {
           entry.album_id = undefined;

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -19,6 +19,15 @@ import { clearQueueFromStorage, loadQueueFromStorage, saveQueueToStorage } from 
 // queued, dropping the badge on dj-site/iOS and failing to propagate as
 // rotation to the wxyc.info archive. (Mirrors convertQueryToSubmission /
 // convertBinToFlowsheet, which forward rotation_id independent of album_id.)
+// The fields a linked library row supplies. Editing one of these on a queued
+// entry deviates from that row; editing anything else (track title, request,
+// segue) does not, since the row never claimed to describe them.
+const ALBUM_SCOPED_QUEUE_FIELDS: readonly (keyof FlowsheetSongEntry)[] = [
+  "artist_name",
+  "album_title",
+  "record_label",
+];
+
 function withSanitizedAlbumLinkage<
   T extends {
     album_id?: number;
@@ -220,7 +229,22 @@ export const flowsheetSlice = createAppSlice({
     updateQueueEntry: (state, action: PayloadAction<{ entry_id: number; field: keyof FlowsheetSongEntry; value: string | boolean }>) => {
       const entry = state.queue.find((e) => e.id === action.payload.entry_id);
       if (entry) {
+        const previous = entry[action.payload.field];
         (entry as any)[action.payload.field] = action.payload.value;
+        // Same deviation rule the searchbar applies in setSearchProperty:
+        // once the DJ edits a field the linked library row supplied, that
+        // linkage no longer describes the entry and must not ride the wire,
+        // because BS's album_id branch spreads the library row over the
+        // request and would hand the replaced value straight back. This is
+        // the only place a queued entry's credit can be corrected, so
+        // without it a Various-Artists row rehydrated from storage silently
+        // discards the performer the DJ just typed.
+        if (
+          ALBUM_SCOPED_QUEUE_FIELDS.includes(action.payload.field) &&
+          previous !== action.payload.value
+        ) {
+          entry.album_id = undefined;
+        }
       }
       saveQueueToStorage(state.queue);
     },

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -169,11 +169,13 @@ export const flowsheetSlice = createAppSlice({
         artist: string;
         album: string;
         label: string;
-        // Whether the release supplied an artist, for the case where the
-        // seeded string cannot say: a refused credit is withheld from the
-        // seed but was still supplied, and the deviation rule below must
-        // treat a performer typed over it as a departure from the release.
-        artistProvided?: boolean;
+        // Whether the release supplied an artist, which the seeded string
+        // cannot answer: a refused credit is withheld from the seed but was
+        // still supplied, and the deviation rule must treat a performer
+        // typed over it as a departure from the release. Required, because
+        // inferring it from an empty seed is the mistake this field exists
+        // to prevent.
+        artistProvided: boolean;
         album_id?: number;
         rotation_id?: number;
         rotation_bin?: Rotation;
@@ -188,7 +190,7 @@ export const flowsheetSlice = createAppSlice({
       state.search.query.track_position = undefined;
       state.search.selectedResult = 0;
       state.search.selectionProvided = {
-        artist: action.payload.artistProvided ?? action.payload.artist !== "",
+        artist: action.payload.artistProvided,
         album: action.payload.album !== "",
         label: action.payload.label !== "",
       };
@@ -244,8 +246,14 @@ export const flowsheetSlice = createAppSlice({
         // the only place a queued entry's credit can be corrected, so
         // without it a Various-Artists row rehydrated from storage silently
         // discards the performer the DJ just typed.
+        //
+        // Filling a field the row left EMPTY is added data, not a deviation
+        // — the linkage still describes the entry and survives, exactly as
+        // it does in the searchbar.
         if (
           ALBUM_SCOPED_QUEUE_FIELDS.includes(action.payload.field) &&
+          previous !== "" &&
+          previous !== undefined &&
           previous !== action.payload.value
         ) {
           entry.album_id = undefined;

--- a/lib/features/flowsheet/submission-error.ts
+++ b/lib/features/flowsheet/submission-error.ts
@@ -1,0 +1,26 @@
+/**
+ * The message to show a DJ when a flowsheet write fails.
+ *
+ * Backend-Service reports a refused write as an RTK Query error whose
+ * `data.message` carries the reason a DJ can act on ("Show not live", a
+ * validation complaint); everything outside that shape — a thrown `Error`, a
+ * rejected string, a network failure — has no such reason and falls back.
+ * Interpolating the error object directly renders "[object Object]" and
+ * strands the DJ, which is the whole point of unwrapping it here.
+ */
+export function flowsheetWriteErrorMessage(err: unknown): string {
+  if (
+    err &&
+    typeof err === "object" &&
+    "data" in err &&
+    err.data &&
+    typeof err.data === "object" &&
+    "message" in err.data &&
+    typeof (err.data as { message: unknown }).message === "string"
+  ) {
+    return (err.data as { message: string }).message;
+  }
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "Could not add to flowsheet";
+}

--- a/lib/features/flowsheet/various-artists-guard.ts
+++ b/lib/features/flowsheet/various-artists-guard.ts
@@ -39,6 +39,13 @@ export const MISSING_ARTIST_REJECTION_MESSAGE =
   "Name the artist who performed the track.";
 
 /**
+ * Copy for the mail bin's Play Now refusal when the release carries no
+ * credit at all. Same dead end as the compilation credit and the same
+ * remedy, but the DJ never typed a credit to be told off for.
+ */
+export const MISSING_ARTIST_BIN_PLAY_MESSAGE = `${MISSING_ARTIST_REJECTION_MESSAGE} Add it to the queue instead, then type the performer into the artist cell before playing it.`;
+
+/**
  * Whole-name predicate for the flowsheet submit block: true when the artist
  * field holds a compilation credit instead of a performer.
  *
@@ -91,6 +98,22 @@ export function seedableArtistName(release: ReleaseCredit): string {
 }
 
 /**
+ * True when a release leaves the artist field blank — because its credit is
+ * refused, or because it carries no credit at all.
+ *
+ * The two arrive at the same place by different routes, and every surface
+ * that has to react to a blank artist cares about the place, not the route:
+ * a field is needed to type the performer into, the album linkage must not
+ * ride the wire over what gets typed, and the flowsheet refuses the write
+ * until it does. `releaseCreditIsRefused` stays the right question only
+ * where the compilation credit specifically is the subject — the copy that
+ * names it, and the escape hatch that seeds around it.
+ */
+export function releaseCannotSupplyArtist(release: ReleaseCredit): boolean {
+  return seedableArtistName(release).trim() === "";
+}
+
+/**
  * Success copy for a release added to the queue, shared by the mail bin and
  * both catalog result surfaces because all three queue through the same
  * conversion.
@@ -100,10 +123,11 @@ export function seedableArtistName(release: ReleaseCredit): string {
  * meets the requirement for the first time at the Play refusal, with no idea
  * it was coming.
  */
-export function queueAdditionMessage(
-  release: ReleaseCredit & { title?: string | null }
-): string {
-  const added = `Added ${release?.title ?? ""} to queue`;
+export function queueAdditionMessage(release: {
+  title?: string | null;
+  artist?: { name?: string | null } | null;
+}): string {
+  const added = `Added ${release.title ?? ""} to queue`;
   return releaseCreditIsRefused(release)
     ? `${added}. Name the performer in the artist cell before playing it.`
     : added;

--- a/lib/features/flowsheet/various-artists-guard.ts
+++ b/lib/features/flowsheet/various-artists-guard.ts
@@ -30,6 +30,16 @@ export const VARIOUS_ARTISTS_BIN_PLAY_MESSAGE =
   'Use the artist who performed the track, not "Various Artists". Add it to the queue instead, then type the performer into the artist cell before playing it.';
 
 /**
+ * Copy for a blank artist, which is a different mistake from a refused
+ * credit and must not borrow its message: a DJ who left the field empty
+ * never typed "Various Artists", so telling them not to names a fix they
+ * did not need. Emptiness is legal in the queue and refused only at the
+ * flowsheet boundary, so this fires later than the credit refusal does.
+ */
+export const MISSING_ARTIST_REJECTION_MESSAGE =
+  "Name the artist who performed the track.";
+
+/**
  * Whole-name predicate for the flowsheet submit block: true when the artist
  * field holds a compilation credit instead of a performer.
  *

--- a/lib/features/flowsheet/various-artists-guard.ts
+++ b/lib/features/flowsheet/various-artists-guard.ts
@@ -21,6 +21,15 @@ export const VARIOUS_ARTISTS_REJECTION_MESSAGE =
   'Use the artist who performed the track, not "Various Artists".';
 
 /**
+ * Copy for the mail bin's Play Now refusal specifically. Play Now is a
+ * single click with no artist field to satisfy the refusal in place, unlike
+ * every other refusal surface — so the message has to name a different
+ * remedy: queue it, then name the performer in the now-editable queue row.
+ */
+export const VARIOUS_ARTISTS_BIN_PLAY_MESSAGE =
+  'Use the artist who performed the track, not "Various Artists". Add it to the queue instead, then type the performer into the artist cell before playing it.';
+
+/**
  * Whole-name predicate for the flowsheet submit block: true when the artist
  * field holds a compilation credit instead of a performer.
  *

--- a/lib/features/flowsheet/various-artists-guard.ts
+++ b/lib/features/flowsheet/various-artists-guard.ts
@@ -89,3 +89,22 @@ export function seedableArtistName(release: ReleaseCredit): string {
   const name = release?.artist?.name ?? "";
   return isVariousArtistsEntry(name) ? "" : name;
 }
+
+/**
+ * Success copy for a release added to the queue, shared by the mail bin and
+ * both catalog result surfaces because all three queue through the same
+ * conversion.
+ *
+ * A refused credit is queued with a blank artist rather than the credit, so
+ * the toast has to say what is still missing — told only "added", the DJ
+ * meets the requirement for the first time at the Play refusal, with no idea
+ * it was coming.
+ */
+export function queueAdditionMessage(
+  release: ReleaseCredit & { title?: string | null }
+): string {
+  const added = `Added ${release?.title ?? ""} to queue`;
+  return releaseCreditIsRefused(release)
+    ? `${added}. Name the performer in the artist cell before playing it.`
+    : added;
+}

--- a/lib/features/flowsheet/various-artists-guard.ts
+++ b/lib/features/flowsheet/various-artists-guard.ts
@@ -26,8 +26,7 @@ export const VARIOUS_ARTISTS_REJECTION_MESSAGE =
  * every other refusal surface — so the message has to name a different
  * remedy: queue it, then name the performer in the now-editable queue row.
  */
-export const VARIOUS_ARTISTS_BIN_PLAY_MESSAGE =
-  'Use the artist who performed the track, not "Various Artists". Add it to the queue instead, then type the performer into the artist cell before playing it.';
+export const VARIOUS_ARTISTS_BIN_PLAY_MESSAGE = `${VARIOUS_ARTISTS_REJECTION_MESSAGE} Add it to the queue instead, then type the performer into the artist cell before playing it.`;
 
 /**
  * Copy for a blank artist, which is a different mistake from a refused

--- a/lib/features/flowsheet/various-artists-guard.ts
+++ b/lib/features/flowsheet/various-artists-guard.ts
@@ -118,17 +118,18 @@ export function releaseCannotSupplyArtist(release: ReleaseCredit): boolean {
  * both catalog result surfaces because all three queue through the same
  * conversion.
  *
- * A refused credit is queued with a blank artist rather than the credit, so
- * the toast has to say what is still missing — told only "added", the DJ
- * meets the requirement for the first time at the Play refusal, with no idea
- * it was coming.
+ * A release that cannot supply an artist is queued blank, so the toast has to
+ * say what is still missing — told only "added", the DJ meets the requirement
+ * for the first time at the Play refusal, with no idea it was coming. Keyed
+ * on what the queue row lacks rather than on the refused credit specifically,
+ * because the conversion blanks and unlinks both cases identically.
  */
 export function queueAdditionMessage(release: {
   title?: string | null;
   artist?: { name?: string | null } | null;
 }): string {
   const added = `Added ${release.title ?? ""} to queue`;
-  return releaseCreditIsRefused(release)
+  return releaseCannotSupplyArtist(release)
     ? `${added}. Name the performer in the artist cell before playing it.`
     : added;
 }

--- a/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions.ts
+++ b/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions.ts
@@ -10,7 +10,10 @@ import {
   FlowsheetQuery,
   FlowsheetSubmissionParams,
 } from "@/lib/features/flowsheet/types";
-import { VARIOUS_ARTISTS_BIN_PLAY_MESSAGE } from "@/lib/features/flowsheet/various-artists-guard";
+import {
+  releaseCreditIsRefused,
+  VARIOUS_ARTISTS_BIN_PLAY_MESSAGE,
+} from "@/lib/features/flowsheet/various-artists-guard";
 import { useAppDispatch } from "@/lib/hooks";
 import {
   InfoOutlined,
@@ -83,7 +86,15 @@ export function useBinEntryActions(
         shiftRemoves: true,
         run: (opts) => {
           addToQueue(convertBinToQueue(entry));
-          toast.success(`Added ${entry.title} to queue`);
+          // A refused credit is queued with a blank artist rather than the
+          // credit, so the success toast has to say what is still missing —
+          // otherwise the DJ meets the requirement for the first time at
+          // the Play refusal, with no idea it was coming.
+          toast.success(
+            releaseCreditIsRefused(entry)
+              ? `Added ${entry.title} to queue. Name the performer in the artist cell before playing it.`
+              : `Added ${entry.title} to queue`
+          );
           if (opts?.shiftKey) deleteFromBin(entry.id);
         },
       });

--- a/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions.ts
+++ b/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions.ts
@@ -10,6 +10,7 @@ import {
   FlowsheetQuery,
   FlowsheetSubmissionParams,
 } from "@/lib/features/flowsheet/types";
+import { VARIOUS_ARTISTS_BIN_PLAY_MESSAGE } from "@/lib/features/flowsheet/various-artists-guard";
 import { useAppDispatch } from "@/lib/hooks";
 import {
   InfoOutlined,
@@ -93,7 +94,14 @@ export function useBinEntryActions(
         color: "primary",
         shiftRemoves: true,
         run: (opts) => {
-          addToFlowsheet(convertBinToFlowsheet(entry))
+          const submission = convertBinToFlowsheet(entry);
+          if (!submission) {
+            // No artist field to satisfy the refusal in place — point the DJ
+            // at the escape hatch instead of just saying no.
+            toast.error(VARIOUS_ARTISTS_BIN_PLAY_MESSAGE);
+            return;
+          }
+          addToFlowsheet(submission)
             // Only file the album away once it actually reached the
             // flowsheet — a failed play shouldn't also lose the bin entry.
             .then(() => {

--- a/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions.ts
+++ b/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions.ts
@@ -11,7 +11,7 @@ import {
   FlowsheetSubmissionParams,
 } from "@/lib/features/flowsheet/types";
 import {
-  releaseCreditIsRefused,
+  queueAdditionMessage,
   VARIOUS_ARTISTS_BIN_PLAY_MESSAGE,
 } from "@/lib/features/flowsheet/various-artists-guard";
 import { useAppDispatch } from "@/lib/hooks";
@@ -86,15 +86,7 @@ export function useBinEntryActions(
         shiftRemoves: true,
         run: (opts) => {
           addToQueue(convertBinToQueue(entry));
-          // A refused credit is queued with a blank artist rather than the
-          // credit, so the success toast has to say what is still missing —
-          // otherwise the DJ meets the requirement for the first time at
-          // the Play refusal, with no idea it was coming.
-          toast.success(
-            releaseCreditIsRefused(entry)
-              ? `Added ${entry.title} to queue. Name the performer in the artist cell before playing it.`
-              : `Added ${entry.title} to queue`
-          );
+          toast.success(queueAdditionMessage(entry));
           if (opts?.shiftKey) deleteFromBin(entry.id);
         },
       });

--- a/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions.ts
+++ b/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions.ts
@@ -11,7 +11,9 @@ import {
   FlowsheetSubmissionParams,
 } from "@/lib/features/flowsheet/types";
 import {
+  MISSING_ARTIST_BIN_PLAY_MESSAGE,
   queueAdditionMessage,
+  releaseCreditIsRefused,
   VARIOUS_ARTISTS_BIN_PLAY_MESSAGE,
 } from "@/lib/features/flowsheet/various-artists-guard";
 import { useAppDispatch } from "@/lib/hooks";
@@ -100,8 +102,14 @@ export function useBinEntryActions(
           const submission = convertBinToFlowsheet(entry);
           if (!submission) {
             // No artist field to satisfy the refusal in place — point the DJ
-            // at the escape hatch instead of just saying no.
-            toast.error(VARIOUS_ARTISTS_BIN_PLAY_MESSAGE);
+            // at the escape hatch instead of just saying no. A release that
+            // carries no credit and one whose credit is refused dead-end the
+            // same way, but only the second involves a credit worth naming.
+            toast.error(
+              releaseCreditIsRefused(entry)
+                ? VARIOUS_ARTISTS_BIN_PLAY_MESSAGE
+                : MISSING_ARTIST_BIN_PLAY_MESSAGE
+            );
             return;
           }
           addToFlowsheet(submission)

--- a/src/components/experiences/modern/catalog/Results/MobileResult.tsx
+++ b/src/components/experiences/modern/catalog/Results/MobileResult.tsx
@@ -13,6 +13,7 @@ import { applicationSlice } from "@/lib/features/application/frontend";
 import { FlowsheetQuery } from "@/lib/features/flowsheet/types";
 import { useAppDispatch } from "@/lib/hooks";
 import { convertBinToQueue } from "@/lib/features/bin/conversions";
+import { queueAdditionMessage } from "@/lib/features/flowsheet/various-artists-guard";
 import { AlbumArtwork } from "../AlbumArtwork";
 import AddRemoveBin from "./AddRemoveBin";
 import { MatchedTrackChips } from "./MatchedTrackChips";
@@ -138,7 +139,7 @@ function CatalogMobileResult({
             color="neutral"
             onClick={() => {
               addToQueue(convertBinToQueue(album));
-              toast.success(`Added ${album.title} to queue`);
+              toast.success(queueAdditionMessage(album));
             }}
           >
             <QueueMusic />

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -20,6 +20,7 @@ import AddRemoveBin from "./AddRemoveBin";
 import { MatchedTrackChips } from "./MatchedTrackChips";
 import { ReleaseChips } from "./ReleaseChips";
 import { convertBinToQueue } from "@/lib/features/bin/conversions";
+import { queueAdditionMessage } from "@/lib/features/flowsheet/various-artists-guard";
 import { toast } from "sonner";
 import { memo } from "react";
 
@@ -210,7 +211,7 @@ function CatalogResult({
                 size="sm"
                 onClick={() => {
                   addToQueue(convertBinToQueue(album));
-                  toast.success(`Added ${album.title} to queue`);
+                  toast.success(queueAdditionMessage(album));
                 }}
               >
                 <QueueMusic />

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.ts
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { hasLinkedAlbumId } from "@/lib/features/flowsheet/linkage";
+import { flowsheetWriteErrorMessage } from "@/lib/features/flowsheet/submission-error";
 import {
   FlowsheetSongEntry,
   FlowsheetSubmissionParams,
@@ -11,7 +11,6 @@ import {
   MISSING_ARTIST_REJECTION_MESSAGE,
   VARIOUS_ARTISTS_REJECTION_MESSAGE,
 } from "@/lib/features/flowsheet/various-artists-guard";
-import { useAppDispatch } from "@/lib/hooks";
 import { useFlowsheetActions } from "@/src/hooks/flowsheetHooks";
 import { useCallback } from "react";
 import { toast } from "sonner";
@@ -22,8 +21,7 @@ export function usePlayNow(entry: FlowsheetSongEntry) {
   // Routed through the shared flowsheet chokepoint (rather than a raw
   // mutation trigger) so this replay carries the same auth guard and
   // tag-invalidation refetch every other flowsheet write gets.
-  const { addToFlowsheet } = useFlowsheetActions();
-  const dispatch = useAppDispatch();
+  const { addToFlowsheet, removeFromQueue } = useFlowsheetActions();
 
   return useCallback(() => {
     // A blank artist reaches the queue only through the bin's escape hatch
@@ -62,10 +60,10 @@ export function usePlayNow(entry: FlowsheetSongEntry) {
       }),
     } as FlowsheetSubmissionParams)
       .then(() => {
-        dispatch(flowsheetSlice.actions.removeFromQueue(entry.id));
+        removeFromQueue(entry.id);
       })
       .catch((error) => {
-        toast.error(`Failed to add to flowsheet: ${error}`);
+        toast.error(flowsheetWriteErrorMessage(error));
       });
-  }, [addToFlowsheet, dispatch, entry]);
+  }, [addToFlowsheet, removeFromQueue, entry]);
 }

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.ts
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/features/flowsheet/types";
 import {
   isVariousArtistsEntry,
+  MISSING_ARTIST_REJECTION_MESSAGE,
   VARIOUS_ARTISTS_REJECTION_MESSAGE,
 } from "@/lib/features/flowsheet/various-artists-guard";
 import { useAppDispatch } from "@/lib/hooks";
@@ -30,11 +31,13 @@ export function usePlayNow(entry: FlowsheetSongEntry) {
     // edit to the queue row's artist cell; a literal compilation credit
     // reaches it only from a queue entry rehydrated from localStorage that
     // predates this guard. Neither has anywhere else to be caught before
-    // the flowsheet write.
-    if (
-      !entry.artist_name?.trim() ||
-      isVariousArtistsEntry(entry.artist_name)
-    ) {
+    // the flowsheet write, and they take different copy because they are
+    // different mistakes.
+    if (!entry.artist_name?.trim()) {
+      toast.error(MISSING_ARTIST_REJECTION_MESSAGE);
+      return;
+    }
+    if (isVariousArtistsEntry(entry.artist_name)) {
       toast.error(VARIOUS_ARTISTS_REJECTION_MESSAGE);
       return;
     }

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.ts
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow.ts
@@ -1,28 +1,44 @@
 "use client";
 
-import { useAddToFlowsheetMutation } from "@/lib/features/flowsheet/api";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { hasLinkedAlbumId } from "@/lib/features/flowsheet/linkage";
 import {
   FlowsheetSongEntry,
   FlowsheetSubmissionParams,
 } from "@/lib/features/flowsheet/types";
+import {
+  isVariousArtistsEntry,
+  VARIOUS_ARTISTS_REJECTION_MESSAGE,
+} from "@/lib/features/flowsheet/various-artists-guard";
 import { useAppDispatch } from "@/lib/hooks";
-import { useRegistry } from "@/src/hooks/authenticationHooks";
+import { useFlowsheetActions } from "@/src/hooks/flowsheetHooks";
 import { useCallback } from "react";
 import { toast } from "sonner";
 
 // Shared by the desktop row's hover PlayArrow and the mobile card's Play
 // button so the submission payload can't drift between the two.
 export function usePlayNow(entry: FlowsheetSongEntry) {
-  const { loading: userloading, info: userData } = useRegistry();
-  const [addToFlowsheet] = useAddToFlowsheetMutation();
+  // Routed through the shared flowsheet chokepoint (rather than a raw
+  // mutation trigger) so this replay carries the same auth guard and
+  // tag-invalidation refetch every other flowsheet write gets.
+  const { addToFlowsheet } = useFlowsheetActions();
   const dispatch = useAppDispatch();
 
   return useCallback(() => {
-    if (!userData || userData.id === undefined || userloading) {
+    // A blank artist reaches the queue only through the bin's escape hatch
+    // (queued blank rather than carrying the refused credit) or a manual
+    // edit to the queue row's artist cell; a literal compilation credit
+    // reaches it only from a queue entry rehydrated from localStorage that
+    // predates this guard. Neither has anywhere else to be caught before
+    // the flowsheet write.
+    if (
+      !entry.artist_name?.trim() ||
+      isVariousArtistsEntry(entry.artist_name)
+    ) {
+      toast.error(VARIOUS_ARTISTS_REJECTION_MESSAGE);
       return;
     }
+
     // Queue entries can carry `album_id: undefined` (freeform) or a
     // synthesized negative id (library-unlinked bin rows, which BS throws
     // on — #701). Only a real positive album_id may go on the wire (#607).
@@ -42,12 +58,11 @@ export function usePlayNow(entry: FlowsheetSongEntry) {
         rotation_bin: entry.rotation,
       }),
     } as FlowsheetSubmissionParams)
-      .unwrap()
       .then(() => {
         dispatch(flowsheetSlice.actions.removeFromQueue(entry.id));
       })
       .catch((error) => {
         toast.error(`Failed to add to flowsheet: ${error}`);
       });
-  }, [addToFlowsheet, dispatch, entry, userData, userloading]);
+  }, [addToFlowsheet, dispatch, entry]);
 }

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -4,7 +4,7 @@ import { isCompilationRelease } from "@/lib/features/catalog/is-compilation-arti
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import {
-  releaseCreditIsRefused,
+  releaseCannotSupplyArtist,
   seedableArtistName,
 } from "@/lib/features/flowsheet/various-artists-guard";
 import { Rotation } from "@/lib/features/rotation/types";
@@ -92,11 +92,13 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
       dispatch(flowsheetSlice.actions.setSearchProperty({ name: "label", value: release.label ?? "" }));
       dispatch(
         flowsheetSlice.actions.setRotationMetadata({
-          // Withheld when the credit is refused: BS's album_id branch spreads
-          // the library row's artist_name over the request's, so keeping the
-          // linkage would hand back the very credit the DJ just replaced.
-          // Classic makes the same trade by switching submission variants.
-          album_id: releaseCreditIsRefused(release) ? undefined : release.id,
+          // Withheld whenever the release leaves the artist blank: BS's
+          // album_id branch spreads the library row's artist_name over the
+          // request's, so keeping the linkage would hand back the very
+          // credit — or the very blank — the DJ is about to replace in the
+          // field below. Classic makes the same trade by switching
+          // submission variants.
+          album_id: releaseCannotSupplyArtist(release) ? undefined : release.id,
           rotation_id: release.rotation_id,
           rotation_bin: release.rotation_bin,
         })
@@ -116,12 +118,9 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
   const trackCreditsAreDisambiguating =
     !!selectedRelease && isCompilationRelease(selectedRelease);
 
-  // Distinct from the above on purpose — see releaseCreditIsRefused. Keyed
-  // on the seed rather than the refusal so it also covers a release that
-  // carries no credit at all: both leave the artist blank, and submission
-  // refuses a blank, so both need the field that can satisfy the refusal.
+  // Distinct from the above on purpose — see releaseCannotSupplyArtist.
   const needsPerformerName =
-    !!selectedRelease && !seedableArtistName(selectedRelease);
+    !!selectedRelease && releaseCannotSupplyArtist(selectedRelease);
 
   const handleSelectTrack = useCallback(
     (track: RotationTrack) => {

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -116,9 +116,12 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
   const trackCreditsAreDisambiguating =
     !!selectedRelease && isCompilationRelease(selectedRelease);
 
-  // Distinct from the above on purpose — see releaseCreditIsRefused.
+  // Distinct from the above on purpose — see releaseCreditIsRefused. Keyed
+  // on the seed rather than the refusal so it also covers a release that
+  // carries no credit at all: both leave the artist blank, and submission
+  // refuses a blank, so both need the field that can satisfy the refusal.
   const needsPerformerName =
-    !!selectedRelease && releaseCreditIsRefused(selectedRelease);
+    !!selectedRelease && !seedableArtistName(selectedRelease);
 
   const handleSelectTrack = useCallback(
     (track: RotationTrack) => {

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -16,6 +16,7 @@ import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import {
   isVariousArtistsEntry,
   MISSING_ARTIST_REJECTION_MESSAGE,
+  releaseCreditIsRefused,
   seedableArtistName,
   VARIOUS_ARTISTS_REJECTION_MESSAGE,
 } from "@/lib/features/flowsheet/various-artists-guard";
@@ -671,12 +672,23 @@ export const useFlowsheetSubmit = () => {
       };
     } else {
       // Selected result fields win; each falls back to the DJ's typed value.
+      //
+      // The artist is withheld for a refused credit on the same terms the
+      // field the DJ sees withholds it, so the submission can never carry a
+      // value the input does not show. The album linkage goes with it: BS's
+      // album_id branch spreads the library row over the request, so keeping
+      // it would hand the credit back over whatever performer the DJ typed.
+      // rotation_id is not album-scoped and survives.
       return {
         song: flowSheetRawQuery.song as string,
-        artist: selectedEntry.artist?.name || flowSheetRawQuery.artist as string,
+        artist:
+          seedableArtistName(selectedEntry) ||
+          (flowSheetRawQuery.artist as string),
         album: selectedEntry.title || flowSheetRawQuery.album as string,
         label: selectedEntry.label || flowSheetRawQuery.label as string,
-        album_id: selectedEntry.id ?? undefined,
+        album_id: releaseCreditIsRefused(selectedEntry)
+          ? undefined
+          : selectedEntry.id ?? undefined,
         rotation_bin: selectedEntry.rotation_bin ?? undefined,
         rotation_id: selectedEntry.rotation_id ?? undefined,
         track_position: flowSheetRawQuery.track_position,

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -16,6 +16,7 @@ import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import {
   isVariousArtistsEntry,
   MISSING_ARTIST_REJECTION_MESSAGE,
+  seedableArtistName,
   VARIOUS_ARTISTS_REJECTION_MESSAGE,
 } from "@/lib/features/flowsheet/various-artists-guard";
 import {
@@ -296,7 +297,11 @@ export const useFlowsheetSearch = () => {
           // Song always reflects the DJ's own input, even under a selection.
           return searchQuery.song as string;
         case "artist":
-          return selectedEntry.artist?.name || (searchQuery.artist as string);
+          // Withheld for a refused credit, like the freeze payload it
+          // previews: a highlighted result that displayed the credit would
+          // put it back into the field on the DJ's first keystroke, since
+          // the browser derives that keystroke's value from what is shown.
+          return seedableArtistName(selectedEntry) || (searchQuery.artist as string);
         case "album":
           return selectedEntry.title || (searchQuery.album as string);
         case "label":

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -693,6 +693,16 @@ export const useFlowsheetSubmit = () => {
       toast.error(VARIOUS_ARTISTS_REJECTION_MESSAGE);
       return;
     }
+    // Only a compilation rotation release seeds this field blank
+    // (RotationEntryFields.needsPerformerName) — every other source (bin,
+    // catalog, LML, a normally-credited rotation pick) supplies a real
+    // name. HTML5 `required` can't catch this: it only guards the field
+    // Rotation mode renders when a performer is needed, and the queue
+    // button/Ctrl+Enter never run constraint validation regardless.
+    if (!(selectedResultData.artist ?? "").trim()) {
+      toast.error(VARIOUS_ARTISTS_REJECTION_MESSAGE);
+      return;
+    }
     addToQueue(selectedResultData);
     dispatch(flowsheetSlice.actions.resetSearch());
   }, [addToQueue, selectedResultData, dispatch]);

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -16,7 +16,7 @@ import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import {
   isVariousArtistsEntry,
   MISSING_ARTIST_REJECTION_MESSAGE,
-  releaseCreditIsRefused,
+  releaseCannotSupplyArtist,
   seedableArtistName,
   VARIOUS_ARTISTS_REJECTION_MESSAGE,
 } from "@/lib/features/flowsheet/various-artists-guard";
@@ -675,10 +675,12 @@ export const useFlowsheetSubmit = () => {
       //
       // The artist is withheld for a refused credit on the same terms the
       // field the DJ sees withholds it, so the submission can never carry a
-      // value the input does not show. The album linkage goes with it: BS's
-      // album_id branch spreads the library row over the request, so keeping
-      // it would hand the credit back over whatever performer the DJ typed.
-      // rotation_id is not album-scoped and survives.
+      // value the input does not show. The album linkage goes with it
+      // whenever the release leaves the artist blank at all: BS's album_id
+      // branch spreads the library row over the request, so keeping the
+      // linkage would hand that blank — or that credit — back over whatever
+      // performer the DJ typed into the fallback. rotation_id is not
+      // album-scoped and survives.
       return {
         song: flowSheetRawQuery.song as string,
         artist:
@@ -686,7 +688,7 @@ export const useFlowsheetSubmit = () => {
           (flowSheetRawQuery.artist as string),
         album: selectedEntry.title || flowSheetRawQuery.album as string,
         label: selectedEntry.label || flowSheetRawQuery.label as string,
-        album_id: releaseCreditIsRefused(selectedEntry)
+        album_id: releaseCannotSupplyArtist(selectedEntry)
           ? undefined
           : selectedEntry.id ?? undefined,
         rotation_bin: selectedEntry.rotation_bin ?? undefined,

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -25,6 +25,7 @@ import {
 import { safeCapture } from "@/lib/posthog";
 import { useFlowsheetPollingInterval } from "./useSSEConnection";
 import { partitionFlowsheetEntries } from "@/lib/features/flowsheet/partition";
+import { flowsheetWriteErrorMessage } from "@/lib/features/flowsheet/submission-error";
 import {
   FlowsheetEntry,
   FlowsheetQuery,
@@ -694,16 +695,11 @@ export const useFlowsheetSubmit = () => {
       toast.error(VARIOUS_ARTISTS_REJECTION_MESSAGE);
       return;
     }
-    // Only a compilation rotation release seeds this field blank
-    // (RotationEntryFields.needsPerformerName) — every other source (bin,
-    // catalog, LML, a normally-credited rotation pick) supplies a real
-    // name. HTML5 `required` can't catch this: it only guards the field
-    // Rotation mode renders when a performer is needed, and the queue
-    // button/Ctrl+Enter never run constraint validation regardless.
-    if (!(selectedResultData.artist ?? "").trim()) {
-      toast.error(MISSING_ARTIST_REJECTION_MESSAGE);
-      return;
-    }
+    // A blank artist is deliberately allowed through: the queue is a draft,
+    // and naming the performer later in the queue row's editable artist
+    // cell is both a real workflow and the remedy the mail bin's refusal
+    // redirects to. Emptiness is refused at the flowsheet boundary instead
+    // (handleSubmit and usePlayNow).
     addToQueue(selectedResultData);
     dispatch(flowsheetSlice.actions.resetSearch());
   }, [addToQueue, selectedResultData, dispatch]);
@@ -730,6 +726,14 @@ export const useFlowsheetSubmit = () => {
         toast.error(VARIOUS_ARTISTS_REJECTION_MESSAGE);
         return;
       }
+      // The flowsheet is the permanent record, so emptiness is refused here
+      // rather than on the queue path. Only `song` carries HTML5 `required`
+      // in the searchbar, and a clicked result row never touches an input,
+      // so markup validation cannot stand in for this.
+      if (!(selectedResultData.artist ?? "").trim()) {
+        toast.error(MISSING_ARTIST_REJECTION_MESSAGE);
+        return;
+      }
       if (isRotationPick && selectedEntry) {
         safeCapture("flowsheet_submit_rotation_link", {
           rotation_id_present: selectedEntry.rotation_id != null,
@@ -741,19 +745,7 @@ export const useFlowsheetSubmit = () => {
         await addToFlowsheet(convertQueryToSubmission(selectedResultData));
         dispatch(flowsheetSlice.actions.resetSearch());
       } catch (err) {
-        const message =
-          err &&
-          typeof err === "object" &&
-          "data" in err &&
-          err.data &&
-          typeof err.data === "object" &&
-          "message" in err.data &&
-          typeof (err.data as { message: unknown }).message === "string"
-            ? (err.data as { message: string }).message
-            : err instanceof Error
-              ? err.message
-              : "Could not add to flowsheet";
-        toast.error(message);
+        toast.error(flowsheetWriteErrorMessage(err));
       }
     },
     [

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -15,6 +15,7 @@ import { convertQueryToSubmission } from "@/lib/features/flowsheet/conversions";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import {
   isVariousArtistsEntry,
+  MISSING_ARTIST_REJECTION_MESSAGE,
   VARIOUS_ARTISTS_REJECTION_MESSAGE,
 } from "@/lib/features/flowsheet/various-artists-guard";
 import {
@@ -700,7 +701,7 @@ export const useFlowsheetSubmit = () => {
     // Rotation mode renders when a performer is needed, and the queue
     // button/Ctrl+Enter never run constraint validation regardless.
     if (!(selectedResultData.artist ?? "").trim()) {
-      toast.error(VARIOUS_ARTISTS_REJECTION_MESSAGE);
+      toast.error(MISSING_ARTIST_REJECTION_MESSAGE);
       return;
     }
     addToQueue(selectedResultData);

--- a/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
+++ b/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { Unarchive } from "@mui/icons-material";
 import type { AlbumEntry } from "@/lib/features/catalog/types";
+import { VARIOUS_ARTISTS_BIN_PLAY_MESSAGE } from "@/lib/features/flowsheet/various-artists-guard";
 
 const dispatch = vi.fn();
 const addToQueue = vi.fn();
@@ -137,8 +138,11 @@ describe("useBinEntryActions", () => {
     byId.play.run();
 
     expect(addToFlowsheet).not.toHaveBeenCalled();
+    // Pinned to the bin-specific constant, not a substring both messages
+    // share: the remedy it names is the only thing standing between the DJ
+    // and a dead end, and the generic copy would satisfy a looser matcher.
     expect(toastErrorMock).toHaveBeenCalledWith(
-      expect.stringMatching(/not "various artists"/i)
+      VARIOUS_ARTISTS_BIN_PLAY_MESSAGE
     );
   });
 

--- a/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
+++ b/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
@@ -8,12 +8,20 @@ const addToQueue = vi.fn();
 const addToFlowsheet = vi.fn(() => Promise.resolve());
 const deleteFromBin = vi.fn();
 
+const convertBinToQueueMock = vi.fn((e: AlbumEntry) => ({ q: e.id }));
+const convertBinToFlowsheetMock = vi.fn(
+  (e: AlbumEntry): { f: number } | null => ({ f: e.id })
+);
+
 vi.mock("@/lib/hooks", () => ({ useAppDispatch: () => dispatch }));
 vi.mock("@/lib/features/bin/conversions", () => ({
-  convertBinToQueue: (e: AlbumEntry) => ({ q: e.id }),
-  convertBinToFlowsheet: (e: AlbumEntry) => ({ f: e.id }),
+  convertBinToQueue: (e: AlbumEntry) => convertBinToQueueMock(e),
+  convertBinToFlowsheet: (e: AlbumEntry) => convertBinToFlowsheetMock(e),
 }));
-vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+const toastErrorMock = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: (...args: unknown[]) => toastErrorMock(...args) },
+}));
 vi.mock("@/lib/features/application/frontend", () => ({
   applicationSlice: {
     actions: { openPanel: (p: unknown) => ({ type: "openPanel", payload: p }) },
@@ -118,6 +126,30 @@ describe("useBinEntryActions", () => {
     byId.play.run();
     await Promise.resolve();
     await Promise.resolve();
+    expect(deleteFromBin).not.toHaveBeenCalled();
+  });
+
+  it("refuses Play Now for a refused release credit instead of writing to the flowsheet", () => {
+    convertBinToFlowsheetMock.mockReturnValueOnce(null);
+    const { result } = renderHook(() => useBinEntryActions(entry, true, deps));
+    const byId = Object.fromEntries(result.current.map((a) => [a.id, a]));
+
+    byId.play.run();
+
+    expect(addToFlowsheet).not.toHaveBeenCalled();
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      expect.stringMatching(/not "various artists"/i)
+    );
+  });
+
+  it("does not remove a refused entry from the bin, even with Shift held", async () => {
+    convertBinToFlowsheetMock.mockReturnValueOnce(null);
+    const { result } = renderHook(() => useBinEntryActions(entry, true, deps));
+    const byId = Object.fromEntries(result.current.map((a) => [a.id, a]));
+
+    byId.play.run({ shiftKey: true });
+    await Promise.resolve();
+
     expect(deleteFromBin).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
+++ b/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
@@ -20,8 +20,12 @@ vi.mock("@/lib/features/bin/conversions", () => ({
   convertBinToFlowsheet: (e: AlbumEntry) => convertBinToFlowsheetMock(e),
 }));
 const toastErrorMock = vi.fn();
+const toastSuccessMock = vi.fn();
 vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: (...args: unknown[]) => toastErrorMock(...args) },
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
 }));
 vi.mock("@/lib/features/application/frontend", () => ({
   applicationSlice: {
@@ -31,7 +35,19 @@ vi.mock("@/lib/features/application/frontend", () => ({
 
 import { useBinEntryActions } from "@/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions";
 
-const entry = { id: 7, title: "DOGA" } as AlbumEntry;
+// The credit matters to the queue toast, so it has to be on the fixture —
+// an entry with no artist at all makes the refused branch unreachable and
+// the assertions below vacuous.
+const entry = {
+  id: 7,
+  title: "DOGA",
+  artist: { name: "Juana Molina" },
+} as AlbumEntry;
+const compilationEntry = {
+  id: 8,
+  title: "Edits",
+  artist: { name: "Various Artists" },
+} as AlbumEntry;
 // The write callbacks are hoisted in BinContent and passed down; the hook
 // itself no longer runs useQueue/useFlowsheet/useDeleteFromBin per row.
 const deps = { addToQueue, addToFlowsheet, deleteFromBin };
@@ -144,6 +160,30 @@ describe("useBinEntryActions", () => {
     expect(toastErrorMock).toHaveBeenCalledWith(
       VARIOUS_ARTISTS_BIN_PLAY_MESSAGE
     );
+  });
+
+  // The queue conversion drops the credit silently, so the toast is the only
+  // notice the DJ gets that the artist cell still needs filling.
+  it("says what the queued entry is still missing when the credit is refused", () => {
+    const { result } = renderHook(() =>
+      useBinEntryActions(compilationEntry, true, deps)
+    );
+    const byId = Object.fromEntries(result.current.map((a) => [a.id, a]));
+
+    byId.queue.run();
+
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Added Edits to queue. Name the performer in the artist cell before playing it."
+    );
+  });
+
+  it("confirms a credited entry without the caveat", () => {
+    const { result } = renderHook(() => useBinEntryActions(entry, true, deps));
+    const byId = Object.fromEntries(result.current.map((a) => [a.id, a]));
+
+    byId.queue.run();
+
+    expect(toastSuccessMock).toHaveBeenCalledWith("Added DOGA to queue");
   });
 
   it("does not remove a refused entry from the bin, even with Shift held", async () => {

--- a/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
+++ b/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
@@ -2,7 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { Unarchive } from "@mui/icons-material";
 import type { AlbumEntry } from "@/lib/features/catalog/types";
-import { VARIOUS_ARTISTS_BIN_PLAY_MESSAGE } from "@/lib/features/flowsheet/various-artists-guard";
+import {
+  MISSING_ARTIST_BIN_PLAY_MESSAGE,
+  VARIOUS_ARTISTS_BIN_PLAY_MESSAGE,
+} from "@/lib/features/flowsheet/various-artists-guard";
 
 const dispatch = vi.fn();
 const addToQueue = vi.fn();
@@ -148,7 +151,9 @@ describe("useBinEntryActions", () => {
 
   it("refuses Play Now for a refused release credit instead of writing to the flowsheet", () => {
     convertBinToFlowsheetMock.mockReturnValueOnce(null);
-    const { result } = renderHook(() => useBinEntryActions(entry, true, deps));
+    const { result } = renderHook(() =>
+      useBinEntryActions(compilationEntry, true, deps)
+    );
     const byId = Object.fromEntries(result.current.map((a) => [a.id, a]));
 
     byId.play.run();
@@ -159,6 +164,24 @@ describe("useBinEntryActions", () => {
     // and a dead end, and the generic copy would satisfy a looser matcher.
     expect(toastErrorMock).toHaveBeenCalledWith(
       VARIOUS_ARTISTS_BIN_PLAY_MESSAGE
+    );
+  });
+
+  // Same dead end, but the DJ never typed a credit — telling them not to
+  // write "Various Artists" would name a mistake they did not make.
+  it("refuses Play Now for a release with no credit and does not blame Various Artists", () => {
+    convertBinToFlowsheetMock.mockReturnValueOnce(null);
+    const uncredited = { id: 9, title: "Untitled" } as AlbumEntry;
+    const { result } = renderHook(() =>
+      useBinEntryActions(uncredited, true, deps)
+    );
+    const byId = Object.fromEntries(result.current.map((a) => [a.id, a]));
+
+    byId.play.run();
+
+    expect(addToFlowsheet).not.toHaveBeenCalled();
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      MISSING_ARTIST_BIN_PLAY_MESSAGE
     );
   });
 

--- a/tests/integration/components/modern/catalog/Results/MobileResult.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/MobileResult.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { createTestAlbum, createTestArtist } from "@/tests/helpers";
 import { renderWithProviders } from "@/tests/helpers/render";
 
@@ -119,5 +120,51 @@ describe("CatalogMobileResult album artwork", () => {
 
     expect(screen.queryByRole("img")).toBeNull();
     expect(screen.getByText("Not on Discogs")).toBeInTheDocument();
+  });
+
+  // Catalog search shares the mail bin's queue conversion, so the
+  // compilation-credit rule reaches this surface too — a V/A release queued
+  // from a search result must arrive blank and unlinked, ready for the DJ to
+  // name the performer in the queue row.
+  describe("adding a compilation to the queue", () => {
+    const compilation = createTestAlbum({
+      title: "Edits",
+      artist: createTestArtist({ name: "Various Artists" }),
+      label: "self-released",
+    });
+    const credited = createTestAlbum({
+      title: "On Your Own Love Again",
+      artist: createTestArtist({ name: "Jessica Pratt" }),
+      label: "Drag City",
+    });
+
+    it("queues a blank artist and withholds the library linkage", async () => {
+      const addToQueue = vi.fn();
+      renderWithProviders(
+        <CatalogMobileResult album={compilation} live={true} addToQueue={addToQueue} />
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Add to Queue" }));
+
+      expect(addToQueue).toHaveBeenCalledWith(
+        expect.objectContaining({ artist: "", album_id: undefined })
+      );
+    });
+
+    it("leaves a normally-credited release linked", async () => {
+      const addToQueue = vi.fn();
+      renderWithProviders(
+        <CatalogMobileResult album={credited} live={true} addToQueue={addToQueue} />
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "Add to Queue" }));
+
+      expect(addToQueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artist: "Jessica Pratt",
+          album_id: credited.id,
+        })
+      );
+    });
   });
 });

--- a/tests/integration/components/modern/catalog/Results/Result.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/Result.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { createTestAlbum, createTestArtist } from "@/tests/helpers";
 import { renderWithProviders } from "@/tests/helpers/render";
 
@@ -11,6 +11,11 @@ vi.mock("next/navigation", () => ({
 vi.mock("next/link", () => ({
   default: ({ children, href }: { children: React.ReactNode; href: string }) =>
     <a href={href}>{children}</a>,
+}));
+
+const toastSuccessMock = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { success: (...args: unknown[]) => toastSuccessMock(...args) },
 }));
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
@@ -378,5 +383,73 @@ describe("CatalogResult album artwork", () => {
 
     expect(screen.getByAltText(`${album.artist.name} - ${album.title}`)).toBeInTheDocument();
     expect(screen.queryByText("Not on Discogs")).toBeNull();
+  });
+});
+
+// Catalog search shares the mail bin's queue conversion, so the
+// compilation-credit rule reaches this surface too — and the toast is the
+// only notice the DJ gets that the credit was withheld.
+describe("CatalogResult adding a compilation to the queue", () => {
+  const clickAddToQueue = () => {
+    const button = screen
+      .getAllByRole("button")
+      .find(
+        (btn) => btn.querySelector('svg[data-testid="QueueMusicIcon"]') !== null
+      );
+    expect(button).toBeDefined();
+    fireEvent.click(button!);
+  };
+
+  it("queues a blank artist, withholds the linkage, and says what is missing", () => {
+    const compilation = createTestAlbum({
+      title: "Edits",
+      artist: createTestArtist({ name: "Various Artists" }),
+      label: "self-released",
+    });
+    const addToQueue = vi.fn();
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={compilation} live={true} addToQueue={addToQueue} />
+        </tbody>
+      </table>
+    );
+    clickAddToQueue();
+
+    expect(addToQueue).toHaveBeenCalledWith(
+      expect.objectContaining({ artist: "", album_id: undefined })
+    );
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Added Edits to queue. Name the performer in the artist cell before playing it."
+    );
+  });
+
+  it("leaves a normally-credited release linked and confirms without a caveat", () => {
+    const credited = createTestAlbum({
+      title: "On Your Own Love Again",
+      artist: createTestArtist({ name: "Jessica Pratt" }),
+      label: "Drag City",
+    });
+    const addToQueue = vi.fn();
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult album={credited} live={true} addToQueue={addToQueue} />
+        </tbody>
+      </table>
+    );
+    clickAddToQueue();
+
+    expect(addToQueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artist: "Jessica Pratt",
+        album_id: credited.id,
+      })
+    );
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Added On Your Own Love Again to queue"
+    );
   });
 });

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
@@ -23,6 +23,7 @@ const mockUseFlowsheet = vi.fn();
 const mockAddToFlowsheet = vi.fn();
 const mockDispatch = vi.fn();
 const mockUpdateFlowsheet = vi.fn();
+const mockRemoveFromQueue = vi.fn();
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
   useShowControl: () => mockUseShowControl(),
@@ -147,12 +148,13 @@ describe("SongEntry", () => {
       currentShow: 100,
     });
 
-    // usePlayNow now writes through useFlowsheetActions too — its
-    // addToFlowsheet must resolve to the same mock the Play button tests
-    // below configure via mockAddToFlowsheet.
+    // usePlayNow draws addToFlowsheet and removeFromQueue from this same
+    // hook, so an incomplete return value throws inside the Play handler
+    // rather than failing an assertion.
     mockUseFlowsheet.mockReturnValue({
       updateFlowsheet: mockUpdateFlowsheet,
       addToFlowsheet: mockAddToFlowsheet,
+      removeFromQueue: mockRemoveFromQueue,
     });
 
     mockAddToFlowsheet.mockReturnValue(Promise.resolve());
@@ -704,88 +706,78 @@ describe("SongEntry", () => {
   });
 
   describe("Play button in queue", () => {
-    it("should call addToFlowsheet when play button is clicked", async () => {
+    // The refusal, the queue removal, and the failure toast are the hook's
+    // behavior and are pinned in usePlayNow's own tests. What only this
+    // level can show is that the button reaches the hook at all.
+    const clickPlay = () => {
+      const firstTd = screen
+        .getByTestId("draggable-wrapper")
+        .querySelector("td");
+      fireEvent.mouseEnter(firstTd!);
+      const playButton = screen
+        .getAllByRole("button")
+        .find(
+          (btn) => btn.querySelector('svg[data-testid="PlayArrowIcon"]') !== null
+        );
+      expect(playButton).toBeDefined();
+      fireEvent.click(playButton!);
+    };
+
+    it("submits the queued entry when the play button is clicked", async () => {
       mockUseShowControl.mockReturnValue({
         live: true,
         autoplay: false,
         currentShow: 100,
       });
-
       mockAddToFlowsheet.mockReturnValue(Promise.resolve());
 
       render(<SongEntry entry={mockEntry} playing={false} queue={true} />);
+      clickPlay();
 
-      const firstTd = screen.getByTestId("draggable-wrapper").querySelector("td");
-      fireEvent.mouseEnter(firstTd!);
-
-      // Wait for the play button to appear
       await waitFor(() => {
-        const playButtons = screen.getAllByRole("button");
-        // Find the play button (not drag or remove)
-        const playButton = playButtons.find(btn =>
-          btn.querySelector('svg[data-testid="PlayArrowIcon"]') !== null ||
-          btn.textContent?.includes("Play") ||
-          !btn.getAttribute("data-testid")?.includes("drag") &&
-          !btn.getAttribute("data-testid")?.includes("remove")
+        expect(mockAddToFlowsheet).toHaveBeenCalledWith(
+          expect.objectContaining({
+            track_title: mockEntry.track_title,
+            artist_name: mockEntry.artist_name,
+            album_title: mockEntry.album_title,
+          })
         );
-        if (playButton && !playButton.getAttribute("data-testid")) {
-          fireEvent.click(playButton);
-        }
       });
-
-      // addToFlowsheet should be called with entry data
-      // The promise resolves successfully
     });
 
-    it("should dispatch removeFromQueue after successful addToFlowsheet", async () => {
+    it("clears the entry from the queue once the write lands", async () => {
       mockUseShowControl.mockReturnValue({
         live: true,
         autoplay: false,
         currentShow: 100,
       });
-
-      // Return a resolved promise
-      mockAddToFlowsheet.mockImplementation(() => ({
-        then: (callback: any) => {
-          callback();
-          return { catch: vi.fn() };
-        },
-      }));
+      mockAddToFlowsheet.mockReturnValue(Promise.resolve());
 
       render(<SongEntry entry={mockEntry} playing={false} queue={true} />);
+      clickPlay();
 
-      const firstTd = screen.getByTestId("draggable-wrapper").querySelector("td");
-      fireEvent.mouseEnter(firstTd!);
-
-      // Check that dispatch was ready to be called
-      // The actual dispatch happens on successful addToFlowsheet
+      await waitFor(() => {
+        expect(mockRemoveFromQueue).toHaveBeenCalledWith(mockEntry.id);
+      });
     });
 
-    it("should show toast error when addToFlowsheet fails", async () => {
-      const { toast } = await import("sonner");
-
+    it("leaves the entry in the queue when the write fails", async () => {
       mockUseShowControl.mockReturnValue({
         live: true,
         autoplay: false,
         currentShow: 100,
       });
-
-      // Return a rejected promise
-      const mockError = new Error("Failed to add");
-      mockAddToFlowsheet.mockImplementation(() => ({
-        then: (successCallback: any) => ({
-          catch: (errorCallback: any) => {
-            errorCallback(mockError);
-          },
-        }),
-      }));
+      mockAddToFlowsheet.mockReturnValue(
+        Promise.reject(new Error("Show not live"))
+      );
 
       render(<SongEntry entry={mockEntry} playing={false} queue={true} />);
+      clickPlay();
 
-      const firstTd = screen.getByTestId("draggable-wrapper").querySelector("td");
-      fireEvent.mouseEnter(firstTd!);
-
-      // Error handling should be set up
+      await waitFor(() => {
+        expect(mockAddToFlowsheet).toHaveBeenCalled();
+      });
+      expect(mockRemoveFromQueue).not.toHaveBeenCalled();
     });
 
     it("should not show play button when not in queue", () => {
@@ -918,12 +910,13 @@ describe("SongEntry two-line row structure", () => {
       autoplay: false,
       currentShow: 100,
     });
-    // usePlayNow now writes through useFlowsheetActions too — its
-    // addToFlowsheet must resolve to the same mock the Play button tests
-    // below configure via mockAddToFlowsheet.
+    // usePlayNow draws addToFlowsheet and removeFromQueue from this same
+    // hook, so an incomplete return value throws inside the Play handler
+    // rather than failing an assertion.
     mockUseFlowsheet.mockReturnValue({
       updateFlowsheet: mockUpdateFlowsheet,
       addToFlowsheet: mockAddToFlowsheet,
+      removeFromQueue: mockRemoveFromQueue,
     });
   });
 

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntry.test.tsx
@@ -147,8 +147,12 @@ describe("SongEntry", () => {
       currentShow: 100,
     });
 
+    // usePlayNow now writes through useFlowsheetActions too — its
+    // addToFlowsheet must resolve to the same mock the Play button tests
+    // below configure via mockAddToFlowsheet.
     mockUseFlowsheet.mockReturnValue({
       updateFlowsheet: mockUpdateFlowsheet,
+      addToFlowsheet: mockAddToFlowsheet,
     });
 
     mockAddToFlowsheet.mockReturnValue(Promise.resolve());
@@ -914,8 +918,12 @@ describe("SongEntry two-line row structure", () => {
       autoplay: false,
       currentShow: 100,
     });
+    // usePlayNow now writes through useFlowsheetActions too — its
+    // addToFlowsheet must resolve to the same mock the Play button tests
+    // below configure via mockAddToFlowsheet.
     mockUseFlowsheet.mockReturnValue({
       updateFlowsheet: mockUpdateFlowsheet,
+      addToFlowsheet: mockAddToFlowsheet,
     });
   });
 

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/usePlayNow.test.ts
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/usePlayNow.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import type { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
-import { MISSING_ARTIST_REJECTION_MESSAGE } from "@/lib/features/flowsheet/various-artists-guard";
+import {
+  MISSING_ARTIST_REJECTION_MESSAGE,
+  VARIOUS_ARTISTS_REJECTION_MESSAGE,
+} from "@/lib/features/flowsheet/various-artists-guard";
 import { usePlayNow } from "@/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow";
 
 const addToFlowsheetMock = vi.fn((_params: Record<string, unknown>) => ({
@@ -102,7 +105,7 @@ describe("usePlayNow various-artists refusal", () => {
 
       expect(addToFlowsheetMock).not.toHaveBeenCalled();
       expect(toastErrorMock).toHaveBeenCalledWith(
-        expect.stringMatching(/not "various artists"/i)
+        VARIOUS_ARTISTS_REJECTION_MESSAGE
       );
     }
   );

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/usePlayNow.test.ts
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/usePlayNow.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import type { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
+import { MISSING_ARTIST_REJECTION_MESSAGE } from "@/lib/features/flowsheet/various-artists-guard";
 import { usePlayNow } from "@/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow";
 
 const addToFlowsheetMock = vi.fn((_params: Record<string, unknown>) => ({
   unwrap: () => Promise.resolve(),
 }));
 
-// usePlayNow now writes through useFlowsheetActions (the shared flowsheet
+// usePlayNow writes through useFlowsheetActions (the shared flowsheet
 // chokepoint), which also opens three mutation hooks it never fires here —
 // they still have to resolve or the hook throws on render.
 vi.mock("@/lib/features/flowsheet/api", () => ({
@@ -121,10 +122,24 @@ describe("usePlayNow various-artists refusal", () => {
 
       expect(addToFlowsheetMock).not.toHaveBeenCalled();
       expect(toastErrorMock).toHaveBeenCalledWith(
-        expect.stringMatching(/not "various artists"/i)
+        MISSING_ARTIST_REJECTION_MESSAGE
       );
     }
   );
+
+  // The blank field and the refused credit are different mistakes and get
+  // different copy: a DJ who left the artist empty never typed "Various
+  // Artists", so telling them not to would name a fix they didn't need.
+  it("does not blame Various Artists when the artist is merely blank", () => {
+    const { result } = renderHook(() =>
+      usePlayNow(queueEntry({ artist_name: "" }))
+    );
+    result.current();
+
+    expect(toastErrorMock).not.toHaveBeenCalledWith(
+      expect.stringMatching(/various artists/i)
+    );
+  });
 
   it("still plays a normally-credited queue entry", () => {
     const { result } = renderHook(() =>

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/usePlayNow.test.ts
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/usePlayNow.test.ts
@@ -7,8 +7,14 @@ const addToFlowsheetMock = vi.fn((_params: Record<string, unknown>) => ({
   unwrap: () => Promise.resolve(),
 }));
 
+// usePlayNow now writes through useFlowsheetActions (the shared flowsheet
+// chokepoint), which also opens three mutation hooks it never fires here —
+// they still have to resolve or the hook throws on render.
 vi.mock("@/lib/features/flowsheet/api", () => ({
   useAddToFlowsheetMutation: () => [addToFlowsheetMock],
+  useRemoveFromFlowsheetMutation: () => [vi.fn()],
+  useUpdateFlowsheetMutation: () => [vi.fn()],
+  useSwitchEntriesMutation: () => [vi.fn()],
 }));
 
 vi.mock("@/src/hooks/authenticationHooks", () => ({
@@ -17,6 +23,11 @@ vi.mock("@/src/hooks/authenticationHooks", () => ({
 
 vi.mock("@/lib/hooks", () => ({
   useAppDispatch: () => vi.fn(),
+}));
+
+const toastErrorMock = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => toastErrorMock(...args) },
 }));
 
 const queueEntry = (overrides: Partial<FlowsheetSongEntry>): FlowsheetSongEntry => ({
@@ -34,6 +45,7 @@ const queueEntry = (overrides: Partial<FlowsheetSongEntry>): FlowsheetSongEntry 
 describe("usePlayNow submission payload (#607/#701 gate)", () => {
   beforeEach(() => {
     addToFlowsheetMock.mockClear();
+    toastErrorMock.mockClear();
   });
 
   it("omits album_id/rotation_bin for a freeform queue entry (album_id undefined)", () => {
@@ -67,5 +79,60 @@ describe("usePlayNow submission payload (#607/#701 gate)", () => {
     expect(payload.album_id).toBe(42);
     expect(payload.rotation_id).toBe(9);
     expect(payload.rotation_bin).toBe("H");
+  });
+});
+
+describe("usePlayNow various-artists refusal", () => {
+  beforeEach(() => {
+    addToFlowsheetMock.mockClear();
+    toastErrorMock.mockClear();
+  });
+
+  // Rehydrated from localStorage, this is the pre-guard shape: entries
+  // queued before the guard shipped carry the compilation credit verbatim
+  // and are still live on DJs' machines.
+  it.each(["Various Artists", "VA", "Var. Artists"])(
+    "refuses a queue entry credited %s and does not write to the flowsheet",
+    (artist_name) => {
+      const { result } = renderHook(() =>
+        usePlayNow(queueEntry({ artist_name }))
+      );
+      result.current();
+
+      expect(addToFlowsheetMock).not.toHaveBeenCalled();
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        expect.stringMatching(/not "various artists"/i)
+      );
+    }
+  );
+
+  // The bin's Add to Queue escape hatch queues a refused credit with a
+  // blank artist for the DJ to fill in; a queue row can also be blanked by
+  // hand via the editable artist cell. Either way, replay must refuse until
+  // a performer is named — there is no such thing as a blank flowsheet
+  // credit.
+  it.each(["", "   "])(
+    "refuses a queue entry with a blank artist (%j) and does not write to the flowsheet",
+    (artist_name) => {
+      const { result } = renderHook(() =>
+        usePlayNow(queueEntry({ artist_name }))
+      );
+      result.current();
+
+      expect(addToFlowsheetMock).not.toHaveBeenCalled();
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        expect.stringMatching(/not "various artists"/i)
+      );
+    }
+  );
+
+  it("still plays a normally-credited queue entry", () => {
+    const { result } = renderHook(() =>
+      usePlayNow(queueEntry({ artist_name: "Duke Ellington & John Coltrane" }))
+    );
+    result.current();
+
+    expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+    expect(toastErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
@@ -160,6 +160,7 @@ describe("FlowsheetBackendResult", () => {
         type: "freezeSelectionToQuery",
         payload: {
           artist: "Test Artist",
+          artistProvided: true,
           album: "Test Album",
           label: "Test Label",
           album_id: 1,

--- a/tests/integration/components/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -232,6 +232,32 @@ describe("RotationEntryFields", () => {
     expect(screen.getByTestId("flowsheet-search-artist")).toBeInTheDocument();
   });
 
+  // And the field only means something once the linkage is gone: BS's
+  // album_id branch would otherwise spread the library row's empty
+  // artist_name over whatever the DJ types into it.
+  it("withholds album_id for a release that carries no credit at all", () => {
+    const uncredited = {
+      ...createTestAlbum({
+        id: 8,
+        title: "Untitled",
+        rotation_id: 43,
+        rotation_bin: "H",
+      }),
+      artist: null,
+    } as unknown as ReturnType<typeof createTestAlbum>;
+    mockRotationData = [lightningBoltOoioo, uncredited];
+
+    const { store } = renderWithProviders(
+      inModernTheme(<RotationEntryFields disabled={false} />)
+    );
+
+    selectBinAndRelease(uncredited);
+
+    const query = flowsheetSlice.selectors.getSearchQuery(store.getState());
+    expect(query.album_id).toBeUndefined();
+    expect(query.rotation_id).toBe(43);
+  });
+
   it("drops the artist input again when the DJ switches to a credited release", () => {
     renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
 

--- a/tests/integration/components/modern/flowsheet/Search/RotationEntryFields.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/RotationEntryFields.test.tsx
@@ -205,6 +205,33 @@ describe("RotationEntryFields", () => {
     expect(screen.getByTestId("flowsheet-search-artist")).toBeInTheDocument();
   });
 
+  // A release carrying no credit at all seeds the same blank artist a
+  // refused credit does, and submission refuses a blank just as firmly — so
+  // it needs the same field, or the refusal is a dead end with nowhere to
+  // type the performer.
+  it("renders an artist input for a release that carries no credit at all", () => {
+    const uncredited = {
+      ...createTestAlbum({
+        id: 8,
+        title: "Untitled",
+        rotation_id: 43,
+        rotation_bin: "H",
+      }),
+      artist: null,
+    } as unknown as ReturnType<typeof createTestAlbum>;
+    mockRotationData = [lightningBoltOoioo, uncredited];
+
+    renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
+
+    expect(
+      screen.queryByTestId("flowsheet-search-artist")
+    ).not.toBeInTheDocument();
+
+    selectBinAndRelease(uncredited);
+
+    expect(screen.getByTestId("flowsheet-search-artist")).toBeInTheDocument();
+  });
+
   it("drops the artist input again when the DJ switches to a credited release", () => {
     renderWithProviders(inModernTheme(<RotationEntryFields disabled={false} />));
 

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -2405,6 +2405,66 @@ describe("flowsheetHooks", () => {
       );
     });
 
+    // The submission has to carry what the input paints, or the refusal
+    // names a string the DJ cannot see. The linkage goes with the withheld
+    // credit: kept, BS's album_id branch would spread the library row's
+    // credit back over the performer the DJ typed.
+    describe("a highlighted result whose credit is refused", () => {
+      const compilation = [
+        createTestAlbum({
+          id: 4243,
+          title: "Edits",
+          artist: createTestArtist({ name: "Various Artists" }),
+        }),
+      ];
+
+      it("submits no credit and no linkage, matching the blank field", () => {
+        mockUseCatalogFlowsheetSearch.mockReturnValue({
+          searchResults: compilation,
+        });
+
+        const { result } = renderBoth(1);
+
+        expect(result.current.search.getDisplayValue("artist")).toBe("");
+        expect(result.current.submit.selectedResultData.artist).toBe("");
+        expect(result.current.submit.selectedResultData.album_id).toBeUndefined();
+      });
+
+      it("carries the performer the DJ typed, still without the linkage", () => {
+        mockUseCatalogFlowsheetSearch.mockReturnValue({
+          searchResults: compilation,
+        });
+
+        const { result } = renderHook(
+          () => ({ search: useFlowsheetSearch(), submit: useFlowsheetSubmit() }),
+          {
+            wrapper: createHookWrapper(
+              { flowsheet: flowsheetSlice, liveUpdates: liveUpdatesSlice },
+              {
+                flowsheet: {
+                  ...flowsheetSlice.getInitialState(),
+                  search: {
+                    ...flowsheetSlice.getInitialState().search,
+                    selectedResult: 1,
+                    query: {
+                      ...flowsheetSlice.getInitialState().search.query,
+                      song: "Call Your Name",
+                      artist: "Chuquimamani-Condori",
+                    },
+                  },
+                },
+              }
+            ),
+          }
+        );
+
+        expect(result.current.submit.selectedResultData.artist).toBe(
+          "Chuquimamani-Condori"
+        );
+        expect(result.current.submit.selectedResultData.album_id).toBeUndefined();
+      });
+    });
+
     it("agrees at the last visible capped row (index 50 → the 50th painted album)", () => {
       mockUseCatalogFlowsheetSearch.mockReturnValue({ searchResults: manyAlbums });
 

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -2430,6 +2430,25 @@ describe("flowsheetHooks", () => {
         expect(result.current.submit.selectedResultData.album_id).toBeUndefined();
       });
 
+      // A release that carries no credit reaches the same fallback, and
+      // keeping its linkage would let BS spread the library row's blank
+      // artist back over the performer the DJ typed.
+      it("withholds the linkage for a release that carries no credit either", () => {
+        mockUseCatalogFlowsheetSearch.mockReturnValue({
+          searchResults: [
+            createTestAlbum({
+              id: 4244,
+              title: "Untitled",
+              artist: createTestArtist({ name: "" }),
+            }),
+          ],
+        });
+
+        const { result } = renderBoth(1);
+
+        expect(result.current.submit.selectedResultData.album_id).toBeUndefined();
+      });
+
       it("carries the performer the DJ typed, still without the linkage", () => {
         mockUseCatalogFlowsheetSearch.mockReturnValue({
           searchResults: compilation,

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -577,6 +577,41 @@ describe("flowsheetHooks", () => {
       expect(result.current.searchOpen).toBe(false);
     });
 
+    // The artist input paints getDisplayValue, and the browser builds the
+    // next keystroke's value from what is painted — so a highlighted result
+    // that showed the refused credit would put it straight back into the
+    // field the freeze payload was careful to leave blank.
+    it("withholds a refused credit from the highlighted result's artist display", () => {
+      mockUseCatalogFlowsheetSearch.mockReturnValue({
+        searchResults: [
+          createTestAlbum({
+            id: 4242,
+            title: "Edits",
+            artist: createTestArtist({ name: "Various Artists" }),
+          }),
+        ],
+      });
+
+      const { result } = renderHook(() => useFlowsheetSearch(), {
+        wrapper: createHookWrapper(
+          { flowsheet: flowsheetSlice, liveUpdates: liveUpdatesSlice },
+          {
+            flowsheet: {
+              ...flowsheetSlice.getInitialState(),
+              search: {
+                ...flowsheetSlice.getInitialState().search,
+                selectedResult: 1,
+              },
+            },
+          }
+        ),
+      });
+
+      expect(result.current.selectedEntry?.id).toBe(4242);
+      expect(result.current.getDisplayValue("album")).toBe("Edits");
+      expect(result.current.getDisplayValue("artist")).toBe("");
+    });
+
     it("should return raw query value when selectedIndex is 0", () => {
       const { result } = renderHook(() => useFlowsheetSearch(), {
         wrapper: createWrapper(),
@@ -1429,6 +1464,7 @@ describe("flowsheetHooks", () => {
           result.current.dispatch(
             flowsheetSlice.actions.freezeSelectionToQuery({
               artist: "Chuquimamani-Condori",
+              artistProvided: true,
               album: "DJ E",
               label: "",
               album_id: -42,

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -1397,6 +1397,39 @@ describe("flowsheetHooks", () => {
         expect(result.current.search.searchQuery.artist).toBe("");
       });
 
+      // A compilation rotation release renders its artist field seeded
+      // empty (RotationEntryFields.needsPerformerName); a DJ who queues
+      // before typing into it hits this rather than the required-song
+      // check, matching Classic's canSubmitTrack rotation gate
+      // (`!rotationNeedsArtist || artistName.trim().length > 0`).
+      it("rejects a blank artist and leaves the search intact", () => {
+        const { result } = renderCombined();
+
+        act(() => {
+          result.current.search.setSearchProperty("song", "Call Your Name");
+        });
+        act(() => {
+          result.current.submit.submitToQueue();
+        });
+
+        expect(result.current.queue.queue.length).toBe(0);
+        expect(result.current.search.searchQuery.song).toBe("Call Your Name");
+      });
+
+      it("rejects a whitespace-only artist", () => {
+        const { result } = renderCombined();
+
+        act(() => {
+          result.current.search.setSearchProperty("artist", "   ");
+          result.current.search.setSearchProperty("song", "Call Your Name");
+        });
+        act(() => {
+          result.current.submit.submitToQueue();
+        });
+
+        expect(result.current.queue.queue.length).toBe(0);
+      });
+
       it("drops a synthesized negative album_id but keeps rotation linkage on the queue path", () => {
         const { result } = renderCombined();
 

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -10,6 +10,7 @@ import {
   useFlowsheetSubmit,
 } from "@/src/hooks/flowsheetHooks";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { MISSING_ARTIST_REJECTION_MESSAGE } from "@/lib/features/flowsheet/various-artists-guard";
 import { useAppDispatch } from "@/lib/hooks";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 import { liveUpdatesSlice } from "@/lib/features/flowsheet/live-updates-slice";
@@ -1414,6 +1415,24 @@ describe("flowsheetHooks", () => {
 
         expect(result.current.queue.queue.length).toBe(0);
         expect(result.current.search.searchQuery.song).toBe("Call Your Name");
+      });
+
+      // The blank field and the refused credit are different mistakes and
+      // get different copy: a DJ who never typed "Various Artists" should
+      // not be told to stop.
+      it("names the missing artist rather than blaming Various Artists", () => {
+        const { result } = renderCombined();
+
+        act(() => {
+          result.current.search.setSearchProperty("song", "Call Your Name");
+        });
+        act(() => {
+          result.current.submit.submitToQueue();
+        });
+
+        expect(mockToastError).toHaveBeenCalledWith(
+          MISSING_ARTIST_REJECTION_MESSAGE
+        );
       });
 
       it("rejects a whitespace-only artist", () => {

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -1398,56 +1398,29 @@ describe("flowsheetHooks", () => {
         expect(result.current.search.searchQuery.artist).toBe("");
       });
 
-      // A compilation rotation release renders its artist field seeded
-      // empty (RotationEntryFields.needsPerformerName); a DJ who queues
-      // before typing into it hits this rather than the required-song
-      // check, matching Classic's canSubmitTrack rotation gate
-      // (`!rotationNeedsArtist || artistName.trim().length > 0`).
-      it("rejects a blank artist and leaves the search intact", () => {
-        const { result } = renderCombined();
+      // Emptiness is refused at the flowsheet boundary, not here. A queued
+      // entry is a draft: parking a song title and naming the performer
+      // later in the queue row's editable artist cell is a real workflow,
+      // and it is the same affordance the mail bin's refusal redirects to.
+      it.each([["", "blank"], ["   ", "whitespace-only"]])(
+        "queues a %s artist so it can be named in the queue row later",
+        (artist) => {
+          const { result } = renderCombined();
 
-        act(() => {
-          result.current.search.setSearchProperty("song", "Call Your Name");
-        });
-        act(() => {
-          result.current.submit.submitToQueue();
-        });
+          act(() => {
+            result.current.search.setSearchProperty("artist", artist);
+            result.current.search.setSearchProperty("song", "Call Your Name");
+          });
+          act(() => {
+            result.current.submit.submitToQueue();
+          });
 
-        expect(result.current.queue.queue.length).toBe(0);
-        expect(result.current.search.searchQuery.song).toBe("Call Your Name");
-      });
-
-      // The blank field and the refused credit are different mistakes and
-      // get different copy: a DJ who never typed "Various Artists" should
-      // not be told to stop.
-      it("names the missing artist rather than blaming Various Artists", () => {
-        const { result } = renderCombined();
-
-        act(() => {
-          result.current.search.setSearchProperty("song", "Call Your Name");
-        });
-        act(() => {
-          result.current.submit.submitToQueue();
-        });
-
-        expect(mockToastError).toHaveBeenCalledWith(
-          MISSING_ARTIST_REJECTION_MESSAGE
-        );
-      });
-
-      it("rejects a whitespace-only artist", () => {
-        const { result } = renderCombined();
-
-        act(() => {
-          result.current.search.setSearchProperty("artist", "   ");
-          result.current.search.setSearchProperty("song", "Call Your Name");
-        });
-        act(() => {
-          result.current.submit.submitToQueue();
-        });
-
-        expect(result.current.queue.queue.length).toBe(0);
-      });
+          expect(result.current.queue.queue.length).toBe(1);
+          expect(result.current.queue.queue[0].track_title).toBe(
+            "Call Your Name"
+          );
+        }
+      );
 
       it("drops a synthesized negative album_id but keeps rotation linkage on the queue path", () => {
         const { result } = renderCombined();
@@ -1532,9 +1505,10 @@ describe("flowsheetHooks", () => {
     });
 
     it("should call handleSubmit and add to flowsheet when ctrl is not pressed", () => {
-      // Preload a song title — handleSubmit now requires it (covers the
-      // row-click bypass of the form's HTML5 validation; see the
-      // "song-title validation" describe block below).
+      // Preload both fields handleSubmit requires. Neither can be left to
+      // the form's HTML5 validation, which a clicked result row bypasses —
+      // see the "song-title validation" and "various-artists validation"
+      // describe blocks below.
       const wrapper = createHookWrapper(
         { flowsheet: flowsheetSlice, liveUpdates: liveUpdatesSlice },
         {
@@ -1545,6 +1519,7 @@ describe("flowsheetHooks", () => {
               query: {
                 ...flowsheetSlice.getInitialState().search.query,
                 song: "la paradoja",
+                artist: "Juana Molina",
               },
             },
           },
@@ -2061,6 +2036,32 @@ describe("flowsheetHooks", () => {
           expect(mockToastError).not.toHaveBeenCalled();
         }
       );
+
+      // The flowsheet is the permanent record, so this is where emptiness is
+      // refused — the queue accepts it as a draft. Only `song` carries HTML5
+      // `required` in the searchbar, and a clicked result row never touches
+      // an input at all, so markup validation cannot cover this.
+      it.each(["", "   "])(
+        "refuses a blank artist (%j) and does not call addToFlowsheet",
+        async (artist) => {
+          await submitWith(artist);
+
+          expect(mockAddToFlowsheet).not.toHaveBeenCalled();
+          expect(mockToastError).toHaveBeenCalledWith(
+            MISSING_ARTIST_REJECTION_MESSAGE
+          );
+        }
+      );
+
+      // A DJ who left the artist empty never typed "Various Artists", so
+      // borrowing the credit's copy would name a fix they did not need.
+      it("does not blame Various Artists when the artist is merely blank", async () => {
+        await submitWith("");
+
+        expect(mockToastError).not.toHaveBeenCalledWith(
+          expect.stringMatching(/various artists/i)
+        );
+      });
 
       it("checks the song title before the artist so a blank entry names the first problem", async () => {
         const { result } = renderHook(() => useFlowsheetSubmit(), {

--- a/tests/unit/lib/features/bin/conversions.test.ts
+++ b/tests/unit/lib/features/bin/conversions.test.ts
@@ -295,6 +295,20 @@ describe("bin conversions", () => {
         expect(convertBinToFlowsheet(binEntry)).toBeNull();
       });
 
+      // A release that carries no credit dead-ends the same way: the
+      // flowsheet is the permanent record and refuses a blank artist
+      // everywhere else, and Play Now has no field to fill in either.
+      it.each([
+        ["an empty name", ""],
+        ["a whitespace-only name", "   "],
+      ])("returns null for a release with %s", (_label, name) => {
+        const binEntry = createBinEntry({
+          id: 42,
+          artist: createTestArtist({ name }),
+        });
+        expect(convertBinToFlowsheet(binEntry)).toBeNull();
+      });
+
       it("still plays normally when a compilation is filed under a credited album artist", () => {
         const binEntry = createBinEntry({
           id: 42,
@@ -399,6 +413,19 @@ describe("bin conversions", () => {
         });
         const result = convertBinToQueue(binEntry);
         expect(result.rotation_id).toBe(TEST_ENTITY_IDS.ROTATION.HEAVY);
+      });
+
+      // A release with no credit reaches the same blank cell, so it needs the
+      // same trade: left linked, BS would spread the library row's empty
+      // artist back over the performer the DJ types into that cell.
+      it("withholds album_id for a linked release that carries no credit", () => {
+        const binEntry = createBinEntry({
+          id: 42,
+          artist: createTestArtist({ name: "" }),
+        });
+        const result = convertBinToQueue(binEntry);
+        expect(result.artist).toBe("");
+        expect(result.album_id).toBeUndefined();
       });
 
       it("still queues normally when a compilation is filed under a credited album artist", () => {

--- a/tests/unit/lib/features/bin/conversions.test.ts
+++ b/tests/unit/lib/features/bin/conversions.test.ts
@@ -7,6 +7,7 @@ import { convertToAlbumEntry } from "@/lib/features/catalog/conversions";
 import {
   createTestBinResponse,
   createTestAlbum,
+  createTestArtist,
   TEST_ENTITY_IDS,
   TEST_SEARCH_STRINGS,
 } from "@/tests/helpers";
@@ -269,6 +270,41 @@ describe("bin conversions", () => {
         expect(result.album_id).toBe(42);
       });
     });
+
+    // Play Now is a single click with no artist field, so a refused credit
+    // can't be satisfied in place — the escape hatch is Add to Queue instead
+    // (see convertBinToQueue below), and Play Now refuses outright rather
+    // than submitting a payload BS would resolve back to the credit anyway.
+    describe("refused release credit", () => {
+      it.each(["Various Artists", "VA", "Var. Artists"])(
+        "returns null for a linked release credited %s",
+        (name) => {
+          const binEntry = createBinEntry({
+            id: 42,
+            artist: createTestArtist({ name }),
+          });
+          expect(convertBinToFlowsheet(binEntry)).toBeNull();
+        }
+      );
+
+      it("returns null for an unlinked (synthesized negative id) release credited Various Artists", () => {
+        const binEntry = createBinEntry({
+          id: -1,
+          artist: createTestArtist({ name: "Various Artists" }),
+        });
+        expect(convertBinToFlowsheet(binEntry)).toBeNull();
+      });
+
+      it("still plays normally when a compilation is filed under a credited album artist", () => {
+        const binEntry = createBinEntry({
+          id: 42,
+          artist: createTestArtist({ name: "Kruder & Dorfmeister" }),
+        });
+        const result = convertBinToFlowsheet(binEntry) as BinFlowsheetResult;
+        expect(result).not.toBeNull();
+        expect(result.album_id).toBe(42);
+      });
+    });
   });
 
   describe("convertBinToQueue", () => {
@@ -325,6 +361,55 @@ describe("bin conversions", () => {
       const binEntry = createBinEntry();
       const result = convertBinToQueue(binEntry);
       expect(result.request).toBe(false);
+    });
+
+    // The escape hatch for a refused bin credit: Add to Queue still succeeds,
+    // but with a blank artist cell (editable in place) rather than the
+    // compilation credit, and album_id withheld so a later Play from the
+    // queue can't have BS resolve the credit straight back once the DJ
+    // types a real performer into that cell (mirrors
+    // RotationEntryFields.handleSelectRelease's withholding trade).
+    describe("refused release credit", () => {
+      it.each(["Various Artists", "VA", "Var. Artists"])(
+        "seeds a blank artist for a release credited %s",
+        (name) => {
+          const binEntry = createBinEntry({
+            id: 42,
+            artist: createTestArtist({ name }),
+          });
+          const result = convertBinToQueue(binEntry);
+          expect(result.artist).toBe("");
+        }
+      );
+
+      it("withholds album_id for a linked release with a refused credit", () => {
+        const binEntry = createBinEntry({
+          id: 42,
+          artist: createTestArtist({ name: "Various Artists" }),
+        });
+        const result = convertBinToQueue(binEntry);
+        expect(result.album_id).toBeUndefined();
+      });
+
+      it("keeps rotation_id when album_id is withheld", () => {
+        const binEntry = createBinEntry({
+          id: 42,
+          artist: createTestArtist({ name: "Various Artists" }),
+          rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
+        });
+        const result = convertBinToQueue(binEntry);
+        expect(result.rotation_id).toBe(TEST_ENTITY_IDS.ROTATION.HEAVY);
+      });
+
+      it("still queues normally when a compilation is filed under a credited album artist", () => {
+        const binEntry = createBinEntry({
+          id: 42,
+          artist: createTestArtist({ name: "Kruder & Dorfmeister" }),
+        });
+        const result = convertBinToQueue(binEntry);
+        expect(result.artist).toBe("Kruder & Dorfmeister");
+        expect(result.album_id).toBe(42);
+      });
     });
   });
 });

--- a/tests/unit/lib/features/flowsheet/conversions.test.ts
+++ b/tests/unit/lib/features/flowsheet/conversions.test.ts
@@ -778,6 +778,7 @@ describe("flowsheet conversions", () => {
         })
       ).toEqual({
         artist: "Juana Molina",
+        artistProvided: true,
         album: "DOGA",
         label: "Sonamos",
         album_id: 42,
@@ -789,9 +790,32 @@ describe("flowsheet conversions", () => {
     it("defaults missing fields to empty strings and undefined ids", () => {
       expect(entryToFreezePayload({})).toEqual({
         artist: "",
+        artistProvided: false,
         album: "",
         label: "",
         album_id: undefined,
+        rotation_id: undefined,
+        rotation_bin: undefined,
+      });
+    });
+
+    // Withholding the seed must not read downstream as "the release had no
+    // artist": the deviation rule keys on what the release supplied, and a
+    // credit it refuses is still something it supplied.
+    it("reports the artist as provided when a refused credit is withheld from the seed", () => {
+      expect(
+        entryToFreezePayload({
+          id: 42,
+          artist: { name: "Various Artists" },
+          title: "Edits",
+          label: "self-released",
+        })
+      ).toEqual({
+        artist: "",
+        artistProvided: true,
+        album: "Edits",
+        label: "self-released",
+        album_id: 42,
         rotation_id: undefined,
         rotation_bin: undefined,
       });

--- a/tests/unit/lib/features/flowsheet/conversions.test.ts
+++ b/tests/unit/lib/features/flowsheet/conversions.test.ts
@@ -799,6 +799,21 @@ describe("flowsheet conversions", () => {
       });
     });
 
+    // A linked row's credit column wins on the wire whether it is blank or
+    // not, so naming a performer still departs from the release and still
+    // has to strip the linkage.
+    it("reports the artist as provided for a linked release that carries no credit", () => {
+      expect(
+        entryToFreezePayload({
+          id: 42,
+          artist: { name: "" },
+          title: "Untitled",
+        })
+      ).toEqual(
+        expect.objectContaining({ artist: "", artistProvided: true, album_id: 42 })
+      );
+    });
+
     // Withholding the seed must not read downstream as "the release had no
     // artist": the deviation rule keys on what the release supplied, and a
     // credit it refuses is still something it supplied.

--- a/tests/unit/lib/features/flowsheet/flowsheet.test.ts
+++ b/tests/unit/lib/features/flowsheet/flowsheet.test.ts
@@ -128,6 +128,7 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         harness().reduce(
           actions.freezeSelectionToQuery({
             artist: "Stereolab",
+            artistProvided: true,
             album: "DOGA",
             label: "Duophonic",
             album_id: 42,
@@ -170,6 +171,7 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         let state = harness().reduce(
           actions.freezeSelectionToQuery({
             artist: "Chuquimamani-Condori",
+            artistProvided: true,
             album: "DJ E",
             label: "",
             album_id: 11,
@@ -244,6 +246,7 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
           actions.setSelectedResult(2),
           actions.freezeSelectionToQuery({
             artist: "Juana Molina",
+            artistProvided: true,
             album: "DOGA",
             label: "Sonamos",
             album_id: 42,
@@ -263,6 +266,7 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         const seeded = harness().reduce(
           actions.freezeSelectionToQuery({
             artist: "Stereolab",
+            artistProvided: true,
             album: "Aluminum Tunes",
             label: "Duophonic",
             album_id: 7,
@@ -271,6 +275,7 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         const result = harness().reduce(
           actions.freezeSelectionToQuery({
             artist: "Cat Power",
+            artistProvided: true,
             album: "Moon Pix",
             label: "Matador Records",
           }),
@@ -288,6 +293,7 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         const result = harness().reduce(
           actions.freezeSelectionToQuery({
             artist: "Jessica Pratt",
+            artistProvided: true,
             album: "On Your Own Love Again",
             label: "Drag City",
             album_id: 11,
@@ -301,6 +307,7 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         const result = harness().reduce(
           actions.freezeSelectionToQuery({
             artist: "Juana Molina",
+            artistProvided: true,
             album: "DOGA",
             label: "Sonamos",
             album_id: 42,
@@ -345,6 +352,7 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         const frozen = harness().reduce(
           actions.freezeSelectionToQuery({
             artist: "",
+            artistProvided: false,
             album: "Edits",
             label: "self-released",
             album_id: 42,
@@ -366,6 +374,7 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         const seeded = harness().reduce(
           actions.freezeSelectionToQuery({
             artist: "Stereolab",
+            artistProvided: true,
             album: "Aluminum Tunes",
             label: "Duophonic",
             rotation_id: 5,
@@ -375,6 +384,7 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         const result = harness().reduce(
           actions.freezeSelectionToQuery({
             artist: "Cat Power",
+            artistProvided: true,
             album: "Moon Pix",
             label: "Matador Records",
           }),
@@ -665,6 +675,27 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         withItem
       );
 
+      expect(result.queue[0].album_id).toBe(1001);
+    });
+
+    // The searchbar's half of this rule exempts a field the release left
+    // empty — filling it is added data, and the linkage still describes the
+    // entry. The queue's half has to agree, or a library row with no label
+    // loses its linkage the moment the DJ supplies one.
+    it("keeps album_id when a field the library row left empty is filled", () => {
+      const withItem = harness().reduce(
+        actions.addToQueue(createTestFlowsheetQuery({ album_id: 1001, label: "" }))
+      );
+      const result = harness().reduce(
+        actions.updateQueueEntry({
+          entry_id: withItem.queue[0].id,
+          field: "record_label",
+          value: "Drag City",
+        }),
+        withItem
+      );
+
+      expect(result.queue[0].record_label).toBe("Drag City");
       expect(result.queue[0].album_id).toBe(1001);
     });
 

--- a/tests/unit/lib/features/flowsheet/flowsheet.test.ts
+++ b/tests/unit/lib/features/flowsheet/flowsheet.test.ts
@@ -312,6 +312,56 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         expect(result.search.query.rotation_bin).toBe("H");
       });
 
+      // A refused credit is seeded blank, but the release still supplied one.
+      // Typing a performer over it is a deviation from the linked row, so the
+      // linkage must not survive the correction — read as "the release left
+      // this empty" the deviation rule stands down, album_id rides the wire,
+      // and BS's album_id branch spreads the refused credit straight back.
+      it("drops the linkage when a performer is named over a withheld credit", () => {
+        const frozen = harness().reduce(
+          actions.freezeSelectionToQuery({
+            artist: "",
+            artistProvided: true,
+            album: "Edits",
+            label: "self-released",
+            album_id: 42,
+          })
+        );
+        const result = harness().reduce(
+          actions.setSearchProperty({
+            name: "artist",
+            value: "Chuquimamani-Condori",
+            deviates: true,
+          }),
+          frozen
+        );
+
+        expect(result.search.query.album_id).toBeUndefined();
+      });
+
+      // The other blank: a release that genuinely carries no artist supplied
+      // nothing, so filling the field is added data and the selection stands.
+      it("keeps the linkage when a field the release left empty is filled", () => {
+        const frozen = harness().reduce(
+          actions.freezeSelectionToQuery({
+            artist: "",
+            album: "Edits",
+            label: "self-released",
+            album_id: 42,
+          })
+        );
+        const result = harness().reduce(
+          actions.setSearchProperty({
+            name: "artist",
+            value: "Chuquimamani-Condori",
+            deviates: true,
+          }),
+          frozen
+        );
+
+        expect(result.search.query.album_id).toBe(42);
+      });
+
       it("should clear rotation_id and rotation_bin when not provided", () => {
         const seeded = harness().reduce(
           actions.freezeSelectionToQuery({

--- a/tests/unit/lib/features/flowsheet/flowsheet.test.ts
+++ b/tests/unit/lib/features/flowsheet/flowsheet.test.ts
@@ -573,6 +573,67 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.queue[0].track_title).toBe(withItem.queue[0].track_title);
     });
 
+    // Editing a field the library row supplied deviates from that row, so
+    // the album linkage must not ride the wire: Backend-Service's album_id
+    // branch spreads the library row over the request and would hand the
+    // old value straight back. rotation_id and rotation are not
+    // album-scoped and survive (see withSanitizedAlbumLinkage).
+    it.each(["artist_name", "album_title", "record_label"] as const)(
+      "drops album_id when %s is edited away from the linked row",
+      (field) => {
+        const withItem = harness().reduce(
+          actions.addToQueue(
+            createTestFlowsheetQuery({ album_id: 1001, rotation_id: 7 })
+          )
+        );
+        const result = harness().reduce(
+          actions.updateQueueEntry({
+            entry_id: withItem.queue[0].id,
+            field,
+            value: "Chuquimamani-Condori",
+          }),
+          withItem
+        );
+
+        expect(result.queue[0].album_id).toBeUndefined();
+        expect(result.queue[0].rotation_id).toBe(7);
+      }
+    );
+
+    it("keeps album_id when the edit leaves the value unchanged", () => {
+      const withItem = harness().reduce(
+        actions.addToQueue(
+          createTestFlowsheetQuery({ album_id: 1001, artist: "Jessica Pratt" })
+        )
+      );
+      const result = harness().reduce(
+        actions.updateQueueEntry({
+          entry_id: withItem.queue[0].id,
+          field: "artist_name",
+          value: "Jessica Pratt",
+        }),
+        withItem
+      );
+
+      expect(result.queue[0].album_id).toBe(1001);
+    });
+
+    it("keeps album_id when a field the library row does not own is edited", () => {
+      const withItem = harness().reduce(
+        actions.addToQueue(createTestFlowsheetQuery({ album_id: 1001 }))
+      );
+      const result = harness().reduce(
+        actions.updateQueueEntry({
+          entry_id: withItem.queue[0].id,
+          field: "track_title",
+          value: "Back, Baby",
+        }),
+        withItem
+      );
+
+      expect(result.queue[0].album_id).toBe(1001);
+    });
+
     it("should call saveQueueToStorage when updating queue entry", () => {
       const withItem = harness().reduce(actions.addToQueue(createTestFlowsheetQuery()));
       mockedSaveQueue.mockClear();

--- a/tests/unit/lib/features/flowsheet/flowsheet.test.ts
+++ b/tests/unit/lib/features/flowsheet/flowsheet.test.ts
@@ -678,6 +678,28 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.queue[0].album_id).toBe(1001);
     });
 
+    // A linked row always carries an artist, so a blank artist on a linked
+    // queue entry means the conversion withheld the credit — the one case
+    // the empty-field exemption must not cover. Exempted, the linkage rides
+    // the wire and BS hands the withheld credit back over the performer the
+    // DJ just named.
+    it("drops album_id when a withheld artist is named on a linked queue entry", () => {
+      const withItem = harness().reduce(
+        actions.addToQueue(createTestFlowsheetQuery({ album_id: 1001, artist: "" }))
+      );
+      const result = harness().reduce(
+        actions.updateQueueEntry({
+          entry_id: withItem.queue[0].id,
+          field: "artist_name",
+          value: "Chuquimamani-Condori",
+        }),
+        withItem
+      );
+
+      expect(result.queue[0].artist_name).toBe("Chuquimamani-Condori");
+      expect(result.queue[0].album_id).toBeUndefined();
+    });
+
     // The searchbar's half of this rule exempts a field the release left
     // empty — filling it is added data, and the linkage still describes the
     // entry. The queue's half has to agree, or a library row with no label

--- a/tests/unit/lib/features/flowsheet/submission-error.test.ts
+++ b/tests/unit/lib/features/flowsheet/submission-error.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { flowsheetWriteErrorMessage } from "@/lib/features/flowsheet/submission-error";
+
+describe("flowsheetWriteErrorMessage", () => {
+  it("prefers the reason Backend-Service sent", () => {
+    expect(
+      flowsheetWriteErrorMessage({ status: 400, data: { message: "Show not live" } })
+    ).toBe("Show not live");
+  });
+
+  it("falls back to an Error's message", () => {
+    expect(flowsheetWriteErrorMessage(new Error("Network request failed"))).toBe(
+      "Network request failed"
+    );
+  });
+
+  // The shared write path rejects with a bare string when no DJ is signed in.
+  it("passes a rejected string through", () => {
+    expect(flowsheetWriteErrorMessage("User not logged in")).toBe(
+      "User not logged in"
+    );
+  });
+
+  it.each([
+    { label: "undefined", err: undefined },
+    { label: "null", err: null },
+    { label: "an empty object", err: {} },
+    { label: "a payload with no message", err: { data: {} } },
+    { label: "a non-string message", err: { data: { message: 42 } } },
+  ])("falls back to generic copy for $label", ({ err }) => {
+    expect(flowsheetWriteErrorMessage(err)).toBe("Could not add to flowsheet");
+  });
+
+  // Interpolating the raw error is what produced "[object Object]".
+  it("never renders an object placeholder", () => {
+    expect(flowsheetWriteErrorMessage({ status: 500 })).not.toContain("[object");
+  });
+});

--- a/tests/unit/lib/features/flowsheet/various-artists-guard.test.ts
+++ b/tests/unit/lib/features/flowsheet/various-artists-guard.test.ts
@@ -163,4 +163,19 @@ describe("queueAdditionMessage", () => {
       );
     }
   );
+
+  // A release carrying no credit is queued just as blank as one whose credit
+  // is refused, and withholds its linkage on the same terms. The caveat has
+  // to track what the queue row is missing, not which route left it empty —
+  // otherwise this release is the one case that reaches the Play refusal
+  // unwarned.
+  it.each([
+    { label: "an empty credit", artist: { name: "" } },
+    { label: "a null credit name", artist: { name: null } },
+    { label: "no artist at all", artist: null },
+  ])("names what is still missing for a release with $label", ({ artist }) => {
+    expect(queueAdditionMessage({ title: "Edits", artist })).toBe(
+      "Added Edits to queue. Name the performer in the artist cell before playing it."
+    );
+  });
 });

--- a/tests/unit/lib/features/flowsheet/various-artists-guard.test.ts
+++ b/tests/unit/lib/features/flowsheet/various-artists-guard.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   isVariousArtistsEntry,
   queueAdditionMessage,
+  releaseCannotSupplyArtist,
   releaseCreditIsRefused,
   seedableArtistName,
 } from "@/lib/features/flowsheet/various-artists-guard";
@@ -113,6 +114,32 @@ describe("seedableArtistName", () => {
 
   it("returns an empty string for a null-artist release", () => {
     expect(seedableArtistName({ artist: null })).toBe("");
+  });
+});
+
+describe("releaseCannotSupplyArtist", () => {
+  it.each(["Various Artists", "VA", "Var. Artists"])(
+    "is true for a release credited %s",
+    (name) => {
+      expect(releaseCannotSupplyArtist({ artist: { name } })).toBe(true);
+    }
+  );
+
+  // The other route to the same blank field: nothing was refused, there was
+  // simply nothing to seed.
+  it.each([
+    ["a null artist", { artist: null }],
+    ["an absent artist", {}],
+    ["an empty name", { artist: { name: "" } }],
+    ["a whitespace-only name", { artist: { name: "   " } }],
+  ])("is true for %s", (_label, release) => {
+    expect(releaseCannotSupplyArtist(release)).toBe(true);
+  });
+
+  it("is false for a release that names its performer", () => {
+    expect(
+      releaseCannotSupplyArtist({ artist: { name: "Chuquimamani-Condori" } })
+    ).toBe(false);
   });
 });
 

--- a/tests/unit/lib/features/flowsheet/various-artists-guard.test.ts
+++ b/tests/unit/lib/features/flowsheet/various-artists-guard.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   isVariousArtistsEntry,
+  queueAdditionMessage,
   releaseCreditIsRefused,
   seedableArtistName,
 } from "@/lib/features/flowsheet/various-artists-guard";
@@ -113,4 +114,26 @@ describe("seedableArtistName", () => {
   it("returns an empty string for a null-artist release", () => {
     expect(seedableArtistName({ artist: null })).toBe("");
   });
+});
+
+describe("queueAdditionMessage", () => {
+  it("confirms the addition without a caveat for a credited release", () => {
+    expect(
+      queueAdditionMessage({
+        title: "On Your Own Love Again",
+        artist: { name: "Jessica Pratt" },
+      })
+    ).toBe("Added On Your Own Love Again to queue");
+  });
+
+  // The conversion queues a refused credit blank, so a bare "added" would let
+  // the DJ meet the requirement for the first time at the Play refusal.
+  it.each(["Various Artists", "VA", "Var. Artists"])(
+    "names what is still missing for a release credited %s",
+    (name) => {
+      expect(queueAdditionMessage({ title: "Edits", artist: { name } })).toBe(
+        "Added Edits to queue. Name the performer in the artist cell before playing it."
+      );
+    }
+  );
 });


### PR DESCRIPTION
Closes #1122

#1121 refused a compilation credit in the entry form. Several paths reached the flowsheet or the queue without passing through it, and closing them turned out to require one rule rather than four patches.

## The rule

**A release that cannot supply a performing artist is queued blank and unlinked, and refused at the flowsheet boundary.**

"Cannot supply" covers two cases that dead-end identically — a credit submission refuses ("Various Artists" and its abbreviations), and no credit at all. `releaseCannotSupplyArtist` is the predicate; `releaseCreditIsRefused` survives only where the compilation credit specifically is the subject, which is the copy that names it.

Blank is **legal in the queue** and **refused at the flowsheet**. The queue is a draft: parking a song title and naming the performer later in the editable artist cell is a real workflow, and it is the same affordance the mail bin's refusal redirects to. `submitToQueue` therefore has no blank gate; `handleSubmit` and `usePlayNow` do.

## The paths that were open

| Path | What it wrote |
|---|---|
| Mail bin → Play Now | `artist_name` on the unlinked branch; BS's `album_id` lookup on the linked one |
| Mail bin / catalog → Add to Queue | the compilation credit, seeded into the queue |
| Queue replay (`usePlayNow`) | whatever the entry carried, including localStorage entries predating the guard |
| Modern `submitToQueue` → correct the artist | a withheld credit laundered past every guard, see below |
| Highlighted result → `handleSubmit` | `selectedResultData` kept `album_id` for a release supplying no artist |

## Why the check runs against the release, not the payload

The linked bin shape carries `album_id` and no artist string at all, so a guard reading `FlowsheetSubmissionParams.artist_name` cannot see the more common of the two bin branches. The conversions check the `AlbumEntry` before the linked/unlinked branch can hide it.

Withholding `album_id` is what makes a correction stick. BS's `album_id` branch spreads the library row over the request, so any path that keeps the linkage hands the credit — or the blank — straight back over whatever the DJ typed. `rotation_id` is not album-scoped and survives throughout, so the rotation badge does too.

Three variants of that same trap were closed in review:

- **Queue-row edits.** `withSanitizedAlbumLinkage` only strips non-positive ids, and `updateQueueEntry` wrote a single field, so a rehydrated entry kept `album_id` through the correction. It now applies the searchbar's deviation rule. A linked row always carries a credit, so a blank artist there means the conversion withheld one — naming the performer corrects that row rather than adding to it, and strips the linkage.
- **The freeze payload.** Seeding the artist empty made `freezeSelectionToQuery` read the release as having supplied none, so the deviation rule stood down. `artistProvided` now carries the release's own answer, true for every linked release whatever its credit column holds.
- **The queue hop.** freeze → `submitToQueue` → correct-the-artist landed `{artist_name: "", album_id: 42}` and laundered the credit past all of it.

## Escape hatches

Every refusal leaves somewhere to type the performer. Play Now has no field, so it refuses and redirects to Add to Queue, which seeds a blank artist into the queue row — rendered as "Artist Unspecified" with a pencil affordance. The success toast names what is still missing, so the requirement is not first met at the Play refusal. Rotation mode surfaces a performer field for a release with no credit, as it already did for a refused one.

## Also in here

`usePlayNow` writes through `useFlowsheetActions` rather than a raw mutation trigger, which is what makes it a guarded surface at all. `flowsheetWriteErrorMessage` replaces a duplicated extraction ladder and the interpolation that rendered `[object Object]`. `entryToFreezePayload` seeds through `seedableArtistName`. `convertBinToQueue` also serves catalog Add-to-Queue on both result surfaces — documented at the function and covered by tests there.

`COMPILATION_ARTIST_PATTERNS` and its tests are untouched.

## Behavior changes worth noting

- Routing `usePlayNow` through `useFlowsheetActions` means a logged-out Play click surfaces a toast where it previously no-op'd silently.
- A refused or blank release loses its library linkage when queued. Deliberate: the linkage is what would overwrite the correction. `rotation_id` survives, so the badge does.

## Tests

`SongEntry.test.tsx`'s three "Play button in queue" tests asserted nothing — they passed with `usePlayNow`'s body deleted. Replaced with three that exercise submission, queue removal, and the failure path.

Full suite: 309 files / 4423 tests pass (4347 on main). Lint 0 errors, 197 warnings — two fewer than main. `tsc --noEmit` clean.

## Follow-ups, not in scope

- The flowsheet **row-edit** path (`updateFlowsheet`) can still set a posted entry's artist to a compilation credit or blank it, in both experiences. The last unguarded writer.
- Classic's `EntryForm` keys `rotationNeedsArtist` on `releaseCreditIsRefused`, so the two experiences disagree about a release with no credit.
- The guard is replicated across call sites rather than living in `useFlowsheetActions.addToFlowsheet`; classic's `EntryForm` fires the raw mutation, so a chokepoint there would not cover it.
- `setSearchProperty` clears `rotation_id`/`rotation_bin` alongside `album_id`, contradicting the rotation invariant documented in `conversions.ts`. Pre-existing, but now reachable on the correction flow.
- `releaseCreditIsRefused` ignores the `album_artist` column that `MobileResult` treats as the compilation marker.
- The `releasesByBin` memoization in Classic's `EntryForm`, recorded in #1122's Out of scope section.
- A server-side equivalent. Tubafrenzy refuses in the servlet too; this guard stays client-side until Backend-Service has one.
