### PR TITLE
fix(flowsheet): carry linkage provenance on queue entries instead of inferring it

### DIFF
--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -200,6 +200,22 @@ export const flowsheetSlice = createAppSlice({
     },
     addToQueue: (state, action: PayloadAction<FlowsheetQuery>) => {
       const newId = state.queueIdCounter;
+      // Captured once here, the way selectionProvided is captured once at
+      // freeze time — never re-derived from the field's rolling value later,
+      // or a second edit would misread its own first character as
+      // "supplied". A linked row always carries an artist column (every
+      // producer of this payload — convertBinToQueue, the rotation picker,
+      // the searchbar's queue submit — withholds album_id itself whenever
+      // the release can't supply one), so artist_name is unconditionally
+      // provided here; album_title/record_label reflect whether the release
+      // actually seeded a value.
+      const linkageProvided = hasLinkedAlbumId(action.payload.album_id)
+        ? {
+            artist_name: true,
+            album_title: action.payload.album !== "" && action.payload.album !== undefined,
+            record_label: action.payload.label !== "" && action.payload.label !== undefined,
+          }
+        : undefined;
       state.queue.push(
         withSanitizedAlbumLinkage({
           id: newId,
@@ -214,6 +230,7 @@ export const flowsheetSlice = createAppSlice({
           rotation: action.payload.rotation_bin,
           rotation_id: action.payload.rotation_id,
           album_id: action.payload.album_id,
+          linkageProvided,
         })
       );
       state.queueIdCounter += 1;
@@ -238,27 +255,32 @@ export const flowsheetSlice = createAppSlice({
       if (entry) {
         const previous = entry[action.payload.field];
         (entry as any)[action.payload.field] = action.payload.value;
-        // Same deviation rule the searchbar applies in setSearchProperty:
-        // once the DJ edits a field the linked library row supplied, that
-        // linkage no longer describes the entry and must not ride the wire,
-        // because BS's album_id branch spreads the library row over the
-        // request and would hand the replaced value straight back. This is
-        // the only place a queued entry's credit can be corrected, so
-        // without it a Various-Artists row rehydrated from storage silently
-        // discards the performer the DJ just typed.
+        // Same deviation rule the searchbar applies in setSearchProperty,
+        // judged against linkageProvided (captured once when the row was
+        // queued) rather than the rolling value: once the DJ edits a field
+        // the linked library row supplied, that linkage no longer describes
+        // the entry and must not ride the wire, because BS's album_id
+        // branch spreads the library row over the request and would hand
+        // the replaced value straight back. This is the only place a
+        // queued entry's credit can be corrected, so without it a
+        // Various-Artists row rehydrated from storage silently discards the
+        // performer the DJ just typed.
         //
         // Filling a field the row left EMPTY is added data, not a deviation
         // — the linkage still describes the entry and survives, exactly as
-        // it does in the searchbar. The artist is the exception: a linked
-        // row always carries a credit, so a blank artist there means the
-        // conversion withheld one, and naming the performer corrects that
-        // row rather than adding to it.
-        const supplied =
-          action.payload.field === "artist_name" ||
-          (previous !== "" && previous !== undefined);
+        // it does in the searchbar. A row with no linkageProvided (queued
+        // before this field existed) reads as fully provided: losing the
+        // linkage on that edit is safer than letting a stale linkage
+        // overwrite the DJ's correction.
+        const provided =
+          entry.linkageProvided?.[
+            action.payload.field as keyof NonNullable<
+              FlowsheetSongEntry["linkageProvided"]
+            >
+          ] ?? true;
         if (
           ALBUM_SCOPED_QUEUE_FIELDS.includes(action.payload.field) &&
-          supplied &&
+          provided &&
           previous !== action.payload.value
         ) {
           entry.album_id = undefined;

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -1,6 +1,13 @@
 import { createAppSlice } from "@/lib/createAppSlice";
 import { PayloadAction } from "@reduxjs/toolkit";
-import { FlowsheetFrontendState, FlowsheetQuery, FlowsheetSearchProperty, FlowsheetSongEntry } from "./types";
+import {
+  ALBUM_SCOPED_QUEUE_FIELDS,
+  AlbumScopedQueueField,
+  FlowsheetFrontendState,
+  FlowsheetQuery,
+  FlowsheetSearchProperty,
+  FlowsheetSongEntry,
+} from "./types";
 import { Rotation } from "../rotation/types";
 import { hasLinkedAlbumId } from "./linkage";
 import { clearQueueFromStorage, loadQueueFromStorage, saveQueueToStorage } from "./queue-storage";
@@ -35,14 +42,13 @@ function withSanitizedAlbumLinkage<
   };
 }
 
-// The fields a linked library row supplies. Editing one of these on a queued
-// entry deviates from that row; editing anything else (track title, request,
-// segue) does not, since the row never claimed to describe them.
-const ALBUM_SCOPED_QUEUE_FIELDS: readonly (keyof FlowsheetSongEntry)[] = [
-  "artist_name",
-  "album_title",
-  "record_label",
-];
+// Array.includes can't narrow on its own, and this is the only thing standing
+// between the payload's field name and a typed linkageProvided lookup.
+function isAlbumScopedField(
+  field: keyof FlowsheetSongEntry
+): field is AlbumScopedQueueField {
+  return (ALBUM_SCOPED_QUEUE_FIELDS as readonly string[]).includes(field);
+}
 
 export const defaultFlowsheetFrontendState: FlowsheetFrontendState = {
   autoplay: false,
@@ -200,20 +206,16 @@ export const flowsheetSlice = createAppSlice({
     },
     addToQueue: (state, action: PayloadAction<FlowsheetQuery>) => {
       const newId = state.queueIdCounter;
-      // Captured once here, the way selectionProvided is captured once at
-      // freeze time — never re-derived from the field's rolling value later,
-      // or a second edit would misread its own first character as
-      // "supplied". A linked row always carries an artist column (every
-      // producer of this payload — convertBinToQueue, the rotation picker,
-      // the searchbar's queue submit — withholds album_id itself whenever
-      // the release can't supply one), so artist_name is unconditionally
-      // provided here; album_title/record_label reflect whether the release
-      // actually seeded a value.
+      // A linked row always carries an artist column — every producer of this
+      // payload (convertBinToQueue, the rotation picker, the searchbar's queue
+      // submit) withholds album_id itself whenever the release can't supply
+      // one — so artist_name is unconditionally provided here.
+      // album_title/record_label reflect whether the release seeded a value.
       const linkageProvided = hasLinkedAlbumId(action.payload.album_id)
         ? {
             artist_name: true,
-            album_title: action.payload.album !== "" && action.payload.album !== undefined,
-            record_label: action.payload.label !== "" && action.payload.label !== undefined,
+            album_title: action.payload.album !== "",
+            record_label: action.payload.label !== "",
           }
         : undefined;
       state.queue.push(
@@ -255,32 +257,21 @@ export const flowsheetSlice = createAppSlice({
       if (entry) {
         const previous = entry[action.payload.field];
         (entry as any)[action.payload.field] = action.payload.value;
-        // Same deviation rule the searchbar applies in setSearchProperty,
-        // judged against linkageProvided (captured once when the row was
-        // queued) rather than the rolling value: once the DJ edits a field
-        // the linked library row supplied, that linkage no longer describes
-        // the entry and must not ride the wire, because BS's album_id
-        // branch spreads the library row over the request and would hand
-        // the replaced value straight back. This is the only place a
-        // queued entry's credit can be corrected, so without it a
+        // The deviation rule setSearchProperty applies to the searchbar,
+        // judged against linkageProvided rather than the rolling value: once
+        // the DJ edits a field the linked library row supplied, that linkage
+        // no longer describes the entry and must not ride the wire, because
+        // BS's album_id branch spreads the library row over the request and
+        // would hand the replaced value straight back. This is the only place
+        // a queued entry's credit can be corrected, so without it a
         // Various-Artists row rehydrated from storage silently discards the
         // performer the DJ just typed.
         //
-        // Filling a field the row left EMPTY is added data, not a deviation
-        // — the linkage still describes the entry and survives, exactly as
-        // it does in the searchbar. A row with no linkageProvided (queued
-        // before this field existed) reads as fully provided: losing the
-        // linkage on that edit is safer than letting a stale linkage
-        // overwrite the DJ's correction.
-        const provided =
-          entry.linkageProvided?.[
-            action.payload.field as keyof NonNullable<
-              FlowsheetSongEntry["linkageProvided"]
-            >
-          ] ?? true;
+        // Filling a field the row left EMPTY is added data, not a deviation —
+        // the linkage still describes the entry and survives.
         if (
-          ALBUM_SCOPED_QUEUE_FIELDS.includes(action.payload.field) &&
-          provided &&
+          isAlbumScopedField(action.payload.field) &&
+          (entry.linkageProvided?.[action.payload.field] ?? true) &&
           previous !== action.payload.value
         ) {
           entry.album_id = undefined;

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -76,7 +76,22 @@ export type FlowsheetSongBase = {
   discogsUnavailableNote?: string | null;
 };
 
-export type FlowsheetSongEntry = FlowsheetEntryBase & FlowsheetSongBase;
+export type FlowsheetSongEntry = FlowsheetEntryBase &
+  FlowsheetSongBase & {
+    // Which of this row's album-scoped fields the linked release supplied,
+    // captured once when the row entered the queue — mirrors the search
+    // state's selectionProvided, keyed on the queue entry's own field names
+    // (see ALBUM_SCOPED_QUEUE_FIELDS) so the reducer needs no name mapping.
+    // Absent on rows persisted before this field existed; updateQueueEntry
+    // reads that absence as fully provided, since losing album_id on a
+    // rehydrated edit is safer than a stale linkage overwriting the DJ's
+    // correction.
+    linkageProvided?: {
+      artist_name: boolean;
+      album_title: boolean;
+      record_label: boolean;
+    };
+  };
 
 export type FlowsheetShowBlockEntry = FlowsheetEntryBase &
   DateTimeEntry & {

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -76,21 +76,35 @@ export type FlowsheetSongBase = {
   discogsUnavailableNote?: string | null;
 };
 
+// The fields a linked library row supplies. Editing one of these on a queued
+// entry deviates from that row; editing anything else (track title, request,
+// segue) does not, since the row never claimed to describe them.
+//
+// `satisfies` against FlowsheetSongBase rather than FlowsheetSongEntry: the
+// entry type derives linkageProvided's keys from this tuple, so checking
+// against it would be circular.
+export const ALBUM_SCOPED_QUEUE_FIELDS = [
+  "artist_name",
+  "album_title",
+  "record_label",
+] as const satisfies readonly (keyof FlowsheetSongBase)[];
+
+export type AlbumScopedQueueField = (typeof ALBUM_SCOPED_QUEUE_FIELDS)[number];
+
 export type FlowsheetSongEntry = FlowsheetEntryBase &
   FlowsheetSongBase & {
     // Which of this row's album-scoped fields the linked release supplied,
-    // captured once when the row entered the queue — mirrors the search
-    // state's selectionProvided, keyed on the queue entry's own field names
-    // (see ALBUM_SCOPED_QUEUE_FIELDS) so the reducer needs no name mapping.
-    // Absent on rows persisted before this field existed; updateQueueEntry
-    // reads that absence as fully provided, since losing album_id on a
-    // rehydrated edit is safer than a stale linkage overwriting the DJ's
-    // correction.
-    linkageProvided?: {
-      artist_name: boolean;
-      album_title: boolean;
-      record_label: boolean;
-    };
+    // captured once when the row entered the queue and never re-derived from
+    // the field's rolling value, or a second edit would misread its own first
+    // keystroke as "supplied".
+    //
+    // Absent on rows persisted to localStorage before this field existed, and
+    // updateQueueEntry reads that absence as fully provided: losing album_id
+    // on a rehydrated edit is safer than a stale linkage overwriting the DJ's
+    // correction. That default is the one place this diverges from the search
+    // state's selectionProvided, which is never persisted and so can treat
+    // absence as "nothing is selected".
+    linkageProvided?: Record<AlbumScopedQueueField, boolean>;
   };
 
 export type FlowsheetShowBlockEntry = FlowsheetEntryBase &

--- a/tests/unit/lib/features/flowsheet/flowsheet.test.ts
+++ b/tests/unit/lib/features/flowsheet/flowsheet.test.ts
@@ -520,6 +520,53 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       });
     });
 
+    // Captured once at queue time, the way selectionProvided is captured
+    // once at freeze time — updateQueueEntry reads this snapshot instead of
+    // re-deriving "supplied" from the field's rolling value.
+    describe("addToQueue linkageProvided", () => {
+      it("marks every album-scoped field provided when the linked release supplied all three", () => {
+        const result = harness().reduce(
+          actions.addToQueue(
+            createTestFlowsheetQuery({
+              album_id: 1001,
+              artist: "Jessica Pratt",
+              album: "On Your Own Love Again",
+              label: "Drag City",
+            })
+          )
+        );
+        expect(result.queue[0].linkageProvided).toEqual({
+          artist_name: true,
+          album_title: true,
+          record_label: true,
+        });
+      });
+
+      it("marks record_label not provided when the linked release left it blank", () => {
+        const result = harness().reduce(
+          actions.addToQueue(createTestFlowsheetQuery({ album_id: 1001, label: "" }))
+        );
+        expect(result.queue[0].linkageProvided?.record_label).toBe(false);
+      });
+
+      // A linked release always carries an artist column; a blank string
+      // here means its credit is withheld, not that the release never
+      // supplied one — so artist_name is provided regardless.
+      it("marks artist_name provided even when the linked release withholds its credit", () => {
+        const result = harness().reduce(
+          actions.addToQueue(createTestFlowsheetQuery({ album_id: 1001, artist: "" }))
+        );
+        expect(result.queue[0].linkageProvided?.artist_name).toBe(true);
+      });
+
+      it("leaves linkageProvided unset for an unlinked entry", () => {
+        const result = harness().reduce(
+          actions.addToQueue(createTestFlowsheetQuery({ album_id: undefined }))
+        );
+        expect(result.queue[0].linkageProvided).toBeUndefined();
+      });
+    });
+
     it("should remove item from queue", () => {
       const query = createTestFlowsheetQuery();
       const withItem = harness().reduce(actions.addToQueue(query));
@@ -719,6 +766,88 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
 
       expect(result.queue[0].record_label).toBe("Drag City");
       expect(result.queue[0].album_id).toBe(1001);
+    });
+
+    // linkageProvided is captured once when the row is queued, not
+    // re-derived from the field's rolling value — a second edit of a field
+    // the release left empty must not misread its own first character as
+    // "supplied" and drop a linkage that never deviated.
+    it("keeps album_id when a field the library row left empty is edited twice", () => {
+      const withItem = harness().reduce(
+        actions.addToQueue(createTestFlowsheetQuery({ album_id: 1001, label: "" }))
+      );
+      const firstEdit = harness().reduce(
+        actions.updateQueueEntry({
+          entry_id: withItem.queue[0].id,
+          field: "record_label",
+          value: "Drag City",
+        }),
+        withItem
+      );
+      expect(firstEdit.queue[0].album_id).toBe(1001);
+
+      const secondEdit = harness().reduce(
+        actions.updateQueueEntry({
+          entry_id: firstEdit.queue[0].id,
+          field: "record_label",
+          value: "Sonamos",
+        }),
+        firstEdit
+      );
+
+      expect(secondEdit.queue[0].record_label).toBe("Sonamos");
+      expect(secondEdit.queue[0].album_id).toBe(1001);
+    });
+
+    describe("linkageProvided rehydration default", () => {
+      // FlowsheetSongEntry is persisted to localStorage, so a row queued
+      // before linkageProvided existed rehydrates without it. The default
+      // must read as fully provided: losing album_id on that edit is safer
+      // than letting a stale linkage overwrite the DJ's correction.
+      it("drops album_id on an album-scoped edit for a rehydrated entry with no linkageProvided, even though the edited field was empty", () => {
+        const rehydrated = createTestFlowsheetEntry({
+          id: 1,
+          album_id: 1001,
+          record_label: "",
+        });
+        mockedLoadQueue.mockReturnValueOnce([rehydrated]);
+        const loaded = harness().reduce(actions.loadQueue());
+        expect(loaded.queue[0].linkageProvided).toBeUndefined();
+
+        const result = harness().reduce(
+          actions.updateQueueEntry({
+            entry_id: loaded.queue[0].id,
+            field: "record_label",
+            value: "Sonamos",
+          }),
+          loaded
+        );
+
+        expect(result.queue[0].record_label).toBe("Sonamos");
+        expect(result.queue[0].album_id).toBeUndefined();
+      });
+
+      it("drops album_id when correcting a rehydrated entry's withheld artist", () => {
+        const rehydrated = createTestFlowsheetEntry({
+          id: 1,
+          album_id: 1001,
+          artist_name: "",
+        });
+        mockedLoadQueue.mockReturnValueOnce([rehydrated]);
+        const loaded = harness().reduce(actions.loadQueue());
+
+        const result = harness().reduce(
+          actions.updateQueueEntry({
+            entry_id: loaded.queue[0].id,
+            field: "artist_name",
+            value: "Chuquimamani-Condori",
+          }),
+          loaded
+        );
+
+        expect(result.queue[0].artist_name).toBe("Chuquimamani-Condori");
+        expect(result.queue[0].album_id).toBeUndefined();
+      });
     });
 
     it("keeps album_id when a field the library row does not own is edited", () => {


### PR DESCRIPTION
## Summary

`updateQueueEntry` decided whether editing a field deviated from the linked library row by re-reading the field's own rolling value, which forced a hardcoded `field === "artist_name"` special case (a withheld credit and a genuinely-absent one both render as `""`) and dropped `album_id` on a second edit to a field the release left empty, since the second edit's `previous` value now reads as non-empty.

This carries provenance instead, the way the searchbar's `selectionProvided` already does for the freeze payload.

- `FlowsheetSongEntry` gains `linkageProvided?: { artist_name: boolean; album_title: boolean; record_label: boolean }`, keyed on the queue entry's own field names (matching `ALBUM_SCOPED_QUEUE_FIELDS`) so the reducer lookup needs no name mapping.
- `addToQueue` captures it once, at queue time: `artist_name` is unconditionally `true` whenever the row is linked (every producer of the payload withholds `album_id` itself when a release can't supply an artist, so a blank string here always means a withheld credit, never an absent field), `album_title`/`record_label` reflect whether the release actually seeded a value.
- `updateQueueEntry` reads `entry.linkageProvided?.[field]` instead of re-deriving "supplied" from the rolling value. The `field === "artist_name"` special case is gone.

**localStorage rehydration default.** `FlowsheetSongEntry` is persisted to `localStorage` (`saveQueueToStorage` / `loadQueue`), so a queue row parked before this change rehydrates with `linkageProvided` absent. The reducer's default for a missing field is `?? true` — read as fully provided, so an album-scoped edit drops `album_id` rather than keeping a linkage that would let Backend-Service's `album_id` branch overwrite the DJ's correction. Losing the linkage on that edit is the safe direction; the entry submits freeform instead. Covered by `linkageProvided rehydration default` in the test file.

## Overlap with #1128

This touches `lib/features/flowsheet/frontend.ts` and `tests/unit/lib/features/flowsheet/flowsheet.test.ts`, both of which a sibling branch (`fix/1128-preserve-rotation-id-on-deviation`) also touches — that one edits `setSearchProperty` (~lines 119-152), this one edits `addToQueue` / `updateQueueEntry` (~lines 200-290) and adds tests in separate `describe` blocks. No shared lines changed.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint` (0 errors, 197 warnings baseline)
- [x] `npx vitest run tests/unit/lib/features/flowsheet/ tests/unit/lib/features/bin/` — 576 tests passing, including the pre-existing freeze → submitToQueue → correct-the-artist regression coverage (still strips `album_id`) and the new double-edit / rehydration-default cases

Closes #1126