### PR TITLE
chore(deps): drop the orphan esbuild devDependency and take pg 8.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,12 +43,11 @@
         "@vitest/coverage-v8": "^4.1.10",
         "@vitest/ui": "^4.0.18",
         "bats": "^1.11.0",
-        "esbuild": "^0.28.0",
         "eslint": "^9.39.5",
         "eslint-config-next": "^16.3.0",
         "jsdom": "^30.0.1",
         "msw": "^2.15.0",
-        "pg": "^8.22.0",
+        "pg": "^8.23.0",
         "typescript": "^6.0.3",
         "vitest": "^4.0.18",
         "wrangler": "^4.121.0"
@@ -13406,15 +13405,15 @@
       "license": "MIT"
     },
     "node_modules/pg": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
-      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
-        "pg-protocol": "^1.15.0",
+        "pg-protocol": "^1.16.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -13468,9 +13467,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
-      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -62,12 +62,11 @@
     "@vitest/coverage-v8": "^4.1.10",
     "@vitest/ui": "^4.0.18",
     "bats": "^1.11.0",
-    "esbuild": "^0.28.0",
     "eslint": "^9.39.5",
     "eslint-config-next": "^16.3.0",
     "jsdom": "^30.0.1",
     "msw": "^2.15.0",
-    "pg": "^8.22.0",
+    "pg": "^8.23.0",
     "typescript": "^6.0.3",
     "vitest": "^4.0.18",
     "wrangler": "^4.121.0"


### PR DESCRIPTION
Supersedes #1154, which bumps the same two dependencies. `pg` is taken as proposed there; `esbuild` is deleted instead of bumped.

## Why delete rather than bump

Nothing in dj-site imports `esbuild`. Across every tracked file it appears only in `package.json` itself:

```
$ git ls-files | grep -v package-lock.json | xargs grep -ln "esbuild"
package.json
```

So the declaration buys nothing directly. What it does do is set a floor that other packages then have to work around — and **wrangler pins `esbuild` to an exact `0.28.1`, not a range**. Raising the top-level floor to `^0.28.2` therefore cannot dedupe. npm's only way to satisfy both is to nest a second complete esbuild install under wrangler, which is exactly what #1154's lockfile does: `node_modules/wrangler/node_modules/esbuild` plus all twenty-odd platform-specific `@esbuild/*` optional packages.

Deleting the declaration leaves the installed tree unchanged. Verified by installing both ways:

| | before | after deletion |
|---|---|---|
| top level | `esbuild@0.28.1` | `esbuild@0.28.1` (now attributed to wrangler) |
| `vite@8.0.16` | deduped onto it | deduped onto it |
| `@opennextjs/aws@4.1.0` | nested `0.25.4` | nested `0.25.4` |

Same two copies, same versions. The only thing that goes away is the orphan declaration and the future Dependabot PRs it will keep generating against a package no code uses.

`pg` is a genuine dependency — `e2e/helpers/pg-notify.ts` imports it for the Tier 1 SSE E2E test — and 8.23.0 is within the existing `^8.22.0` range, so the lockfile moves with or without the manifest edit. The manifest floor is raised to match #1154.

## Test plan

- [x] `npm run lint` — 0 errors, 197 warnings (unchanged baseline)
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 315 files / 4541 tests pass
- [x] `npm run build:opennext` — completes; `_worker.js` and `_routes.json` emitted
- [x] `npm ls esbuild` compared before and after removal; installed copies identical

## Related

- Supersedes WXYC/dj-site#1154
