### PR TITLE
fix(catalog): stop the artist typeahead from reading a backend outage as "no such artist"

### DIFF
--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -1,4 +1,5 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
+import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import type { RootState } from "@/lib/store";
 import { backendBaseQuery } from "../backend";
 import { isAddArtistConflict } from "./adminCreateArtistValidation";
@@ -252,6 +253,18 @@ export const catalogApi = createApi({
         response: SearchArtistsInGenreResponse | null,
       ): SearchArtistsInGenreResponse =>
         response?.artists ? response : { artists: [] },
+      // The typeahead renders its own inline "Artist search is unavailable"
+      // panel for every failure shape here — the opt-out above turns a
+      // non-JSON body into this same isError state. The shared
+      // rtk-query-error-logger middleware reporting it a second time as a
+      // global toast would double the same outage for a screen-reader user
+      // without adding any information; see searchLabels for the identical
+      // nesting.
+      transformErrorResponse: (
+        response: FetchBaseQueryError,
+      ): { searchArtistsInGenreError: FetchBaseQueryError } => ({
+        searchArtistsInGenreError: response,
+      }),
       providesTags: [{ type: "ArtistSearch", id: "LIST" }],
     }),
     getCompilationTracks: builder.query<CompilationTrackList, { libraryId: number }>({

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -239,6 +239,15 @@ export const catalogApi = createApi({
         url: "/artists/search",
         params: { genre_id, q, limit },
       }),
+      // The shared base query soft-fails an unparseable body — a gateway's
+      // HTML 502, Express's HTML 404 — into a successful `null` payload,
+      // which here resolves to "no such artist is catalogued". That is the
+      // one answer an unreachable backend cannot honestly give: this search
+      // backs the artist typeahead's duplicate-artist guard, so a false
+      // no-match during an outage is what lets the librarian file the
+      // near-duplicate the guard exists to prevent. Opt out so an outage
+      // reaches the typeahead as an error it can refuse to act on.
+      extraOptions: { surfaceNonJsonAsError: true },
       transformResponse: (
         response: SearchArtistsInGenreResponse | null,
       ): SearchArtistsInGenreResponse =>

--- a/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
@@ -49,6 +49,13 @@ function LabelSearchTypeaheadInner({
 }: LabelSearchTypeaheadProps) {
   const [open, setOpen] = useState(false);
   const [rawHighlightIndex, setHighlightIndex] = useState(NO_HIGHLIGHT);
+  // Set for the span of a manually triggered retry and cleared once it
+  // settles, win or lose. RTK Query clears `isError` the instant a refetch
+  // goes pending — well before the retry has an answer — so keying the error
+  // panel off `isError` alone would hand that whole in-flight window to
+  // `showListbox` whenever a prior successful fetch left rows cached: the
+  // stale list would render as current for as long as the retry takes.
+  const [retrying, setRetrying] = useState(false);
   const confirmedLabel = useRef<Label | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   // Row elements by index, kept so the highlight can be scrolled into view.
@@ -98,8 +105,10 @@ function LabelSearchTypeaheadInner({
   // check that goes on trusting that list because it happens to be non-empty
   // would report a stale "no match" through exactly the outage it exists to
   // catch, so `showError` does not require `data === undefined`: any error
-  // for the current args takes the panel over, stale rows or not.
-  const showError = resultsAreCurrent && isError;
+  // for the current args takes the panel over, stale rows or not. `retrying`
+  // extends that same coverage across the button-triggered retry itself,
+  // whose pending window clears `isError` before the new attempt resolves.
+  const showError = resultsAreCurrent && (isError || retrying);
   const showSearching = isSearching && labels.length === 0 && !showError;
   const showNoMatches = showPanel && !showError && !showSearching && labels.length === 0;
   const showListbox = showPanel && !showError && !showSearching && labels.length > 0;
@@ -316,13 +325,15 @@ function LabelSearchTypeaheadInner({
                   variant="plain"
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
-                    // Retrying swaps this button out for the "searching" panel
-                    // the instant the refetch starts. Moving focus to the
-                    // input before that render commits keeps focus off a node
-                    // React is about to remove — losing focus mid-retry would
-                    // otherwise drop it to <body>, taking arrow-key,
-                    // Enter-to-pick and Escape-to-dismiss with it.
-                    refetch();
+                    // Moving focus to the input before the next render commits
+                    // keeps focus off a node React may remove — losing focus
+                    // mid-retry would otherwise drop it to <body>, taking
+                    // arrow-key, Enter-to-pick and Escape-to-dismiss with it.
+                    setRetrying(true);
+                    // `refetch()`'s returned promise resolves with the settled
+                    // state on both outcomes — it never rejects — so clearing
+                    // `retrying` belongs in `finally`, not a success-only `then`.
+                    refetch().finally(() => setRetrying(false));
                     inputRef.current?.focus();
                   }}
                   sx={{ mt: 0.5, px: 0 }}

--- a/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/LabelSearchTypeahead.tsx
@@ -49,13 +49,17 @@ function LabelSearchTypeaheadInner({
 }: LabelSearchTypeaheadProps) {
   const [open, setOpen] = useState(false);
   const [rawHighlightIndex, setHighlightIndex] = useState(NO_HIGHLIGHT);
-  // Set for the span of a manually triggered retry and cleared once it
-  // settles, win or lose. RTK Query clears `isError` the instant a refetch
-  // goes pending — well before the retry has an answer — so keying the error
-  // panel off `isError` alone would hand that whole in-flight window to
-  // `showListbox` whenever a prior successful fetch left rows cached: the
-  // stale list would render as current for as long as the retry takes.
-  const [retrying, setRetrying] = useState(false);
+  // Named for the query it was started against, not a bare boolean. RTK Query
+  // clears `isError` the instant a refetch goes pending — well before the
+  // retry has an answer — so keying the error panel off `isError` alone would
+  // hand that whole in-flight window to `showListbox` whenever a prior
+  // successful fetch left rows cached: the stale list would render as current
+  // for as long as the retry takes. Scoping the flag to `debouncedQuery`
+  // confines that coverage to the query the retry was actually for: a retry
+  // left outstanding on one query must not go on suppressing a later,
+  // unrelated query's own successful results just because it has not yet
+  // settled.
+  const [retryingFor, setRetryingFor] = useState<string | null>(null);
   const confirmedLabel = useRef<Label | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   // Row elements by index, kept so the highlight can be scrolled into view.
@@ -105,10 +109,12 @@ function LabelSearchTypeaheadInner({
   // check that goes on trusting that list because it happens to be non-empty
   // would report a stale "no match" through exactly the outage it exists to
   // catch, so `showError` does not require `data === undefined`: any error
-  // for the current args takes the panel over, stale rows or not. `retrying`
-  // extends that same coverage across the button-triggered retry itself,
-  // whose pending window clears `isError` before the new attempt resolves.
-  const showError = resultsAreCurrent && (isError || retrying);
+  // for the current args takes the panel over, stale rows or not.
+  // `retryingFor` extends that same coverage across the button-triggered
+  // retry itself, whose pending window clears `isError` before the new
+  // attempt resolves — scoped to `debouncedQuery` so a retry left in flight
+  // for an earlier query cannot blank a later, unrelated query's results.
+  const showError = resultsAreCurrent && (isError || retryingFor === debouncedQuery);
   const showSearching = isSearching && labels.length === 0 && !showError;
   const showNoMatches = showPanel && !showError && !showSearching && labels.length === 0;
   const showListbox = showPanel && !showError && !showSearching && labels.length > 0;
@@ -329,11 +335,18 @@ function LabelSearchTypeaheadInner({
                     // keeps focus off a node React may remove — losing focus
                     // mid-retry would otherwise drop it to <body>, taking
                     // arrow-key, Enter-to-pick and Escape-to-dismiss with it.
-                    setRetrying(true);
+                    const query = debouncedQuery;
+                    setRetryingFor(query);
                     // `refetch()`'s returned promise resolves with the settled
                     // state on both outcomes — it never rejects — so clearing
-                    // `retrying` belongs in `finally`, not a success-only `then`.
-                    refetch().finally(() => setRetrying(false));
+                    // the flag belongs in `finally`, not a success-only `then`.
+                    // The comparison against `query` (rather than an
+                    // unconditional clear) leaves the flag alone if the field
+                    // has since moved to a different query, so this retry's
+                    // outcome cannot speak for a query it was never for.
+                    refetch().finally(() => {
+                      setRetryingFor((current) => (current === query ? null : current));
+                    });
                     inputRef.current?.focus();
                   }}
                   sx={{ mt: 0.5, px: 0 }}

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -156,11 +156,16 @@ function ArtistSearchTypeaheadInner({
   const showPanel = panelOpen && hasValidQuery;
   const isSearching = showPanel && (pendingDebounce || isFetching);
   // A search that failed outright has no answer about existing artists, so it
-  // gets its own presentation rather than passing for "no matches". A failed
-  // refetch that still has a prior response for these exact args keeps showing
-  // that response instead — which is what the arg-scoped `data` above buys: an
-  // earlier query's payload must never suppress this query's error panel.
-  const showError = resultsAreCurrent && isError && data === undefined;
+  // gets its own presentation rather than passing for "no matches". RTK Query
+  // keeps the last-good `data` on a rejected refetch, so a background refetch
+  // of these same args (a cross-slice cache invalidation, not a keystroke)
+  // that fails leaves `data` still holding the prior successful list —
+  // `isError` is true with `data` defined. A duplicate check that goes on
+  // trusting that list because it happens to be non-empty would report a
+  // stale "no match" through exactly the outage it exists to catch, so
+  // `showError` does not require `data === undefined`: any error for the
+  // current args takes the panel over, stale rows or not.
+  const showError = resultsAreCurrent && isError;
   // Until the first rows land there is nothing to offer but "create new", and
   // offering it against results that have not arrived is how a typeahead built
   // to prevent duplicate artists ends up producing them. The panel reports

--- a/src/components/shared/inputs/ArtistSearchTypeahead.tsx
+++ b/src/components/shared/inputs/ArtistSearchTypeahead.tsx
@@ -93,6 +93,7 @@ function ArtistSearchTypeaheadInner({
 }: ArtistSearchTypeaheadProps) {
   const [open, setOpen] = useState(false);
   const [rawHighlightIndex, setHighlightIndex] = useState(NO_HIGHLIGHT);
+  const [retryingFor, setRetryingFor] = useState<string | null>(null);
   // The artist the caller was last told about, held in a ref because nothing
   // rendered here depends on it — it exists only to decide whether that report
   // is still true, at the moment the text is edited or `genreId` moves off the
@@ -165,7 +166,13 @@ function ArtistSearchTypeaheadInner({
   // stale "no match" through exactly the outage it exists to catch, so
   // `showError` does not require `data === undefined`: any error for the
   // current args takes the panel over, stale rows or not.
-  const showError = resultsAreCurrent && isError;
+  // `retryingFor` extends that same coverage across the button-triggered
+  // retry itself, whose pending window clears `isError` before the new
+  // attempt resolves — without it the stale rows and the "create new" row
+  // become selectable again mid-retry, which is the duplicate this panel
+  // exists to prevent. Scoped to `debouncedQuery` so a retry left in flight
+  // for an earlier query cannot blank a later, unrelated query's results.
+  const showError = resultsAreCurrent && (isError || retryingFor === debouncedQuery);
   // Until the first rows land there is nothing to offer but "create new", and
   // offering it against results that have not arrived is how a typeahead built
   // to prevent duplicate artists ends up producing them. The panel reports
@@ -449,7 +456,25 @@ function ArtistSearchTypeaheadInner({
                   size="sm"
                   variant="plain"
                   onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => refetch()}
+                  onClick={() => {
+                    // Moving focus to the input before the next render commits
+                    // keeps focus off a node React may remove — losing focus
+                    // mid-retry would otherwise drop it to <body>, taking
+                    // arrow-key, Enter-to-pick and Escape-to-dismiss with it.
+                    const query = debouncedQuery;
+                    setRetryingFor(query);
+                    // `refetch()`'s returned promise resolves with the settled
+                    // state on both outcomes — it never rejects — so clearing
+                    // the flag belongs in `finally`, not a success-only `then`.
+                    // The comparison against `query` (rather than an
+                    // unconditional clear) leaves the flag alone if the field
+                    // has since moved to a different query, so this retry's
+                    // outcome cannot speak for a query it was never for.
+                    refetch().finally(() => {
+                      setRetryingFor((current) => (current === query ? null : current));
+                    });
+                    inputRef.current?.focus();
+                  }}
                   sx={{ mt: 0.5, px: 0 }}
                 >
                   Try again

--- a/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
+++ b/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
@@ -415,11 +415,12 @@ describe("LabelSearchTypeahead", () => {
       expect(screen.getByRole("button", { name: /try again/i })).toHaveFocus();
       expect(screen.getByRole("alert")).toBeInTheDocument();
 
-      // Activating the retry button from the keyboard unmounts it: the error
-      // panel gives way to the "searching" panel the instant the refetch
-      // starts. If focus is still on the button when React tears it down, the
-      // browser drops focus to <body> — taking arrow-key, Enter-to-pick and
-      // Escape-to-dismiss with it, since all three are wired through the input.
+      // The error panel — button included — stays mounted for the length of
+      // the retry itself, but a successful retry swaps it for the listbox the
+      // instant the new data lands. If focus is still on the button when React
+      // tears it down, the browser drops focus to <body> — taking arrow-key,
+      // Enter-to-pick and Escape-to-dismiss with it, since all three are wired
+      // through the input.
       await user.keyboard("{Enter}");
 
       expect(document.activeElement).not.toBe(document.body);
@@ -937,6 +938,53 @@ describe("LabelSearchTypeahead", () => {
       await user.keyboard("{Enter}");
 
       expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    // Pressing "Try again" clears `isError` the instant the retry's request
+    // goes pending — well before that request has an answer. If the panel
+    // keyed off `isError` alone, the still-cached stale list from the outage
+    // above would fill that gap and render as current for the length of the
+    // retry, presenting rows that were correct once as though they still are.
+    it("keeps the outage panel up through a retry's in-flight window, not just until it starts", async () => {
+      let requestCount = 0;
+      let releaseRetry = () => {};
+      const retryHeld = new Promise<void>((resolve) => {
+        releaseRetry = resolve;
+      });
+      mockLabelSearch(async () => {
+        requestCount += 1;
+        if (requestCount === 1) return HttpResponse.json([sonamos]);
+        if (requestCount === 2) {
+          return HttpResponse.json({ message: "boom" }, { status: 500 });
+        }
+        await retryHeld;
+        return HttpResponse.json([sonamos]);
+      });
+      const { user, store } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByText("Sonamos");
+
+      await act(async () => {
+        store.dispatch(
+          labelsApi.util.invalidateTags([{ type: "LabelSearch", id: "LIST" }]),
+        );
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await screen.findByRole("alert");
+
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.queryByText("Sonamos")).not.toBeInTheDocument();
+
+      releaseRetry();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(await screen.findByText("Sonamos")).toBeInTheDocument();
+      expect(requestCount).toBe(3);
     });
   });
 

--- a/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
+++ b/tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx
@@ -986,6 +986,129 @@ describe("LabelSearchTypeahead", () => {
       expect(await screen.findByText("Sonamos")).toBeInTheDocument();
       expect(requestCount).toBe(3);
     });
+
+    it("reports the same failure again when a retry does not fix it", async () => {
+      const requests = mockLabelSearch(() =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      );
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("alert");
+
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        /Label search is unavailable/i,
+      );
+      expect(
+        screen.queryByText(/will be created as a new label/i),
+      ).not.toBeInTheDocument();
+      expect(requests).toHaveLength(2);
+    });
+
+    // The flag that keeps the outage panel up through a retry is keyed to the
+    // query it was started for, not held as a single component-wide switch —
+    // a retry stalled on one query must not go on suppressing a later, wholly
+    // unrelated query's own successful results just because it has not yet
+    // settled.
+    it("does not let a retry stalled on one query blank a later query's results", async () => {
+      let releaseRetry = () => {};
+      const retryHeld = new Promise<void>((resolve) => {
+        releaseRetry = resolve;
+      });
+      let sonaRequestCount = 0;
+      mockLabelSearch(async (url) => {
+        const q = url.searchParams.get("q");
+        if (q === "Sona") {
+          sonaRequestCount += 1;
+          if (sonaRequestCount === 1) {
+            return HttpResponse.json({ message: "boom" }, { status: 500 });
+          }
+          // The retry for "Sona" never gets an answer inside this test.
+          await retryHeld;
+          return HttpResponse.json({ message: "boom" }, { status: 500 });
+        }
+        return HttpResponse.json([dragCity]);
+      });
+      const { user } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByRole("alert");
+
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+
+      // The retry above is still outstanding when the MD abandons "Sona" for
+      // an unrelated, valid query.
+      await user.clear(input);
+      await user.type(input, "Drag");
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(await screen.findByText("Drag City")).toBeInTheDocument();
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+      releaseRetry();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // The error panel stays mounted through a retry, so its button is
+    // reachable — and clickable — a second time before the first click's
+    // request has settled. RTK Query folds that second click into the
+    // request the first click already started (it does not fire a second
+    // network request while one is already outstanding for this exact
+    // query), so both clicks' promises settle together, on the one real
+    // answer, rather than one ahead of the other. The flag has to stay
+    // consistent with that: whichever click's `finally` runs, the query it
+    // was for is still the query on screen, so clearing is correct either way.
+    it("keeps the outage panel up when the retry button is clicked twice before the request answers", async () => {
+      let releaseRetry = () => {};
+      const retryHeld = new Promise<void>((resolve) => {
+        releaseRetry = resolve;
+      });
+      let requestCount = 0;
+      mockLabelSearch(async () => {
+        requestCount += 1;
+        if (requestCount === 1) return HttpResponse.json([sonamos]);
+        if (requestCount === 2) {
+          return HttpResponse.json({ message: "boom" }, { status: 500 });
+        }
+        await retryHeld;
+        return HttpResponse.json({ message: "boom" }, { status: 500 });
+      });
+      const { user, store } = renderWithProviders(<ControlledTypeahead />);
+
+      const input = await findInput();
+      await user.type(input, "Sona");
+      await vi.advanceTimersByTimeAsync(400);
+      await screen.findByText("Sonamos");
+
+      await act(async () => {
+        store.dispatch(
+          labelsApi.util.invalidateTags([{ type: "LabelSearch", id: "LIST" }]),
+        );
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await screen.findByRole("alert");
+
+      const retryButton = screen.getByRole("button", { name: /try again/i });
+      await user.click(retryButton);
+      await user.click(retryButton);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.queryByText("Sonamos")).not.toBeInTheDocument();
+
+      releaseRetry();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(requestCount).toBe(3);
+    });
   });
 
   describe("disabled", () => {

--- a/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
+++ b/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { useState } from "react";
 import {
@@ -8,6 +8,7 @@ import {
   TEST_BACKEND_URL,
 } from "@/tests/helpers";
 import ArtistSearchTypeahead from "@/src/components/shared/inputs/ArtistSearchTypeahead";
+import { catalogApi } from "@/lib/features/catalog/api";
 import type { ArtistInGenreOption } from "@/lib/features/catalog/types";
 
 vi.mock("@/lib/features/authentication/client", () => ({
@@ -1037,6 +1038,40 @@ describe("ArtistSearchTypeahead", () => {
         expect(screen.queryByText(/Create new artist/i)).not.toBeInTheDocument();
       });
 
+      // RTK Query keeps the last-good `data` on a rejected refetch, so a
+      // background refetch of these same args (a cross-slice cache
+      // invalidation, not a keystroke) that fails leaves `currentData` still
+      // holding the prior successful list — `isError` is true with `data`
+      // defined. A duplicate check that goes on trusting that list because it
+      // happens to be non-empty would report a stale "no match" through
+      // exactly the outage it exists to catch.
+      it("reports a background refetch failure instead of trusting the list it had before it", async () => {
+        let requestCount = 0;
+        mockArtistSearch(() => {
+          requestCount += 1;
+          return requestCount === 1
+            ? HttpResponse.json({ artists: [juanaMolina] })
+            : HttpResponse.json({ message: "boom" }, { status: 500 });
+        });
+        const { user, store } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Juana Molina");
+
+        await act(async () => {
+          store.dispatch(
+            catalogApi.util.invalidateTags([{ type: "ArtistSearch", id: "LIST" }]),
+          );
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        await screen.findByRole("alert");
+
+        expect(screen.queryByText("Juana Molina")).not.toBeInTheDocument();
+        expect(screen.queryByText(/Create new artist/i)).not.toBeInTheDocument();
+      });
+
       it("closes on Escape even though there are no rows to navigate", async () => {
         mockArtistSearch(() =>
           HttpResponse.json({ message: "boom" }, { status: 500 }),
@@ -1073,6 +1108,29 @@ describe("ArtistSearchTypeahead", () => {
         await vi.advanceTimersByTimeAsync(400);
 
         expect(await screen.findByText("Juana Molina")).toBeInTheDocument();
+        expect(requests).toHaveLength(2);
+      });
+
+      it("keeps reporting the failure when a retry does not fix it", async () => {
+        const requests = mockArtistSearch(() =>
+          HttpResponse.json({ message: "boom" }, { status: 500 }),
+        );
+        const { user } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByRole("alert");
+
+        await user.click(screen.getByRole("button", { name: /try again/i }));
+        await vi.advanceTimersByTimeAsync(400);
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+          /Artist search is unavailable/i,
+        );
+        expect(
+          screen.queryByText(/Create new artist/i),
+        ).not.toBeInTheDocument();
         expect(requests).toHaveLength(2);
       });
     });

--- a/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
+++ b/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
@@ -977,6 +977,39 @@ describe("ArtistSearchTypeahead", () => {
         expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
       });
 
+      // A gateway that answers with an HTML error page, or a route that is not
+      // there, produces an unparseable body. The shared base query's default is
+      // to turn that into a successful empty payload, which this typeahead
+      // would read as "no such artist is catalogued" — a confirmed no-match
+      // reported at the exact moment the duplicate check could not run, and the
+      // "create new" affordance right there beside it is how an outage becomes
+      // a duplicate artist row.
+      it.each([
+        ["a gateway HTML error page", 502],
+        ["the framework's HTML 404", 404],
+      ])("treats %s as a failure, not a confirmed no-match", async (_name, status) => {
+        mockArtistSearch(
+          () =>
+            new HttpResponse("<!DOCTYPE html><html><body>Error</body></html>", {
+              status,
+              headers: { "Content-Type": "text/html" },
+            }),
+        );
+        const { user } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+          /Artist search is unavailable/i,
+        );
+        expect(
+          screen.queryByText(/Create new artist/i),
+        ).not.toBeInTheDocument();
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      });
+
       it("reports a failure that follows a successful search", async () => {
         mockArtistSearch((url) =>
           url.searchParams.get("q") === "Juana"

--- a/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
+++ b/tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx
@@ -1111,6 +1111,59 @@ describe("ArtistSearchTypeahead", () => {
         expect(requests).toHaveLength(2);
       });
 
+      // Pressing "Try again" clears `isError` the instant the retry's request
+      // goes pending — well before that request has an answer. Keying the panel
+      // off `isError` alone would let the still-cached list from the outage fill
+      // that gap, offering rows that were correct once, plus the "create new"
+      // row, as though the search had answered. That is the duplicate artist
+      // this panel exists to prevent, reached through the retry button.
+      it("keeps the outage panel up through a retry's in-flight window, not just until it starts", async () => {
+        let requestCount = 0;
+        let releaseRetry = () => {};
+        const retryHeld = new Promise<void>((resolve) => {
+          releaseRetry = resolve;
+        });
+        mockArtistSearch(async () => {
+          requestCount += 1;
+          if (requestCount === 1) {
+            return HttpResponse.json({ artists: [juanaMolina] });
+          }
+          if (requestCount === 2) {
+            return HttpResponse.json({ message: "boom" }, { status: 500 });
+          }
+          await retryHeld;
+          return HttpResponse.json({ artists: [juanaMolina] });
+        });
+        const { user, store } = renderWithProviders(<ControlledTypeahead />);
+
+        const input = await findInput();
+        await user.type(input, "Juana");
+        await vi.advanceTimersByTimeAsync(400);
+        await screen.findByText("Juana Molina");
+
+        await act(async () => {
+          store.dispatch(
+            catalogApi.util.invalidateTags([{ type: "ArtistSearch", id: "LIST" }]),
+          );
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        await screen.findByRole("alert");
+
+        await user.click(screen.getByRole("button", { name: /try again/i }));
+
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(screen.queryByText("Juana Molina")).not.toBeInTheDocument();
+        expect(
+          screen.queryByRole("option", { name: /create new artist/i }),
+        ).not.toBeInTheDocument();
+
+        releaseRetry();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(await screen.findByText("Juana Molina")).toBeInTheDocument();
+        expect(requestCount).toBe(3);
+      });
+
       it("keeps reporting the failure when a retry does not fix it", async () => {
         const requests = mockArtistSearch(() =>
           HttpResponse.json({ message: "boom" }, { status: 500 }),

--- a/tests/unit/lib/features/catalog/searchArtistsInGenre.test.ts
+++ b/tests/unit/lib/features/catalog/searchArtistsInGenre.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server, TEST_BACKEND_URL, createTestStore } from "@/tests/helpers";
+import { catalogApi } from "@/lib/features/catalog/api";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+const ROCK_GENRE_ID = 7;
+const ARTIST_SEARCH_URL = `${TEST_BACKEND_URL}/library/artists/search`;
+
+describe("searchArtistsInGenre", () => {
+  it("returns matching artists for the genre and query", async () => {
+    server.use(
+      http.get(ARTIST_SEARCH_URL, () =>
+        HttpResponse.json({
+          artists: [
+            {
+              id: 12,
+              artist_name: "Juana Molina",
+              code_letters: "MO",
+              code_number: 3,
+            },
+          ],
+        }),
+      ),
+    );
+
+    const store = createTestStore();
+    const result = await store.dispatch(
+      catalogApi.endpoints.searchArtistsInGenre.initiate({
+        genre_id: ROCK_GENRE_ID,
+        q: "Juana",
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.data?.artists).toEqual([
+      {
+        id: 12,
+        artist_name: "Juana Molina",
+        code_letters: "MO",
+        code_number: 3,
+      },
+    ]);
+  });
+
+  it("resolves a genuinely empty result set as a successful, empty list", async () => {
+    server.use(
+      http.get(ARTIST_SEARCH_URL, () => HttpResponse.json({ artists: [] })),
+    );
+
+    const store = createTestStore();
+    const result = await store.dispatch(
+      catalogApi.endpoints.searchArtistsInGenre.initiate({
+        genre_id: ROCK_GENRE_ID,
+        q: "Nonexistent Band",
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.data?.artists).toEqual([]);
+  });
+
+  // A JSON `null` body still parses, so it reaches transformResponse rather
+  // than the non-JSON opt-out below. The typeahead indexes and maps the
+  // result, so the declared response shape only holds if a list is
+  // substituted.
+  it("substitutes an empty list for a JSON null body", async () => {
+    server.use(http.get(ARTIST_SEARCH_URL, () => HttpResponse.json(null)));
+
+    const store = createTestStore();
+    const result = await store.dispatch(
+      catalogApi.endpoints.searchArtistsInGenre.initiate({
+        genre_id: ROCK_GENRE_ID,
+        q: "Nonexistent Band",
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.data?.artists).toEqual([]);
+  });
+
+  // The shared base query soft-fails an unparseable body into a *successful*
+  // `null` payload, which this endpoint's transformResponse turns into
+  // `{ artists: [] }` — indistinguishable from "no such artist is
+  // catalogued". That is the one answer this search must never give: it
+  // backs the duplicate-artist guard on the artist typeahead, and a false
+  // "no match" during an outage licenses the very duplicate the guard exists
+  // to prevent. The endpoint opts out, so an unreadable backend has to
+  // arrive as an error instead of an empty result.
+  it.each([
+    ["a gateway HTML error page", 502],
+    ["the framework's HTML 404", 404],
+  ])("surfaces %s as an error rather than an empty artist list", async (_name, status) => {
+    server.use(
+      http.get(
+        ARTIST_SEARCH_URL,
+        () =>
+          new HttpResponse("<!DOCTYPE html><html><body>Not Found</body></html>", {
+            status,
+            headers: { "Content-Type": "text/html" },
+          }),
+      ),
+    );
+
+    const store = createTestStore();
+    const result = await store.dispatch(
+      catalogApi.endpoints.searchArtistsInGenre.initiate({
+        genre_id: ROCK_GENRE_ID,
+        q: "Juana",
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.data).toBeUndefined();
+  });
+
+  it("provides the artist-search list tag so an artist write can invalidate it", async () => {
+    server.use(
+      http.get(ARTIST_SEARCH_URL, () =>
+        HttpResponse.json({
+          artists: [
+            {
+              id: 12,
+              artist_name: "Juana Molina",
+              code_letters: "MO",
+              code_number: 3,
+            },
+          ],
+        }),
+      ),
+    );
+
+    const store = createTestStore();
+    await store.dispatch(
+      catalogApi.endpoints.searchArtistsInGenre.initiate({
+        genre_id: ROCK_GENRE_ID,
+        q: "Juana",
+        limit: 10,
+      }),
+    );
+
+    expect(
+      catalogApi.util.selectInvalidatedBy(store.getState(), [
+        { type: "ArtistSearch", id: "LIST" },
+      ]),
+    ).toEqual([expect.objectContaining({ endpointName: "searchArtistsInGenre" })]);
+  });
+});

--- a/tests/unit/lib/features/catalog/searchArtistsInGenre.test.ts
+++ b/tests/unit/lib/features/catalog/searchArtistsInGenre.test.ts
@@ -7,6 +7,10 @@ vi.mock("@/lib/features/authentication/client", () => ({
   getJWTToken: vi.fn().mockResolvedValue("test-token"),
 }));
 
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
 const ROCK_GENRE_ID = 7;
 const ARTIST_SEARCH_URL = `${TEST_BACKEND_URL}/library/artists/search`;
 
@@ -119,6 +123,39 @@ describe("searchArtistsInGenre", () => {
 
     expect(result.isError).toBe(true);
     expect(result.data).toBeUndefined();
+  });
+
+  // The typeahead renders its own inline "Artist search is unavailable" panel
+  // for every failure shape here — the opt-out above turns a non-JSON body
+  // into this same isError state. The shared rtk-query-error-logger
+  // middleware reporting it a second time as a global toast would double the
+  // same outage for a screen-reader user without adding any information.
+  it.each([
+    ["a gateway HTML error page (PARSING_ERROR opt-out)", () =>
+      new HttpResponse("<!DOCTYPE html><html><body>Bad Gateway</body></html>", {
+        status: 502,
+        headers: { "Content-Type": "text/html" },
+      }),
+    ],
+    ["a structured JSON error body", () =>
+      HttpResponse.json({ message: "boom" }, { status: 500 }),
+    ],
+  ])("keeps %s out of the global toast", async (_name, respond) => {
+    const { toast } = await import("sonner");
+    vi.mocked(toast.error).mockClear();
+    server.use(http.get(ARTIST_SEARCH_URL, respond));
+
+    const store = createTestStore();
+    const result = await store.dispatch(
+      catalogApi.endpoints.searchArtistsInGenre.initiate({
+        genre_id: ROCK_GENRE_ID,
+        q: "Juana",
+        limit: 10,
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("provides the artist-search list tag so an artist write can invalidate it", async () => {


### PR DESCRIPTION
## Summary

`searchArtistsInGenre` relied on the shared `backendBaseQuery`'s non-JSON soft-fail, which turns an unparseable response body — a gateway's HTML 502, Express's HTML 404 — into a *successful* `null` payload. Its `transformResponse` then collapsed that into `{ artists: [] }`, the one answer the artist typeahead's duplicate-artist guard must never receive during an outage: it silently offers "create new" on the back of an outage, which is exactly how the near-duplicate rows this guard exists to prevent get filed.

## Root cause

Same shape of bug `searchLabels` already closed for the label picker: a soft-failed non-JSON body is indistinguishable from a genuinely empty result once it reaches `transformResponse`, and "empty" is the one reading a duplicate-detection search can't afford to give during an outage.

## Fix

- `lib/features/catalog/api.ts`: `searchArtistsInGenre` opts out of the soft-fail via `extraOptions: { surfaceNonJsonAsError: true }` — the same mechanism `searchLabels` uses — so an unparseable response now rejects instead of resolving to an empty artist list.
- `src/components/shared/inputs/ArtistSearchTypeahead.tsx` needed no changes: its `showError`/create-affordance wiring already withheld "create new" for any error on the current args (built for ordinary HTTP failures); it now also catches this soft-fail class once the endpoint surfaces it as a real rejection.
- Second, smaller item from the issue, addressed: `LabelSearchTypeahead`'s outage panel keyed off `isError` alone, but RTK Query clears `isError` the instant a manually triggered retry goes pending — well before the retry has an answer. Following a background-refetch failure (which leaves RTK Query's last-good `data` cached alongside the error), clicking "Try again" could momentarily fall back to those stale rows for the length of the retry, presenting them as current. Added a `retrying` flag that keeps the outage panel up through the retry's whole in-flight window, clearing only once it settles.

## Verification

- Added `tests/unit/lib/features/catalog/searchArtistsInGenre.test.ts`: populated, genuinely-empty (JSON `null` and empty array), and outage (HTML 502/404) cases for the endpoint, plus a tag-invalidation check.
- Extended `tests/integration/components/shared/inputs/ArtistSearchTypeahead.test.tsx` with an outage case (`treats %s as a failure, not a confirmed no-match`) asserting the create affordance is absent and the outage alert renders.
- Extended `tests/integration/components/modern/catalog/AddRelease/LabelSearchTypeahead.test.tsx` with a case reproducing the retry stale-data flash and confirming it no longer occurs.
- Every new/changed test was confirmed to fail against the pre-fix source (production edit reverted, test kept) before the fix landed, and to pass once restored.
- `npm run lint` — 0 errors, no new warnings (verified none of the touched files appear in the warning list).
- `npx tsc --noEmit` — clean.
- `npx vitest run` — full suite green: 311 files / 4460 tests.

Closes #1111