### PR TITLE
fix(flowsheet): refuse a compilation credit or blank artist on posted row edits

### DIFF
--- a/src/components/experiences/classic/flowsheet/EntryRow.tsx
+++ b/src/components/experiences/classic/flowsheet/EntryRow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type DragEvent as ReactDragEvent } from "react";
+import { toast } from "sonner";
 import {
   FlowsheetEntry,
   isFlowsheetSongEntry,
@@ -10,6 +11,7 @@ import {
   isFlowsheetEndShowEntry,
   UpdateRequestBody,
 } from "@/lib/features/flowsheet/types";
+import { flowsheetArtistRejection } from "@/lib/features/flowsheet/various-artists-guard";
 import EntryActionMenu from "./EntryActionMenu";
 import { formatShortDate, formatShortTime } from "./marker-format";
 import "@/src/styles/classic/segue.css";
@@ -91,6 +93,16 @@ export default function EntryRow({
       record_label: draft.record_label.trim(),
     };
     if (!trimmed.track_title) return;
+    // Classic has no queue — every row this edits is already posted, so the
+    // artist is refused unconditionally, matching the flowsheet-write rule
+    // in flowsheetArtistRejection. Checked before onUpdate, not inside it,
+    // so a refusal leaves the row in edit mode for the same reason the
+    // empty-track_title check above does.
+    const rejection = flowsheetArtistRejection(trimmed.artist_name);
+    if (rejection) {
+      toast.error(rejection);
+      return;
+    }
     onUpdate(entry.id, {
       ...trimmed,
       request_flag: draft.request_flag,

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
+import { flowsheetArtistRejection } from "@/lib/features/flowsheet/various-artists-guard";
 import { useFlowsheetActions, useLiveStatus } from "@/src/hooks/flowsheetHooks";
 import { toTitleCase } from "@/src/utilities/stringutilities";
 import { Box, IconButton, Tooltip, Typography, TypographyProps } from "@mui/joy";
 import { CheckRounded, EditOutlined } from "@mui/icons-material";
 import { ClickAwayListener } from "@mui/base/ClickAwayListener";
 import { useCallback, useEffect, useState, type FormEvent } from "react";
+import { toast } from "sonner";
 import { useAppDispatch } from "@/lib/hooks";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 
@@ -52,22 +54,36 @@ export default function FlowsheetEntryField({
   const saveAndClose = useCallback(
     (e: MouseEvent | TouchEvent | FormEvent<HTMLFormElement>) => {
       e.preventDefault();
-      setEditing(false);
 
       if (queue) {
+        setEditing(false);
         dispatch(flowsheetSlice.actions.updateQueueEntry({
           entry_id: entry.id,
           field: name,
           value: value,
         }));
-      } else {
-        updateFlowsheet({
-          entry_id: entry.id,
-          data: {
-            [name]: value,
-          },
-        });
+        return;
       }
+
+      // A blank artist is a queue-only escape hatch (branch above); a posted
+      // row is the permanent record, so this field alone must refuse both
+      // blank and a compilation credit. Checked before setEditing(false) so
+      // a refusal leaves the input open with the DJ's typed value intact.
+      if (name === "artist_name") {
+        const rejection = flowsheetArtistRejection(value);
+        if (rejection) {
+          toast.error(rejection);
+          return;
+        }
+      }
+
+      setEditing(false);
+      updateFlowsheet({
+        entry_id: entry.id,
+        data: {
+          [name]: value,
+        },
+      });
     },
     [entry, value, queue, name, dispatch, updateFlowsheet]
   );

--- a/src/components/experiences/modern/flowsheet/Entries/SongEntry/MobileSongEntry.tsx
+++ b/src/components/experiences/modern/flowsheet/Entries/SongEntry/MobileSongEntry.tsx
@@ -2,6 +2,7 @@
 
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
+import { flowsheetArtistRejection } from "@/lib/features/flowsheet/various-artists-guard";
 import { useAppDispatch } from "@/lib/hooks";
 import { useFlowsheetActions, useShowControl } from "@/src/hooks/flowsheetHooks";
 import { useFlowsheetMoveContext } from "@/src/components/experiences/modern/flowsheet/Entries/dragContext";
@@ -27,6 +28,7 @@ import {
   Typography,
 } from "@mui/joy";
 import { memo, useEffect, useState } from "react";
+import { toast } from "sonner";
 import RemoveButton from "../Components/RemoveButton";
 import FlowsheetEntryField from "./FlowsheetEntryField";
 import SongEntryControls from "./SongEntryControls";
@@ -120,10 +122,22 @@ const MobileSongEntry = memo(function MobileSongEntry({
           })
         )
       );
-    } else {
-      // One call carries all four fields.
-      updateFlowsheet({ entry_id: entry.id, data: { ...draft } });
+      setEditing(false);
+      return;
     }
+
+    // Posted entries are the permanent record: refuse before the combined
+    // write, or a rejected artist would still carry the other three fields
+    // through. Checked before setEditing(false) so refusal leaves the draft
+    // open for the DJ to fix rather than discarding it.
+    const rejection = flowsheetArtistRejection(draft.artist_name);
+    if (rejection) {
+      toast.error(rejection);
+      return;
+    }
+
+    // One call carries all four fields.
+    updateFlowsheet({ entry_id: entry.id, data: { ...draft } });
     setEditing(false);
   };
 

--- a/tests/integration/components/classic/flowsheet/EntryRow.test.tsx
+++ b/tests/integration/components/classic/flowsheet/EntryRow.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, screen } from "@testing-library/react";
 import { renderWithProviders } from "@/tests/helpers/render";
 import { createTestFlowsheetEntry } from "@/tests/helpers";
@@ -7,7 +7,16 @@ import type {
   FlowsheetEntry,
   UpdateRequestBody,
 } from "@/lib/features/flowsheet/types";
+import {
+  MISSING_ARTIST_REJECTION_MESSAGE,
+  VARIOUS_ARTISTS_REJECTION_MESSAGE,
+} from "@/lib/features/flowsheet/various-artists-guard";
 import EntryRow from "@/src/components/experiences/classic/flowsheet/EntryRow";
+
+const toastErrorMock = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => toastErrorMock(...args) },
+}));
 
 // renderInTable wraps EntryRow in a <table><tbody> so the row's <td> elements
 // are mounted in a valid layout context (RTL otherwise warns).
