### PR TITLE
Relicense to PolyForm Noncommercial 1.0.0

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,32 @@
+# Commercial Licensing
+
+This software is released under the [PolyForm Noncommercial License 1.0.0](./LICENSE). Commercial licenses are available separately.
+
+## You do not need a commercial license
+
+The public license already permits, free of charge and without asking us:
+
+- **Educational institutions** — universities, colleges, schools, and their departments
+- **Charitable organizations and nonprofits**, including other college and community radio stations
+- **Public research organizations** and **government institutions**
+- **Personal use** — study, research, experiment, hobby projects, and private entertainment
+
+The license grants this "regardless of the source of funding or obligations resulting from the funding," so grant-funded and university-funded work is covered. If you are a student station wanting to run your own flowsheet on this, you are already licensed. Go ahead.
+
+## You need a commercial license
+
+If you want to use this software for a commercial purpose — including selling it, selling a service built on it, or using it internally at a for-profit company — contact us and we will work out terms.
+
+**Contact:** legal@wxyc.org
+
+Please include:
+
+- Your organization
+- Which repositories you're interested in
+- A short description of the intended use
+
+We are a student-run radio station, not a software vendor, and we are reasonable to deal with.
+
+## Attribution
+
+Whether or not you need a commercial license, the public license requires that anyone you pass the software to also receives the license text and the `Required Notice:` lines at the bottom of [LICENSE](./LICENSE). Keep them intact.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,80 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.
+
+---
+
+Required Notice: Copyright WXYC 89.3 FM (https://wxyc.org)
+Required Notice: Source: https://github.com/WXYC/dj-site
+
+Commercial licenses are available. See COMMERCIAL.md.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "dj-site",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dj-site",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "private": true,
   "engines": {
     "node": "24.x"


### PR DESCRIPTION
Adds the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0) (SPDX `PolyForm-Noncommercial-1.0.0`) as part of the org-wide relicensing. Wave 1 — the 17 repos with a sole copyright holder — landed first; this repo is in the wave that has outside contributors.

### What stays free

Named as permitted purposes in the license itself, with no need to ask:

- Personal study, research, experiment, hobby projects, private entertainment
- Educational institutions
- Charitable organizations and nonprofits — including other college and community radio stations
- Public research organizations, public safety and health organizations, and government institutions

The license grants this "regardless of the source of funding or obligations resulting from the funding," so grant- and university-funded use is covered.

### What changes

Commercial use requires a separate agreement. See `COMMERCIAL.md`.

### Attribution

The `Required Notice:` lines at the bottom of `LICENSE` must be passed along to anyone who receives any part of the software, which makes attribution a license condition rather than a convention.

### Prior releases

Prospective only. Versions already published under the previous license remain under it permanently, and existing copies keep the rights they were given.

### Notes for review

- The license body above the `---` is upstream PolyForm text, verbatim. Only the trailing notice block is repo-specific.
- PolyForm Noncommercial is source-available, not OSI-approved — deliberately so, since OSI approval requires permitting commercial use.
