### PR TITLE
fix(catalog): report a genre-scoped artist-name conflict distinctly from a code conflict

### DIFF
--- a/lib/features/catalog/adminCreateArtistValidation.ts
+++ b/lib/features/catalog/adminCreateArtistValidation.ts
@@ -14,10 +14,11 @@ export function parseRequiredPositiveInt(raw: string): number | null {
  * refused the same way, so this — not the body's shape — is what a caller
  * gates resubmission on.
  *
- * Deliberately blind to the body: the backend's only 409 is the code-taken
- * one, but an intermediary can answer 409 with JSON of its own, and a body
- * that fails to parse narrows what can be *said* about the refusal, never
- * whether one happened.
+ * Deliberately blind to the body: the backend answers 409 for more than one
+ * reason (the code-triple conflict, the genre-scoped artist-name conflict),
+ * an intermediary can answer 409 with JSON of its own, and a body that fails
+ * to parse narrows what can be *said* about the refusal, never whether one
+ * happened.
  */
 export function isConflictRejection(
   err: unknown,
@@ -27,19 +28,22 @@ export function isConflictRejection(
 }
 
 /**
- * True when a `POST /library/artists` rejection is the code-taken 409 naming
- * the artist that already holds the code — the only one a caller can report by
- * name instead of as a generic failure.
+ * True when a `POST /library/artists` rejection is a 409 that names an
+ * artist the request conflicts with — the shape both the code-triple
+ * conflict and the genre-scoped artist-name conflict share, so a caller can
+ * report by name instead of as a generic failure. Which of the two it is is
+ * a separate question, answered by `isArtistNameConflictData` against the
+ * same body.
  *
  * Two places have to agree on this exact test, which is why it is one function
  * rather than two: the endpoint drops the body's generic `message` so the
  * recoverable outcome is reported once rather than as a banner plus a toast,
  * and the caller dereferences `artist.artist_name` while rendering that banner
- * with no error boundary beneath it. Were the strip the broader test, a second
- * 409 reason — or an intermediary answering 409 with its own JSON — would lose
- * its message before anything could surface it, leaving only a generic
- * fallback. Were the banner's the broader one, it would throw on a body that
- * carries no artist.
+ * with no error boundary beneath it. Were the strip the broader test, a 409
+ * reason this form cannot name an artist from — or an intermediary answering
+ * 409 with its own JSON — would lose its message before anything could
+ * surface it, leaving only a generic fallback. Were the banner's the broader
+ * one, it would throw on a body that carries no artist.
  */
 export function isAddArtistConflict(
   err: unknown,
@@ -52,5 +56,25 @@ export function isAddArtistConflict(
     !!artist &&
     typeof artist === "object" &&
     typeof (artist as { artist_name?: unknown }).artist_name === "string"
+  );
+}
+
+/**
+ * True when a `POST /library/artists` 409 body identifies itself as the
+ * genre-scoped artist-name conflict rather than the pre-existing code-triple
+ * conflict. The discriminant is `reason === "artist_name_conflict"` on the
+ * raw body; every other value — including a body with no `reason` field at
+ * all, which is exactly what today's deployed backend sends on its one 409 —
+ * is the code-triple case. Takes the raw, untyped body rather than routing
+ * through `isAddArtistConflict` so the distinction stays correct even against
+ * a body this form cannot otherwise name an artist from.
+ */
+export function isArtistNameConflictData(
+  data: unknown,
+): data is { reason: "artist_name_conflict" } {
+  return (
+    !!data &&
+    typeof data === "object" &&
+    (data as { reason?: unknown }).reason === "artist_name_conflict"
   );
 }

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -2,7 +2,10 @@ import { createApi } from "@reduxjs/toolkit/query/react";
 import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import type { RootState } from "@/lib/store";
 import { backendBaseQuery } from "../backend";
-import { isAddArtistConflict } from "./adminCreateArtistValidation";
+import {
+  isAddArtistConflict,
+  isArtistNameConflictData,
+} from "./adminCreateArtistValidation";
 import { CATALOG_QUERY_PAGE_LIMIT } from "./constants";
 import { convertToAlbumEntry } from "./conversions";
 import { patchCatalogSearchCaches } from "./patchSearchCaches";
@@ -192,20 +195,22 @@ export const catalogApi = createApi({
       //
       // Invalidation fires on a rejected mutation as well as a fulfilled one,
       // so the rejections that provably wrote nothing opt out: anything the
-      // server answered below 500, of which the code-taken 409 is the routine
-      // one. Invalidating CatalogList/ArtistSearch on those would spend two
-      // round trips reconfirming lists that cannot have changed. The peek tag
-      // is the one exception: every 409 on this endpoint means the
-      // code_letters/genre_id/code_number triple is taken, so it IS the
-      // evidence that this cache entry — and only this one — is stale, since
-      // it names the exact pair the preview just showed as free. That holds
-      // regardless of whether the body happens to parse as
-      // `isAddArtistConflict` — that check exists so the caller can name the
-      // conflicting artist in a banner, not to decide whether the pair is
-      // actually free. A 5xx or a transport failure still gets every tag —
-      // the row may well have been written on a response the client never
-      // saw, and ArtistSearch backs the typeahead that is all that stands
-      // between a retry and a duplicate artist.
+      // server answered below 500, of which a 409 is the routine one.
+      // Invalidating CatalogList/ArtistSearch on those would spend two round
+      // trips reconfirming lists that cannot have changed. The peek tag is
+      // narrower still: a code-triple conflict names the exact
+      // code_letters/genre_id pair the preview just showed as free, so it IS
+      // evidence that cache entry is stale — regardless of whether the body
+      // happens to parse as `isAddArtistConflict`, which exists so the caller
+      // can name the conflicting artist in a banner, not to decide whether
+      // the pair is actually free. A genre-scoped artist-name conflict is not
+      // that evidence: it says nothing about the code triple at all, so
+      // `isArtistNameConflictData` carves it out rather than invalidating a
+      // cache entry the rejection gives no reason to distrust. A 5xx or a
+      // transport failure still gets every tag — the row may well have been
+      // written on a response the client never saw, and ArtistSearch backs
+      // the typeahead that is all that stands between a retry and a
+      // duplicate artist.
       invalidatesTags: (_result, error, { code_letters, genre_id }) => {
         const codePeekTag = {
           type: "ArtistCodePeek" as const,
@@ -220,7 +225,8 @@ export const catalogApi = createApi({
             codePeekTag,
           ];
         }
-        return error.status === 409 ? [codePeekTag] : [];
+        if (error.status !== 409) return [];
+        return isArtistNameConflictData(error.data) ? [] : [codePeekTag];
       },
     }),
     peekArtistCode: builder.query<PeekArtistCodeResponse, PeekArtistCodeQuery>({

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -96,15 +96,19 @@ export type AddArtistRequestBody = {
 };
 
 /**
- * Body of the 409 `POST /library/artists` returns when the
- * (code_letters, genre_id, code_number) triple is already taken, as the
- * caller sees it: the conflicting artist, so it can be named rather than
- * reported as a generic failure. The backend also sends a generic `message`
- * alongside it; `addArtist` strips that before the rejection reaches any
- * consumer, so nothing here should read it.
+ * Body of a 409 `POST /library/artists` returns, as the caller sees it: the
+ * conflicting artist, so it can be named rather than reported as a generic
+ * failure. Two distinct conflicts share this shape. The pre-existing
+ * (code_letters, genre_id, code_number) triple conflict sets no `reason` at
+ * all — the shape today's deployed backend sends on its one 409. The
+ * genre-scoped artist-name conflict sets `reason: "artist_name_conflict"`.
+ * The backend also sends a generic `message` alongside `artist`; `addArtist`
+ * strips that before the rejection reaches any consumer, so nothing here
+ * should read it.
  */
 export type AddArtistConflict = {
   artist: { artist_id: number; artist_name: string; code_letters: string };
+  reason?: "artist_name_conflict";
 };
 
 export type PeekArtistCodeQuery = {

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -19,6 +19,7 @@ import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 import { useAddArtistMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
 import {
   isAddArtistConflict,
+  isArtistNameConflictData,
   isConflictRejection,
   parseRequiredPositiveInt,
 } from "@/lib/features/catalog/adminCreateArtistValidation";
@@ -132,10 +133,11 @@ function ArtistAddFields() {
   const codeLettersInputRef = useRef<HTMLInputElement | null>(null);
   const [codeNumberRaw, setCodeNumberRaw] = useState("");
   const [alphabeticalName, setAlphabeticalName] = useState("");
-  // Snapshots the code the server actually rejected, alongside the response —
-  // `conflict` must not be read against live `codeLetters`/`codeNumberRaw`,
-  // since an MD editing either field after a 409 would otherwise have the
-  // banner keep reporting the new, unsubmitted value as taken.
+  // Snapshots the code and name the server actually rejected, alongside the
+  // response — `conflict` must not be read against live
+  // `codeLetters`/`codeNumberRaw`/`name`, since an MD editing any of them
+  // after a 409 would otherwise have the banner keep reporting the new,
+  // unsubmitted value as taken.
   //
   // `response` is null when the 409 named no artist the banner could render —
   // an intermediary's own JSON, or a shape this form cannot read. The
@@ -145,6 +147,7 @@ function ArtistAddFields() {
   const [conflict, setConflict] = useState<{
     code_letters: string;
     code_number: string;
+    name: string;
     response: AddArtistConflict | null;
   } | null>(null);
   const [added, setAdded] = useState<{ code_letters: string; code_number: number } | null>(
@@ -195,11 +198,11 @@ function ArtistAddFields() {
     !isLoading &&
     existingArtist === null &&
     !dedupCheckStale &&
-    // The code_letters/code_number/genre handlers below already clear
-    // `conflict` on any edit that could change the outcome, so a standing
-    // conflict here means the (code_letters, genre_id, code_number) triple is
-    // still the exact one the server just rejected — resubmitting it
-    // unchanged can only reach the same 409.
+    // Each handler below clears `conflict` once its own edit could change the
+    // rejected outcome — code_letters/code_number/genre for a code-triple
+    // conflict, the name for a name conflict — so a standing conflict here
+    // means the fields relevant to it are still exactly what the server just
+    // rejected: resubmitting unchanged can only reach the same 409.
     conflict === null &&
     trimmedName.length > 0 &&
     !nameTooLong &&
@@ -226,6 +229,15 @@ function ArtistAddFields() {
     // hasn't answered yet.
     if (value.trim() !== trimmedName) {
       setDedupCheckStale(false);
+    }
+    // A name conflict is keyed on the name itself, unlike the code-triple
+    // conflict: editing it away from the rejected value is exactly the
+    // remedy that lets a resubmission succeed, so it must not stay blocked by
+    // state left over from the name the server actually rejected. A standing
+    // code-triple conflict is untouched here — its triple has nothing to do
+    // with the name field.
+    if (conflict?.response && isArtistNameConflictData(conflict.response)) {
+      setConflict(null);
     }
   };
 
@@ -264,6 +276,7 @@ function ArtistAddFields() {
         setConflict({
           code_letters: trimmedCodeLetters,
           code_number: codeNumberRaw.trim(),
+          name: trimmedName,
           response: isAddArtistConflict(err) ? err.data : null,
         });
       }
@@ -464,13 +477,19 @@ function ArtistAddFields() {
             genre_id={genreId}
           />
 
-          {conflict?.response && (
-            <Typography level="body-sm" color="danger" role="alert">
-              {conflict.code_letters}
-              {conflict.code_number} is already taken by{" "}
-              {conflict.response.artist.artist_name}.
-            </Typography>
-          )}
+          {conflict?.response &&
+            (isArtistNameConflictData(conflict.response) ? (
+              <Typography level="body-sm" color="danger" role="alert">
+                {conflict.name} is already taken in this genre by{" "}
+                {conflict.response.artist.artist_name}.
+              </Typography>
+            ) : (
+              <Typography level="body-sm" color="danger" role="alert">
+                {conflict.code_letters}
+                {conflict.code_number} is already taken by{" "}
+                {conflict.response.artist.artist_name}.
+              </Typography>
+            ))}
 
           {added && (
             <Typography level="body-sm" color="success" role="status">

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -289,6 +289,21 @@ function ArtistAddFields() {
     }
   };
 
+  // An edit to the code triple changes what the server was asked about the
+  // code and nothing else. A standing NAME conflict has to survive it: the
+  // name is still exactly the one that was rejected, and dropping the banner
+  // would re-enable submit for a resubmission that can only reach the same
+  // 409 — steering the librarian to keep adjusting a code that was never the
+  // problem. Genre is deliberately not routed through here: the name check is
+  // genre-scoped too, so changing it reopens both questions.
+  const clearCodeTripleConflict = () => {
+    setConflict((current) =>
+      current?.response && isArtistNameConflictData(current.response)
+        ? current
+        : null,
+    );
+  };
+
   const handleCodeLettersChange = (
     event: React.ChangeEvent<HTMLInputElement>,
   ) => {
@@ -303,13 +318,13 @@ function ArtistAddFields() {
       caret:
         caret === null ? null : normalizeCodeLetters(raw.slice(0, caret)).length,
     });
-    setConflict(null);
+    clearCodeTripleConflict();
     setAdded(null);
   };
 
   const handleCodeNumberChange = (value: string) => {
     setCodeNumberRaw(value);
-    setConflict(null);
+    clearCodeTripleConflict();
     setAdded(null);
   };
 

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -141,6 +141,19 @@ function conflictResponse(overrides: Record<string, unknown> = {}) {
   );
 }
 
+/** The genre-scoped artist-name conflict: distinguishable only by `reason`. */
+function nameConflictResponse(overrides: Record<string, unknown> = {}) {
+  return HttpResponse.json(
+    {
+      message: "Artist name already exists in that genre.",
+      reason: "artist_name_conflict",
+      artist: { artist_id: 5, artist_name: "Stereolab", code_letters: MOLINA },
+      ...overrides,
+    },
+    { status: 409 },
+  );
+}
+
 /** The FormControl wrapping a field, so a helper-text assertion names its owner. */
 function fieldGroup(field: HTMLElement): HTMLElement {
   const group = field.closest(".MuiFormControl-root");
@@ -300,6 +313,23 @@ describe("ArtistAddForm", () => {
       // A recoverable outcome gets one surface. The backend's 409 carries a
       // generic message that the global rejected-query middleware would
       // otherwise toast on top of this banner.
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("renders a name-collision banner naming the existing artist, not the code, on a genre-scoped name conflict", async () => {
+      mockAddArtist(() => nameConflictResponse());
+      const { user } = renderWithProviders(<ArtistAddForm />);
+
+      await fillCoreFields(user);
+      await user.click(screen.getByRole("button", { name: /add artist/i }));
+
+      // The code is free here — the name is what collided — so the banner
+      // must say so instead of the code-taken phrasing, which would name the
+      // one remedy (changing the code) that cannot fix this rejection.
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveTextContent("Juana Molina");
+      expect(alert).toHaveTextContent("Stereolab");
+      expect(alert).not.toHaveTextContent(`${MOLINA}12`);
       expect(toast.error).not.toHaveBeenCalled();
     });
 
@@ -583,13 +613,35 @@ describe("ArtistAddForm", () => {
         await user.click(screen.getByRole("button", { name: /add artist/i }));
         await waitFor(() => expect(toast.error).toHaveBeenCalled());
 
-        // Every 409 on this endpoint means the code_letters/genre_id/code_number
-        // triple is taken, regardless of whether the body happens to carry a
-        // parseable `artist` to name in a banner — that shape only decides how
-        // the rejection is presented, not whether the pair is actually free.
+        // A 409 that isn't identifiable as a name conflict means the
+        // code_letters/genre_id/code_number triple is taken, regardless of
+        // whether the body happens to carry a parseable `artist` to name in a
+        // banner — that shape only decides how the rejection is presented,
+        // not whether the pair is actually free.
         await waitFor(() =>
           expect(getQueries().length).toBeGreaterThan(peeksBeforeSubmit),
         );
+      });
+
+      it("leaves the preview alone after a genre-scoped name conflict, which says nothing about the code triple", async () => {
+        const { getQueries } = mockPeekCode();
+        mockAddArtist(() => nameConflictResponse());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await waitFor(() => expect(getQueries().length).toBeGreaterThan(0));
+        const peeksBeforeSubmit = getQueries().length;
+
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+        expect(await screen.findByRole("alert")).toHaveTextContent("Stereolab");
+
+        // Unlike the code-triple conflict, a name conflict leaves the
+        // code_letters/genre_id pair this preview covers untouched — the pair
+        // it just showed as free may still be free, so nothing here justifies
+        // a refetch. Brief settle so an errant invalidation's refetch could
+        // complete before the negative assertion below.
+        await new Promise((r) => setTimeout(r, 10));
+        expect(getQueries()).toHaveLength(peeksBeforeSubmit);
       });
 
       it("leaves the preview alone after a non-409 rejection below 500", async () => {
@@ -928,6 +980,9 @@ describe("ArtistAddForm", () => {
       });
 
       it("leaves the conflict banner and the submit block standing when only the artist name is edited", async () => {
+        // No `reason` field — the shape today's deployed backend sends for
+        // its one 409, and the case this must stay pinned to exactly as it
+        // behaves today.
         mockAddArtist(() => conflictResponse());
         const { user } = renderWithProviders(<ArtistAddForm />);
 
@@ -936,14 +991,32 @@ describe("ArtistAddForm", () => {
         expect(await screen.findByRole("alert")).toHaveTextContent(`${MOLINA}12`);
 
         // The artist name is not part of the (code_letters, genre_id,
-        // code_number) triple the server rejected, so editing it must not
-        // read as an answer about that rejection — unlike the code_letters,
-        // code_number, and genre handlers, handleNameChange must not clear a
-        // still-accurate conflict.
+        // code_number) triple a code-triple conflict rejected, so editing it
+        // must not read as an answer about that rejection — unlike the
+        // code_letters, code_number, and genre handlers, handleNameChange
+        // must not clear a still-accurate code conflict.
         await user.type(screen.getByPlaceholderText("Search artists..."), " II");
 
         expect(screen.getByRole("alert")).toHaveTextContent(`${MOLINA}12`);
         expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+      });
+
+      it("clears a name-conflict banner and re-enables submission once the artist name is edited", async () => {
+        mockAddArtist(() => nameConflictResponse());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+        expect(await screen.findByRole("alert")).toHaveTextContent("Stereolab");
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeDisabled();
+
+        // Unlike the code-triple case, the artist name IS what a name
+        // conflict rejected — editing it is the one remedy that can change
+        // the outcome, so it must not be left stuck behind a reload.
+        await user.type(screen.getByPlaceholderText("Search artists..."), " Trio");
+
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /add artist/i })).toBeEnabled();
       });
     });
 

--- a/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
+++ b/tests/integration/components/modern/catalog/ArtistAddForm.test.tsx
@@ -356,6 +356,33 @@ describe("ArtistAddForm", () => {
       },
     );
 
+    it.each([
+      ["the code number", async (user: ReturnType<typeof renderWithProviders>["user"]) =>
+        user.type(screen.getByLabelText("Code number"), "3")],
+      ["the call letters", async (user: ReturnType<typeof renderWithProviders>["user"]) =>
+        user.type(screen.getByLabelText(/call letters/i), "X")],
+    ])(
+      "leaves a name conflict standing when %s is edited, since the name is still the rejected one",
+      async (_label, edit) => {
+        mockAddArtist(() => nameConflictResponse());
+        const { user } = renderWithProviders(<ArtistAddForm />);
+
+        await fillCoreFields(user);
+        await user.click(screen.getByRole("button", { name: /add artist/i }));
+        expect(await screen.findByRole("alert")).toHaveTextContent("Stereolab");
+
+        // The code triple was never what the server objected to. Dropping the
+        // banner here would re-enable submit for a name the server just
+        // rejected, and send the librarian back around the same 409.
+        await edit(user);
+
+        expect(screen.getByRole("alert")).toHaveTextContent("Stereolab");
+        expect(
+          screen.getByRole("button", { name: /add artist/i }),
+        ).toBeDisabled();
+      },
+    );
+
     it("clears the stale conflict banner when the genre changes", async () => {
       mockGenres([
         { id: GENRE_ID, genre_name: "Rock" },

--- a/tests/unit/lib/features/catalog/adminCreateArtistValidation.test.ts
+++ b/tests/unit/lib/features/catalog/adminCreateArtistValidation.test.ts
@@ -44,10 +44,16 @@ describe("isArtistNameConflictData", () => {
 
   it.each([
     [
-      "a body with no reason field at all, exactly what today's deployed backend sends",
+      "a body with no reason field at all, which is what a backend predating the discriminant sends",
       { artist: { artist_id: 5, artist_name: "Stereolab", code_letters: "ST" } },
     ],
-    ["a reason value this endpoint has never sent", { reason: "artist_code_conflict" }],
+    [
+      "the code-triple conflict's own discriminant, which must not route to the name-conflict remedy",
+      {
+        reason: "artist_code_conflict",
+        artist: { artist_id: 5, artist_name: "Stereolab", code_letters: "ST" },
+      },
+    ],
     ["a non-object body", "Artist code already exists for that genre and code letters."],
     ["null", null],
     ["undefined", undefined],

--- a/tests/unit/lib/features/catalog/adminCreateArtistValidation.test.ts
+++ b/tests/unit/lib/features/catalog/adminCreateArtistValidation.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { parseRequiredPositiveInt } from "@/lib/features/catalog/adminCreateArtistValidation";
+import {
+  isArtistNameConflictData,
+  parseRequiredPositiveInt,
+} from "@/lib/features/catalog/adminCreateArtistValidation";
 
 describe("parseRequiredPositiveInt", () => {
   it.each([
@@ -26,5 +29,29 @@ describe("parseRequiredPositiveInt", () => {
 
   it("rejects leading-zero decimals (not valid code-number literals)", () => {
     expect(parseRequiredPositiveInt("007")).toBeNull();
+  });
+});
+
+describe("isArtistNameConflictData", () => {
+  it("is true when the body carries the name-conflict reason", () => {
+    expect(
+      isArtistNameConflictData({
+        reason: "artist_name_conflict",
+        artist: { artist_id: 5, artist_name: "Stereolab", code_letters: "ST" },
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    [
+      "a body with no reason field at all, exactly what today's deployed backend sends",
+      { artist: { artist_id: 5, artist_name: "Stereolab", code_letters: "ST" } },
+    ],
+    ["a reason value this endpoint has never sent", { reason: "artist_code_conflict" }],
+    ["a non-object body", "Artist code already exists for that genre and code letters."],
+    ["null", null],
+    ["undefined", undefined],
+  ])("is false for %s", (_label, data) => {
+    expect(isArtistNameConflictData(data)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Backend-Service is adding a second 409 to `POST /library/artists`: a genre-scoped artist-name conflict, alongside the existing code-triple conflict. Both bodies carry `artist` (the conflicting artist); the name-conflict body additionally sets `reason: "artist_name_conflict"`, which the code-triple body never sets. That backend change is gated on this PR landing first, because the currently deployed `ArtistAddForm` mishandles the new body badly:

- `isAddArtistConflict` matches the name-conflict body structurally (it carries `artist.artist_name`), so `transformErrorResponse` strips the server's real explanation before the global toast can show it.
- The banner renders `{code_letters}{code_number} is already taken by {artist_name}` — false for a name conflict, since the code is free and the name is taken.
- `canSubmit` requires `conflict === null`, and nothing clears `conflict` on a name edit, by design — that premise stops holding once a name can cause a 409. The MD is steered toward the one remedy that cannot work (changing the code) while the one that would work (changing the name) leaves the button disabled. The only escape was a page reload.

## Changes

- `isArtistNameConflictData` (new, in `adminCreateArtistValidation.ts`) discriminates the two 409 shapes by `reason === "artist_name_conflict"`. Any other value — including a body with no `reason` field at all, which is exactly what today's deployed backend sends on its one 409 — is treated as the pre-existing code-triple case, so this branch is safe to deploy against the current backend.
- `ArtistAddForm` now snapshots the rejected artist name alongside the rejected code, renders a banner naming the name collision and the existing artist for a name conflict (instead of the false code-taken message), and clears a standing name conflict when the artist name is edited. A standing code conflict keeps its existing behavior — a name edit does not clear it.
- `addArtist`'s `invalidatesTags` in `api.ts` scopes the `ArtistCodePeek` cache invalidation away from a name conflict: a name conflict says nothing about whether the `code_letters`/`genre_id` pair is taken, so invalidating that cache entry on it was spurious.
- `AddArtistConflict` (`types.ts`) gains the optional `reason` field.
- Three comments asserting the backend has only one 409 reason are corrected to describe both conflict shapes (`isConflictRejection`'s doc, `isAddArtistConflict`'s doc, and the `invalidatesTags` rationale in `api.ts`).

## Test plan

- [x] `npx vitest run tests/unit/lib/features/catalog/adminCreateArtistValidation.test.ts` — new `isArtistNameConflictData` coverage
- [x] `npx vitest run tests/integration/components/modern/catalog/ArtistAddForm.test.tsx` — new coverage: name-conflict banner wording, name-edit clearing a name conflict, `ArtistCodePeek` invalidation scoping; pre-existing tests using a `reason`-less body (today's deployed shape) pin that path is unchanged
- [x] Confirmed each new test fails for the right reason against the pre-fix source (`git stash push --` source files only, re-run, confirm red, `git stash pop`)
- [x] `npm run lint` — 0 errors, 197 pre-existing warnings
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` (full suite) — 311 files / 4476 tests pass

Closes #1108