@@ -702,5 +711,79 @@ describe("Classic EntryRow action menu + inline edit (song rows)", () => {
     expect(
       screen.queryByRole("button", { name: /actions/i })
     ).toBeNull();
+  });
+});
+
+// Classic has no queue — every row EntryRow edits is already posted to the
+// permanent flowsheet, so the artist guard applies unconditionally on Save.
+describe("Classic EntryRow artist guard on save (posted entries only, no queue)", () => {
+  const baseEntry = () =>
+    createTestFlowsheetEntry({
+      id: 40,
+      artist_name: "Cat Power",
+      track_title: "Metal Heart",
+      album_title: "Moon Pix",
+      record_label: "Matador",
+      request_flag: false,
+    });
+
+  beforeEach(() => {
+    toastErrorMock.mockClear();
+  });
+
+  function editArtistAndSave(container: HTMLElement, artistValue: string) {
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }));
+    fireEvent.click(screen.getByText("Edit"));
+    fireEvent.change(
+      container.querySelector('input[name="artist_name"]') as HTMLInputElement,
+      { target: { value: artistValue } }
+    );
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+  }
+
+  it.each(["Various Artists", "V/A", "VA"])(
+    "refuses saving the artist as %s and leaves the row in edit mode",
+    (artist) => {
+      const onUpdate = vi.fn();
+      const { container } = renderRow({ entry: baseEntry(), onUpdate });
+
+      editArtistAndSave(container, artist);
+
+      expect(onUpdate).not.toHaveBeenCalled();
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        VARIOUS_ARTISTS_REJECTION_MESSAGE
+      );
+      expect(container.querySelector('input[name="artist_name"]')).not.toBeNull();
+    }
+  );
+
+  it.each(["", "   "])(
+    "refuses saving a blank artist (%j) and leaves the row in edit mode",
+    (artist) => {
+      const onUpdate = vi.fn();
+      const { container } = renderRow({ entry: baseEntry(), onUpdate });
+
+      editArtistAndSave(container, artist);
+
+      expect(onUpdate).not.toHaveBeenCalled();
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        MISSING_ARTIST_REJECTION_MESSAGE
+      );
+      expect(container.querySelector('input[name="artist_name"]')).not.toBeNull();
+    }
+  );
+
+  it("saves normally and exits edit mode when the artist is a real performer", () => {
+    const onUpdate = vi.fn();
+    const { container } = renderRow({ entry: baseEntry(), onUpdate });
+
+    editArtistAndSave(container, "Chuquimamani-Condori");
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      40,
+      expect.objectContaining({ artist_name: "Chuquimamani-Condori" })
+    );
+    expect(toastErrorMock).not.toHaveBeenCalled();
+    expect(container.querySelector('input[name="artist_name"]')).toBeNull();
   });
 });

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers";
 import FlowsheetEntryField from "@/src/components/experiences/modern/flowsheet/Entries/SongEntry/FlowsheetEntryField";
 import { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
+import {
+  MISSING_ARTIST_REJECTION_MESSAGE,
+  VARIOUS_ARTISTS_REJECTION_MESSAGE,
+} from "@/lib/features/flowsheet/various-artists-guard";
 
 // Mock hooks
 const mockUseLiveStatus = vi.fn();
@@ -31,6 +36,11 @@ vi.mock("@/lib/features/flowsheet/frontend", () => ({
 
 vi.mock("@/src/utilities/stringutilities", () => ({
   toTitleCase: (str: string) => str.charAt(0).toUpperCase() + str.slice(1),
+}));
+
+const toastErrorMock = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => toastErrorMock(...args) },
 }));
 
 describe("FlowsheetEntryField", () => {
@@ -726,6 +736,126 @@ describe("FlowsheetEntryField", () => {
           artist_name: "API Artist",
         },
       });
+    });
+  });
+
+  // FlowsheetEntryField is shared by queue rows and posted rows (`canEdit =
+  // editable && live`). A blank artist is a deliberate escape hatch on a
+  // queue row — the mail bin's refusal redirects here — so the guard below
+  // must apply only to the non-queue (posted) branch.
+  describe("Posted-row artist guard (queue rows stay unguarded)", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockUseLiveStatus.mockReturnValue({ live: true });
+      mockUseFlowsheet.mockReturnValue({ updateFlowsheet: mockUpdateFlowsheet });
+    });
+
+    function editAndSubmit(entry: FlowsheetSongEntry, queue: boolean, value: string) {
+      renderWithProviders(
+        <FlowsheetEntryField
+          entry={entry}
+          name="artist_name"
+          label="artist"
+          queue={queue}
+          playing={false}
+          editable={true}
+        />
+      );
+      fireEvent.doubleClick(screen.getByText(entry.artist_name));
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value } });
+      fireEvent.submit(input.closest("form")!);
+    }
+
+    it.each(["Various Artists", "V/A", "VA"])(
+      "refuses editing a posted entry's artist to %s",
+      (artist) => {
+        editAndSubmit(mockEntry, false, artist);
+
+        expect(mockUpdateFlowsheet).not.toHaveBeenCalled();
+        expect(toastErrorMock).toHaveBeenCalledWith(
+          VARIOUS_ARTISTS_REJECTION_MESSAGE
+        );
+        // The field stays in edit mode so the DJ can fix the typed value.
+        expect(screen.getByRole("textbox")).toHaveValue(artist);
+      }
+    );
+
+    it.each(["", "   "])(
+      "refuses editing a posted entry's artist to blank (%j)",
+      (artist) => {
+        editAndSubmit(mockEntry, false, artist);
+
+        expect(mockUpdateFlowsheet).not.toHaveBeenCalled();
+        expect(toastErrorMock).toHaveBeenCalledWith(
+          MISSING_ARTIST_REJECTION_MESSAGE
+        );
+        expect(screen.getByRole("textbox")).toBeInTheDocument();
+      }
+    );
+
+    it("still blanks a queue row's artist (the mail bin escape hatch)", async () => {
+      const { flowsheetSlice } = await import(
+        "@/lib/features/flowsheet/frontend"
+      );
+
+      editAndSubmit(mockEntry, true, "");
+
+      expect(flowsheetSlice.actions.updateQueueEntry).toHaveBeenCalledWith({
+        entry_id: 1,
+        field: "artist_name",
+        value: "",
+      });
+      expect(mockUpdateFlowsheet).not.toHaveBeenCalled();
+      expect(toastErrorMock).not.toHaveBeenCalled();
+    });
+
+    it("still accepts a compilation-credit string on a queue row", async () => {
+      const { flowsheetSlice } = await import(
+        "@/lib/features/flowsheet/frontend"
+      );
+
+      editAndSubmit(mockEntry, true, "Various Artists");
+
+      expect(flowsheetSlice.actions.updateQueueEntry).toHaveBeenCalledWith({
+        entry_id: 1,
+        field: "artist_name",
+        value: "Various Artists",
+      });
+      expect(toastErrorMock).not.toHaveBeenCalled();
+    });
+
+    it("does not apply the artist guard to a blank song title", () => {
+      renderWithProviders(
+        <FlowsheetEntryField
+          entry={mockEntry}
+          name="track_title"
+          label="track"
+          queue={false}
+          playing={false}
+          editable={true}
+        />
+      );
+      fireEvent.doubleClick(screen.getByText("Test Track"));
+      const input = screen.getByRole("textbox");
+      fireEvent.change(input, { target: { value: "" } });
+      fireEvent.submit(input.closest("form")!);
+
+      expect(mockUpdateFlowsheet).toHaveBeenCalledWith({
+        entry_id: 1,
+        data: { track_title: "" },
+      });
+      expect(toastErrorMock).not.toHaveBeenCalled();
+    });
+
+    it("saves normally when the posted entry's artist is a real performer", () => {
+      editAndSubmit(mockEntry, false, "Duke Ellington & John Coltrane");
+
+      expect(mockUpdateFlowsheet).toHaveBeenCalledWith({
+        entry_id: 1,
+        data: { artist_name: "Duke Ellington & John Coltrane" },
+      });
+      expect(toastErrorMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/MobileSongEntry.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/MobileSongEntry.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { FlowsheetSongEntry } from "@/lib/features/flowsheet/types";
+import {
+  MISSING_ARTIST_REJECTION_MESSAGE,
+  VARIOUS_ARTISTS_REJECTION_MESSAGE,
+} from "@/lib/features/flowsheet/various-artists-guard";
 import { FlowsheetMoveContext } from "@/src/components/experiences/modern/flowsheet/Entries/dragContext";
 import MobileSongEntry from "@/src/components/experiences/modern/flowsheet/Entries/SongEntry/MobileSongEntry";
 import { createTestFlowsheetEntry, renderWithProviders } from "@/tests/helpers";
@@ -9,14 +13,21 @@ const mockUseShowControl = vi.fn(() => ({
   live: true,
   currentShow: 100,
 }));
+const mockUpdateFlowsheet = vi.fn();
+const mockDispatch = vi.fn();
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
   useShowControl: () => mockUseShowControl(),
-  useFlowsheetActions: () => ({ updateFlowsheet: vi.fn() }),
+  useFlowsheetActions: () => ({ updateFlowsheet: mockUpdateFlowsheet }),
 }));
 
 vi.mock("@/lib/hooks", () => ({
-  useAppDispatch: () => vi.fn(),
+  useAppDispatch: () => mockDispatch,
+}));
+
+const toastErrorMock = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => toastErrorMock(...args) },
 }));
 
 vi.mock("@/src/components/experiences/modern/flowsheet/Entries/SongEntry/usePlayNow", () => ({
@@ -166,5 +177,95 @@ describe("MobileSongEntry discogsUnavailable artwork gate", () => {
     expect(
       await screen.findByText("embargoed until 2026-09-01")
     ).toBeInTheDocument();
+  });
+});
+
+// saveAll carries all four fields in one call, so a rejected artist has to
+// block the whole write, not just the artist field. The escape hatch that
+// lets a queue row's artist stay blank lives in the `queue` branch above
+// this guard, so it must not be reachable through it.
+describe("MobileSongEntry save-all artist guard", () => {
+  const FIELD_ORDER = ["track_title", "artist_name", "album_title", "record_label"];
+
+  const entry = (overrides: Partial<FlowsheetSongEntry> = {}) =>
+    createTestFlowsheetEntry({
+      id: 50,
+      show_id: 100,
+      track_title: "Metal Heart",
+      artist_name: "Cat Power",
+      album_title: "Moon Pix",
+      record_label: "Matador",
+      request_flag: false,
+      ...overrides,
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseShowControl.mockReturnValue({ live: true, currentShow: 100 });
+  });
+
+  function editArtistAndSave(props: Partial<Parameters<typeof MobileSongEntry>[0]>, artistValue: string) {
+    renderWithProviders(
+      <FlowsheetMoveContext.Provider value={{ moveEntry: mockMoveEntry }}>
+        <MobileSongEntry entry={entry()} playing={false} queue={false} {...props} />
+      </FlowsheetMoveContext.Provider>
+    );
+    fireEvent.click(screen.getByLabelText("Edit entry"));
+    const artistInput = screen.getAllByRole("textbox")[FIELD_ORDER.indexOf("artist_name")];
+    fireEvent.change(artistInput, { target: { value: artistValue } });
+    fireEvent.click(screen.getByLabelText("Save entry"));
+  }
+
+  it.each(["Various Artists", "V/A", "VA"])(
+    "refuses saving a posted entry's artist as %s",
+    (artist) => {
+      editArtistAndSave({ queue: false }, artist);
+
+      expect(mockUpdateFlowsheet).not.toHaveBeenCalled();
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        VARIOUS_ARTISTS_REJECTION_MESSAGE
+      );
+      // Still in edit mode — the Save control, not the Edit control, is present.
+      expect(screen.getByLabelText("Save entry")).toBeInTheDocument();
+    }
+  );
+
+  it.each(["", "   "])(
+    "refuses saving a posted entry with a blank artist (%j)",
+    (artist) => {
+      editArtistAndSave({ queue: false }, artist);
+
+      expect(mockUpdateFlowsheet).not.toHaveBeenCalled();
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        MISSING_ARTIST_REJECTION_MESSAGE
+      );
+      expect(screen.getByLabelText("Save entry")).toBeInTheDocument();
+    }
+  );
+
+  it("saves normally when the posted entry's artist is a real performer", () => {
+    editArtistAndSave({ queue: false }, "Jessica Pratt");
+
+    expect(mockUpdateFlowsheet).toHaveBeenCalledWith({
+      entry_id: 50,
+      data: expect.objectContaining({ artist_name: "Jessica Pratt" }),
+    });
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("still blanks a queue row's artist (the mail bin escape hatch)", async () => {
+    const { flowsheetSlice } = await import("@/lib/features/flowsheet/frontend");
+
+    editArtistAndSave({ queue: true }, "");
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      flowsheetSlice.actions.updateQueueEntry({
+        entry_id: 50,
+        field: "artist_name",
+        value: "",
+      })
+    );
+    expect(mockUpdateFlowsheet).not.toHaveBeenCalled();
+    expect(toastErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntryControls.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Entries/SongEntry/SongEntryControls.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithProviders, createTestFlowsheetEntry } from "@/tests/helpers";
+import SongEntryControls from "@/src/components/experiences/modern/flowsheet/Entries/SongEntry/SongEntryControls";
+
+const mockUpdateFlowsheet = vi.fn();
+const mockRemoveFromQueue = vi.fn();
+const mockRemoveFromFlowsheet = vi.fn();
+
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useFlowsheetActions: () => ({
+    updateFlowsheet: mockUpdateFlowsheet,
+    removeFromQueue: mockRemoveFromQueue,
+    removeFromFlowsheet: mockRemoveFromFlowsheet,
+  }),
+}));
+
+const toastErrorMock = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (...args: unknown[]) => toastErrorMock(...args) },
+}));
+
+// SongEntryControls' commit() only ever carries "segue" or "request_flag" —
+// its own type signature makes an artist_name payload unreachable, so the
+// artist guard added to the other flowsheet-write call sites has nothing to
+// check here. These tests pin that: the checkbox commits keep working
+// unmodified, and never trip the guard's toast.
+describe("SongEntryControls segue/request commits (unaffected by the artist guard)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const entry = () =>
+    createTestFlowsheetEntry({
+      id: 60,
+      artist_name: "Stereolab",
+      track_title: "Miss Modular",
+      album_title: "Dots and Loops",
+      record_label: "Duophonic",
+      segue: false,
+      request_flag: false,
+    });
+
+  it("commits a segue toggle straight through updateFlowsheet on a posted entry", () => {
+    renderWithProviders(
+      <SongEntryControls entry={entry()} queue={false} editable={true} />
+    );
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Segue from previous track" })
+    );
+
+    expect(mockUpdateFlowsheet).toHaveBeenCalledWith({
+      entry_id: 60,
+      data: { segue: true },
+    });
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("commits a request toggle straight through updateFlowsheet on a posted entry", () => {
+    renderWithProviders(
+      <SongEntryControls entry={entry()} queue={false} editable={true} />
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Requested track" }));
+
+    expect(mockUpdateFlowsheet).toHaveBeenCalledWith({
+      entry_id: 60,
+      data: { request_flag: true },
+    });
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("routes a segue toggle to the queue reducer instead of updateFlowsheet when queued", () => {
+    renderWithProviders(
+      <SongEntryControls entry={entry()} queue={true} editable={true} />
+    );
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Segue from previous track" })
+    );
+
+    expect(mockUpdateFlowsheet).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`updateFlowsheet` was the last flowsheet writer with no artist guard — a DJ could edit a posted entry's artist cell to a compilation credit ("Various Artists", "V/A", "VA") or to blank, and it would write straight through to the permanent record. This closes that gap using the existing `flowsheetArtistRejection` predicate from `lib/features/flowsheet/various-artists-guard.ts`, in both experiences.

Guards are placed where each surface commits the field edit, not inside the RTK Query mutation:
- Classic: `EntryRow.tsx` `saveEdit()` — classic has no queue, so every row it edits is already posted; the guard applies unconditionally.
- Modern: `FlowsheetEntryField.tsx` `saveAndClose()` and `MobileSongEntry.tsx` `saveAll()` — both are shared by queue rows and posted rows, so the guard applies only on the non-queue branch. A blank artist stays legal on a queue row, preserving the mail-bin escape hatch where a refused compilation credit redirects the DJ to queue the release blank and name the performer in the editable cell afterward.

The ticket also named `SongEntryControls.tsx:47` as an unguarded call site. Its `commit()` function's type signature restricts the field to `"segue" | "request_flag"` — it can never carry an `artist_name` payload, so no guard applies there. A test pins this so the type-level guarantee has a behavioral backstop.

## Test plan

- [x] `npx tsc --noEmit` — exit 0
- [x] `npm run lint` — 0 errors, 197 warnings (baseline)
- [x] Targeted flowsheet suite (`tests/integration/components/modern/flowsheet/Entries/SongEntry/`, `tests/integration/components/classic/flowsheet/`) — 278/278 passing
- [x] Editing a posted entry's artist to "Various Artists" / "V/A" / "VA" is refused, in classic and modern
- [x] Editing a posted entry's artist to blank is refused, in classic and modern
- [x] Blanking a queue row's artist still works (regression guard for the mail-bin escape hatch)
- [x] Unit tests for each real call site (`EntryRow`, `FlowsheetEntryField`, `MobileSongEntry`, `SongEntryControls`)
- [x] Refusal copy comes from `various-artists-guard.ts`, not a new literal

Touches `frontend.ts`-adjacent flowsheet files and may need a rebase against sibling PRs for #1126/#1128.

Closes #1125
