### PR TITLE
E2E: classic-experience coverage on authenticated dashboard screens

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -74,7 +74,7 @@ npm run test:e2e -- --grep @smoke
 
 ## Test Users
 
-All seeded test users use the password: `testpassword123`. `test_classic_md` is the one exception — see its row below.
+Seeded test users all use the password: `testpassword123`. `test_classic_md` is provisioned at setup time and uses its own password — see its row below.
 
 | Username | Role | Purpose |
 |----------|------|---------|

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -87,6 +87,7 @@ All test users use the password: `testpassword123`
 | `test_deletable_user` | dj | User for deletion tests |
 | `test_promotable_user` | member | User for role promotion tests |
 | `test_demotable_sm` | stationManager | User for role demotion tests |
+| `test_classic_md` | musicDirector | Not seeded — created by `auth.setup.ts` via the admin roster. Its account `appSkin` is switched to classic once at setup time, so classic-experience specs on authenticated dashboard URLs (`e2e/tests/rbac/role-access.spec.ts`) have a dedicated identity instead of racing a shared seeded user's preference |
 
 ## Test Structure
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -74,7 +74,7 @@ npm run test:e2e -- --grep @smoke
 
 ## Test Users
 
-All test users use the password: `testpassword123`
+All seeded test users use the password: `testpassword123`. `test_classic_md` is the one exception — see its row below.
 
 | Username | Role | Purpose |
 |----------|------|---------|
@@ -87,7 +87,7 @@ All test users use the password: `testpassword123`
 | `test_deletable_user` | dj | User for deletion tests |
 | `test_promotable_user` | member | User for role promotion tests |
 | `test_demotable_sm` | stationManager | User for role demotion tests |
-| `test_classic_md` | musicDirector | Not seeded — created by `auth.setup.ts` via the admin roster. Its account `appSkin` is switched to classic once at setup time, so classic-experience specs on authenticated dashboard URLs (`e2e/tests/rbac/role-access.spec.ts`) have a dedicated identity instead of racing a shared seeded user's preference |
+| `test_classic_md` | musicDirector | Not seeded — created by `auth.setup.ts` via the admin roster. Its account `appSkin` is switched to classic once at setup time, so classic-experience specs on authenticated dashboard URLs (`e2e/tests/rbac/role-access.spec.ts`) have a dedicated identity instead of racing a shared seeded user's preference. Password is `TestClassicMd1`, not the shared `testpassword123` — it's set through the onboarding form, which requires `isStrongPassword` |
 
 ## Test Structure
 

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -6,6 +6,7 @@ import {
 } from "./fixtures/auth.fixture";
 import { RosterPage } from "./pages/roster.page";
 import { setExperienceViaAccount } from "./helpers/experience";
+import { APP_SKIN_STORAGE_KEY } from "../lib/features/experiences/preferences";
 import crypto from "crypto";
 import path from "path";
 import fs from "fs";
