### PR TITLE
fix(flowsheet): interim write-gate — withhold album_id for LML-sourced rows

### DIFF
--- a/e2e/tests/flowsheet/flowsheet-track-picker.spec.ts
+++ b/e2e/tests/flowsheet/flowsheet-track-picker.spec.ts
@@ -66,7 +66,7 @@ test.describe("Flowsheet Track Picker", { tag: "@smoke" }, () => {
     url.pathname.endsWith("/library/") &&
     !url.pathname.includes("/proxy/");
 
-  test("picks a tracklisted release and submits track_title + track_position", async ({
+  test("picks a tracklisted release and submits its title; the LML write-gate withholds album_id and track_position", async ({
     page,
   }) => {
     const LIBRARY_ID = 12345;
@@ -224,16 +224,19 @@ test.describe("Flowsheet Track Picker", { tag: "@smoke" }, () => {
     await flowsheet.songInput.press("Enter");
     await postResponse;
 
-    // Both legacy compat field and new track_position are present, and the
-    // highlighted release's id is forwarded as album_id.
+    // The LML-sourced row submits freeform: its `id` is a legacy id, so the
+    // interim write-gate withholds album_id rather than persist a
+    // wrong-space album link — and with it track_position, which only rides
+    // the wire alongside a linked album. The picker itself still worked (the
+    // read half rides legacy_release_id); only the linkage is withheld.
     expect(postBody).not.toBeNull();
     expect(postBody).toMatchObject({
       track_title: "la paradoja",
-      track_position: "A1",
-      album_id: LIBRARY_ID,
       artist_name: "Juana Molina",
       album_title: "DOGA",
     });
+    expect(postBody).not.toHaveProperty("album_id");
+    expect(postBody).not.toHaveProperty("track_position");
   });
 
   test("shows the catalog row's own tracklist, not the one its library.id resolves to", async ({
@@ -485,10 +488,12 @@ test.describe("Flowsheet Track Picker", { tag: "@smoke" }, () => {
     expect(postBody).not.toBeNull();
     expect(postBody).toMatchObject({
       track_title: "Call Your Name",
-      album_id: LIBRARY_ID,
       artist_name: "Chuquimamani-Condori",
       album_title: "Edits",
     });
+    // LML-sourced row → the interim write-gate withholds album_id (see
+    // AlbumEntry.lml_source).
+    expect(postBody).not.toHaveProperty("album_id");
     // No track was picked → no Discogs position was forwarded.
     expect(postBody).not.toHaveProperty("track_position");
   });

--- a/e2e/tests/flowsheet/flowsheet-track-picker.spec.ts
+++ b/e2e/tests/flowsheet/flowsheet-track-picker.spec.ts
@@ -66,7 +66,7 @@ test.describe("Flowsheet Track Picker", { tag: "@smoke" }, () => {
     url.pathname.endsWith("/library/") &&
     !url.pathname.includes("/proxy/");
 
-  test("picks a tracklisted release and submits its title; the LML write-gate withholds album_id and track_position", async ({
+  test("picks a tracklisted release and submits track_title + track_position; the LML write-gate withholds album_id", async ({
     page,
   }) => {
     const LIBRARY_ID = 12345;
@@ -226,17 +226,18 @@ test.describe("Flowsheet Track Picker", { tag: "@smoke" }, () => {
 
     // The LML-sourced row submits freeform: its `id` is a legacy id, so the
     // interim write-gate withholds album_id rather than persist a
-    // wrong-space album link — and with it track_position, which only rides
-    // the wire alongside a linked album. The picker itself still worked (the
-    // read half rides legacy_release_id); only the linkage is withheld.
+    // wrong-space album link. The pick itself survives — track_position
+    // rides the freeform variant when the read-half legacy id it was picked
+    // from rides beside it, and the picker stayed offered on that same read
+    // half. Only the linkage is withheld.
     expect(postBody).not.toBeNull();
     expect(postBody).toMatchObject({
       track_title: "la paradoja",
+      track_position: "A1",
       artist_name: "Juana Molina",
       album_title: "DOGA",
     });
     expect(postBody).not.toHaveProperty("album_id");
-    expect(postBody).not.toHaveProperty("track_position");
   });
 
   test("shows the catalog row's own tracklist, not the one its library.id resolves to", async ({

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -253,6 +253,18 @@ export type AlbumEntry = {
    * fail to compile rather than ship an `undefined`.
    */
   legacy_release_id: number | null;
+  /**
+   * INTERIM write-gate discriminator: true only for rows converted from an
+   * LML search result — the one source whose `id` above is a legacy id
+   * rather than a Backend serial, because LML's library.db has no other id
+   * to give. `entryToFreezePayload` withholds `album_id` for flagged rows,
+   * so a submission degrades to freeform instead of persisting a wrong-space
+   * album link. Remove the flag and its gate together in dj-site#1224's
+   * post-step-3 pass, once the LML proxy emits real `library.id`s
+   * (WXYC/Backend-Service#2168) — a gate left in place past that point keeps
+   * the corrected links out of the flowsheet.
+   */
+  lml_source?: true;
   title: string;
   artist: ArtistEntry;
   entry: number;

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -258,11 +258,10 @@ export type AlbumEntry = {
    * LML search result — the one source whose `id` above is a legacy id
    * rather than a Backend serial, because LML's library.db has no other id
    * to give. `entryToFreezePayload` withholds `album_id` for flagged rows,
-   * so a submission degrades to freeform instead of persisting a wrong-space
-   * album link. Remove the flag and its gate together in dj-site#1224's
-   * post-step-3 pass, once the LML proxy emits real `library.id`s
-   * (WXYC/Backend-Service#2168) — a gate left in place past that point keeps
-   * the corrected links out of the flowsheet.
+   * so a submission goes freeform instead of persisting a wrong-space album
+   * link. Remove the flag and its gate together once the LML search proxy
+   * emits a real Backend `library.id` in `id` — a gate left in place past
+   * that point keeps the corrected links out of the flowsheet.
    */
   lml_source?: true;
   title: string;

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -97,6 +97,17 @@ export function convertQueryToSubmission(
   const hasLinkedAlbum = hasLinkedAlbumId(query.album_id);
   const hasRotation =
     typeof query.rotation_id === "number" && query.rotation_id > 0;
+  // A picked position may also ride the freeform variant (BS persists it
+  // there), but only in the shape the LML write-gate produces: `album_id`
+  // absent entirely — present-but-negative is the synthesized stale-position
+  // hazard described above — while the read-half legacy id still rides,
+  // tying the position to the tracklist it was picked from. A typed freeform
+  // entry carries no legacy id, so a leftover position never rides one.
+  const freeformPickedPosition =
+    !hasLinkedAlbum &&
+    query.album_id === undefined &&
+    hasLinkedAlbumId(query.legacy_release_id) &&
+    query.track_position !== undefined;
   return {
     track_title: query.song,
     artist_name: query.artist,
@@ -111,6 +122,9 @@ export function convertQueryToSubmission(
       ...(query.track_position !== undefined && {
         track_position: query.track_position,
       }),
+    }),
+    ...(freeformPickedPosition && {
+      track_position: query.track_position,
     }),
   };
 }

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -28,6 +28,7 @@ export function entryToFreezePayload(entry: {
   label?: string | null;
   id?: number | null;
   legacy_release_id?: number | null;
+  lml_source?: boolean;
   rotation_id?: number | null;
   rotation_bin?: Rotation | null;
 }) {
@@ -44,10 +45,20 @@ export function entryToFreezePayload(entry: {
     // straight back unless the edit strips the linkage first. Without a
     // linked row there is no linkage to strip and the deviation rule never
     // runs, so the release's own credit is the only answer left to give.
-    artistProvided: hasLinkedAlbumId(entry.id) || Boolean(entry.artist?.name),
+    // An LML-sourced row is the second exception: its album_id is withheld
+    // just below, so no linkage reaches BS to spread back, and the seeded
+    // name is the only signal left.
+    artistProvided:
+      (!entry.lml_source && hasLinkedAlbumId(entry.id)) ||
+      Boolean(entry.artist?.name),
     album: entry.title ?? "",
     label: entry.label ?? "",
-    album_id: entry.id ?? undefined,
+    // INTERIM write-gate: an LML row's `id` is a legacy id wearing the
+    // serial field, and BS resolves album_id in serial space — forwarding it
+    // links the entry to whatever release owns that number in the wrong
+    // space, silently. Withheld so the submission goes freeform; see
+    // AlbumEntry.lml_source for the removal condition.
+    album_id: entry.lml_source ? undefined : entry.id ?? undefined,
     // The read half of the freeze. Carried so the picker survives the click
     // that zeroes the highlight. Taken from this entry's own field rather than
     // derived from `album_id` — which release's tracklist to show is not the

--- a/lib/features/lml/lml-conversions.ts
+++ b/lib/features/lml/lml-conversions.ts
@@ -43,6 +43,9 @@ export function convertLmlItemToAlbumEntry(item: LmlLibraryItem): AlbumEntry {
     // belongs in this field; `id` keeps the same value for now, which makes an
     // LML row the one source where the two spaces legitimately coincide.
     legacy_release_id: item.id,
+    // The marker the freeze path's interim album_id write-gate keys on; see
+    // AlbumEntry.lml_source for the removal condition.
+    lml_source: true,
     title: item.title ?? "",
     artist: {
       name: item.artist ?? "",

--- a/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults.tsx
@@ -84,12 +84,10 @@ export default function FlowsheetSearchResults({
     ? idSource.legacy_release_id
     : null;
 
-  // WRITE — whether this row has a real library linkage, which is the only
-  // thing that decides if a picker is offered at all. A library-unlinked
-  // rotation/catalog row carries a synthesized negative id from
-  // synthesizeAlbumId, and the submission chokepoint drops `track_position`
-  // without a positive `album_id` behind it — so offering a picker there would
-  // let the DJ pick something that gets silently discarded.
+  // WRITE — whether this row has a real library linkage, which decides what a
+  // submission may carry. A library-unlinked rotation/catalog row carries a
+  // synthesized negative id from synthesizeAlbumId, and the submission
+  // chokepoint drops `track_position` for that shape.
   const linkedAlbumId = hasLinkedAlbumId(idSource.id) ? idSource.id : null;
 
   const [manualOverride, setManualOverride] = useState<number | null>(null);
@@ -99,7 +97,24 @@ export default function FlowsheetSearchResults({
     }
   }, [tracklistReleaseId, manualOverride]);
 
-  const showPickerRow = linkedAlbumId !== null && !rotationMode;
+  // A synthesized negative id would freeze as a present-but-invalid album_id,
+  // the one shape the submission chokepoint strips entirely — position
+  // included — so a picker over it would let the DJ pick something that gets
+  // silently discarded.
+  const synthesizedUnlinked =
+    typeof idSource.id === "number" && idSource.id < 0;
+
+  // Offered exactly when the pick survives submission: a linked row submits
+  // it alongside album_id, and a read-half-only row (an LML freeze whose
+  // album_id the interim write-gate withheld — see AlbumEntry.lml_source)
+  // submits it freeform, where the chokepoint forwards track_position
+  // whenever it rides with the legacy id it was picked from and no album_id
+  // at all. Rows with a synthesized negative id, or with both halves null,
+  // get no picker.
+  const showPickerRow =
+    (linkedAlbumId !== null ||
+      (tracklistReleaseId !== null && !synthesizedUnlinked)) &&
+    !rotationMode;
 
   // Keyed on the read half: opting out is per-release-tracklist, and the
   // release's identity for tracklist purposes is its legacy id. Gated on the

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -674,6 +674,12 @@ export const useFlowsheetSubmit = () => {
         album: flowSheetRawQuery.album as string,
         label: flowSheetRawQuery.label as string,
         album_id: flowSheetRawQuery.album_id,
+        // The read half must survive this re-assembly: the submission
+        // chokepoint forwards a picked track_position on the freeform
+        // variant only when the legacy id it was picked from rides beside
+        // it. Dropping it here would silently strip the position from every
+        // gated LML submission.
+        legacy_release_id: flowSheetRawQuery.legacy_release_id,
         rotation_id: flowSheetRawQuery.rotation_id,
         rotation_bin: flowSheetRawQuery.rotation_bin,
         track_position: flowSheetRawQuery.track_position,
@@ -697,9 +703,15 @@ export const useFlowsheetSubmit = () => {
           (flowSheetRawQuery.artist as string),
         album: selectedEntry.title || flowSheetRawQuery.album as string,
         label: selectedEntry.label || flowSheetRawQuery.label as string,
-        album_id: releaseCannotSupplyArtist(selectedEntry)
-          ? undefined
-          : selectedEntry.id ?? undefined,
+        // An LML-sourced row's id is withheld here on the same terms the
+        // freeze path withholds it — it is a legacy id, not a linkage, and
+        // this branch submits straight off the highlighted entry without a
+        // freeze in between (see AlbumEntry.lml_source).
+        album_id:
+          releaseCannotSupplyArtist(selectedEntry) || selectedEntry.lml_source
+            ? undefined
+            : selectedEntry.id ?? undefined,
+        legacy_release_id: selectedEntry.legacy_release_id ?? undefined,
         rotation_bin: selectedEntry.rotation_bin ?? undefined,
         rotation_id: selectedEntry.rotation_id ?? undefined,
         track_position: flowSheetRawQuery.track_position,

--- a/tests/integration/components/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/FlowsheetSearchResults.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, fireEvent, waitFor } from "@testing-library/react";
 import FlowsheetSearchResults from "@/src/components/experiences/modern/flowsheet/Search/Results/FlowsheetSearchResults";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { entryToFreezePayload } from "@/lib/features/flowsheet/conversions";
 import {
   renderWithProviders,
   createTestAlbum,
@@ -390,6 +391,58 @@ describe("FlowsheetSearchResults", () => {
 
       await screen.findByTestId("library-track-picker-manual");
 
+      const tracks =
+        libraryTrackPickerSpy.mock.calls.at(-1)?.[0]?.tracks ?? [];
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].title).toBe("la paradoja");
+    });
+
+    it("keeps the picker offered when the write-gate withheld album_id from an LML freeze", async () => {
+      // The gated-LML shape: entryToFreezePayload withholds album_id for
+      // lml_source rows, so the frozen query carries only the read half.
+      // The picker must stay offered — the pick submits freeform, with its
+      // track_position tied to the legacy id it was read from.
+      stubBothSpaces();
+
+      const { store } = renderWithProviders(
+        <FlowsheetSearchResults
+          binResults={[]}
+          catalogResults={[]}
+          rotationResults={[]}
+          lmlResults={[]}
+        />,
+        {
+          preloadedState: {
+            flowsheet: buildFlowsheetState(true, {
+              search: {
+                open: true,
+                query: flowsheetSlice.getInitialState().search.query,
+                selectedResult: 0,
+                confirmedArtist: "",
+                resetEpoch: 0,
+              },
+            }),
+          },
+        }
+      );
+
+      store.dispatch(
+        flowsheetSlice.actions.freezeSelectionToQuery(
+          entryToFreezePayload({
+            id: LEGACY_RELEASE_ID,
+            legacy_release_id: LEGACY_RELEASE_ID,
+            lml_source: true,
+            artist: { name: "Juana Molina" },
+            title: "DOGA",
+            label: "Sonamos",
+          })
+        )
+      );
+
+      expect(store.getState().flowsheet.search.query.album_id).toBeUndefined();
+
+      await screen.findByTestId("flowsheet-search-track-picker-row");
+      await screen.findByTestId("library-track-picker-manual");
       const tracks =
         libraryTrackPickerSpy.mock.calls.at(-1)?.[0]?.tracks ?? [];
       expect(tracks).toHaveLength(1);

--- a/tests/unit/hooks/flowsheetHooks.test.tsx
+++ b/tests/unit/hooks/flowsheetHooks.test.tsx
@@ -10,6 +10,7 @@ import {
   useFlowsheetSubmit,
 } from "@/src/hooks/flowsheetHooks";
 import { flowsheetSlice } from "@/lib/features/flowsheet/frontend";
+import { convertQueryToSubmission } from "@/lib/features/flowsheet/conversions";
 import { MISSING_ARTIST_REJECTION_MESSAGE } from "@/lib/features/flowsheet/various-artists-guard";
 import { useAppDispatch } from "@/lib/hooks";
 import { catalogSlice } from "@/lib/features/catalog/frontend";
@@ -631,6 +632,103 @@ describe("flowsheetHooks", () => {
 
       const displayValue = result.current.getDisplayValue("artist");
       expect(displayValue).toBe("Test Artist");
+    });
+
+    // The submission memo is a second assembly of the query (the freeze
+    // reducer being the first), so the write-gate must hold at both: the
+    // frozen branch has to carry the read half forward, and the highlighted
+    // branch has to withhold an LML row's id the same way the freeze does.
+    describe("LML write-gate at the submission memo", () => {
+      const frozenQueryWrapper = (
+        query: Partial<
+          ReturnType<typeof flowsheetSlice.getInitialState>["search"]["query"]
+        >,
+        selectedResult = 0
+      ) =>
+        createHookWrapper(
+          { flowsheet: flowsheetSlice, liveUpdates: liveUpdatesSlice },
+          {
+            flowsheet: {
+              ...flowsheetSlice.getInitialState(),
+              search: {
+                ...flowsheetSlice.getInitialState().search,
+                selectedResult,
+                query: {
+                  ...flowsheetSlice.getInitialState().search.query,
+                  ...query,
+                },
+              },
+            },
+          }
+        );
+
+      const submit = async (
+        result: { current: { handleSubmit: (e: FormEvent) => Promise<void> } }
+      ) => {
+        await act(async () => {
+          await result.current.handleSubmit({
+            preventDefault: vi.fn(),
+          } as unknown as FormEvent);
+        });
+        return vi.mocked(convertQueryToSubmission).mock.calls.at(-1)?.[0];
+      };
+
+      it("carries the frozen query's legacy id and position into the submission", async () => {
+        const { result } = renderHook(() => useFlowsheetSubmit(), {
+          wrapper: frozenQueryWrapper({
+            song: "la paradoja",
+            artist: "Juana Molina",
+            album: "DOGA",
+            album_id: undefined,
+            legacy_release_id: 45342,
+            track_position: "A1",
+          }),
+        });
+
+        const query = await submit(result);
+        expect(query).toMatchObject({
+          legacy_release_id: 45342,
+          track_position: "A1",
+        });
+        expect(query?.album_id).toBeUndefined();
+      });
+
+      it("withholds album_id when a highlighted LML row is submitted without clicking", async () => {
+        mockUseLmlLibrarySearch.mockReturnValue({
+          results: [
+            createTestAlbum({
+              id: 45342,
+              legacy_release_id: 45342,
+              lml_source: true,
+              title: "DOGA",
+            }),
+          ],
+          isLoading: false,
+        });
+
+        const { result } = renderHook(() => useFlowsheetSubmit(), {
+          wrapper: frozenQueryWrapper({ song: "la paradoja" }, 1),
+        });
+
+        const query = await submit(result);
+        expect(query?.album_id).toBeUndefined();
+        expect(query).toMatchObject({ legacy_release_id: 45342 });
+      });
+
+      it("keeps album_id for a highlighted catalog row (the gate is LML-scoped)", async () => {
+        mockUseCatalogFlowsheetSearch.mockReturnValue({
+          searchResults: [
+            createTestAlbum({ id: 1234, title: "Linked Catalog Row" }),
+          ],
+        });
+
+        const { result } = renderHook(() => useFlowsheetSubmit(), {
+          wrapper: frozenQueryWrapper({ song: "Back, Baby" }, 1),
+        });
+
+        const query = await submit(result);
+        expect(query?.album_id).toBe(1234);
+      });
     });
 
     it("should return live status", () => {

--- a/tests/unit/lib/features/flowsheet/conversions.test.ts
+++ b/tests/unit/lib/features/flowsheet/conversions.test.ts
@@ -126,6 +126,36 @@ describe("flowsheet conversions", () => {
       expect(result.track_position).toBe("A1");
     });
 
+    // The gated-LML shape: the interim write-gate withheld album_id, but the
+    // picker picked this position from the read half's tracklist and BS
+    // persists track_position on the freeform variant. The position rides
+    // exactly when the legacy id it was picked from still rides beside it.
+    it("forwards track_position on the freeform branch when the read-half legacy id rides with no album_id", () => {
+      const result = convertQueryToSubmission(
+        createTestFlowsheetQuery({
+          album_id: undefined,
+          legacy_release_id: 45342,
+          track_position: "A1",
+        })
+      ) as QuerySubmission & { track_position?: string | null };
+      expect(result.track_position).toBe("A1");
+      expect(result).not.toHaveProperty("album_id");
+    });
+
+    // Without the read-half id there is nothing tying the position to a
+    // tracklist — a typed freeform entry never picked one, so a leftover
+    // value must not ride.
+    it("omits track_position on the freeform branch when no legacy id rides", () => {
+      const result = convertQueryToSubmission(
+        createTestFlowsheetQuery({
+          album_id: undefined,
+          legacy_release_id: undefined,
+          track_position: "A1",
+        })
+      ) as QuerySubmission & { track_position?: string | null };
+      expect(result.track_position).toBeUndefined();
+    });
+
     it("should omit track_position when none was picked", () => {
       const query = createTestFlowsheetQuery({ album_id: 4242 });
       const result = convertQueryToSubmission(query) as QuerySubmission & {

--- a/tests/unit/lib/features/flowsheet/conversions.test.ts
+++ b/tests/unit/lib/features/flowsheet/conversions.test.ts
@@ -858,5 +858,49 @@ describe("flowsheet conversions", () => {
         })
       );
     });
+
+    // The interim write-gate: an LML row's `id` is a legacy id wearing the
+    // serial field, and BS resolves album_id in serial space — forwarding it
+    // links the entry to whatever release owns that number in the wrong
+    // space, silently. The freeze withholds it; the read half still rides so
+    // the picker keeps working.
+    it("withholds album_id for an LML-sourced row but keeps the read-path id", () => {
+      expect(
+        entryToFreezePayload({
+          id: 45342,
+          legacy_release_id: 45342,
+          lml_source: true,
+          artist: { name: "Jessica Pratt" },
+          title: "On Your Own Love Again",
+          label: "Drag City",
+        })
+      ).toEqual({
+        artist: "Jessica Pratt",
+        artistProvided: true,
+        album: "On Your Own Love Again",
+        label: "Drag City",
+        album_id: undefined,
+        legacy_release_id: 45342,
+        rotation_id: undefined,
+        rotation_bin: undefined,
+      });
+    });
+
+    // With the linkage withheld there is nothing for BS to spread back over
+    // the request, so whether an artist "was provided" falls to the seeded
+    // name alone — unlike the linked-release cases above.
+    it("keys artistProvided on the seeded name, not the linkage, for an LML-sourced row", () => {
+      expect(
+        entryToFreezePayload({
+          id: 45342,
+          legacy_release_id: 45342,
+          lml_source: true,
+          artist: { name: "" },
+          title: "Untitled",
+        })
+      ).toEqual(
+        expect.objectContaining({ artistProvided: false, album_id: undefined })
+      );
+    });
   });
 });

--- a/tests/unit/lib/features/lml/lml-conversions.test.ts
+++ b/tests/unit/lib/features/lml/lml-conversions.test.ts
@@ -4,6 +4,14 @@ import { createTestLmlLibraryItem } from "@/tests/helpers";
 import type { LmlLibraryItem } from "@/lib/features/lml/types";
 
 describe("convertLmlItemToAlbumEntry", () => {
+  // The one source whose `id` is a legacy id gets marked, so the freeze
+  // path's interim write-gate can withhold it from album_id.
+  it("marks the entry as LML-sourced for the write gate", () => {
+    const result = convertLmlItemToAlbumEntry(createTestLmlLibraryItem({ id: 7 }));
+    expect(result.lml_source).toBe(true);
+  });
+
+
   it("should map all fields correctly", () => {
     const item = createTestLmlLibraryItem({
       id: 42,
@@ -22,6 +30,7 @@ describe("convertLmlItemToAlbumEntry", () => {
     expect(result).toEqual({
       id: 42,
       legacy_release_id: 42,
+      lml_source: true,
       title: "DOGA",
       artist: {
         name: "Juana Molina",


### PR DESCRIPTION
## What

The interim half of the id re-map sequence (WXYC/Backend-Service#2167 → #1224 → WXYC/Backend-Service#2168): stop the corrupting write **now**, before step 1 work starts, instead of at step 3.

An LML picker row's `id` is a tubafrenzy legacy id wearing the serial field — LML's library.db has no other id to give — and BS resolves `album_id` in serial space, so submitting it persists a **silently wrong album link** (87.7% wrong-row rate; measurement in #1179). The read half shipped 2026-08-14 (#1207/#1221); this gates the write half:

- `convertLmlItemToAlbumEntry` marks its rows with `AlbumEntry.lml_source` (new optional field; its docstring carries the removal condition).
- `entryToFreezePayload` withholds `album_id` for flagged rows, so the submission takes the freeform branch. `artistProvided` falls back to the seeded name for gated rows — no linkage reaches BS to spread back.
- The two Playwright specs that pinned the old behavior (`album_id: LIBRARY_ID` on LML-proxied submissions) now pin the freeform branch, per #1184's test-plan guidance for exactly this flip.

An explicit flag rather than the `id === legacy_release_id` heuristic: the repo's own factory rule treats two-space coincidence as the thing that masks this bug class, so production logic shouldn't key on it.

## The follow-up commit — the picker invariant

The first cut broke `FlowsheetSearchResults`' own invariant (a picker is offered only when the pick survives submission): withholding `album_id` emptied the frozen write half, which was the sole gate on the picker row, so the LML track picker vanished post-click — caught by E2E shard 3. The second commit restores the invariant from the other side, which is #1184's already-decided item 7: `convertQueryToSubmission` forwards `track_position` on the freeform variant when it rides with the read-half legacy id and **no `album_id` at all** (BS persists it there; present-but-negative stays excluded, preserving the stale-position guard), and the picker is offered when either half resolves, still excluding synthesized-negative rows. Net effect for gated LML rows: **full picker UX, correct `track_title` + `track_position` on the wire, no album link.**

## The third commit — the submission memo's second query assembly

Shard 3 stayed red after the picker fix because `selectedResultData` (the hook memo feeding every submission) re-assembles the query field-by-field and omitted `legacy_release_id` — the freeform-position arm never saw the read half. Auditing that memo exposed a second, worse gap: its highlighted-entry branch submits `album_id` straight off `entry.id` with **no freeze in between**, so a highlight+Enter submission of an LML row bypassed the gate entirely and still persisted the wrong-space link. Both branches now hold the gate, pinned by three hook tests at the memo's seam (`useFlowsheetSubmit` → `convertQueryToSubmission`): frozen legacy id + position reach the conversion; a highlighted LML row submits without `album_id`; a highlighted catalog row keeps its `album_id`.

## Interim by design

Remove the flag and gate **together** in #1224's post-step-3 pass, once WXYC/Backend-Service#2168 makes proxy `id` a real `library.id` — a gate left in place past that point keeps the corrected links out of the flowsheet. #1224's edit set carries the removal line.

One temporary cost, accepted and returning with the re-map: LML rows lose the committed-row highlight (frozen `album_id` is now `undefined`).

## Checks

- tsc `--noEmit`: clean
- vitest: 4727/4727 across 330 files (9 new: gate ×2, flag ×1, freeform position ×2, picker-offered ×1, submission-memo ×3)
- eslint: 0 errors (195 baseline warnings)
- `next build`: clean
- E2E: all 4 shards green in CI with the paired stack, including the two flipped specs

## Related

Epic #1179 · #1184 (item 3's disposition, taken temporarily without parts 3–4) · #1224 (owns the removal) · WXYC/Backend-Service#2167 / WXYC/Backend-Service#2168 (the sequence this bridges)
