### PR TITLE
Make store and preloadedState mutually exclusive in renderWithProviders

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,7 +31,7 @@ and server (`tests/fakes/`), and fixture factories (`tests/fixtures/`).
 
 ### Rendering
 
-- **`renderWithProviders(ui, options?)`** -- Wraps component in Redux `Provider` + MUI `CssVarsProvider`. Returns `{ ...rtlResult, store, user }`. Accepts a custom `store`, or a `preloadedState` to seed the store it creates.
+- **`renderWithProviders(ui, options?)`** -- Wraps component in Redux `Provider` + MUI `CssVarsProvider`. Returns `{ ...rtlResult, store, user }`. Seed state with `preloadedState` (the store is built for you). If you need to share a store across multiple renders or interact with it before rendering, build it yourself with `createTestStore(preloadedState?)` and pass it as `store`. `store` and `preloadedState` are mutually exclusive -- passing both is a compile error, since a supplied store already has its own state and `preloadedState` would be silently discarded.
 - **`createTestStore(preloadedState?)`** -- Creates a fresh `AppStore` instance, optionally seeded.
 
 ### Factory Functions

--- a/tests/helpers/render.tsx
+++ b/tests/helpers/render.tsx
@@ -8,11 +8,15 @@ import { CssVarsProvider } from "@mui/joy/styles";
 import type { AppStore, RootState } from "@/lib/store";
 import { makeStore } from "@/lib/store";
 
-// Extended render options to include preloaded state and store
-interface ExtendedRenderOptions extends Omit<RenderOptions, "wrapper"> {
-  preloadedState?: Partial<RootState>;
-  store?: AppStore;
-}
+// A caller seeds state via preloadedState (the store is built for them) or
+// hands in an already-built store (e.g. to share one across renders) — never
+// both, since a supplied store already has its own state and preloadedState
+// would be silently discarded. This union makes that combination a type error.
+type SeedOptions =
+  | { preloadedState?: Partial<RootState>; store?: never }
+  | { store: AppStore; preloadedState?: never };
+
+type ExtendedRenderOptions = Omit<RenderOptions, "wrapper"> & SeedOptions;
 
 // Custom render result that includes the store and user event utilities
 interface CustomRenderResult extends RenderResult {

--- a/tests/integration/components/modern/Header/MobileHeader.test.tsx
+++ b/tests/integration/components/modern/Header/MobileHeader.test.tsx
@@ -1,10 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, fireEvent } from "@testing-library/react";
 import MobileHeader from "@/src/components/experiences/modern/Header/MobileHeader";
-import { Provider } from "react-redux";
-import { configureStore } from "@reduxjs/toolkit";
 import { applicationSlice } from "@/lib/features/application/frontend";
