### PR TITLE
test: shared classic page-authority harness — 'reached' asserts rendered landmarks

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -142,10 +142,7 @@ describeConversion("convertToSong", convertToSong, [
 
 ### Classic Page Authority Harness
 
-`tests/helpers/classic-page-authority-harness.ts` covers the
-`requireAuth()` -> `requireRole()` gate that every page under
-`app/dashboard/@classic/**` runs in front of its screen-specific content.
-The dynamic imports inside the `vi.mock` factories must name the harness by path — factories cannot close over statically-imported bindings. The top-level static import of the setUp/assert functions is ordinary; it targets the harness module directly because the `@/tests/helpers` barrel does not re-export it.
+`tests/helpers/classic-page-authority-harness.ts` covers the `requireAuth()` -> `requireRole()` gate that every page under `app/dashboard/@classic/**` runs in front of its screen-specific content. The dynamic imports inside the `vi.mock` factories must name the harness by path — factories cannot close over statically-imported bindings. The top-level static import of the setUp/assert functions is ordinary; it targets the harness module directly because the `@/tests/helpers` barrel does not re-export it.
 
 ```tsx
 import {
@@ -179,6 +176,14 @@ vi.mock("@/src/components/experiences/classic/library/MissingReleases", () => ({
   default: () => <div data-testid="missing-releases-table" />,
 }));
 
+// The page renders through Layout/Main -> Navigation, which reaches the real
+// better-auth client through useLogout(). Replace the nav rather than pulling
+// a live auth client into a server-component test; a page whose own nav is
+// under test would use createAuthClientModuleMock() instead.
+vi.mock("@/src/components/experiences/classic/Navigation", () => ({
+  default: () => <nav data-testid="classic-nav" />,
+}));
+
 import ClassicMissingReleasesPage from "@/app/dashboard/@classic/library/missing/page";
 
 describe("Classic /dashboard/library/missing page", () => {
@@ -197,9 +202,9 @@ describe("Classic /dashboard/library/missing page", () => {
 ```
 
 - **`setUpClassicPageAuthorityEnv()`** -- registers the `beforeEach`/`afterEach` that reset the mocks and pin `NEXT_PUBLIC_DASHBOARD_HOME_PAGE` so redirect assertions are deterministic. Call once per `describe` block.
-- **`setUpClassicPageAuthority(role, adminPluginRole?)`** -- arranges the session/org-role mocks for one scenario. `role` is the WXYC tier the org-role resolver returns (`"dj" | "musicDirector" | "stationManager" | "unauthenticated" | undefined`). `undefined` is a valid session with no station role -- `requireRole` denies it to the dashboard home; `"unauthenticated"` is no session at all -- `requireAuth` denies it to `/login?bounced=no-session` before role resolution runs. `adminPluginRole` models a WXYC tier string leaking into the unrelated better-auth admin-plugin session column, which must never grant access on its own.
+- **`setUpClassicPageAuthority(role, adminPluginRole?)`** -- arranges the session/org-role mocks for one scenario. `role` is the WXYC tier the org-role resolver returns — any `WXYCRole`, plus `"unauthenticated"` and `undefined` (the type is derived from `WXYCRole`, so a tier added upstream is testable here without editing the harness). `undefined` is a valid session with no station role -- `requireRole` denies it to the dashboard home; `"unauthenticated"` is no session at all -- `requireAuth` denies it to `/login?bounced=no-session` before role resolution runs. `adminPluginRole` models a WXYC tier string leaking into the unrelated better-auth admin-plugin session column, which must never grant access on its own.
 - **`assertReachesClassicPage(page, ...landmarkTestIds)`** -- awaits and renders the page, then asserts no redirect happened AND every named landmark testid is in the document. Checking only "no redirect" passes vacuously for a page that renders nothing, so it can't distinguish "allowed and working" from "allowed and broken" -- the signature requires at least one landmark (the page's own screen-specific one) for exactly that reason.
-- **`assertDeniedClassicPage(page, destination?)`** -- asserts the page denies access by redirecting to `destination` (defaults to `/dashboard`).
+- **`assertDeniedClassicPage(page, destination?)`** -- asserts the page denies access by redirecting to `destination`, which defaults to `DEFAULT_DASHBOARD_HOME_PAGE` (the same constant the env pin uses, so the two can't drift apart).
 
 ### Auth Client Mock
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -140,6 +140,68 @@ describeConversion("convertToSong", convertToSong, [
 ]);
 ```
 
+### Classic Page Authority Harness
+
+`tests/helpers/classic-page-authority-harness.ts` covers the
+`requireAuth()` -> `requireRole()` gate that every page under
+`app/dashboard/@classic/**` runs in front of its screen-specific content.
+Import it directly (not through the `@/tests/helpers` barrel) since its
+mock-shape functions must be pulled into `vi.mock` factories by path:
+
+```typescript
+import {
+  setUpClassicPageAuthority,
+  setUpClassicPageAuthorityEnv,
+  assertReachesClassicPage,
+  assertDeniedClassicPage,
+} from "@/tests/helpers/classic-page-authority-harness";
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/headers", async () => {
+  const { classicPageAuthorityHeadersMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityHeadersMock();
+});
+vi.mock("next/navigation", async () => {
+  const { classicPageAuthorityNavigationMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityNavigationMock();
+});
+vi.mock("@/lib/features/authentication/server-client", async () => {
+  const { classicPageAuthorityServerClientMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityServerClientMock();
+});
+vi.mock("@/lib/features/authentication/organization-utils.server", async () => {
+  const { classicPageAuthorityOrganizationUtilsMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityOrganizationUtilsMock();
+});
+
+// Mock the page's own screen content so the landmark below proves the page
+// rendered, not just that it exists.
+vi.mock("@/src/components/experiences/classic/library/MissingReleases", () => ({
+  default: () => <div data-testid="missing-releases-table" />,
+}));
+
+import ClassicMissingReleasesPage from "@/app/dashboard/@classic/library/missing/page";
+
+describe("Classic /dashboard/library/missing page", () => {
+  setUpClassicPageAuthorityEnv();
+
+  it("reaches the page for a DJ", async () => {
+    setUpClassicPageAuthority("dj");
+    await assertReachesClassicPage(ClassicMissingReleasesPage, "missing-releases-table");
+  });
+
+  it("redirects a member with no station role", async () => {
+    setUpClassicPageAuthority(undefined);
+    await assertDeniedClassicPage(ClassicMissingReleasesPage);
+  });
+});
+```
+
+- **`setUpClassicPageAuthorityEnv()`** -- registers the `beforeEach`/`afterEach` that reset the mocks and pin `NEXT_PUBLIC_DASHBOARD_HOME_PAGE` so redirect assertions are deterministic. Call once per `describe` block.
+- **`setUpClassicPageAuthority(role, adminPluginRole?)`** -- arranges the session/org-role mocks for one scenario. `role` is the WXYC tier the org-role resolver returns (`"dj" | "musicDirector" | "stationManager" | undefined`); `adminPluginRole` models a WXYC tier string leaking into the unrelated better-auth admin-plugin session column, which must never grant access on its own.
+- **`assertReachesClassicPage(page, ...landmarkTestIds)`** -- awaits and renders the page, then asserts no redirect happened AND every named landmark testid is in the document. Checking only "no redirect" passes vacuously for a page that renders nothing, so it can't distinguish "allowed and working" from "allowed and broken" -- always pass at least the page's own screen-specific landmark.
+- **`assertDeniedClassicPage(page, destination?)`** -- asserts the page denies access by redirecting to `destination` (defaults to `/dashboard`).
+
 ### Auth Client Mock
 
 `createAuthClientModuleMock()` (`tests/helpers/auth-client-mock.ts`) replaces `@/lib/features/authentication/client` with an unauthenticated session. Every test that renders a component reaching `useAuthentication` — directly, or through `useRegistry` / `useBin` / `usePlayNow` — must use it. Letting the real module instantiate installs a better-auth session store whose teardown is deferred a second past the last subscriber; a short test file finishes inside that second, the deferred teardown then runs against removed jsdom globals, and the resulting `window is not defined` is reported as an unhandled error that fails the run with every test green.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -145,10 +145,9 @@ describeConversion("convertToSong", convertToSong, [
 `tests/helpers/classic-page-authority-harness.ts` covers the
 `requireAuth()` -> `requireRole()` gate that every page under
 `app/dashboard/@classic/**` runs in front of its screen-specific content.
-Import it directly (not through the `@/tests/helpers` barrel) since its
-mock-shape functions must be pulled into `vi.mock` factories by path:
+The dynamic imports inside the `vi.mock` factories must name the harness by path — factories cannot close over statically-imported bindings. The top-level static import of the setUp/assert functions is ordinary; it targets the harness module directly because the `@/tests/helpers` barrel does not re-export it.
 
-```typescript
+```tsx
 import {
   setUpClassicPageAuthority,
   setUpClassicPageAuthorityEnv,
@@ -198,8 +197,8 @@ describe("Classic /dashboard/library/missing page", () => {
 ```
 
 - **`setUpClassicPageAuthorityEnv()`** -- registers the `beforeEach`/`afterEach` that reset the mocks and pin `NEXT_PUBLIC_DASHBOARD_HOME_PAGE` so redirect assertions are deterministic. Call once per `describe` block.
-- **`setUpClassicPageAuthority(role, adminPluginRole?)`** -- arranges the session/org-role mocks for one scenario. `role` is the WXYC tier the org-role resolver returns (`"dj" | "musicDirector" | "stationManager" | undefined`); `adminPluginRole` models a WXYC tier string leaking into the unrelated better-auth admin-plugin session column, which must never grant access on its own.
-- **`assertReachesClassicPage(page, ...landmarkTestIds)`** -- awaits and renders the page, then asserts no redirect happened AND every named landmark testid is in the document. Checking only "no redirect" passes vacuously for a page that renders nothing, so it can't distinguish "allowed and working" from "allowed and broken" -- always pass at least the page's own screen-specific landmark.
+- **`setUpClassicPageAuthority(role, adminPluginRole?)`** -- arranges the session/org-role mocks for one scenario. `role` is the WXYC tier the org-role resolver returns (`"dj" | "musicDirector" | "stationManager" | "unauthenticated" | undefined`). `undefined` is a valid session with no station role -- `requireRole` denies it to the dashboard home; `"unauthenticated"` is no session at all -- `requireAuth` denies it to `/login?bounced=no-session` before role resolution runs. `adminPluginRole` models a WXYC tier string leaking into the unrelated better-auth admin-plugin session column, which must never grant access on its own.
+- **`assertReachesClassicPage(page, ...landmarkTestIds)`** -- awaits and renders the page, then asserts no redirect happened AND every named landmark testid is in the document. Checking only "no redirect" passes vacuously for a page that renders nothing, so it can't distinguish "allowed and working" from "allowed and broken" -- the signature requires at least one landmark (the page's own screen-specific one) for exactly that reason.
 - **`assertDeniedClassicPage(page, destination?)`** -- asserts the page denies access by redirecting to `destination` (defaults to `/dashboard`).
 
 ### Auth Client Mock

--- a/tests/helpers/classic-page-authority-harness.ts
+++ b/tests/helpers/classic-page-authority-harness.ts
@@ -1,0 +1,147 @@
+import { vi, beforeEach, afterEach, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { renderWithProviders } from "./render";
+
+/**
+ * Shared mock preamble + assertions for the classic dashboard page-authority
+ * tests (`tests/integration/app/dashboard/@classic/**`). Every one of those
+ * pages runs the same `requireAuth()` -> `requireRole()` gate in front of
+ * screen-specific content, so the server-session/role/flag mock stack and the
+ * "did it actually render" assertions are identical across pages -- only the
+ * required role, the granted role(s), and the rendered landmark differ.
+ *
+ * `vi.mock` factories cannot close over statically-imported bindings (see
+ * `auth-client-mock.ts`), so pull the mock-shape functions in by path inside
+ * each factory:
+ *
+ * ```ts
+ * vi.mock("next/headers", async () => {
+ *   const { classicPageAuthorityHeadersMock } = await import(
+ *     "@/tests/helpers/classic-page-authority-harness"
+ *   );
+ *   return classicPageAuthorityHeadersMock();
+ * });
+ * ```
+ */
+
+export type ClassicPageRole = "dj" | "musicDirector" | "stationManager" | undefined;
+
+export const mockCookiesToString = vi.fn(() => "session=test-cookie");
+
+// A real redirect() call inside a streaming server component resolves with
+// HTTP 200 and a NEXT_REDIRECT marker in the body, not a 307 -- asserting on
+// that marker (not a status code) is what actually distinguishes "gated" from
+// "reached" here.
+export const mockRedirect = vi.fn((url: string) => {
+  throw new Error(`NEXT_REDIRECT:${url}`);
+});
+
+export const mockGetSession = vi.fn();
+export const mockGetUserRoleInOrganization = vi.fn();
+export const mockGetAppOrganizationId = vi.fn(() => undefined);
+
+/** Replacement for `next/headers`. */
+export function classicPageAuthorityHeadersMock() {
+  return { cookies: () => ({ toString: mockCookiesToString }) };
+}
+
+/** Replacement for `next/navigation`. */
+export function classicPageAuthorityNavigationMock() {
+  return { redirect: (url: string) => mockRedirect(url) };
+}
+
+/** Replacement for `@/lib/features/authentication/server-client`. */
+export function classicPageAuthorityServerClientMock() {
+  return {
+    serverAuthClient: {
+      getSession: (options: unknown) => mockGetSession(options),
+    },
+  };
+}
+
+/**
+ * Replacement for `@/lib/features/authentication/organization-utils.server`.
+ * Reproduces the deployed shape: APP_ORGANIZATION is unset, so the only role
+ * source is the JWT-first resolver this mock stands in for.
+ */
+export function classicPageAuthorityOrganizationUtilsMock() {
+  return {
+    getUserRoleInOrganization: (userId: string, orgId: string | undefined, cookie?: string) =>
+      mockGetUserRoleInOrganization(userId, orgId, cookie),
+    getAppOrganizationId: () => mockGetAppOrganizationId(),
+  };
+}
+
+function classicPageSessionData(adminPluginRole: string | null) {
+  return {
+    user: {
+      id: "user-1",
+      email: "dj@wxyc.org",
+      name: "Test User",
+      username: "testuser",
+      // better-auth's admin-plugin column -- never the WXYC tier under test.
+      role: adminPluginRole,
+      emailVerified: true,
+      hasCompletedOnboarding: true,
+    },
+    session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+  };
+}
+
+/**
+ * Arranges the session/role mocks for one authority scenario. `role` is the
+ * WXYC tier the org-role resolver returns; pass `undefined` for a member with
+ * no station role (below DJ) or a fully unauthenticated JWT. `adminPluginRole`
+ * models a WXYC tier string leaking into the unrelated better-auth
+ * admin-plugin session column, which must never grant access on its own.
+ */
+export function setUpClassicPageAuthority(role: ClassicPageRole, adminPluginRole: string | null = null) {
+  mockGetSession.mockResolvedValue({ data: classicPageSessionData(adminPluginRole), error: null });
+  mockGetUserRoleInOrganization.mockResolvedValue(role);
+}
+
+/**
+ * Registers the beforeEach/afterEach that reset the classic-page-authority
+ * mocks and pin `NEXT_PUBLIC_DASHBOARD_HOME_PAGE` so redirect assertions are
+ * deterministic -- `requireRole` falls back to `DEFAULT_DASHBOARD_HOME_PAGE`
+ * otherwise, which would make the assertion depend on the ambient
+ * environment. Call once inside each page's `describe` block.
+ */
+export function setUpClassicPageAuthorityEnv() {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserRoleInOrganization.mockReset();
+    mockGetAppOrganizationId.mockReturnValue(undefined);
+    mockCookiesToString.mockReturnValue("session=test-cookie");
+    process.env = { ...originalEnv, NEXT_PUBLIC_DASHBOARD_HOME_PAGE: "/dashboard" };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+}
+
+/**
+ * Awaits and renders the page, then asserts it was actually reached: no
+ * redirect, AND every named landmark testid rendered. Checking only "no
+ * redirect" passes vacuously for a page that renders nothing, so it cannot
+ * distinguish "allowed and working" from "allowed and broken".
+ */
+export async function assertReachesClassicPage(page: () => Promise<ReactElement>, ...landmarkTestIds: string[]) {
+  const result = await page();
+  renderWithProviders(result);
+
+  expect(mockRedirect).not.toHaveBeenCalled();
+  for (const testId of landmarkTestIds) {
+    expect(screen.getByTestId(testId)).toBeInTheDocument();
+  }
+}
+
+/** Asserts the page denies access by redirecting to `destination`. */
+export async function assertDeniedClassicPage(page: () => Promise<ReactElement>, destination = "/dashboard") {
+  await expect(page()).rejects.toThrow(`NEXT_REDIRECT:${destination}`);
+  expect(mockRedirect).toHaveBeenCalledWith(destination);
+}

--- a/tests/helpers/classic-page-authority-harness.ts
+++ b/tests/helpers/classic-page-authority-harness.ts
@@ -25,7 +25,7 @@ import { renderWithProviders } from "./render";
  * ```
  */
 
-export type ClassicPageRole = "dj" | "musicDirector" | "stationManager" | undefined;
+export type ClassicPageRole = "dj" | "musicDirector" | "stationManager" | "unauthenticated" | undefined;
 
 export const mockCookiesToString = vi.fn(() => "session=test-cookie");
 
@@ -46,9 +46,28 @@ export function classicPageAuthorityHeadersMock() {
   return { cookies: () => ({ toString: mockCookiesToString }) };
 }
 
-/** Replacement for `next/navigation`. */
+/**
+ * Replacement for `next/navigation`. The pages under test only call
+ * `redirect()`, but replacing the module replaces it for everything the page
+ * renders — and the classic pages render through `Layout/Main` ->
+ * `Navigation`, whose client hooks (`usePathname`, `useRouter`,
+ * `useSearchParams`) would otherwise come back undefined and throw. The
+ * hook stubs keep the mock's shape matching the module graph it serves.
+ */
 export function classicPageAuthorityNavigationMock() {
-  return { redirect: (url: string) => mockRedirect(url) };
+  return {
+    redirect: (url: string) => mockRedirect(url),
+    usePathname: () => "/dashboard",
+    useRouter: () => ({
+      push: vi.fn(),
+      replace: vi.fn(),
+      refresh: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      prefetch: vi.fn(),
+    }),
+    useSearchParams: () => new URLSearchParams(),
+  };
 }
 
 /** Replacement for `@/lib/features/authentication/server-client`. */
@@ -92,11 +111,19 @@ function classicPageSessionData(adminPluginRole: string | null) {
 /**
  * Arranges the session/role mocks for one authority scenario. `role` is the
  * WXYC tier the org-role resolver returns; pass `undefined` for a member with
- * no station role (below DJ) or a fully unauthenticated JWT. `adminPluginRole`
- * models a WXYC tier string leaking into the unrelated better-auth
- * admin-plugin session column, which must never grant access on its own.
+ * a valid session but no station role (below DJ) — `requireRole` denies that
+ * member to the dashboard home. Pass `"unauthenticated"` for no session at
+ * all — a different exit: `requireAuth` denies it to
+ * `/login?bounced=no-session` before any role resolution runs, so
+ * `adminPluginRole` is meaningless there. `adminPluginRole` models a WXYC
+ * tier string leaking into the unrelated better-auth admin-plugin session
+ * column, which must never grant access on its own.
  */
 export function setUpClassicPageAuthority(role: ClassicPageRole, adminPluginRole: string | null = null) {
+  if (role === "unauthenticated") {
+    mockGetSession.mockResolvedValue({ data: null, error: null });
+    return;
+  }
   mockGetSession.mockResolvedValue({ data: classicPageSessionData(adminPluginRole), error: null });
   mockGetUserRoleInOrganization.mockResolvedValue(role);
 }
@@ -113,6 +140,10 @@ export function setUpClassicPageAuthorityEnv() {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset (not just clear) the arrangement mocks: clearAllMocks preserves
+    // persistent mockResolvedValue implementations and un-consumed *Once
+    // queues, so one test's session/role arrangement would leak into the next.
+    mockGetSession.mockReset();
     mockGetUserRoleInOrganization.mockReset();
     mockGetAppOrganizationId.mockReturnValue(undefined);
     mockCookiesToString.mockReturnValue("session=test-cookie");
@@ -128,9 +159,11 @@ export function setUpClassicPageAuthorityEnv() {
  * Awaits and renders the page, then asserts it was actually reached: no
  * redirect, AND every named landmark testid rendered. Checking only "no
  * redirect" passes vacuously for a page that renders nothing, so it cannot
- * distinguish "allowed and working" from "allowed and broken".
+ * distinguish "allowed and working" from "allowed and broken" — which is why
+ * the signature requires at least one landmark: with none, this would
+ * degenerate into exactly that vacuous absence-of-redirect check.
  */
-export async function assertReachesClassicPage(page: () => Promise<ReactElement>, ...landmarkTestIds: string[]) {
+export async function assertReachesClassicPage(page: () => Promise<ReactElement>, ...landmarkTestIds: [string, ...string[]]) {
   const result = await page();
   renderWithProviders(result);
 

--- a/tests/helpers/classic-page-authority-harness.ts
+++ b/tests/helpers/classic-page-authority-harness.ts
@@ -1,6 +1,8 @@
 import { vi, beforeEach, afterEach, expect } from "vitest";
 import { screen } from "@testing-library/react";
 import type { ReactElement } from "react";
+import type { WXYCRole } from "@wxyc/shared/auth-client/auth";
+import { DEFAULT_DASHBOARD_HOME_PAGE } from "@/lib/features/application/constants";
 import { renderWithProviders } from "./render";
 
 /**
@@ -25,7 +27,10 @@ import { renderWithProviders } from "./render";
  * ```
  */
 
-export type ClassicPageRole = "dj" | "musicDirector" | "stationManager" | "unauthenticated" | undefined;
+// Derived from WXYCRole rather than re-listing the tiers, so a tier added or
+// renamed in @wxyc/shared surfaces here as a type error instead of silently
+// leaving a station role untestable.
+export type ClassicPageRole = WXYCRole | "unauthenticated" | undefined;
 
 export const mockCookiesToString = vi.fn(() => "session=test-cookie");
 
@@ -147,7 +152,7 @@ export function setUpClassicPageAuthorityEnv() {
     mockGetUserRoleInOrganization.mockReset();
     mockGetAppOrganizationId.mockReturnValue(undefined);
     mockCookiesToString.mockReturnValue("session=test-cookie");
-    process.env = { ...originalEnv, NEXT_PUBLIC_DASHBOARD_HOME_PAGE: "/dashboard" };
+    process.env = { ...originalEnv, NEXT_PUBLIC_DASHBOARD_HOME_PAGE: DEFAULT_DASHBOARD_HOME_PAGE };
   });
 
   afterEach(() => {
@@ -173,8 +178,17 @@ export async function assertReachesClassicPage(page: () => Promise<ReactElement>
   }
 }
 
-/** Asserts the page denies access by redirecting to `destination`. */
-export async function assertDeniedClassicPage(page: () => Promise<ReactElement>, destination = "/dashboard") {
+/**
+ * Asserts the page denies access by redirecting to `destination`, which
+ * defaults to the dashboard home the role gate sends an under-authorized
+ * member to. `rejects.toThrow` matches on substring, so a destination that is
+ * a prefix of the real one would pass on the marker alone — the exact-argument
+ * assertion below is what actually pins it.
+ */
+export async function assertDeniedClassicPage(
+  page: () => Promise<ReactElement>,
+  destination: string = DEFAULT_DASHBOARD_HOME_PAGE,
+) {
   await expect(page()).rejects.toThrow(`NEXT_REDIRECT:${destination}`);
   expect(mockRedirect).toHaveBeenCalledWith(destination);
 }

--- a/tests/integration/app/dashboard/@classic/library/missing/page.test.tsx
+++ b/tests/integration/app/dashboard/@classic/library/missing/page.test.tsx
@@ -62,4 +62,10 @@ describe("Classic /dashboard/library/missing page — missingReleases.jsp, DJ-ac
 
     await assertDeniedClassicPage(ClassicMissingReleasesPage);
   });
+
+  it("bounces an unauthenticated visitor to login, not to the dashboard home", async () => {
+    setUpClassicPageAuthority("unauthenticated");
+
+    await assertDeniedClassicPage(ClassicMissingReleasesPage, "/login?bounced=no-session");
+  });
 });

