### PR TITLE
fix(flowsheet): surface the classic rotation performer field for a release with no credit

### DIFF
--- a/src/components/experiences/classic/flowsheet/EntryForm.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryForm.tsx
@@ -9,6 +9,7 @@ import { sortRotationReleases } from "@/lib/features/rotation/sort";
 import { Rotation } from "@/lib/features/rotation/types";
 import {
   isVariousArtistsEntry,
+  releaseCannotSupplyArtist,
   releaseCreditIsRefused,
   seedableArtistName,
   VARIOUS_ARTISTS_REJECTION_MESSAGE,
@@ -90,15 +91,24 @@ export default function EntryForm({
     (r) => r.rotation_id === selectedRotationId
   );
   // Rotation mode hides the Artist field and submits the release-level artist.
-  // When that artist is a credit submission refuses, the field has to come back
-  // or the refusal has nothing that can satisfy it. Keyed on the refused credit
-  // rather than on `isCompilationRelease`: a compilation filed under a credited
-  // album artist is submittable as-is and must keep its library linkage.
-  const rotationNeedsArtist =
+  // When that release can't supply one — its credit is refused, or it carries
+  // no credit at all — the field has to come back or the refusal has nothing
+  // that can satisfy it. Keyed on `releaseCannotSupplyArtist` rather than on
+  // `isCompilationRelease`: a compilation filed under a credited album artist
+  // is submittable as-is and must keep its library linkage.
+  const rotationCannotSupplyArtist =
+    releaseType === "rotationRelease" &&
+    releaseCannotSupplyArtist(selectedRotationRelease ?? null);
+  // Narrower than the above: true only when the release's own credit is the
+  // compilation designation submission refuses, not merely blank. Stays
+  // narrow because it drives copy that names the compilation specifically —
+  // a blank credit isn't a compilation, so that copy would name a fix the DJ
+  // didn't need.
+  const rotationCreditIsRefused =
     releaseType === "rotationRelease" &&
     releaseCreditIsRefused(selectedRotationRelease ?? null);
   const showArtistField =
-    releaseType !== "rotationRelease" || rotationNeedsArtist;
+    releaseType !== "rotationRelease" || rotationCannotSupplyArtist;
   const artistRefused = showArtistField && isVariousArtistsEntry(artistName);
 
   const handleRotationSelect = (rotationId: number) => {
@@ -131,7 +141,7 @@ export default function EntryForm({
     !artistRefused &&
     (releaseType === "rotationRelease"
       ? selectedRotationId > 0 &&
-        (!rotationNeedsArtist || artistName.trim().length > 0)
+        (!rotationCannotSupplyArtist || artistName.trim().length > 0)
       : artistName.trim().length > 0);
   const canSubmit = entryType === "track" ? canSubmitTrack : true;
 
@@ -165,12 +175,13 @@ export default function EntryForm({
       // a non-error submit; recovering the linkage requires BS to accept
       // `rotation_id` without `album_id` (Option C, BS-side schema work).
       // Aligned with sibling dj-site#608's fix shape.
-      if (rotationNeedsArtist) {
+      if (rotationCannotSupplyArtist) {
         // The catalog-linked variant carries no `artist_name` — BS resolves it
         // from `album_id`, which on a compilation resolves straight back to the
-        // credit the DJ just replaced. Only the freeform variant preserves the
-        // performer they typed. `rotation_id` rides that variant, so the
-        // rotation badge survives the trade.
+        // credit the DJ just replaced, or on a no-credit release resolves to
+        // nothing at all. Only the freeform variant preserves the performer
+        // they typed. `rotation_id` rides that variant, so the rotation badge
+        // survives the trade.
         submissionData = {
           artist_name: artistName,
           album_title: release.title,
@@ -344,7 +355,7 @@ export default function EntryForm({
                           artistRefused ? "artistNameError" : undefined
                         }
                       />
-                      {rotationNeedsArtist && !artistRefused && (
+                      {rotationCreditIsRefused && !artistRefused && (
                         <div className="field-hint">
                           Compilation — name the artist on this track
                         </div>

--- a/tests/integration/components/classic/flowsheet/EntryForm.test.tsx
+++ b/tests/integration/components/classic/flowsheet/EntryForm.test.tsx
@@ -525,12 +525,16 @@ describe("Classic EntryForm — null artist (regression)", () => {
     expect(texts.some((t) => t.includes("- Untitled"))).toBe(true);
   });
 
-  it("seeds an empty artist and submits freeform when a null-artist release is selected", async () => {
+  it("seeds an empty artist field and submits freeform once the DJ names the performer", async () => {
     rotationDataMock = rotationWithNullArtistRow();
     const { user } = renderWithProviders(<EntryForm />);
     await user.selectOptions(getNamedSelect("releaseType"), "rotationRelease");
     await user.selectOptions(getNamedSelect("rotationType"), "heavy");
     await selectByText(user, getNamedSelect("heavyRelease"), "Untitled");
+    // A release with no credit can't supply an artist, so the field surfaces
+    // seeded blank rather than crashing on the null artist object.
+    expect(getNamedInput("artistName").value).toBe("");
+    await user.type(getNamedInput("artistName"), "Chuquimamani-Condori");
     await user.type(getNamedInput("songTitle"), "Charcoal Bow");
     await user.click(screen.getByRole("button", { name: /^add$/i }));
 
@@ -539,8 +543,9 @@ describe("Classic EntryForm — null artist (regression)", () => {
     });
     const payload = addToFlowsheetMock.mock.calls[0][0];
     expect(payload.track_title).toBe("Charcoal Bow");
-    // Unlinked row (negative id) → freeform variant; null artist coalesces to "".
-    expect(payload.artist_name).toBe("");
+    // Unlinked row (negative id) → freeform variant; the DJ's typed name is
+    // what rides the wire, not the null credit.
+    expect(payload.artist_name).toBe("Chuquimamani-Condori");
     expect(payload.album_title).toBe("Untitled");
   });
 });
@@ -824,6 +829,84 @@ describe("Classic EntryForm — Various Artists refusal", () => {
       const payload = addToFlowsheetMock.mock.calls[0][0];
       expect(payload.album_id).toBe(6201);
       expect(payload.rotation_id).toBe(6202);
+    });
+
+    // A rotation release with no credit at all dead-ends the same way a
+    // refused credit does: the artist cell is empty and the DJ needs
+    // somewhere to type. Regression for the field staying hidden because the
+    // gate only recognized a refused credit, not a merely blank one.
+    const uncredited = () =>
+      ({
+        ...createTestRotationAlbum(Rotation.H, {
+          id: 6601,
+          rotation_id: 6602,
+          title: "Sallie Gardner at a Gallop",
+          label: "self-released",
+        }),
+        artist: null,
+      }) as unknown as ReturnType<typeof createTestRotationAlbum>;
+
+    it("reveals the Artist row for a release with no credit at all", async () => {
+      rotationDataMock = [uncredited()];
+      const { user } = renderWithProviders(<EntryForm />);
+      await pickRotation(user, "Sallie Gardner");
+
+      expect(getNamedInput("artistName")).toBeInTheDocument();
+      expect(getNamedInput("artistName").value).toBe("");
+    });
+
+    it("holds Add until the DJ names the performer on a no-credit release", async () => {
+      rotationDataMock = [uncredited()];
+      const { user } = renderWithProviders(<EntryForm />);
+      await pickRotation(user, "Sallie Gardner");
+      await user.type(getNamedInput("songTitle"), "Call Your Name");
+
+      expect(addButton().disabled).toBe(true);
+
+      await user.type(getNamedInput("artistName"), "Chuquimamani-Condori");
+
+      expect(addButton().disabled).toBe(false);
+    });
+
+    it("submits the typed artist freeform for a no-credit release", async () => {
+      rotationDataMock = [uncredited()];
+      const { user } = renderWithProviders(<EntryForm />);
+      await pickRotation(user, "Sallie Gardner");
+      await user.type(getNamedInput("songTitle"), "Call Your Name");
+      await user.type(getNamedInput("artistName"), "Chuquimamani-Condori");
+      await user.click(addButton());
+
+      await waitFor(() => {
+        expect(addToFlowsheetMock).toHaveBeenCalledTimes(1);
+      });
+      const payload = addToFlowsheetMock.mock.calls[0][0];
+      expect(payload.artist_name).toBe("Chuquimamani-Condori");
+      expect(payload.album_title).toBe("Sallie Gardner at a Gallop");
+      expect(payload.track_title).toBe("Call Your Name");
+      expect(payload.rotation_id).toBe(6602);
+    });
+
+    // The narrower predicate stays load-bearing for copy that names the
+    // compilation specifically: a blank credit isn't a compilation, so
+    // telling the DJ that would name a fix they didn't need.
+    it("shows the compilation hint for a refused credit but not for a merely blank one", async () => {
+      rotationDataMock = [compilation()];
+      const { user } = renderWithProviders(<EntryForm />);
+      await pickRotation(user, "In-Correcto");
+
+      expect(
+        screen.getByText(/compilation — name the artist on this track/i)
+      ).toBeInTheDocument();
+
+      rotationDataMock = [uncredited()];
+      const { user: user2 } = renderWithProviders(<EntryForm />);
+      await user2.selectOptions(getNamedSelect("releaseType"), "rotationRelease");
+      await user2.selectOptions(getNamedSelect("rotationType"), "heavy");
+      await selectByText(user2, getNamedSelect("heavyRelease"), "Sallie Gardner");
+
+      expect(
+        screen.queryByText(/compilation — name the artist on this track/i)
+      ).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

The two experiences disagreed about a rotation release carrying no artist credit at all. Modern gates the performer field on `releaseCannotSupplyArtist` (blank credit or refused credit); classic gated it on the narrower `releaseCreditIsRefused` (refused credit only), so classic hid the performer field for a no-credit rotation release and would let it through blank with nothing on screen to fix.

`EntryForm.tsx` now keys field visibility, the submit-enable condition, and the submit path on `releaseCannotSupplyArtist`. The compilation-specific hint copy ("Compilation — name the artist on this track") stays on the narrower `releaseCreditIsRefused`, since a blank credit isn't a compilation and that copy would name a fix the DJ didn't need.

- A rotation release with a blank credit now surfaces the performer field in classic, matching modern
- The "Various Artists" refusal copy still fires only for an actually-refused credit
- Added coverage for a no-credit rotation release: field visibility, submit gating, freeform submission, and the compilation-hint boundary

Closes #1127

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint` (0 errors, 197 warnings — unchanged baseline)
- [x] `npm test` (310 files / 4455 tests passing)