### PR TITLE
fix(flowsheet): resolve the track picker in the legacy_release_id space

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -63,6 +63,7 @@ Message factories: `createTestStartShowMessage(djName?, dateTime?)`, `createTest
 
 ```typescript
 TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM     // 1001
+TEST_ENTITY_IDS.LEGACY_RELEASE.ROCK_ALBUM  // 7001 -- same row, other id space
 TEST_ENTITY_IDS.ARTIST.ROCK_ARTIST   // 2001
 TEST_ENTITY_IDS.FLOWSHEET.ENTRY_1    // 3001
 TEST_ENTITY_IDS.SHOW.CURRENT_SHOW    // 4001
@@ -191,4 +192,5 @@ Playwright specs stay in `e2e/`, and bats scripts in `scripts/__tests__/`.
 - Use the API harness for verifying RTK Query endpoint structure
 - Use `createTest*` factory functions instead of inline test data
 - Reference `TEST_ENTITY_IDS` and `TEST_SEARCH_STRINGS` constants for IDs and strings
+- Keep an album fixture's `legacy_release_id` **distinct from its `id`**. They are two id spaces over the same row — `id` is Backend's `library.id` serial, `legacy_release_id` is the tubafrenzy `LIBRARY_RELEASE_ID` the per-track store is keyed by — and a fixture where the two coincide cannot tell a path that resolves in the right space from one that resolves in the wrong space. Pair an `TEST_ENTITY_IDS.ALBUM` id with the `TEST_ENTITY_IDS.LEGACY_RELEASE` entry of the same name; never copy one into the other. This applies to hand-built rows too, including wire-shaped ones (`createTestAlbumSearchResult`), where the type is optional and the compiler will not ask
 - Use `renderWithProviders` for all component tests (never bare RTL `render`)

--- a/e2e/tests/flowsheet/flowsheet-track-picker.spec.ts
+++ b/e2e/tests/flowsheet/flowsheet-track-picker.spec.ts
@@ -16,6 +16,9 @@ const authDir = path.join(__dirname, "../../.auth");
  *  2. Free-text fallback: DJ picks a release with no Discogs identity /
  *     empty tracklist → picker collapses to "type the song title above" →
  *     submission carries `track_title` but no `track_position`.
+ *  3. Id space: a card-catalog row, whose `library.id` and `legacy_release_id`
+ *     differ, shows its own tracklist rather than the unrelated release its
+ *     `library.id` resolves to in the other space.
  *
  * Mocks the LML proxy endpoints (`/proxy/library/search`,
  * `/proxy/library/:id/tracks`) and the flowsheet POST so the spec doesn't
@@ -231,6 +234,130 @@ test.describe("Flowsheet Track Picker", { tag: "@smoke" }, () => {
       artist_name: "Juana Molina",
       album_title: "DOGA",
     });
