### PR TITLE
Reland #1219: resolve the track picker in the legacy_release_id space

### DIFF
--- a/e2e/tests/flowsheet/flowsheet-track-picker.spec.ts
+++ b/e2e/tests/flowsheet/flowsheet-track-picker.spec.ts
@@ -16,6 +16,9 @@ const authDir = path.join(__dirname, "../../.auth");
  *  2. Free-text fallback: DJ picks a release with no Discogs identity /
  *     empty tracklist → picker collapses to "type the song title above" →
  *     submission carries `track_title` but no `track_position`.
+ *  3. Id space: a card-catalog row, whose `library.id` and `legacy_release_id`
+ *     differ, shows its own tracklist rather than the unrelated release its
+ *     `library.id` resolves to in the other space.
  *
  * Mocks the LML proxy endpoints (`/proxy/library/search`,
  * `/proxy/library/:id/tracks`) and the flowsheet POST so the spec doesn't
@@ -231,6 +234,130 @@ test.describe("Flowsheet Track Picker", { tag: "@smoke" }, () => {
       artist_name: "Juana Molina",
       album_title: "DOGA",
     });
+  });
+
+  test("shows the catalog row's own tracklist, not the one its library.id resolves to", async ({
+    page,
+  }) => {
+    // The two sibling tests both source their release from the library-search
+    // proxy, where the row's `id` and its `legacy_release_id` happen to be the
+    // same number — so neither can tell the two id spaces apart. A card-catalog
+    // row is where they diverge, and where reading the wrong one returns a real
+    // but unrelated release's tracklist with a 200.
+    const LIBRARY_ID = 1234;
+    const LEGACY_RELEASE_ID = 45342;
+
+    // Suppress the library-search proxy so only the catalog row populates the
+    // list and lands at a known index.
+    await page.route("**/proxy/library/search**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ results: [], total: 0, query: null }),
+      });
+    });
+
+    await page.route(isCatalogSearch, async (route) => {
+      if (route.request().method() !== "GET") {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: LIBRARY_ID,
+            legacy_release_id: LEGACY_RELEASE_ID,
+            add_date: "2026-05-01T00:00:00.000Z",
+            album_title: "On Your Own Love Again",
+            artist_name: "Jessica Pratt",
+            code_letters: "PR",
+            code_artist_number: 3,
+            code_number: 1,
+            format_name: "Vinyl",
+            genre_name: "Rock",
+            label: "Drag City",
+            plays: 4,
+          },
+        ]),
+      });
+    });
+
+    // Both id spaces answer, with different tracklists. Stubbing only the
+    // correct one would let a wrong-space read fail as an unrouted request —
+    // which surfaces as a collapsed picker, not as the wrong answer it is.
+    await page.route(`**/proxy/library/${LIBRARY_ID}/tracks`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          library_id: LIBRARY_ID,
+          discogs_release_id: 111111,
+          source: "discogs",
+          tracks: [
+            {
+              position: "B2",
+              title: "WRONG RELEASE",
+              artist_credit: "Someone Else",
+              duration_ms: null,
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.route(
+      `**/proxy/library/${LEGACY_RELEASE_ID}/tracks`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            library_id: LEGACY_RELEASE_ID,
+            discogs_release_id: 222222,
+            source: "discogs",
+            tracks: [
+              {
+                position: "A1",
+                title: "Wrong Hand",
+                artist_credit: "Jessica Pratt",
+                duration_ms: 168000,
+              },
+            ],
+          }),
+        });
+      }
+    );
+
+    await flowsheet.songInput.click();
+    await flowsheet.artistInput.fill("Jessica Pratt");
+    await flowsheet.albumInput.fill("On Your Own Love Again");
+
+    // Located by content rather than by index: bin and rotation results are
+    // not mocked here, so a seeded row matching this artist would shift the
+    // positional index and silently click the wrong release.
+    const resultRow = page
+      .locator('[data-testid^="flowsheet-search-result-"]')
+      .filter({ hasText: "On Your Own Love Again" })
+      .first();
+    await expect(resultRow).toBeVisible({ timeout: 10_000 });
+    await resultRow.click();
+
+    const pickerTrigger = page.locator('[data-testid="track-picker-combobox"]');
+    await expect(pickerTrigger).toBeVisible({ timeout: 10_000 });
+    await pickerTrigger.click();
+    await expect(
+      page.locator('[data-testid="track-picker-panel"]')
+    ).toBeVisible();
+
+    // The release the DJ clicked, not the one its library.id collides with.
+    await expect(
+      page.locator('[data-testid="track-picker-option-0"]')
+    ).toContainText("Wrong Hand");
+    await expect(
+      page.locator('[data-testid="track-picker-panel"]')
+    ).not.toContainText("WRONG RELEASE");
   });
 
   test("falls back to free-text song input when the release has no tracklist", async ({

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -27,6 +27,7 @@ export function entryToFreezePayload(entry: {
   title?: string | null;
   label?: string | null;
   id?: number | null;
+  legacy_release_id?: number | null;
   rotation_id?: number | null;
   rotation_bin?: Rotation | null;
 }) {
@@ -47,6 +48,11 @@ export function entryToFreezePayload(entry: {
     album: entry.title ?? "",
     label: entry.label ?? "",
     album_id: entry.id ?? undefined,
+    // The read half of the freeze. Carried so the picker survives the click
+    // that zeroes the highlight, and resolved independently of `album_id` —
+    // which release's tracklist to show is not the same question as which
+    // release a submission should link to.
+    legacy_release_id: entry.legacy_release_id ?? undefined,
     rotation_id: entry.rotation_id ?? undefined,
     rotation_bin: entry.rotation_bin ?? undefined,
   };

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -49,9 +49,11 @@ export function entryToFreezePayload(entry: {
     label: entry.label ?? "",
     album_id: entry.id ?? undefined,
     // The read half of the freeze. Carried so the picker survives the click
-    // that zeroes the highlight, and resolved independently of `album_id` —
-    // which release's tracklist to show is not the same question as which
-    // release a submission should link to.
+    // that zeroes the highlight. Taken from this entry's own field rather than
+    // derived from `album_id` — which release's tracklist to show is not the
+    // same question as which release a submission should link to, and a row
+    // can answer one without answering the other. Both come off the SAME
+    // entry, which is what keeps the pair describing one release.
     legacy_release_id: entry.legacy_release_id ?? undefined,
     rotation_id: entry.rotation_id ?? undefined,
     rotation_bin: entry.rotation_bin ?? undefined,

--- a/lib/features/flowsheet/frontend.ts
+++ b/lib/features/flowsheet/frontend.ts
@@ -66,6 +66,7 @@ export const defaultFlowsheetFrontendState: FlowsheetFrontendState = {
       request: false,
       segue: undefined,
       album_id: undefined,
+      legacy_release_id: undefined,
       rotation_bin: undefined,
       rotation_id: undefined,
       track_position: undefined,
@@ -90,6 +91,7 @@ export const flowsheetSlice = createAppSlice({
       state.rotationMode = action.payload;
       if (!action.payload) {
         state.search.query.album_id = undefined;
+        state.search.query.legacy_release_id = undefined;
         state.search.query.rotation_id = undefined;
         state.search.query.rotation_bin = undefined;
         state.search.query.track_position = undefined;
@@ -97,9 +99,15 @@ export const flowsheetSlice = createAppSlice({
     },
     setRotationMetadata: (
       state,
-      action: PayloadAction<{ album_id?: number; rotation_id?: number; rotation_bin?: Rotation }>
+      action: PayloadAction<{
+        album_id?: number;
+        legacy_release_id?: number;
+        rotation_id?: number;
+        rotation_bin?: Rotation;
+      }>
     ) => {
       state.search.query.album_id = action.payload.album_id;
+      state.search.query.legacy_release_id = action.payload.legacy_release_id;
       state.search.query.rotation_id = action.payload.rotation_id;
       state.search.query.rotation_bin = action.payload.rotation_bin;
       // track_position references a release_track row on the previous
@@ -154,6 +162,10 @@ export const flowsheetSlice = createAppSlice({
         // album row (see the file-header invariant), so they survive a
         // deviation — only the album-scoped fields drop.
         state.search.query.album_id = undefined;
+        // Cleared with album_id, not after it: a legacy id left behind keeps
+        // the picker serving the previous release's tracklist against a query
+        // that no longer references that release.
+        state.search.query.legacy_release_id = undefined;
         state.search.query.track_position = undefined;
         state.search.selectionProvided = undefined;
       }
@@ -184,6 +196,10 @@ export const flowsheetSlice = createAppSlice({
         // to prevent.
         artistProvided: boolean;
         album_id?: number;
+        // Decided independently of album_id: a caller may withhold the write
+        // linkage while the release's tracklist is still the right one to
+        // show. See RotationEntryFields' withheld-credit case.
+        legacy_release_id?: number;
         rotation_id?: number;
         rotation_bin?: Rotation;
       }>
@@ -192,6 +208,7 @@ export const flowsheetSlice = createAppSlice({
       state.search.query.album = action.payload.album;
       state.search.query.label = action.payload.label;
       state.search.query.album_id = action.payload.album_id;
+      state.search.query.legacy_release_id = action.payload.legacy_release_id;
       state.search.query.rotation_id = action.payload.rotation_id;
       state.search.query.rotation_bin = action.payload.rotation_bin;
       state.search.query.track_position = undefined;

--- a/lib/features/flowsheet/linkage.ts
+++ b/lib/features/flowsheet/linkage.ts
@@ -8,6 +8,11 @@
  * catalog/conversions) and are rejected by endpoints that validate a
  * positive-integer id boundary. Callers gate the linked-album submission
  * shape on this — previously five files re-derived the check locally.
+ *
+ * Read-path callers pass a `legacy_release_id` rather than an `album_id`. The
+ * question is the same one — is this a real server-issued id — and the answer
+ * does not depend on which space the id is in, which is why the parameter is
+ * deliberately not typed to either.
  */
 export function hasLinkedAlbumId(
   albumId: number | null | undefined

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -38,6 +38,22 @@ export type FlowsheetQuery = {
   request: boolean;
   segue?: boolean;
   album_id?: number;
+  /**
+   * The frozen release's `legacy_release_id` — the id space the track picker
+   * resolves in, kept alongside `album_id` (the space a submission writes in)
+   * rather than derived from it, because the two are different spaces over the
+   * same row and neither can be computed from the other client-side.
+   *
+   * Carried on the query because a click zeroes the highlight: post-click
+   * there is no result row left to read the id from, and the picker still has
+   * to know which release it is showing.
+   *
+   * Moves in lockstep with `album_id` in every reducer that sets or clears
+   * either. A stale value left behind after `album_id` clears means the picker
+   * goes on serving the previous release's tracklist — silently, since nothing
+   * about that combination is invalid.
+   */
+  legacy_release_id?: number;
   rotation_bin?: Rotation;
   rotation_id?: number;
   /**
@@ -51,7 +67,12 @@ export type FlowsheetQuery = {
 
 export type FlowsheetSearchProperty = keyof Omit<
   FlowsheetQuery,
-  "request" | "segue" | "album_id" | "rotation_bin" | "rotation_id"
+  | "request"
+  | "segue"
+  | "album_id"
+  | "legacy_release_id"
+  | "rotation_bin"
+  | "rotation_id"
 >;
 
 export type FlowsheetEntryBase = {

--- a/lib/features/metadata/api.ts
+++ b/lib/features/metadata/api.ts
@@ -23,9 +23,30 @@ export const metadataApi = createApi({
         params: { artistId },
       }),
     }),
+    /**
+     * Tracklist for a release, for the flowsheet track picker.
+     *
+     * **The argument is a `legacy_release_id`, not a `library.id`** — the two
+     * are different id spaces over the same row. Backend resolves this path
+     * param with `getDiscogsReleaseIdByLegacyId`, which filters on
+     * `library.legacy_release_id`; the URL segment is named `libraryId` there
+     * for historical reasons and means the same thing it does here.
+     *
+     * Passing a `library.id` does not fail loudly. The two spaces are nearly
+     * coextensive, so the lookup lands on a real but unrelated release and
+     * returns its tracklist with a 200. Getting this argument right is the
+     * whole point of the field's existence.
+     *
+     * The argument is also this endpoint's RTK Query cache key, so every
+     * caller — the hover prefetch and the picker query alike — has to agree on
+     * the id space or they warm and read different cache entries.
+     *
+     * Backend rejects a non-positive value with a 400, so callers gate on real
+     * linkage rather than passing a placeholder.
+     */
     getLibraryTracks: builder.query<LibraryTracksResponse, number>({
-      query: (libraryId) => ({
-        url: `/library/${libraryId}/tracks`,
+      query: (legacyReleaseId) => ({
+        url: `/library/${legacyReleaseId}/tracks`,
       }),
     }),
   }),

--- a/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker.tsx
@@ -12,19 +12,23 @@ type PickerTrack = LibraryTrack & TrackPickerEntry;
 /**
  * Hook that resolves the picker state for a given library release.
  *
+ * Takes a **`legacy_release_id`**, not a `library.id` — see the id-space note
+ * on the `getLibraryTracks` endpoint. `null` means no release is resolved and
+ * the query is skipped.
+ *
  * `picker.show` is the parent's render gate: true means render
  * `<LibraryTrackPicker>` in place of the free-text song input, false means
  * leave the free-text input alone. The picker collapses back to free-text on
- * three signals — no release selected, query still in flight, and a release
+ * three signals — no release resolved, query still in flight, and a release
  * with no Discogs-resolvable tracklist (`source: null` or `tracks: []`).
  */
-export function useLibraryTrackPicker(albumId: number | null) {
-  const { data, isLoading } = useGetLibraryTracksQuery(albumId ?? 0, {
-    skip: albumId === null,
+export function useLibraryTrackPicker(legacyReleaseId: number | null) {
+  const { data, isLoading } = useGetLibraryTracksQuery(legacyReleaseId ?? 0, {
+    skip: legacyReleaseId === null,
   });
 
   return useMemo(() => {
-    if (albumId === null) {
+    if (legacyReleaseId === null) {
       return { show: false, isLoading: false, tracks: [] as PickerTrack[] };
     }
     if (isLoading) {
@@ -35,7 +39,7 @@ export function useLibraryTrackPicker(albumId: number | null) {
       artists: t.artist_credit ? [t.artist_credit] : [],
     }));
     return { show: tracks.length > 0, isLoading: false, tracks };
-  }, [albumId, isLoading, data?.tracks]);
+  }, [legacyReleaseId, isLoading, data?.tracks]);
 }
 
 /**

--- a/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
@@ -70,7 +70,12 @@ function FlowsheetBackendResult({
         },
       }}
       onMouseOver={() => {
-        if (hasLinkedAlbumId(entry.id)) prefetchTracks(entry.id);
+        // Gate and argument are the same field on purpose. They are the cache
+        // key this endpoint is keyed by, so gating on one id space while
+        // fetching in the other would warm an entry the picker never reads —
+        // and would stop firing entirely for rows that carry no library.id.
+        if (hasLinkedAlbumId(entry.legacy_release_id))
+          prefetchTracks(entry.legacy_release_id);
       }}
       // Autofill, never submit; prevented mousedown keeps input focus
       onMouseDown={(e) => {

--- a/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
@@ -62,20 +62,27 @@ export default function FlowsheetSearchResults({
     searchQuery.artist || searchQuery.song || searchQuery.album || searchQuery.label
   );
 
-  // Two ids, two questions, two id spaces.
-  //
+  // Two ids, two questions, two id spaces — but one row answers both. A
+  // highlighted row answers them itself, INCLUDING by answering "no"; only
+  // when there is no highlight at all does the frozen query answer. Resolving
+  // each id independently would let one side reach past the highlighted row
+  // into a frozen release that outlived the highlight which set it, and a
+  // picker straddling two releases hands the flowsheet one release's track
+  // position paired with the other's album_id — a write the submission
+  // boundary has no way to recognize as wrong.
+  const idSource = highlightedResult ?? {
+    id: searchQuery.album_id ?? null,
+    legacy_release_id: searchQuery.legacy_release_id ?? null,
+  };
+
   // READ — which release's tracklist to fetch. The tracklist endpoint resolves
   // its path param against `library.legacy_release_id`, so this side must
   // resolve there too. Post-click there is no highlight left to read from (the
   // dominant flow is click the release, then pick the track), so the frozen
   // query has to carry the legacy id itself.
-  const tracklistReleaseId = hasLinkedAlbumId(
-    highlightedResult?.legacy_release_id
-  )
-    ? highlightedResult.legacy_release_id
-    : hasLinkedAlbumId(searchQuery.legacy_release_id)
-      ? searchQuery.legacy_release_id
-      : null;
+  const tracklistReleaseId = hasLinkedAlbumId(idSource.legacy_release_id)
+    ? idSource.legacy_release_id
+    : null;
 
   // WRITE — whether this row has a real library linkage, which is the only
   // thing that decides if a picker is offered at all. A library-unlinked
@@ -83,11 +90,7 @@ export default function FlowsheetSearchResults({
   // synthesizeAlbumId, and the submission chokepoint drops `track_position`
   // without a positive `album_id` behind it — so offering a picker there would
   // let the DJ pick something that gets silently discarded.
-  const linkedAlbumId = hasLinkedAlbumId(highlightedResult?.id)
-    ? highlightedResult.id
-    : hasLinkedAlbumId(searchQuery.album_id)
-      ? searchQuery.album_id
-      : null;
+  const linkedAlbumId = hasLinkedAlbumId(idSource.id) ? idSource.id : null;
 
   const [manualOverride, setManualOverride] = useState<number | null>(null);
   useEffect(() => {
@@ -96,15 +99,18 @@ export default function FlowsheetSearchResults({
     }
   }, [tracklistReleaseId, manualOverride]);
 
+  const showPickerRow = linkedAlbumId !== null && !rotationMode;
+
   // Keyed on the read half: opting out is per-release-tracklist, and the
-  // release's identity for tracklist purposes is its legacy id.
+  // release's identity for tracklist purposes is its legacy id. Gated on the
+  // row rendering at all, because the tracklist has no other consumer —
+  // rotation mode keeps a legacy id in the query that nothing there reads, and
+  // fetching for it would be a request per rotation pick with no destination.
   const pickerReleaseId =
-    tracklistReleaseId !== null && tracklistReleaseId !== manualOverride
+    showPickerRow && tracklistReleaseId !== manualOverride
       ? tracklistReleaseId
       : null;
   const picker = useLibraryTrackPicker(pickerReleaseId);
-
-  const showPickerRow = linkedAlbumId !== null && !rotationMode;
 
   // Panel CONTENT only — the Sheet/Popper/transitions live in FlowsheetSearchbar
   return (

--- a/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
@@ -58,41 +58,53 @@ export default function FlowsheetSearchResults({
 
   // A click-to-autofill zeroes the highlight; the frozen query keeps the album
   const searchQuery = useAppSelector(flowsheetSlice.selectors.getSearchQuery);
-  const frozenAlbumId = searchQuery.album_id;
   const hasTypedText = Boolean(
     searchQuery.artist || searchQuery.song || searchQuery.album || searchQuery.label
   );
 
-  // A library-unlinked rotation/catalog row carries a synthesized negative
-  // id from synthesizeAlbumId — there's no real release to pick tracks from,
-  // and #702's chokepoint drops track_position anyway. Skip the picker entirely
-  // for those rows instead of letting the DJ pick something we'll silently
-  // discard. (dj-site#704)
-  // `highlightedResult.id === null` (an LML row) falls through to the
-  // frozen-query check below exactly like a non-positive id does today —
-  // widening `AlbumEntry.id` must not make the picker disappear for the one
-  // source where it currently works. Real fix is #1184.
-  const effectiveAlbumId =
-    highlightedResult && highlightedResult.id !== null && highlightedResult.id > 0
-      ? highlightedResult.id
-      : hasLinkedAlbumId(frozenAlbumId)
-        ? (frozenAlbumId as number)
-        : null;
+  // Two ids, two questions, two id spaces.
+  //
+  // READ — which release's tracklist to fetch. The tracklist endpoint resolves
+  // its path param against `library.legacy_release_id`, so this side must
+  // resolve there too. Post-click there is no highlight left to read from (the
+  // dominant flow is click the release, then pick the track), so the frozen
+  // query has to carry the legacy id itself.
+  const tracklistReleaseId = hasLinkedAlbumId(
+    highlightedResult?.legacy_release_id
+  )
+    ? highlightedResult.legacy_release_id
+    : hasLinkedAlbumId(searchQuery.legacy_release_id)
+      ? searchQuery.legacy_release_id
+      : null;
+
+  // WRITE — whether this row has a real library linkage, which is the only
+  // thing that decides if a picker is offered at all. A library-unlinked
+  // rotation/catalog row carries a synthesized negative id from
+  // synthesizeAlbumId, and the submission chokepoint drops `track_position`
+  // without a positive `album_id` behind it — so offering a picker there would
+  // let the DJ pick something that gets silently discarded.
+  const linkedAlbumId = hasLinkedAlbumId(highlightedResult?.id)
+    ? highlightedResult.id
+    : hasLinkedAlbumId(searchQuery.album_id)
+      ? searchQuery.album_id
+      : null;
 
   const [manualOverride, setManualOverride] = useState<number | null>(null);
   useEffect(() => {
-    if (manualOverride !== null && effectiveAlbumId !== manualOverride) {
+    if (manualOverride !== null && tracklistReleaseId !== manualOverride) {
       setManualOverride(null);
     }
-  }, [effectiveAlbumId, manualOverride]);
+  }, [tracklistReleaseId, manualOverride]);
 
-  const pickerAlbumId =
-    effectiveAlbumId !== null && effectiveAlbumId !== manualOverride
-      ? effectiveAlbumId
+  // Keyed on the read half: opting out is per-release-tracklist, and the
+  // release's identity for tracklist purposes is its legacy id.
+  const pickerReleaseId =
+    tracklistReleaseId !== null && tracklistReleaseId !== manualOverride
+      ? tracklistReleaseId
       : null;
-  const picker = useLibraryTrackPicker(pickerAlbumId);
+  const picker = useLibraryTrackPicker(pickerReleaseId);
 
-  const showPickerRow = effectiveAlbumId !== null && !rotationMode;
+  const showPickerRow = linkedAlbumId !== null && !rotationMode;
 
   // Panel CONTENT only — the Sheet/Popper/transitions live in FlowsheetSearchbar
   return (
@@ -189,8 +201,8 @@ export default function FlowsheetSearchResults({
                   isLoading={picker.isLoading}
                   disabled={false}
                   onManualEntry={() => {
-                    if (effectiveAlbumId !== null)
-                      setManualOverride(effectiveAlbumId);
+                    if (tracklistReleaseId !== null)
+                      setManualOverride(tracklistReleaseId);
                     dispatch(
                       flowsheetSlice.actions.setSearchProperty({
                         name: "song",

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -72,6 +72,7 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
       dispatch(
         flowsheetSlice.actions.setRotationMetadata({
           album_id: undefined,
+          legacy_release_id: undefined,
           rotation_id: undefined,
           rotation_bin: bin,
         })
@@ -99,6 +100,11 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
           // field below. Classic makes the same trade by switching
           // submission variants.
           album_id: releaseCannotSupplyArtist(release) ? undefined : (release.id ?? undefined),
+          // NOT subject to the withholding above: that trade is about which
+          // artist_name BS hands back on a write, and says nothing about which
+          // release's tracklist to show. Gating this on it would drop the
+          // picker for exactly the releases whose credit is refused.
+          legacy_release_id: release.legacy_release_id ?? undefined,
           rotation_id: release.rotation_id,
           rotation_bin: release.rotation_bin,
         })

--- a/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/RotationEntryFields.tsx
@@ -100,10 +100,13 @@ export default function RotationEntryFields({ disabled }: { disabled: boolean })
           // field below. Classic makes the same trade by switching
           // submission variants.
           album_id: releaseCannotSupplyArtist(release) ? undefined : (release.id ?? undefined),
-          // NOT subject to the withholding above: that trade is about which
-          // artist_name BS hands back on a write, and says nothing about which
-          // release's tracklist to show. Gating this on it would drop the
-          // picker for exactly the releases whose credit is refused.
+          // Assigned unconditionally, and not subject to the withholding
+          // above. The reducer overwrites the query's album linkage wholesale,
+          // so omitting this would leave the PREVIOUS selection's legacy id
+          // standing beside this selection's album_id — the one way the pair
+          // can come to describe two different releases. The withholding is
+          // about which artist_name BS hands back on a write and has no
+          // bearing on which release this row is.
           legacy_release_id: release.legacy_release_id ?? undefined,
           rotation_id: release.rotation_id,
           rotation_bin: release.rotation_bin,

--- a/tests/fakes/libraryTracks.ts
+++ b/tests/fakes/libraryTracks.ts
@@ -1,0 +1,39 @@
+import { http, HttpResponse } from "msw";
+import type { RequestHandler } from "msw";
+import { TEST_BACKEND_URL } from "../helpers/constants";
+
+/**
+ * MSW handler for `GET /proxy/library/:legacyReleaseId/tracks`.
+ *
+ * Deliberately NOT added to the base `handlers` set, which is the empty-default
+ * base — the repo pattern is a per-spec `server.use`. This lives here so the
+ * two specs that need it (`LibraryTrackPicker` and `FlowsheetSearchResults`)
+ * share one definition instead of importing across a `.test.tsx`, which has no
+ * precedent in this repo.
+ *
+ * **The path param is a `legacy_release_id`, not a `library.id`.** Backend
+ * resolves it via `getDiscogsReleaseIdByLegacyId`, which filters on
+ * `library.legacy_release_id`. Stubbing a `library.id` here produces a handler
+ * that never matches the request the app actually makes.
+ */
+export function libraryTracksHandler(
+  legacyReleaseId: number,
+  tracks: Array<{ position: string; title: string; artist_credit: string }>,
+  source: "discogs" | null = "discogs",
+): RequestHandler {
+  return http.get(
+    `${TEST_BACKEND_URL}/proxy/library/${legacyReleaseId}/tracks`,
+    () =>
+      HttpResponse.json({
+        library_id: legacyReleaseId,
+        discogs_release_id: source === "discogs" ? 42 : null,
+        source,
+        tracks: tracks.map((t) => ({ ...t, duration_ms: null })),
+      }),
+  );
+}
+
+/** Convenience single track, for specs that only need the picker to populate. */
+export const ONE_TRACK = [
+  { position: "A1", title: "la paradoja", artist_credit: "Juana Molina" },
+];

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -18,3 +18,4 @@ export * from "./conversion-harness";
 
 export { server } from "../fakes/server";
 export { handlers } from "../fakes/handlers";
+export { libraryTracksHandler, ONE_TRACK } from "../fakes/libraryTracks";

--- a/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
@@ -170,38 +170,85 @@ describe("FlowsheetBackendResult", () => {
   });
 
   describe("Tracklist prefetch", () => {
-    it("prefetches tracks on mouse over when the row carries a real library link", () => {
-      // id and index are deliberately distinct values so this test can tell
-      // apart a component that reads entry.id from one that reads index.
-      const linkedEntry: AlbumEntry = createTestAlbum({
-        ...mockEntry,
-        id: 1,
-      });
-      renderWithProviders(
-        <FlowsheetBackendResult entry={linkedEntry} index={42} />
-      );
-
+    const hoverRow = () => {
       const resultRow = screen
         .getByText("Juana Molina")
         .closest('[data-testid^="flowsheet-search-result-"]');
       fireEvent.mouseOver(resultRow!);
+    };
 
-      expect(mockPrefetchTracks).toHaveBeenCalledWith(1);
+    it("prefetches the row's legacy_release_id, not its library.id", () => {
+      // `id`, `legacy_release_id`, and `index` are three distinct values, so
+      // this can tell apart a component reading the right one from a component
+      // reading either of the two plausible wrong ones. The endpoint resolves
+      // its path param against `library.legacy_release_id`, so `id` is the
+      // wrong space — and because the two spaces are nearly coextensive, a
+      // wrong-space lookup lands on a real but unrelated release rather than
+      // failing.
+      const catalogEntry: AlbumEntry = createTestAlbum({
+        ...mockEntry,
+        id: 1,
+        legacy_release_id: 45342,
+      });
+      renderWithProviders(
+        <FlowsheetBackendResult entry={catalogEntry} index={42} />
+      );
+
+      hoverRow();
+
+      expect(mockPrefetchTracks).toHaveBeenCalledWith(45342);
     });
 
-    it("does not prefetch tracks for a library-unlinked row (synthesized negative id)", () => {
+    it("prefetches a row that carries no library.id at all", () => {
+      // An LML-sourced row knows a legacy release id but no `library.id`. The
+      // gate has to key on the same field the argument does, or this row —
+      // the one source whose picker works today — silently stops prefetching.
+      const lmlEntry: AlbumEntry = createTestAlbum({
+        ...mockEntry,
+        id: null,
+        legacy_release_id: 45342,
+      });
+      renderWithProviders(
+        <FlowsheetBackendResult entry={lmlEntry} index={42} />
+      );
+
+      hoverRow();
+
+      expect(mockPrefetchTracks).toHaveBeenCalledWith(45342);
+    });
+
+    it("does not prefetch for a library-unlinked row (synthesized negative id, no legacy id)", () => {
+      // An unlinked rotation row: the LEFT JOIN found no library row, so there
+      // is no legacy id either. Backend 400s on a non-positive path param, so
+      // this gate is what keeps the hover from erroring.
       const unlinkedEntry: AlbumEntry = createTestAlbum({
         ...mockEntry,
         id: -1,
+        legacy_release_id: null,
       });
       renderWithProviders(
         <FlowsheetBackendResult entry={unlinkedEntry} index={42} />
       );
 
-      const resultRow = screen
-        .getByText("Juana Molina")
-        .closest('[data-testid^="flowsheet-search-result-"]');
-      fireEvent.mouseOver(resultRow!);
+      hoverRow();
+
+      expect(mockPrefetchTracks).not.toHaveBeenCalled();
+    });
+
+    it("does not prefetch when the legacy id is absent despite a real library link", () => {
+      // Backend's column is NOT NULL, so this shape means an emitter that
+      // predates the field rather than routine data. It must degrade to no
+      // prefetch, not fall back to `id` — falling back is the defect.
+      const noLegacyEntry: AlbumEntry = createTestAlbum({
+        ...mockEntry,
+        id: 42,
+        legacy_release_id: null,
+      });
+      renderWithProviders(
+        <FlowsheetBackendResult entry={noLegacyEntry} index={7} />
+      );
+
+      hoverRow();
 
       expect(mockPrefetchTracks).not.toHaveBeenCalled();
     });

--- a/tests/integration/components/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, fireEvent } from "@testing-library/react";
-import { http, HttpResponse } from "msw";
 import FlowsheetSearchResults from "@/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import {
   renderWithProviders,
   createTestAlbum,
   server,
-  TEST_BACKEND_URL,
+  libraryTracksHandler,
+  ONE_TRACK,
 } from "@/tests/helpers";
 import type { RootState } from "@/lib/store";
 
@@ -48,24 +48,8 @@ vi.mock("@/src/components/experiences/modern/flowsheet/Search/LibraryTrackPicker
   };
 });
 
-function mockLibraryTracksResponse(libraryId: number) {
-  server.use(
-    http.get(`${TEST_BACKEND_URL}/proxy/library/${libraryId}/tracks`, () =>
-      HttpResponse.json({
-        library_id: libraryId,
-        discogs_release_id: 42,
-        source: "discogs",
-        tracks: [
-          {
-            position: "A1",
-            title: "la paradoja",
-            artist_credit: "Juana Molina",
-            duration_ms: null,
-          },
-        ],
-      })
-    )
-  );
+function mockLibraryTracksResponse(legacyReleaseId: number) {
+  server.use(libraryTracksHandler(legacyReleaseId, ONE_TRACK));
 }
 
 function buildFlowsheetState(
@@ -254,9 +238,14 @@ describe("FlowsheetSearchResults", () => {
   // previously picked, otherwise a stale "A1" rides through on submit
   // pointing at an album the DJ no longer intends.
   it("clears track_position in Redux when the manual-entry button is clicked", async () => {
-    mockLibraryTracksResponse(1234);
+    // Stubbed on the legacy id, which is what the picker requests.
+    mockLibraryTracksResponse(45342);
     const linkedResult = [
-      createTestAlbum({ id: 1234, title: "Linked Library Row" }),
+      createTestAlbum({
+        id: 1234,
+        legacy_release_id: 45342,
+        title: "Linked Library Row",
+      }),
     ];
 
     const { store } = renderWithProviders(
@@ -287,6 +276,169 @@ describe("FlowsheetSearchResults", () => {
     fireEvent.click(await screen.findByTestId("library-track-picker-manual"));
 
     expect(store.getState().flowsheet.search.query.track_position).toBeUndefined();
+  });
+
+  // The picker read and the flowsheet write resolve in two different id
+  // spaces over the same row. Reading in the wrong one almost never misses —
+  // the spaces are nearly coextensive — so it returns a real but unrelated
+  // release's tracklist, presented as this release's, with a 200 and nothing
+  // in telemetry. These cases pin the read to the space the endpoint actually
+  // resolves in.
+  describe("id space the picker resolves in", () => {
+    // Two live handlers, one per id space, returning distinguishable
+    // tracklists. Asserting on WHICH tracklist arrives is what makes a
+    // wrong-space read visible; stubbing only the correct id would let a
+    // wrong-space read fail as an unstubbed request, which reads as a
+    // collapsed picker rather than a wrong answer.
+    const LIBRARY_ID = 1234;
+    const LEGACY_RELEASE_ID = 45342;
+
+    const stubBothSpaces = () => {
+      server.use(
+        libraryTracksHandler(LIBRARY_ID, [
+          {
+            position: "B2",
+            title: "WRONG RELEASE — resolved in the library.id space",
+            artist_credit: "Not This Artist",
+          },
+        ]),
+        libraryTracksHandler(LEGACY_RELEASE_ID, ONE_TRACK),
+      );
+    };
+
+    const highlightedRow = [
+      createTestAlbum({
+        id: LIBRARY_ID,
+        legacy_release_id: LEGACY_RELEASE_ID,
+        title: "Linked Library Row",
+      }),
+    ];
+
+    it("fetches the highlighted row's legacy_release_id, not its library.id", async () => {
+      stubBothSpaces();
+
+      renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={highlightedRow}
+          catalogResults={[]}
+          rotationResults={[]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 1,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
+      );
+
+      await screen.findByTestId("library-track-picker-manual");
+
+      const tracks =
+        libraryTrackPickerSpy.mock.calls.at(-1)?.[0]?.tracks ?? [];
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].title).toBe("la paradoja");
+    });
+
+    it("keeps resolving on the legacy id after a click clears the highlight", async () => {
+      // The dominant flow is click the release, then pick the track — and the
+      // click zeroes selectedResult, so there is no highlighted row left to
+      // read. The frozen query has to carry the legacy id itself; carrying
+      // only album_id would send the picker back into the library.id space
+      // for the whole post-click interaction.
+      stubBothSpaces();
+
+      const { store } = renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={highlightedRow}
+          catalogResults={[]}
+          rotationResults={[]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 0,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
+      );
+
+      store.dispatch(
+        flowsheetSlice.actions.freezeSelectionToQuery({
+          artist: "Juana Molina",
+          album: "DOGA",
+          label: "Sonamos",
+          artistProvided: true,
+          album_id: LIBRARY_ID,
+          legacy_release_id: LEGACY_RELEASE_ID,
+        })
+      );
+
+      await screen.findByTestId("library-track-picker-manual");
+
+      const tracks =
+        libraryTrackPickerSpy.mock.calls.at(-1)?.[0]?.tracks ?? [];
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].title).toBe("la paradoja");
+    });
+
+    it("offers no picker for a row with a library link but no legacy id", async () => {
+      // Backend's column is NOT NULL, so this is an emitter that predates the
+      // field, not routine data. It must collapse to free text rather than
+      // fall back to the library.id space.
+      stubBothSpaces();
+
+      renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={[
+            createTestAlbum({
+              id: LIBRARY_ID,
+              legacy_release_id: null,
+              title: "No Legacy Id",
+            }),
+          ]}
+          catalogResults={[]}
+          rotationResults={[]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 1,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
+      );
+
+      // The picker ROW still renders — the row is library-linked, so a track
+      // is still offerable as free text — but the dropdown never populates.
+      expect(
+        screen.getByTestId("flowsheet-search-track-picker-row")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("library-track-picker-manual")
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("should calculate correct offsets for results", () => {

--- a/tests/integration/components/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import FlowsheetSearchResults from "@/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
 import {
@@ -438,6 +438,196 @@ describe("FlowsheetSearchResults", () => {
       expect(
         screen.queryByTestId("library-track-picker-manual")
       ).not.toBeInTheDocument();
+    });
+
+    // The two ids answer two different questions, but they must answer them
+    // about the SAME row. A frozen release outlives the highlight that created
+    // it, so resolving each id independently lets one side reach past the
+    // highlighted row into the frozen query — and a picker that straddles two
+    // releases pairs one release's track position with the other's album_id.
+    // Both cases below arrive through the ordinary sequence: click a release,
+    // then arrow onto another row.
+    const freezeReleaseA = (store: ReturnType<typeof renderWithProviders>["store"]) =>
+      store.dispatch(
+        flowsheetSlice.actions.freezeSelectionToQuery({
+          artist: "Juana Molina",
+          album: "DOGA",
+          label: "Sonamos",
+          artistProvided: true,
+          album_id: LIBRARY_ID,
+          legacy_release_id: LEGACY_RELEASE_ID,
+        })
+      );
+
+    it("drops the frozen release's tracklist when the highlight moves to a row with no legacy id", async () => {
+      stubBothSpaces();
+
+      const { store } = renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={[
+            createTestAlbum({
+              id: 5678,
+              legacy_release_id: null,
+              title: "No Legacy Id",
+            }),
+          ]}
+          catalogResults={[]}
+          rotationResults={[]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 0,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
+      );
+
+      // Settle on the frozen release first, so the collapse below is the
+      // highlight taking effect rather than the query never having resolved.
+      freezeReleaseA(store);
+      await screen.findByTestId("library-track-picker-manual");
+
+      store.dispatch(flowsheetSlice.actions.setSelectedResult(1));
+
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("library-track-picker-manual")
+        ).not.toBeInTheDocument()
+      );
+      // Still library-linked, so free text is still offerable.
+      expect(
+        screen.getByTestId("flowsheet-search-track-picker-row")
+      ).toBeInTheDocument();
+    });
+
+    it("withdraws the picker when the highlight moves to a library-unlinked row", async () => {
+      // Unlinked rows carry a client-synthesized negative id and no legacy id,
+      // so neither question has an answer. Falling back to the frozen release
+      // for either one offers a picker whose pick the submission boundary
+      // discards for want of a positive album_id.
+      stubBothSpaces();
+
+      const { store } = renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={[]}
+          catalogResults={[]}
+          rotationResults={[
+            createTestAlbum({
+              id: -8812,
+              legacy_release_id: null,
+              title: "Unlinked Rotation Row",
+            }),
+          ]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 0,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
+      );
+
+      freezeReleaseA(store);
+      await screen.findByTestId("library-track-picker-manual");
+
+      store.dispatch(flowsheetSlice.actions.setSelectedResult(1));
+
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId("flowsheet-search-track-picker-row")
+        ).not.toBeInTheDocument()
+      );
+    });
+
+    it("fetches no tracklist while rotation mode holds a legacy id in the query", async () => {
+      // Rotation mode writes the pair into the query but offers no picker row,
+      // so the tracklist has no consumer there. The request is the only
+      // observable difference, hence the counter.
+      stubBothSpaces();
+
+      const trackRequests: string[] = [];
+      const record = ({ request }: { request: Request }) => {
+        if (new URL(request.url).pathname.endsWith("/tracks")) {
+          trackRequests.push(request.url);
+        }
+      };
+      server.events.on("request:start", record);
+
+      try {
+        const rotation = renderWithProviders(
+          <FlowsheetSearchResults
+            binResults={[]}
+            catalogResults={[]}
+            rotationResults={[]}
+            lmlResults={[]}
+          />,
+          {
+            preloadedState: {
+              flowsheet: buildFlowsheetState(true, {
+                rotationMode: true,
+                search: {
+                  open: true,
+                  query: flowsheetSlice.getInitialState().search.query,
+                  selectedResult: 0,
+                  confirmedArtist: "",
+                  resetEpoch: 0,
+                },
+              }),
+            },
+          }
+        );
+
+        freezeReleaseA(rotation.store);
+        await new Promise((r) => setTimeout(r, 20));
+        expect(trackRequests).toHaveLength(0);
+        rotation.unmount();
+
+        // The same query state outside rotation mode DOES fetch — without this
+        // half, a component that never fetches at all would pass the above.
+        const normal = renderWithProviders(
+          <FlowsheetSearchResults
+            binResults={[]}
+            catalogResults={[]}
+            rotationResults={[]}
+            lmlResults={[]}
+          />,
+          {
+            preloadedState: {
+              flowsheet: buildFlowsheetState(true, {
+                search: {
+                  open: true,
+                  query: flowsheetSlice.getInitialState().search.query,
+                  selectedResult: 0,
+                  confirmedArtist: "",
+                  resetEpoch: 0,
+                },
+              }),
+            },
+          }
+        );
+
+        freezeReleaseA(normal.store);
+        await screen.findByTestId("library-track-picker-manual");
+        expect(trackRequests).toHaveLength(1);
+      } finally {
+        server.events.removeListener("request:start", record);
+      }
     });
   });
 

--- a/tests/unit/lib/features/flowsheet/conversions.test.ts
+++ b/tests/unit/lib/features/flowsheet/conversions.test.ts
@@ -770,6 +770,7 @@ describe("flowsheet conversions", () => {
       expect(
         entryToFreezePayload({
           id: 42,
+          legacy_release_id: 45342,
           artist: { name: "Juana Molina" },
           title: "DOGA",
           label: "Sonamos",
@@ -782,6 +783,7 @@ describe("flowsheet conversions", () => {
         album: "DOGA",
         label: "Sonamos",
         album_id: 42,
+        legacy_release_id: 45342,
         rotation_id: 7,
         rotation_bin: "H",
       });
@@ -794,6 +796,7 @@ describe("flowsheet conversions", () => {
         album: "",
         label: "",
         album_id: undefined,
+        legacy_release_id: undefined,
         rotation_id: undefined,
         rotation_bin: undefined,
       });
@@ -831,9 +834,29 @@ describe("flowsheet conversions", () => {
         album: "Edits",
         label: "self-released",
         album_id: 42,
+        legacy_release_id: undefined,
         rotation_id: undefined,
         rotation_bin: undefined,
       });
+    });
+
+    // The two ids travel together but are decided separately: album_id is a
+    // write-path value the caller may withhold, legacy_release_id is a
+    // read-path value that describes which release's tracklist to fetch.
+    it("carries the legacy id for a row that has no library.id", () => {
+      expect(
+        entryToFreezePayload({
+          id: null,
+          legacy_release_id: 45342,
+          artist: { name: "Jessica Pratt" },
+          title: "On Your Own Love Again",
+        })
+      ).toEqual(
+        expect.objectContaining({
+          album_id: undefined,
+          legacy_release_id: 45342,
+        })
+      );
     });
   });
 });

--- a/tests/unit/lib/features/flowsheet/flowsheet.test.ts
+++ b/tests/unit/lib/features/flowsheet/flowsheet.test.ts
@@ -1146,12 +1146,13 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
         );
       });
 
-      it("carries a legacy id even when the write half withholds album_id", () => {
-        // A rotation release whose credit submission refuses has its album_id
-        // withheld so BS can't hand the credit back. That is a write-side
-        // decision and says nothing about which tracklist to show, so the read
-        // half must survive it — otherwise picking such a release silently
-        // loses the picker.
+      it("takes each id from its own payload field rather than deriving one from the other", () => {
+        // A row can carry a legacy id without a library link — an LML row is
+        // exactly that shape — and a caller can withhold album_id deliberately.
+        // The reducer must not infer either id's presence from the other's, or
+        // the payload loses a value its caller meant to send. Whether a picker
+        // is then OFFERED is the component's call, made from album_id; this is
+        // only about the reducer carrying what it was handed.
         const result = harness().reduce(
           actions.freezeSelectionToQuery({
             ...frozen,

--- a/tests/unit/lib/features/flowsheet/flowsheet.test.ts
+++ b/tests/unit/lib/features/flowsheet/flowsheet.test.ts
@@ -1072,6 +1072,97 @@ describeSlice(flowsheetSlice, defaultFlowsheetFrontendState, ({ harness, actions
       expect(result.search.query.track_position).toBeUndefined();
     });
 
+    // The query carries two ids for the frozen release: album_id (what a
+    // submission writes) and legacy_release_id (what the track picker reads).
+    // They must move together in every reducer that touches either. Leaving a
+    // stale legacy id behind after album_id clears is the worst case — the
+    // picker goes on serving the previous release's tracklist against a query
+    // that no longer references it, and nothing errors.
+    describe("the query's two ids move in lockstep", () => {
+      const frozen = {
+        artist: "Juana Molina",
+        album: "DOGA",
+        label: "Sonamos",
+        artistProvided: true,
+        album_id: 1234,
+        legacy_release_id: 45342,
+      };
+
+      it("freezeSelectionToQuery sets both", () => {
+        const result = harness().reduce(
+          actions.freezeSelectionToQuery(frozen)
+        );
+        expect(result.search.query.album_id).toBe(1234);
+        expect(result.search.query.legacy_release_id).toBe(45342);
+      });
+
+      it.each([
+        [
+          "setRotationMode(false)",
+          () => harness().chain(
+            actions.freezeSelectionToQuery(frozen),
+            actions.setRotationMode(false)
+          ),
+        ],
+        [
+          "resetSearch",
+          () => harness().chain(
+            actions.freezeSelectionToQuery(frozen),
+            actions.resetSearch()
+          ),
+        ],
+        [
+          "a deviating edit to a supplied field",
+          () => harness().chain(
+            actions.freezeSelectionToQuery(frozen),
+            actions.setSearchProperty({
+              name: "artist",
+              value: "Someone Else",
+              deviates: true,
+            })
+          ),
+        ],
+      ])("%s clears both", (_name, run) => {
+        const result = run();
+        expect(result.search.query.album_id).toBeUndefined();
+        expect(result.search.query.legacy_release_id).toBeUndefined();
+      });
+
+      it("setRotationMetadata replaces both", () => {
+        const result = harness().chain(
+          actions.freezeSelectionToQuery(frozen),
+          actions.setRotationMetadata({
+            album_id: TEST_ENTITY_IDS.ALBUM.ROTATION_ALBUM,
+            legacy_release_id: TEST_ENTITY_IDS.LEGACY_RELEASE.ROTATION_ALBUM,
+            rotation_id: TEST_ENTITY_IDS.ROTATION.HEAVY,
+            rotation_bin: "H" as const,
+          })
+        );
+        expect(result.search.query.album_id).toBe(
+          TEST_ENTITY_IDS.ALBUM.ROTATION_ALBUM
+        );
+        expect(result.search.query.legacy_release_id).toBe(
+          TEST_ENTITY_IDS.LEGACY_RELEASE.ROTATION_ALBUM
+        );
+      });
+
+      it("carries a legacy id even when the write half withholds album_id", () => {
+        // A rotation release whose credit submission refuses has its album_id
+        // withheld so BS can't hand the credit back. That is a write-side
+        // decision and says nothing about which tracklist to show, so the read
+        // half must survive it — otherwise picking such a release silently
+        // loses the picker.
+        const result = harness().reduce(
+          actions.freezeSelectionToQuery({
+            ...frozen,
+            album_id: undefined,
+          })
+        );
+        expect(result.search.query.album_id).toBeUndefined();
+        expect(result.search.query.legacy_release_id).toBe(45342);
+      });
+    });
+
     it("should preserve rotation mode across resetSearch", () => {
       const result = harness().chain(
         actions.setRotationMode(true),


### PR DESCRIPTION
Relands #1219, whose content never reached `main`.

## What happened

#1207 and #1219 were both rebase-merged on 2026-08-14 at 20:40 PDT, three seconds apart. #1207 landed on `main` correctly. #1219 did not: its merge commit `f4fe7e01` was written to `refs/heads/feat/1184-legacy-release-id-substrate` — #1219's stacked base — and is not an ancestor of `origin/main`. GitHub still marked the PR MERGED and deleted its head branch, so nothing surfaced the gap.

The effect is that **the fix for the silent 87.7% shipped nowhere**. `main`'s `FlowsheetSearchResults.tsx` contains no `idSource`, no `tracklistReleaseId`, and no `linkedAlbumId`; the picker still resolves its tracklist read in the wrong id space for catalog, bin, and linked-rotation rows.

Confirmed with `git cherry origin/main origin/feat/1184-legacy-release-id-substrate`, which marks #1207's two commits as already-upstream by patch-id and #1219's two as not:

```
- f72c2b91  feat(catalog): carry legacy_release_id alongside library.id on AlbumEntry
- d3c6c30d  fix(catalog): learn a legacy id the cached search row is missing
+ db38fa18  fix(flowsheet): resolve the track picker in the legacy_release_id space
+ f4fe7e01  fix(flowsheet): resolve both picker ids from one row
```

## What's here

The two `+` commits, rebased onto current `main`. The rebase skipped both already-applied substrate commits on its own (`warning: skipped previously applied commit`), so this branch carries exactly #1219's delta and nothing else — no re-application of #1207, no revert of anything merged since.

The content is unchanged from #1219 as reviewed and approved. That PR's body remains the description of what these commits do and why; this one exists only because those commits need a path to `main`. A straight fast-forward was not available: the substrate branch is also behind `main` on the classic-catalog work merged since, so a rebase was required either way.

## Verification

Run in the branch's own worktree, after rebasing onto `main`:

| Check | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | exit 0 — **0 errors**, 195 warnings (pre-existing backlog, unchanged count) |
| `npm run test:run` | **4718 passed / 4718**, 330 files |
| `npm run build` | success |

The suite is larger than the 4682 recorded on #1219 because `main` has since gained tests from the classic-catalog merges; the delta is not from this branch. The two suites were run separately rather than concurrently — running them together on this machine produces timeout failures that are a contention artifact, not a real result.

## Follow-up

`origin/feat/1184-legacy-release-id-substrate` still exists and still holds the orphaned merge. It can be deleted once this lands, but not before.

Parts 3 (write fix) and 4 (LML dedupe re-key) of #1184 remain unwritten, so #1184 stays open.

## Related

Epic #1179 · #1184 (parent) · #1207 (part 1, merged correctly) · #1219 (the merge this relands)