@@ -207,14 +208,42 @@ const CLASSIC_MD_USER = {
 
 const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
 
+// Every octet of a dotted-quad, so this can't accidentally accept something
+// like "127.0.0.1.evil.com" (which `new URL().hostname` never produces
+// anyway, but the pattern should still refuse it on its own terms).
+const IPV4_LOOPBACK_PATTERN = /^127\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
 /**
- * This gates the only write path in this file: `ensureClassicMdAccountExists`
- * creates a musicDirector account through the live admin roster against
- * whatever `E2E_BASE_URL` (and `NEXT_PUBLIC_BETTER_AUTH_URL`) point at. Every
- * other setup step only logs in. Without this, a mistyped or inherited env
- * var pointed at a shared environment has no structural guard between it and
- * a real MD account there — only the incidental fact that the station-manager
- * login would have to succeed first.
+ * Whether `hostname` — as returned by `new URL(value).hostname` — names a
+ * loopback address. Exact-match against {@link LOOPBACK_HOSTNAMES} plus two
+ * loopback forms that set membership alone misses: `new URL` returns the
+ * IPv6 literal bracketed (`"[::1]"`), and the entire `127.0.0.0/8` block is
+ * loopback, not just `127.0.0.1` (this repo's own `docs/ci-cd.md` uses
+ * `127.0.0.99`). This still rejects `localhost.evil.com` and similar —
+ * deliberately no suffix/`includes` matching.
+ */
+function isLoopbackHostname(hostname: string): boolean {
+  const unbracketed =
+    hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname;
+  if (LOOPBACK_HOSTNAMES.has(unbracketed)) return true;
+  const match = IPV4_LOOPBACK_PATTERN.exec(unbracketed);
+  if (!match) return false;
+  return match.slice(1).every((octet) => Number(octet) <= 255);
+}
+
+/**
+ * Gates every write the "provision classic-preference identity" step can
+ * make against whatever `E2E_BASE_URL` (and `NEXT_PUBLIC_BETTER_AUTH_URL`)
+ * point at: `ensureClassicMdAccountExists` creates a musicDirector account
+ * through the live admin roster, and `setExperienceViaAccount` flips that
+ * account's `appSkin` through the live switch flow. Every other setup step
+ * only logs in. Called at the top of that step's body — not just inside
+ * `ensureClassicMdAccountExists` — because a successful login skips account
+ * creation entirely and would otherwise reach the appSkin write unguarded.
+ * Without this, a mistyped or inherited env var pointed at a shared
+ * environment has no structural guard between it and a real account there.
  */
 function assertLocalWriteTarget(): void {
   const targets: Array<[envVar: string, value: string | undefined]> = [
@@ -231,7 +260,7 @@ function assertLocalWriteTarget(): void {
         `Refusing to provision ${CLASSIC_MD_USER.username}: ${envVar}="${value}" is not a valid URL.`
       );
     }
-    if (!LOOPBACK_HOSTNAMES.has(hostname)) {
+    if (!isLoopbackHostname(hostname)) {
       throw new Error(
         `Refusing to provision ${CLASSIC_MD_USER.username} against a non-local target: ` +
           `${envVar}="${value}" resolves to host "${hostname}", not loopback.`
@@ -252,7 +281,7 @@ async function classicMdAccountExists(rosterPage: RosterPage): Promise<boolean> 
   await rosterPage.searchInput.fill(CLASSIC_MD_USER.realName);
   return await rosterPage
     .getUserRow(CLASSIC_MD_USER.username)
-    .waitFor({ state: "visible", timeout: 5000 })
+    .waitFor({ state: "visible", timeout: 15000 })
     .then(() => true)
     .catch(() => false);
 }
@@ -312,6 +341,10 @@ async function ensureClassicMdAccountExists(browser: Browser): Promise<void> {
  * Used by classic-experience specs on authenticated dashboard URLs.
  */
 setup("provision classic-preference identity", async ({ page, browser }) => {
+  // Gates every write below (account creation AND the appSkin switch), not
+  // just the account-creation branch — see assertLocalWriteTarget's doc.
+  assertLocalWriteTarget();
+
   // First-run path chains an admin roster creation, an invite-token
   // onboarding, and a full-page experience-switch reload — comfortably past
   // the file's 20s default on a cold local stack.
@@ -344,14 +377,20 @@ setup("provision classic-preference identity", async ({ page, browser }) => {
   await setExperienceViaAccount(page, "classic", "/dashboard/help");
 
   // The switch flow also sets the app_state cookie to classic (see
-  // useExperienceSwitch), so by this point the cookie and the account field
-  // agree and either alone would render the classic slot. Drop the cookie
-  // from what gets persisted so the specs that assert against this identity
-  // are demonstrably exercising the account's appSkin field, not a cookie
-  // that happens to carry the same value — if appSkin ever became nullable,
-  // a persisted cookie would silently keep those specs passing for the wrong
-  // reason.
+  // useExperienceSwitch) AND the wxyc_app_skin localStorage key (see
+  // writeLocalAppSkin), so by this point the cookie, localStorage, and the
+  // account field all agree and any one alone would render the classic slot.
+  // useThemePreferenceSync (mounted unconditionally in the root layout) falls
+  // back to localStorage whenever the cookie is absent, re-persisting the
+  // cookie and reloading — so dropping only the cookie leaves localStorage as
+  // a live second lever that reproduces the classic render without the
+  // account's appSkin ever being consulted. Strip both from what gets
+  // persisted so the specs that assert against this identity are
+  // demonstrably exercising the account's appSkin field alone — if appSkin
+  // ever became nullable, a persisted cookie or localStorage entry would
+  // silently keep those specs passing for the wrong reason.
   await page.context().clearCookies({ name: "app_state" });
+  await page.evaluate((key) => localStorage.removeItem(key), APP_SKIN_STORAGE_KEY);
   await page.context().storageState({ path: statePath });
   fs.writeFileSync(seedSidecarPath(statePath), seedKey());
 });

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -31,10 +31,12 @@ const SESSION_CACHE_SALT = "1";
 // here as TEST_USERS; if that source starts pulling credentials from another
 // file, add its path below. The key does NOT prove the session row still
 // exists server-side (a reseeded database drops it) — persistedSessionIsUsable
-// covers that.
+// covers that. CLASSIC_MD_USER is declared inline further down this same
+// file, so __filename covers it too.
 const USER_FIXTURE_SOURCES = [
   path.join(__dirname, "fixtures", "auth.fixture.ts"),
   path.join(__dirname, "..", "tests", "fixtures", "fixtures.ts"),
+  __filename,
 ];
 
 function seedKey(): string {
@@ -203,6 +205,58 @@ const CLASSIC_MD_USER = {
   djName: "Test Classic MD",
 };
 
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+/**
+ * This gates the only write path in this file: `ensureClassicMdAccountExists`
+ * creates a musicDirector account through the live admin roster against
+ * whatever `E2E_BASE_URL` (and `NEXT_PUBLIC_BETTER_AUTH_URL`) point at. Every
+ * other setup step only logs in. Without this, a mistyped or inherited env
+ * var pointed at a shared environment has no structural guard between it and
+ * a real MD account there — only the incidental fact that the station-manager
+ * login would have to succeed first.
+ */
+function assertLocalWriteTarget(): void {
+  const targets: Array<[envVar: string, value: string | undefined]> = [
+    ["E2E_BASE_URL", process.env.E2E_BASE_URL || "http://localhost:3000"],
+    ["NEXT_PUBLIC_BETTER_AUTH_URL", process.env.NEXT_PUBLIC_BETTER_AUTH_URL],
+  ];
+  for (const [envVar, value] of targets) {
+    if (!value) continue;
+    let hostname: string;
+    try {
+      hostname = new URL(value).hostname;
+    } catch {
+      throw new Error(
+        `Refusing to provision ${CLASSIC_MD_USER.username}: ${envVar}="${value}" is not a valid URL.`
+      );
+    }
+    if (!LOOPBACK_HOSTNAMES.has(hostname)) {
+      throw new Error(
+        `Refusing to provision ${CLASSIC_MD_USER.username} against a non-local target: ` +
+          `${envVar}="${value}" resolves to host "${hostname}", not loopback.`
+      );
+    }
+  }
+}
+
+/**
+ * True when {@link CLASSIC_MD_USER} already has a roster row. The roster is
+ * server-side paginated (ROSTER_PAGE_SIZE=50) with no sort order, so a raw
+ * listing only answers "is this account among an arbitrary 50 rows", not
+ * "does it exist" — the suite creates more than 50 non-anonymous accounts
+ * within roughly two full local runs. Filtering through the roster's search
+ * input (server-side, by name) is unambiguous regardless of roster size.
+ */
+async function classicMdAccountExists(rosterPage: RosterPage): Promise<boolean> {
+  await rosterPage.searchInput.fill(CLASSIC_MD_USER.realName);
+  return await rosterPage
+    .getUserRow(CLASSIC_MD_USER.username)
+    .waitFor({ state: "visible", timeout: 5000 })
+    .then(() => true)
+    .catch(() => false);
+}
+
 /**
  * Creates {@link CLASSIC_MD_USER} via the station manager's roster if it
  * doesn't already exist. Idempotent: setup runs repeatedly against a
@@ -210,9 +264,18 @@ const CLASSIC_MD_USER = {
  * not recreated (which would surface as a duplicate-username error toast).
  */
 async function ensureClassicMdAccountExists(browser: Browser): Promise<void> {
+  assertLocalWriteTarget();
+
   const baseURL = process.env.E2E_BASE_URL || "http://localhost:3000";
   const context = await browser.newContext({
     baseURL,
+    // Requires the "authenticate as station manager" setup test (declared
+    // above in this file) to have already written stationManager.json. That
+    // ordering holds only because the setup project sets fullyParallel:
+    // false and Playwright runs one file's tests in declaration order —
+    // nothing enforces it, and a failed station-manager step doesn't stop
+    // this one. A future split across files would surface a missing file
+    // here as an opaque ENOENT from browser.newContext.
     storageState: `${authDir}/stationManager.json`,
   });
   const adminPage = await context.newPage();
@@ -221,11 +284,7 @@ async function ensureClassicMdAccountExists(browser: Browser): Promise<void> {
     await adminPage.goto("/dashboard/admin/roster");
     await rosterPage.waitForTableLoaded();
 
-    const alreadyExists = await rosterPage
-      .getUserRow(CLASSIC_MD_USER.username)
-      .isVisible()
-      .catch(() => false);
-    if (alreadyExists) {
+    if (await classicMdAccountExists(rosterPage)) {
       console.log(`[auth] ${CLASSIC_MD_USER.username} already provisioned, skipping creation`);
       return;
     }
@@ -240,7 +299,8 @@ async function ensureClassicMdAccountExists(browser: Browser): Promise<void> {
     });
     // The row, not the toast: sonner auto-dismisses on its own timer, so a
     // slow local stack can outlast it between submit and this check. The row
-    // appearing is the same reconciliation signal `alreadyExists` reads above.
+    // appearing is the same reconciliation signal `classicMdAccountExists`
+    // reads above (the search filter is still applied from that check).
     await rosterPage.expectUserInRoster(CLASSIC_MD_USER.username);
   } finally {
     await context.close();
@@ -282,6 +342,16 @@ setup("provision classic-preference identity", async ({ page, browser }) => {
   // fresh default) renders ExperienceGap there and offers the real switch
   // flow this identity exists to have already taken.
   await setExperienceViaAccount(page, "classic", "/dashboard/help");
+
+  // The switch flow also sets the app_state cookie to classic (see
+  // useExperienceSwitch), so by this point the cookie and the account field
+  // agree and either alone would render the classic slot. Drop the cookie
+  // from what gets persisted so the specs that assert against this identity
+  // are demonstrably exercising the account's appSkin field, not a cookie
+  // that happens to carry the same value — if appSkin ever became nullable,
+  // a persisted cookie would silently keep those specs passing for the wrong
+  // reason.
+  await page.context().clearCookies({ name: "app_state" });
   await page.context().storageState({ path: statePath });
   fs.writeFileSync(seedSidecarPath(statePath), seedKey());
 });

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,5 +1,11 @@
-import { test as setup, expect, request } from "@playwright/test";
-import { TEST_USERS, getAuthServiceBaseUrl } from "./fixtures/auth.fixture";
+import { test as setup, expect, request, Browser } from "@playwright/test";
+import {
+  TEST_USERS,
+  getAuthServiceBaseUrl,
+  completeOnboardingWithInviteToken,
+} from "./fixtures/auth.fixture";
+import { RosterPage } from "./pages/roster.page";
+import { setExperienceViaAccount } from "./helpers/experience";
 import crypto from "crypto";
 import path from "path";
 import fs from "fs";
@@ -173,6 +179,111 @@ setup("authenticate as station manager", async ({ page }) => {
     TEST_USERS.stationManager.password,
     `${authDir}/stationManager.json`
   );
+});
+
+/**
+ * A dedicated identity whose experience preference is classic, so classic
+ * assertions on authenticated dashboard URLs are ordinary tests rather than a
+ * race against every other spec's shared seeded users. Not in TEST_USERS: it
+ * is not seeded by Backend-Service (see dev_env/setup-e2e-test-users.ts for
+ * that set) — it is created here, once, via the same admin roster path the
+ * admin specs exercise, and its appSkin is set through the app's own
+ * experience-switch flow rather than a raw API call, so the fixture never
+ * predicts an internal endpoint shape it doesn't own.
+ */
+const CLASSIC_MD_USER = {
+  username: "test_classic_md",
+  // Set through the onboarding form (unlike TEST_USERS, which are seeded
+  // directly into the database), so it must satisfy isStrongPassword —
+  // TEST_USERS' shared "testpassword123" has no uppercase and would leave
+  // the onboarding form's Submit button permanently disabled.
+  password: "TestClassicMd1",
+  email: "test_classic_md@wxyc.org",
+  realName: "Test Classic MD",
+  djName: "Test Classic MD",
+};
+
+/**
+ * Creates {@link CLASSIC_MD_USER} via the station manager's roster if it
+ * doesn't already exist. Idempotent: setup runs repeatedly against a
+ * persistent local stack, so a prior run's account must be reconciled with,
+ * not recreated (which would surface as a duplicate-username error toast).
+ */
+async function ensureClassicMdAccountExists(browser: Browser): Promise<void> {
+  const baseURL = process.env.E2E_BASE_URL || "http://localhost:3000";
+  const context = await browser.newContext({
+    baseURL,
+    storageState: `${authDir}/stationManager.json`,
+  });
+  const adminPage = await context.newPage();
+  try {
+    const rosterPage = new RosterPage(adminPage);
+    await adminPage.goto("/dashboard/admin/roster");
+    await rosterPage.waitForTableLoaded();
+
+    const alreadyExists = await rosterPage
+      .getUserRow(CLASSIC_MD_USER.username)
+      .isVisible()
+      .catch(() => false);
+    if (alreadyExists) {
+      console.log(`[auth] ${CLASSIC_MD_USER.username} already provisioned, skipping creation`);
+      return;
+    }
+
+    console.log(`[auth] creating ${CLASSIC_MD_USER.username} via admin roster`);
+    await rosterPage.createAccount({
+      realName: CLASSIC_MD_USER.realName,
+      username: CLASSIC_MD_USER.username,
+      email: CLASSIC_MD_USER.email,
+      djName: CLASSIC_MD_USER.djName,
+      role: "musicDirector",
+    });
+    // The row, not the toast: sonner auto-dismisses on its own timer, so a
+    // slow local stack can outlast it between submit and this check. The row
+    // appearing is the same reconciliation signal `alreadyExists` reads above.
+    await rosterPage.expectUserInRoster(CLASSIC_MD_USER.username);
+  } finally {
+    await context.close();
+  }
+}
+
+/**
+ * Setup authentication state for the classic-preference identity.
+ * Used by classic-experience specs on authenticated dashboard URLs.
+ */
+setup("provision classic-preference identity", async ({ page, browser }) => {
+  // First-run path chains an admin roster creation, an invite-token
+  // onboarding, and a full-page experience-switch reload — comfortably past
+  // the file's 20s default on a cold local stack.
+  setup.setTimeout(60_000);
+
+  const statePath = `${authDir}/classicMd.json`;
+
+  if (await persistedSessionIsUsable(statePath)) {
+    console.log(`[auth] reusing cached session for ${CLASSIC_MD_USER.username}`);
+    return;
+  }
+
+  let loggedIn = true;
+  try {
+    await performLogin(page, CLASSIC_MD_USER.username, CLASSIC_MD_USER.password, statePath);
+  } catch (error) {
+    console.log(`[auth] ${CLASSIC_MD_USER.username} not yet provisioned (${error})`);
+    loggedIn = false;
+  }
+
+  if (!loggedIn) {
+    console.log(`[auth] logging in ${CLASSIC_MD_USER.username} failed, provisioning account`);
+    await ensureClassicMdAccountExists(browser);
+    await completeOnboardingWithInviteToken(page, CLASSIC_MD_USER.email, CLASSIC_MD_USER.password);
+  }
+
+  // /dashboard/help is classic-only, so the modern slot (the account's
+  // fresh default) renders ExperienceGap there and offers the real switch
+  // flow this identity exists to have already taken.
+  await setExperienceViaAccount(page, "classic", "/dashboard/help");
+  await page.context().storageState({ path: statePath });
+  fs.writeFileSync(seedSidecarPath(statePath), seedKey());
 });
 
 /**

--- a/e2e/helpers/experience.ts
+++ b/e2e/helpers/experience.ts
@@ -1,4 +1,4 @@
-import type { BrowserContext } from "@playwright/test";
+import type { BrowserContext, Page } from "@playwright/test";
 
 import { defaultApplicationState } from "../../lib/features/application/types";
 import type { ExperienceId } from "../../lib/features/experiences/types";
@@ -27,4 +27,53 @@ export async function setExperienceCookie(
       url: baseURL,
     },
   ]);
+}
+
+/**
+ * Authenticated counterpart to {@link setExperienceCookie}.
+ *
+ * A signed-in context can't be moved by the cookie (see that function's
+ * doc), because `createServerSideProps` overwrites it with the account's
+ * `appSkin` field whenever a session resolves. The only lever a signed-in
+ * context actually reads is that account field, so this pulls it — but
+ * through the app's own "switch experience" control (the button
+ * `ExperienceGap` renders, wired to `useExperienceSwitch`, which calls
+ * `authClient.updateUser({ appSkin })`) rather than writing the field
+ * directly. That keeps this helper honest about what a real user flow does,
+ * and avoids predicting an internal endpoint shape it doesn't own.
+ *
+ * `gapURL` must be a route the *current* experience's slot has no page for,
+ * so the target experience's `ExperienceGap` renders and offers the switch
+ * button — e.g. `/dashboard/help` is classic-only, so it works for
+ * `target: "classic"` from a modern account; a modern-only admin route (the
+ * signed-in account needs a role that can reach it) works for
+ * `target: "modern"` from a classic account.
+ *
+ * Idempotent: a no-op when the account is already on `target`. Mutates
+ * shared server state on the signed-in account, so only call this against a
+ * dedicated identity no other spec observes.
+ */
+export async function setExperienceViaAccount(
+  page: Page,
+  target: ExperienceId,
+  gapURL: string
+): Promise<void> {
+  await page.goto(gapURL);
+
+  const targetContainer = page.locator(
+    target === "classic" ? "#classic-container" : "#modern-container"
+  );
+  if (await targetContainer.isVisible({ timeout: 5000 }).catch(() => false)) {
+    return;
+  }
+
+  const switchButton = page.getByRole("button", {
+    name:
+      target === "classic"
+        ? /switch to the classic interface/i
+        : /switch to the modern interface/i,
+  });
+  await switchButton.waitFor({ state: "visible", timeout: 15000 });
+  await switchButton.click();
+  await targetContainer.waitFor({ state: "visible", timeout: 15000 });
 }

--- a/e2e/helpers/experience.ts
+++ b/e2e/helpers/experience.ts
@@ -49,9 +49,14 @@ export async function setExperienceCookie(
  * signed-in account needs a role that can reach it) works for
  * `target: "modern"` from a classic account.
  *
- * Idempotent: a no-op when the account is already on `target`. Mutates
- * shared server state on the signed-in account, so only call this against a
- * dedicated identity no other spec observes.
+ * Idempotent: waits (up to 5s) for `target`'s container to appear before
+ * falling back to the switch flow, rather than reading an instantaneous DOM
+ * snapshot right after `page.goto` resolves — `ThemedLayout` renders the
+ * chosen slot inside a `Suspense` boundary awaiting a Backend-Service round
+ * trip, so a snapshot taken too early can read as "not there yet" even when
+ * the account is already on `target`. Mutates shared server state on the
+ * signed-in account, so only call this against a dedicated identity no other
+ * spec observes.
  */
 export async function setExperienceViaAccount(
   page: Page,
@@ -63,7 +68,11 @@ export async function setExperienceViaAccount(
   const targetContainer = page.locator(
     target === "classic" ? "#classic-container" : "#modern-container"
   );
-  if (await targetContainer.isVisible({ timeout: 5000 }).catch(() => false)) {
+  const alreadyOnTarget = await targetContainer
+    .waitFor({ state: "visible", timeout: 5000 })
+    .then(() => true)
+    .catch(() => false);
+  if (alreadyOnTarget) {
     return;
   }
 

--- a/e2e/tests/rbac/role-access.spec.ts
+++ b/e2e/tests/rbac/role-access.spec.ts
@@ -205,5 +205,39 @@ test.describe("Role-Based Access Control", () => {
         ).toBeVisible();
       });
     });
+
+    // classicMd.json is a dedicated identity whose account appSkin is classic,
+    // provisioned once in e2e/auth.setup.ts's "provision classic-preference
+    // identity" step. Every other seeded user's appSkin defaults to
+    // modern-light and is unsafe to flip (shared server state — see that
+    // setup step's comment), so this is the only account that can assert the
+    // classic slot on a signed-in dashboard URL without racing another spec.
+    test.describe("Classic (authenticated)", () => {
+      test.use({ storageState: path.join(authDir, "classicMd.json") });
+
+      test("should render the classic slot on an authenticated dashboard URL", async ({
+        page,
+      }) => {
+        await page.goto("/dashboard/flowsheet");
+        await expect(page.locator("#classic-container")).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.locator("#modern-container")).toHaveCount(0);
+      });
+
+      // /dashboard/admin/catalog is modern-only and requires at least MD —
+      // the classicMd identity is provisioned with the musicDirector role
+      // specifically so it can reach a modern-only URL and exercise the
+      // classic slot's app/dashboard/@classic/default.tsx fallback.
+      test("should offer a way out at a modern-only URL", async ({ page }) => {
+        await page.goto("/dashboard/admin/catalog");
+        await expect(page.locator("#classic-container")).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(
+          page.getByRole("button", { name: /switch to the modern interface/i })
+        ).toBeVisible();
+      });
+    });
   });
 });

--- a/e2e/tests/rbac/role-access.spec.ts
+++ b/e2e/tests/rbac/role-access.spec.ts
@@ -225,10 +225,14 @@ test.describe("Role-Based Access Control", () => {
         await expect(page.locator("#modern-container")).toHaveCount(0);
       });
 
-      // /dashboard/admin/catalog is modern-only and requires at least MD —
-      // the classicMd identity is provisioned with the musicDirector role
-      // specifically so it can reach a modern-only URL and exercise the
-      // classic slot's app/dashboard/@classic/default.tsx fallback.
+      // /dashboard/admin/catalog is modern-only, but that role gate is never
+      // evaluated here: for a classic account ThemedLayout renders only the
+      // classic slot, so the modern page (and its requireRole check) never
+      // renders, and middleware/layout only require an authenticated
+      // session. This spec and the one above only need authentication. The
+      // identity keeps the musicDirector role anyway — upcoming classic
+      // librarian screens are MD-gated server-side, so this fixture needs to
+      // already hold MD to be usable once those specs land.
       test("should offer a way out at a modern-only URL", async ({ page }) => {
         await page.goto("/dashboard/admin/catalog");
         await expect(page.locator("#classic-container")).toBeVisible({


### PR DESCRIPTION
## Summary

- Provisions a dedicated E2E identity (`test_classic_md`) in `e2e/auth.setup.ts`, created via the same admin roster path the admin specs already exercise, with its `appSkin` moved to classic through the app's own experience-switch button — never by mutating a shared seeded user's account field.
- Adds `setExperienceViaAccount` to `e2e/helpers/experience.ts`, the authenticated counterpart to `setExperienceCookie`, documented against that function's inert-cookie constraint (`createServerSideProps` overwrites the cookie-seeded preference with the account's `appSkin` once a session resolves).
- Adds two specs to `e2e/tests/rbac/role-access.spec.ts` against the new identity: the classic slot rendering on an authenticated dashboard URL (`/dashboard/flowsheet`), and the classic `app/dashboard/@classic/default.tsx` fallback at a modern-only URL (`/dashboard/admin/catalog`, reachable because the identity holds the `musicDirector` role).
- Documents the new identity in `e2e/README.md`'s test-user table.

## Approach

Implements suggested approach 2 from the issue (setup-time creation in `e2e/auth.setup.ts`), per the [decision comment](https://github.com/WXYC/dj-site/issues/1177#issuecomment-5285429134) recorded on the issue: approach 1 (a new Backend-Service seed user) would couple this to `BACKEND_PINNED_REF` in `.github/workflows/e2e-tests.yml` for no benefit to a fixture whose whole purpose is to unblock local test authoring. This PR does not touch Backend-Service's `dev_env/setup-e2e-test-users.ts` and does not move that pin.

The setup step is idempotent across runs: a cached, still-live storage state short-circuits everything on repeat runs; a fresh provisioning attempt checks the roster for an existing row before creating one. It never mutates an existing seeded user's `appSkin` — the hazard the issue measured (`test_music_director` flipped to classic made `artist-search-crash-smoke`, in the protected `@smoke` gate, fail 1 run in 3) doesn't apply here because this identity has no other observer.

## Outstanding (by design, not in scope for this PR)

The issue's fifth acceptance criterion — `artist-search-crash-smoke` and the other `musicDirector.json` / `dj2.json` specs passing across 5+ consecutive full-suite runs — is a soak an author runs locally against a full stack, not something this PR's CI can establish. Approach 2 makes the shared-state hazard absent by construction (it never mutates an existing seeded user's `appSkin`), rather than proving it absent by observation, so the soak is a confirmation step rather than a gate.

## Test plan

- [x] `npm run lint` — 0 errors (pre-existing warning backlog untouched)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 320 files / 4586 tests passing
- [ ] Playwright E2E suite (author-run against a local full stack; not run repeatedly as part of this PR per the issue's own caveat about the five-run soak)

Closes #1177