### PR TITLE
Add classic code-miss create screen (createLibraryCode.jsp)

### DIFF
--- a/app/dashboard/@classic/library/artist/new/page.tsx
+++ b/app/dashboard/@classic/library/artist/new/page.tsx
@@ -1,0 +1,45 @@
+import { Metadata } from "next";
+import { getPageTitle } from "@/lib/utils/page-title";
+import { requireAuth, requireRole } from "@/lib/features/authentication/server-utils";
+import { Authorization } from "@/lib/features/admin/types";
+import Main from "@/src/components/experiences/classic/Layout/Main";
+import CreateLibraryCodeForm from "@/src/components/experiences/classic/catalog/CreateLibraryCodeForm";
+import { firstSearchParam } from "@/lib/utils/search-params";
+
+export const metadata: Metadata = {
+  title: getPageTitle("Create Library Code"),
+};
+
+type ClassicCreateLibraryCodePageProps = {
+  searchParams: Promise<{
+    genre_id?: string | string[];
+    code_letters?: string | string[];
+    code_number?: string | string[];
+  }>;
+};
+
+/**
+ * Reproduces `createLibraryCode.jsp`: the miss branch of
+ * `findOrCreateLibraryCode` (`ArtistAdminServlet:161`). URL-reachable on its
+ * own route, taking the code that missed as query params, ahead of
+ * WXYC/dj-site#1198 wiring the chooser's no-match branch into it. Not linked
+ * in nav -- see `isClassicLibrarianNavEnabled`.
+ */
+export default async function ClassicCreateLibraryCodePage({
+  searchParams,
+}: ClassicCreateLibraryCodePageProps) {
+  const session = await requireAuth();
+  await requireRole(session, Authorization.MD);
+
+  const params = await searchParams;
+
+  return (
+    <Main>
+      <CreateLibraryCodeForm
+        genreIdRaw={firstSearchParam(params.genre_id) ?? ""}
+        codeLetters={firstSearchParam(params.code_letters) ?? ""}
+        codeNumberRaw={firstSearchParam(params.code_number) ?? ""}
+      />
+    </Main>
+  );
+}

