### PR TITLE
Extract the genre-outage rendering convention into lib/features/catalog

### DIFF
--- a/lib/features/catalog/genreAvailability.ts
+++ b/lib/features/catalog/genreAvailability.ts
@@ -1,0 +1,25 @@
+/**
+ * An unissued or failed `useGetGenresQuery` must never render as an empty
+ * genre list — a librarian filing against a backend outage must never read
+ * "there are no genres", for the same reason `searchArtistsInGenre` opted
+ * out of caching a false no-match during an outage (see
+ * `lib/features/catalog/api.ts`, `surfaceNonJsonAsError` on that endpoint).
+ *
+ * RTK Query keeps the last good `data` on a rejected refetch, so `isError`
+ * can be true while a perfectly good cached list is still on screen — a
+ * genre a form could file against right now. This predicate therefore tests
+ * absence-of-list (`data == null` once the initial load has settled), never
+ * `isError`: a failed refetch over cached data is not an outage, and reading
+ * the error flag would put a "can't be filed right now" alert beside a form
+ * that still works.
+ *
+ * `genresLoading` alone covers the mount render — `useGetGenresQuery` passes
+ * no `skip`, so RTK Query synthesizes `isLoading: true` for that first
+ * render regardless of whether the request has resolved.
+ */
+export function isGenresUnavailable(
+  genresLoading: boolean,
+  genres: unknown[] | null | undefined,
+): boolean {
+  return !genresLoading && genres == null;
+}

--- a/lib/features/catalog/genreAvailability.ts
+++ b/lib/features/catalog/genreAvailability.ts
@@ -1,25 +1,37 @@
 /**
  * An unissued or failed `useGetGenresQuery` must never render as an empty
  * genre list — a librarian filing against a backend outage must never read
- * "there are no genres", for the same reason `searchArtistsInGenre` opted
- * out of caching a false no-match during an outage (see
- * `lib/features/catalog/api.ts`, `surfaceNonJsonAsError` on that endpoint).
+ * "there are no genres", the same misreading `searchArtistsInGenre` guards
+ * against by opting out of the shared non-JSON soft-fail
+ * (`extraOptions: { surfaceNonJsonAsError: true }` in
+ * `lib/features/catalog/api.ts`).
  *
- * RTK Query keeps the last good `data` on a rejected refetch, so `isError`
- * can be true while a perfectly good cached list is still on screen — a
- * genre a form could file against right now. This predicate therefore tests
- * absence-of-list (`data == null` once the initial load has settled), never
- * `isError`: a failed refetch over cached data is not an outage, and reading
- * the error flag would put a "can't be filed right now" alert beside a form
- * that still works.
+ * The predicate reads absence-of-list, never `isError`, because the two
+ * diverge in both directions:
  *
- * `genresLoading` alone covers the mount render — `useGetGenresQuery` passes
- * no `skip`, so RTK Query synthesizes `isLoading: true` for that first
- * render regardless of whether the request has resolved.
+ * - A refetch that fails with a structured JSON error leaves the last good
+ *   `data` in place: `isError` goes true while a perfectly good cached list
+ *   is still on screen — genres a form could file against right now — so
+ *   reading the flag would put a "can't be filed right now" alert beside a
+ *   form that still works.
+ * - A refetch that fails with a non-JSON body (a gateway's HTML 502) never
+ *   errors at all: the shared base query soft-fails it into a fulfilled
+ *   `{ data: null }` that replaces the cached list (see
+ *   `lib/features/backend.ts`). That is an outage with nothing left to file
+ *   against, and it is why the check must be loose `== null` — the
+ *   soft-fail's payload is `null`, deliberately distinct from RTK Query's
+ *   in-flight `undefined`, and a strict `=== undefined` guard would miss it.
+ *
+ * `isUninitialized` separates "no data because nothing was asked" from
+ * "asked and got nothing": a query held back by `skip` reports
+ * `isLoading: false` with `data: undefined`, which would otherwise read as
+ * an outage before any request existed. `isLoading` then covers the initial
+ * in-flight render once the request is underway.
  */