+  });
+
+  test("shows the catalog row's own tracklist, not the one its library.id resolves to", async ({
+    page,
+  }) => {
+    // The two sibling tests both source their release from the library-search
+    // proxy, where the row's `id` and its `legacy_release_id` happen to be the
+    // same number — so neither can tell the two id spaces apart. A card-catalog
+    // row is where they diverge, and where reading the wrong one returns a real
+    // but unrelated release's tracklist with a 200.
+    const LIBRARY_ID = 1234;
+    const LEGACY_RELEASE_ID = 45342;
+
+    // Suppress the library-search proxy so only the catalog row populates the
+    // list and lands at a known index.
+    await page.route("**/proxy/library/search**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ results: [], total: 0, query: null }),
+      });
+    });
+
+    await page.route(isCatalogSearch, async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: LIBRARY_ID,
+            legacy_release_id: LEGACY_RELEASE_ID,
+            add_date: "2026-05-01T00:00:00.000Z",
+            album_title: "On Your Own Love Again",
+            artist_name: "Jessica Pratt",
+            code_letters: "PR",
+            code_artist_number: 3,
+            code_number: 1,
+            format_name: "Vinyl",
+            genre_name: "Rock",
+            label: "Drag City",
+            plays: 4,
+          },
+        ]),
+      });
+    });
+
+    // Both id spaces answer, with different tracklists. Stubbing only the
+    // correct one would let a wrong-space read fail as an unrouted request —
+    // which surfaces as a collapsed picker, not as the wrong answer it is.
+    await page.route(`**/proxy/library/${LIBRARY_ID}/tracks`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          library_id: LIBRARY_ID,
+          discogs_release_id: 111111,
+          source: "discogs",
+          tracks: [
+            {
+              position: "B2",
+              title: "WRONG RELEASE",
+              artist_credit: "Someone Else",
+              duration_ms: null,
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.route(
+      `**/proxy/library/${LEGACY_RELEASE_ID}/tracks`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            library_id: LEGACY_RELEASE_ID,
+            discogs_release_id: 222222,
+            source: "discogs",
+            tracks: [
+              {
+                position: "A1",
+                title: "Wrong Hand",
+                artist_credit: "Jessica Pratt",
+                duration_ms: 168000,
+              },
+            ],
+          }),
+        });
+      }
+    );
+
+    await flowsheet.songInput.click();
+    await flowsheet.artistInput.fill("Jessica Pratt");
+    await flowsheet.albumInput.fill("On Your Own Love Again");
+
+    // Located by content rather than by index: bin and rotation results are
+    // not mocked here, so a seeded row matching this artist would shift the
+    // positional index and silently click the wrong release.
+    const resultRow = page
+      .locator('[data-testid^="flowsheet-search-result-"]')
+      .filter({ hasText: "On Your Own Love Again" })
+      .first();
+    await expect(resultRow).toBeVisible({ timeout: 10_000 });
+    await resultRow.click();
+
+    const pickerTrigger = page.locator('[data-testid="track-picker-combobox"]');
+    await expect(pickerTrigger).toBeVisible({ timeout: 10_000 });
+    await pickerTrigger.click();
+    await expect(
+      page.locator('[data-testid="track-picker-panel"]')
+    ).toBeVisible();
+
+    // The release the DJ clicked, not the one its library.id collides with.
+    await expect(
+      page.locator('[data-testid="track-picker-option-0"]')
+    ).toContainText("Wrong Hand");
+    await expect(
+      page.locator('[data-testid="track-picker-panel"]')
+    ).not.toContainText("WRONG RELEASE");
   });
 
   test("falls back to free-text song input when the release has no tracklist", async ({

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -80,6 +80,16 @@ export function convertToAlbumEntry(
 
   return {
     id,
+    // Both union arms carry it: catalog search and rotation rows arrive as
+    // AlbumSearchResultJSON, bin rows as BinLibraryDetails. Coalesced to
+    // `null` rather than left `undefined` so an absent field and a null one
+    // are indistinguishable downstream — the property is always present.
+    //
+    // Note this is NOT gated on `isSearchResult` or on the row being linked:
+    // it is a property of the underlying library row, independent of whether
+    // `id` resolved, and gating it would drop it for exactly the rows whose
+    // ids diverge most.
+    legacy_release_id: response.legacy_release_id ?? null,
     title: response.album_title ?? "",
     artist: {
       name: response.artist_name ?? "",

--- a/lib/features/catalog/patchSearchResult.ts
+++ b/lib/features/catalog/patchSearchResult.ts
@@ -43,6 +43,10 @@ export function mergeAlbumIntoSearchResult(
     ...existing,
     ...updated,
     id: existing.id,
+    // Pinned from the same row as `id` above. Taking one id from the cached
+    // row and letting `...updated` supply the other would leave the merged row
+    // carrying two id spaces that point at different releases.
+    legacy_release_id: existing.legacy_release_id,
     artist: callNumberFromResponse ? updated.artist : existing.artist,
     entry: callNumberFromResponse ? updated.entry : existing.entry,
     matched_via: existing.matched_via,

--- a/lib/features/catalog/patchSearchResult.ts
+++ b/lib/features/catalog/patchSearchResult.ts
@@ -45,8 +45,11 @@ export function mergeAlbumIntoSearchResult(
     id: existing.id,
     // Pinned from the same row as `id` above. Taking one id from the cached
     // row and letting `...updated` supply the other would leave the merged row
-    // carrying two id spaces that point at different releases.
-    legacy_release_id: existing.legacy_release_id,
+    // carrying two id spaces that point at different releases. The `??` is
+    // safe against exactly that: the caller locates `existing` BY `updated.id`,
+    // so both sides are the same library row and the response can only ever
+    // supply the legacy id the cached row was missing — never a competing one.
+    legacy_release_id: existing.legacy_release_id ?? updated.legacy_release_id,
     artist: callNumberFromResponse ? updated.artist : existing.artist,
     entry: callNumberFromResponse ? updated.entry : existing.entry,
     matched_via: existing.matched_via,

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -31,13 +31,21 @@ export const TrackMatchSource = {
  * `matched_via` is omitted from the base and re-declared so the local
  * `TrackMatchHint` applies: intersecting the two array types instead would
  * demand a value satisfying both, which no single response row can.
+ *
+ * `legacy_release_id` is widened to allow `null`. This type carries rotation
+ * rows as well as catalog search rows, and the published contract types the
+ * two differently — `AlbumSearchResult` non-null (catalog search inner-joins
+ * library) but `Rotation` nullable (`getRotationFromDB` LEFT JOINs, and most
+ * production rotation rows have no library row behind them). The union of the
+ * shapes this type actually carries is the nullable one.
  */
 export type AlbumSearchResultJSON = Omit<
   AlbumSearchResult,
-  "add_date" | "matched_via"
+  "add_date" | "matched_via" | "legacy_release_id"
 > & {
   add_date: string;
   matched_via?: TrackMatchHint[];
+  legacy_release_id?: number | null;
 };
 
 export type SearchCatalogQueryParams = {
@@ -227,7 +235,24 @@ export type AlbumParams = AddAlbumRequestBody;
 export type ArtistParams = AddArtistRequestBody;
 
 export type AlbumEntry = {
+  /**
+   * Backend's `library.id` serial — the id every write path sends as
+   * `album_id`, and the only id an endpoint under `/library/:id` accepts.
+   * `null` where no library row is known.
+   */
   id: number | null;
+  /**
+   * The row's tubafrenzy `LIBRARY_RELEASE_ID` (Backend's
+   * `library.legacy_release_id`) — a **different id space** from `id`, and the
+   * one the per-track store is keyed by. `null` where the source row has no
+   * library row behind it (an unlinked rotation row) or predates the field.
+   *
+   * Required rather than optional on purpose: every failure mode of a missing
+   * value is silent — a read resolves `null` and quietly returns nothing, a
+   * dedupe quietly no-ops — so a conversion path that forgets to map it should
+   * fail to compile rather than ship an `undefined`.
+   */
+  legacy_release_id: number | null;
   title: string;
   artist: ArtistEntry;
   entry: number;

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -27,6 +27,7 @@ export function entryToFreezePayload(entry: {
   title?: string | null;
   label?: string | null;
   id?: number | null;
+  legacy_release_id?: number | null;
   rotation_id?: number | null;
   rotation_bin?: Rotation | null;
 }) {
@@ -47,6 +48,11 @@ export function entryToFreezePayload(entry: {
     album: entry.title ?? "",
     label: entry.label ?? "",
     album_id: entry.id ?? undefined,
+    // The read half of the freeze. Carried so the picker survives the click
+    // that zeroes the highlight, and resolved independently of `album_id` —
+    // which release's tracklist to show is not the same question as which
+    // release a submission should link to.
+    legacy_release_id: entry.legacy_release_id ?? undefined,
     rotation_id: entry.rotation_id ?? undefined,
     rotation_bin: entry.rotation_bin ?? undefined,
   };

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -49,9 +49,11 @@ export function entryToFreezePayload(entry: {
     label: entry.label ?? "",
     album_id: entry.id ?? undefined,
     // The read half of the freeze. Carried so the picker survives the click
-    // that zeroes the highlight, and resolved independently of `album_id` —
-    // which release's tracklist to show is not the same question as which
-    // release a submission should link to.
+    // that zeroes the highlight. Taken from this entry's own field rather than
+    // derived from `album_id` — which release's tracklist to show is not the
+    // same question as which release a submission should link to, and a row
+    // can answer one without answering the other. Both come off the SAME
+    // entry, which is what keeps the pair describing one release.
     legacy_release_id: entry.legacy_release_id ?? undefined,
     rotation_id: entry.rotation_id ?? undefined,
     rotation_bin: entry.rotation_bin ?? undefined,

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -66,6 +66,7 @@ export const defaultFlowsheetFrontendState: FlowsheetFrontendState = {
       request: false,
       segue: undefined,
       album_id: undefined,
+      legacy_release_id: undefined,
       rotation_bin: undefined,
       rotation_id: undefined,
       track_position: undefined,
@@ -90,6 +91,7 @@ export const flowsheetSlice = createAppSlice({
       state.rotationMode = action.payload;
       if (!action.payload) {
         state.search.query.album_id = undefined;
+        state.search.query.legacy_release_id = undefined;
         state.search.query.rotation_id = undefined;
         state.search.query.rotation_bin = undefined;
         state.search.query.track_position = undefined;
@@ -97,9 +99,15 @@ export const flowsheetSlice = createAppSlice({
     },
     setRotationMetadata: (
       state,
-      action: PayloadAction<{ album_id?: number; rotation_id?: number; rotation_bin?: Rotation }>
+      action: PayloadAction<{
+        album_id?: number;
+        legacy_release_id?: number;
+        rotation_id?: number;
+        rotation_bin?: Rotation;
+      }>
     ) => {
       state.search.query.album_id = action.payload.album_id;
+      state.search.query.legacy_release_id = action.payload.legacy_release_id;
       state.search.query.rotation_id = action.payload.rotation_id;
       state.search.query.rotation_bin = action.payload.rotation_bin;
       // track_position references a release_track row on the previous
@@ -154,6 +162,10 @@ export const flowsheetSlice = createAppSlice({
         // album row (see the file-header invariant), so they survive a
         // deviation — only the album-scoped fields drop.
         state.search.query.album_id = undefined;
+        // Cleared with album_id, not after it: a legacy id left behind keeps
+        // the picker serving the previous release's tracklist against a query
+        // that no longer references that release.
+        state.search.query.legacy_release_id = undefined;
         state.search.query.track_position = undefined;
         state.search.selectionProvided = undefined;
       }
@@ -184,6 +196,10 @@ export const flowsheetSlice = createAppSlice({
         // to prevent.
         artistProvided: boolean;
         album_id?: number;
+        // Decided independently of album_id: a caller may withhold the write
+        // linkage while the release's tracklist is still the right one to
+        // show. See RotationEntryFields' withheld-credit case.
+        legacy_release_id?: number;
         rotation_id?: number;
         rotation_bin?: Rotation;
       }>
@@ -192,6 +208,7 @@ export const flowsheetSlice = createAppSlice({
       state.search.query.album = action.payload.album;
       state.search.query.label = action.payload.label;
       state.search.query.album_id = action.payload.album_id;
+      state.search.query.legacy_release_id = action.payload.legacy_release_id;
       state.search.query.rotation_id = action.payload.rotation_id;
       state.search.query.rotation_bin = action.payload.rotation_bin;
       state.search.query.track_position = undefined;

--- a/lib/features/flowsheet/linkage.ts
+++ b/lib/features/flowsheet/linkage.ts
@@ -8,6 +8,11 @@
  * catalog/conversions) and are rejected by endpoints that validate a
  * positive-integer id boundary. Callers gate the linked-album submission
  * shape on this — previously five files re-derived the check locally.
+ *
+ * Read-path callers pass a `legacy_release_id` rather than an `album_id`. The
+ * question is the same one — is this a real server-issued id — and the answer
+ * does not depend on which space the id is in, which is why the parameter is
+ * deliberately not typed to either.
  */
 export function hasLinkedAlbumId(
   albumId: number | null | undefined

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -38,6 +38,22 @@ export type FlowsheetQuery = {
   request: boolean;
   segue?: boolean;
   album_id?: number;
+  /**
+   * The frozen release's `legacy_release_id` — the id space the track picker
+   * resolves in, kept alongside `album_id` (the space a submission writes in)
+   * rather than derived from it, because the two are different spaces over the
+   * same row and neither can be computed from the other client-side.
+   *
+   * Carried on the query because a click zeroes the highlight: post-click
+   * there is no result row left to read the id from, and the picker still has
+   * to know which release it is showing.
+   *
+   * Moves in lockstep with `album_id` in every reducer that sets or clears
+   * either. A stale value left behind after `album_id` clears means the picker
+   * goes on serving the previous release's tracklist — silently, since nothing
+   * about that combination is invalid.
+   */
+  legacy_release_id?: number;
   rotation_bin?: Rotation;
   rotation_id?: number;
   /**
@@ -51,7 +67,12 @@ export type FlowsheetQuery = {
 
 export type FlowsheetSearchProperty = keyof Omit<
   FlowsheetQuery,
-  "request" | "segue" | "album_id" | "rotation_bin" | "rotation_id"
+  | "request"
+  | "segue"
+  | "album_id"
+  | "legacy_release_id"
+  | "rotation_bin"
+  | "rotation_id"
 >;
 
 export type FlowsheetEntryBase = {

--- a/lib/features/lml/lml-conversions.ts
+++ b/lib/features/lml/lml-conversions.ts
@@ -38,6 +38,11 @@ function normalizeGenre(genre: string | null): Genre {
 export function convertLmlItemToAlbumEntry(item: LmlLibraryItem): AlbumEntry {
   return {
     id: item.id,
+    // LML's `library.db` is keyed by the tubafrenzy LIBRARY_RELEASE_ID, so the
+    // `id` it returns is a legacy release id, not a Backend `library.id`. It
+    // belongs in this field; `id` keeps the same value for now, which makes an
+    // LML row the one source where the two spaces legitimately coincide.
+    legacy_release_id: item.id,
     title: item.title ?? "",
     artist: {
       name: item.artist ?? "",

--- a/lib/features/metadata/api.ts
+++ b/lib/features/metadata/api.ts
@@ -23,9 +23,30 @@ export const metadataApi = createApi({
         params: { artistId },
       }),
     }),
+    /**
+     * Tracklist for a release, for the flowsheet track picker.
+     *
+     * **The argument is a `legacy_release_id`, not a `library.id`** — the two
+     * are different id spaces over the same row. Backend resolves this path
+     * param with `getDiscogsReleaseIdByLegacyId`, which filters on
+     * `library.legacy_release_id`; the URL segment is named `libraryId` there
+     * for historical reasons and means the same thing it does here.
+     *
+     * Passing a `library.id` does not fail loudly. The two spaces are nearly
+     * coextensive, so the lookup lands on a real but unrelated release and
+     * returns its tracklist with a 200. Getting this argument right is the
+     * whole point of the field's existence.
+     *
+     * The argument is also this endpoint's RTK Query cache key, so every
+     * caller — the hover prefetch and the picker query alike — has to agree on
+     * the id space or they warm and read different cache entries.
+     *
+     * Backend rejects a non-positive value with a 400, so callers gate on real
+     * linkage rather than passing a placeholder.
+     */
     getLibraryTracks: builder.query<LibraryTracksResponse, number>({
-      query: (libraryId) => ({
-        url: `/library/${libraryId}/tracks`,
+      query: (legacyReleaseId) => ({
+        url: `/library/${legacyReleaseId}/tracks`,
       }),
     }),
   }),

--- a/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker.tsx
@@ -12,19 +12,23 @@ type PickerTrack = LibraryTrack & TrackPickerEntry;
 /**
  * Hook that resolves the picker state for a given library release.
  *
+ * Takes a **`legacy_release_id`**, not a `library.id` — see the id-space note
+ * on the `getLibraryTracks` endpoint. `null` means no release is resolved and
+ * the query is skipped.
+ *
  * `picker.show` is the parent's render gate: true means render
  * `<LibraryTrackPicker>` in place of the free-text song input, false means
  * leave the free-text input alone. The picker collapses back to free-text on
- * three signals — no release selected, query still in flight, and a release
+ * three signals — no release resolved, query still in flight, and a release
  * with no Discogs-resolvable tracklist (`source: null` or `tracks: []`).
  */
-export function useLibraryTrackPicker(albumId: number | null) {
-  const { data, isLoading } = useGetLibraryTracksQuery(albumId ?? 0, {
-    skip: albumId === null,
+export function useLibraryTrackPicker(legacyReleaseId: number | null) {
+  const { data, isLoading } = useGetLibraryTracksQuery(legacyReleaseId ?? 0, {
+    skip: legacyReleaseId === null,
   });
 
   return useMemo(() => {
-    if (albumId === null) {
+    if (legacyReleaseId === null) {
       return { show: false, isLoading: false, tracks: [] as PickerTrack[] };
     }
     if (isLoading) {
@@ -35,7 +39,7 @@ export function useLibraryTrackPicker(albumId: number | null) {
       artists: t.artist_credit ? [t.artist_credit] : [],
     }));
     return { show: tracks.length > 0, isLoading: false, tracks };
-  }, [albumId, isLoading, data?.tracks]);
+  }, [legacyReleaseId, isLoading, data?.tracks]);
 }
 
 /**

--- a/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
@@ -70,7 +70,12 @@ function FlowsheetBackendResult({
         },
       }}
       onMouseOver={() => {
-        if (hasLinkedAlbumId(entry.id)) prefetchTracks(entry.id);
+        // Gate and argument are the same field on purpose. They are the cache
+        // key this endpoint is keyed by, so gating on one id space while
+        // fetching in the other would warm an entry the picker never reads —
+        // and would stop firing entirely for rows that carry no library.id.
+        if (hasLinkedAlbumId(entry.legacy_release_id))
+          prefetchTracks(entry.legacy_release_id);
       }}
       // Autofill, never submit; prevented mousedown keeps input focus
       onMouseDown={(e) => {

--- a/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
@@ -62,20 +62,27 @@ export default function FlowsheetSearchResults({
     searchQuery.artist || searchQuery.song || searchQuery.album || searchQuery.label
   );
 
-  // Two ids, two questions, two id spaces.
-  //
+  // Two ids, two questions, two id spaces — but one row answers both. A
+  // highlighted row answers them itself, INCLUDING by answering "no"; only
+  // when there is no highlight at all does the frozen query answer. Resolving
+  // each id independently would let one side reach past the highlighted row
+  // into a frozen release that outlived the highlight which set it, and a
+  // picker straddling two releases hands the flowsheet one release's track
+  // position paired with the other's album_id — a write the submission
+  // boundary has no way to recognize as wrong.
+  const idSource = highlightedResult ?? {
+    id: searchQuery.album_id ?? null,
+    legacy_release_id: searchQuery.legacy_release_id ?? null,
+  };
+
   // READ — which release's tracklist to fetch. The tracklist endpoint resolves
   // its path param against `library.legacy_release_id`, so this side must
   // resolve there too. Post-click there is no highlight left to read from (the
   // dominant flow is click the release, then pick the track), so the frozen
   // query has to carry the legacy id itself.
-  const tracklistReleaseId = hasLinkedAlbumId(
-    highlightedResult?.legacy_release_id
-  )
-    ? highlightedResult.legacy_release_id
-    : hasLinkedAlbumId(searchQuery.legacy_release_id)
-      ? searchQuery.legacy_release_id
-      : null;
+  const tracklistReleaseId = hasLinkedAlbumId(idSource.legacy_release_id)
+    ? idSource.legacy_release_id
+    : null;
 
   // WRITE — whether this row has a real library linkage, which is the only
   // thing that decides if a picker is offered at all. A library-unlinked
@@ -83,11 +90,7 @@ export default function FlowsheetSearchResults({
   // synthesizeAlbumId, and the submission chokepoint drops `track_position`
   // without a positive `album_id` behind it — so offering a picker there would
   // let the DJ pick something that gets silently discarded.
-  const linkedAlbumId = hasLinkedAlbumId(highlightedResult?.id)
-    ? highlightedResult.id
-    : hasLinkedAlbumId(searchQuery.album_id)
-      ? searchQuery.album_id
-      : null;
+  const linkedAlbumId = hasLinkedAlbumId(idSource.id) ? idSource.id : null;
 
   const [manualOverride, setManualOverride] = useState<number | null>(null);
   useEffect(() => {
@@ -96,15 +99,18 @@ export default function FlowsheetSearchResults({
     }
   }, [tracklistReleaseId, manualOverride]);
 
+  const showPickerRow = linkedAlbumId !== null && !rotationMode;
+
   // Keyed on the read half: opting out is per-release-tracklist, and the
-  // release's identity for tracklist purposes is its legacy id.
+  // release's identity for tracklist purposes is its legacy id. Gated on the
+  // row rendering at all, because the tracklist has no other consumer —
+  // rotation mode keeps a legacy id in the query that nothing there reads, and
+  // fetching for it would be a request per rotation pick with no destination.
   const pickerReleaseId =
-    tracklistReleaseId !== null && tracklistReleaseId !== manualOverride
+    showPickerRow && tracklistReleaseId !== manualOverride
       ? tracklistReleaseId
       : null;
   const picker = useLibraryTrackPicker(pickerReleaseId);
-
-  const showPickerRow = linkedAlbumId !== null && !rotationMode;
 
   // Panel CONTENT only — the Sheet/Popper/transitions live in FlowsheetSearchbar
   return (

--- a/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
@@ -58,41 +58,53 @@ export default function FlowsheetSearchResults({
 
   // A click-to-autofill zeroes the highlight; the frozen query keeps the album
   const searchQuery = useAppSelector(flowsheetSlice.selectors.getSearchQuery);
-  const frozenAlbumId = searchQuery.album_id;
   const hasTypedText = Boolean(
     searchQuery.artist || searchQuery.song || searchQuery.album || searchQuery.label
   );
 
-  // A library-unlinked rotation/catalog row carries a synthesized negative
-  // id from synthesizeAlbumId — there's no real release to pick tracks from,
-  // and #702's chokepoint drops track_position anyway. Skip the picker entirely
-  // for those rows instead of letting the DJ pick something we'll silently
-  // discard. (dj-site#704)
-  // `highlightedResult.id === null` (an LML row) falls through to the
-  // frozen-query check below exactly like a non-positive id does today —
-  // widening `AlbumEntry.id` must not make the picker disappear for the one
-  // source where it currently works. Real fix is #1184.
-  const effectiveAlbumId =
-    highlightedResult && highlightedResult.id !== null && highlightedResult.id > 0
-      ? highlightedResult.id
-      : hasLinkedAlbumId(frozenAlbumId)
-        ? (frozenAlbumId as number)
-        : null;
+  // Two ids, two questions, two id spaces.
+  //
+  // READ — which release's tracklist to fetch. The tracklist endpoint resolves
+  // its path param against `library.legacy_release_id`, so this side must
+  // resolve there too. Post-click there is no highlight left to read from (the
+  // dominant flow is click the release, then pick the track), so the frozen
+  // query has to carry the legacy id itself.
+  const tracklistReleaseId = hasLinkedAlbumId(
+    highlightedResult?.legacy_release_id
+  )
+    ? highlightedResult.legacy_release_id
+    : hasLinkedAlbumId(searchQuery.legacy_release_id)
+      ? searchQuery.legacy_release_id
+      : null;
+
+  // WRITE — whether this row has a real library linkage, which is the only
+  // thing that decides if a picker is offered at all. A library-unlinked
+  // rotation/catalog row carries a synthesized negative id from
+  // synthesizeAlbumId, and the submission chokepoint drops `track_position`
+  // without a positive `album_id` behind it — so offering a picker there would
+  // let the DJ pick something that gets silently discarded.
+  const linkedAlbumId = hasLinkedAlbumId(highlightedResult?.id)
+    ? highlightedResult.id
+    : hasLinkedAlbumId(searchQuery.album_id)
+      ? searchQuery.album_id
+      : null;
 
   const [manualOverride, setManualOverride] = useState<number | null>(null);
   useEffect(() => {
-    if (manualOverride !== null && effectiveAlbumId !== manualOverride) {
+    if (manualOverride !== null && tracklistReleaseId !== manualOverride) {
       setManualOverride(null);
     }
-  }, [effectiveAlbumId, manualOverride]);
+  }, [tracklistReleaseId, manualOverride]);
 
-  const pickerAlbumId =
-    effectiveAlbumId !== null && effectiveAlbumId !== manualOverride
-      ? effectiveAlbumId
+  // Keyed on the read half: opting out is per-release-tracklist, and the
+  // release's identity for tracklist purposes is its legacy id.
+  const pickerReleaseId =
+    tracklistReleaseId !== null && tracklistReleaseId !== manualOverride
+      ? tracklistReleaseId
       : null;
-  const picker = useLibraryTrackPicker(pickerAlbumId);
+  const picker = useLibraryTrackPicker(pickerReleaseId);
 
-  const showPickerRow = effectiveAlbumId !== null && !rotationMode;
+  const showPickerRow = linkedAlbumId !== null && !rotationMode;
 
   // Panel CONTENT only — the Sheet/Popper/transitions live in FlowsheetSearchbar
   return (
@@ -189,8 +201,8 @@ export default function FlowsheetSearchResults({
                   isLoading={picker.isLoading}
                   disabled={false}
                   onManualEntry={() => {
-                    if (effectiveAlbumId !== null)
-                      setManualOverride(effectiveAlbumId);
+                    if (tracklistReleaseId !== null)
+                      setManualOverride(tracklistReleaseId);
                     dispatch(
                       flowsheetSlice.actions.setSearchProperty({
                         name: "song",

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -72,6 +72,7 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
       dispatch(
         flowsheetSlice.actions.setRotationMetadata({
           album_id: undefined,
+          legacy_release_id: undefined,
           rotation_id: undefined,
           rotation_bin: bin,
         })
@@ -99,6 +100,11 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
           // field below. Classic makes the same trade by switching
           // submission variants.
           album_id: releaseCannotSupplyArtist(release) ? undefined : (release.id ?? undefined),
+          // NOT subject to the withholding above: that trade is about which
+          // artist_name BS hands back on a write, and says nothing about which
+          // release's tracklist to show. Gating this on it would drop the
+          // picker for exactly the releases whose credit is refused.
+          legacy_release_id: release.legacy_release_id ?? undefined,
           rotation_id: release.rotation_id,
           rotation_bin: release.rotation_bin,
         })

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -100,10 +100,13 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
           // field below. Classic makes the same trade by switching
           // submission variants.
           album_id: releaseCannotSupplyArtist(release) ? undefined : (release.id ?? undefined),
-          // NOT subject to the withholding above: that trade is about which
-          // artist_name BS hands back on a write, and says nothing about which
-          // release's tracklist to show. Gating this on it would drop the
-          // picker for exactly the releases whose credit is refused.
+          // Assigned unconditionally, and not subject to the withholding
+          // above. The reducer overwrites the query's album linkage wholesale,
+          // so omitting this would leave the PREVIOUS selection's legacy id
+          // standing beside this selection's album_id — the one way the pair
+          // can come to describe two different releases. The withholding is
+          // about which artist_name BS hands back on a write and has no
+          // bearing on which release this row is.
           legacy_release_id: release.legacy_release_id ?? undefined,
           rotation_id: release.rotation_id,
           rotation_bin: release.rotation_bin,

--- a/tests/fakes/libraryTracks.ts
+++ b/tests/fakes/libraryTracks.ts
@@ -1,0 +1,39 @@
+import { http, HttpResponse } from "msw";
+import type { RequestHandler } from "msw";
+import { TEST_BACKEND_URL } from "../helpers/constants";
+
+/**
+ * MSW handler for `GET /proxy/library/:legacyReleaseId/tracks`.
+ *
+ * Deliberately NOT added to the base `handlers` set, which is the empty-default
+ * base — the repo pattern is a per-spec `server.use`. This lives here so the
+ * two specs that need it (`LibraryTrackPicker` and `FlowsheetSearchResults`)
+ * share one definition instead of importing across a `.test.tsx`, which has no
+ * precedent in this repo.
+ *
+ * **The path param is a `legacy_release_id`, not a `library.id`.** Backend
+ * resolves it via `getDiscogsReleaseIdByLegacyId`, which filters on
+ * `library.legacy_release_id`. Stubbing a `library.id` here produces a handler
+ * that never matches the request the app actually makes.
+ */
+export function libraryTracksHandler(
+  legacyReleaseId: number,
+  tracks: Array<{ position: string; title: string; artist_credit: string }>,
+  source: "discogs" | null = "discogs",
+): RequestHandler {
+  return http.get(
+    `${TEST_BACKEND_URL}/proxy/library/${legacyReleaseId}/tracks`,
+    () =>
+      HttpResponse.json({
+        library_id: legacyReleaseId,
+        discogs_release_id: source === "discogs" ? 42 : null,
+        source,
+        tracks: tracks.map((t) => ({ ...t, duration_ms: null })),
+      }),
+  );
+}
+
+/** Convenience single track, for specs that only need the picker to populate. */
+export const ONE_TRACK = [
+  { position: "A1", title: "la paradoja", artist_credit: "Juana Molina" },
+];

--- a/tests/fixtures/fixtures.ts
+++ b/tests/fixtures/fixtures.ts
@@ -177,6 +177,9 @@ export function createTestArtist(overrides: Partial<ArtistEntry> = {}): ArtistEn
 export function createTestAlbum(overrides: Partial<AlbumEntry> = {}): AlbumEntry {
   return {
     id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM,
+    // Deliberately NOT a copy of `id` — see the LEGACY_RELEASE note in
+    // tests/helpers/constants.ts.
+    legacy_release_id: TEST_ENTITY_IDS.LEGACY_RELEASE.ROCK_ALBUM,
     title: TEST_SEARCH_STRINGS.ALBUM_NAME,
     artist: createTestArtist(),
     entry: 1,
@@ -199,6 +202,11 @@ export function createTestAlbumSearchResult(
 ): AlbumSearchResultJSON {
   return {
     id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM,
+    // The wire type leaves this optional, so the compiler will not demand it
+    // here — but a spec that builds a row through this factory and converts it
+    // would otherwise exercise the no-legacy-id branch while appearing to test
+    // the populated one.
+    legacy_release_id: TEST_ENTITY_IDS.LEGACY_RELEASE.ROCK_ALBUM,
     add_date: toDateString(TEST_TIMESTAMPS.ONE_WEEK_AGO),
     album_title: TEST_SEARCH_STRINGS.ALBUM_NAME,
     artist_name: TEST_SEARCH_STRINGS.ARTIST_NAME,
@@ -279,6 +287,7 @@ export function createTestAlbumList(count: number = 3): AlbumEntry[] {
   return Array.from({ length: count }, (_, index) =>
     createTestAlbum({
       id: TEST_ENTITY_IDS.ALBUM.ROCK_ALBUM + index,
+      legacy_release_id: TEST_ENTITY_IDS.LEGACY_RELEASE.ROCK_ALBUM + index,
       title: `${TEST_SEARCH_STRINGS.ALBUM_NAME} ${index + 1}`,
       artist: createTestArtist({
         id: TEST_ENTITY_IDS.ARTIST.ROCK_ARTIST + index,
@@ -305,6 +314,7 @@ export function createTestRotationAlbum(
 ): AlbumEntry {
   return createTestAlbum({
     id: TEST_ENTITY_IDS.ALBUM.ROTATION_ALBUM,
+    legacy_release_id: TEST_ENTITY_IDS.LEGACY_RELEASE.ROTATION_ALBUM,
     rotation_bin: rotation,
     rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
     ...overrides,

--- a/tests/helpers/constants.ts
+++ b/tests/helpers/constants.ts
@@ -16,6 +16,17 @@ export const TEST_ENTITY_IDS = {
     ELECTRONIC_ALBUM: 1003,
     ROTATION_ALBUM: 1004,
   },
+  // The `legacy_release_id` id space, deliberately disjoint from ALBUM (the
+  // `library.id` space). A fixture whose two ids coincide cannot distinguish a
+  // path that resolves in the right space from one that resolves in the wrong
+  // one, so every album factory pairs an ALBUM id with the LEGACY_RELEASE id
+  // of the same name — never a copy of the ALBUM id.
+  LEGACY_RELEASE: {
+    ROCK_ALBUM: 7001,
+    JAZZ_ALBUM: 7002,
+    ELECTRONIC_ALBUM: 7003,
+    ROTATION_ALBUM: 7004,
+  },
   ARTIST: {
     ROCK_ARTIST: 2001,
     JAZZ_ARTIST: 2002,

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -18,3 +18,4 @@ export * from "./conversion-harness";
 
 export { server } from "../fakes/server";
 export { handlers } from "../fakes/handlers";
+export { libraryTracksHandler, ONE_TRACK } from "../fakes/libraryTracks";

--- a/tests/integration/components/modern/Rightbar/Bin/BinContent.test.tsx
+++ b/tests/integration/components/modern/Rightbar/Bin/BinContent.test.tsx
@@ -126,6 +126,10 @@ describe("BinContent", () => {
   const mockBinEntries: AlbumEntry[] = [
     {
       id: 1,
+      // Distinct from `id` on purpose: the two are separate id spaces,
+      // and a fixture where they coincide can't tell a right-space read
+      // from a wrong-space one.
+      legacy_release_id: 45001,
       title: "Album One",
       entry: 1,
       format: "CD",
@@ -145,6 +149,10 @@ describe("BinContent", () => {
     },
     {
       id: 2,
+      // Distinct from `id` on purpose: the two are separate id spaces,
+      // and a fixture where they coincide can't tell a right-space read
+      // from a wrong-space one.
+      legacy_release_id: 45002,
       title: "Album Two",
       entry: 2,
       format: "Vinyl",
@@ -164,6 +172,10 @@ describe("BinContent", () => {
     },
     {
       id: 3,
+      // Distinct from `id` on purpose: the two are separate id spaces,
+      // and a fixture where they coincide can't tell a right-space read
+      // from a wrong-space one.
+      legacy_release_id: 45003,
       title: "Album Three",
       entry: 3,
       format: "CD",

--- a/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
@@ -170,38 +170,85 @@ describe("FlowsheetBackendResult", () => {
   });
 
   describe("Tracklist prefetch", () => {
-    it("prefetches tracks on mouse over when the row carries a real library link", () => {
-      // id and index are deliberately distinct values so this test can tell
-      // apart a component that reads entry.id from one that reads index.
-      const linkedEntry: AlbumEntry = createTestAlbum({
-        ...mockEntry,
-        id: 1,
-      });
-      renderWithProviders(
-        <FlowsheetBackendResult entry={linkedEntry} index={42} />
-      );
-
+    const hoverRow = () => {
       const resultRow = screen
         .getByText("Juana Molina")
         .closest('[data-testid^="flowsheet-search-result-"]');
       fireEvent.mouseOver(resultRow!);
+    };
 
-      expect(mockPrefetchTracks).toHaveBeenCalledWith(1);
+    it("prefetches the row's legacy_release_id, not its library.id", () => {
+      // `id`, `legacy_release_id`, and `index` are three distinct values, so
+      // this can tell apart a component reading the right one from a component
+      // reading either of the two plausible wrong ones. The endpoint resolves
+      // its path param against `library.legacy_release_id`, so `id` is the
+      // wrong space — and because the two spaces are nearly coextensive, a
+      // wrong-space lookup lands on a real but unrelated release rather than
+      // failing.
+      const catalogEntry: AlbumEntry = createTestAlbum({
+        ...mockEntry,
+        id: 1,
+        legacy_release_id: 45342,
+      });
+      renderWithProviders(
+        <FlowsheetBackendResult entry={catalogEntry} index={42} />
+      );
+
+      hoverRow();
+
+      expect(mockPrefetchTracks).toHaveBeenCalledWith(45342);
     });
 
-    it("does not prefetch tracks for a library-unlinked row (synthesized negative id)", () => {
+    it("prefetches a row that carries no library.id at all", () => {
+      // An LML-sourced row knows a legacy release id but no `library.id`. The
+      // gate has to key on the same field the argument does, or this row —
+      // the one source whose picker works today — silently stops prefetching.
+      const lmlEntry: AlbumEntry = createTestAlbum({
+        ...mockEntry,
+        id: null,
+        legacy_release_id: 45342,
+      });
+      renderWithProviders(
+        <FlowsheetBackendResult entry={lmlEntry} index={42} />
+      );
+
+      hoverRow();
+
+      expect(mockPrefetchTracks).toHaveBeenCalledWith(45342);
+    });
+
+    it("does not prefetch for a library-unlinked row (synthesized negative id, no legacy id)", () => {
+      // An unlinked rotation row: the LEFT JOIN found no library row, so there
+      // is no legacy id either. Backend 400s on a non-positive path param, so
+      // this gate is what keeps the hover from erroring.
       const unlinkedEntry: AlbumEntry = createTestAlbum({
         ...mockEntry,
         id: -1,
+        legacy_release_id: null,
       });
       renderWithProviders(
         <FlowsheetBackendResult entry={unlinkedEntry} index={42} />
       );
 
-      const resultRow = screen
-        .getByText("Juana Molina")
-        .closest('[data-testid^="flowsheet-search-result-"]');
-      fireEvent.mouseOver(resultRow!);
+      hoverRow();
+
+      expect(mockPrefetchTracks).not.toHaveBeenCalled();
+    });
+
+    it("does not prefetch when the legacy id is absent despite a real library link", () => {
+      // Backend's column is NOT NULL, so this shape means an emitter that
+      // predates the field rather than routine data. It must degrade to no
+      // prefetch, not fall back to `id` — falling back is the defect.
+      const noLegacyEntry: AlbumEntry = createTestAlbum({
+        ...mockEntry,
+        id: 42,
+        legacy_release_id: null,
+      });
+      renderWithProviders(
+        <FlowsheetBackendResult entry={noLegacyEntry} index={7} />
+      );
+
+      hoverRow();
 
       expect(mockPrefetchTracks).not.toHaveBeenCalled();
     });

--- a/tests/integration/components/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, fireEvent } from "@testing-library/react";
-import { http, HttpResponse } from "msw";
 import FlowsheetSearchResults from "@/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import {
   renderWithProviders,
   createTestAlbum,
   server,
-  TEST_BACKEND_URL,
+  libraryTracksHandler,
+  ONE_TRACK,
 } from "@/tests/helpers";
 import type { RootState } from "@/lib/store";
 
@@ -48,24 +48,8 @@ vi.mock("@/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker
   };
 });
 
-function mockLibraryTracksResponse(libraryId: number) {
-  server.use(
-    http.get(`${TEST_BACKEND_URL}/proxy/library/${libraryId}/tracks`, () =>
-      HttpResponse.json({
-        library_id: libraryId,
-        discogs_release_id: 42,
-        source: "discogs",
-        tracks: [
-          {
-            position: "A1",
-            title: "la paradoja",
-            artist_credit: "Juana Molina",
-            duration_ms: null,
-          },
-        ],
-      })
-    )
-  );
+function mockLibraryTracksResponse(legacyReleaseId: number) {
+  server.use(libraryTracksHandler(legacyReleaseId, ONE_TRACK));
 }
 
 function buildFlowsheetState(
@@ -254,9 +238,14 @@ describe("FlowsheetSearchResults", () => {
   // previously picked, otherwise a stale "A1" rides through on submit
   // pointing at an album the DJ no longer intends.
   it("clears track_position in Redux when the manual-entry button is clicked", async () => {
-    mockLibraryTracksResponse(1234);
+    // Stubbed on the legacy id, which is what the picker requests.
+    mockLibraryTracksResponse(45342);
     const linkedResult = [
-      createTestAlbum({ id: 1234, title: "Linked Library Row" }),
+      createTestAlbum({
+        id: 1234,
+        legacy_release_id: 45342,
+        title: "Linked Library Row",
+      }),
     ];
 
     const { store } = renderWithProviders(
@@ -287,6 +276,169 @@ describe("FlowsheetSearchResults", () => {
     fireEvent.click(await screen.findByTestId("library-track-picker-manual"));
 
     expect(store.getState().flowsheet.search.query.track_position).toBeUndefined();
+  });
+
+  // The picker read and the flowsheet write resolve in two different id
+  // spaces over the same row. Reading in the wrong one almost never misses —
+  // the spaces are nearly coextensive — so it returns a real but unrelated
+  // release's tracklist, presented as this release's, with a 200 and nothing
+  // in telemetry. These cases pin the read to the space the endpoint actually
+  // resolves in.
+  describe("id space the picker resolves in", () => {
+    // Two live handlers, one per id space, returning distinguishable
+    // tracklists. Asserting on WHICH tracklist arrives is what makes a
+    // wrong-space read visible; stubbing only the correct id would let a
+    // wrong-space read fail as an unstubbed request, which reads as a
+    // collapsed picker rather than a wrong answer.
+    const LIBRARY_ID = 1234;
+    const LEGACY_RELEASE_ID = 45342;
+
+    const stubBothSpaces = () => {
+      server.use(
+        libraryTracksHandler(LIBRARY_ID, [
+          {
+            position: "B2",
+            title: "WRONG RELEASE — resolved in the library.id space",
+            artist_credit: "Not This Artist",
+          },
+        ]),
+        libraryTracksHandler(LEGACY_RELEASE_ID, ONE_TRACK),
+      );
+    };
+
+    const highlightedRow = [
+      createTestAlbum({
+        id: LIBRARY_ID,
+        legacy_release_id: LEGACY_RELEASE_ID,
+        title: "Linked Library Row",
+      }),
+    ];
+
+    it("fetches the highlighted row's legacy_release_id, not its library.id", async () => {
+      stubBothSpaces();
+
+      renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={highlightedRow}
+          catalogResults={[]}
+          rotationResults={[]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 1,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
+      );
+
+      await screen.findByTestId("library-track-picker-manual");
+
+      const tracks =
+        libraryTrackPickerSpy.mock.calls.at(-1)?.[0]?.tracks ?? [];
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].title).toBe("la paradoja");
+    });
+
+    it("keeps resolving on the legacy id after a click clears the highlight", async () => {
+      // The dominant flow is click the release, then pick the track — and the
+      // click zeroes selectedResult, so there is no highlighted row left to
+      // read. The frozen query has to carry the legacy id itself; carrying
+      // only album_id would send the picker back into the library.id space
+      // for the whole post-click interaction.
+      stubBothSpaces();
+
+      const { store } = renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={highlightedRow}
+          catalogResults={[]}
+          rotationResults={[]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 0,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
+      );
+
+      store.dispatch(
+        flowsheetSlice.actions.freezeSelectionToQuery({
+          artist: "Juana Molina",
+          album: "DOGA",
+          label: "Sonamos",
+          artistProvided: true,
+          album_id: LIBRARY_ID,
+          legacy_release_id: LEGACY_RELEASE_ID,
+        })
+      );
+
+      await screen.findByTestId("library-track-picker-manual");
+
+      const tracks =
+        libraryTrackPickerSpy.mock.calls.at(-1)?.[0]?.tracks ?? [];
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].title).toBe("la paradoja");
+    });
+
+    it("offers no picker for a row with a library link but no legacy id", async () => {
+      // Backend's column is NOT NULL, so this is an emitter that predates the
+      // field, not routine data. It must collapse to free text rather than
+      // fall back to the library.id space.
+      stubBothSpaces();
+
+      renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={[
+            createTestAlbum({
+              id: LIBRARY_ID,
+              legacy_release_id: null,
+              title: "No Legacy Id",
+            }),
+          ]}
+          catalogResults={[]}
+          rotationResults={[]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 1,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
+      );
+
+      // The picker ROW still renders — the row is library-linked, so a track
+      // is still offerable as free text — but the dropdown never populates.
+      expect(
+        screen.getByTestId("flowsheet-search-track-picker-row")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("library-track-picker-manual")
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("should calculate correct offsets for results", () => {

--- a/tests/integration/components/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import FlowsheetSearchResults from "@/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import {
@@ -438,6 +438,196 @@ describe("FlowsheetSearchResults", () => {
       expect(
         screen.queryByTestId("library-track-picker-manual")
       ).not.toBeInTheDocument();
+    });
+
+    // The two ids answer two different questions, but they must answer them
+    // about the SAME row. A frozen release outlives the highlight that created
+    // it, so resolving each id independently lets one side reach past the
+    // highlighted row into the frozen query — and a picker that straddles two
+    // releases pairs one release's track position with the other's album_id.
+    // Both cases below arrive through the ordinary sequence: click a release,
+    // then arrow onto another row.
+    const freezeReleaseA = (store: ReturnType<typeof renderWithProviders>["store"]) =>
+      store.dispatch(
+        flowsheetSlice.actions.freezeSelectionToQuery({
+          artist: "Juana Molina",
+          album: "DOGA",
+          label: "Sonamos",
+          artistProvided: true,
+          album_id: LIBRARY_ID,
+          legacy_release_id: LEGACY_RELEASE_ID,
+        })
+      );
+
+    it("drops the frozen release's tracklist when the highlight moves to a row with no legacy id", async () => {
+      stubBothSpaces();
+
+      const { store } = renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={[
+            createTestAlbum({
+              id: 5678,
+              legacy_release_id: null,
+              title: "No Legacy Id",
+            }),
+          ]}
+          catalogResults={[]}
+          rotationResults={[]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 0,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
+      );
+
+      // Settle on the frozen release first, so the collapse below is the
+      // highlight taking effect rather than the query never having resolved.
+      freezeReleaseA(store);
+      await screen.findByTestId("library-track-picker-manual");
+
+      store.dispatch(flowsheetSlice.actions.setSelectedResult(1));
+
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("library-track-picker-manual")
+        ).not.toBeInTheDocument()
+      );
+      // Still library-linked, so free text is still offerable.
+      expect(
+        screen.getByTestId("flowsheet-search-track-picker-row")
+      ).toBeInTheDocument();
+    });
+
+    it("withdraws the picker when the highlight moves to a library-unlinked row", async () => {
+      // Unlinked rows carry a client-synthesized negative id and no legacy id,
+      // so neither question has an answer. Falling back to the frozen release
+      // for either one offers a picker whose pick the submission boundary
+      // discards for want of a positive album_id.
+      stubBothSpaces();
+
+      const { store } = renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={[]}
+          catalogResults={[]}
+          rotationResults={[
+            createTestAlbum({
+              id: -8812,
+              legacy_release_id: null,
+              title: "Unlinked Rotation Row",
+            }),
+          ]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 0,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
+      );
+
+      freezeReleaseA(store);
+      await screen.findByTestId("library-track-picker-manual");
+
+      store.dispatch(flowsheetSlice.actions.setSelectedResult(1));
+
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("flowsheet-search-track-picker-row")
+        ).not.toBeInTheDocument()
+      );
+    });
+
+    it("fetches no tracklist while rotation mode holds a legacy id in the query", async () => {
+      // Rotation mode writes the pair into the query but offers no picker row,
+      // so the tracklist has no consumer there. The request is the only
+      // observable difference, hence the counter.
+      stubBothSpaces();
+
+      const trackRequests: string[] = [];
+      const record = ({ request }: { request: Request }) => {
+        if (new URL(request.url).pathname.endsWith("/tracks")) {
+          trackRequests.push(request.url);
+        }
+      };
+      server.events.on("request:start", record);
+
+      try {
+        const rotation = renderWithProviders(
+          <FlowsheetSearchResults
+            binResults={[]}
+            catalogResults={[]}
+            rotationResults={[]}
+            lmlResults={[]}
+          />,
+          {
+            preloadedState: {
+              flowsheet: buildFlowsheetState(true, {
+                rotationMode: true,
+                search: {
+                  open: true,
+                  query: flowsheetSlice.getInitialState().search.query,
+                  selectedResult: 0,
+                  confirmedArtist: "",
+                  resetEpoch: 0,
+                },
+              }),
+            },
+          }
+        );
+
+        freezeReleaseA(rotation.store);
+        await new Promise((r) => setTimeout(r, 20));
+        expect(trackRequests).toHaveLength(0);
+        rotation.unmount();
+
+        // The same query state outside rotation mode DOES fetch — without this
+        // half, a component that never fetches at all would pass the above.
+        const normal = renderWithProviders(
+          <FlowsheetSearchResults
+            binResults={[]}
+            catalogResults={[]}
+            rotationResults={[]}
+            lmlResults={[]}
+          />,
+          {
+            preloadedState: {
+              flowsheet: buildFlowsheetState(true, {
+                search: {
+                  open: true,
+                  query: flowsheetSlice.getInitialState().search.query,
+                  selectedResult: 0,
+                  confirmedArtist: "",
+                  resetEpoch: 0,
+                },
+              }),
+            },
+          }
+        );
+
+        freezeReleaseA(normal.store);
+        await screen.findByTestId("library-track-picker-manual");
+        expect(trackRequests).toHaveLength(1);
+      } finally {
+        server.events.removeListener("request:start", record);
+      }
     });
   });
 

--- a/tests/unit/lib/features/catalog/conversions.test.ts
+++ b/tests/unit/lib/features/catalog/conversions.test.ts
@@ -440,6 +440,78 @@ describe("catalog conversions", () => {
       });
     });
 
+    // `id` (Backend's `library.id` serial) and `legacy_release_id` (the
+    // tubafrenzy `LIBRARY_RELEASE_ID` the per-track store is keyed by) are two
+    // disjoint id spaces over the same row. The converter's job here is only to
+    // carry the second one through intact so each downstream path can resolve
+    // in the space it actually needs; nothing about which path reads which
+    // changes yet.
+    //
+    // Every fixture below keeps the two values distinct on purpose. Equal ids
+    // cannot tell a read that resolves in the right space from one that
+    // resolves in the wrong space, which is precisely the failure being
+    // guarded against.
+    describe("legacy_release_id rides alongside library.id", () => {
+      it.each([
+        [
+          "catalog search",
+          { ...catalogSearchRow, legacy_release_id: 45342 },
+          2001,
+          45342,
+        ],
+        [
+          "library-linked rotation",
+          { ...linkedRow, legacy_release_id: 45001 },
+          1001,
+          45001,
+        ],
+      ] as const)(
+        "carries both ids on a %s row",
+        (_source, row, expectedId, expectedLegacy) => {
+          const result = convertToAlbumEntry(row as AlbumSearchResultJSON);
+          expect(result.id).toBe(expectedId);
+          expect(result.legacy_release_id).toBe(expectedLegacy);
+        },
+      );
+
+      it("carries both ids on a bin row", () => {
+        // BinLibraryDetails inner-joins library, so the field is always present
+        // and non-null on a real bin row.
+        const result = convertToAlbumEntry({
+          ...binDetails,
+          legacy_release_id: 45234,
+        } as BinLibraryDetails);
+        expect(result.id).toBe(1234);
+        expect(result.legacy_release_id).toBe(45234);
+      });
+
+      it.each([
+        ["absent", catalogSearchRow],
+        ["explicitly null", { ...catalogSearchRow, legacy_release_id: null }],
+      ] as const)(
+        "resolves an %s legacy_release_id to null, never undefined",
+        (_shape, row) => {
+          const result = convertToAlbumEntry(row as AlbumSearchResultJSON);
+          // `null` and `undefined` are not interchangeable here: an absent
+          // field would make the required property optional in practice, and a
+          // consumer distinguishing "no legacy id" from "field forgotten"
+          // could no longer do so.
+          expect(result.legacy_release_id).toBeNull();
+          expect("legacy_release_id" in result).toBe(true);
+        },
+      );
+
+      it("leaves an unlinked rotation row's legacy_release_id null while its id synthesizes", () => {
+        // 144 of 206 production rotation rows are library-unlinked: the LEFT
+        // JOIN yields no library row, so there is no legacy id to carry. The
+        // synthesized negative `id` is existing behavior and deliberately
+        // untouched here.
+        const result = convertToAlbumEntry(unlinkedRowNullId);
+        expect(result.legacy_release_id).toBeNull();
+        expect(result.id).toBeLessThan(0);
+      });
+    });
+
     describe("end-to-end: rotation pick → mutation submission", () => {
       // Asserts the chain the picker uses (per the #691 forensics):
       //   useGetRotationQuery (rotationApi.transformResponse)

--- a/tests/unit/lib/features/catalog/patchSearchResult.test.ts
+++ b/tests/unit/lib/features/catalog/patchSearchResult.test.ts
@@ -175,6 +175,22 @@ describe("mergeAlbumIntoSearchResult", () => {
     expect(merged.legacy_release_id).toBe(existing.legacy_release_id);
   });
 
+  it("learns a legacy id the cached row is missing", () => {
+    // Both rows are the same library row — the caller finds `existing` by
+    // `updated.id` — so taking the legacy id from the response cannot mix
+    // spaces. Pinning it unconditionally would discard a value the cached row
+    // never had, and every consequence of that is silent: the row's tracklist
+    // read resolves nothing and the picker stays collapsed for as long as the
+    // cache entry lives.
+    const existing = createTestAlbum({ id: 42, legacy_release_id: null });
+    const updated = createTestAlbum({ id: 42, legacy_release_id: 45042 });
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.id).toBe(42);
+    expect(merged.legacy_release_id).toBe(45042);
+  });
+
   it("keeps the id pair coherent on the rotation-only patch branch", () => {
     // The rotation-only branch spreads `existing` wholesale and overrides just
     // the two rotation fields, so both ids ride along from one row. Pinned so a

--- a/tests/unit/lib/features/catalog/patchSearchResult.test.ts
+++ b/tests/unit/lib/features/catalog/patchSearchResult.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { createTestAlbum, createTestArtist } from "@/tests/helpers";
 import { mergeAlbumIntoSearchResult } from "@/lib/features/catalog/patchSearchResult";
+import { Rotation } from "@/lib/features/rotation/types";
 
 describe("mergeAlbumIntoSearchResult", () => {
   it("updates editable fields while preserving search-only metadata", () => {
@@ -157,6 +158,46 @@ describe("mergeAlbumIntoSearchResult", () => {
     const merged = mergeAlbumIntoSearchResult(existing, updated);
 
     expect(merged.discogsUnavailableNote).toBe("embargoed until 2026-09-01");
+  });
+
+  it("keeps the id pair coherent, taking both ids from the cached row", () => {
+    // The merge deliberately pins `id` to the cached row rather than letting
+    // `...updated` supply it. `legacy_release_id` has to be pinned from the
+    // same side or the merged row ends up carrying two id spaces that point at
+    // different releases — this defect, reintroduced through cache merging.
+    // The two rows' legacy ids must differ or the assertion cannot fail.
+    const existing = createTestAlbum({ id: 42, legacy_release_id: 45042 });
+    const updated = createTestAlbum({ id: 42, legacy_release_id: 99999 });
+
+    const merged = mergeAlbumIntoSearchResult(existing, updated);
+
+    expect(merged.id).toBe(existing.id);
+    expect(merged.legacy_release_id).toBe(existing.legacy_release_id);
+  });
+
+  it("keeps the id pair coherent on the rotation-only patch branch", () => {
+    // The rotation-only branch spreads `existing` wholesale and overrides just
+    // the two rotation fields, so both ids ride along from one row. Pinned so a
+    // future edit to that branch can't split them.
+    const existing = createTestAlbum({ id: 42, legacy_release_id: 45042 });
+    const rotationPatch = createTestAlbum({
+      id: 7,
+      legacy_release_id: 99999,
+      title: "",
+      label: "",
+      entry: 0,
+      artist: createTestArtist({ name: "", lettercode: "", numbercode: 0 }),
+      genre_id: undefined,
+      format_id: undefined,
+      rotation_bin: Rotation.H,
+      rotation_id: 5001,
+    });
+
+    const merged = mergeAlbumIntoSearchResult(existing, rotationPatch);
+
+    expect(merged.rotation_bin).toBe(Rotation.H);
+    expect(merged.id).toBe(42);
+    expect(merged.legacy_release_id).toBe(45042);
   });
 
   it("merges albums with empty title fields from LML-only rows", () => {

--- a/tests/unit/lib/features/catalog/patchSearchRotation.test.ts
+++ b/tests/unit/lib/features/catalog/patchSearchRotation.test.ts
@@ -3,6 +3,7 @@ import { patchCatalogSearchRotation } from "@/lib/features/catalog/patchSearchCa
 import { catalogApi } from "@/lib/features/catalog/api";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
 import { createTestAlbum } from "@/tests/helpers";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
 
 describe("patchCatalogSearchRotation", () => {
   afterEach(() => {
@@ -91,6 +92,52 @@ describe("patchCatalogSearchRotation", () => {
         expect(draft.pages[0].results[0].id).toBe(42);
         expect(draft.pages[0].results[0].rotation_bin).toBe("H");
         expect(draft.pages[0].total).toBe(2);
+        return { type: "catalogApi/updateQueryData" } as never;
+      },
+    );
+
+    patchCatalogSearchRotation(
+      dispatch,
+      () => ({} as never),
+      42,
+      { rotation_bin: "H", rotation_id: 99 },
+      album,
+    );
+  });
+
+  it("carries both ids through the inserted row", () => {
+    // The insert path spreads a whole row and overrides only the two rotation
+    // fields, so `id` and `legacy_release_id` ride along together. Pinned
+    // because a row inserted with one id space and not the other resolves in
+    // whichever space the reader happens to pick.
+    const dispatch = vi.fn();
+    const album = createTestAlbum({
+      id: 42,
+      legacy_release_id: 45042,
+      rotation_bin: "H",
+      rotation_id: 99,
+    });
+
+    vi.spyOn(catalogApi.util, "selectCachedArgsForQuery").mockReturnValue([
+      { rotation_bins: "H" },
+    ]);
+
+    vi.spyOn(catalogApi.endpoints.getInformation, "select").mockReturnValue(
+      (() => () => undefined) as unknown as ReturnType<
+        typeof catalogApi.endpoints.getInformation.select
+      >,
+    );
+
+    vi.spyOn(catalogApi.util, "updateQueryData").mockImplementation(
+      (_endpoint, _args, updater) => {
+        const draft = {
+          pages: [
+            { results: [] as AlbumEntry[], total: 0, page: 0, totalPages: 1 },
+          ],
+        };
+        updater(draft);
+        expect(draft.pages[0].results[0].id).toBe(42);
+        expect(draft.pages[0].results[0].legacy_release_id).toBe(45042);
         return { type: "catalogApi/updateQueryData" } as never;
       },
     );

--- a/tests/unit/lib/features/flowsheet/conversions.test.ts
+++ b/tests/unit/lib/features/flowsheet/conversions.test.ts
@@ -770,6 +770,7 @@ describe("flowsheet conversions", () => {
       expect(
         entryToFreezePayload({
           id: 42,
+          legacy_release_id: 45342,
           artist: { name: "Juana Molina" },
           title: "DOGA",
           label: "Sonamos",
@@ -782,6 +783,7 @@ describe("flowsheet conversions", () => {
         album: "DOGA",
         label: "Sonamos",
         album_id: 42,
+        legacy_release_id: 45342,
         rotation_id: 7,
         rotation_bin: "H",
       });
@@ -794,6 +796,7 @@ describe("flowsheet conversions", () => {
         album: "",
         label: "",
         album_id: undefined,
+        legacy_release_id: undefined,
         rotation_id: undefined,
         rotation_bin: undefined,
       });
@@ -831,9 +834,29 @@ describe("flowsheet conversions", () => {
         album: "Edits",
         label: "self-released",
         album_id: 42,
+        legacy_release_id: undefined,
         rotation_id: undefined,
         rotation_bin: undefined,
       });
+    });
+
+    // The two ids travel together but are decided separately: album_id is a
+    // write-path value the caller may withhold, legacy_release_id is a
+    // read-path value that describes which release's tracklist to fetch.
+    it("carries the legacy id for a row that has no library.id", () => {
+      expect(
+        entryToFreezePayload({
+          id: null,
+          legacy_release_id: 45342,
+          artist: { name: "Jessica Pratt" },
+          title: "On Your Own Love Again",
+        })
+      ).toEqual(
+        expect.objectContaining({
+          album_id: undefined,
+          legacy_release_id: 45342,
+        })
+      );
     });
   });
 });

--- a/tests/unit/lib/features/flowsheet/flowsheet.test.ts
+++ b/tests/unit/lib/features/flowsheet/flowsheet.test.ts
@@ -1146,12 +1146,13 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         );
       });
 
-      it("carries a legacy id even when the write half withholds album_id", () => {
-        // A rotation release whose credit submission refuses has its album_id
-        // withheld so BS can't hand the credit back. That is a write-side
-        // decision and says nothing about which tracklist to show, so the read
-        // half must survive it — otherwise picking such a release silently
-        // loses the picker.
+      it("takes each id from its own payload field rather than deriving one from the other", () => {
+        // A row can carry a legacy id without a library link — an LML row is
+        // exactly that shape — and a caller can withhold album_id deliberately.
+        // The reducer must not infer either id's presence from the other's, or
+        // the payload loses a value its caller meant to send. Whether a picker
+        // is then OFFERED is the component's call, made from album_id; this is
+        // only about the reducer carrying what it was handed.
         const result = harness().reduce(
           actions.freezeSelectionToQuery({
             ...frozen,

--- a/tests/unit/lib/features/flowsheet/flowsheet.test.ts
+++ b/tests/unit/lib/features/flowsheet/flowsheet.test.ts
@@ -1072,6 +1072,97 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.search.query.track_position).toBeUndefined();
     });
 
+    // The query carries two ids for the frozen release: album_id (what a
+    // submission writes) and legacy_release_id (what the track picker reads).
+    // They must move together in every reducer that touches either. Leaving a
+    // stale legacy id behind after album_id clears is the worst case — the
+    // picker goes on serving the previous release's tracklist against a query
+    // that no longer references it, and nothing errors.
+    describe("the query's two ids move in lockstep", () => {
+      const frozen = {
+        artist: "Juana Molina",
+        album: "DOGA",
+        label: "Sonamos",
+        artistProvided: true,
+        album_id: 1234,
+        legacy_release_id: 45342,
+      };
+
+      it("freezeSelectionToQuery sets both", () => {
+        const result = harness().reduce(
+          actions.freezeSelectionToQuery(frozen)
+        );
+        expect(result.search.query.album_id).toBe(1234);
+        expect(result.search.query.legacy_release_id).toBe(45342);
+      });
+
+      it.each([
+        [
+          "setRotationMode(false)",
+          () => harness().chain(
+            actions.freezeSelectionToQuery(frozen),
+            actions.setRotationMode(false)
+          ),
+        ],
+        [
+          "resetSearch",
+          () => harness().chain(
+            actions.freezeSelectionToQuery(frozen),
+            actions.resetSearch()
+          ),
+        ],
+        [
+          "a deviating edit to a supplied field",
+          () => harness().chain(
+            actions.freezeSelectionToQuery(frozen),
+            actions.setSearchProperty({
+              name: "artist",
+              value: "Someone Else",
+              deviates: true,
+            })
+          ),
+        ],
+      ])("%s clears both", (_name, run) => {
+        const result = run();
+        expect(result.search.query.album_id).toBeUndefined();
+        expect(result.search.query.legacy_release_id).toBeUndefined();
+      });
+
+      it("setRotationMetadata replaces both", () => {
+        const result = harness().chain(
+          actions.freezeSelectionToQuery(frozen),
+          actions.setRotationMetadata({
+            album_id: TEST_ENTITY_IDS.ALBUM.ROTATION_ALBUM,
+            legacy_release_id: TEST_ENTITY_IDS.LEGACY_RELEASE.ROTATION_ALBUM,
+            rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
+            rotation_bin: "H" as const,
+          })
+        );
+        expect(result.search.query.album_id).toBe(
+          TEST_ENTITY_IDS.ALBUM.ROTATION_ALBUM
+        );
+        expect(result.search.query.legacy_release_id).toBe(
+          TEST_ENTITY_IDS.LEGACY_RELEASE.ROTATION_ALBUM
+        );
+      });
+
+      it("carries a legacy id even when the write half withholds album_id", () => {
+        // A rotation release whose credit submission refuses has its album_id
+        // withheld so BS can't hand the credit back. That is a write-side
+        // decision and says nothing about which tracklist to show, so the read
+        // half must survive it — otherwise picking such a release silently
+        // loses the picker.
+        const result = harness().reduce(
+          actions.freezeSelectionToQuery({
+            ...frozen,
+            album_id: undefined,
+          })
+        );
+        expect(result.search.query.album_id).toBeUndefined();
+        expect(result.search.query.legacy_release_id).toBe(45342);
+      });
+    });
+
     it("should preserve rotation mode across resetSearch", () => {
       const result = harness().chain(
         actions.setRotationMode(true),

--- a/tests/unit/lib/features/lml/lml-conversions.test.ts
+++ b/tests/unit/lib/features/lml/lml-conversions.test.ts
@@ -21,6 +21,7 @@ describe("convertLmlItemToAlbumEntry", () => {
 
     expect(result).toEqual({
       id: 42,
+      legacy_release_id: 42,
       title: "DOGA",
       artist: {
         name: "Juana Molina",
@@ -152,6 +153,18 @@ describe("convertLmlItemToAlbumEntry", () => {
     const item = createTestLmlLibraryItem({ matched_via });
     const result = convertLmlItemToAlbumEntry(item);
     expect(result.matched_via).toEqual(matched_via);
+  });
+
+  it("should carry LmlLibraryItem.id into legacy_release_id", () => {
+    // LML's `library.db` is keyed by the tubafrenzy LIBRARY_RELEASE_ID, so the
+    // `id` it returns is a `legacy_release_id`, not a Backend `library.id`.
+    // Populating the field it actually belongs in is this change; `id` keeps
+    // its current value for now, so an LML row is the one source where the two
+    // spaces legitimately coincide.
+    const item = createTestLmlLibraryItem({ id: 45342 });
+    const result = convertLmlItemToAlbumEntry(item);
+    expect(result.legacy_release_id).toBe(45342);
+    expect(result.id).toBe(45342);
   });
 
   it("should always set rotation_bin, rotation_id, plays, and add_date to undefined", () => {


### PR DESCRIPTION
Part 2 of 4 for #1184. **Does not close it** — this fixes the read half. **Stacked on #1207**; base retargets to `main` once that merges.

> [!IMPORTANT]
> This is the PR that fixes the silent 87.7%. It is also the one whose failure mode is invisible: every path it touches returns a 200 today and will return a 200 after, so nothing here can be verified by "does it error".

## The bug, restated from the source

`GET /proxy/library/:libraryId/tracks` resolves its path param with `getDiscogsReleaseIdByLegacyId`, which is:

```ts
.from(library)
.innerJoin(library_identity, eq(library_identity.library_id, library.id))
.where(eq(library.legacy_release_id, legacyId))   // <-- the id space
```

The URL segment is named `libraryId`, and dj-site passed `AlbumEntry.id` — which for catalog, bin, and linked-rotation rows is Backend's `library.id` serial. Wrong space. And because the two spaces are nearly coextensive (`library.id` spans 1–70,484; `legacy_release_id` 1–72,286), the lookup **almost never misses** — it lands on a real, unrelated release and returns its tracklist under a 200. 87.7% of production library rows resolve to a different row in the opposite space; 3 resolve to themselves.

## What moved

**4a — prefetch gate and argument, together.** `hasLinkedAlbumId(entry.legacy_release_id)` gating `prefetchTracks(entry.legacy_release_id)`. Moving only the argument would leave the gate keyed on `id`, which stops the prefetch firing for rows carrying no `library.id`; moving only the gate would warm a cache entry the picker never reads. They are the same RTK Query cache key, so they are one edit.

**4b — `effectiveAlbumId` split in two.** It fused a read-path value (`highlightedResult.id`) with a write-path one (`searchQuery.album_id`). Now:

- `tracklistReleaseId` — *which release's tracklist*. Resolves in the legacy space. Drives the query and the manual-override key.
- `linkedAlbumId` — *is this row library-linked at all*. Stays `library.id`. Only decides whether a picker is offered, preserving the existing behavior of hiding it for unlinked rows whose picked `track_position` the submission chokepoint discards.

**Two questions, but one row answers both.** The first cut of this split let each id fall back from the highlighted row to the frozen query *on its own*, which is wrong in a way the split itself creates: a frozen release outlives the highlight that set it, so a row answering only one of the two questions let the other reach past it into the earlier release. Both ids now resolve from a single `idSource` — the highlighted row when there is one, **including when its answer is "no"**, and the frozen query only when there is no highlight at all.

That mattered immediately. Click a linked release, then arrow onto a library-unlinked row: unlinked rows carry a synthesized negative id and no legacy id, so under independent fallback *both* questions fell through to the frozen release and the picker was offered over a row whose pick the submission boundary then discards — the exact outcome `showPickerRow` exists to prevent, on the ~70% of rotation rows that are unlinked. The other direction is worse and rarer: a row with a real `library.id` but no legacy id would show the frozen release's tracklist under its own highlight, and a pick from it rides out as *this* row's `album_id` paired with *that* release's `track_position`. Both halves are individually well-formed, so `convertQueryToSubmission` passes it straight through.

**The frozen query carries the legacy id.** The dominant flow is click the release, *then* pick the track — and the click zeroes the highlight, so there is no result row left to read from. `FlowsheetQuery` gains `legacy_release_id`, emitted by `entryToFreezePayload`, and it moves in lockstep with `album_id` in **every** reducer that sets or clears either: the default query, `setRotationMode(false)`, `setRotationMetadata`, the deviation branch of `setSearchProperty`, and `freezeSelectionToQuery`. `resetSearch` inherits it by replacing the whole query object.

Lockstep is the load-bearing part. A stale legacy id left behind after `album_id` clears keeps the picker serving the *previous* release's tracklist against a query that no longer references it — and nothing about that combination is invalid, so nothing would surface it.

**4c/4d — the id space made legible at the boundary.** `useLibraryTrackPicker(legacyReleaseId)` and the `getLibraryTracks` endpoint's parameter renamed off `libraryId`, with the id-space note on the endpoint definition where every caller passes through. The endpoint name itself is unchanged — the URL really is `/library/:id/tracks`, and renaming it would churn `useGetLibraryTracksQuery` across specs for no semantic gain.

## The withheld `album_id`, and a rationale that didn't hold

`RotationEntryFields` withholds `album_id` for a release whose credit submission refuses, so Backend can't hand that credit back on the write. The legacy id is still assigned there — but the reason first given for that, in both a code comment and a test name, was wrong on its own terms: it claimed gating the legacy id on the withholding "would drop the picker for exactly the releases whose credit is refused." It wouldn't. `showPickerRow` gates on `album_id`, so a withheld `album_id` already hides the picker row; and `showPickerRow` also requires `!rotationMode`, while `setRotationMetadata` only ever fires from rotation UI. The value could not reach a picker by either route.

The reason that does hold is the reducer's: `setRotationMetadata` overwrites the query's album linkage **wholesale**, so omitting the legacy id would leave the *previous* selection's standing beside the new `album_id` — the one way that pair can come to describe two releases. Comment and test name now say that instead.

Its one real consequence was a request per rotation pick with nowhere to land, since `useLibraryTrackPicker` skips only on `null`. The tracklist query is now gated on the picker row rendering at all, which is the honest statement of when those tracks have a consumer.

## Why this is safe to land before part 3

An LML row carries the **same value** in `id` and `legacy_release_id` after #1207 (part 3 is what sets `id: null`). So LML — the one source whose picker works today — resolves identically before and after this PR, while catalog, bin, and linked rotation start resolving correctly. That is the whole 87.7%, with no dependency on the risky null.

The two existing Playwright picker cases source their release from the library-search proxy, where the ids coincide, and both still pass unchanged. That is the property, not a coincidence.

## Verification

Tests and implementation landed in one pass here, so both fixes were **verified by mutation** rather than by a red-then-green transcript:

| Mutation | Result |
|---|---|
| 4a prefetch reverted to `entry.id` | **3 tests red** |
| 4b read half reverted to `id` / `album_id` | **3 tests red** |
| tracklist query ungated from `showPickerRow` | **1 test red** |

The two straddle cases went the other way — written first against the independent-fallback code and confirmed red there, then fixed.

All checks below were re-run **after** rebasing onto #1207's updated head, not before:

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | exit 0 — **0 errors, 195 warnings** (unchanged) |
| `npm run test:run` | **4682 passed / 4682**, 327 files (4667 on #1207; +15) |
| `npm run build` | success |

One run of the suite reported a single failure — a 5057ms timeout in `VaTracklistStep.test.tsx`, a catalog spec this branch doesn't touch — which passes on its own and passed in the clean full run. Recorded rather than dropped, since it and #1207's contended run are the same machine-load artifact.

## New tests

**`FlowsheetBackendResult.test.tsx`** — `id`, `legacy_release_id`, and `index` are three distinct values, so the assertion can tell the right field from either plausible wrong one. Plus: a row with no `library.id` must still prefetch; an unlinked row (negative id, null legacy) must not; a linked row with a null legacy id must not fall back to `id`.

**`FlowsheetSearchResults.test.tsx`** — stubs **both** id spaces with distinguishable tracklists and asserts which one arrives. Stubbing only the correct id would let a wrong-space read fail as an unstubbed request, which surfaces as a collapsed picker rather than the wrong answer it actually is. Covers the highlighted-row path, the post-click frozen path, and the null-legacy degradation.

**`FlowsheetSearchResults.test.tsx`, the straddle cases** — both drive the real sequence (freeze a release, *then* move the highlight) rather than seeding a pre-straddled state, and both settle on the frozen release's populated picker first, so the collapse they assert is the highlight taking effect and not a query that never resolved. A synchronous negative assertion would have passed against the broken code. The rotation-mode case counts requests and then proves the counter can move, by re-rendering the same query state outside rotation mode and asserting it does fetch.

**`flowsheet.test.ts`** — parameterized over every reducer that clears the pair, plus the two that set it, plus the case where a caller supplies one id without the other (an LML row's shape, and what `RotationEntryFields` does deliberately). That last one asserts what the reducer carries, not what the UI offers — the earlier name claimed the latter.

**Playwright — the case that could not have been caught before.** Both existing picker specs stub catalog search to `[]`, so the 87.7% case was entirely unverified end-to-end. The new case sources from the card catalog, where the two ids genuinely differ, stubs both spaces with different tracklists, and asserts the picker shows the clicked release's. Its result row is located by content rather than index, since bin and rotation are not mocked and a seeded row would otherwise shift the position and silently click the wrong release.

**MSW** — `mockLibraryTracksResponse` extracted to `tests/fakes/libraryTracks.ts` and consumed by both specs, per the issue's note. Deliberately *not* added to the base `handlers` set (that file is the empty-default base; the repo pattern is per-spec `server.use`), and not imported across a `.test.tsx`, which has no precedent here.

## Scope note

The issue's test plan groups all Playwright work together. I moved the **catalog-sourced case** here rather than to part 3, because it verifies *this* PR's fix; the `album_id` → freeform flip stays in part 3, where the change that causes it lives.

Items **5, 6, 7, 8, 10** and item 3's `id: null` half are untouched and remain parts 3 and 4. `isCommitted` still compares on `id`, which is correct while `id` is still populated.

## Merge gates

Unchanged from #1207 and satisfied — see [the gate-1 evidence on #1184](https://github.com/WXYC/dj-site/issues/1184#issuecomment-5295942661). This PR is the one that genuinely depends on gate 1: it reads a field the running Backend must already emit, and if that field were absent the picker would collapse to free text for three of the four sources. The prod probe confirmed presence on all of them (`/library` 45/45, `/library/info` 1/1, `/library/rotation` 206/206, bin via Backend CI).

## Related

Epic #1179 · #1184 (parent) · #1207 (part 1, this PR's base) · WXYC/Backend-Service#2128 (the emitter) · #1196 (will converge the linkage predicates this PR now calls from a read path)
