### PR TITLE
Widen AlbumEntry.id to number | null (type-only)

### DIFF
--- a/lib/features/bin/conversions.ts
+++ b/lib/features/bin/conversions.ts
@@ -28,9 +28,12 @@ export function convertBinToFlowsheet(
   // rotation_id stays on the wire (BS#1308 / @wxyc/shared 1.9.0 added it to
   // FlowsheetCreateSongFreeform), so the iOS rotation-artwork resolver can
   // still find unlinked-rotation bin plays by rotation_id alone.
-  const hasLinkedAlbum = hasLinkedAlbumId(binEntry.id);
-
-  if (hasLinkedAlbum) {
+  //
+  // Called inline (not via a saved boolean) so the predicate narrows
+  // `binEntry.id` to `number` for the branch below — bin rows always resolve
+  // to a real `library.id` via an inner join, but the field is `number | null`
+  // to accommodate LML catalog rows, which never reach the bin.
+  if (hasLinkedAlbumId(binEntry.id)) {
     return {
       album_id: binEntry.id,
       track_title: binEntry.title,
@@ -69,7 +72,7 @@ export function convertBinToQueue(binEntry: AlbumEntry): FlowsheetQuery {
     // blank — right back once the DJ types a real performer into the queued
     // row (mirrors RotationEntryFields.handleSelectRelease's withholding
     // trade).
-    album_id: cannotSupplyArtist ? undefined : binEntry.id,
+    album_id: cannotSupplyArtist ? undefined : (binEntry.id ?? undefined),
     song: "",
     album: binEntry.title,
     artist: seedableArtistName(binEntry),

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -349,7 +349,10 @@ export const catalogApi = createApi({
       transformResponse: (response: AlbumSearchResultJSON | null) =>
         response ? convertToAlbumEntry(response) : undefined,
       providesTags: (result) =>
-        result ? [{ type: "AlbumDetail", id: result.id }] : [],
+        // `/library/info` always resolves an existing catalog row — id is
+        // never null here, but the shared AlbumEntry type accommodates LML
+        // rows that never reach this endpoint.
+        result ? [{ type: "AlbumDetail", id: result.id ?? undefined }] : [],
     }),
     markMissing: builder.mutation<AlbumEntry, { albumId: number }>({
       query: ({ albumId }) => ({

--- a/lib/features/catalog/patchSearchCaches.ts
+++ b/lib/features/catalog/patchSearchCaches.ts
@@ -91,7 +91,9 @@ function insertAlbumIntoInfiniteDraft(
   album: AlbumEntry,
   args: CatalogSearchQueryCacheArg,
 ): void {
-  if (findAlbumInSearchDraft(draft, album.id)) return;
+  // Every row this module touches comes from a `/library/query` cache page —
+  // LML rows never enter it — so `album.id` is always a real `library.id`.
+  if (findAlbumInSearchDraft(draft, album.id!)) return;
 
   if (!draft.pages.length) {
     draft.pages = [
@@ -170,14 +172,14 @@ function applyRotationToSearchCache(
   args: CatalogSearchQueryCacheArg,
   album: AlbumEntry,
 ): void {
-  const existing = findAlbumInSearchDraft(draft, album.id);
+  const existing = findAlbumInSearchDraft(draft, album.id!);
   const matches = albumMatchesCatalogQueryArg(album, args);
 
   if (existing) {
     existing.rotation_bin = album.rotation_bin;
     existing.rotation_id = album.rotation_id;
     if (!matches) {
-      removeAlbumFromInfiniteDraft(draft, album.id);
+      removeAlbumFromInfiniteDraft(draft, album.id!);
     }
     return;
   }
@@ -260,12 +262,12 @@ export function patchCatalogSearchCaches(
         "searchLibraryQueryInfinite",
         args,
         (draft) => {
-          const existing = findAlbumInSearchDraft(draft, updated.id);
+          const existing = findAlbumInSearchDraft(draft, updated.id!);
           if (!existing) return;
 
           const merged = mergeAlbumIntoSearchResult(existing, updated);
           if (!albumMatchesCatalogQueryArg(merged, args)) {
-            removeAlbumFromInfiniteDraft(draft, updated.id);
+            removeAlbumFromInfiniteDraft(draft, updated.id!);
             return;
           }
 

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -223,7 +223,7 @@ export type AlbumParams = AddAlbumRequestBody;
 export type ArtistParams = AddArtistRequestBody;
 
 export type AlbumEntry = {
-  id: number;
+  id: number | null;
   title: string;
   artist: ArtistEntry;
   entry: number;

--- a/lib/features/flowsheet/linkage.ts
+++ b/lib/features/flowsheet/linkage.ts
@@ -6,6 +6,8 @@
  * submission shape on this — previously five files re-derived the check
  * locally (#607/#608/#701/#702 lineage).
  */
-export function hasLinkedAlbumId(albumId: unknown): albumId is number {
+export function hasLinkedAlbumId(
+  albumId: number | null | undefined
+): albumId is number {
   return typeof albumId === "number" && albumId > 0;
 }

--- a/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions.ts
+++ b/src/components/experiences/modern/Rightbar/Bin/useBinEntryActions.ts
@@ -69,11 +69,12 @@ export function useBinEntryActions(
         label: "More information",
         Icon: InfoOutlined,
         color: "neutral",
+        // Bin rows always carry a real library.id; only LML rows go null.
         run: () =>
           dispatch(
             applicationSlice.actions.openPanel({
               type: "album-detail",
-              albumId: entry.id,
+              albumId: entry.id!,
             }),
           ),
       },
@@ -89,7 +90,7 @@ export function useBinEntryActions(
         run: (opts) => {
           addToQueue(convertBinToQueue(entry));
           toast.success(queueAdditionMessage(entry));
-          if (opts?.shiftKey) deleteFromBin(entry.id);
+          if (opts?.shiftKey) deleteFromBin(entry.id!);
         },
       });
       actions.push({
@@ -116,7 +117,7 @@ export function useBinEntryActions(
             // Only file the album away once it actually reached the
             // flowsheet — a failed play shouldn't also lose the bin entry.
             .then(() => {
-              if (opts?.shiftKey) deleteFromBin(entry.id);
+              if (opts?.shiftKey) deleteFromBin(entry.id!);
             })
             .catch(() =>
               toast.error(`Failed to add ${entry.title} to flowsheet`),
@@ -130,7 +131,7 @@ export function useBinEntryActions(
       label: "Remove from Bin",
       Icon: Unarchive,
       color: "warning",
-      run: () => deleteFromBin(entry.id),
+      run: () => deleteFromBin(entry.id!),
     });
 
     return actions;

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumEditForm.tsx
@@ -276,7 +276,8 @@ function AlbumEditFormFields({ album }: AlbumEditFormProps) {
     if (!canSave) return;
     let updated: AlbumEntry;
     try {
-      updated = await updateAlbum({ albumId: album.id, body: changes }).unwrap();
+      // Catalog rows always carry a real library.id; only LML rows go null.
+      updated = await updateAlbum({ albumId: album.id!, body: changes }).unwrap();
     } catch (err) {
       if (isUnmessagedHttpError(err)) {
         toast.error("Failed to update album");

--- a/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/DiscogsUnavailableControl.tsx
@@ -55,8 +55,9 @@ function DiscogsUnavailableControl({ album }: DiscogsUnavailableControlProps) {
     }
 
     try {
+      // Catalog rows always carry a real library.id; only LML rows go null.
       await updateAlbum({
-        albumId: album.id,
+        albumId: album.id!,
         body: { discogsUnavailable: next, discogsUnavailableNote: nextNote },
       }).unwrap();
     } catch (err) {
@@ -77,8 +78,9 @@ function DiscogsUnavailableControl({ album }: DiscogsUnavailableControlProps) {
 
     setNotePending(true);
     try {
+      // Catalog rows always carry a real library.id; only LML rows go null.
       await updateAlbum({
-        albumId: album.id,
+        albumId: album.id!,
         body: { discogsUnavailable: true, discogsUnavailableNote: nextNote },
       }).unwrap();
       setSavedNote(nextNote ?? "");

--- a/src/components/experiences/modern/Rightbar/panels/album/LibraryStatus.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/LibraryStatus.tsx
@@ -11,6 +11,7 @@ interface LibraryStatusProps {
   album: AlbumEntry;
 }
 
+// Catalog rows always carry a real library.id; only LML rows go null.
 export default function LibraryStatus({ album }: LibraryStatusProps) {
   const [markMissing] = useMarkMissingMutation();
   const [markFound] = useMarkFoundMutation();
@@ -30,7 +31,7 @@ export default function LibraryStatus({ album }: LibraryStatusProps) {
           size="sm"
           variant="outlined"
           color="success"
-          onClick={() => markFound({ albumId: album.id })}
+          onClick={() => markFound({ albumId: album.id! })}
           sx={{ cursor: "pointer" }}
         >
           Mark Found
@@ -48,7 +49,7 @@ export default function LibraryStatus({ album }: LibraryStatusProps) {
         size="sm"
         variant="outlined"
         color="danger"
-        onClick={() => markMissing({ albumId: album.id })}
+        onClick={() => markMissing({ albumId: album.id! })}
         sx={{ cursor: "pointer" }}
       >
         Mark Missing

--- a/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/RotationClassifyControl.tsx
@@ -62,8 +62,9 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
 
   // `synthesizeAlbumId` hands out negative ids to rows the library never
   // linked (see conversions.ts); neither read nor write may treat one of
-  // those as a real album, so both derive from this single flag.
-  const albumIdValid = album.id > 0;
+  // those as a real album, so both derive from this single flag. A null id
+  // (LML row) is equally invalid here, though this panel never sees one.
+  const albumIdValid = album.id !== null && album.id > 0;
 
   // Both reads project `library.id` as the row id, so matching on it is
   // matching library album to library album. `getRotationFromDB` dedupes
@@ -106,7 +107,8 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
     if (!selectedBin || !albumIdValid) return;
     try {
       await addRotationEntry({
-        album_id: album.id,
+        // Guarded by the `albumIdValid` check above.
+        album_id: album.id!,
         rotation_bin: selectedBin,
       }).unwrap();
       setSelectedBin(null);

--- a/src/components/experiences/modern/catalog/Results/AddToBin.tsx
+++ b/src/components/experiences/modern/catalog/Results/AddToBin.tsx
@@ -10,9 +10,10 @@ export default function AddToBin({
   const { addToBin, loading: binLoading } = useAddToBin();
 
   return (
+    // Catalog/bin/rotation rows always carry a real library.id; only LML rows go null.
     <Tooltip title={`Add ${album.title} to bin`}>
       <IconButton
-        onClick={() => addToBin(album.id)}
+        onClick={() => addToBin(album.id!)}
         loading={binLoading}
         {...props}
       >

--- a/src/components/experiences/modern/catalog/Results/MobileResult.tsx
+++ b/src/components/experiences/modern/catalog/Results/MobileResult.tsx
@@ -37,8 +37,9 @@ function CatalogMobileResult({
 
   const artistDisplay = album.album_artist ? "Various Artists" : album.artist.name;
 
+  // Catalog rows always carry a real library.id; only LML rows go null.
   const openDetail = () =>
-    dispatch(applicationSlice.actions.openPanel({ type: "album-detail", albumId: album.id }));
+    dispatch(applicationSlice.actions.openPanel({ type: "album-detail", albumId: album.id! }));
 
   // The actions sit in the top-right corner, so only the top text lines
   // (title, artist) need to reserve room for them; everything below runs

--- a/src/components/experiences/modern/catalog/Results/RemoveFromBin.tsx
+++ b/src/components/experiences/modern/catalog/Results/RemoveFromBin.tsx
@@ -10,9 +10,10 @@ export default function RemoveFromBin({
   const { deleteFromBin, loading } = useDeleteFromBin();
 
   return (
+    // Catalog/bin/rotation rows always carry a real library.id; only LML rows go null.
     <Tooltip title={`Remove ${album.title} from bin`}>
       <IconButton
-        onClick={() => deleteFromBin(album.id)}
+        onClick={() => deleteFromBin(album.id!)}
         color="warning"
         loading={loading}
         {...props}

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -40,7 +40,8 @@ function CatalogResult({
 
   const { selected, setSelection, sortBy } = useCatalogQuerySearch();
 
-  const isSelected = selected.includes(album.id);
+  // Catalog rows always carry a real library.id; only LML rows go null.
+  const isSelected = selected.includes(album.id!);
 
   const artistDisplay = album.album_artist ? "Various Artists" : album.artist.name;
   const artistDetail = album.album_artist ?? album.alternate_artist;
@@ -59,7 +60,7 @@ function CatalogResult({
     <tr
       key={album.id}
       className={isSelected ? "row-selected" : undefined}
-      onClick={() => dispatch(applicationSlice.actions.openPanel({ type: "album-detail", albumId: album.id }))}
+      onClick={() => dispatch(applicationSlice.actions.openPanel({ type: "album-detail", albumId: album.id! }))}
       style={{ cursor: "pointer" }}
     >
       <td
@@ -72,7 +73,7 @@ function CatalogResult({
           onChange={(event) => {
             setSelection(
               event.target.checked
-                ? [...selected, album.id]
+                ? [...selected, album.id!]
                 : selected.filter((item) => item !== album.id)
             );
           }}
@@ -198,7 +199,7 @@ function CatalogResult({
               variant="plain"
               color="neutral"
               size="sm"
-              onClick={() => dispatch(applicationSlice.actions.openPanel({ type: "album-detail", albumId: album.id }))}
+              onClick={() => dispatch(applicationSlice.actions.openPanel({ type: "album-detail", albumId: album.id! }))}
             >
               <InfoOutlinedIcon />
             </IconButton>

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -203,9 +203,10 @@ export default function Results({
                     selected.length === releaseList.length
                   }
                   onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                    // Catalog rows always carry a real library.id; only LML rows go null.
                     setSelection(
                       event.target.checked
-                        ? releaseList.map((row) => row.id)
+                        ? releaseList.map((row) => row.id!)
                         : []
                     );
                   }}

--- a/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
@@ -68,8 +68,12 @@ export default function FlowsheetSearchResults({
   // and #702's chokepoint drops track_position anyway. Skip the picker entirely
   // for those rows instead of letting the DJ pick something we'll silently
   // discard. (dj-site#704)
+  // `highlightedResult.id === null` (an LML row) falls through to the
+  // frozen-query check below exactly like a non-positive id does today —
+  // widening `AlbumEntry.id` must not make the picker disappear for the one
+  // source where it currently works. Real fix is #1184.
   const effectiveAlbumId =
-    highlightedResult && highlightedResult.id > 0
+    highlightedResult && highlightedResult.id !== null && highlightedResult.id > 0
       ? highlightedResult.id
       : hasLinkedAlbumId(frozenAlbumId)
         ? (frozenAlbumId as number)

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -98,7 +98,7 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
           // credit — or the very blank — the DJ is about to replace in the
           // field below. Classic makes the same trade by switching
           // submission variants.
-          album_id: releaseCannotSupplyArtist(release) ? undefined : release.id,
+          album_id: releaseCannotSupplyArtist(release) ? undefined : (release.id ?? undefined),
           rotation_id: release.rotation_id,
           rotation_bin: release.rotation_bin,
         })

--- a/src/hooks/binHooks.ts
+++ b/src/hooks/binHooks.ts
@@ -80,7 +80,8 @@ export const useClearBin = () => {
     try {
       const outcomes = await Promise.allSettled(
         bin.map((entry) =>
-          deleteFromBin({ dj_id: info.id!, album_id: entry.id }).unwrap()
+          // Bin rows always carry a real library.id; only LML rows go null.
+          deleteFromBin({ dj_id: info.id!, album_id: entry.id! }).unwrap()
         )
       );
       // Name what survived so the DJ knows which albums to retry — the

--- a/src/hooks/catalogHooks.ts
+++ b/src/hooks/catalogHooks.ts
@@ -31,13 +31,17 @@ import type { Rotation } from "@/lib/features/rotation/types";
 
 const MIN_QUERY_LENGTH = 2;
 
-/** Keep first occurrence per album id (backend may return duplicates in one page). */
+/**
+ * Keep first occurrence per album id (backend may return duplicates in one
+ * page). Catalog-page rows always carry a real library.id; only LML rows
+ * (never passed here) go null.
+ */
 export function dedupeAlbumEntriesById(entries: AlbumEntry[]): AlbumEntry[] {
   const seen = new Set<number>();
   const out: AlbumEntry[] = [];
   for (const entry of entries) {
-    if (seen.has(entry.id)) continue;
-    seen.add(entry.id);
+    if (seen.has(entry.id!)) continue;
+    seen.add(entry.id!);
     out.push(entry);
   }
   return out;

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -232,11 +232,16 @@ const useFlowsheetSearchResults = () => {
   });
 
   const lmlResults = useMemo(() => {
+    // bin/rotation/catalog rows always carry a real library.id; widening
+    // `seen` to `Set<number | null>` would make every LML row (id possibly
+    // null) test `!seen.has(null)` — always true — turning the dedupe into a
+    // guaranteed no-op. Keep `Set<number>` and filter the null case
+    // explicitly instead. Real fix is #1184.
     const seen = new Set<number>();
-    for (const r of binResults) seen.add(r.id);
-    for (const r of rotationResults) seen.add(r.id);
-    for (const r of catalogResults) seen.add(r.id);
-    return rawLmlResults.filter((r) => !seen.has(r.id));
+    for (const r of binResults) if (r.id !== null) seen.add(r.id);
+    for (const r of rotationResults) if (r.id !== null) seen.add(r.id);
+    for (const r of catalogResults) if (r.id !== null) seen.add(r.id);
+    return rawLmlResults.filter((r) => r.id === null || !seen.has(r.id));
   }, [binResults, rotationResults, catalogResults, rawLmlResults]);
 
   const allSearchResults = useMemo(

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -238,8 +238,9 @@ const useFlowsheetSearchResults = () => {
     // Set<number> or Set<number | null>, since bin/rotation/catalog never
     // contribute a null id for `seen` to match against either way. So this
     // dedupe is a no-op for null-id LML rows regardless of the Set's type
-    // parameter; #1184 must dedupe those rows against bin/rotation/catalog
-    // explicitly once LML starts returning them.
+    // parameter: once LML starts returning null ids, deduping those rows
+    // against bin/rotation/catalog needs an explicit identity check
+    // elsewhere — this predicate does not provide one.
     const seen = new Set<number>();
     for (const r of binResults) if (r.id !== null) seen.add(r.id);
     for (const r of rotationResults) if (r.id !== null) seen.add(r.id);

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -232,11 +232,14 @@ const useFlowsheetSearchResults = () => {
   });
 
   const lmlResults = useMemo(() => {
-    // bin/rotation/catalog rows always carry a real library.id; widening
-    // `seen` to `Set<number | null>` would make every LML row (id possibly
-    // null) test `!seen.has(null)` — always true — turning the dedupe into a
-    // guaranteed no-op. Keep `Set<number>` and filter the null case
-    // explicitly instead. Real fix is #1184.
+    // bin/rotation/catalog rows always carry a real library.id; LML rows may
+    // carry id: null. The `r.id === null || ...` clause below keeps every
+    // null-id row unconditionally — that's true whether `seen` is typed
+    // Set<number> or Set<number | null>, since bin/rotation/catalog never
+    // contribute a null id for `seen` to match against either way. So this
+    // dedupe is a no-op for null-id LML rows regardless of the Set's type
+    // parameter; #1184 must dedupe those rows against bin/rotation/catalog
+    // explicitly once LML starts returning them.
     const seen = new Set<number>();
     for (const r of binResults) if (r.id !== null) seen.add(r.id);
     for (const r of rotationResults) if (r.id !== null) seen.add(r.id);

--- a/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
+++ b/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
@@ -14,7 +14,8 @@ const deleteFromBin = vi.fn();
 
 const convertBinToQueueMock = vi.fn((e: AlbumEntry) => ({ q: e.id }));
 const convertBinToFlowsheetMock = vi.fn(
-  (e: AlbumEntry): { f: number } | null => ({ f: e.id })
+  // Test fixtures always carry a real numeric id.
+  (e: AlbumEntry): { f: number } | null => ({ f: e.id! })
 );
 
 vi.mock("@/lib/hooks", () => ({ useAppDispatch: () => dispatch }));

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -60,8 +60,12 @@ vi.mock("@/src/hooks/catalogHooks", () => ({
 
 // Mock LML hooks (#563 — useLmlLibrarySearch now wraps lmlApi RTK Query, which
 // isn't in the createHookWrapper store these tests use).
+const mockUseLmlLibrarySearch = vi.fn(() => ({
+  results: [] as ReturnType<typeof createTestAlbum>[],
+  isLoading: false,
+}));
 vi.mock("@/src/hooks/useLmlLibrarySearch", () => ({
-  useLmlLibrarySearch: () => ({ results: [], isLoading: false }),
+  useLmlLibrarySearch: () => mockUseLmlLibrarySearch(),
 }));
 
 // Mock flowsheet API hooks
@@ -217,6 +221,10 @@ describe("flowsheetHooks", () => {
     mockUseRotationFlowsheetSearch.mockReturnValue({
       searchResults: [],
       loading: false,
+    });
+    mockUseLmlLibrarySearch.mockReturnValue({
+      results: [],
+      isLoading: false,
     });
     // Clear localStorage
     if (typeof window !== "undefined") {
@@ -1331,6 +1339,30 @@ describe("flowsheetHooks", () => {
       });
 
       expect(Array.isArray(result.current.rotationResults)).toBe(true);
+    });
+
+    // Pins the null-id path of the LML dedupe: a null-id LML row is never
+    // dropped by the `seen`-based dedupe (it isn't a real duplicate of
+    // anything catalog/bin/rotation could carry), while an LML row that
+    // shares an id with an already-seen catalog row is still deduped away.
+    it("keeps a null-id LML row and drops one that duplicates a seen catalog id", () => {
+      mockUseCatalogFlowsheetSearch.mockReturnValue({
+        searchResults: [createTestAlbum({ id: 42, title: "DOGA" })],
+      });
+      mockUseLmlLibrarySearch.mockReturnValue({
+        results: [
+          createTestAlbum({ id: 42, title: "DOGA (LML duplicate)" }),
+          createTestAlbum({ id: null, title: "Edits" }),
+        ],
+        isLoading: false,
+      });
+
+      const { result } = renderHook(() => useFlowsheetSubmit(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.lmlResults).toHaveLength(1);
+      expect(result.current.lmlResults[0].title).toBe("Edits");
     });
 
     it("should return selectedResultData", () => {

--- a/tests/unit/lib/features/catalog/conversions.test.ts
+++ b/tests/unit/lib/features/catalog/conversions.test.ts
@@ -456,7 +456,7 @@ describe("catalog conversions", () => {
         const state = flowsheetSlice.reducer(
           defaultFlowsheetFrontendState,
           flowsheetSlice.actions.setRotationMetadata({
-            album_id: albumEntry.id,
+            album_id: albumEntry.id ?? undefined,
             rotation_id: albumEntry.rotation_id,
             rotation_bin: albumEntry.rotation_bin,
           })
@@ -485,7 +485,7 @@ describe("catalog conversions", () => {
         const state = flowsheetSlice.reducer(
           defaultFlowsheetFrontendState,
           flowsheetSlice.actions.setRotationMetadata({
-            album_id: albumEntry.id,
+            album_id: albumEntry.id ?? undefined,
             rotation_id: albumEntry.rotation_id,
             rotation_bin: albumEntry.rotation_bin,
           })
@@ -535,7 +535,7 @@ describe("catalog conversions", () => {
         const state = flowsheetSlice.reducer(
           defaultFlowsheetFrontendState,
           flowsheetSlice.actions.setRotationMetadata({
-            album_id: albumEntry.id,
+            album_id: albumEntry.id ?? undefined,
             rotation_id: albumEntry.rotation_id,
             rotation_bin: albumEntry.rotation_bin,
           })

--- a/tests/unit/lib/features/flowsheet/linkage.test.ts
+++ b/tests/unit/lib/features/flowsheet/linkage.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { hasLinkedAlbumId } from "@/lib/features/flowsheet/linkage";
+
+describe("hasLinkedAlbumId", () => {
+  it("is true for a positive album id", () => {
+    expect(hasLinkedAlbumId(1001)).toBe(true);
+  });
+
+  it("is false for a synthesized negative id", () => {
+    expect(hasLinkedAlbumId(-1)).toBe(false);
+  });
+
+  it("is false for zero", () => {
+    expect(hasLinkedAlbumId(0)).toBe(false);
+  });
+
+  it("is false for null", () => {
+    expect(hasLinkedAlbumId(null)).toBe(false);
+  });
+
+  it("is false for undefined", () => {
+    expect(hasLinkedAlbumId(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Type-only change with zero runtime behavior change. `AlbumEntry.id` widens from `number` to `number | null` in `lib/features/catalog/types.ts`, in preparation for LML rows carrying no `library.id` (#1184). Nothing produces `null` yet.

`hasLinkedAlbumId` (`lib/features/flowsheet/linkage.ts`) narrows from `unknown` to `number | null | undefined`, `albumId is number`. Previously it absorbed the widening silently — `unknown` accepts anything, so no call site would have raised a compile error. Narrowing it makes the widening (and any future one) compiler-visible.

## Flagged sites — behavior explicitly preserved

- `FlowsheetSearchResults.tsx`'s `effectiveAlbumId` derivation now guards `highlightedResult.id !== null` before the `> 0` comparison. The naive null-propagating fix would make the picker disappear for LML rows — the one source where it currently works. Real fix lands in #1184.
- `flowsheetHooks.ts`'s LML dedupe keeps `Set<number>` (not widened to `Set<number | null>`) and filters `null` explicitly on both the populate and lookup sides. Widening the set's type would make every LML row test `!seen.has(null)` — always true — turning the dedupe into a no-op. Real fix lands in #1184.

## Per-site benign confirmations

Every other call site the widening touched is on the catalog-page, bin, or rotation surface, where rows always resolve to a real `library.id` (catalog rows come from `/library/` or `/library/query`; bin rows resolve via an inner join) — LML rows never enter these paths. Each is fixed with the narrowest possible change (non-null assertion or `?? undefined` coercion) and a one-line comment recording the invariant, in: `lib/features/bin/conversions.ts`, `lib/features/catalog/api.ts`, `lib/features/catalog/patchSearchCaches.ts`, `src/hooks/catalogHooks.ts`, `src/hooks/binHooks.ts`, `AddToBin.tsx`, `RemoveFromBin.tsx`, `Result.tsx`, `MobileResult.tsx`, `Results.tsx`, `RotationEntryFields.tsx`, `useBinEntryActions.ts`, `AlbumEditForm.tsx`, `DiscogsUnavailableControl.tsx`, `LibraryStatus.tsx`, `RotationClassifyControl.tsx`.

Added `tests/unit/lib/features/flowsheet/linkage.test.ts` covering `hasLinkedAlbumId`'s null/undefined branches explicitly, since the narrowed signature makes those inputs first-class.

Closes #1182

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (pre-existing warning backlog unchanged)
- [x] `npm run test:run` — full suite green except 3 pre-existing flaky timeouts in `VaTracklistStep.test.tsx` under full-suite load; all 24 pass in isolation both before and after this change, confirming the flake is unrelated