--- a/tests/integration/app/dashboard/@classic/library/missing/page.test.tsx
+++ b/tests/integration/app/dashboard/@classic/library/missing/page.test.tsx
@@ -1,41 +1,28 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { screen } from "@testing-library/react";
-import { renderWithProviders } from "@/tests/helpers";
+import { describe, it, vi } from "vitest";
+import {
+  setUpClassicPageAuthority,
+  setUpClassicPageAuthorityEnv,
+  assertReachesClassicPage,
+  assertDeniedClassicPage,
+} from "@/tests/helpers/classic-page-authority-harness";
 
 vi.mock("server-only", () => ({}));
-
-const mockCookiesToString = vi.fn(() => "session=test-cookie");
-vi.mock("next/headers", () => ({
-  cookies: () => ({ toString: mockCookiesToString }),
-}));
-
-// A real redirect() call inside a streaming server component resolves with
-// HTTP 200 and a NEXT_REDIRECT marker in the body, not a 307 — asserting on
-// that marker (not a status code) is what actually distinguishes "gated" from
-// "reached" here.
-const mockRedirect = vi.fn((url: string) => {
-  throw new Error(`NEXT_REDIRECT:${url}`);
+vi.mock("next/headers", async () => {
+  const { classicPageAuthorityHeadersMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityHeadersMock();
 });
-vi.mock("next/navigation", () => ({
-  redirect: (url: string) => mockRedirect(url),
-}));
-
-const mockGetSession = vi.fn();
-vi.mock("@/lib/features/authentication/server-client", () => ({
-  serverAuthClient: {
-    getSession: (options: unknown) => mockGetSession(options),
-  },
-}));
-
-// Reproduces the deployed shape: APP_ORGANIZATION is unset, so the only role
-// source is the JWT-first resolver this mock stands in for.
-const mockGetUserRoleInOrganization = vi.fn();
-const mockGetAppOrganizationId = vi.fn(() => undefined);
-vi.mock("@/lib/features/authentication/organization-utils.server", () => ({
-  getUserRoleInOrganization: (userId: string, orgId: string | undefined, cookie?: string) =>
-    mockGetUserRoleInOrganization(userId, orgId, cookie),
-  getAppOrganizationId: () => mockGetAppOrganizationId(),
-}));
+vi.mock("next/navigation", async () => {
+  const { classicPageAuthorityNavigationMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityNavigationMock();
+});
+vi.mock("@/lib/features/authentication/server-client", async () => {
+  const { classicPageAuthorityServerClientMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityServerClientMock();
+});
+vi.mock("@/lib/features/authentication/organization-utils.server", async () => {
+  const { classicPageAuthorityOrganizationUtilsMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityOrganizationUtilsMock();
+});
 
 // The page's own responsibility under test is the auth gate, not the RTK
 // Query-backed table content or the shared classic nav bar.
@@ -48,72 +35,31 @@ vi.mock("@/src/components/experiences/classic/Navigation", () => ({
 
 import ClassicMissingReleasesPage from "@/app/dashboard/@classic/library/missing/page";
 
-function sessionData(role: string | null) {
-  return {
-    user: {
-      id: "user-1",
-      email: "dj@wxyc.org",
-      name: "Test User",
-      username: "testuser",
-      // better-auth's admin-plugin column — never the WXYC tier under test.
-      role,
-      emailVerified: true,
-      hasCompletedOnboarding: true,
-    },
-    session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
-  };
-}
-
 // This screen is the one triage flagged as most likely to be "tightened" to
 // MD by a well-meaning later change (dj-site#1073, PR #1082 was closed as
 // exactly that regression) — asserting a plain DJ reaches it is the point of
 // this test, not incidental coverage.
 describe("Classic /dashboard/library/missing page — missingReleases.jsp, DJ-accessible not MD-gated", () => {
-  const originalEnv = process.env;
+  setUpClassicPageAuthorityEnv();
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetUserRoleInOrganization.mockReset();
-    mockGetAppOrganizationId.mockReturnValue(undefined);
-    mockCookiesToString.mockReturnValue("session=test-cookie");
-    process.env = { ...originalEnv, NEXT_PUBLIC_DASHBOARD_HOME_PAGE: "/dashboard" };
-  });
-
-  afterEach(() => {
-    process.env = originalEnv;
-  });
-
-  // Asserting the rendered content, not just the absence of a redirect: a page
-  // that returned null would satisfy "did not redirect" while showing the DJ
-  // nothing.
   it.each([
-    { role: "dj", label: "a plain DJ session — the non-negotiable authority constraint" },
-    { role: "musicDirector", label: "a music director" },
+    { role: "dj" as const, label: "a plain DJ session — the non-negotiable authority constraint" },
+    { role: "musicDirector" as const, label: "a music director" },
   ])("reaches the Missing Releases screen for $label", async ({ role }) => {
-    mockGetSession.mockResolvedValue({ data: sessionData(null), error: null });
-    mockGetUserRoleInOrganization.mockResolvedValue(role);
+    setUpClassicPageAuthority(role);
 
-    const result = await ClassicMissingReleasesPage();
-    renderWithProviders(result);
-
-    expect(mockRedirect).not.toHaveBeenCalled();
-    expect(screen.getByTestId("missing-releases-table")).toBeInTheDocument();
-    expect(screen.getByTestId("classic-nav")).toBeInTheDocument();
+    await assertReachesClassicPage(ClassicMissingReleasesPage, "missing-releases-table", "classic-nav");
   });
 
   it("redirects a member with no station role (below DJ)", async () => {
-    mockGetSession.mockResolvedValue({ data: sessionData(null), error: null });
-    mockGetUserRoleInOrganization.mockResolvedValue(undefined);
+    setUpClassicPageAuthority(undefined);
 
-    await expect(ClassicMissingReleasesPage()).rejects.toThrow("NEXT_REDIRECT:/dashboard");
-    expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
+    await assertDeniedClassicPage(ClassicMissingReleasesPage);
   });
 
   it("never grants access from the admin-plugin role column, even when it holds a WXYC tier string", async () => {
-    mockGetSession.mockResolvedValue({ data: sessionData("musicDirector"), error: null });
-    mockGetUserRoleInOrganization.mockResolvedValue(undefined);
+    setUpClassicPageAuthority(undefined, "musicDirector");
 
-    await expect(ClassicMissingReleasesPage()).rejects.toThrow("NEXT_REDIRECT:/dashboard");
-    expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
+    await assertDeniedClassicPage(ClassicMissingReleasesPage);
   });
 });

--- a/tests/integration/app/dashboard/@classic/library/page.test.tsx
+++ b/tests/integration/app/dashboard/@classic/library/page.test.tsx
@@ -61,4 +61,10 @@ describe("classic library page — chooseLibraryCodeOrArtist.jsp entry point", (
 
     await assertDeniedClassicPage(LibraryPage);
   });
+
+  it("bounces an unauthenticated visitor to login, not to the dashboard home", async () => {
+    setUpClassicPageAuthority("unauthenticated");
+
+    await assertDeniedClassicPage(LibraryPage, "/login?bounced=no-session");
+  });
 });

--- a/tests/integration/app/dashboard/@classic/library/page.test.tsx
+++ b/tests/integration/app/dashboard/@classic/library/page.test.tsx
@@ -1,40 +1,28 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderWithProviders } from "@/tests/helpers";
+import { describe, it, vi } from "vitest";
+import {
+  setUpClassicPageAuthority,
+  setUpClassicPageAuthorityEnv,
+  assertReachesClassicPage,
+  assertDeniedClassicPage,
+} from "@/tests/helpers/classic-page-authority-harness";
 
 vi.mock("server-only", () => ({}));
-
-const mockCookiesToString = vi.fn(() => "session=test-cookie");
-vi.mock("next/headers", () => ({
-  cookies: () => ({ toString: mockCookiesToString }),
-}));
-
-// A real redirect() call inside a streaming server component resolves with
-// HTTP 200 and a NEXT_REDIRECT marker in the body, not a 307 — asserting on
-// that marker (not a status code) is what actually distinguishes "gated" from
-// "reached" here.
-const mockRedirect = vi.fn((url: string) => {
-  throw new Error(`NEXT_REDIRECT:${url}`);
+vi.mock("next/headers", async () => {
+  const { classicPageAuthorityHeadersMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityHeadersMock();
 });
-vi.mock("next/navigation", () => ({
-  redirect: (url: string) => mockRedirect(url),
-}));
-
-const mockGetSession = vi.fn();
-vi.mock("@/lib/features/authentication/server-client", () => ({
-  serverAuthClient: {
-    getSession: (options: unknown) => mockGetSession(options),
-  },
-}));
-
-// Reproduces the deployed shape: APP_ORGANIZATION is unset, so the only role
-// source is the JWT-first resolver this mock stands in for.
-const mockGetUserRoleInOrganization = vi.fn();
-const mockGetAppOrganizationId = vi.fn(() => undefined);
-vi.mock("@/lib/features/authentication/organization-utils.server", () => ({
-  getUserRoleInOrganization: (userId: string, orgId: string | undefined, cookie?: string) =>
-    mockGetUserRoleInOrganization(userId, orgId, cookie),
-  getAppOrganizationId: () => mockGetAppOrganizationId(),
-}));
+vi.mock("next/navigation", async () => {
+  const { classicPageAuthorityNavigationMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityNavigationMock();
+});
+vi.mock("@/lib/features/authentication/server-client", async () => {
+  const { classicPageAuthorityServerClientMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityServerClientMock();
+});
+vi.mock("@/lib/features/authentication/organization-utils.server", async () => {
+  const { classicPageAuthorityOrganizationUtilsMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityOrganizationUtilsMock();
+});
 
 // The page's own responsibility under test is the auth gate, not these
 // forms' RTK Query-backed content.
@@ -50,73 +38,27 @@ vi.mock("@/src/components/experiences/classic/catalog/NewArtistForm", () => ({
 
 import LibraryPage from "@/app/dashboard/@classic/library/page";
 
-function sessionData(role: string | null) {
-  return {
-    user: {
-      id: "user-1",
-      email: "dj@wxyc.org",
-      name: "Test User",
-      username: "testuser",
-      // better-auth's admin-plugin column — never the WXYC tier under test.
-      role,
-      emailVerified: true,
-      hasCompletedOnboarding: true,
-    },
-    session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
-  };
-}
-
 describe("classic library page — chooseLibraryCodeOrArtist.jsp entry point", () => {
-  const originalEnv = process.env;
+  setUpClassicPageAuthorityEnv();
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetUserRoleInOrganization.mockReset();
-    mockGetAppOrganizationId.mockReturnValue(undefined);
-    mockCookiesToString.mockReturnValue("session=test-cookie");
-    // Pinned so the redirect destination asserted below is deterministic —
-    // requireRole falls back to DEFAULT_DASHBOARD_HOME_PAGE otherwise, which
-    // would make the assertion depend on the ambient environment.
-    process.env = { ...originalEnv, NEXT_PUBLIC_DASHBOARD_HOME_PAGE: "/dashboard" };
-  });
+  it.each([
+    { role: "musicDirector" as const, label: "a music director" },
+    { role: "stationManager" as const, label: "a station manager" },
+  ])("reaches the page for $label", async ({ role }) => {
+    setUpClassicPageAuthority(role);
 
-  afterEach(() => {
-    process.env = originalEnv;
-  });
-
-  it("reaches the page for a music director", async () => {
-    mockGetSession.mockResolvedValue({ data: sessionData(null), error: null });
-    mockGetUserRoleInOrganization.mockResolvedValue("musicDirector");
-
-    const result = await LibraryPage();
-    renderWithProviders(result);
-
-    expect(mockRedirect).not.toHaveBeenCalled();
+    await assertReachesClassicPage(LibraryPage, "classic-main", "artist-search-form", "new-artist-form");
   });
 
   it("redirects a DJ away from the library entry point", async () => {
-    mockGetSession.mockResolvedValue({ data: sessionData(null), error: null });
-    mockGetUserRoleInOrganization.mockResolvedValue("dj");
+    setUpClassicPageAuthority("dj");
 
-    await expect(LibraryPage()).rejects.toThrow("NEXT_REDIRECT:/dashboard");
-    expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
-  });
-
-  it("still reaches the page for a station manager", async () => {
-    mockGetSession.mockResolvedValue({ data: sessionData(null), error: null });
-    mockGetUserRoleInOrganization.mockResolvedValue("stationManager");
-
-    const result = await LibraryPage();
-    renderWithProviders(result);
-
-    expect(mockRedirect).not.toHaveBeenCalled();
+    await assertDeniedClassicPage(LibraryPage);
   });
 
   it("never grants access from the admin-plugin role column, even when it holds a WXYC tier string", async () => {
-    mockGetSession.mockResolvedValue({ data: sessionData("musicDirector"), error: null });
-    mockGetUserRoleInOrganization.mockResolvedValue(undefined);
+    setUpClassicPageAuthority(undefined, "musicDirector");
 
-    await expect(LibraryPage()).rejects.toThrow("NEXT_REDIRECT:/dashboard");
-    expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
+    await assertDeniedClassicPage(LibraryPage);
   });
 });


### PR DESCRIPTION
Closes #1209.

## What

Extracts the shared page-authority test harness the classic dashboard page tests were each hand-rolling, and makes "reached the page" mean "rendered the page".

- **`tests/helpers/classic-page-authority-harness.ts`** (new): the server-session/role/flag mock stack as reusable `vi.mock` factory shapes (`next/headers`, `next/navigation`, the server auth client, the org-role resolver), role-parameterized arrangement via `setUpClassicPageAuthority(role, adminPluginRole?)`, env pinning via `setUpClassicPageAuthorityEnv()`, and two assertion helpers:
  - `assertReachesClassicPage(page, ...landmarkTestIds)` — no redirect **and** every named landmark rendered. Asserting only "did not redirect" passes vacuously for a page that renders nothing, so it cannot distinguish "allowed and working" from "allowed and broken".
  - `assertDeniedClassicPage(page, destination?)` — the redirect case, pinned to a deterministic destination.
- **Both wave-1 page tests migrate**: `tests/integration/app/dashboard/@classic/library/page.test.tsx` (catalog chooser) and `.../library/missing/page.test.tsx` (Missing Releases). Net line reduction in the migrated tests (−112 lines across the two page-test files; the PR overall is +273/−176 counting the new harness and docs); no assertion weakened — several strengthened, since "reached" now requires the page's own landmarks.
- **`docs/testing.md`**: harness documented alongside the existing helper catalog.

## Why

Two structural problems were about to be copied into every future classic slice: a ~50-line duplicated mock preamble per page test, and vacuous reached-assertions. See #1209 for the full rationale and acceptance criteria.

## Verification

Local CI green: lint, `tsc --noEmit`, `vitest run` — 327 files / 4,656 tests passed.

## Related

- WXYC/dj-site#1163 — epic
- WXYC/dj-site#1199, WXYC/dj-site#1202 — the wave-1 PRs whose page tests migrate here