-import { render } from "@testing-library/react";
+import { renderWithProviders, createTestStore } from "@/tests/helpers";
 
 // Mock Logo component
 vi.mock("@/src/components/shared/Branding/Logo", () => ({
@@ -47,14 +45,10 @@ function declaredStyle(element: Element, property: string): string | undefined {
   return undefined;
 }
 
-function createTestStore(initialState?: { rightbar?: { sidebarOpen?: boolean } }) {
-  return configureStore({
-    reducer: {
-      application: applicationSlice.reducer,
-    },
-    preloadedState: initialState
-      ? { application: { ...applicationSlice.getInitialState(), ...initialState } as any }
-      : undefined,
+function createStoreWithSidebar(sidebarOpen: boolean) {
+  const initial = applicationSlice.getInitialState();
+  return createTestStore({
+    application: { ...initial, rightbar: { ...initial.rightbar, sidebarOpen } },
   });
 }
 
@@ -67,11 +61,7 @@ describe("MobileHeader", () => {
     it("should render as a Sheet component", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const sheet = document.querySelector(".MuiSheet-root");
       expect(sheet).toBeInTheDocument();
@@ -80,11 +70,7 @@ describe("MobileHeader", () => {
     it("should render Logo component", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       expect(screen.getByTestId("logo")).toBeInTheDocument();
     });
@@ -92,11 +78,7 @@ describe("MobileHeader", () => {
     it("should render menu toggle button", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       expect(screen.getByRole("button")).toBeInTheDocument();
     });
@@ -104,11 +86,7 @@ describe("MobileHeader", () => {
     it("should render DragHandle icon in menu button", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       expect(screen.getByTestId("drag-handle-icon")).toBeInTheDocument();
     });
@@ -119,11 +97,7 @@ describe("MobileHeader", () => {
       const store = createTestStore();
       const dispatchSpy = vi.spyOn(store, "dispatch");
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const button = screen.getByRole("button");
       fireEvent.click(button);
@@ -136,11 +110,7 @@ describe("MobileHeader", () => {
     it("should call toggleSidebarCSS when button is clicked", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const button = screen.getByRole("button");
       fireEvent.click(button);
@@ -149,15 +119,9 @@ describe("MobileHeader", () => {
     });
 
     it("should toggle sidebar state in store when clicked", () => {
-      const store = createTestStore({
-        rightbar: { sidebarOpen: false },
-      });
+      const store = createStoreWithSidebar(false);
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       // Initial state
       expect(store.getState().application.rightbar.sidebarOpen).toBe(false);
@@ -170,15 +134,9 @@ describe("MobileHeader", () => {
     });
 
     it("should toggle sidebar from open to closed", () => {
-      const store = createTestStore({
-        rightbar: { sidebarOpen: true },
-      });
+      const store = createStoreWithSidebar(true);
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       // Initial state
       expect(store.getState().application.rightbar.sidebarOpen).toBe(true);
@@ -195,11 +153,7 @@ describe("MobileHeader", () => {
     it("should have outlined variant on button", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const button = screen.getByRole("button");
       expect(button).toHaveClass("MuiIconButton-variantOutlined");
@@ -208,11 +162,7 @@ describe("MobileHeader", () => {
     it("should have neutral color on button", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const button = screen.getByRole("button");
       expect(button).toHaveClass("MuiIconButton-colorNeutral");
@@ -221,11 +171,7 @@ describe("MobileHeader", () => {
     it("should have small size on button", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const button = screen.getByRole("button");
       expect(button).toHaveClass("MuiIconButton-sizeSm");
@@ -236,11 +182,7 @@ describe("MobileHeader", () => {
     it("should position header at top of viewport", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const sheet = document.querySelector(".MuiSheet-root");
       expect(sheet).toHaveStyle({ position: "fixed", top: "0px" });
@@ -249,11 +191,7 @@ describe("MobileHeader", () => {
     it("should have full viewport width", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const sheet = document.querySelector(".MuiSheet-root")!;
       expect(declaredStyle(sheet, "width")).toBe("100vw");
@@ -262,15 +200,9 @@ describe("MobileHeader", () => {
 
   describe("Multiple Interactions", () => {
     it("should handle multiple toggle clicks", () => {
-      const store = createTestStore({
-        rightbar: { sidebarOpen: false },
-      });
+      const store = createStoreWithSidebar(false);
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const button = screen.getByRole("button");
 
@@ -290,11 +222,7 @@ describe("MobileHeader", () => {
     it("should call toggleSidebarCSS on each click", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const button = screen.getByRole("button");
 
@@ -310,11 +238,7 @@ describe("MobileHeader", () => {
     it("should have accessible button element", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const button = screen.getByRole("button");
       expect(button).toBeInTheDocument();
@@ -324,11 +248,7 @@ describe("MobileHeader", () => {
     it("should be keyboard accessible", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const button = screen.getByRole("button");
       button.focus();
@@ -340,11 +260,7 @@ describe("MobileHeader", () => {
     it("should have three child elements in header (button, logo container, empty box)", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const sheet = document.querySelector(".MuiSheet-root");
       // Button, Logo Box, Empty Box
@@ -354,11 +270,7 @@ describe("MobileHeader", () => {
     it("should render logo inside a container box", () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <MobileHeader />
-        </Provider>
-      );
+      renderWithProviders(<MobileHeader />, { store });
 
       const logo = screen.getByTestId("logo");
       expect(logo.parentElement).toHaveClass("MuiBox-root");

--- a/tests/integration/components/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FlowsheetSearchbar from "@/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar";
 import { renderWithProviders, createTestStore } from "@/tests/helpers";

--- a/tests/integration/components/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/FlowsheetSearchbar.test.tsx
@@ -1,9 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FlowsheetSearchbar from "@/src/components/experiences/modern/flowsheet/Search/FlowsheetSearchbar";
-import { Provider } from "react-redux";
-import { configureStore } from "@reduxjs/toolkit";
+import { renderWithProviders, createTestStore } from "@/tests/helpers";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import { useGhostText } from "@/src/hooks/useGhostText";
 import { useFlowsheetSearch } from "@/src/hooks/flowsheetHooks";
@@ -111,15 +110,6 @@ function createStoreWithQueryContent(artist = "Stereolab") {
   });
 }
 
-function createTestStore(preloadedState = {}) {
-  return configureStore({
-    reducer: {
-      flowsheet: flowsheetSlice.reducer,
-    },
-    preloadedState,
-  });
-}
-
 describe("FlowsheetSearchbar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -139,11 +129,7 @@ describe("FlowsheetSearchbar", () => {
   it("should render search form", () => {
     const store = createTestStore();
 
-    const { container } = render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    const { container } = renderWithProviders(<FlowsheetSearchbar />, { store });
 
     expect(container.querySelector("form")).toBeInTheDocument();
   });
@@ -151,11 +137,7 @@ describe("FlowsheetSearchbar", () => {
   it("should not stretch to fill the page column (regression: giant gap above the flowsheet)", () => {
     const store = createTestStore();
 
-    const { container } = render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    const { container } = renderWithProviders(<FlowsheetSearchbar />, { store });
 
     // MainContent is a column flex pinned to 100dvh; flex-grow on the
     // searchbar's outer wrapper absorbs all leftover vertical space and
@@ -170,11 +152,7 @@ describe("FlowsheetSearchbar", () => {
   it("should render BreakpointButton", () => {
     const store = createTestStore();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     expect(screen.getByTestId("breakpoint-button")).toBeInTheDocument();
   });
@@ -182,11 +160,7 @@ describe("FlowsheetSearchbar", () => {
   it("should render TalksetButton", () => {
     const store = createTestStore();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     expect(screen.getByTestId("talkset-button")).toBeInTheDocument();
   });
@@ -194,11 +168,7 @@ describe("FlowsheetSearchbar", () => {
   it("should render search inputs in Artist | Song | Album | Label order", () => {
     const store = createTestStore();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     const artist = screen.getByTestId("input-artist");
     const song = screen.getByTestId("input-song");
@@ -223,11 +193,7 @@ describe("FlowsheetSearchbar", () => {
   it("should not render the results panel while the search is closed", () => {
     const store = createTestStore();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     expect(screen.queryByTestId("search-results")).not.toBeInTheDocument();
   });
@@ -236,11 +202,7 @@ describe("FlowsheetSearchbar", () => {
     mockSearchOpen = true;
     const store = createTestStore();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     expect(screen.getByTestId("search-results")).toBeInTheDocument();
   });
@@ -250,11 +212,7 @@ describe("FlowsheetSearchbar", () => {
   it("should render the rotation toggle in the leading cell", () => {
     const store = createTestStore();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     expect(screen.getByTestId("rotation-toggle")).toBeInTheDocument();
     expect(screen.queryByTestId("search-icon")).not.toBeInTheDocument();
@@ -267,11 +225,7 @@ describe("FlowsheetSearchbar", () => {
     mockCtrlKeyPressed = false;
     const store = createStoreWithQueryContent();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     const queueButton = screen.getByTestId("flowsheet-search-queue");
     expect(queueButton).toBeInTheDocument();
@@ -283,11 +237,7 @@ describe("FlowsheetSearchbar", () => {
     mockLive = true;
     const store = createStoreWithQueryContent();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     const clearButton = screen.getByTestId("flowsheet-search-clear");
     fireEvent.click(clearButton);
@@ -297,11 +247,7 @@ describe("FlowsheetSearchbar", () => {
   it("should not show the clear button while the query is empty", () => {
     const store = createTestStore();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     expect(
       screen.queryByTestId("flowsheet-search-clear")
@@ -317,11 +263,7 @@ describe("FlowsheetSearchbar", () => {
       flowsheet: { ...initial, rotationMode: true },
     });
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     const clearButton = screen.getByTestId("flowsheet-search-clear");
     fireEvent.click(clearButton);
@@ -335,11 +277,7 @@ describe("FlowsheetSearchbar", () => {
     mockLive = false;
     const store = createTestStore();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     for (const name of ["artist", "song", "album", "label"]) {
       expect(screen.getByTestId(`input-${name}`)).toBeDisabled();
@@ -350,11 +288,7 @@ describe("FlowsheetSearchbar", () => {
     mockLive = true;
     const store = createTestStore();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     fireEvent.focus(screen.getByTestId("breakpoint-button"));
     fireEvent.click(screen.getByTestId("talkset-button"));
@@ -365,11 +299,7 @@ describe("FlowsheetSearchbar", () => {
   it("should not show the queue button while the search is closed", () => {
     const store = createTestStore();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     expect(
       screen.queryByTestId("flowsheet-search-queue")
@@ -379,11 +309,7 @@ describe("FlowsheetSearchbar", () => {
   it("should render submit button", () => {
     const store = createTestStore();
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchbar />
-      </Provider>
-    );
+    renderWithProviders(<FlowsheetSearchbar />, { store });
 
     // The button shows "/" when not in search mode
     const buttons = screen.getAllByRole("button");
@@ -395,11 +321,7 @@ describe("FlowsheetSearchbar", () => {
       mockLive = true;
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       // Simulate keydown event on document
       fireEvent.keyDown(document, { key: "/" });
@@ -413,11 +335,7 @@ describe("FlowsheetSearchbar", () => {
       mockLive = true;
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       const input = screen.getByTestId("input-song");
       input.focus();
@@ -438,11 +356,7 @@ describe("FlowsheetSearchbar", () => {
       mockLive = false;
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       fireEvent.keyDown(document, { key: "/" });
 
@@ -457,11 +371,7 @@ describe("FlowsheetSearchbar", () => {
 
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       fireEvent.keyDown(document, { key: "ArrowDown" });
 
@@ -485,11 +395,7 @@ describe("FlowsheetSearchbar", () => {
         },
       });
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       fireEvent.keyDown(document, { key: "ArrowUp" });
 
@@ -516,11 +422,7 @@ describe("FlowsheetSearchbar", () => {
         },
       });
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       fireEvent.keyDown(document, { key: "ArrowDown" });
 
@@ -539,11 +441,7 @@ describe("FlowsheetSearchbar", () => {
         },
       });
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       fireEvent.keyDown(document, { key: "ArrowUp" });
 
@@ -556,11 +454,12 @@ describe("FlowsheetSearchbar", () => {
     it("should reset search on click away", async () => {
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
+      renderWithProviders(
+        <>
           <FlowsheetSearchbar />
           <div data-testid="outside">Outside</div>
-        </Provider>
+        </>,
+        { store }
       );
 
       // Click outside the search bar
@@ -575,11 +474,7 @@ describe("FlowsheetSearchbar", () => {
     it("should call handleSubmit on form submit", async () => {
       const store = createTestStore();
 
-      const { container } = render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      const { container } = renderWithProviders(<FlowsheetSearchbar />, { store });
 
       const form = container.querySelector("form")!;
       fireEvent.submit(form);
@@ -590,11 +485,7 @@ describe("FlowsheetSearchbar", () => {
     it("should prevent default on form submit", async () => {
       const store = createTestStore();
 
-      const { container } = render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      const { container } = renderWithProviders(<FlowsheetSearchbar />, { store });
 
       const form = container.querySelector("form")!;
       const submitEvent = new Event("submit", { bubbles: true, cancelable: true });
@@ -614,11 +505,7 @@ describe("FlowsheetSearchbar", () => {
       mockSearchOpen = false;
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       expect(screen.getByTestId("breakpoint-button")).toBeInTheDocument();
       expect(screen.getByTestId("talkset-button")).toBeInTheDocument();
@@ -633,11 +520,7 @@ describe("FlowsheetSearchbar", () => {
     it("should swap out special-entry buttons once the DJ has typed", () => {
       const store = createStoreWithQueryContent();
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       expect(screen.queryByTestId("breakpoint-button")).not.toBeInTheDocument();
       expect(screen.queryByTestId("talkset-button")).not.toBeInTheDocument();
@@ -674,11 +557,7 @@ describe("FlowsheetSearchbar", () => {
 
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       // Button should be rendered (with play icon from mock)
       const buttons = screen.getAllByRole("button");
@@ -689,11 +568,7 @@ describe("FlowsheetSearchbar", () => {
       mockLive = false;
       const store = createStoreWithQueryContent();
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       expect(screen.getByTestId("flowsheet-search-submit")).toBeDisabled();
     });
@@ -704,11 +579,7 @@ describe("FlowsheetSearchbar", () => {
       mockLive = true;
       const store = createTestStore();
 
-      const { container } = render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      const { container } = renderWithProviders(<FlowsheetSearchbar />, { store });
 
       const form = container.querySelector("form")!;
       fireEvent.focus(form);
@@ -720,11 +591,7 @@ describe("FlowsheetSearchbar", () => {
       mockLive = false;
       const store = createTestStore();
 
-      const { container } = render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      const { container } = renderWithProviders(<FlowsheetSearchbar />, { store });
 
       const form = container.querySelector("form")!;
       fireEvent.focus(form);
@@ -736,11 +603,7 @@ describe("FlowsheetSearchbar", () => {
       mockLive = true;
       const store = createTestStore();
 
-      const { container } = render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      const { container } = renderWithProviders(<FlowsheetSearchbar />, { store });
 
       const form = container.querySelector("form")!;
       await userEvent.click(form);
@@ -776,11 +639,7 @@ describe("FlowsheetSearchbar", () => {
 
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       const buttons = screen.getAllByRole("button");
       expect(buttons.length).toBeGreaterThan(0);
@@ -792,11 +651,7 @@ describe("FlowsheetSearchbar", () => {
       const removeEventListenerSpy = vi.spyOn(document, "removeEventListener");
       const store = createTestStore();
 
-      const { unmount } = render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      const { unmount } = renderWithProviders(<FlowsheetSearchbar />, { store });
 
       unmount();
 
@@ -863,11 +718,7 @@ describe("FlowsheetSearchbar", () => {
       mockSongGhost();
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       expect(mockSetSearchProperty).toHaveBeenCalledWith(
         "album",
@@ -897,11 +748,7 @@ describe("FlowsheetSearchbar", () => {
       } as unknown as ReturnType<typeof useFlowsheetSearch>);
       const store = createTestStore();
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      renderWithProviders(<FlowsheetSearchbar />, { store });
 
       expect(mockSetSearchProperty).not.toHaveBeenCalledWith(
         "album",
@@ -950,11 +797,7 @@ describe("FlowsheetSearchbar", () => {
       );
 
       const store = createTestStore();
-      const { rerender } = render(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      const { rerender } = renderWithProviders(<FlowsheetSearchbar />, { store });
 
       // Phase 1: the empty album auto-fills from the suggestion.
       expect(mockSetSearchProperty).toHaveBeenCalledWith(
@@ -974,11 +817,7 @@ describe("FlowsheetSearchbar", () => {
           request: false,
         },
       };
-      rerender(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      rerender(<FlowsheetSearchbar />);
 
       // Phase 3: a new entry where the DJ hand-types the same album string the
       // previous entry auto-filled, while a *different* suggestion is active.
@@ -995,11 +834,7 @@ describe("FlowsheetSearchbar", () => {
           request: false,
         },
       };
-      rerender(
-        <Provider store={store}>
-          <FlowsheetSearchbar />
-        </Provider>
-      );
+      rerender(<FlowsheetSearchbar />);
 
       expect(mockSetSearchProperty).not.toHaveBeenCalledWith(
         "album",

--- a/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
@@ -96,15 +96,15 @@ describe("FlowsheetBackendResult", () => {
 
   describe("Selected state styling", () => {
     it("renders in both selected and unselected states", () => {
-      const { unmount, store } = renderWithProviders(
-        <FlowsheetBackendResult entry={mockEntry} index={1} />
-      );
-      unmount();
-
-      // selectedResult defaults to 0; dispatch to select index 1 instead.
-      store.dispatch(flowsheetSlice.actions.setSelectedResult(1));
+      // selectedResult defaults to 0; seed it to 1 so index 1 renders selected.
+      const initial = flowsheetSlice.getInitialState();
       renderWithProviders(<FlowsheetBackendResult entry={mockEntry} index={1} />, {
-        store,
+        preloadedState: {
+          flowsheet: {
+            ...initial,
+            search: { ...initial.search, selectedResult: 1 },
+          },
+        },
       });
       expect(screen.getByText("Juana Molina")).toBeInTheDocument();
     });

--- a/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
@@ -95,7 +95,7 @@ describe("FlowsheetBackendResult", () => {
   });
 
   describe("Selected state styling", () => {
-    it("renders in both selected and unselected states", () => {
+    it("renders in the selected state", () => {
       // selectedResult defaults to 0; seed it to 1 so index 1 renders selected.
       const initial = flowsheetSlice.getInitialState();
       renderWithProviders(<FlowsheetBackendResult entry={mockEntry} index={1} />, {

--- a/tests/unit/helpers/render.test.tsx
+++ b/tests/unit/helpers/render.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { createTestStore, renderWithProviders } from "@/tests/helpers";
+
+describe("renderWithProviders", () => {
+  it("seeds the store it builds from preloadedState", () => {
+    const { store } = renderWithProviders(<div />, {
+      preloadedState: {
+        flowsheet: { ...flowsheetSlice.getInitialState(), autoplay: true },
+      },
+    });
+
+    expect(flowsheetSlice.selectors.getAutoplay(store.getState())).toBe(true);
+  });
+
+  it("uses a caller-supplied store as-is", () => {
+    const seeded = createTestStore({
+      flowsheet: { ...flowsheetSlice.getInitialState(), autoplay: true },
+    });
+
+    const { store } = renderWithProviders(<div />, { store: seeded });
+
+    expect(store).toBe(seeded);
+    expect(flowsheetSlice.selectors.getAutoplay(store.getState())).toBe(true);
+  });
+
+  it("rejects passing both store and preloadedState at compile time — a supplied store's state would silently win, dropping preloadedState", () => {
+    const seeded = createTestStore();
+
+    // @ts-expect-error — store and preloadedState are mutually exclusive; see
+    // the SeedOptions union in tests/helpers/render.tsx.
+    renderWithProviders(<div />, { store: seeded, preloadedState: {} });
+  });
+});


### PR DESCRIPTION
## Summary

`ExtendedRenderOptions` declared `store` and `preloadedState` as independently optional. Because `store` is a defaulted parameter (`store = makeStore(preloadedState)`), a caller passing both silently lost the preloaded state -- a narrower instance of the exact trap the prior `preloadedState` fix was filed to remove.

- `tests/helpers/render.tsx` -- `ExtendedRenderOptions` is now a discriminated union of `{ preloadedState }` XOR `{ store }`, so supplying both fails at compile time. Added `tests/unit/helpers/render.test.tsx` covering both branches plus a `@ts-expect-error` case for the disallowed combination.
- `FlowsheetBackendResult.test.tsx` -- collapsed the render/unmount/dispatch/re-render dance (the concrete caller that motivated this issue) into a single `renderWithProviders(..., { preloadedState })` call.
- `FlowsheetSearchbar.test.tsx` and `MobileHeader.test.tsx` -- migrated their local `createTestStore` shadows (partial reducer maps) onto the shared helper's full store. Neither component calls an RTK Query hook directly under test -- both mock every hook that would -- so the full store carries no risk of firing real requests.
- `docs/testing.md` -- documents `preloadedState` as the seeding mechanism, `store` for sharing/pre-interacting with a store you built yourself, and states the exclusivity rule.

`FlowsheetSearchResults.test.tsx` was deliberately left untouched -- that conversion belongs to #1183.

Closes #1194

## Test plan

- [x] `npx vitest run` -- 320 files / 4586 tests pass
- [x] `npx tsc --noEmit` -- clean, including the `@ts-expect-error` compile-time regression test
- [x] `npm run lint` -- 0 errors (pre-existing warning backlog unchanged)