### PR TITLE
Thread preloadedState through makeStore so renderWithProviders honors it

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,8 +31,8 @@ and server (`tests/fakes/`), and fixture factories (`tests/fixtures/`).
 
 ### Rendering
 
-- **`renderWithProviders(ui, options?)`** -- Wraps component in Redux `Provider` + MUI `CssVarsProvider`. Returns `{ ...rtlResult, store, user }`. Accepts a custom `store`; seed state by dispatching actions against the returned `store` before or after render, not via a `preloadedState` option.
-- **`createTestStore()`** -- Creates a fresh `AppStore` instance.
+- **`renderWithProviders(ui, options?)`** -- Wraps component in Redux `Provider` + MUI `CssVarsProvider`. Returns `{ ...rtlResult, store, user }`. Accepts a custom `store`, or a `preloadedState` to seed the store it creates.
+- **`createTestStore(preloadedState?)`** -- Creates a fresh `AppStore` instance, optionally seeded.
 
 ### Factory Functions
 

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -51,10 +51,11 @@ const rootReducer = combineSlices(
 
 export type RootState = ReturnType<typeof rootReducer>;
 
-export const makeStore = () => {
+export const makeStore = (preloadedState?: Partial<RootState>) => {
   const liveUpdatesListener = createLiveUpdatesListenerMiddleware("dashboard");
   const store = configureStore({
     reducer: rootReducer,
+    preloadedState,
     middleware: (getDefaultMiddleware) => {
       return getDefaultMiddleware()
         .prepend(liveUpdatesListener.middleware)

--- a/tests/helpers/render.tsx
+++ b/tests/helpers/render.tsx
@@ -39,23 +39,19 @@ function createTestWrapper(store: AppStore) {
  * const { getByText, store } = renderWithProviders(<MyComponent />);
  *
  * @example
- * // Seed state by dispatching against the returned store, then re-render
- * const { store, rerender } = renderWithProviders(<MyComponent />);
- * store.dispatch(flowsheetSlice.actions.setAutoplay(true));
- * rerender(<MyComponent />);
+ * // Seed state via preloadedState
+ * const { store } = renderWithProviders(<MyComponent />, {
+ *   preloadedState: { flowsheet: { ...flowsheetSlice.getInitialState(), autoplay: true } },
+ * });
  */
 export function renderWithProviders(
   ui: ReactElement,
   {
     preloadedState,
-    store = makeStore(),
+    store = makeStore(preloadedState),
     ...renderOptions
   }: ExtendedRenderOptions = {}
 ): CustomRenderResult {
-  // Apply preloaded state to the store if provided
-  // Note: For full preloadedState support, makeStore would need to accept it
-  // This is a simplified version that works with the current store setup
-
   const user = userEvent.setup();
   const wrapper = createTestWrapper(store);
 
@@ -70,8 +66,8 @@ export function renderWithProviders(
  * Create a store for use in tests.
  * Returns a fresh store instance for each test.
  */
-export function createTestStore(): AppStore {
-  return makeStore();
+export function createTestStore(preloadedState?: Partial<RootState>): AppStore {
+  return makeStore(preloadedState);
 }
 
 // Re-export everything from @testing-library/react

--- a/tests/unit/lib/store.test.tsx
+++ b/tests/unit/lib/store.test.tsx
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import { useAppSelector } from "@/lib/hooks";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -9,6 +11,9 @@ vi.mock("sonner", () => ({
 
 import { rtkQueryErrorLogger } from "@/lib/rtk-query-error-logger";
 import { toast } from "sonner";
+import { makeStore } from "@/lib/store";
+import { applicationSlice } from "@/lib/features/application/frontend";
+import { renderWithProviders } from "@/tests/helpers/render";
 
 function createRejectedAction(payload: unknown) {
   return {
@@ -84,5 +89,44 @@ describe("rtkQueryErrorLogger (Bug 29)", () => {
     const action = { type: "some/action" };
     middleware(action);
     expect(next).toHaveBeenCalledWith(action);
+  });
+});
+
+describe("makeStore", () => {
+  it("forwards preloadedState to configureStore", () => {
+    const store = makeStore({
+      application: {
+        ...applicationSlice.getInitialState(),
+        rightbar: {
+          ...applicationSlice.getInitialState().rightbar,
+          sidebarOpen: true,
+        },
+      },
+    });
+
+    expect(store.getState().application.rightbar.sidebarOpen).toBe(true);
+  });
+});
+
+describe("renderWithProviders preloadedState", () => {
+  function SidebarOpenProbe() {
+    const sidebarOpen = useAppSelector((s) => s.application.rightbar.sidebarOpen);
+    return <div data-testid="sidebar-open">{String(sidebarOpen)}</div>;
+  }
+
+  it("seeds the store rendered by renderWithProviders", () => {
+    renderWithProviders(<SidebarOpenProbe />, {
+      preloadedState: {
+        application: {
+          ...applicationSlice.getInitialState(),
+          rightbar: {
+            ...applicationSlice.getInitialState().rightbar,
+            sidebarOpen: true,
+          },
+        },
+      },
+    });
+
+    expect(screen.getByTestId("sidebar-open")).toHaveTextContent("true");
   });
 });


### PR DESCRIPTION
## Summary

`makeStore()` ignored an optional preloaded-state argument (it took none), and `renderWithProviders` destructured a `preloadedState` option but never used it — always calling `makeStore()` with no argument. Specs that seeded state via `renderWithProviders(..., { preloadedState })` were silently asserting against a default store instead of the seeded one.

- `makeStore` (`lib/store.ts`) now accepts an optional `preloadedState?: Partial<RootState>` and forwards it to `configureStore`. `StoreProvider` (`makeStore()`'s only non-test caller) is unaffected.
- `renderWithProviders` (`tests/helpers/render.tsx`) now defaults `store = makeStore(preloadedState)` instead of discarding the option; the stale "makeStore would need to accept it" comment and `@example` are updated to reflect that the option works.
- `createTestStore()` now accepts and forwards an optional `preloadedState`.
- `docs/testing.md` re-corrected to describe the working option (reversing the discard note added by #1180, per that issue's own note about the doc-line race).

Closes #1181

## Test plan

- [x] Added a failing-first spec (`tests/unit/lib/store.test.tsx`) asserting `makeStore(preloadedState)` and `renderWithProviders(..., { preloadedState })` both observe the seeded state; confirmed it failed before the fix and passes after.
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npx tsc --noEmit` — clean
- [x] Full suite: `npx vitest run` — 319 files / 4583 tests, all passing (no spec was passing vacuously on the discarded option; `LibraryTrackPicker.test.tsx`, the one confirmed real `renderWithProviders`-preloadedState consumer, stays green and untouched per #1181's coordination note with #1184)