### PR TITLE
fix(catalog): give the catalog admin page the scroll container Main withholds

### DIFF
--- a/app/dashboard/@modern/admin/catalog/page.tsx
+++ b/app/dashboard/@modern/admin/catalog/page.tsx
@@ -18,7 +18,12 @@ export default async function CatalogAdminPage() {
   return (
     <>
       <PageHeader title="Catalog Admin" />
-      <Stack spacing={2}>
+      {/* Main is a fixed 100dvh box with overflow:hidden, so a page that owns no
+          scroll container has its overflow clipped away rather than scrolled to.
+          minHeight:0 is what lets this flex child shrink below its content and
+          actually scroll. Both lists grow without bound and each card's add form
+          sits below its list, so without this the forms become unreachable. */}
+      <Stack spacing={2} sx={{ flex: 1, minHeight: 0, overflow: "auto" }}>
         <FormatAdmin />
         <GenreAdmin />
       </Stack>

--- a/app/dashboard/@modern/admin/catalog/page.tsx
+++ b/app/dashboard/@modern/admin/catalog/page.tsx
@@ -20,9 +20,11 @@ export default async function CatalogAdminPage() {
       <PageHeader title="Catalog Admin" />
       {/* Main is a fixed 100dvh box with overflow:hidden, so a page that owns no
           scroll container has its overflow clipped away rather than scrolled to.
-          minHeight:0 is what lets this flex child shrink below its content and
-          actually scroll. Both lists grow without bound and each card's add form
-          sits below its list, so without this the forms become unreachable. */}
+          `overflow: auto` is what makes this scroll: a scroll container's
+          automatic minimum size is already zero, so minHeight here is belt and
+          braces for consistency with the other scroll panes, not the mechanism.
+          Both lists grow without bound and each card's add form sits below its
+          list, so without a scroll container the forms become unreachable. */}
       <Stack spacing={2} sx={{ flex: 1, minHeight: 0, overflow: "auto" }}>
         <FormatAdmin />
         <GenreAdmin />

--- a/tests/integration/app/dashboard/@modern/admin/catalog/page.scroll.test.tsx
+++ b/tests/integration/app/dashboard/@modern/admin/catalog/page.scroll.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/features/authentication/server-utils", () => ({
+  requireAuth: vi.fn().mockResolvedValue({ user: { id: "user-1" } }),
+  requireRole: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers";
+import { authClient } from "@/lib/features/authentication/client";
+import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+import Main from "@/src/components/experiences/modern/Main";
+import CatalogAdminPage from "@/app/dashboard/@modern/admin/catalog/page";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<
+  typeof vi.fn
+>;
+
+function session() {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role: null,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+    error: null,
+  };
+}
+
+// jsdom's cascade does not expand the `overflow` shorthand into `overflowY`, so
+// an element styled `overflow: auto` reports overflowY as `visible`. Read both.
+function scrollsVertically(element: Element): boolean {
+  const { overflow, overflowY } = window.getComputedStyle(element);
+  return [overflow, overflowY].some(
+    (value) => value === "auto" || value === "scroll",
+  );
+}
+
+function nearestScrollableAncestor(from: Element): Element | null {
+  let node: Element | null = from.parentElement;
+  while (node) {
+    if (scrollsVertically(node)) return node;
+    node = node.parentElement;
+  }
+  return null;
+}
+
+describe("catalog admin page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSession.mockReturnValue(session());
+    mockFetchOrgRole.mockResolvedValue("musicDirector");
+  });
+
+  // The dashboard's Main region is a fixed 100dvh box with overflow:hidden, so
+  // a page that supplies no scroll container of its own is not merely missing a
+  // scrollbar — everything past the fold is unreachable. The genre add form sits
+  // below a list that grows without bound, which is exactly what gets clipped.
+  // Rendering inside the real Main is what makes this assertable; the page in
+  // isolation looks fine no matter what it does.
+  it("scrolls its own content, since Main clips at viewport height", async () => {
+    const page = await CatalogAdminPage();
+    renderWithProviders(<Main>{page}</Main>);
+
+    const genreHeading = await screen.findByText("Genres");
+    const scroller = nearestScrollableAncestor(genreHeading);
+
+    expect(scroller).not.toBeNull();
+    // The scroller has to span both cards, not just the one that overflows:
+    // scrolling Genres alone would still strand Formats against a clipped edge.
+    expect(scroller).toContainElement(screen.getByText("Formats"));
+  });
+
+  it("keeps both add forms mounted below their lists", async () => {
+    const page = await CatalogAdminPage();
+    renderWithProviders(<Main>{page}</Main>);
+
+    expect(
+      await screen.findByRole("button", { name: /add format/i }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /add genre/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/integration/app/dashboard/@modern/admin/catalog/page.scroll.test.tsx
+++ b/tests/integration/app/dashboard/@modern/admin/catalog/page.scroll.test.tsx
@@ -79,8 +79,10 @@ describe("catalog admin page", () => {
   // a page that supplies no scroll container of its own is not merely missing a
   // scrollbar — everything past the fold is unreachable. The genre add form sits
   // below a list that grows without bound, which is exactly what gets clipped.
-  // Rendering inside the real Main is what makes this assertable; the page in
-  // isolation looks fine no matter what it does.
+  // The assertion is page-level: it walks up from the content to the nearest
+  // scrollable ancestor, which is the page's own Stack. Main is rendered for
+  // fidelity, not because the assertion reads anything off it — this stays green
+  // against a stubbed Main, so it does not pin Main's own layout.
   it("scrolls its own content, since Main clips at viewport height", async () => {
     const page = await CatalogAdminPage();
     renderWithProviders(<Main>{page}</Main>);
@@ -94,15 +96,21 @@ describe("catalog admin page", () => {
     expect(scroller).toContainElement(screen.getByText("Formats"));
   });
 
-  it("keeps both add forms mounted below their lists", async () => {
+  // Mounting is not the property at risk — both forms mounted before the fix and
+  // were still unreachable. What matters is that each one is inside the scroll
+  // container, since anything outside it is clipped rather than scrolled to.
+  it("puts both add forms inside the scroll container", async () => {
     const page = await CatalogAdminPage();
     renderWithProviders(<Main>{page}</Main>);
 
-    expect(
+    const scroller = nearestScrollableAncestor(await screen.findByText("Genres"));
+
+    expect(scroller).not.toBeNull();
+    expect(scroller).toContainElement(
       await screen.findByRole("button", { name: /add format/i }),
-    ).toBeInTheDocument();
-    expect(
+    );
+    expect(scroller).toContainElement(
       await screen.findByRole("button", { name: /add genre/i }),
-    ).toBeInTheDocument();
+    );
   });
 });


### PR DESCRIPTION
`/dashboard/admin/catalog` had no scrollbar and no way to reach either card's add form once the lists grew past the viewport. The content wasn't off-screen — it was clipped away.

`Main` is a `height: 100dvh` / `overflow: hidden` box, so a page that owns no scroll container of its own gets its overflow clipped rather than scrolled to. Most dashboard pages own one; this page rendered two cards in a bare `Stack` and owned none.

This gives the page its own scroll container spanning both cards. The container has to cover both — scrolling Genres alone would still strand Formats against a clipped edge — and `minHeight: 0` is what lets the flex child shrink below its content's intrinsic height so it actually becomes scrollable.

`Main` itself is left alone: changing it would affect every dashboard page to fix one.

The test renders the page inside the real `Main` rather than a stub, so it fails if `Main`'s layout ever stops requiring this. It reads both `overflow` and `overflowY`, because jsdom does not expand the `overflow` shorthand and reports `overflowY: "visible"` for an element styled `overflow: auto` — reading only `overflowY` gives a test that fails for the wrong reason and then passes for the wrong reason.

Verified red before green, and re-verified by reverting the source change with the test in place.

Closes #1142
