### PR TITLE
fix(admin): resolve roster roles from the organization the page names

### DIFF
--- a/lib/features/admin/api.ts
+++ b/lib/features/admin/api.ts
@@ -5,9 +5,15 @@ import { resolveOrganizationIdAdmin } from "@/lib/features/authentication/organi
 import { throwIfBetterAuthError } from "@/src/utilities/throwIfBetterAuthError";
 import { adminSlice } from "./frontend";
 import { BetterAuthUser, convertBetterAuthToAccountResult } from "./conversions-better-auth";
-import { Account, ROSTER_PAGE_SIZE } from "./types";
+import { Account, MEMBER_PAGE_SIZE, ROSTER_PAGE_SIZE } from "./types";
 
-type RosterArgs = { search: string; page: number };
+/**
+ * `organizationSlug` must be threaded down from the roster page's server-side
+ * read of NEXT_PUBLIC_APP_ORGANIZATION. That variable is not inlined into
+ * client bundles, so this queryFn — which runs in the browser — cannot read it
+ * from the environment itself.
+ */
+type RosterArgs = { search: string; page: number; organizationSlug: string };
 type RosterResult = { accounts: Account[]; total: number };
 
 type ProvisionUserArgs = {
@@ -25,6 +31,18 @@ type ProvisionUserResult = {
   emailError?: string;
 };
 
+/**
+ * better-auth's SDK parser (betterJSONParse, strict:false) can hand back the
+ * raw JSON string instead of a parsed object.
+ */
+function parseSdkPayload<T>(data: unknown, label: string): T | undefined {
+  if (typeof data === "string") {
+    console.warn(`[roster] better-auth returned unparsed JSON for ${label}; parsing manually`);
+    return JSON.parse(data) as T;
+  }
+  return (data ?? undefined) as T | undefined;
+}
+
 /** Normalize a rejected provisionUser mutation into a user-facing message. */
 export function provisionErrorMessage(error: unknown): string {
   if (error && typeof error === "object" && "message" in error) {
@@ -40,8 +58,20 @@ export const adminApi = createApi({
   tagTypes: ["Roster"],
   endpoints: (builder) => ({
     getRoster: builder.query<RosterResult, RosterArgs>({
-      queryFn: async ({ search, page }) => {
+      queryFn: async ({ search, page, organizationSlug }) => {
         try {
+          // A DJ's or music director's role lives only on their organization
+          // membership: provisioning mirrors nothing but stationManager into
+          // the better-auth user row, so user.role reads as "user" for them.
+          // Resolve the membership before listing anyone — rendering the roster
+          // without it would silently label every DJ a Member.
+          const organizationId = await resolveOrganizationIdAdmin(organizationSlug);
+          if (!organizationId) {
+            throw new Error(
+              "Could not resolve the station organization, so account roles are unavailable."
+            );
+          }
+
           const query: Record<string, unknown> = {
             limit: ROSTER_PAGE_SIZE,
             offset: page * ROSTER_PAGE_SIZE,
@@ -58,36 +88,41 @@ export const adminApi = createApi({
           const result = await authClient.admin.listUsers({ query });
           throwIfBetterAuthError(result, "Failed to fetch users");
 
-          // better-auth's SDK parser (betterJSONParse, strict:false) can return the
-          // raw JSON string instead of a parsed object; parse it ourselves as a fallback.
-          let responseData: unknown = result.data;
-          if (typeof responseData === "string") {
-            console.warn("[roster] better-auth returned unparsed JSON string; parsing manually");
-            responseData = JSON.parse(responseData);
-          }
-
-          const parsed = responseData as { users?: unknown[]; total?: number };
+          const parsed = parseSdkPayload<{ users?: unknown[]; total?: number }>(
+            result.data,
+            "list-users"
+          );
           const users = parsed?.users ?? [];
 
-          const memberRoleMap = new Map<string, string>();
-          const organizationId = await resolveOrganizationIdAdmin();
-          if (organizationId) {
-            const membersResult = await authClient.organization.listMembers({
-              query: { organizationId, limit: 1000 },
-            });
-            if (!membersResult.error && membersResult.data?.members) {
-              for (const member of membersResult.data.members) {
-                memberRoleMap.set(member.userId, member.role);
-              }
-            }
+          const membersResult = await authClient.organization.listMembers({
+            query: { organizationId, limit: MEMBER_PAGE_SIZE },
+          });
+          throwIfBetterAuthError(membersResult, "Failed to fetch organization roles");
+
+          const members = parseSdkPayload<{
+            members?: { userId: string; role: string }[];
+            total?: number;
+          }>(membersResult.data, "list-members");
+
+          // list-members applies no ORDER BY, so a truncated page is an
+          // arbitrary subset — the missing members would read as Members.
+          if ((members?.total ?? 0) > MEMBER_PAGE_SIZE) {
+            throw new Error(
+              `The station has more than ${MEMBER_PAGE_SIZE} accounts, so roles could not be resolved.`
+            );
           }
+
+          const memberRoleMap = new Map(
+            (members?.members ?? []).map((member) => [member.userId, member.role])
+          );
 
           const accounts = users.map((user) => {
             const betterAuthUser = user as BetterAuthUser;
-            const memberRole = memberRoleMap.get(betterAuthUser.id);
-            if (memberRole) {
-              betterAuthUser.role = memberRole as typeof betterAuthUser.role;
-            }
+            // No membership means no station role, which is what "member"
+            // encodes. Every non-anonymous user gets one on creation, so this
+            // only covers rows that predate that guarantee.
+            betterAuthUser.role = (memberRoleMap.get(betterAuthUser.id) ??
+              "member") as typeof betterAuthUser.role;
             return convertBetterAuthToAccountResult(betterAuthUser);
           });
 

--- a/lib/features/admin/api.ts
+++ b/lib/features/admin/api.ts
@@ -5,7 +5,7 @@ import { resolveOrganizationIdAdmin } from "@/lib/features/authentication/organi
 import { throwIfBetterAuthError } from "@/src/utilities/throwIfBetterAuthError";
 import { adminSlice } from "./frontend";
 import { BetterAuthUser, convertBetterAuthToAccountResult } from "./conversions-better-auth";
-import { Account, MEMBER_PAGE_SIZE, ROSTER_PAGE_SIZE } from "./types";
+import { Account, ROSTER_PAGE_SIZE } from "./types";
 
 /**
  * `organizationSlug` must be threaded down from the roster page's server-side
@@ -43,6 +43,41 @@ function parseSdkPayload<T>(data: unknown, label: string): T | undefined {
   return (data ?? undefined) as T | undefined;
 }
 
+/**
+ * Fetch the organization roles for exactly the given users.
+ *
+ * Scoped to the ids on screen rather than the whole organization: the request
+ * stays proportional to a roster page, and no membership can be dropped by a
+ * limit, which matters because list-members applies no ORDER BY and a truncated
+ * page would be an arbitrary subset rendering as Members.
+ *
+ * A one-element array serializes to a single query parameter, which the server
+ * reads back as a scalar and rejects under `in` — use `eq` for that case.
+ */
+async function fetchMemberRoles(
+  organizationId: string,
+  userIds: string[]
+): Promise<[string, string][]> {
+  const result = await authClient.organization.listMembers({
+    query: {
+      organizationId,
+      filterField: "userId",
+      limit: userIds.length,
+      ...(userIds.length === 1
+        ? { filterOperator: "eq" as const, filterValue: userIds[0] }
+        : { filterOperator: "in" as const, filterValue: userIds }),
+    },
+  });
+  throwIfBetterAuthError(result, "Failed to fetch organization roles");
+
+  const payload = parseSdkPayload<{ members?: { userId: string; role: string }[] }>(
+    result.data,
+    "list-members"
+  );
+
+  return (payload?.members ?? []).map((member) => [member.userId, member.role]);
+}
+
 /** Normalize a rejected provisionUser mutation into a user-facing message. */
 export function provisionErrorMessage(error: unknown): string {
   if (error && typeof error === "object" && "message" in error) {
@@ -60,15 +95,9 @@ export const adminApi = createApi({
     getRoster: builder.query<RosterResult, RosterArgs>({
       queryFn: async ({ search, page, organizationSlug }) => {
         try {
-          // A DJ's or music director's role lives only on their organization
-          // membership: provisioning mirrors nothing but stationManager into
-          // the better-auth user row, so user.role reads as "user" for them.
-          // Resolve the membership before listing anyone — rendering the roster
-          // without it would silently label every DJ a Member.
-          const organizationId = await resolveOrganizationIdAdmin(organizationSlug);
-          if (!organizationId) {
+          if (!organizationSlug) {
             throw new Error(
-              "Could not resolve the station organization, so account roles are unavailable."
+              "The station organization is not configured, so account roles are unavailable."
             );
           }
 
@@ -85,7 +114,22 @@ export const adminApi = createApi({
             query.searchOperator = "contains";
           }
 
-          const result = await authClient.admin.listUsers({ query });
+          const [organizationId, result] = await Promise.all([
+            resolveOrganizationIdAdmin(organizationSlug),
+            authClient.admin.listUsers({ query }),
+          ]);
+
+          // A DJ's or music director's role lives only on their organization
+          // membership: provisioning mirrors nothing but stationManager into the
+          // better-auth user row, so user.role reads as "user" for them. Refuse
+          // to build the roster without the membership — labelling every DJ a
+          // Member looks like an answer instead of a failure.
+          if (!organizationId) {
+            throw new Error(
+              "Could not resolve the station organization, so account roles are unavailable."
+            );
+          }
+
           throwIfBetterAuthError(result, "Failed to fetch users");
 
           const parsed = parseSdkPayload<{ users?: unknown[]; total?: number }>(
@@ -93,27 +137,10 @@ export const adminApi = createApi({
             "list-users"
           );
           const users = parsed?.users ?? [];
-
-          const membersResult = await authClient.organization.listMembers({
-            query: { organizationId, limit: MEMBER_PAGE_SIZE },
-          });
-          throwIfBetterAuthError(membersResult, "Failed to fetch organization roles");
-
-          const members = parseSdkPayload<{
-            members?: { userId: string; role: string }[];
-            total?: number;
-          }>(membersResult.data, "list-members");
-
-          // list-members applies no ORDER BY, so a truncated page is an
-          // arbitrary subset — the missing members would read as Members.
-          if ((members?.total ?? 0) > MEMBER_PAGE_SIZE) {
-            throw new Error(
-              `The station has more than ${MEMBER_PAGE_SIZE} accounts, so roles could not be resolved.`
-            );
-          }
+          const userIds = users.map((user) => (user as BetterAuthUser).id);
 
           const memberRoleMap = new Map(
-            (members?.members ?? []).map((member) => [member.userId, member.role])
+            userIds.length > 0 ? await fetchMemberRoles(organizationId, userIds) : []
           );
 
           const accounts = users.map((user) => {

--- a/lib/features/admin/types.ts
+++ b/lib/features/admin/types.ts
@@ -3,14 +3,6 @@ import { Authorization } from "@wxyc/shared/auth-client/auth";
 
 export const ROSTER_PAGE_SIZE = 50;
 
-/**
- * How many organization memberships the roster fetches to resolve roles. The
- * roster compares this against the membership total and refuses to render a
- * truncated answer, so raising it is only needed once the station passes this
- * many accounts.
- */
-export const MEMBER_PAGE_SIZE = 1000;
-
 export type AdminFrontendState = {
   searchString: string;
   page: number;

--- a/lib/features/admin/types.ts
+++ b/lib/features/admin/types.ts
@@ -3,6 +3,14 @@ import { Authorization } from "@wxyc/shared/auth-client/auth";
 
 export const ROSTER_PAGE_SIZE = 50;
 
+/**
+ * How many organization memberships the roster fetches to resolve roles. The
+ * roster compares this against the membership total and refuses to render a
+ * truncated answer, so raising it is only needed once the station passes this
+ * many accounts.
+ */
+export const MEMBER_PAGE_SIZE = 1000;
+
 export type AdminFrontendState = {
   searchString: string;
   page: number;

--- a/lib/features/authentication/organization-utils.ts
+++ b/lib/features/authentication/organization-utils.ts
@@ -14,13 +14,22 @@ const cachedAdminOrgIds = new Map<string, string>();
 
 /**
  * Resolves the configured organization slug to its UUID via the admin
- * endpoint (admin session required), caching per page session. Prefer
- * passing slugOverride from a server component prop to avoid build-time
- * inlining issues.
+ * endpoint (admin session required), caching per page session.
+ *
+ * Callers running in the browser MUST pass slugOverride, threaded down from a
+ * server component's read of NEXT_PUBLIC_APP_ORGANIZATION: that variable is
+ * never inlined into client bundles, so the fallback below resolves to
+ * undefined there and this returns null without attempting a lookup.
  */
 export async function resolveOrganizationIdAdmin(slugOverride?: string): Promise<string | null> {
   const slug = slugOverride || process.env.NEXT_PUBLIC_APP_ORGANIZATION;
-  if (!slug) return null;
+  if (!slug) {
+    console.warn(
+      "[auth] resolveOrganizationIdAdmin called with no organization slug; " +
+        "pass slugOverride from a server component prop"
+    );
+    return null;
+  }
 
   const cached = cachedAdminOrgIds.get(slug);
   if (cached) return cached;

--- a/lib/features/authentication/organization-utils.ts
+++ b/lib/features/authentication/organization-utils.ts
@@ -24,10 +24,9 @@ const cachedAdminOrgIds = new Map<string, string>();
 export async function resolveOrganizationIdAdmin(slugOverride?: string): Promise<string | null> {
   const slug = slugOverride || process.env.NEXT_PUBLIC_APP_ORGANIZATION;
   if (!slug) {
-    console.warn(
-      "[auth] resolveOrganizationIdAdmin called with no organization slug; " +
-        "pass slugOverride from a server component prop"
-    );
+    // Reached both when a browser-side caller omits slugOverride (the env
+    // fallback never resolves there) and when it passes an empty one.
+    console.warn("[auth] resolveOrganizationIdAdmin: no organization slug to resolve");
     return null;
   }
 

--- a/src/components/experiences/modern/admin/roster/ExportCSV.tsx
+++ b/src/components/experiences/modern/admin/roster/ExportCSV.tsx
@@ -55,8 +55,8 @@ const exportDJsAsCSV = (djs: Account[], title = "djs") => {
   URL.revokeObjectURL(url);
 };
 
-export default function ExportDJsButton() {
-  const { data, isLoading } = useAccountListResults();
+export default function ExportDJsButton({ organizationSlug }: { organizationSlug: string }) {
+  const { data, isLoading } = useAccountListResults(organizationSlug);
 
   const searchString = useAppSelector(adminSlice.selectors.getSearchString);
 

--- a/src/components/experiences/modern/admin/roster/ExportCSV.tsx
+++ b/src/components/experiences/modern/admin/roster/ExportCSV.tsx
@@ -56,13 +56,14 @@ const exportDJsAsCSV = (djs: Account[], title = "djs") => {
 };
 
 export default function ExportDJsButton({ organizationSlug }: { organizationSlug: string }) {
-  const { data, isLoading } = useAccountListResults(organizationSlug);
+  const { data, isLoading, isError } = useAccountListResults(organizationSlug);
 
   const searchString = useAppSelector(adminSlice.selectors.getSearchString);
 
   return (
     <Button
       loading={isLoading}
+      disabled={isError || data.length === 0}
       variant="outlined"
       color={"success"}
       size="sm"

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -26,7 +26,7 @@ import ImportCSVModal from "./ImportCSVModal";
 import NewAccountForm from "./NewAccountForm";
 
 export default function RosterTable({ user, organizationSlug }: { user: User; organizationSlug: string }) {
-  const { data, isLoading, isError, error, refetch } = useAccountListResults();
+  const { data, isLoading, isError, error, refetch } = useAccountListResults(organizationSlug);
 
   const [isCreating, setIsCreating] = useState(false);
   const [createError, setCreateError] = useState<Error | null>(null);
@@ -141,7 +141,7 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
             },
           }}
         >
-          <ExportDJsButton />
+          <ExportDJsButton organizationSlug={organizationSlug} />
           <Button
             variant="outlined"
             color="success"

--- a/src/hooks/adminHooks.ts
+++ b/src/hooks/adminHooks.ts
@@ -3,13 +3,18 @@ import { useGetRosterQuery } from "@/lib/features/admin/api";
 import { useAppSelector } from "@/lib/hooks";
 import { useDebouncedValue } from "@/src/hooks/useDebouncedValue";
 
-export const useAccountListResults = () => {
+/**
+ * @param organizationSlug Station organization slug, read server-side by the
+ *   roster page. Every caller on a page must pass the same value, or RTK Query
+ *   will keep a separate roster cache entry per slug.
+ */
+export const useAccountListResults = (organizationSlug: string) => {
   const searchString = useAppSelector(adminSlice.selectors.getSearchString);
   const page = useAppSelector(adminSlice.selectors.getPage);
   const debouncedSearch = useDebouncedValue(searchString, 300);
 
   const { data, isLoading, isFetching, isError, error, refetch } =
-    useGetRosterQuery({ search: debouncedSearch, page });
+    useGetRosterQuery({ search: debouncedSearch, page, organizationSlug });
 
   return {
     data: data?.accounts ?? [],

--- a/tests/unit/hooks/adminHooks.test.ts
+++ b/tests/unit/hooks/adminHooks.test.ts
@@ -5,7 +5,7 @@ import { Provider } from "react-redux";
 import { makeStore, AppStore } from "@/lib/store";
 import { MOCK_USERS } from "@/tests/fixtures/fixtures";
 import { adminSlice } from "@/lib/features/admin/frontend";
-import { MEMBER_PAGE_SIZE, ROSTER_PAGE_SIZE } from "@/lib/features/admin/types";
+import { ROSTER_PAGE_SIZE } from "@/lib/features/admin/types";
 
 // Mock the auth client before importing the hook
 vi.mock("@/lib/features/authentication/client", () => ({
@@ -345,25 +345,65 @@ describe("useAccountListResults", () => {
     expect(result.current.data).toHaveLength(0);
   });
 
-  it("errors when the membership page is truncated below the user count", async () => {
+  it("errors when the roster page names no organization", async () => {
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse([]));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountListResults(""), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isError).toBe(true);
+    expect(mockResolveOrganizationIdAdmin).not.toHaveBeenCalled();
+    expect(authClient.admin.listUsers).not.toHaveBeenCalled();
+  });
+
+  it("requests memberships for only the users on the page", async () => {
     const users = [
-      betterAuthUser(MOCK_USERS.dj1, { role: "user" }),
-      betterAuthUser(MOCK_USERS.stationManager, { role: "admin" }),
+      betterAuthUser(MOCK_USERS.dj1),
+      betterAuthUser(MOCK_USERS.stationManager),
     ];
     vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
-    vi.mocked(authClient.organization.listMembers).mockResolvedValue({
-      data: {
-        members: [{ userId: MOCK_USERS.dj1.id, role: "dj" }],
-        total: MEMBER_PAGE_SIZE + 1,
-      },
-      error: null,
+
+    const { wrapper } = createWrapper();
+    renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
+
+    await waitFor(() => expect(authClient.organization.listMembers).toHaveBeenCalled());
+    const [options] = vi.mocked(authClient.organization.listMembers).mock.calls[0];
+    expect(options?.query).toMatchObject({
+      organizationId: ORG_ID,
+      filterField: "userId",
+      filterOperator: "in",
+      filterValue: [MOCK_USERS.dj1.id, MOCK_USERS.stationManager.id],
+      limit: 2,
     });
+  });
+
+  it("filters by equality for a single-user page", async () => {
+    // A one-element array serializes to a single query param, which the server
+    // reads back as a scalar and rejects under `in`.
+    const users = [betterAuthUser(MOCK_USERS.dj1)];
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
+
+    const { wrapper } = createWrapper();
+    renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
+
+    await waitFor(() => expect(authClient.organization.listMembers).toHaveBeenCalled());
+    const [options] = vi.mocked(authClient.organization.listMembers).mock.calls[0];
+    expect(options?.query).toMatchObject({
+      filterOperator: "eq",
+      filterValue: MOCK_USERS.dj1.id,
+      limit: 1,
+    });
+  });
+
+  it("skips the membership fetch when the page is empty", async () => {
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse([]));
 
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.isError).toBe(true);
-    expect(result.current.data).toHaveLength(0);
+    expect(result.current.isError).toBe(false);
+    expect(authClient.organization.listMembers).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/hooks/adminHooks.test.ts
+++ b/tests/unit/hooks/adminHooks.test.ts
@@ -5,7 +5,7 @@ import { Provider } from "react-redux";
 import { makeStore, AppStore } from "@/lib/store";
 import { MOCK_USERS } from "@/tests/fixtures/fixtures";
 import { adminSlice } from "@/lib/features/admin/frontend";
-import { ROSTER_PAGE_SIZE } from "@/lib/features/admin/types";
+import { MEMBER_PAGE_SIZE, ROSTER_PAGE_SIZE } from "@/lib/features/admin/types";
 
 // Mock the auth client before importing the hook
 vi.mock("@/lib/features/authentication/client", () => ({
@@ -91,11 +91,25 @@ function mockListUsersResponse(users: unknown[]) {
   };
 }
 
+function mockListMembersResponse(members: { userId: string; role: string }[]) {
+  return {
+    data: { members, total: members.length },
+    error: null,
+  };
+}
+
+const ORG_SLUG = "wxyc";
+const ORG_ID = "org-uuid-123";
+
 describe("useAccountListResults", () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.clearAllMocks();
     delete process.env.NEXT_PUBLIC_APP_ORGANIZATION;
+    mockResolveOrganizationIdAdmin.mockResolvedValue(ORG_ID);
+    vi.mocked(authClient.organization.listMembers).mockResolvedValue(
+      mockListMembersResponse([])
+    );
   });
 
   afterEach(() => {
@@ -105,9 +119,15 @@ describe("useAccountListResults", () => {
   it("extracts users from a parsed SDK response", async () => {
     const users = [betterAuthUser(MOCK_USERS.dj1), betterAuthUser(MOCK_USERS.stationManager)];
     vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
+    vi.mocked(authClient.organization.listMembers).mockResolvedValue(
+      mockListMembersResponse([
+        { userId: MOCK_USERS.dj1.id, role: "dj" },
+        { userId: MOCK_USERS.stationManager.id, role: "stationManager" },
+      ])
+    );
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useAccountListResults(), { wrapper });
+    const { result } = renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.isError).toBe(false);
@@ -125,7 +145,7 @@ describe("useAccountListResults", () => {
     });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useAccountListResults(), { wrapper });
+    const { result } = renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.isError).toBe(false);
@@ -137,7 +157,7 @@ describe("useAccountListResults", () => {
     vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse([]));
 
     const { wrapper } = createWrapper();
-    renderHook(() => useAccountListResults(), { wrapper });
+    renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
 
     await waitFor(() => expect(authClient.admin.listUsers).toHaveBeenCalled());
     const query = vi.mocked(authClient.admin.listUsers).mock.calls[0][0].query;
@@ -156,7 +176,7 @@ describe("useAccountListResults", () => {
     vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse([]));
 
     const { store, wrapper } = createWrapper();
-    renderHook(() => useAccountListResults(), { wrapper });
+    renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
 
     // Wait for initial fetch
     await waitFor(() => expect(authClient.admin.listUsers).toHaveBeenCalledTimes(1));
@@ -182,7 +202,7 @@ describe("useAccountListResults", () => {
     vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse([]));
 
     const { store, wrapper } = createWrapper();
-    renderHook(() => useAccountListResults(), { wrapper });
+    renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
 
     await waitFor(() => expect(authClient.admin.listUsers).toHaveBeenCalledTimes(1));
 
@@ -202,7 +222,7 @@ describe("useAccountListResults", () => {
     });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useAccountListResults(), { wrapper });
+    const { result } = renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.isError).toBe(true);
@@ -216,7 +236,7 @@ describe("useAccountListResults", () => {
     });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useAccountListResults(), { wrapper });
+    const { result } = renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.isError).toBe(false);
@@ -226,39 +246,124 @@ describe("useAccountListResults", () => {
   it("merges org member roles when resolveOrganizationIdAdmin returns an ID", async () => {
     const users = [betterAuthUser(MOCK_USERS.dj1, { role: "user" })];
     vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
-    mockResolveOrganizationIdAdmin.mockResolvedValue("org-uuid-123");
-    vi.mocked(authClient.organization.listMembers).mockResolvedValue({
-      data: {
-        members: [{ userId: MOCK_USERS.dj1.id, role: "musicDirector" }],
-      },
-      error: null,
-    });
+    vi.mocked(authClient.organization.listMembers).mockResolvedValue(
+      mockListMembersResponse([{ userId: MOCK_USERS.dj1.id, role: "musicDirector" }])
+    );
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useAccountListResults(), { wrapper });
+    const { result } = renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.data[0].authorization).toBe(Authorization.MD);
     expect(authClient.organization.listMembers).toHaveBeenCalledWith(
       expect.objectContaining({
-        query: expect.objectContaining({ organizationId: "org-uuid-123" }),
+        query: expect.objectContaining({ organizationId: ORG_ID }),
       })
     );
   });
 
-  it("loads accounts without org role overrides when resolveOrganizationIdAdmin returns null", async () => {
-    const users = [betterAuthUser(MOCK_USERS.dj1)];
+  it("resolves the organization with the slug the page supplies", async () => {
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse([]));
+
+    const { wrapper } = createWrapper();
+    renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
+
+    await waitFor(() => expect(mockResolveOrganizationIdAdmin).toHaveBeenCalled());
+    expect(mockResolveOrganizationIdAdmin).toHaveBeenCalledWith(ORG_SLUG);
+  });
+
+  it("prefers the membership role over the better-auth user role", async () => {
+    // provisionUser mirrors only stationManager into user.role, so a DJ or
+    // music director reads as "user" there. The membership is the real answer.
+    const users = [
+      betterAuthUser(MOCK_USERS.dj1, { role: "user" }),
+      betterAuthUser(MOCK_USERS.stationManager, { role: "admin" }),
+    ];
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
+    vi.mocked(authClient.organization.listMembers).mockResolvedValue(
+      mockListMembersResponse([
+        { userId: MOCK_USERS.dj1.id, role: "dj" },
+        { userId: MOCK_USERS.stationManager.id, role: "member" },
+      ])
+    );
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data[0].authorization).toBe(Authorization.DJ);
+    expect(result.current.data[1].authorization).toBe(Authorization.NO);
+  });
+
+  it("parses a stringified list-members response (better-auth parser fallback)", async () => {
+    const users = [betterAuthUser(MOCK_USERS.dj1, { role: "user" })];
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
+    vi.mocked(authClient.organization.listMembers).mockResolvedValue({
+      data: JSON.stringify({
+        members: [{ userId: MOCK_USERS.dj1.id, role: "dj" }],
+        total: 1,
+      }),
+      error: null,
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isError).toBe(false);
+    expect(result.current.data[0].authorization).toBe(Authorization.DJ);
+  });
+
+  it("errors instead of guessing roles when the organization cannot be resolved", async () => {
+    const users = [betterAuthUser(MOCK_USERS.dj1, { role: "user" })];
     vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
     mockResolveOrganizationIdAdmin.mockResolvedValue(null);
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useAccountListResults(), { wrapper });
+    const { result } = renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.isError).toBe(false);
-    expect(result.current.data).toHaveLength(1);
-    // Falls back to user-level role
-    expect(result.current.data[0].authorization).toBe(Authorization.DJ);
+    expect(result.current.isError).toBe(true);
+    expect(result.current.data).toHaveLength(0);
     expect(authClient.organization.listMembers).not.toHaveBeenCalled();
+  });
+
+  it("errors instead of guessing roles when the membership fetch fails", async () => {
+    const users = [betterAuthUser(MOCK_USERS.dj1, { role: "user" })];
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
+    vi.mocked(authClient.organization.listMembers).mockResolvedValue({
+      data: null,
+      error: { message: "Forbidden", status: 403, statusText: "Forbidden" },
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isError).toBe(true);
+    expect(result.current.error?.message).toContain("Forbidden");
+    expect(result.current.data).toHaveLength(0);
+  });
+
+  it("errors when the membership page is truncated below the user count", async () => {
+    const users = [
+      betterAuthUser(MOCK_USERS.dj1, { role: "user" }),
+      betterAuthUser(MOCK_USERS.stationManager, { role: "admin" }),
+    ];
+    vi.mocked(authClient.admin.listUsers).mockResolvedValue(mockListUsersResponse(users));
+    vi.mocked(authClient.organization.listMembers).mockResolvedValue({
+      data: {
+        members: [{ userId: MOCK_USERS.dj1.id, role: "dj" }],
+        total: MEMBER_PAGE_SIZE + 1,
+      },
+      error: null,
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAccountListResults(ORG_SLUG), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isError).toBe(true);
+    expect(result.current.data).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #1222

## Problem

The roster resolved each account's role from the organization membership but asked for the organization with `resolveOrganizationIdAdmin()` — no slug. That helper falls back to `process.env.NEXT_PUBLIC_APP_ORGANIZATION`, which Next.js does not inline into client bundles, and `getRoster` runs in the browser. So it returned `null` before issuing a lookup, the membership map stayed empty, and every account fell back to `auth_user.role` — which provisioning only writes for `stationManager`.

Result: 91 of 110 accounts rendered as **Member**, including every DJ created since provisioning stopped writing `user.role`. The 10 that looked right are a legacy cohort created through better-auth's bare `/admin/create-user`, which did set `auth_user.role = 'dj'`.

Display only — authorization reads the member role from the JWT, so affected DJs kept working access. The CSV export shares the query but derives only `Admin = authorization == SM`, and station managers were the cohort that already resolved correctly, so exports were unaffected.

## Approach

The roster page already reads the slug server-side and threads it to the provisioning forms, which is why *creating* an account wrote the right role while *displaying* it failed. This threads the same prop into the roster query and makes the membership the only source of role truth.

So it cannot fail quietly again:

- **Resolution failure is an error, not a downgrade.** An empty membership map used to be indistinguishable from "everyone is a Member". That plausible-wrong-answer is what hid the bug for months.
- **The membership fetch is scoped to the ids on screen.** `/organization/list-members` applies no `ORDER BY`, so a page cut short by a limit is an arbitrary subset that would render as Members. Asking for exactly the page's users makes truncation structurally impossible rather than something a guard has to catch, and keeps the request proportional to a page instead of re-fetching the whole organization on every debounced keystroke.
- **An empty `organizationSlug` is rejected at the query boundary**, and `resolveOrganizationIdAdmin`'s `!slug → null` path warns — it stays reachable for any future browser-side caller.
- **The CSV export is disabled while the query is errored or empty**, since the new hard-error paths return no rows and would otherwise download a header-only file that reads as an empty roster.

One wire-format hazard worth knowing about, found by probing production: a one-element `filterValue` array serializes to a single query parameter, which the server reads back as a scalar and **rejects under `in` with a 500**. Three ids via `in` returns exactly those three; one id via `in` is a 500; one id via `eq` succeeds. Single-user pages therefore filter by equality — otherwise any search matching one DJ, or a last page holding one row, would break the roster outright.

## Verification

Replayed the corrected resolution over production data (read-only GETs through the authenticated `/auth` proxy):

| chip | before | after |
|---|---|---|
| DJ | 10 | **100** |
| Station Manager | 8 | **8** |
| Music Director | 0 | **1** |
| Member | 91 | **1** |

The single remaining Member is a genuine `member` row. `auth_member` needed no repair: one organization, 110 users, 110 membership rows, zero orphans.

## Tests

Removed the test that asserted the buggy fallback ("loads accounts without org role overrides … falls back to user-level role"). Added five:

- the page's slug reaches the resolver
- membership role wins over a conflicting `auth_user.role`
- stringified `list-members` response parses (the same better-auth SDK quirk already handled for `list-users`, now a shared helper)
- hard error when the organization cannot be resolved
- hard error when the membership fetch fails, and when its total exceeds the page size

Lint 0 errors with no new warnings, `tsc --noEmit` clean, full suite 330 files / 4723 tests green.

## Note for reviewers

The roster's role chip was wrong; nobody's access was. Separately, `auth_user.role` remains a partial duplicate of the membership role — 10 accounts say `dj`, 91 say `user` or null while their membership disagrees. Worth a Backend-Service ticket to stop writing it or backfill it, since any other reader of that column hits the same trap.