-export function isGenresUnavailable(
-  genresLoading: boolean,
-  genres: unknown[] | null | undefined,
-): boolean {
-  return !genresLoading && genres == null;
+export function isGenresUnavailable(query: {
+  isUninitialized: boolean;
+  isLoading: boolean;
+  data?: readonly unknown[] | null;
+}): boolean {
+  return !query.isUninitialized && !query.isLoading && query.data == null;
 }

--- a/src/components/experiences/classic/catalog/NewArtistForm.tsx
+++ b/src/components/experiences/classic/catalog/NewArtistForm.tsx
@@ -45,17 +45,17 @@ export default function NewArtistForm() {
   const codeLettersId = useId();
   const codeNumberId = useId();
 
+  const genresQuery = useGetGenresQuery();
   const {
     data: genres,
-    isLoading: genresLoading,
     isFetching: genresFetching,
     refetch: refetchGenres,
-  } = useGetGenresQuery();
+  } = genresQuery;
   const [addArtist, { isLoading }] = useAddArtistMutation();
   // See isGenresUnavailable's doc for the cached-list trap: `isError` can be
   // true while a good cached list is still on screen, so this reads
   // absence-of-list, never the error flag.
-  const genresUnavailable = isGenresUnavailable(genresLoading, genres);
+  const genresUnavailable = isGenresUnavailable(genresQuery);
   const [peekArtistCode, { data: peekData, isFetching: peekFetching }] =
     useLazyPeekArtistCodeQuery();
 
@@ -122,11 +122,11 @@ export default function NewArtistForm() {
     // A list that goes away under a held selection leaves the dropdown
     // showing its placeholder while `genreId` still names the old genre;
     // submitting would then file under a genre the form has stopped
-    // displaying, beside a message saying nothing can be filed at all.
+    // displaying. The inline alert beside the select already announces the
+    // outage and clears itself on recovery — writing it into
+    // `validationMessage` too would render the sentence twice and leave a
+    // stale copy standing after a successful retry.
     if (genresUnavailable) {
-      setValidationMessage(
-        "Genres are unavailable, so an artist can't be filed right now.",
-      );
       return;
     }
     if (genreId == null) {

--- a/src/components/experiences/classic/catalog/NewArtistForm.tsx
+++ b/src/components/experiences/classic/catalog/NewArtistForm.tsx
@@ -12,6 +12,7 @@ import {
   isArtistNameConflictData,
   parseRequiredPositiveInt,
 } from "@/lib/features/catalog/adminCreateArtistValidation";
+import { isGenresUnavailable } from "@/lib/features/catalog/genreAvailability";
 import type { AddArtistRequestBody, PeekArtistCodeQuery } from "@/lib/features/catalog/types";
 import { useDebouncedValue } from "@/src/hooks/useDebouncedValue";
 
@@ -44,8 +45,17 @@ export default function NewArtistForm() {
   const codeLettersId = useId();
   const codeNumberId = useId();
 
-  const { data: genres } = useGetGenresQuery();
+  const {
+    data: genres,
+    isLoading: genresLoading,
+    isFetching: genresFetching,
+    refetch: refetchGenres,
+  } = useGetGenresQuery();
   const [addArtist, { isLoading }] = useAddArtistMutation();
+  // See isGenresUnavailable's doc for the cached-list trap: `isError` can be
+  // true while a good cached list is still on screen, so this reads
+  // absence-of-list, never the error flag.
+  const genresUnavailable = isGenresUnavailable(genresLoading, genres);
   const [peekArtistCode, { data: peekData, isFetching: peekFetching }] =
     useLazyPeekArtistCodeQuery();
 
@@ -107,6 +117,16 @@ export default function NewArtistForm() {
     const nameResult = validateNewArtistNames(presentationName, alphabeticalName);
     if (!nameResult.valid) {
       setValidationMessage(nameResult.message);
+      return;
+    }
+    // A list that goes away under a held selection leaves the dropdown
+    // showing its placeholder while `genreId` still names the old genre;
+    // submitting would then file under a genre the form has stopped
+    // displaying, beside a message saying nothing can be filed at all.
+    if (genresUnavailable) {
+      setValidationMessage(
+        "Genres are unavailable, so an artist can't be filed right now.",
+      );
       return;
     }
     if (genreId == null) {
@@ -216,7 +236,7 @@ export default function NewArtistForm() {
                 id={genreFieldId}
                 aria-label="Genre"
                 value={genreId ?? ""}
-                disabled={isLoading}
+                disabled={isLoading || genresUnavailable}
                 onChange={(e) => {
                   setGenreId(e.target.value ? Number(e.target.value) : null);
                   setAdded(null);
@@ -231,6 +251,19 @@ export default function NewArtistForm() {
                   </option>
                 ))}
               </select>
+              {genresUnavailable && (
+                <div role="alert" className="artist-error-message">
+                  Genres are unavailable, so an artist can&apos;t be filed
+                  right now.{" "}
+                  <button
+                    type="button"
+                    disabled={genresFetching}
+                    onClick={() => refetchGenres()}
+                  >
+                    Try again
+                  </button>
+                </div>
+              )}
             </td>
           </tr>
           <tr>

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -86,12 +86,12 @@ function ArtistAddForm() {
 }
 
 function ArtistAddFields() {
+  const genresQuery = useGetGenresQuery();
   const {
     data: genres,
-    isLoading: genresLoading,
     isFetching: genresFetching,
     refetch: refetchGenres,
-  } = useGetGenresQuery();
+  } = genresQuery;
   const [addArtist, { isLoading }] = useAddArtistMutation();
 
   const [name, setName] = useState("");
@@ -175,7 +175,7 @@ function ArtistAddFields() {
   // `genre_id` is unreachable either way, so the outage has to say so rather
   // than presenting an empty list as "no genres exist" — but a refetch that
   // rejects over a good cached list must not read as the same outage.
-  const genresUnavailable = isGenresUnavailable(genresLoading, genres);
+  const genresUnavailable = isGenresUnavailable(genresQuery);
 
   // Puts the caret back where the edit left it. React writes the normalized
   // value into the node during the commit's mutation phase, which is the write

--- a/src/components/experiences/modern/catalog/ArtistAddForm.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAddForm.tsx
@@ -23,6 +23,7 @@ import {
   isConflictRejection,
   parseRequiredPositiveInt,
 } from "@/lib/features/catalog/adminCreateArtistValidation";
+import { isGenresUnavailable } from "@/lib/features/catalog/genreAvailability";
 import type {
   AddArtistConflict,
   AddArtistRequestBody,
@@ -169,18 +170,12 @@ function ArtistAddFields() {
       ? parsedCodeNumber
       : null;
   const codeNumberInvalid = codeNumberRaw.trim().length > 0 && codeNumber === null;
-  // A failed genres GET leaves an empty dropdown behind: fetchBaseQuery's
-  // rejection leaves `data` undefined, while the backend adapter's soft-fail
-  // turns a non-JSON GET failure into `{ data: null }` with no error at all.
-  // Either way `genre_id` is unreachable and the form can never submit, so the
-  // outage has to say so rather than presenting an empty list as "no genres
-  // exist". The test is the absence of a list, not `isError`: a refetch that
-  // rejects leaves the last good list in the cache and the form still submits
-  // perfectly well against it, so reading the error flag would put a "can't be
-  // filed right now" alert beside an enabled submit button. `genresLoading`
-  // alone covers the mount render: `useGetGenresQuery` passes no `skip`, so
-  // RTK Query synthesizes `isLoading: true` for that first render regardless.
-  const genresUnavailable = !genresLoading && genres == null;
+  // See isGenresUnavailable's doc for why this is `data == null`, not
+  // `isError`: a failed genres GET leaves an empty dropdown behind, and
+  // `genre_id` is unreachable either way, so the outage has to say so rather
+  // than presenting an empty list as "no genres exist" — but a refetch that
+  // rejects over a good cached list must not read as the same outage.
+  const genresUnavailable = isGenresUnavailable(genresLoading, genres);
 
   // Puts the caret back where the edit left it. React writes the normalized
   // value into the node during the commit's mutation phase, which is the write

--- a/tests/integration/components/classic/catalog/NewArtistForm.test.tsx
+++ b/tests/integration/components/classic/catalog/NewArtistForm.test.tsx
@@ -2,11 +2,16 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
+import { catalogApi } from "@/lib/features/catalog/api";
 
-vi.mock("@/lib/features/authentication/client", () => ({
-  authClient: { useSession: vi.fn() },
-  getJWTToken: vi.fn().mockResolvedValue("test-token"),
-}));
+// The real better-auth client installs listeners whose teardown is deferred a
+// second past the last subscriber; a short file finishes inside that second.
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import(
+    "@/tests/helpers/auth-client-mock"
+  );
+  return createAuthClientModuleMock();
+});
 
 import NewArtistForm from "@/src/components/experiences/classic/catalog/NewArtistForm";
 
@@ -255,6 +260,70 @@ describe("classic NewArtistForm — chooseLibraryCodeOrArtist.jsp's newArtistFor
     await user.click(screen.getByRole("button", { name: "Submit" }));
 
     expect(await screen.findByText("Failed to add artist.")).toBeInTheDocument();
+  });
+
+  describe("genre outage", () => {
+    it("explains a genres outage and offers a retry instead of an empty dropdown", async () => {
+      let genreCalls = 0;
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/genres`, () => {
+          genreCalls += 1;
+          return genreCalls === 1
+            ? HttpResponse.json({ message: "genres unavailable" }, { status: 500 })
+            : HttpResponse.json([{ id: GENRE_ID, genre_name: "Blues" }]);
+        }),
+      );
+      const { user } = renderWithProviders(<NewArtistForm />);
+
+      // genre_id is required to submit, so an empty dropdown leaves the form
+      // permanently un-submittable with nothing explaining why.
+      expect(await screen.findByText(/genres are unavailable/i)).toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: "Blues" })).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+
+      await waitFor(() =>
+        expect(screen.queryByText(/genres are unavailable/i)).not.toBeInTheDocument(),
+      );
+      expect(await screen.findByRole("option", { name: "Blues" })).toBeInTheDocument();
+    });
+
+    it("keeps filing against the last good genre list when a refetch fails", async () => {
+      let genreCalls = 0;
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/genres`, () => {
+          genreCalls += 1;
+          return genreCalls === 1
+            ? HttpResponse.json([{ id: GENRE_ID, genre_name: "Blues" }])
+            : HttpResponse.json({ message: "genres unavailable" }, { status: 500 });
+        }),
+      );
+      const { getBodies } = mockAddArtist(() => created());
+      const { user, store } = renderWithProviders(<NewArtistForm />);
+
+      await selectGenre(user);
+
+      // Adding a genre elsewhere invalidates this list; if that refetch
+      // rejects, the cached list is still there and every one of its genres
+      // is still fileable. Claiming an outage would show a "can't be filed
+      // right now" message beside a submit that works.
+      store.dispatch(
+        catalogApi.util.invalidateTags([{ type: "GenreList", id: "LIST" }]),
+      );
+      await waitFor(() => expect(genreCalls).toBe(2));
+
+      expect(screen.queryByText(/genres are unavailable/i)).not.toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "Blues" })).toBeInTheDocument();
+
+      await user.type(screen.getByLabelText(/artist presentation name/i), "Juana Molina");
+      await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
+      await user.type(screen.getByLabelText(/call letters/i), "MO");
+      await user.type(screen.getByLabelText(/call numbers/i), "12");
+      await user.click(screen.getByRole("button", { name: "Submit" }));
+
+      await waitFor(() => expect(getBodies()).toHaveLength(1));
+      expect(getBodies()[0]).toMatchObject({ genre_id: GENRE_ID });
+    });
   });
 
   it("resets every field back to empty on Reset values", async () => {

--- a/tests/integration/components/classic/catalog/NewArtistForm.test.tsx
+++ b/tests/integration/components/classic/catalog/NewArtistForm.test.tsx
@@ -10,7 +10,14 @@ vi.mock("@/lib/features/authentication/client", async () => {
   const { createAuthClientModuleMock } = await import(
     "@/tests/helpers/auth-client-mock"
   );
-  return createAuthClientModuleMock();
+  // The shared mock leaves the session unauthenticated (getJWTToken resolves
+  // null), which silently drops the Authorization header from every request
+  // this file makes; resolve a token so the authenticated request path stays
+  // exercised.
+  return {
+    ...createAuthClientModuleMock(),
+    getJWTToken: vi.fn(async () => "test-token"),
+  };
 });
 
 import NewArtistForm from "@/src/components/experiences/classic/catalog/NewArtistForm";
@@ -310,7 +317,16 @@ describe("classic NewArtistForm — chooseLibraryCodeOrArtist.jsp's newArtistFor
       store.dispatch(
         catalogApi.util.invalidateTags([{ type: "GenreList", id: "LIST" }]),
       );
+      // `genreCalls` reaching 2 only proves MSW entered the handler; the
+      // rejection lands afterwards. Wait for it to settle in the cache so the
+      // no-alert assertion observes the post-rejection render instead of
+      // winning a race against it.
       await waitFor(() => expect(genreCalls).toBe(2));
+      await waitFor(() =>
+        expect(
+          catalogApi.endpoints.getGenres.select()(store.getState()).isError,
+        ).toBe(true),
+      );
 
       expect(screen.queryByText(/genres are unavailable/i)).not.toBeInTheDocument();
       expect(screen.getByRole("option", { name: "Blues" })).toBeInTheDocument();
@@ -321,6 +337,58 @@ describe("classic NewArtistForm — chooseLibraryCodeOrArtist.jsp's newArtistFor
       await user.type(screen.getByLabelText(/call numbers/i), "12");
       await user.click(screen.getByRole("button", { name: "Submit" }));
 
+      await waitFor(() => expect(getBodies()).toHaveLength(1));
+      expect(getBodies()[0]).toMatchObject({ genre_id: GENRE_ID });
+    });
+
+    it("flips to unavailable when a non-JSON refetch replaces the cached list, refuses the submit, and recovers", async () => {
+      let genreCalls = 0;
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/genres`, () => {
+          genreCalls += 1;
+          // Call 2 is the refetch: an HTML error page, which the shared base
+          // query soft-fails into a fulfilled `{ data: null }` that replaces
+          // the cached list — unlike the JSON 500 above, which keeps it.
+          if (genreCalls === 2) {
+            return new HttpResponse(
+              "<!DOCTYPE html><html><body>Bad Gateway</body></html>",
+              { status: 502, headers: { "Content-Type": "text/html" } },
+            );
+          }
+          return HttpResponse.json([{ id: GENRE_ID, genre_name: "Blues" }]);
+        }),
+      );
+      const { getBodies } = mockAddArtist(() => created());
+      const { user, store } = renderWithProviders(<NewArtistForm />);
+
+      await selectGenre(user);
+      await user.type(screen.getByLabelText(/artist presentation name/i), "Juana Molina");
+      await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
+      await user.type(screen.getByLabelText(/call letters/i), "MO");
+      await user.type(screen.getByLabelText(/call numbers/i), "12");
+
+      store.dispatch(
+        catalogApi.util.invalidateTags([{ type: "GenreList", id: "LIST" }]),
+      );
+      expect(await screen.findByText(/genres are unavailable/i)).toBeInTheDocument();
+
+      // `genreId` still holds the vanished list's selection, so submitting
+      // now would file under a genre the form has stopped displaying. The
+      // refusal must not add a second copy of the sentence: the inline alert
+      // is the one announcement, and it alone must clear on recovery.
+      await user.click(screen.getByRole("button", { name: "Submit" }));
+      expect(screen.getAllByText(/genres are unavailable/i)).toHaveLength(1);
+
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+      await waitFor(() =>
+        expect(screen.queryByText(/genres are unavailable/i)).not.toBeInTheDocument(),
+      );
+      expect(await screen.findByRole("option", { name: "Blues" })).toBeInTheDocument();
+
+      // Exactly one POST reaches the backend: the recovered submit. Had the
+      // refused submit fired anyway, its body would have been recorded long
+      // before this one.
+      await user.click(screen.getByRole("button", { name: "Submit" }));
       await waitFor(() => expect(getBodies()).toHaveLength(1));
       expect(getBodies()[0]).toMatchObject({ genre_id: GENRE_ID });
     });

--- a/tests/unit/lib/features/catalog/genreAvailability.test.ts
+++ b/tests/unit/lib/features/catalog/genreAvailability.test.ts
@@ -2,22 +2,46 @@ import { describe, it, expect } from "vitest";
 import { isGenresUnavailable } from "@/lib/features/catalog/genreAvailability";
 
 describe("isGenresUnavailable", () => {
-  it("is not unavailable while the initial load is still in flight", () => {
-    expect(isGenresUnavailable(true, undefined)).toBe(false);
+  it("is not unavailable while the query is skipped and no request exists", () => {
+    // A skipped query settles at `isLoading: false` with no data — the same
+    // shape as an outage, distinguished only by `isUninitialized`.
+    expect(
+      isGenresUnavailable({ isUninitialized: true, isLoading: false, data: undefined }),
+    ).toBe(false);
   });
 
-  it("is unavailable once loading settles with no data", () => {
-    expect(isGenresUnavailable(false, undefined)).toBe(true);
-    expect(isGenresUnavailable(false, null)).toBe(true);
+  it("is not unavailable while the initial load is still in flight", () => {
+    expect(
+      isGenresUnavailable({ isUninitialized: false, isLoading: true, data: undefined }),
+    ).toBe(false);
+  });
+
+  it.each([
+    ["a load that never produced data", undefined],
+    // `null` is the shared base query's non-JSON soft-fail payload replacing
+    // the cache, not a hypothetical: the predicate's loose nullish check
+    // exists to catch it.
+    ["a non-JSON soft-fail that replaced the cache", null],
+  ])("is unavailable once loading settles with %s", (_name, data) => {
+    expect(isGenresUnavailable({ isUninitialized: false, isLoading: false, data })).toBe(
+      true,
+    );
   });
 
   it("is not unavailable once a list has arrived", () => {
-    expect(isGenresUnavailable(false, [{ id: 1, genre_name: "Rock" }])).toBe(false);
+    const genres: readonly { id: number; genre_name: string }[] = [
+      { id: 1, genre_name: "Rock" },
+    ];
+    expect(
+      isGenresUnavailable({ isUninitialized: false, isLoading: false, data: genres }),
+    ).toBe(false);
   });
 
   it("is not unavailable while an empty-but-present list is cached", () => {
     // An empty array is a real, successfully-fetched answer — distinct from
     // `null`/`undefined`, which mean no answer was ever received.
-    expect(isGenresUnavailable(false, [])).toBe(false);
+    expect(
+      isGenresUnavailable({ isUninitialized: false, isLoading: false, data: [] }),
+    ).toBe(false);
   });
 });

--- a/tests/unit/lib/features/catalog/genreAvailability.test.ts
+++ b/tests/unit/lib/features/catalog/genreAvailability.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { isGenresUnavailable } from "@/lib/features/catalog/genreAvailability";
+
+describe("isGenresUnavailable", () => {
+  it("is not unavailable while the initial load is still in flight", () => {
+    expect(isGenresUnavailable(true, undefined)).toBe(false);
+  });
+
+  it("is unavailable once loading settles with no data", () => {
+    expect(isGenresUnavailable(false, undefined)).toBe(true);
+    expect(isGenresUnavailable(false, null)).toBe(true);
+  });
+
+  it("is not unavailable once a list has arrived", () => {
+    expect(isGenresUnavailable(false, [{ id: 1, genre_name: "Rock" }])).toBe(false);
+  });
+
+  it("is not unavailable while an empty-but-present list is cached", () => {
+    // An empty array is a real, successfully-fetched answer — distinct from
+    // `null`/`undefined`, which mean no answer was ever received.
+    expect(isGenresUnavailable(false, [])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Modern's `ArtistAddForm` already computed `genresUnavailable = !genresLoading && genres == null` inline. This pulls that predicate out into a shared, JSDoc'd `isGenresUnavailable` in `lib/features/catalog/genreAvailability.ts`, pins the cached-list trap in its doc — RTK Query keeps the last good `data` on a rejected refetch, so `isError` can be true while a perfectly good cached list is on screen, so the predicate has to test absence-of-list, never `isError` — and consumes it from both experiences' artist-create forms.

- `ArtistAddForm.tsx` (modern) is a pure move onto the shared predicate: no behavior change, its existing test suite passes with no assertion changes.
- `NewArtistForm.tsx` (classic) now renders an explicit unavailable state with a retry action instead of silently presenting an empty genre `<select>` on an unissued or failed request, matching the convention `searchArtistsInGenre`'s outage opt-out already established in `lib/features/catalog/api.ts`.
- `NewArtistForm.test.tsx`'s hand-rolled auth-client mock is migrated to the shared `createAuthClientModuleMock()` helper (already the pattern in `tests/integration/components/classic/library/MissingReleases.test.tsx`) since the file was already being touched for the new coverage.

## Test plan

- [x] New unit tests for `isGenresUnavailable` covering loading/absent/present/empty-list cases
- [x] New classic `NewArtistForm` integration tests: (a) an outage renders the explicit unavailable state and no genre options, with a working retry; (b) a failed refetch over a cached list keeps the list rendering and filing works
- [x] Existing modern `ArtistAddForm` outage tests pass unchanged after the extraction
- [x] `npx vitest run` — 328 files / 4662 tests pass
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npx tsc --noEmit` — clean

Closes #1208