### PR TITLE
feat(catalog): carry legacy_release_id alongside library.id on AlbumEntry

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -63,6 +63,7 @@ Message factories: `createTestStartShowMessage(djName?, dateTime?)`, `createTest
 
 ```typescript
 TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM     // 1001
+TEST_ENTITY_IDS.LEGACY_RELEASE.ROCK_ALBUM  // 7001 -- same row, other id space
 TEST_ENTITY_IDS.ARTIST.ROCK_ARTIST   // 2001
 TEST_ENTITY_IDS.FLOWSHEET.ENTRY_1    // 3001
 TEST_ENTITY_IDS.SHOW.CURRENT_SHOW    // 4001
@@ -191,4 +192,5 @@ Playwright specs stay in `e2e/`, and bats scripts in `scripts/__tests__/`.
 - Use the API harness for verifying RTK Query endpoint structure
 - Use `createTest*` factory functions instead of inline test data
 - Reference `TEST_ENTITY_IDS` and `TEST_SEARCH_STRINGS` constants for IDs and strings
+- Keep an album fixture's `legacy_release_id` **distinct from its `id`**. They are two id spaces over the same row — `id` is Backend's `library.id` serial, `legacy_release_id` is the tubafrenzy `LIBRARY_RELEASE_ID` the per-track store is keyed by — and a fixture where the two coincide cannot tell a path that resolves in the right space from one that resolves in the wrong space. Pair an `TEST_ENTITY_IDS.ALBUM` id with the `TEST_ENTITY_IDS.LEGACY_RELEASE` entry of the same name; never copy one into the other. This applies to hand-built rows too, including wire-shaped ones (`createTestAlbumSearchResult`), where the type is optional and the compiler will not ask
 - Use `renderWithProviders` for all component tests (never bare RTL `render`)

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -80,6 +80,16 @@ export function convertToAlbumEntry(
 
   return {
     id,
+    // Both union arms carry it: catalog search and rotation rows arrive as
+    // AlbumSearchResultJSON, bin rows as BinLibraryDetails. Coalesced to
+    // `null` rather than left `undefined` so an absent field and a null one
+    // are indistinguishable downstream — the property is always present.
+    //
+    // Note this is NOT gated on `isSearchResult` or on the row being linked:
+    // it is a property of the underlying library row, independent of whether
+    // `id` resolved, and gating it would drop it for exactly the rows whose
+    // ids diverge most.
+    legacy_release_id: response.legacy_release_id ?? null,
     title: response.album_title ?? "",
     artist: {
       name: response.artist_name ?? "",

--- a/lib/features/catalog/patchSearchResult.ts
+++ b/lib/features/catalog/patchSearchResult.ts
@@ -43,6 +43,10 @@ export function mergeAlbumIntoSearchResult(
     ...existing,
     ...updated,
     id: existing.id,
+    // Pinned from the same row as `id` above. Taking one id from the cached
+    // row and letting `...updated` supply the other would leave the merged row
+    // carrying two id spaces that point at different releases.
+    legacy_release_id: existing.legacy_release_id,
     artist: callNumberFromResponse ? updated.artist : existing.artist,
     entry: callNumberFromResponse ? updated.entry : existing.entry,
     matched_via: existing.matched_via,

--- a/lib/features/catalog/patchSearchResult.ts
+++ b/lib/features/catalog/patchSearchResult.ts
@@ -45,8 +45,11 @@ export function mergeAlbumIntoSearchResult(
     id: existing.id,
     // Pinned from the same row as `id` above. Taking one id from the cached
     // row and letting `...updated` supply the other would leave the merged row
-    // carrying two id spaces that point at different releases.
-    legacy_release_id: existing.legacy_release_id,
+    // carrying two id spaces that point at different releases. The `??` is
+    // safe against exactly that: the caller locates `existing` BY `updated.id`,
+    // so both sides are the same library row and the response can only ever
+    // supply the legacy id the cached row was missing — never a competing one.
+    legacy_release_id: existing.legacy_release_id ?? updated.legacy_release_id,
     artist: callNumberFromResponse ? updated.artist : existing.artist,
     entry: callNumberFromResponse ? updated.entry : existing.entry,
     matched_via: existing.matched_via,

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -31,13 +31,21 @@ export const TrackMatchSource = {
  * `matched_via` is omitted from the base and re-declared so the local
  * `TrackMatchHint` applies: intersecting the two array types instead would
  * demand a value satisfying both, which no single response row can.
+ *
+ * `legacy_release_id` is widened to allow `null`. This type carries rotation
+ * rows as well as catalog search rows, and the published contract types the
+ * two differently — `AlbumSearchResult` non-null (catalog search inner-joins
+ * library) but `Rotation` nullable (`getRotationFromDB` LEFT JOINs, and most
+ * production rotation rows have no library row behind them). The union of the
+ * shapes this type actually carries is the nullable one.
  */
 export type AlbumSearchResultJSON = Omit<
   AlbumSearchResult,
-  "add_date" | "matched_via"
+  "add_date" | "matched_via" | "legacy_release_id"
 > & {
   add_date: string;
   matched_via?: TrackMatchHint[];
+  legacy_release_id?: number | null;
 };
 
 export type SearchCatalogQueryParams = {
@@ -227,7 +235,24 @@ export type AlbumParams = AddAlbumRequestBody;
 export type ArtistParams = AddArtistRequestBody;
 
 export type AlbumEntry = {
+  /**
+   * Backend's `library.id` serial — the id every write path sends as
+   * `album_id`, and the only id an endpoint under `/library/:id` accepts.
+   * `null` where no library row is known.
+   */
   id: number | null;
+  /**
+   * The row's tubafrenzy `LIBRARY_RELEASE_ID` (Backend's
+   * `library.legacy_release_id`) — a **different id space** from `id`, and the
+   * one the per-track store is keyed by. `null` where the source row has no
+   * library row behind it (an unlinked rotation row) or predates the field.
+   *
+   * Required rather than optional on purpose: every failure mode of a missing
+   * value is silent — a read resolves `null` and quietly returns nothing, a
+   * dedupe quietly no-ops — so a conversion path that forgets to map it should
+   * fail to compile rather than ship an `undefined`.
+   */
+  legacy_release_id: number | null;
   title: string;
   artist: ArtistEntry;
   entry: number;

--- a/lib/features/lml/lml-conversions.ts
+++ b/lib/features/lml/lml-conversions.ts
@@ -38,6 +38,11 @@ function normalizeGenre(genre: string | null): Genre {
 export function convertLmlItemToAlbumEntry(item: LmlLibraryItem): AlbumEntry {
   return {
     id: item.id,
+    // LML's `library.db` is keyed by the tubafrenzy LIBRARY_RELEASE_ID, so the
+    // `id` it returns is a legacy release id, not a Backend `library.id`. It
+    // belongs in this field; `id` keeps the same value for now, which makes an
+    // LML row the one source where the two spaces legitimately coincide.
+    legacy_release_id: item.id,
     title: item.title ?? "",
     artist: {
       name: item.artist ?? "",

--- a/tests/fixtures/fixtures.ts
+++ b/tests/fixtures/fixtures.ts
@@ -177,6 +177,9 @@ export function createTestArtist(overrides: Partial<ArtistEntry> = {}): ArtistEn
 export function createTestAlbum(overrides: Partial<AlbumEntry> = {}): AlbumEntry {
   return {
     id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM,
+    // Deliberately NOT a copy of `id` — see the LEGACY_RELEASE note in
+    // tests/helpers/constants.ts.
+    legacy_release_id: TEST_ENTITY_IDS.LEGACY_RELEASE.ROCK_ALBUM,
     title: TEST_SEARCH_STRINGS.ALBUM_NAME,
     artist: createTestArtist(),
     entry: 1,
@@ -199,6 +202,11 @@ export function createTestAlbumSearchResult(
 ): AlbumSearchResultJSON {
   return {
     id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM,
+    // The wire type leaves this optional, so the compiler will not demand it
+    // here — but a spec that builds a row through this factory and converts it
+    // would otherwise exercise the no-legacy-id branch while appearing to test
+    // the populated one.
+    legacy_release_id: TEST_ENTITY_IDS.LEGACY_RELEASE.ROCK_ALBUM,
     add_date: toDateString(TEST_TIMESTAMPS.ONE_WEEK_AGO),
     album_title: TEST_SEARCH_STRINGS.ALBUM_NAME,
     artist_name: TEST_SEARCH_STRINGS.ARTIST_NAME,
@@ -279,6 +287,7 @@ export function createTestAlbumList(count: number = 3): AlbumEntry[] {
   return Array.from({ length: count }, (_, index) =>
     createTestAlbum({
       id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM + index,
+      legacy_release_id: TEST_ENTITY_IDS.LEGACY_RELEASE.ROCK_ALBUM + index,
       title: `${TEST_SEARCH_STRINGS.ALBUM_NAME} ${index + 1}`,
       artist: createTestArtist({
         id: TEST_ENTITY_IDS.ARTIST.ROCK_ARTIST + index,
@@ -305,6 +314,7 @@ export function createTestRotationAlbum(
 ): AlbumEntry {
   return createTestAlbum({
     id: TEST_ENTITY_IDS.ALBUM.ROTATION_ALBUM,
+    legacy_release_id: TEST_ENTITY_IDS.LEGACY_RELEASE.ROTATION_ALBUM,
     rotation_bin: rotation,
     rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
     ...overrides,

--- a/tests/helpers/constants.ts
+++ b/tests/helpers/constants.ts
@@ -16,6 +16,17 @@ export const TEST_ENTITY_IDS = {
     ELECTRONIC_ALBUM: 1003,
     ROTATION_ALBUM: 1004,
   },
+  // The `legacy_release_id` id space, deliberately disjoint from ALBUM (the
+  // `library.id` space). A fixture whose two ids coincide cannot distinguish a
+  // path that resolves in the right space from one that resolves in the wrong
+  // one, so every album factory pairs an ALBUM id with the LEGACY_RELEASE id
+  // of the same name — never a copy of the ALBUM id.
+  LEGACY_RELEASE: {
+    ROCK_ALBUM: 7001,
+    JAZZ_ALBUM: 7002,
+    ELECTRONIC_ALBUM: 7003,
+    ROTATION_ALBUM: 7004,
+  },
   ARTIST: {
     ROCK_ARTIST: 2001,
     JAZZ_ARTIST: 2002,

--- a/tests/integration/components/modern/Rightbar/Bin/BinContent.test.tsx
+++ b/tests/integration/components/modern/Rightbar/Bin/BinContent.test.tsx
@@ -126,6 +126,10 @@ describe("BinContent", () => {
   const mockBinEntries: AlbumEntry[] = [
     {
       id: 1,
+      // Distinct from `id` on purpose: the two are separate id spaces,
+      // and a fixture where they coincide can't tell a right-space read
+      // from a wrong-space one.
+      legacy_release_id: 45001,
       title: "Album One",
       entry: 1,
       format: "CD",
@@ -145,6 +149,10 @@ describe("BinContent", () => {
     },
     {
       id: 2,
+      // Distinct from `id` on purpose: the two are separate id spaces,
+      // and a fixture where they coincide can't tell a right-space read
+      // from a wrong-space one.
+      legacy_release_id: 45002,
       title: "Album Two",
       entry: 2,
       format: "Vinyl",
@@ -164,6 +172,10 @@ describe("BinContent", () => {
     },
     {
       id: 3,
+      // Distinct from `id` on purpose: the two are separate id spaces,
+      // and a fixture where they coincide can't tell a right-space read
+      // from a wrong-space one.
+      legacy_release_id: 45003,
       title: "Album Three",
       entry: 3,
       format: "CD",

--- a/tests/unit/lib/features/catalog/conversions.test.ts
+++ b/tests/unit/lib/features/catalog/conversions.test.ts
@@ -440,6 +440,78 @@ describe("catalog conversions", () => {
       });
     });
 
+    // `id` (Backend's `library.id` serial) and `legacy_release_id` (the
+    // tubafrenzy `LIBRARY_RELEASE_ID` the per-track store is keyed by) are two
+    // disjoint id spaces over the same row. The converter's job here is only to
+    // carry the second one through intact so each downstream path can resolve
+    // in the space it actually needs; nothing about which path reads which
+    // changes yet.
+    //
+    // Every fixture below keeps the two values distinct on purpose. Equal ids
+    // cannot tell a read that resolves in the right space from one that
+    // resolves in the wrong space, which is precisely the failure being
+    // guarded against.
+    describe("legacy_release_id rides alongside library.id", () => {
+      it.each([
+        [
+          "catalog search",
+          { ...catalogSearchRow, legacy_release_id: 45342 },
+          2001,
+          45342,
+        ],
+        [
+          "library-linked rotation",
+          { ...linkedRow, legacy_release_id: 45001 },
+          1001,
+          45001,
+        ],
+      ] as const)(
+        "carries both ids on a %s row",
+        (_source, row, expectedId, expectedLegacy) => {
+          const result = convertToAlbumEntry(row as AlbumSearchResultJSON);
+          expect(result.id).toBe(expectedId);
+          expect(result.legacy_release_id).toBe(expectedLegacy);
+        },
+      );
+
+      it("carries both ids on a bin row", () => {
+        // BinLibraryDetails inner-joins library, so the field is always present
+        // and non-null on a real bin row.
+        const result = convertToAlbumEntry({
+          ...binDetails,
+          legacy_release_id: 45234,
+        } as BinLibraryDetails);
+        expect(result.id).toBe(1234);
+        expect(result.legacy_release_id).toBe(45234);
+      });
+
+      it.each([
+        ["absent", catalogSearchRow],
+        ["explicitly null", { ...catalogSearchRow, legacy_release_id: null }],
+      ] as const)(
+        "resolves an %s legacy_release_id to null, never undefined",
+        (_shape, row) => {
+          const result = convertToAlbumEntry(row as AlbumSearchResultJSON);
+          // `null` and `undefined` are not interchangeable here: an absent
+          // field would make the required property optional in practice, and a
+          // consumer distinguishing "no legacy id" from "field forgotten"
+          // could no longer do so.
+          expect(result.legacy_release_id).toBeNull();
+          expect("legacy_release_id" in result).toBe(true);
+        },
+      );
+
+      it("leaves an unlinked rotation row's legacy_release_id null while its id synthesizes", () => {
+        // 144 of 206 production rotation rows are library-unlinked: the LEFT
+        // JOIN yields no library row, so there is no legacy id to carry. The
+        // synthesized negative `id` is existing behavior and deliberately
+        // untouched here.
+        const result = convertToAlbumEntry(unlinkedRowNullId);
+        expect(result.legacy_release_id).toBeNull();
+        expect(result.id).toBeLessThan(0);
+      });
+    });
+
     describe("end-to-end: rotation pick → mutation submission", () => {
       // Asserts the chain the picker uses (per the #691 forensics):
       //   useGetRotationQuery (rotationApi.transformResponse)

--- a/tests/unit/lib/features/catalog/patchSearchResult.test.ts
+++ b/tests/unit/lib/features/catalog/patchSearchResult.test.ts
@@ -175,6 +175,22 @@ describe("mergeAlbumIntoSearchResult", () => {
     expect(merged.legacy_release_id).toBe(existing.legacy_release_id);
   });
 
+  it("learns a legacy id the cached row is missing", () => {
+    // Both rows are the same library row — the caller finds `existing` by
+    // `updated.id` — so taking the legacy id from the response cannot mix
+    // spaces. Pinning it unconditionally would discard a value the cached row
+    // never had, and every consequence of that is silent: the row's tracklist
+    // read resolves nothing and the picker stays collapsed for as long as the
+    // cache entry lives.
+    const existing = createTestAlbum({ id: 42, legacy_release_id: null });
+    const updated = createTestAlbum({ id: 42, legacy_release_id: 45042 });
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.id).toBe(42);
+    expect(merged.legacy_release_id).toBe(45042);
+  });
+
   it("keeps the id pair coherent on the rotation-only patch branch", () => {
     // The rotation-only branch spreads `existing` wholesale and overrides just
     // the two rotation fields, so both ids ride along from one row. Pinned so a

--- a/tests/unit/lib/features/catalog/patchSearchResult.test.ts
+++ b/tests/unit/lib/features/catalog/patchSearchResult.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { createTestAlbum, createTestArtist } from "@/tests/helpers";
 import { mergeAlbumIntoSearchResult } from "@/lib/features/catalog/patchSearchResult";
+import { Rotation } from "@/lib/features/rotation/types";
 
 describe("mergeAlbumIntoSearchResult", () => {
   it("updates editable fields while preserving search-only metadata", () => {
@@ -157,6 +158,46 @@ describe("mergeAlbumIntoSearchResult", () => {
     const merged = mergeAlbumIntoSearchResult(existing, updated);
 
     expect(merged.discogsUnavailableNote).toBe("embargoed until 2026-09-01");
+  });
+
+  it("keeps the id pair coherent, taking both ids from the cached row", () => {
+    // The merge deliberately pins `id` to the cached row rather than letting
+    // `...updated` supply it. `legacy_release_id` has to be pinned from the
+    // same side or the merged row ends up carrying two id spaces that point at
+    // different releases — this defect, reintroduced through cache merging.
+    // The two rows' legacy ids must differ or the assertion cannot fail.
+    const existing = createTestAlbum({ id: 42, legacy_release_id: 45042 });
+    const updated = createTestAlbum({ id: 42, legacy_release_id: 99999 });
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.id).toBe(existing.id);
+    expect(merged.legacy_release_id).toBe(existing.legacy_release_id);
+  });
+
+  it("keeps the id pair coherent on the rotation-only patch branch", () => {
+    // The rotation-only branch spreads `existing` wholesale and overrides just
+    // the two rotation fields, so both ids ride along from one row. Pinned so a
+    // future edit to that branch can't split them.
+    const existing = createTestAlbum({ id: 42, legacy_release_id: 45042 });
+    const rotationPatch = createTestAlbum({
+      id: 7,
+      legacy_release_id: 99999,
+      title: "",
+      label: "",
+      entry: 0,
+      artist: createTestArtist({ name: "", lettercode: "", numbercode: 0 }),
+      genre_id: undefined,
+      format_id: undefined,
+      rotation_bin: Rotation.H,
+      rotation_id: 5001,
+    });
+
+    const merged = mergeAlbumIntoSearchResult(existing, rotationPatch);
+
+    expect(merged.rotation_bin).toBe(Rotation.H);
+    expect(merged.id).toBe(42);
+    expect(merged.legacy_release_id).toBe(45042);
   });
 
   it("merges albums with empty title fields from LML-only rows", () => {

--- a/tests/unit/lib/features/catalog/patchSearchRotation.test.ts
+++ b/tests/unit/lib/features/catalog/patchSearchRotation.test.ts
@@ -3,6 +3,7 @@ import { patchCatalogSearchRotation } from "@/lib/features/catalog/patchSearchCa
 import { catalogApi } from "@/lib/features/catalog/api";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 import { createTestAlbum } from "@/tests/helpers";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
 
 describe("patchCatalogSearchRotation", () => {
   afterEach(() => {
@@ -91,6 +92,52 @@ describe("patchCatalogSearchRotation", () => {
         expect(draft.pages[0].results[0].id).toBe(42);
         expect(draft.pages[0].results[0].rotation_bin).toBe("H");
         expect(draft.pages[0].total).toBe(2);
+        return { type: "catalogApi/updateQueryData" } as never;
+      },
+    );
+
+    patchCatalogSearchRotation(
+      dispatch,
+      () => ({} as never),
+      42,
+      { rotation_bin: "H", rotation_id: 99 },
+      album,
+    );
+  });
+
+  it("carries both ids through the inserted row", () => {
+    // The insert path spreads a whole row and overrides only the two rotation
+    // fields, so `id` and `legacy_release_id` ride along together. Pinned
+    // because a row inserted with one id space and not the other resolves in
+    // whichever space the reader happens to pick.
+    const dispatch = vi.fn();
+    const album = createTestAlbum({
+      id: 42,
+      legacy_release_id: 45042,
+      rotation_bin: "H",
+      rotation_id: 99,
+    });
+
+    vi.spyOn(catalogApi.util, "selectCachedArgsForQuery").mockReturnValue([
+      { rotation_bins: "H" },
+    ]);
+
+    vi.spyOn(catalogApi.endpoints.getInformation, "select").mockReturnValue(
+      (() => () => undefined) as unknown as ReturnType<
+        typeof catalogApi.endpoints.getInformation.select
+      >,
+    );
+
+    vi.spyOn(catalogApi.util, "updateQueryData").mockImplementation(
+      (_endpoint, _args, updater) => {
+        const draft = {
+          pages: [
+            { results: [] as AlbumEntry[], total: 0, page: 0, totalPages: 1 },
+          ],
+        };
+        updater(draft);
+        expect(draft.pages[0].results[0].id).toBe(42);
+        expect(draft.pages[0].results[0].legacy_release_id).toBe(45042);
         return { type: "catalogApi/updateQueryData" } as never;
       },
     );

--- a/tests/unit/lib/features/lml/lml-conversions.test.ts
+++ b/tests/unit/lib/features/lml/lml-conversions.test.ts
@@ -21,6 +21,7 @@ describe("convertLmlItemToAlbumEntry", () => {
 
     expect(result).toEqual({
       id: 42,
+      legacy_release_id: 42,
       title: "DOGA",
       artist: {
         name: "Juana Molina",
@@ -152,6 +153,18 @@ describe("convertLmlItemToAlbumEntry", () => {
     const item = createTestLmlLibraryItem({ matched_via });
     const result = convertLmlItemToAlbumEntry(item);
     expect(result.matched_via).toEqual(matched_via);
+  });
+
+  it("should carry LmlLibraryItem.id into legacy_release_id", () => {
+    // LML's `library.db` is keyed by the tubafrenzy LIBRARY_RELEASE_ID, so the
+    // `id` it returns is a `legacy_release_id`, not a Backend `library.id`.
+    // Populating the field it actually belongs in is this change; `id` keeps
+    // its current value for now, so an LML row is the one source where the two
+    // spaces legitimately coincide.
+    const item = createTestLmlLibraryItem({ id: 45342 });
+    const result = convertLmlItemToAlbumEntry(item);
+    expect(result.legacy_release_id).toBe(45342);
+    expect(result.id).toBe(45342);
   });
 
   it("should always set rotation_bin, rotation_id, plays, and add_date to undefined", () => {


### PR DESCRIPTION
Part 1 of 4 for #1184. **Does not close it** — this lands the substrate only. Behavior is unchanged everywhere; the reads and writes switch id spaces in parts 2 and 3.

## Why this is split

#1184's edit set has a seam its body doesn't name: **item 3 does two things** — it populates `legacy_release_id` from LML's `item.id`, *and* it sets `id: null`. Those can land apart, and separating them isolates all the risk.

| PR | Items | Behavior change |
|---|---|---|
| **1 — substrate (this one)** | 1, 2, 2a, + item 3's *populate* half | **None.** Purely additive |
| **2 — read fix** | 4a, 4b, 4c, 4d | Fixes the silent 87.7% |
| **3 — write fix** | item 3's *null* half, 5, 6, 7, 8, Playwright | Stops the data-corrupting write |
| **4 — follow-up** | 10 | Dedupe re-key |

The tempting split is "types first, consumers second". But item 3's `id: null` is what breaks the item 5 highlight, the item 6 `artistProvided` flip, the item 7 `track_position` drop, and the item 4a prefetch gate. Land the null early and each of those is a live regression with **no compile error and no failing test**. Keeping the null in part 3 with all four of its consequences means none of them can ship half-done.

The spec's own constraint — items 4a/4b/4d never separate — is preserved: they are all in part 2.

## What changed

**`AlbumEntry.legacy_release_id: number | null`, required.** Every failure mode of a missing value is silent — a read resolves `null` and quietly returns nothing, a dedupe quietly no-ops — so an unmapped conversion path should fail to compile rather than ship an `undefined`. Both ids carry a docstring naming which space they are.

**`AlbumSearchResultJSON` widens the field to `number | null`.** This type carries rotation rows as well as catalog search rows, and the published contract types the two differently: `AlbumSearchResult.legacy_release_id?: number` (catalog search inner-joins library) but `Rotation.legacy_release_id?: number | null` (`getRotationFromDB` LEFT JOINs). Verified against the installed 3.5.0 `.d.ts` rather than assumed. The union of the shapes this type actually carries is the nullable one, so the field is `Omit`ted from the base and re-declared — the same pattern already used for `matched_via` two lines up.

**`convertToAlbumEntry`** populates it on both union arms, coalescing absent → `null` so the property is always present. Deliberately **not** gated on `isSearchResult` or on the row being linked: it is a property of the underlying library row, independent of whether `id` resolved, and gating it would drop it for exactly the rows whose ids diverge most.

**`convertLmlItemToAlbumEntry`** moves LML's `item.id` into it — that value *is* a legacy release id, since LML's `library.db` is keyed by `LIBRARY_RELEASE_ID` — while leaving `id` at the same value. LML is therefore the one source where the two spaces legitimately coincide, which is exactly what makes part 2's picker switch a no-op for LML and a fix for catalog.

**`mergeAlbumIntoSearchResult`** carries `legacy_release_id` beside the `id: existing.id` it already pins, as `existing.legacy_release_id ?? updated.legacy_release_id`. Letting `...updated` supply one id while the cached row supplies the other would leave the merged row carrying two id spaces that point at **different releases** — this defect, reintroduced through cache merging. The coalesce cannot do that: the caller locates the cached row *by* the response's `id`, so both sides are the same library row and the response can only ever supply a legacy id the cached row lacked. An unconditional pin (what this PR first had) would instead discard it, and the consequence is silent — that row's tracklist read resolves nothing and its picker stays collapsed for the life of the cache entry.

**`resolveAlbumEntryForRotationPatch` needed no change** — confirmed rather than assumed, per the item's instruction. Both its branches spread a whole row and override only the two rotation fields, so the pair rides along coherently. Pinned with a test anyway, so a future rewrite that constructs the row field-by-field can't split them.

## Fixtures

`createTestAlbum`, `createTestAlbumList`, `createTestRotationAlbum`, and `createTestAlbumSearchResult` all get a default from a new `TEST_ENTITY_IDS.LEGACY_RELEASE` block — **distinct from `id`, never a copy**. A fixture where the two spaces coincide cannot tell a path that resolves in the right space from one that resolves in the wrong space, which is the whole bug. `createTestAlbumSearchResult` gets the same treatment even though the wire type is optional and the compiler won't demand it: a spec building a row there and converting it would otherwise exercise the no-legacy-id branch while appearing to test the populated one.

The rule is recorded in `docs/testing.md`'s conventions list, per the acceptance criterion.

## Compiler surface

Making the field required surfaced exactly **three** hand-built `AlbumEntry` literals, all in `BinContent.test.tsx`. Each got a distinct legacy id rather than a conversion to `createTestAlbum` — that conversion is #1183's territory, not this PR's.

Audited for paths that would bypass the compiler: no `as AlbumEntry` cast constructs a row (`AlbumDetailPanel.tsx:47` casts a value that already came through `convertToAlbumEntry`), and `e2e/` — excluded from `tsconfig.json` — builds no `AlbumEntry` at all.

## Verification

Run in a worktree with its own `node_modules` (a stale `dist/` in a shared one is a known source of phantom red here):

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0, no diagnostics |
| `npm run lint` | exit 0 — **0 errors**, 195 warnings (pre-existing backlog, unchanged count) |
| `npm run test:run` | **4667 passed / 4667**, 327 files (4656 before; +11 new) |
| `npm run build` | success |

Tests were written first and confirmed red — 9 failures across 3 files before the implementation landed, and the merge fix below added a tenth.

One caveat on how that number was reached: an earlier run of this suite reported 12 failures across 2 files, which turned out to be timeouts from running two vitest suites concurrently on this machine. Re-run uncontended, the suite is 4667/4667 with exit 0. Nothing in those failures was related to this diff, but the first number was not trustworthy and is recorded here rather than quietly dropped.

## New tests

- `conversions.test.ts` — both ids carried on catalog / linked-rotation / bin rows; absent **and** explicitly-null both resolve to `null` (never `undefined`, and the property is always present); an unlinked rotation row keeps `legacy_release_id: null` while its `id` still synthesizes
- `lml-conversions.test.ts` — `item.id` reaches `legacy_release_id`, `id` unchanged
- `patchSearchResult.test.ts` — id-pair coherence on both merge branches, with the two rows' legacy ids **differing** so the assertion can actually fail; plus the cached row learning a legacy id it lacked. Both directions are mutation-verified: flipping the coalesce order reddens the coherence case, and pinning unconditionally reddens the learning case, so neither assertion is satisfiable by the other's implementation
- `patchSearchRotation.test.ts` — id pair survives the insert path's spread

## Merge gates

Both of #1184's gates were satisfied and evidenced before this branch was cut — see [the gate-1 comment on #1184](https://github.com/WXYC/dj-site/issues/1184#issuecomment-5295942661) for the live prod probe output (`/library` 45/45, `/library/info` 1/1, `/library/rotation` 206/206 key present, bin covered by BS CI), the deploy sha, and the cross-tab proving the 144 rotation nulls are correct rather than a gap.

Gate 1 is what this PR depends on: it reads a field the running Backend must already emit. Since this PR changes no behavior even if the field were absent everywhere, it is the safest of the four to land first regardless.

## Related

Epic #1179 · #1184 (parent; parts 2-4 follow) · #1185 (merged — its 3.5.0 bump is what discharges #1184's local `BinLibraryDetailsJSON` sub-item) · WXYC/Backend-Service#2128 (the emitter) · WXYC/wxyc-shared#340 (the contract)

