### PR TITLE
ci(e2e): declare EMAIL_ENABLED=false in the Backend env and float on Backend main again

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       backend_ref:
-        description: 'Backend-Service branch or commit SHA (blank = the pinned ref)'
+        description: 'Backend-Service branch or commit SHA (blank = BACKEND_PINNED_REF, default main)'
         required: false
         default: ''
 
@@ -17,20 +17,18 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Backend-Service commit this suite runs against by default.
+  # Backend-Service ref this suite runs against by default.
   #
-  # This job used to check Backend-Service out at `main`, so dj-site's merge gate
-  # floated on another repo's default branch: an upstream commit could — and did —
-  # turn every dj-site PR red with no signal at the boundary. Backend-Service
-  # bb84c63f/fb81e2b2 broke 14 admin/auth specs on 2026-08-03 and closed this
-  # repo's merge gate for two days (#1088).
-  #
-  # ef60c249 is the last commit verified green here (4/4 shards, run 31026323488).
-  #
-  # TEMPORARY. Unpin — restore `main` — once WXYC/Backend-Service#1999 lands, or
-  # this suite silently stops testing the Backend that production actually runs.
-  # Advance the pin deliberately when a newer Backend commit is verified green.
-  BACKEND_PINNED_REF: ef60c2492a48cce2f210a9dbdf877c9bb9e39903
+  # Decision (#1088, acceptance criterion 3): this suite floats on Backend
+  # `main`. The 2026-08-05 pin to ef60c249 (#1089) reopened the merge gate, but
+  # a pin goes stale invisibly — within a week it was ten days behind the
+  # Backend that production actually runs. The outage that motivated pinning
+  # (WXYC/Backend-Service#1999: an email-config throw surfaced by the awaited
+  # BS#1969 invite send in an environment with no SES) is fixed at the root,
+  # and this env now declares EMAIL_ENABLED=false like every other Backend test
+  # environment. The resolver below accepts a branch or a commit SHA, so a
+  # future incident can re-pin deliberately with a one-line change here.
+  BACKEND_PINNED_REF: main
   # Frontend configuration
   NEXT_PUBLIC_BACKEND_URL: http://localhost:8085
   NEXT_PUBLIC_BETTER_AUTH_URL: http://localhost:8084/auth
@@ -187,7 +185,7 @@ jobs:
             exit 1
           fi
           echo "ref=${BACKEND_PINNED_REF}" >> "$GITHUB_OUTPUT"
-          echo "Using Backend-Service ref: ${BACKEND_PINNED_REF} (pinned)"
+          echo "Using Backend-Service ref: ${BACKEND_PINNED_REF} (default)"
 
       - name: Checkout Backend-Service
         uses: actions/checkout@v7
@@ -228,6 +226,14 @@ jobs:
           E2E_BACKEND_PORT=8085
           COOKIE_SAME_SITE=lax
           NODE_ENV=test
+          # This environment sends no email and sets no SES vars. Backend's
+          # senders no-op only when email is declared disabled — enabled (the
+          # unset default) plus missing SES config is a loud throw by design.
+          # Every other Backend test environment sets this; without it, the
+          # awaited account-setup invite send reports emailSent:false on every
+          # provision and the roster UI warns instead of confirming, failing
+          # each admin spec at its create-account step (#1088 / BS#1999).
+          EMAIL_ENABLED=false
           # Mirror target: localhost mock that returns 200 to every POST,
           # short-circuiting the 15.5s exponential-backoff retry storm that
           # the default (https://www.wxyc.info, currently cert-expired) would


### PR DESCRIPTION
## Problem

Two halves of closing out #1088, both in `.github/workflows/e2e-tests.yml`:

**1. The E2E Backend `.env` never declared `EMAIL_ENABLED=false`.** Backend-Service treats an unset `EMAIL_ENABLED` as enabled (the production default), and its senders throw on missing SES config when enabled. Every other Backend test environment declares email disabled (`tests/setup/unit.setup.ts`, `dev_env/docker-compose.yml`'s CI profile, Backend's own `test.yml`); this workflow's generated `.env` was the one that didn't. That gap was invisible while Backend fire-and-forgot invite sends — the throw was swallowed and `emailSent` read `true` — and became the outage the moment WXYC/Backend-Service#1969 made the send awaited and observable: every roster provision reported `emailSent: false`, the roster UI showed the warning toast ("setup email failed to send") instead of the success toast, and every admin spec fails at its `createAccount → expectSuccessToast()` setup step. Full mechanism: WXYC/Backend-Service#1999.

**2. `BACKEND_PINNED_REF` returns from the emergency pin to `main`.** #1089 pinned E2E to Backend `ef60c249` to reopen the merge gate; within a week that pin was ten days behind the Backend production actually runs. With the ordering defect fixed upstream (WXYC/Backend-Service#1999) and this env now declaring its intent, the pin's cause is gone. **Recorded float decision (#1088 acceptance criterion 3): the suite floats on Backend `main`.** A pin goes stale invisibly and silently converts real coverage into stale coverage; the resolver keeps accepting a branch or commit SHA, so a future incident can re-pin deliberately with a one-line change, and the cross-repo signal gap (a Backend merge can redden this repo's gate with no signal reaching Backend) is tracked separately in WXYC/Backend-Service#2136.

## Verification

- Combined-branches dispatch: this branch + `backend_ref=fix/1999-email-enabled-check-order`, pin line confirmed in the job log — **success, 4/4 shards** ([run 31714993252](https://github.com/WXYC/dj-site/actions/runs/31714993252)); job log line: `Using Backend-Service ref: fix/1999-email-enabled-check-order`.
- This PR's own `pull_request` E2E run resolves Backend to `main` (the paired-branch convention finds no same-named Backend branch), so its green is the post-merge-shape proof: unpinned float + `EMAIL_ENABLED=false` against the Backend `main` that carries the upstream fix.
- `actionlint` clean apart from the 7 shellcheck findings already present on unmodified `main`.

## Related

- #1088 — the outage issue this closes out (closed with a summary comment once this merges and `main` is green)
- #1089 — the emergency pin being removed
- WXYC/Backend-Service#1999 / #1969 — the upstream root cause and the feature that surfaced it
- Paired PR: WXYC/Backend-Service#2135 (merged 2026-08-13, `31408ce1` on Backend main)
