### PR TITLE
chore(deps): bump @wxyc/shared to 3.5.0

### DIFF
--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -3,7 +3,14 @@ import { Rotation } from "../rotation/types";
 
 export type { AlbumSearchResult };
 
-/** Track-level match hints returned by catalog track search (not yet in @wxyc/shared). */
+/**
+ * Track-level match hints returned by catalog track search.
+ *
+ * Declared here rather than imported from `@wxyc/shared`, which publishes the
+ * same shape with every optional field nullable and `source` narrowed to an
+ * enum. Adopting the published shape is a null-handling change at every
+ * consumer, not a rename, so the two are kept separate deliberately.
+ */
 export type TrackMatchHint = {
   source: string;
   title: string;
@@ -21,19 +28,16 @@ export const TrackMatchSource = {
  * JSON boundary adapter for AlbumSearchResult.
  * RTK Query delivers raw JSON where add_date is a string, not a Date.
  *
- * discogsUnavailable/discogsUnavailableNote/lastDiscogsRecheckAt are declared
- * here by hand rather than picked up from `AlbumSearchResult`: api.yaml only
- * carries them on `Album`/`AlbumInfoResponse` (the `GET /library/info`
- * response schema), not on `AlbumSearchResult`, even though `GET /library/`,
- * `GET /library/query`, and `PATCH /library/:id` all serve from the same
- * backend read model and carry the fields on the wire.
+ * `matched_via` is omitted from the base and re-declared so the local
+ * `TrackMatchHint` applies: intersecting the two array types instead would
+ * demand a value satisfying both, which no single response row can.
  */
-export type AlbumSearchResultJSON = Omit<AlbumSearchResult, "add_date"> & {
+export type AlbumSearchResultJSON = Omit<
+  AlbumSearchResult,
+  "add_date" | "matched_via"
+> & {
   add_date: string;
   matched_via?: TrackMatchHint[];
-  discogsUnavailable?: boolean;
-  discogsUnavailableNote?: string | null;
-  lastDiscogsRecheckAt?: string | null;
 };
 
 export type SearchCatalogQueryParams = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@mui/system": "5.18.0",
         "@opennextjs/cloudflare": "^1.20.2",
         "@reduxjs/toolkit": "^2.12.0",
-        "@wxyc/shared": "^2.6.0",
+        "@wxyc/shared": "^3.5.0",
         "better-auth": "^1.6.26",
         "jwt-decode": "^4.0.0",
         "motion": "^12.42.2",
@@ -7077,10 +7077,10 @@
       "license": "MIT"
     },
     "node_modules/@wxyc/shared": {
-      "version": "2.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/2.6.0/9473a3aef11e99a8b0a0cee2f39064b228407c7e",
-      "integrity": "sha512-AXarRgyHvISrGtijbB/RqGBwBZZw+2fACi7aZZMq4GO7TG+1s/y4Zjkp9q2TZKOHHB0xLyYCUorB71qipfIhMQ==",
-      "license": "MIT",
+      "version": "3.5.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/3.5.0/7fcc3eaf9c87383cc82d2c7f90a87bbdee77becc",
+      "integrity": "sha512-R8ziGiqNbJNuhiedSWgq+xaNYRE+Wwvo9Gl2kyQG4tqS9+pA9ig/CT/F4oiIPnehV5Blvt8QbWrfgU4bExjCrQ==",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "date-fns": "^4.4.0"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@mui/system": "5.18.0",
     "@opennextjs/cloudflare": "^1.20.2",
     "@reduxjs/toolkit": "^2.12.0",
-    "@wxyc/shared": "^2.6.0",
+    "@wxyc/shared": "^3.5.0",
     "better-auth": "^1.6.26",
     "jwt-decode": "^4.0.0",
     "motion": "^12.42.2",


### PR DESCRIPTION
Closes #1185.

Bumps `@wxyc/shared` from the pinned 2.6.0 to **3.5.0** — the publish carrying WXYC/wxyc-shared#340's `legacy_release_id` response fields — and deletes the local declarations that existed only to paper over the stale pin.

## What changed

**`package.json` / `package-lock.json`** — `^2.6.0` → `^3.5.0`. dj-site does not float within its range, so a publish only lands via a lockfile PR like this one.

**`lib/features/catalog/types.ts`** — `AlbumSearchResultJSON` hand-declared `discogsUnavailable`, `discogsUnavailableNote`, and `lastDiscogsRecheckAt` because 2.6.0's `AlbumSearchResult` lacked them. 3.5.0 carries all three, so the declarations and the docstring paragraph explaining their absence are both gone.

Verified against the installed package rather than assumed — 3.5.0's `AlbumSearchResult` now carries `discogsUnavailable`, `discogsUnavailableNote`, `lastDiscogsRecheckAt`, `matched_via`, **and** `legacy_release_id?: number`.

## Two judgment calls worth reviewing

**`matched_via` is now `Omit`ted from the base, not just intersected.** 3.5.0 publishes it too, typed as `components["schemas"]["TrackMatchHint"][]`. Leaving the old `Omit<AlbumSearchResult, "add_date"> & { matched_via?: TrackMatchHint[] }` would have intersected two differently-typed arrays, producing a field that demands a value satisfying both shapes at once — which no single response row can. Omitting it from the base lets the local declaration apply cleanly.

**The local `TrackMatchHint` is deliberately kept.** The published shape is not equivalent: every optional field is nullable (`artist_credit?: string | null`, `position?: string | null`, `confidence?: number | null`) and `source` is narrowed from `string` to a `TrackMatchSource` enum. Adopting it is a null-handling change at every consumer, not a rename — out of scope for a dependency bump whose contract is "no behavior change". Its stale comment ("not yet in `@wxyc/shared`"), which this bump falsifies, is corrected to state the real reason the two are kept separate.

Migrating to the published shape is worth its own ticket; it is not filed yet.

## Verification

Run in the worktree against the freshly installed 3.5.0 (a stale `dist/` in a shared `node_modules` is a known source of phantom red here, so the worktree has its own):

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0, no diagnostics |
| `npm run lint` | exit 0 — **0 errors**, 195 warnings (pre-existing backlog; the diff removes declarations and edits comments, so it cannot add to it) |
| `npm run test:run` | **4656 passed / 4656**, 327 files |

## Acceptance criteria

- [x] Latest 3.x installed; lockfile refreshed; typecheck and full suite green
- [x] Redundant local intersection fields removed; stale docstring fixed
- [x] No behavior change — type-level only; no runtime code touched

## Notes for the reviewer

- `UpdateAlbumRequestBody` and `AlbumEntry` also declare `discogsUnavailable` / `discogsUnavailableNote`. Those are **not** intersections over a published type — they are hand-authored request/domain shapes — so they are deliberately untouched.
- This unblocks a sub-item of #1184: with 3.5.0 installed, that issue no longer needs its local `BinLibraryDetailsJSON` intersection, since `legacy_release_id` now arrives from the published contract.
- Pre-existing #1088 (e2e red on `main`) is a launch precondition for every dj-site merge and is unrelated to this diff.

## Related

Epic #1179 · WXYC/wxyc-shared#340 (the publish this consumes) · #1184 · #1189 (the row-ref contract's equivalent bump — if that publish lands before this merges, one bump can absorb both versions)
