### PR TITLE
test: migrate AlbumEntry inline literals and casts to createTestAlbum

### DIFF
--- a/tests/integration/components/modern/Rightbar/Bin/BinEntry.test.tsx
+++ b/tests/integration/components/modern/Rightbar/Bin/BinEntry.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import BinEntry from "@/src/components/experiences/modern/Rightbar/Bin/BinEntry";
+import { createTestAlbum, createTestArtist } from "@/tests/helpers";
 import type { AlbumEntry } from "@/lib/features/catalog/types";
 
 // Mock child components
@@ -33,19 +34,10 @@ vi.mock("@/src/components/experiences/modern/Rightbar/Bin/BinEntryContextMenu", 
 }));
 
 describe("BinEntry", () => {
-  const mockEntry: AlbumEntry = {
-    id: 1,
-    title: "Test Album",
+  const mockEntry: AlbumEntry = createTestAlbum({
     entry: 5,
-    format: "CD",
-    artist: {
-      id: 1,
-      name: "Test Artist",
-      lettercode: "AB",
-      numbercode: 123,
-      genre: "Rock",
-    },
-  } as AlbumEntry;
+    artist: createTestArtist({ id: 1, lettercode: "AB", numbercode: 123 }),
+  });
 
   // Hoisted once in BinContent and threaded down; the row never runs the
   // heavy queue/flowsheet hooks itself.

--- a/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
+++ b/tests/integration/components/modern/Rightbar/Bin/useBinEntryActions.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { Unarchive } from "@mui/icons-material";
 import type { AlbumEntry } from "@/lib/features/catalog/types";
+import { createTestAlbum, createTestArtist } from "@/tests/helpers";
 import {
   MISSING_ARTIST_BIN_PLAY_MESSAGE,
   VARIOUS_ARTISTS_BIN_PLAY_MESSAGE,
@@ -42,16 +43,16 @@ import { useBinEntryActions } from "@/src/components/experiences/modern/Rightbar
 // The credit matters to the queue toast, so it has to be on the fixture —
 // an entry with no artist at all makes the refused branch unreachable and
 // the assertions below vacuous.
-const entry = {
+const entry = createTestAlbum({
   id: 7,
   title: "DOGA",
-  artist: { name: "Juana Molina" },
-} as AlbumEntry;
-const compilationEntry = {
+  artist: createTestArtist({ name: "Juana Molina" }),
+});
+const compilationEntry = createTestAlbum({
   id: 8,
   title: "Edits",
-  artist: { name: "Various Artists" },
-} as AlbumEntry;
+  artist: createTestArtist({ name: "Various Artists" }),
+});
 // The write callbacks are hoisted in BinContent and passed down; the hook
 // itself no longer runs useQueue/useFlowsheet/useDeleteFromBin per row.
 const deps = { addToQueue, addToFlowsheet, deleteFromBin };
@@ -172,7 +173,11 @@ describe("useBinEntryActions", () => {
   // write "Various Artists" would name a mistake they did not make.
   it("refuses Play Now for a release with no credit and does not blame Various Artists", () => {
     convertBinToFlowsheetMock.mockReturnValueOnce(null);
-    const uncredited = { id: 9, title: "Untitled" } as AlbumEntry;
+    const uncredited = createTestAlbum({
+      id: 9,
+      title: "Untitled",
+      artist: undefined,
+    });
     const { result } = renderHook(() =>
       useBinEntryActions(uncredited, true, deps)
     );

--- a/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, screen } from "@testing-library/react";
 import { renderWithProviders, createTestAlbum, createTestArtist } from "@/tests/helpers";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import FlowsheetBackendResult from "@/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult";
-import type { AlbumEntry } from "@/lib/features/catalog/types";
+import type { AlbumEntry, ArtistEntry } from "@/lib/features/catalog/types";
 
 // lib/store.ts wires metadataApi's reducer + middleware from this same
 // module, so a whole-module factory makes makeStore() throw the moment a
@@ -70,10 +70,10 @@ describe("FlowsheetBackendResult", () => {
 
     it("should show 'vinyl' chip for vinyl format", () => {
       // Note: Component checks format.includes("vinyl") (lowercase)
-      const vinylEntry: AlbumEntry = {
+      const vinylEntry = createTestAlbum({
         ...mockEntry,
         format: "vinyl" as any, // Using lowercase to match component's check
-      };
+      });
 
       renderWithProviders(<FlowsheetBackendResult entry={vinylEntry} index={1} />);
 
@@ -81,10 +81,10 @@ describe("FlowsheetBackendResult", () => {
     });
 
     it("should show 'cd' chip for non-vinyl format", () => {
-      const unknownFormatEntry: AlbumEntry = {
+      const unknownFormatEntry = createTestAlbum({
         ...mockEntry,
         format: "Unknown",
-      };
+      });
 
       renderWithProviders(
         <FlowsheetBackendResult entry={unknownFormatEntry} index={1} />
@@ -209,13 +209,10 @@ describe("FlowsheetBackendResult", () => {
 
   describe("Unknown/missing values", () => {
     it("should display 'Unknown' for missing artist name", () => {
-      const entryWithoutArtist: AlbumEntry = {
+      const entryWithoutArtist = createTestAlbum({
         ...mockEntry,
-        artist: {
-          ...mockEntry.artist,
-          name: "",
-        },
-      };
+        artist: { ...mockEntry.artist, name: "" },
+      });
 
       renderWithProviders(
         <FlowsheetBackendResult entry={entryWithoutArtist} index={1} />
@@ -225,10 +222,7 @@ describe("FlowsheetBackendResult", () => {
     });
 
     it("should display 'Unknown' for missing album title", () => {
-      const entryWithoutTitle: AlbumEntry = {
-        ...mockEntry,
-        title: "",
-      };
+      const entryWithoutTitle = createTestAlbum({ ...mockEntry, title: "" });
 
       renderWithProviders(
         <FlowsheetBackendResult entry={entryWithoutTitle} index={1} />
@@ -239,10 +233,7 @@ describe("FlowsheetBackendResult", () => {
     });
 
     it("should display 'Unknown' for missing label", () => {
-      const entryWithoutLabel: AlbumEntry = {
-        ...mockEntry,
-        label: "",
-      };
+      const entryWithoutLabel = createTestAlbum({ ...mockEntry, label: "" });
 
       renderWithProviders(
         <FlowsheetBackendResult entry={entryWithoutLabel} index={1} />
@@ -253,15 +244,12 @@ describe("FlowsheetBackendResult", () => {
     });
 
     it("should apply italic style for missing values", () => {
-      const entryWithMissingValues: AlbumEntry = {
+      const entryWithMissingValues = createTestAlbum({
         ...mockEntry,
-        artist: {
-          ...mockEntry.artist,
-          name: "",
-        },
+        artist: { ...mockEntry.artist, name: "" },
         title: "",
         label: "",
-      };
+      });
 
       renderWithProviders(
         <FlowsheetBackendResult entry={entryWithMissingValues} index={1} />
@@ -280,10 +268,10 @@ describe("FlowsheetBackendResult", () => {
   // the whole site as the DJ typed.
   describe("Null artist (regression)", () => {
     it("does not throw and shows 'Unknown' when artist is null", () => {
-      const entryWithNullArtist = {
+      const entryWithNullArtist = createTestAlbum({
         ...mockEntry,
-        artist: null,
-      } as unknown as AlbumEntry;
+        artist: null as unknown as ArtistEntry,
+      });
 
       expect(() =>
         renderWithProviders(
@@ -355,13 +343,10 @@ describe("FlowsheetBackendResult", () => {
       const genres = ["Rock", "Jazz", "Electronic", "Hiphop", "Classical"];
 
       genres.forEach((genre) => {
-        const entryWithGenre: AlbumEntry = {
+        const entryWithGenre = createTestAlbum({
           ...mockEntry,
-          artist: {
-            ...mockEntry.artist,
-            genre: genre as any,
-          },
-        };
+          artist: { ...mockEntry.artist, genre: genre as any },
+        });
 
         const { unmount } = renderWithProviders(
           <FlowsheetBackendResult entry={entryWithGenre} index={1} />

--- a/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResults.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResults.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import FlowsheetBackendResults from "@/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResults";
+import { createTestAlbum } from "@/tests/helpers";
 import type { AlbumEntry } from "@/lib/features/catalog/types";
 
 // Mock child component
@@ -14,9 +15,9 @@ vi.mock("@/src/components/experiences/modern/flowsheet/Search/Results/BackendRes
 
 describe("FlowsheetBackendResults", () => {
   const mockResults: AlbumEntry[] = [
-    { id: 1, title: "Album One" } as AlbumEntry,
-    { id: 2, title: "Album Two" } as AlbumEntry,
-    { id: 3, title: "Album Three" } as AlbumEntry,
+    createTestAlbum({ id: 1, title: "Album One" }),
+    createTestAlbum({ id: 2, title: "Album Two" }),
+    createTestAlbum({ id: 3, title: "Album Three" }),
   ];
 
   beforeEach(() => {
@@ -88,7 +89,7 @@ describe("FlowsheetBackendResults", () => {
   it("caps rendering at 50 rows and shows a truncation footer for a huge response (#657)", () => {
     const many: AlbumEntry[] = Array.from(
       { length: 500 },
-      (_, i) => ({ id: i + 1, title: `Album ${i + 1}` } as AlbumEntry)
+      (_, i) => createTestAlbum({ id: i + 1, title: `Album ${i + 1}` })
     );
 
     render(
@@ -105,7 +106,7 @@ describe("FlowsheetBackendResults", () => {
     // Pins the strict > comparison: exactly 50 is NOT truncated.
     const fifty: AlbumEntry[] = Array.from(
       { length: 50 },
-      (_, i) => ({ id: i + 1, title: `Album ${i + 1}` } as AlbumEntry)
+      (_, i) => createTestAlbum({ id: i + 1, title: `Album ${i + 1}` })
     );
 
     render(
@@ -121,7 +122,7 @@ describe("FlowsheetBackendResults", () => {
   it("renders 50 rows plus the footer at one over the cap (#657 boundary)", () => {
     const fiftyOne: AlbumEntry[] = Array.from(
       { length: 51 },
-      (_, i) => ({ id: i + 1, title: `Album ${i + 1}` } as AlbumEntry)
+      (_, i) => createTestAlbum({ id: i + 1, title: `Album ${i + 1}` })
     );
 
     render(
@@ -141,7 +142,7 @@ describe("FlowsheetBackendResults", () => {
   it("renders all rows and no footer when under the cap (#657)", () => {
     const ten: AlbumEntry[] = Array.from(
       { length: 10 },
-      (_, i) => ({ id: i + 1, title: `Album ${i + 1}` } as AlbumEntry)
+      (_, i) => createTestAlbum({ id: i + 1, title: `Album ${i + 1}` })
     );
 
     render(

--- a/tests/integration/components/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
 import FlowsheetSearchResults from "@/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults";
-import { Provider } from "react-redux";
-import { configureStore } from "@reduxjs/toolkit";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
-import type { AlbumEntry } from "@/lib/features/catalog/types";
+import {
+  renderWithProviders,
+  createTestAlbum,
+  server,
+  TEST_BACKEND_URL,
+} from "@/tests/helpers";
+import type { RootState } from "@/lib/store";
 
 // Mock child components
 vi.mock("@/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResults", () => ({
@@ -18,60 +23,74 @@ vi.mock("@/src/components/experiences/modern/flowsheet/Search/Results/BackendRes
   ),
 }));
 
-// LibraryTrackPicker hits the proxy `/library/:id/tracks` endpoint via
-// metadataApi; we don't want this test to wire that into the store. The
-// default stub returns `show: true` so the picker row is rendered when its
-// other guards pass — individual tests override useLibraryTrackPicker as
-// needed.
+// Only the presentational component is mocked, so the "not listed" wiring
+// stays assertable without driving the real combobox — useLibraryTrackPicker
+// is left real. The manual-entry button only renders once its tracks query
+// resolves, so exercising it needs the real hook plus a resolved tracklist.
 const libraryTrackPickerSpy = vi.fn();
-vi.mock("@/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker", () => ({
-  __esModule: true,
-  default: (props: any) => {
-    libraryTrackPickerSpy(props);
-    return (
-      <button
-        data-testid="library-track-picker-manual"
-        onClick={() => props.onManualEntry?.()}
-      >
-        Not listed
-      </button>
-    );
-  },
-  useLibraryTrackPicker: () => ({ show: true, isLoading: false, tracks: [] }),
-}));
+vi.mock("@/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker")
+  >();
+  return {
+    ...actual,
+    default: (props: any) => {
+      libraryTrackPickerSpy(props);
+      return (
+        <button
+          data-testid="library-track-picker-manual"
+          onClick={() => props.onManualEntry?.()}
+        >
+          Not listed
+        </button>
+      );
+    },
+  };
+});
 
-function createTestStore(
+function mockLibraryTracksResponse(libraryId: number) {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/proxy/library/${libraryId}/tracks`, () =>
+      HttpResponse.json({
+        library_id: libraryId,
+        discogs_release_id: 42,
+        source: "discogs",
+        tracks: [
+          {
+            position: "A1",
+            title: "la paradoja",
+            artist_credit: "Juana Molina",
+            duration_ms: null,
+          },
+        ],
+      })
+    )
+  );
+}
+
+function buildFlowsheetState(
   searchOpen = false,
   overrides: Partial<ReturnType<typeof flowsheetSlice.getInitialState>> = {}
-) {
+): RootState["flowsheet"] {
   const initial = flowsheetSlice.getInitialState();
-  return configureStore({
-    reducer: {
-      flowsheet: flowsheetSlice.reducer,
+  return {
+    ...initial,
+    ...overrides,
+    search: {
+      ...initial.search,
+      ...(overrides.search ?? {}),
+      open: searchOpen,
     },
-    preloadedState: {
-      flowsheet: {
-        ...initial,
-        ...overrides,
-        search: {
-          ...initial.search,
-          ...(overrides.search ?? {}),
-          open: searchOpen,
-        },
-      },
-    },
-  });
+  };
 }
 
 describe("FlowsheetSearchResults", () => {
-  const mockBinResults: AlbumEntry[] = [
-    { id: 1, title: "Bin Album" } as AlbumEntry,
+  const mockBinResults = [createTestAlbum({ id: 1, title: "Bin Album" })];
+  const mockCatalogResults = [
+    createTestAlbum({ id: 2, title: "Catalog Album" }),
   ];
-  const mockCatalogResults: AlbumEntry[] = [
-    { id: 2, title: "Catalog Album" } as AlbumEntry,
-  ];
-  const mockRotationResults: AlbumEntry[] = [
-    { id: 3, title: "Rotation Album" } as AlbumEntry,
+  const mockRotationResults = [
+    createTestAlbum({ id: 3, title: "Rotation Album" }),
   ];
 
   beforeEach(() => {
@@ -79,17 +98,14 @@ describe("FlowsheetSearchResults", () => {
   });
 
   it("should render backend results for bin", () => {
-    const store = createTestStore(true);
-
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchResults
-          binResults={mockBinResults}
-          catalogResults={[]}
-          rotationResults={[]}
-          lmlResults={[]}
-        />
-      </Provider>
+    renderWithProviders(
+      <FlowsheetSearchResults
+        binResults={mockBinResults}
+        catalogResults={[]}
+        rotationResults={[]}
+        lmlResults={[]}
+      />,
+      { preloadedState: { flowsheet: buildFlowsheetState(true) } }
     );
 
     const results = screen.getAllByTestId("backend-results");
@@ -97,17 +113,14 @@ describe("FlowsheetSearchResults", () => {
   });
 
   it("should render backend results for catalog", () => {
-    const store = createTestStore(true);
-
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchResults
-          binResults={[]}
-          catalogResults={mockCatalogResults}
-          rotationResults={[]}
-          lmlResults={[]}
-        />
-      </Provider>
+    renderWithProviders(
+      <FlowsheetSearchResults
+        binResults={[]}
+        catalogResults={mockCatalogResults}
+        rotationResults={[]}
+        lmlResults={[]}
+      />,
+      { preloadedState: { flowsheet: buildFlowsheetState(true) } }
     );
 
     const results = screen.getAllByTestId("backend-results");
@@ -115,17 +128,14 @@ describe("FlowsheetSearchResults", () => {
   });
 
   it("should render backend results for rotation", () => {
-    const store = createTestStore(true);
-
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchResults
-          binResults={[]}
-          catalogResults={[]}
-          rotationResults={mockRotationResults}
-          lmlResults={[]}
-        />
-      </Provider>
+    renderWithProviders(
+      <FlowsheetSearchResults
+        binResults={[]}
+        catalogResults={[]}
+        rotationResults={mockRotationResults}
+        lmlResults={[]}
+      />,
+      { preloadedState: { flowsheet: buildFlowsheetState(true) } }
     );
 
     const results = screen.getAllByTestId("backend-results");
@@ -133,20 +143,16 @@ describe("FlowsheetSearchResults", () => {
   });
 
   it("should render backend results for LML library search", () => {
-    const store = createTestStore(true);
-    const mockLmlResults: AlbumEntry[] = [
-      { id: 4, title: "LML Album" } as AlbumEntry,
-    ];
+    const mockLmlResults = [createTestAlbum({ id: 4, title: "LML Album" })];
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchResults
-          binResults={[]}
-          catalogResults={[]}
-          rotationResults={[]}
-          lmlResults={mockLmlResults}
-        />
-      </Provider>
+    renderWithProviders(
+      <FlowsheetSearchResults
+        binResults={[]}
+        catalogResults={[]}
+        rotationResults={[]}
+        lmlResults={mockLmlResults}
+      />,
+      { preloadedState: { flowsheet: buildFlowsheetState(true) } }
     );
 
     const results = screen.getAllByTestId("backend-results");
@@ -154,17 +160,14 @@ describe("FlowsheetSearchResults", () => {
   });
 
   it("should render keyboard shortcut hints", () => {
-    const store = createTestStore(true);
-
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchResults
-          binResults={[]}
-          catalogResults={[]}
-          rotationResults={[]}
-          lmlResults={[]}
-        />
-      </Provider>
+    renderWithProviders(
+      <FlowsheetSearchResults
+        binResults={[]}
+        catalogResults={[]}
+        rotationResults={[]}
+        lmlResults={[]}
+      />,
+      { preloadedState: { flowsheet: buildFlowsheetState(true) } }
     );
 
     expect(screen.getByText("switch fields")).toBeInTheDocument();
@@ -183,28 +186,30 @@ describe("FlowsheetSearchResults", () => {
   // track_position field anyway.
   describe("LibraryTrackPicker visibility over unlinked rotation rows", () => {
     it("hides the picker row when the highlighted result has a synthesized negative id", () => {
-      const store = createTestStore(true, {
-        search: {
-          open: true,
-          query: flowsheetSlice.getInitialState().search.query,
-          selectedResult: 1,
-          confirmedArtist: "",
-          resetEpoch: 0,
-        },
-      });
-      const unlinkedRotationResult: AlbumEntry[] = [
-        { id: -987654, title: "Unlinked Rotation Row" } as AlbumEntry,
+      const unlinkedRotationResult = [
+        createTestAlbum({ id: -987654, title: "Unlinked Rotation Row" }),
       ];
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchResults
-            binResults={unlinkedRotationResult}
-            catalogResults={[]}
-            rotationResults={[]}
-            lmlResults={[]}
-          />
-        </Provider>
+      renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={unlinkedRotationResult}
+          catalogResults={[]}
+          rotationResults={[]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 1,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
       );
 
       expect(
@@ -213,28 +218,30 @@ describe("FlowsheetSearchResults", () => {
     });
 
     it("shows the picker row when the highlighted result has a positive library.id", () => {
-      const store = createTestStore(true, {
-        search: {
-          open: true,
-          query: flowsheetSlice.getInitialState().search.query,
-          selectedResult: 1,
-          confirmedArtist: "",
-          resetEpoch: 0,
-        },
-      });
-      const linkedResult: AlbumEntry[] = [
-        { id: 1234, title: "Linked Library Row" } as AlbumEntry,
+      const linkedResult = [
+        createTestAlbum({ id: 1234, title: "Linked Library Row" }),
       ];
 
-      render(
-        <Provider store={store}>
-          <FlowsheetSearchResults
-            binResults={linkedResult}
-            catalogResults={[]}
-            rotationResults={[]}
-            lmlResults={[]}
-          />
-        </Provider>
+      renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={linkedResult}
+          catalogResults={[]}
+          rotationResults={[]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 1,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
       );
 
       expect(
@@ -246,54 +253,53 @@ describe("FlowsheetSearchResults", () => {
   // dj-site#704: clicking "Not listed" must clear any track_position the DJ
   // previously picked, otherwise a stale "A1" rides through on submit
   // pointing at an album the DJ no longer intends.
-  it("clears track_position in Redux when the manual-entry button is clicked", () => {
-    const store = createTestStore(true, {
-      search: {
-        open: true,
-        query: {
-          ...flowsheetSlice.getInitialState().search.query,
-          track_position: "A1",
-        },
-        selectedResult: 1,
-        confirmedArtist: "",
-        resetEpoch: 0,
-      },
-    });
-    const linkedResult: AlbumEntry[] = [
-      { id: 1234, title: "Linked Library Row" } as AlbumEntry,
+  it("clears track_position in Redux when the manual-entry button is clicked", async () => {
+    mockLibraryTracksResponse(1234);
+    const linkedResult = [
+      createTestAlbum({ id: 1234, title: "Linked Library Row" }),
     ];
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchResults
-          binResults={linkedResult}
-          catalogResults={[]}
-          rotationResults={[]}
-          lmlResults={[]}
-        />
-      </Provider>
+    const { store } = renderWithProviders(
+      <FlowsheetSearchResults
+        binResults={linkedResult}
+        catalogResults={[]}
+        rotationResults={[]}
+        lmlResults={[]}
+      />,
+      {
+        preloadedState: {
+          flowsheet: buildFlowsheetState(true, {
+            search: {
+              open: true,
+              query: {
+                ...flowsheetSlice.getInitialState().search.query,
+                track_position: "A1",
+              },
+              selectedResult: 1,
+              confirmedArtist: "",
+              resetEpoch: 0,
+            },
+          }),
+        },
+      }
     );
 
-    fireEvent.click(screen.getByTestId("library-track-picker-manual"));
+    fireEvent.click(await screen.findByTestId("library-track-picker-manual"));
 
     expect(store.getState().flowsheet.search.query.track_position).toBeUndefined();
   });
 
   it("should calculate correct offsets for results", () => {
-    const store = createTestStore(true);
-    const mockLmlResults: AlbumEntry[] = [
-      { id: 4, title: "LML Album" } as AlbumEntry,
-    ];
+    const mockLmlResults = [createTestAlbum({ id: 4, title: "LML Album" })];
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchResults
-          binResults={mockBinResults}
-          catalogResults={mockCatalogResults}
-          rotationResults={mockRotationResults}
-          lmlResults={mockLmlResults}
-        />
-      </Provider>
+    renderWithProviders(
+      <FlowsheetSearchResults
+        binResults={mockBinResults}
+        catalogResults={mockCatalogResults}
+        rotationResults={mockRotationResults}
+        lmlResults={mockLmlResults}
+      />,
+      { preloadedState: { flowsheet: buildFlowsheetState(true) } }
     );
 
     const results = screen.getAllByTestId("backend-results");
@@ -305,26 +311,21 @@ describe("FlowsheetSearchResults", () => {
   });
 
   it("should derive offsets from the CAPPED section lengths when a section is truncated (#657)", () => {
-    const store = createTestStore(true);
     // 60 bin rows: only 50 are painted, so later sections must start at 51 —
     // full-length offsets would desync the highlight from the visible rows.
-    const manyBinResults: AlbumEntry[] = Array.from(
-      { length: 60 },
-      (_, i) => ({ id: 100 + i, title: `Bin Album ${i}` } as AlbumEntry)
+    const manyBinResults = Array.from({ length: 60 }, (_, i) =>
+      createTestAlbum({ id: 100 + i, title: `Bin Album ${i}` })
     );
-    const mockLmlResults: AlbumEntry[] = [
-      { id: 4, title: "LML Album" } as AlbumEntry,
-    ];
+    const mockLmlResults = [createTestAlbum({ id: 4, title: "LML Album" })];
 
-    render(
-      <Provider store={store}>
-        <FlowsheetSearchResults
-          binResults={manyBinResults}
-          catalogResults={mockCatalogResults}
-          rotationResults={mockRotationResults}
-          lmlResults={mockLmlResults}
-        />
-      </Provider>
+    renderWithProviders(
+      <FlowsheetSearchResults
+        binResults={manyBinResults}
+        catalogResults={mockCatalogResults}
+        rotationResults={mockRotationResults}
+        lmlResults={mockLmlResults}
+      />,
+      { preloadedState: { flowsheet: buildFlowsheetState(true) } }
     );
 
     const results = screen.getAllByTestId("backend-results");

--- a/tests/integration/components/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/RotationReleaseDropdown.test.tsx
@@ -6,7 +6,7 @@ import {
   createTestArtist,
   renderWithProviders,
 } from "@/tests/helpers";
-import type { AlbumEntry } from "@/lib/features/catalog/types";
+import type { AlbumEntry, ArtistEntry } from "@/lib/features/catalog/types";
 
 const releases = [
   createTestAlbum({
@@ -533,8 +533,8 @@ describe("RotationReleaseDropdown — null artist (regression)", () => {
 
   const nullArtist = {
     ...createTestAlbum({ id: 9, title: "Untitled" }),
-    artist: null,
-  } as unknown as AlbumEntry;
+    artist: null as unknown as ArtistEntry,
+  };
 
   // A real bin holds more than one release, so the panel runs the list through
   // `sortRotationReleases` — whose comparator dereferences `artist.name`.

--- a/tests/unit/hooks/binHooks.test.tsx
+++ b/tests/unit/hooks/binHooks.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+import { createTestAlbum } from "@/tests/fixtures/fixtures";
 import type { AlbumEntry } from "@/lib/features/catalog/types";
 
 // --- Mocks for useClearBin's dependencies ---
@@ -48,7 +49,7 @@ async function flushMicrotasks() {
   await Promise.resolve();
 }
 
-const entry = (id: number) => ({ id, title: `Album ${id}` }) as AlbumEntry;
+const entry = (id: number) => createTestAlbum({ id, title: `Album ${id}` });
 
 function setBin(bin: AlbumEntry[] | undefined) {
   mockUseGetBinQuery.mockReturnValue({

--- a/tests/unit/lib/features/catalog/patchSearchResult.test.ts
+++ b/tests/unit/lib/features/catalog/patchSearchResult.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { createTestAlbum, createTestArtist } from "@/tests/helpers";
-import type { AlbumEntry } from "@/lib/features/catalog/types";
 import { mergeAlbumIntoSearchResult } from "@/lib/features/catalog/patchSearchResult";
 
 describe("mergeAlbumIntoSearchResult", () => {
@@ -166,21 +165,15 @@ describe("mergeAlbumIntoSearchResult", () => {
       title: "Old Title",
       genre_id: 1,
     });
-    const updated: AlbumEntry = {
-      ...createTestAlbum({ id: 42 }),
+    const updated = createTestAlbum({
+      id: 42,
       title: "",
       label: "",
       entry: 0,
-      artist: {
-        name: "",
-        lettercode: "AB",
-        numbercode: 1,
-        genre: "Rock",
-        id: 5,
-      },
+      artist: createTestArtist({ id: 5, name: "", lettercode: "AB", numbercode: 1 }),
       genre_id: 7,
       format_id: 3,
-    };
+    });
 
     const merged = mergeAlbumIntoSearchResult(existing, updated);
 

--- a/tests/unit/lib/features/rotation/sort.test.ts
+++ b/tests/unit/lib/features/rotation/sort.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { sortRotationReleases } from "@/lib/features/rotation/sort";
 import { createTestAlbum, createTestArtist } from "@/tests/helpers";
-import type { AlbumEntry } from "@/lib/features/catalog/types";
+import type { ArtistEntry } from "@/lib/features/catalog/types";
 
 describe("sortRotationReleases", () => {
   it("sorts alphabetically by artist name", () => {
@@ -123,8 +123,8 @@ describe("sortRotationReleases", () => {
       }),
       {
         ...createTestAlbum({ id: 2, title: "Untitled" }),
-        artist: null,
-      } as unknown as AlbumEntry,
+        artist: null as unknown as ArtistEntry,
+      },
     ];
     expect(() => sortRotationReleases(releases)).not.toThrow();
     // The null artist coalesces to "" and sorts ahead of "Autechre".

--- a/tests/unit/utilities/filterBySearchTerms.test.ts
+++ b/tests/unit/utilities/filterBySearchTerms.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { filterBySearchTerms } from "@/src/utilities/filterBySearchTerms";
 import { createTestAlbum, createTestArtist } from "@/tests/helpers";
-import type { AlbumEntry } from "@/lib/features/catalog/types";
 
 describe("filterBySearchTerms", () => {
   const query = { artist: "stereolab", album: "", label: "" };
@@ -27,8 +26,8 @@ describe("filterBySearchTerms", () => {
   it("does not throw when an entry's artist.name is null", () => {
     const malformed = {
       ...createTestAlbum(),
-      artist: { ...createTestArtist(), name: null },
-    } as unknown as AlbumEntry;
+      artist: { ...createTestArtist(), name: null as unknown as string },
+    };
 
     expect(() => filterBySearchTerms([malformed], query)).not.toThrow();
   });
@@ -36,8 +35,8 @@ describe("filterBySearchTerms", () => {
   it("excludes a null-named entry but still returns its valid siblings", () => {
     const malformed = {
       ...createTestAlbum({ id: 1 }),
-      artist: { ...createTestArtist(), name: null },
-    } as unknown as AlbumEntry;
+      artist: { ...createTestArtist(), name: null as unknown as string },
+    };
     const valid = createTestAlbum({
       id: 2,
       artist: createTestArtist({ name: "Stereolab" }),


### PR DESCRIPTION
## Summary

Test-only prep for the id-space fix. Specs across the flowsheet, bin, and catalog test trees built `AlbumEntry` rows either with an annotated-literal (`: AlbumEntry = {`) or a cast (`as AlbumEntry` / `as unknown as AlbumEntry`) instead of the `createTestAlbum`/`createTestArtist` factories `docs/testing.md` mandates. This migrates every remaining site onto the factories, and separately converts `FlowsheetSearchResults.test.tsx` off its ad-hoc single-reducer store and bare RTL `render` onto `renderWithProviders` with the real store (including `metadataApi`) and the real `useLibraryTrackPicker` hook — more than the title alone implies, but it's the direction `docs/testing.md` already mandates and it lands green.

- Migrated the specs the issue named directly: `FlowsheetSearchResults.test.tsx`, `FlowsheetBackendResults.test.tsx` (plural), `FlowsheetBackendResult.test.tsx` (singular — its harness was already converted by prior work; only the seven leftover literals + one cast here), `BinEntry.test.tsx`, `patchSearchResult.test.ts`, and `useBinEntryActions.test.tsx`.
- Re-derived the grep at implementation time per the issue's instruction and found four more files matching the same two patterns: `RotationReleaseDropdown.test.tsx`, `binHooks.test.tsx`, `sort.test.ts`, and `filterBySearchTerms.test.ts`. Their casts guard deliberately-invalid runtime data (a `null` artist/name for regression coverage) rather than avoiding the factory, so those are narrowed to the specific field that needs the cast (`ArtistEntry`, or its `name`) instead of casting the whole `AlbumEntry` — the factory stays the base object and both acceptance greps still come back clean.
- `FlowsheetSearchResults.test.tsx`: dropped the ad-hoc `configureStore`/`Provider` harness and the `useLibraryTrackPicker` mock in favor of `renderWithProviders` + `preloadedState` (never combined with `store`, per the now-mutually-exclusive option). Only the presentational `LibraryTrackPicker` component stays mocked (via `importOriginal`) so the "not listed" wiring assertion stays stable; the real hook now runs against the real `metadataApi`, with a local MSW handler supplying a resolved tracklist for the one assertion that needs the manual-entry button to actually render.

Both `git grep -n ': AlbumEntry = {' -- tests` and `git grep -n 'as AlbumEntry\|as unknown as AlbumEntry' -- tests` now return no hits. No production code changed.

Closes #1183

## Test plan
- [x] `npx vitest run` — 320 files / 4586 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (pre-existing warning count only)