### PR TITLE
fix(flowsheet): keep rotation linkage when a search edit deviates from the release

### DIFF
--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -144,9 +144,10 @@ export const flowsheetSlice = createAppSlice({
         provided === true &&
         previous !== action.payload.value
       ) {
+        // rotation_id and rotation_bin identify the rotation row, not the
+        // album row (see the file-header invariant), so they survive a
+        // deviation — only the album-scoped fields drop.
         state.search.query.album_id = undefined;
-        state.search.query.rotation_id = undefined;
-        state.search.query.rotation_bin = undefined;
         state.search.query.track_position = undefined;
         state.search.selectionProvided = undefined;
       }

--- a/tests/unit/lib/features/flowsheet/flowsheet.test.ts
+++ b/tests/unit/lib/features/flowsheet/flowsheet.test.ts
@@ -11,6 +11,7 @@ import {
   TEST_ENTITY_IDS,
 } from "@/tests/helpers";
 import type { FlowsheetFrontendState, FlowsheetEntry } from "@/lib/features/flowsheet/types";
+import { convertQueryToSubmission } from "@/lib/features/flowsheet/conversions";
 
 vi.mock("@/lib/features/flowsheet/queue-storage", () => ({
   saveQueueToStorage: vi.fn(),
@@ -137,7 +138,7 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
           })
         );
 
-      it("editing a filled field with deviates drops the album linkage", () => {
+      it("editing a filled field with deviates drops the album-scoped fields only", () => {
         const result = harness().reduce(
           actions.setSearchProperty({
             name: "album",
@@ -149,9 +150,43 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
 
         expect(result.search.query.album).toBe("DOGA (remaster)");
         expect(result.search.query.album_id).toBeUndefined();
-        expect(result.search.query.rotation_id).toBeUndefined();
-        expect(result.search.query.rotation_bin).toBeUndefined();
         expect(result.search.query.track_position).toBeUndefined();
+      });
+
+      // rotation_id and rotation_bin identify the rotation row, not the album
+      // row (see the file-header invariant), so a deviation from the linked
+      // release must not touch them — only the album-scoped fields drop.
+      it("keeps rotation_id and rotation_bin when deviating from a linked release", () => {
+        const result = harness().reduce(
+          actions.setSearchProperty({
+            name: "album",
+            value: "DOGA (remaster)",
+            deviates: true,
+          }),
+          frozen()
+        );
+
+        expect(result.search.query.album_id).toBeUndefined();
+        expect(result.search.query.rotation_id).toBe(7);
+        expect(result.search.query.rotation_bin).toBe("H");
+      });
+
+      it("keeps the submitted entry's rotation linkage after a deviation", () => {
+        const result = harness().reduce(
+          actions.setSearchProperty({
+            name: "album",
+            value: "DOGA (remaster)",
+            deviates: true,
+          }),
+          frozen()
+        );
+
+        const submission = convertQueryToSubmission(result.search.query) as {
+          album_id?: number;
+          rotation_id?: number;
+        };
+        expect(submission.album_id).toBeUndefined();
+        expect(submission.rotation_id).toBe(7);
       });
 
       it("a non-deviating write preserves the linkage (rotation flows)", () => {


### PR DESCRIPTION
## Problem

`setSearchProperty`'s deviation branch cleared `rotation_id` and `rotation_bin` alongside `album_id`, contradicting the invariant documented at the top of the same file: `rotation_id` identifies the rotation row, not the album row, and must survive a deviation. `withSanitizedAlbumLinkage` already honored that invariant; the deviation branch didn't.

The consequence: editing the artist, album, or label after picking a rotation release (a routine flow since #1123) dropped the ROTATION badge on dj-site, in the iOS app, and in the wxyc.info archive.

## Fix

Deviating from a linked release now drops only the album-scoped fields (`album_id`, `track_position`). `rotation_id` and `rotation_bin` survive, matching `withSanitizedAlbumLinkage` and `convertBinToFlowsheet`.

## Tests

- Renamed the pre-existing deviation test (which had asserted `rotation_id`/`rotation_bin` were cleared — i.e. it had pinned the old, wrong behavior) to drop those two assertions, since that's no longer the expected outcome.
- Added a test asserting `rotation_id`/`rotation_bin` survive a deviation while `album_id` drops.
- Added a test asserting the submitted entry (via `convertQueryToSubmission`) keeps `rotation_id` after a deviation.

## Scope note

Touches the same file (`lib/features/flowsheet/frontend.ts`) and the same test file (`tests/unit/lib/features/flowsheet/flowsheet.test.ts`) as the concurrent #1126 work, which is in the `updateQueueEntry` reducer (~line 236) — a different, non-overlapping region. This change is confined to `setSearchProperty` (~lines 119-154) and its own describe block in the test file.

Closes #1128