--- a/app/dashboard/@classic/library/artist/new/page.tsx
+++ b/app/dashboard/@classic/library/artist/new/page.tsx
@@ -21,9 +21,9 @@ type ClassicCreateLibraryCodePageProps = {
 /**
  * Reproduces `createLibraryCode.jsp`: the miss branch of
  * `findOrCreateLibraryCode` (`ArtistAdminServlet:161`). URL-reachable on its
- * own route, taking the code that missed as query params, ahead of
- * WXYC/dj-site#1198 wiring the chooser's no-match branch into it. Not linked
- * in nav -- see `isClassicLibrarianNavEnabled`.
+ * own route, taking the code that missed as query params, ahead of the
+ * chooser's no-match branch being wired into it. Not linked in nav -- see
+ * `isClassicLibrarianNavEnabled`.
  */
 export default async function ClassicCreateLibraryCodePage({
   searchParams,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ These reproduce tubafrenzy's `/wxycdb` screens. They are **classic-first**: the 
 | URL | Screen | `/wxycdb` source | Authority |
 |---|---|---|---|
 | `/dashboard/library` | Entry: artist vs. Various Artists, multi-match disambiguation | `chooseLibraryCodeOrArtist.jsp`, `multipleArtistsDisplay.jsp` | MD |
-| `/dashboard/library/artist/new` | Create artist + library code | `createArtist.jsp`, `createLibraryCode.jsp` | MD |
+| `/dashboard/library/artist/new` | Code-miss create screen: genre/letters/numbers carried read-only from the miss branch, only the two name fields editable | `createLibraryCode.jsp` | MD |
 | `/dashboard/library/artist/[id]` | Artist card + its release list | `artistCardModify.jsp` | MD |
 | `/dashboard/library/various/[id]` | V/A bucket card, `albumArtist`, per-track credits | `variousArtistsCardModify.jsp` | MD |
 | `/dashboard/library/release/[id]` | Release edit | `libraryReleaseModify.jsp` | MD |
@@ -88,6 +88,8 @@ These reproduce tubafrenzy's `/wxycdb` screens. They are **classic-first**: the 
 | `/dashboard/rotation/[id]/import` | Import rotation release into the library | `rotationReleaseImport.jsp`, `rotationReleaseImportNewArtist.jsp` | MD |
 
 Naming follows `/wxycdb`'s own directory split (`libraryAdmin/`, `rotation/`) rather than nesting under `/dashboard/catalog`, which would collide confusingly with the unrelated modern `/dashboard/admin/catalog` (format + genre admin).
+
+`createArtist.jsp` is deliberately absent from this table: `ArtistAdminServlet:250` renders it only as the post-*delete* restore screen ("you may restore the artist by clicking 'Add!'"), not a creation step, so no row here owns it. It travels with artist delete if a slice ever picks that up.
 
 ### Authority is per screen
 

--- a/src/components/experiences/classic/catalog/CreateLibraryCodeForm.tsx
+++ b/src/components/experiences/classic/catalog/CreateLibraryCodeForm.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useId } from "react";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAddArtistMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
+import { validateNewArtistNames } from "@/lib/features/catalog/chooserValidation";
+import {
+  isAddArtistConflict,
+  isArtistNameConflictData,
+  parseRequiredPositiveInt,
+} from "@/lib/features/catalog/adminCreateArtistValidation";
+import { isGenresUnavailable } from "@/lib/features/catalog/genreAvailability";
+import type { AddArtistRequestBody } from "@/lib/features/catalog/types";
+
+type CreateLibraryCodeFormProps = {
+  genreIdRaw: string;
+  codeLetters: string;
+  codeNumberRaw: string;
+};
+
+const INTERIM_SUCCESS_DESTINATION = "/dashboard/library";
+
+/**
+ * Reproduces `createLibraryCode.jsp`: the miss branch of
+ * `findOrCreateLibraryCode` (`ArtistAdminServlet:161`) -- genre, letters, and
+ * numbers arrive fixed from the miss branch and are read-only here; only the
+ * two name fields are editable, matching the JSP's field order, labels, and
+ * "Add!"/"Reset" button labels.
+ *
+ * Divergences from the JSP, both forced and both enumerated in the PR:
+ * - The dead `Z_` V/A auto-naming branch (`:26`, testing an underscore the
+ *   servlet's own prefix `Z-` never produces) is not reproduced -- see
+ *   NewArtistForm's header for the same call.
+ * - The JSP's successful submit lands on the artist card
+ *   (`goToArtistModifyCard`). That page doesn't exist yet (WXYC/dj-site#1166
+ *   is deploy-gated), so this interim build lands where the chooser's own
+ *   create path already lands today -- `/dashboard/library` -- and will move
+ *   to the card once 1166 ships.
+ *
+ * Genre display follows `isGenresUnavailable`'s convention: an unissued or
+ * failed genres request renders an explicit unavailable state, never a blank
+ * or a guessed name, even though `genreIdRaw` itself came from the URL and
+ * needs no selection here.
+ */
+export default function CreateLibraryCodeForm({
+  genreIdRaw,
+  codeLetters,
+  codeNumberRaw,
+}: CreateLibraryCodeFormProps) {
+  const presentationNameId = useId();
+  const alphabeticalNameId = useId();
+  const router = useRouter();
+
+  const genresQuery = useGetGenresQuery();
+  const {
+    data: genres,
+    isFetching: genresFetching,
+    refetch: refetchGenres,
+  } = genresQuery;
+  const genresUnavailable = isGenresUnavailable(genresQuery);
+  const [addArtist, { isLoading }] = useAddArtistMutation();
+
+  const [presentationName, setPresentationName] = useState("");
+  const [alphabeticalName, setAlphabeticalName] = useState("");
+  const [validationMessage, setValidationMessage] = useState<string | null>(null);
+
+  const genreId = parseRequiredPositiveInt(genreIdRaw);
+  const codeNumber = parseRequiredPositiveInt(codeNumberRaw);
+  const upperCodeLetters = codeLetters.trim().toUpperCase();
+  const codeIncomplete = genreId == null || upperCodeLetters === "" || codeNumber == null;
+
+  const genreName = genres?.find((genre) => genre.id === genreId)?.genre_name;
+
+  const resetFields = () => {
+    setPresentationName("");
+    setAlphabeticalName("");
+    setValidationMessage(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (codeIncomplete) {
+      setValidationMessage(
+        "This link is missing genre, call letters, or call number information.",
+      );
+      return;
+    }
+
+    const nameResult = validateNewArtistNames(presentationName, alphabeticalName);
+    if (!nameResult.valid) {
+      setValidationMessage(nameResult.message);
+      return;
+    }
+
+    // See isGenresUnavailable's doc for the cached-list trap: `genreId`
+    // already carries a valid id from the URL, but the outage banner is the
+    // one place that announces the backend is down, and a submit that
+    // slipped past it would file silently against a genre the librarian
+    // cannot currently be shown the name of.
+    if (genresUnavailable) {
+      return;
+    }
+
+    setValidationMessage(null);
+
+    const body: AddArtistRequestBody = {
+      artist_name: presentationName.trim(),
+      alphabetical_name: alphabeticalName.trim(),
+      code_letters: upperCodeLetters,
+      genre_id: genreId as number,
+      code_number: codeNumber as number,
+    };
+
+    try {
+      await addArtist(body).unwrap();
+      router.push(INTERIM_SUCCESS_DESTINATION);
+    } catch (err) {
+      // Same discriminant as NewArtistForm's addArtist rejection handling:
+      // a taken (code_letters, genre_id, code_number) triple is fixed by
+      // picking a different code, but a genre-scoped artist-name match means
+      // the artist already exists -- no code choice fixes that.
+      if (isAddArtistConflict(err)) {
+        setValidationMessage(
+          isArtistNameConflictData(err.data)
+            ? `${err.data.artist.artist_name} already exists in this genre. File under the existing artist instead of picking a different code.`
+            : `${err.data.artist.artist_name} already holds that library code.`,
+        );
+      } else {
+        setValidationMessage("Failed to add artist.");
+      }
+    }
+  };
+
+  return (
+    <div data-testid="create-library-code-form">
+      <div style={{ textAlign: "center" }}>
+        <h3>
+          This library code does not currently exist in the database. To create it, you need to
+          associate it with an artist (new or existing) and click &apos;Add!&apos;.
+        </h3>
+      </div>
+      <form name="newArtistForm" onSubmit={handleSubmit}>
+        <table cellPadding={5}>
+          <tbody>
+            <tr>
+              <td />
+              <td>
+                <b>Add a Library Code to The Database:</b>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Genre:</b>
+              </td>
+              <td>
+                {genresUnavailable ? (
+                  <span role="alert" className="artist-error-message">
+                    Genres are unavailable, so this code can&apos;t be filed right now.{" "}
+                    <button
+                      type="button"
+                      disabled={genresFetching}
+                      onClick={() => refetchGenres()}
+                    >
+                      Try again
+                    </button>
+                  </span>
+                ) : (
+                  (genreName ?? "—")
+                )}
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Artist Letters:</b>
+              </td>
+              <td>{upperCodeLetters || "—"}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Artist Numbers:</b>
+              </td>
+              <td>{codeNumberRaw || "—"}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <label htmlFor={presentationNameId}>
+                  <b>Artist Presentation Name:</b>
+                </label>
+              </td>
+              <td>
+                <input
+                  id={presentationNameId}
+                  type="text"
+                  value={presentationName}
+                  disabled={isLoading}
+                  onChange={(e) => setPresentationName(e.target.value)}
+                  size={35}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <label htmlFor={alphabeticalNameId}>
+                  <b>Artist Alphabetical Name:</b>
+                </label>
+              </td>
+              <td>
+                <input
+                  id={alphabeticalNameId}
+                  type="text"
+                  value={alphabeticalName}
+                  disabled={isLoading}
+                  onChange={(e) => setAlphabeticalName(e.target.value)}
+                  size={35}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td />
+              <td>
+                <div
+                  className={`validation-message${validationMessage ? " visible" : ""}`}
+                  role={validationMessage ? "alert" : undefined}
+                >
+                  {validationMessage}
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td />
+              <td>
+                <input type="submit" value="Add!" disabled={isLoading} />
+                <input type="reset" value="Reset" onClick={resetFields} disabled={isLoading} />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+    </div>
+  );
+}

--- a/src/components/experiences/classic/catalog/CreateLibraryCodeForm.tsx
+++ b/src/components/experiences/classic/catalog/CreateLibraryCodeForm.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useId } from "react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAddArtistMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
 import { validateNewArtistNames } from "@/lib/features/catalog/chooserValidation";
@@ -21,6 +20,16 @@ type CreateLibraryCodeFormProps = {
 
 const INTERIM_SUCCESS_DESTINATION = "/dashboard/library";
 
+// The heading is the servlet's message, and it has two forms
+// (`ArtistAdminServlet:152-155`): a Various Artists code -- call letters
+// prefixed `Z-`, which is what the chooser's compilation mode builds -- gets
+// the shorter wording, because for those the librarian is filing a shelf
+// bucket rather than associating a named artist.
+const VARIOUS_ARTISTS_HEADING =
+  "This 'Various Artists' library code does not currently exist in the database. To create it, click 'Add!'";
+const ARTIST_HEADING =
+  "This library code does not currently exist in the database. To create it, you need to associate it with an artist (new or existing) and click 'Add!'.";
+
 /**
  * Reproduces `createLibraryCode.jsp`: the miss branch of
  * `findOrCreateLibraryCode` (`ArtistAdminServlet:161`) -- genre, letters, and
@@ -28,15 +37,21 @@ const INTERIM_SUCCESS_DESTINATION = "/dashboard/library";
  * two name fields are editable, matching the JSP's field order, labels, and
  * "Add!"/"Reset" button labels.
  *
- * Divergences from the JSP, both forced and both enumerated in the PR:
+ * Deliberate divergences from the JSP:
  * - The dead `Z_` V/A auto-naming branch (`:26`, testing an underscore the
  *   servlet's own prefix `Z-` never produces) is not reproduced -- see
- *   NewArtistForm's header for the same call.
+ *   NewArtistForm's header for the same call. The servlet's *live* V/A
+ *   handling is reproduced: `Z-` letters get their own heading.
+ * - The servlet forwards no `artistNumbers` on its V/A branch and
+ *   `processAddArtistLibraryCode` skips call numbers for `Z-` entirely, so
+ *   `/wxycdb` files V/A codes with no number at all. `POST /library/artists`
+ *   requires `code_number`, so a V/A code is filed here with the number it
+ *   carried -- and a V/A link that carries none is refused rather than filed
+ *   incomplete.
  * - The JSP's successful submit lands on the artist card
- *   (`goToArtistModifyCard`). That page doesn't exist yet (WXYC/dj-site#1166
- *   is deploy-gated), so this interim build lands where the chooser's own
- *   create path already lands today -- `/dashboard/library` -- and will move
- *   to the card once 1166 ships.
+ *   (`goToArtistModifyCard`), which does not exist here yet, so this interim
+ *   build lands where the chooser's own create path already lands today --
+ *   `/dashboard/library` -- and moves to the card once that screen ships.
  *
  * Genre display follows `isGenresUnavailable`'s convention: an unissued or
  * failed genres request renders an explicit unavailable state, never a blank
@@ -68,9 +83,36 @@ export default function CreateLibraryCodeForm({
   const genreId = parseRequiredPositiveInt(genreIdRaw);
   const codeNumber = parseRequiredPositiveInt(codeNumberRaw);
   const upperCodeLetters = codeLetters.trim().toUpperCase();
-  const codeIncomplete = genreId == null || upperCodeLetters === "" || codeNumber == null;
+  const heading = upperCodeLetters.startsWith("Z-") ? VARIOUS_ARTISTS_HEADING : ARTIST_HEADING;
+
+  // Which part of the carried code is unusable, so the refusal can name it.
+  // The rows below display these values verbatim like the JSP does, so a
+  // message that says "missing" about a value the librarian is looking at
+  // reads as a broken screen rather than a malformed link.
+  const codeProblem =
+    genreId == null
+      ? genreIdRaw.trim() === ""
+        ? "This link carries no genre."
+        : `This link's genre (${genreIdRaw}) is not a genre id.`
+      : upperCodeLetters === ""
+        ? "This link carries no call letters."
+        : codeNumber == null
+          ? codeNumberRaw.trim() === ""
+            ? "This link carries no call number."
+            : `This link's call number (${codeNumberRaw}) is not a whole number above zero.`
+          : null;
 
   const genreName = genres?.find((genre) => genre.id === genreId)?.genre_name;
+  // Absent from a list that did load: the id is real enough to parse but names
+  // no genre this client knows about. Distinct from the outage and from a
+  // missing param -- filing anyway would put the release under a genre the
+  // librarian was never shown, and library codes carry no unique constraint
+  // to catch it afterwards.
+  // Only meaningful once the id itself parsed: a malformed link is a
+  // different refusal, and it keeps Add! enabled so the click produces the
+  // message naming what is wrong rather than a mute disabled button.
+  const genreUnresolved =
+    genreId != null && !genresUnavailable && genres != null && genreName == null;
 
   const resetFields = () => {
     setPresentationName("");
@@ -81,10 +123,8 @@ export default function CreateLibraryCodeForm({
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (codeIncomplete) {
-      setValidationMessage(
-        "This link is missing genre, call letters, or call number information.",
-      );
+    if (codeProblem != null) {
+      setValidationMessage(codeProblem);
       return;
     }
 
@@ -98,8 +138,11 @@ export default function CreateLibraryCodeForm({
     // already carries a valid id from the URL, but the outage banner is the
     // one place that announces the backend is down, and a submit that
     // slipped past it would file silently against a genre the librarian
-    // cannot currently be shown the name of.
-    if (genresUnavailable) {
+    // cannot currently be shown the name of. Clearing first keeps a message
+    // from an earlier attempt from standing beside fields that have since
+    // been corrected.
+    if (genresUnavailable || genreUnresolved) {
+      setValidationMessage(null);
       return;
     }
 
@@ -136,13 +179,10 @@ export default function CreateLibraryCodeForm({
   return (
     <div data-testid="create-library-code-form">
       <div style={{ textAlign: "center" }}>
-        <h3>
-          This library code does not currently exist in the database. To create it, you need to
-          associate it with an artist (new or existing) and click &apos;Add!&apos;.
-        </h3>
+        <h3>{heading}</h3>
       </div>
       <form name="newArtistForm" onSubmit={handleSubmit}>
-        <table cellPadding={5}>
+        <table cellPadding={5} style={{ margin: "0 auto" }}>
           <tbody>
             <tr>
               <td />
@@ -166,8 +206,21 @@ export default function CreateLibraryCodeForm({
                       Try again
                     </button>
                   </span>
+                ) : genreUnresolved ? (
+                  <span role="alert" className="artist-error-message">
+                    No genre in the catalog has id {genreIdRaw}, so this code can&apos;t be filed.
+                  </span>
+                ) : genreName != null ? (
+                  genreName
+                ) : genreId == null ? (
+                  // The link never carried a usable genre; submitting says so
+                  // precisely, so the row just shows what did arrive.
+                  genreIdRaw.trim() || "—"
                 ) : (
-                  (genreName ?? "—")
+                  // Still in flight. Naming the pending state keeps it from
+                  // reading as "this code has no genre", which is a different
+                  // screen with a different outcome.
+                  <span>Loading…</span>
                 )}
               </td>
             </tr>
@@ -231,7 +284,14 @@ export default function CreateLibraryCodeForm({
             <tr>
               <td />
               <td>
-                <input type="submit" value="Add!" disabled={isLoading} />
+                {/* Disabled while the code can't be filed, so the button
+                    never absorbs a click without saying anything -- the
+                    banner beside Genre is the explanation in both cases. */}
+                <input
+                  type="submit"
+                  value="Add!"
+                  disabled={isLoading || genresUnavailable || genreUnresolved}
+                />
                 <input type="reset" value="Reset" onClick={resetFields} disabled={isLoading} />
               </td>
             </tr>

--- a/tests/integration/app/dashboard/@classic/library/artist/new/page.test.tsx
+++ b/tests/integration/app/dashboard/@classic/library/artist/new/page.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, vi } from "vitest";
+import {
+  setUpClassicPageAuthority,
+  setUpClassicPageAuthorityEnv,
+  assertReachesClassicPage,
+  assertDeniedClassicPage,
+} from "@/tests/helpers/classic-page-authority-harness";
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/headers", async () => {
+  const { classicPageAuthorityHeadersMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityHeadersMock();
+});
+vi.mock("next/navigation", async () => {
+  const { classicPageAuthorityNavigationMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityNavigationMock();
+});
+vi.mock("@/lib/features/authentication/server-client", async () => {
+  const { classicPageAuthorityServerClientMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityServerClientMock();
+});
+vi.mock("@/lib/features/authentication/organization-utils.server", async () => {
+  const { classicPageAuthorityOrganizationUtilsMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityOrganizationUtilsMock();
+});
+
+// The page's own responsibility under test is the auth gate, not the form's
+// RTK Query-backed content.
+vi.mock("@/src/components/experiences/classic/Layout/Main", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="classic-main">{children}</div>,
+}));
+vi.mock("@/src/components/experiences/classic/catalog/CreateLibraryCodeForm", () => ({
+  default: () => <div data-testid="create-library-code-form" />,
+}));
+
+import ClassicCreateLibraryCodePage from "@/app/dashboard/@classic/library/artist/new/page";
+
+const searchParams = Promise.resolve({
+  genre_id: "3",
+  code_letters: "mo",
+  code_number: "12",
+});
+
+describe("classic /dashboard/library/artist/new page — createLibraryCode.jsp's miss branch", () => {
+  setUpClassicPageAuthorityEnv();
+
+  it.each([
+    { role: "musicDirector" as const, label: "a music director" },
+    { role: "stationManager" as const, label: "a station manager" },
+  ])("reaches the page for $label", async ({ role }) => {
+    setUpClassicPageAuthority(role);
+
+    await assertReachesClassicPage(
+      () => ClassicCreateLibraryCodePage({ searchParams }),
+      "classic-main",
+      "create-library-code-form",
+    );
+  });
+
+  it("redirects a DJ away from the code-miss create screen", async () => {
+    setUpClassicPageAuthority("dj");
+
+    await assertDeniedClassicPage(() => ClassicCreateLibraryCodePage({ searchParams }));
+  });
+
+  it("never grants access from the admin-plugin role column, even when it holds a WXYC tier string", async () => {
+    setUpClassicPageAuthority(undefined, "musicDirector");
+
+    await assertDeniedClassicPage(() => ClassicCreateLibraryCodePage({ searchParams }));
+  });
+
+  it("bounces an unauthenticated visitor to login, not to the dashboard home", async () => {
+    setUpClassicPageAuthority("unauthenticated");
+
+    await assertDeniedClassicPage(() => ClassicCreateLibraryCodePage({ searchParams }), "/login?bounced=no-session");
+  });
+});

--- a/tests/integration/components/classic/catalog/CreateLibraryCodeForm.test.tsx
+++ b/tests/integration/components/classic/catalog/CreateLibraryCodeForm.test.tsx
@@ -1,0 +1,265 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
+
+// The real better-auth client installs listeners whose teardown is deferred a
+// second past the last subscriber; a short file finishes inside that second.
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import(
+    "@/tests/helpers/auth-client-mock"
+  );
+  return {
+    ...createAuthClientModuleMock(),
+    getJWTToken: vi.fn(async () => "test-token"),
+  };
+});
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+import CreateLibraryCodeForm from "@/src/components/experiences/classic/catalog/CreateLibraryCodeForm";
+
+const GENRE_ID = 3;
+
+function mockGenres(
+  genres: { id: number; genre_name: string }[] = [{ id: GENRE_ID, genre_name: "Blues" }],
+) {
+  server.use(http.get(`${TEST_BACKEND_URL}/library/genres`, () => HttpResponse.json(genres)));
+}
+
+function mockAddArtist(
+  respond: (body: unknown) => Response | Promise<Response>,
+): { getBodies: () => unknown[] } {
+  const bodies: unknown[] = [];
+  server.use(
+    http.post(`${TEST_BACKEND_URL}/library/artists`, async ({ request }) => {
+      const body = await request.json();
+      bodies.push(body);
+      return respond(body);
+    }),
+  );
+  return { getBodies: () => bodies };
+}
+
+function created(overrides: Record<string, unknown> = {}) {
+  return HttpResponse.json(
+    {
+      id: 99,
+      artist_name: "Juana Molina",
+      code_letters: "MO",
+      code_number: 12,
+      genre_id: GENRE_ID,
+      ...overrides,
+    },
+    { status: 201 },
+  );
+}
+
+const defaultProps = {
+  genreIdRaw: String(GENRE_ID),
+  codeLetters: "mo",
+  codeNumberRaw: "12",
+};
+
+describe("classic CreateLibraryCodeForm — createLibraryCode.jsp", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockGenres();
+  });
+
+  it("renders tubafrenzy's field order and labels, read-only except the two name fields", async () => {
+    renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+
+    expect(
+      await screen.findByText(/does not currently exist in the database/i),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Blues")).toBeInTheDocument();
+    expect(screen.getByText("MO")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByLabelText(/artist presentation name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/artist alphabetical name/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add!" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reset" })).toBeInTheDocument();
+  });
+
+  it("uppercases the carried call letters for display and submission", async () => {
+    mockAddArtist(() => created());
+    const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+
+    await screen.findByText("MO");
+    await user.type(screen.getByLabelText(/artist presentation name/i), "Juana Molina");
+    await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
+    await user.click(screen.getByRole("button", { name: "Add!" }));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/dashboard/library"));
+  });
+
+  it("shows the JSP's exact validation message when the presentation name is empty", async () => {
+    const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+    await screen.findByText("Blues");
+    await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
+
+    await user.click(screen.getByRole("button", { name: "Add!" }));
+
+    expect(await screen.findByText("The presentation name cannot be empty.")).toBeInTheDocument();
+  });
+
+  it("shows the JSP's exact validation message when the alphabetical name is empty", async () => {
+    const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+    await screen.findByText("Blues");
+    await user.type(screen.getByLabelText(/artist presentation name/i), "Juana Molina");
+
+    await user.click(screen.getByRole("button", { name: "Add!" }));
+
+    expect(await screen.findByText("The alphabetical name cannot be empty.")).toBeInTheDocument();
+  });
+
+  it("submits POST /library/artists with the carried code and typed names, then lands where the chooser's create path lands today", async () => {
+    const { getBodies } = mockAddArtist(() => created());
+    const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+
+    await screen.findByText("Blues");
+    await user.type(screen.getByLabelText(/artist presentation name/i), "Juana Molina");
+    await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
+    await user.click(screen.getByRole("button", { name: "Add!" }));
+
+    await waitFor(() => expect(getBodies()).toHaveLength(1));
+    expect(getBodies()[0]).toEqual({
+      artist_name: "Juana Molina",
+      alphabetical_name: "Molina, Juana",
+      code_letters: "MO",
+      genre_id: GENRE_ID,
+      code_number: 12,
+    });
+    expect(mockPush).toHaveBeenCalledWith("/dashboard/library");
+  });
+
+  it("shows the code-conflict message on a 409 naming the artist_code_conflict reason", async () => {
+    mockAddArtist(() =>
+      HttpResponse.json(
+        {
+          message: "Artist code already exists for that genre and code letters.",
+          reason: "artist_code_conflict",
+          artist: { artist_id: 1, artist_name: "Stereolab", code_letters: "MO" },
+        },
+        { status: 409 },
+      ),
+    );
+    const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+
+    await screen.findByText("Blues");
+    await user.type(screen.getByLabelText(/artist presentation name/i), "Juana Molina");
+    await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
+    await user.click(screen.getByRole("button", { name: "Add!" }));
+
+    expect(
+      await screen.findByText("Stereolab already holds that library code."),
+    ).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("shows a distinct name-conflict message, steering to the existing artist rather than the code, on a 409 naming the artist_name_conflict reason", async () => {
+    mockAddArtist(() =>
+      HttpResponse.json(
+        {
+          message: "Artist name already exists in that genre.",
+          reason: "artist_name_conflict",
+          artist: { artist_id: 2, artist_name: "Juana Molina", code_letters: "MO" },
+        },
+        { status: 409 },
+      ),
+    );
+    const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+
+    await screen.findByText("Blues");
+    await user.type(screen.getByLabelText(/artist presentation name/i), "Juana Molina");
+    await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
+    await user.click(screen.getByRole("button", { name: "Add!" }));
+
+    expect(
+      await screen.findByText(
+        "Juana Molina already exists in this genre. File under the existing artist instead of picking a different code.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back without crashing on a 409 body with no artist", async () => {
+    mockAddArtist(() => HttpResponse.json({ message: "Conflict" }, { status: 409 }));
+    const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+
+    await screen.findByText("Blues");
+    await user.type(screen.getByLabelText(/artist presentation name/i), "Juana Molina");
+    await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
+    await user.click(screen.getByRole("button", { name: "Add!" }));
+
+    expect(await screen.findByText("Failed to add artist.")).toBeInTheDocument();
+  });
+
+  it("resets the two name fields back to empty on Reset", async () => {
+    const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+    await screen.findByText("Blues");
+
+    await user.type(screen.getByLabelText(/artist presentation name/i), "Juana Molina");
+    await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
+
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(screen.getByLabelText(/artist presentation name/i)).toHaveValue("");
+    expect(screen.getByLabelText(/artist alphabetical name/i)).toHaveValue("");
+  });
+
+  describe("genre outage", () => {
+    it("explains a genres outage instead of guessing or blanking the read-only genre name", async () => {
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
+          HttpResponse.json({ message: "genres unavailable" }, { status: 500 }),
+        ),
+      );
+      renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+
+      expect(await screen.findByText(/genres are unavailable/i)).toBeInTheDocument();
+      expect(screen.queryByText("Blues")).not.toBeInTheDocument();
+    });
+
+    it("recovers via Try again once genres are reachable", async () => {
+      let genreCalls = 0;
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/genres`, () => {
+          genreCalls += 1;
+          return genreCalls === 1
+            ? HttpResponse.json({ message: "genres unavailable" }, { status: 500 })
+            : HttpResponse.json([{ id: GENRE_ID, genre_name: "Blues" }]);
+        }),
+      );
+      const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+
+      expect(await screen.findByText(/genres are unavailable/i)).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+
+      await waitFor(() =>
+        expect(screen.queryByText(/genres are unavailable/i)).not.toBeInTheDocument(),
+      );
+      expect(await screen.findByText("Blues")).toBeInTheDocument();
+    });
+
+    it("refuses the submit while genres are unavailable, without duplicating the outage sentence", async () => {
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
+          HttpResponse.json({ message: "genres unavailable" }, { status: 500 }),
+        ),
+      );
+      const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+
+      await screen.findByText(/genres are unavailable/i);
+      await user.type(screen.getByLabelText(/artist presentation name/i), "Juana Molina");
+      await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
+      await user.click(screen.getByRole("button", { name: "Add!" }));
+
+      expect(screen.getAllByText(/genres are unavailable/i)).toHaveLength(1);
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/integration/components/classic/catalog/CreateLibraryCodeForm.test.tsx
+++ b/tests/integration/components/classic/catalog/CreateLibraryCodeForm.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
-import { http, HttpResponse } from "msw";
+import { http, HttpResponse, delay } from "msw";
 import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
 
 // The real better-auth client installs listeners whose teardown is deferred a
@@ -85,8 +85,31 @@ describe("classic CreateLibraryCodeForm — createLibraryCode.jsp", () => {
     expect(screen.getByRole("button", { name: "Reset" })).toBeInTheDocument();
   });
 
-  it("uppercases the carried call letters for display and submission", async () => {
-    mockAddArtist(() => created());
+  // ArtistAdminServlet picks the heading off the call letters: a `Z-` code is
+  // a Various Artists shelf bucket and gets its own shorter wording, so a
+  // librarian filing a compilation is not told to associate a named artist.
+  it("shows the Various Artists heading for a Z- code and the artist heading otherwise", async () => {
+    const { unmount } = renderWithProviders(
+      <CreateLibraryCodeForm {...defaultProps} codeLetters="z-ro" />,
+    );
+
+    expect(
+      await screen.findByText(
+        "This 'Various Artists' library code does not currently exist in the database. To create it, click 'Add!'",
+      ),
+    ).toBeInTheDocument();
+    unmount();
+
+    renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+    expect(
+      await screen.findByText(
+        "This library code does not currently exist in the database. To create it, you need to associate it with an artist (new or existing) and click 'Add!'.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("uppercases the carried call letters on the wire, not just in the display", async () => {
+    const { getBodies } = mockAddArtist(() => created());
     const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
 
     await screen.findByText("MO");
@@ -94,7 +117,71 @@ describe("classic CreateLibraryCodeForm — createLibraryCode.jsp", () => {
     await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
     await user.click(screen.getByRole("button", { name: "Add!" }));
 
+    await waitFor(() => expect(getBodies()).toHaveLength(1));
+    expect(getBodies()[0]).toMatchObject({ code_letters: "MO" });
     await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/dashboard/library"));
+  });
+
+  // The carried code is displayed verbatim, so every refusal has to name the
+  // part that is wrong: a message about something "missing" beside a row
+  // showing that very value reads as a broken screen, not a bad link.
+  it.each([
+    [{ genreIdRaw: "" }, "This link carries no genre."],
+    [{ genreIdRaw: "abc" }, "This link's genre (abc) is not a genre id."],
+    [{ codeLetters: "" }, "This link carries no call letters."],
+    [{ codeNumberRaw: "" }, "This link carries no call number."],
+    [
+      { codeNumberRaw: "012" },
+      "This link's call number (012) is not a whole number above zero.",
+    ],
+  ])("names the unusable part of the carried code (%o)", async (override, message) => {
+    const { user } = renderWithProviders(
+      <CreateLibraryCodeForm {...defaultProps} {...override} />,
+    );
+
+    await user.type(screen.getByLabelText(/artist presentation name/i), "Juana Molina");
+    await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
+    await user.click(screen.getByRole("button", { name: "Add!" }));
+
+    expect(await screen.findByText(message)).toBeInTheDocument();
+  });
+
+  // The pending window must not borrow the missing-value rendering: "no genre
+  // arrived" and "the genre hasn't loaded yet" have opposite outcomes.
+  it("shows the genre as pending while the list is in flight, not as absent", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/library/genres`, async () => {
+        await delay(50);
+        return HttpResponse.json([{ id: GENRE_ID, genre_name: "Blues" }]);
+      }),
+    );
+    renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(screen.queryByText("—")).not.toBeInTheDocument();
+    expect(await screen.findByText("Blues")).toBeInTheDocument();
+  });
+
+  // A genre id that parses but names nothing in the catalog is not the same
+  // screen as a missing param or an outage: filing anyway would put the
+  // release under a genre the librarian was never shown, and library codes
+  // carry no unique constraint to catch it afterwards.
+  it("refuses to file when the carried genre id is absent from the catalog", async () => {
+    mockGenres([{ id: 999, genre_name: "Jazz" }]);
+    const { getBodies } = mockAddArtist(() => created());
+    const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
+
+    expect(
+      await screen.findByText(`No genre in the catalog has id ${GENRE_ID}, so this code can't be filed.`),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add!" })).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/artist presentation name/i), "Juana Molina");
+    await user.type(screen.getByLabelText(/artist alphabetical name/i), "Molina, Juana");
+    await user.click(screen.getByRole("button", { name: "Add!" }));
+
+    expect(getBodies()).toHaveLength(0);
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   it("shows the JSP's exact validation message when the presentation name is empty", async () => {


### PR DESCRIPTION
## Summary

Builds the classic-experience code-miss create screen, xeroxed from `libraryAdmin/createLibraryCode.jsp` (57 lines) -- the miss branch of `findOrCreateLibraryCode` (`ArtistAdminServlet:161`). Genre, letters, and numbers arrive fixed via URL params and are read-only; only the two name fields are editable, matching the JSP's field order, labels, and "Add!"/"Reset" buttons. On submit it goes through the same `POST /library/artists` contract the chooser's `NewArtistForm` uses, with an explicit `code_number` -- the peek-code hook is the chooser's concern, not this screen's. The screen is URL-reachable on its own route (`/dashboard/library/artist/new`) ahead of #1198 wiring the chooser's no-match branch into it, and is not linked in nav. Page authority is server-side `requireAuth()` + `requireRole(session, Authorization.MD)`.

## What this screen refuses to file, and why

This is the last screen between a librarian and a new shelf entry, and library codes carry no unique constraint to catch a mis-file afterwards. So every state where the code cannot be confirmed refuses rather than files:

- **Genres unavailable** (unissued or failed request, per `isGenresUnavailable`) -- explicit banner with a retry, Add! disabled.
- **A genre id that parses but names no genre in the catalog** -- its own banner, Add! disabled. This is deliberately distinct from the outage: filing anyway would put the release under a genre the librarian was never shown the name of, and it is reachable without any backend fault, since the genre list is cached under `GenreList/LIST` and only invalidated by `addGenre`.
- **A malformed link** -- the refusal names the part that is wrong ("This link's call number (012) is not a whole number above zero.") rather than reporting "missing" about a value the read-only row is displaying.
- **While the genre list is in flight** the row reads `Loading…`, never the placeholder used for an absent value -- pending and absent have opposite outcomes here.

## Divergences from the JSP

- **`createArtist.jsp` is out of scope.** It is the post-delete restore screen (`ArtistAdminServlet:250`), not a creation step -- no slice owns artist delete. `docs/architecture.md`'s URL table is updated to drop it from this route's source column and notes why.
- **The JSP's `Z_` V/A auto-naming branch (`:26`) is not reproduced.** It is dead code in production: the servlet's own V/A prefix is `Z-` (built and tested with a hyphen at `:127`/`:130`/`:132`/`:152`/`:180`), while the JSP tests `fn:startsWith(artistLetters, 'Z_')` with an underscore -- a state no librarian has ever seen. The screen reproduces actual production behavior: editable name fields, no auto-naming.
- **The servlet's *live* V/A branch is reproduced, with one contract-forced exception.** `ArtistAdminServlet:152-155` picks a different heading when the call letters start with `Z-` ("This 'Various Artists' library code does not currently exist in the database. To create it, click 'Add!'"), and this screen now does the same -- a librarian filing a compilation is not told to associate a named artist. What is *not* reproduced: that branch forwards no `artistNumbers`, and `processAddArtistLibraryCode:180` skips call numbers for `Z-` entirely, so `/wxycdb` files V/A codes with no number at all. `POST /library/artists` requires `code_number`, so a V/A code is filed here with the number it carried, and a V/A link carrying none is refused rather than filed incomplete.
- **Interim success destination.** The JSP's successful submit lands on the artist card (`goToArtistModifyCard`) carrying "The artist/library code below has been added to the database." (`ArtistAdminServlet:187`). That page doesn't exist yet in dj-site (Slice 1b / #1166 is deploy-gated), so a successful submit here routes to `/dashboard/library` -- where the chooser's own create path already lands today -- and the success confirmation travels with the card when #1166 ships.

## Test plan

- [x] `npx vitest run` -- full suite green
- [x] `npm run lint` -- zero errors (pre-existing warnings only, none in touched files)
- [x] `npx tsc --noEmit` -- clean
- [x] Integration tests for `CreateLibraryCodeForm` (`createLibraryCode.jsp`): field order/labels, both headings (`Z-` vs not), uppercasing asserted **on the wire**, submit + interim navigation, both 409 conflict variants, generic-failure fallback, Reset, the genre-outage convention (banner, recovery via Try again, submit refusal without a duplicated sentence), the unresolvable-genre refusal, the pending-genre render, and a parameterized case per malformed-link shape
- [x] Page-authority test for `/dashboard/library/artist/new` built on the shared `classic-page-authority-harness`, asserting MD/SM reach, DJ denial, admin-plugin-role-doesn't-count, and unauthenticated bounce to login

Closes #1167
