### PR TITLE
fix(flowsheet): key the auto-filled artist flag on the seeded value

### DIFF
--- a/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar.tsx
@@ -2,6 +2,7 @@
 
 import { entryToFreezePayload } from "@/lib/features/flowsheet/conversions";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { seedableArtistName } from "@/lib/features/flowsheet/various-artists-guard";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import {
   useFlowsheetSearch,
@@ -77,7 +78,11 @@ export default function FlowsheetSearchbar() {
 
   const highlightFills = selectedResult > 0 && selectedEntry !== null;
   const autoFilled = {
-    artist: highlightFills && Boolean(selectedEntry?.artist?.name),
+    // Keyed on the seeded value, not the raw credit: seedableArtistName is
+    // the same function that fills the field, so this can't disagree with
+    // what's shown (a refused compilation credit seeds "" and must not
+    // suppress the typeahead the DJ needs to type the performer by hand).
+    artist: highlightFills && seedableArtistName(selectedEntry) !== "",
     album: highlightFills && Boolean(selectedEntry?.title),
     label: highlightFills && Boolean(selectedEntry?.label),
   };

--- a/tests/integration/components/modern/flowsheet/Search/FlowsheetSearchInput.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/FlowsheetSearchInput.test.tsx
@@ -147,6 +147,26 @@ describe("FlowsheetSearchInput", () => {
       expect(onThaw).not.toHaveBeenCalled();
     });
 
+    // A blank field correctly flagged as not auto-filled (e.g. a refused
+    // compilation credit, which seeds "") has nothing frozen to thaw — typing
+    // must apply straight to the query like any other empty field.
+    it("should not thaw a blank field that is not flagged as auto-filled", () => {
+      const onThaw = vi.fn();
+      render(
+        <FlowsheetSearchInput name="artist" value="" onThaw={onThaw} />
+      );
+
+      fireEvent.change(screen.getByRole("textbox"), {
+        target: { value: "C" },
+      });
+
+      expect(onThaw).not.toHaveBeenCalled();
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: "setSearchProperty",
+        payload: { name: "artist", value: "C", deviates: false },
+      });
+    });
+
     it("should not block keystrokes when auto-filled", () => {
       render(
         <FlowsheetSearchInput

--- a/tests/integration/components/modern/flowsheet/Search/FlowsheetSearchbar.autoFilledArtist.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/FlowsheetSearchbar.autoFilledArtist.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import {
+  renderWithProviders,
+  createTestStore,
+  createTestAlbum,
+  createTestArtist,
+} from "@/tests/helpers";
+import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { seedableArtistName } from "@/lib/features/flowsheet/various-artists-guard";
+import FlowsheetSearchbar from "@/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar";
+import {
+  useFlowsheetSearch,
+  useFlowsheetSubmit,
+} from "@/src/hooks/flowsheetHooks";
+import { useGhostText } from "@/src/hooks/useGhostText";
+
+// useFlowsheetSearch/useFlowsheetSubmit fan out into RTK Query hooks for bin/
+// catalog/rotation/LML search. Mocked here so the test doesn't need MSW
+// handlers for the full search surface — real Redux still drives
+// selectedResult (dispatched below), and FlowsheetSearchInput dispatches
+// straight to the real store, which is what the ghost-text suppression under
+// test actually depends on.
+vi.mock("@/src/hooks/flowsheetHooks", () => ({
+  useFlowsheetSearch: vi.fn(),
+  useFlowsheetSubmit: vi.fn(),
+}));
+
+vi.mock("@/src/hooks/useGhostText", () => ({
+  useGhostText: vi.fn(),
+}));
+
+vi.mock(
+  "@/src/components/experiences/modern/flowsheet/Search/BreakpointButton",
+  () => ({
+    default: () => <button data-testid="breakpoint-button">Breakpoint</button>,
+  })
+);
+vi.mock(
+  "@/src/components/experiences/modern/flowsheet/Search/TalksetButton",
+  () => ({
+    default: () => <button data-testid="talkset-button">Talkset</button>,
+  })
+);
+vi.mock(
+  "@/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults",
+  () => ({
+    default: () => <div data-testid="search-results">Results</div>,
+  })
+);
+vi.mock(
+  "@/src/components/experiences/modern/flowsheet/Search/RotationModeToggle",
+  () => ({
+    default: () => <button data-testid="rotation-toggle">Rotation</button>,
+  })
+);
+vi.mock(
+  "@/src/components/experiences/modern/flowsheet/Search/RotationEntryFields",
+  () => ({
+    default: () => <div data-testid="rotation-entry-fields" />,
+  })
+);
+vi.mock("@mui/icons-material", () => ({
+  PlayArrow: () => <span data-testid="play-icon" />,
+  QueueMusic: () => <span data-testid="queue-icon" />,
+  Close: () => <span data-testid="close-icon" />,
+}));
+
+// A highlighted (arrow-keyed, not yet clicked) search result. FlowsheetSearchInput
+// is left un-mocked so ghost-text rendering reflects the real isAutoFilled
+// wiring in FlowsheetSearchbar rather than a mock's assumption about it.
+function renderWithHighlightedEntry(
+  selectedEntry: ReturnType<typeof createTestAlbum>
+) {
+  const store = createTestStore();
+  store.dispatch(flowsheetSlice.actions.setSelectedResult(1));
+
+  vi.mocked(useFlowsheetSubmit).mockReturnValue({
+    ctrlKeyPressed: false,
+    handleSubmit: vi.fn(),
+    submitToQueue: vi.fn(),
+    binResults: [],
+    catalogResults: [],
+    rotationResults: [],
+    lmlResults: [],
+    selectedEntry,
+  } as unknown as ReturnType<typeof useFlowsheetSubmit>);
+
+  vi.mocked(useFlowsheetSearch).mockReturnValue({
+    live: true,
+    searchOpen: true,
+    setSearchOpen: vi.fn(),
+    resetSearch: vi.fn(),
+    searchQuery: { song: "", artist: "", album: "", label: "", request: false },
+    setSearchProperty: vi.fn(),
+    // Mirrors the real hook: a refused credit is withheld from the field,
+    // same as the highlighted release it previews.
+    getDisplayValue: (name: string) =>
+      name === "artist" ? seedableArtistName(selectedEntry) : "",
+  } as unknown as ReturnType<typeof useFlowsheetSearch>);
+
+  vi.mocked(useGhostText).mockImplementation((field) =>
+    field === "artist"
+      ? {
+          ghostSuffix: "essica Pratt",
+          acceptGhostText: () => null,
+          trackResult: null,
+        }
+      : { ghostSuffix: "", acceptGhostText: () => null, trackResult: null }
+  );
+
+  return renderWithProviders(<FlowsheetSearchbar />, { store });
+}
+
+describe("FlowsheetSearchbar artist ghost text while a result is highlighted", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps artist typeahead working when the highlighted release's credit is refused", () => {
+    const compilation = createTestAlbum({
+      id: 501,
+      title: "Edits",
+      artist: createTestArtist({ name: "Various Artists" }),
+      label: "self-released",
+    });
+
+    renderWithHighlightedEntry(compilation);
+
+    expect(screen.getByTestId("flowsheet-search-artist")).toHaveValue("");
+    expect(screen.getByTestId("ghost-text-artist")).toBeInTheDocument();
+  });
+
+  it("still suppresses artist ghost text for a normally-credited highlighted release", () => {
+    const album = createTestAlbum({
+      id: 502,
+      title: "On Your Own Love Again",
+      artist: createTestArtist({ name: "Jessica Pratt" }),
+      label: "Drag City",
+    });
+
+    renderWithHighlightedEntry(album);
+
+    expect(screen.getByTestId("flowsheet-search-artist")).toHaveValue(
+      "Jessica Pratt"
+    );
+    expect(screen.queryByTestId("ghost-text-artist")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Highlighting a search result whose credit the various-artists guard refuses (e.g. "Various Artists", "V/A") left the artist field empty but flagged as auto-filled. `autoFilled.artist` was computed from whether the release had a raw credit (`Boolean(selectedEntry?.artist?.name)`), but the value actually placed in the field comes from `seedableArtistName`, which returns `""` for a refused credit. The mismatch silently suppressed the artist ghost-text typeahead (`hasGhost = !isAutoFilled && Boolean(ghostSuffix)` in `FlowsheetSearchInput.tsx`) at the one moment the DJ has to type the performer by hand.

## Fix

`FlowsheetSearchbar.tsx` now keys `autoFilled.artist` on `seedableArtistName(selectedEntry) !== ""` — the same function that seeds the field — so the flag can no longer disagree with what the field shows.

## Verification of the two open questions in the issue

- **`isAutoFilled` key-handling branch (`FlowsheetSearchInput.tsx:91`)**: does not misbehave for an empty-but-flagged field. With the flag now keyed on the seeded value, `isAutoFilled` can never be `true` while the field is actually empty for any of the three fields it gates (artist, album, label) — `getDisplayValue` falls back to the raw query the same way the flag falls back to `false`. Added a regression test (`should not thaw a blank field that is not flagged as auto-filled`) confirming a blank, correctly-unflagged field dispatches the typed value directly with no spurious `onThaw`.
- **`album` and `label` auto-filled flags**: confirmed fine, not sharing the defect. They're keyed on `Boolean(selectedEntry?.title)` / `Boolean(selectedEntry?.label)`, which is structurally consistent with `getDisplayValue`'s `selectedEntry.title || searchQuery.album` (and the label equivalent) — unlike the artist field, album/label are seeded directly from the release with no refusal step in between, so the flag and the displayed value can't diverge.

## Testing

- `tests/integration/components/modern/flowsheet/Search/FlowsheetSearchbar.autoFilledArtist.test.tsx` (new): covers both directions — a refused-credit highlight leaves artist typeahead working, a normally-credited highlight still suppresses ghost text.
- `tests/integration/components/modern/flowsheet/Search/FlowsheetSearchInput.test.tsx`: added the empty-but-not-flagged case above.
- `npx tsc --noEmit` — clean.
- `npm run lint` — 0 errors, 197 warnings (baseline, no new warnings).
- `npx vitest run tests/integration/components/modern/flowsheet/Search/` — 16 files / 205 tests passed (full-suite run was affected by unrelated resource-contention timeouts on this machine from concurrent agents; CI runs the full suite across shards).

Closes #1131