### PR TITLE
ci: run checks on every PR base, and re-evaluate the base guard on retarget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,26 +7,22 @@ on:
     # Deliberately NO `branches:` filter. One here starves every PR based on
     # anything but `main` of the entire workflow — no typecheck, no unit
     # tests, no build, no preview. #1219 was reviewed, approved, and merged
-    # with zero automated verification for exactly that reason. The expensive
-    # jobs carry their own base guard instead (see `preview` below, and the
-    # E2E matrix in e2e-tests.yml), so a stacked PR gets the cheap
-    # correctness checks without an N-deep chain paying N times over for a
-    # Cloudflare deploy.
+    # with zero automated verification for exactly that reason.
     #
-    # `edited` is load-bearing, not decoration. A base retarget fires ONLY
-    # `edited`, which is absent from the default type set, so without it a
-    # base guard is never re-evaluated: the parent merges, GitHub retargets
-    # the child's base to `main`, and the stale `skipped` conclusions ride
-    # straight through branch protection — a skipped check SATISFIES a
-    # required one (the #740 silent-pass). The guard alone would rebuild the
-    # #1219 hole; the guard plus `edited` closes it.
+    # Cost control for the expensive jobs lives in the jobs themselves, and it
+    # reports RED on a non-`main` base rather than skipping. That direction is
+    # the whole design: a skipped check SATISFIES a required one (#740), so a
+    # skip becomes a merge authorization the moment GitHub retargets a stacked
+    # PR onto `main` — which it does automatically when the parent merges,
+    # before any new run can exist. Failing instead keeps the PR blocked until
+    # the checks actually run, which is what the `branches:` filter used to
+    # achieve by accident and must not be lost while fixing it.
     #
-    # The cost is that a title or body edit re-runs CI too, and that is the
-    # deliberate trade. The tempting optimization — skip the run unless
-    # `github.event.changes.base` is set — would replace an existing red
-    # conclusion with a skipped one, making "edit the PR title" a way to
-    # launder a failing required check into a satisfied one.
-    types: [opened, synchronize, reopened, edited]
+    # Consequence worth knowing: a retargeted PR stays red until something
+    # re-runs it. `edited` in `types:` would clear that automatically, but it
+    # also fires on every title and body edit — re-running the 4-shard E2E
+    # matrix and a Cloudflare deploy each time — so the manual re-run is the
+    # cheaper half of the trade. Fail closed, clear by hand.
 
 # cancel-in-progress only for PRs: superseded PR runs are safe to cancel to
 # save compute, but a `main` push run carries the production Direct-Upload
@@ -359,19 +355,19 @@ jobs:
   # matches. Fork PRs soft-skip (no secrets); same-repo missing config hard
   # fails (see #740). Every step after config-check is gated on configured.
   #
-  # The `base_ref` half of the guard is the cost control that lets the
-  # `pull_request:` trigger above run with no `branches:` filter: a stacked PR
-  # gets typecheck/unit/build but not a per-PR Cloudflare deployment, which
-  # would otherwise multiply by the depth of the chain. It is only safe
-  # because `edited` is in `types:` — see the trigger comment for why a base
-  # guard without it re-creates #1219.
+  # A non-`main` base is refused in the config-check step below, NOT with an
+  # `if:` guard on the job. Both stop the Cloudflare deploy; only the refusal
+  # leaves a red required check behind, and red is what keeps a stacked PR
+  # blocked through the window where GitHub retargets it onto `main` and
+  # branch protection re-reads its existing conclusions. A skip would read as
+  # satisfied in exactly that window. Cost of refusing this way is one runner
+  # for a few seconds — the step runs before any checkout.
   preview:
     name: Preview URL smoke check
     needs: [changes, typecheck, unit-tests, build]
     if: >-
       github.event_name == 'pull_request'
       && needs.changes.outputs.app_source == 'true'
-      && github.base_ref == 'main'
     runs-on: ubuntu-latest
     # Job-level permissions REPLACE the workflow floor, so contents:read is
     # restated (actions/checkout needs it); pull-requests:write posts the
@@ -401,7 +397,22 @@ jobs:
           BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
           HAS_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
           HAS_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID != '' }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
+          # A stacked PR gets no preview deployment: one per PR in an N-deep
+          # chain is N Cloudflare deploys for a base that isn't shipping. This
+          # refuses rather than skips, and it runs first — before checkout, so
+          # the refusal costs seconds. Red is deliberate: when the parent
+          # merges, GitHub retargets this PR onto `main` and branch protection
+          # re-reads whatever conclusions already exist. A skip would read as
+          # satisfied in that window and let an unverified PR merge; a failure
+          # keeps it blocked until someone re-runs the workflow against the
+          # new base.
+          if [ -n "$BASE_REF" ] && [ "$BASE_REF" != "main" ]; then
+            echo "::error::Preview is not built for a PR based on '${BASE_REF}'. Retarget onto main and re-run this workflow."
+            exit 1
+          fi
+
           # Real forks can never access repo secrets — soft-skip those so we
           # don't block external contributors on infra they don't own. For
           # same-repo PRs (including Dependabot, which runs from a same-repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,29 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # Deliberately NO `branches:` filter. One here starves every PR based on
+    # anything but `main` of the entire workflow — no typecheck, no unit
+    # tests, no build, no preview. #1219 was reviewed, approved, and merged
+    # with zero automated verification for exactly that reason. The expensive
+    # jobs carry their own base guard instead (see `preview` below, and the
+    # E2E matrix in e2e-tests.yml), so a stacked PR gets the cheap
+    # correctness checks without an N-deep chain paying N times over for a
+    # Cloudflare deploy.
+    #
+    # `edited` is load-bearing, not decoration. A base retarget fires ONLY
+    # `edited`, which is absent from the default type set, so without it a
+    # base guard is never re-evaluated: the parent merges, GitHub retargets
+    # the child's base to `main`, and the stale `skipped` conclusions ride
+    # straight through branch protection — a skipped check SATISFIES a
+    # required one (the #740 silent-pass). The guard alone would rebuild the
+    # #1219 hole; the guard plus `edited` closes it.
+    #
+    # The cost is that a title or body edit re-runs CI too, and that is the
+    # deliberate trade. The tempting optimization — skip the run unless
+    # `github.event.changes.base` is set — would replace an existing red
+    # conclusion with a skipped one, making "edit the PR title" a way to
+    # launder a failing required check into a satisfied one.
+    types: [opened, synchronize, reopened, edited]
 
 # cancel-in-progress only for PRs: superseded PR runs are safe to cancel to
 # save compute, but a `main` push run carries the production Direct-Upload
@@ -336,10 +358,20 @@ jobs:
   # pr-preview-smoke.yml; the job name is preserved so branch protection still
   # matches. Fork PRs soft-skip (no secrets); same-repo missing config hard
   # fails (see #740). Every step after config-check is gated on configured.
+  #
+  # The `base_ref` half of the guard is the cost control that lets the
+  # `pull_request:` trigger above run with no `branches:` filter: a stacked PR
+  # gets typecheck/unit/build but not a per-PR Cloudflare deployment, which
+  # would otherwise multiply by the depth of the chain. It is only safe
+  # because `edited` is in `types:` — see the trigger comment for why a base
+  # guard without it re-creates #1219.
   preview:
     name: Preview URL smoke check
     needs: [changes, typecheck, unit-tests, build]
-    if: github.event_name == 'pull_request' && needs.changes.outputs.app_source == 'true'
+    if: >-
+      github.event_name == 'pull_request'
+      && needs.changes.outputs.app_source == 'true'
+      && github.base_ref == 'main'
     runs-on: ubuntu-latest
     # Job-level permissions REPLACE the workflow floor, so contents:read is
     # restated (actions/checkout needs it); pull-requests:write posts the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,21 @@ on:
     # the checks actually run, which is what the `branches:` filter used to
     # achieve by accident and must not be lost while fixing it.
     #
-    # Consequence worth knowing: a retargeted PR stays red until something
-    # re-runs it. `edited` in `types:` would clear that automatically, but it
-    # also fires on every title and body edit — re-running the 4-shard E2E
-    # matrix and a Cloudflare deploy each time — so the manual re-run is the
-    # cheaper half of the trade. Fail closed, clear by hand.
+    # Two consequences worth knowing, because neither is obvious.
+    #
+    # A stacked PR carries two permanently-red required checks until it is
+    # retargeted. That is the intended steady state, not a broken build — but
+    # it means `gh pr checks` and `gh run watch --exit-status` exit non-zero on
+    # every stacked PR, so any automation that treats a red as something to fix
+    # will be tempted to weaken exactly the guards above.
+    #
+    # Clearing the red after a retarget takes a NEW event: push a commit
+    # (`synchronize`) or close and reopen (`reopened`). A workflow re-run does
+    # not work — it replays the stored original event, so `github.base_ref` is
+    # still the old base and the refusal fires again identically. `edited` in
+    # `types:` would automate this, but it also fires on every title and body
+    # edit, re-running the 4-shard E2E matrix and a Cloudflare deploy each
+    # time. Fail closed; clear with a push.
 
 # cancel-in-progress only for PRs: superseded PR runs are safe to cancel to
 # save compute, but a `main` push run carries the production Direct-Upload
@@ -406,10 +416,13 @@ jobs:
           # merges, GitHub retargets this PR onto `main` and branch protection
           # re-reads whatever conclusions already exist. A skip would read as
           # satisfied in that window and let an unverified PR merge; a failure
-          # keeps it blocked until someone re-runs the workflow against the
-          # new base.
-          if [ -n "$BASE_REF" ] && [ "$BASE_REF" != "main" ]; then
-            echo "::error::Preview is not built for a PR based on '${BASE_REF}'. Retarget onto main and re-run this workflow."
+          # keeps it blocked until the checks actually run against `main`.
+          #
+          # Both conditions are load-bearing. `github.base_ref` is empty on
+          # `push`, and "" != "main" is true, so without the event-name check a
+          # push to `main` would fail here.
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ -n "$BASE_REF" ] && [ "$BASE_REF" != "main" ]; then
+            echo "::error::Preview is not built for a PR based on '${BASE_REF}'. Retarget onto main, then push a commit (an empty one is enough) or close and reopen the PR. A workflow re-run will NOT clear this — it replays the original event, base branch included."
             exit 1
           fi
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,12 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # No `branches:` filter, for the reason ci.yml's trigger spells out: with
+    # one, a stacked PR gets no security scanning at all. Unlike ci.yml and
+    # e2e-tests.yml, nothing here is gated on `github.base_ref` — a single
+    # analyze job is cheap enough to run on every PR base, and with no base
+    # guard to re-evaluate there is nothing for `edited` to fix, so the
+    # default type set stays. CodeQL is not a required status check.
   schedule:
     # Weekly baseline: catches new CodeQL query-pack advisories against
     # unchanged code, independent of the push/PR-triggered scans above.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [main]
   pull_request:
-    # No `branches:` filter, and `edited` in `types:`. Both halves matter, and
-    # both are explained at length on ci.yml's identical trigger — the short
-    # version: a `branches: [main]` filter gave #1219 a zero-CI merge, and a
-    # base guard without `edited` re-creates it because a base retarget fires
-    # no other event and a skipped check satisfies a required one.
-    types: [opened, synchronize, reopened, edited]
+    # No `branches:` filter — one gave #1219 a zero-CI merge. The shard matrix
+    # still skips on a non-`main` base for cost, but the `E2E Tests` aggregator
+    # below FAILS there instead of skipping, so the PR stays blocked rather
+    # than arriving pre-satisfied at its retarget onto `main`. See ci.yml's
+    # trigger for the full reasoning, including why `edited` is not in
+    # `types:`.
   workflow_dispatch:
     inputs:
       backend_ref:
@@ -484,27 +484,36 @@ jobs:
   # source, the matrix skips and we should pass — not fail — so workflow-only
   # PRs can satisfy the required check.
   #
-  # That skipped->success mapping is exactly why this job repeats the matrix's
-  # `base_ref` guard instead of inheriting it. Left ungated, a stacked PR
-  # whose matrix skipped for base reasons would report "E2E Tests: success"
-  # having run zero shards — a check that claims verification it never did,
-  # strictly worse than the honest `skipped` that branch protection already
-  # accepts. Gated, the aggregator skips too, and `edited` in `types:` above
-  # brings both back the moment the base retargets to `main`.
+  # That skipped->success mapping is also why a non-`main` base has to be
+  # FAILED here rather than skipped, and why this job stays ungated so it can
+  # do the failing. The matrix skips on a stacked PR to avoid booting four
+  # backends for a base that isn't shipping — but if this aggregator skipped
+  # too, "E2E Tests" would sit satisfied on a PR that ran zero shards, and
+  # GitHub's automatic retarget onto `main` when the parent merges would hand
+  # that satisfied state straight to branch protection. Failing keeps the PR
+  # blocked until the suite actually runs against `main`.
   e2e-all:
     name: E2E Tests
     needs: e2e
-    if: always() && (github.event_name != 'pull_request' || github.base_ref == 'main')
+    if: always()
     runs-on: ubuntu-latest
+    env:
+      BASE_REF: ${{ github.base_ref }}
+      MATRIX_RESULT: ${{ needs.e2e.result }}
     steps:
       - name: Verify all shards passed
         run: |
-          case "${{ needs.e2e.result }}" in
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ "$BASE_REF" != "main" ]; then
+            echo "::error::E2E is not run for a PR based on '${BASE_REF}'. Retarget onto main and re-run this workflow."
+            exit 1
+          fi
+
+          case "$MATRIX_RESULT" in
             success|skipped)
-              echo "E2E matrix result: ${{ needs.e2e.result }}"
+              echo "E2E matrix result: ${MATRIX_RESULT}"
               ;;
             *)
-              echo "One or more E2E shards failed: ${{ needs.e2e.result }}"
+              echo "One or more E2E shards failed: ${MATRIX_RESULT}"
               exit 1
               ;;
           esac

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -503,8 +503,10 @@ jobs:
     steps:
       - name: Verify all shards passed
         run: |
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ "$BASE_REF" != "main" ]; then
-            echo "::error::E2E is not run for a PR based on '${BASE_REF}'. Retarget onto main and re-run this workflow."
+          # `github.base_ref` is empty on `push`; the event-name check is what
+          # keeps a push to `main` from failing on "" != "main".
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ -n "$BASE_REF" ] && [ "$BASE_REF" != "main" ]; then
+            echo "::error::E2E is not run for a PR based on '${BASE_REF}'. Retarget onto main, then push a commit (an empty one is enough) or close and reopen the PR. A workflow re-run will NOT clear this — it replays the original event, base branch included."
             exit 1
           fi
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,7 +4,12 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # No `branches:` filter, and `edited` in `types:`. Both halves matter, and
+    # both are explained at length on ci.yml's identical trigger — the short
+    # version: a `branches: [main]` filter gave #1219 a zero-CI merge, and a
+    # base guard without `edited` re-creates it because a base retarget fires
+    # no other event and a skipped check satisfies a required one.
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
     inputs:
       backend_ref:
@@ -106,10 +111,18 @@ jobs:
               - 'playwright.config.*'
               - '.github/workflows/e2e-tests.yml'
 
+  # `base_ref == 'main'` is the cost control for the unfiltered trigger above:
+  # each shard boots a Backend-Service and a mock tubafrenzy mirror, so
+  # letting the matrix fire on every PR in a stacked chain multiplies the
+  # most expensive thing this repo runs by the depth of the chain. Stacked
+  # PRs get ci.yml's cheap jobs; they pick up E2E when their base retargets to
+  # `main` and `edited` re-evaluates this guard.
   e2e:
     name: E2E Tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.app_source == 'true'
+    if: >-
+      github.event_name != 'pull_request'
+      || (needs.changes.outputs.app_source == 'true' && github.base_ref == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -470,10 +483,18 @@ jobs:
   # `changes` job's path filter (issue #731). On a PR that doesn't touch app
   # source, the matrix skips and we should pass — not fail — so workflow-only
   # PRs can satisfy the required check.
+  #
+  # That skipped->success mapping is exactly why this job repeats the matrix's
+  # `base_ref` guard instead of inheriting it. Left ungated, a stacked PR
+  # whose matrix skipped for base reasons would report "E2E Tests: success"
+  # having run zero shards — a check that claims verification it never did,
+  # strictly worse than the honest `skipped` that branch protection already
+  # accepts. Gated, the aggregator skips too, and `edited` in `types:` above
+  # brings both back the moment the base retargets to `main`.
   e2e-all:
     name: E2E Tests
     needs: e2e
-    if: always()
+    if: always() && (github.event_name != 'pull_request' || github.base_ref == 'main')
     runs-on: ubuntu-latest
     steps:
       - name: Verify all shards passed

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
         "pg": "^8.23.0",
         "typescript": "^6.0.3",
         "vitest": "^4.0.18",
-        "wrangler": "^4.121.0"
+        "wrangler": "^4.121.0",
+        "yaml": "^2.8.2"
       },
       "engines": {
         "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "pg": "^8.23.0",
     "typescript": "^6.0.3",
     "vitest": "^4.0.18",
-    "wrangler": "^4.121.0"
+    "wrangler": "^4.121.0",
+    "yaml": "^2.8.2"
   },
   "optionalDependencies": {
     "@ast-grep/napi-darwin-arm64": "^0.45.1",

--- a/tests/unit/github-workflow-triggers.test.ts
+++ b/tests/unit/github-workflow-triggers.test.ts
@@ -1,32 +1,36 @@
 /**
  * Trigger and base-guard invariants for the PR workflows.
  *
- * Two ways a PR can reach `main` with no automated verification, neither of
- * which produces a red X, an annotation, or anything else a reviewer would
+ * A PR can reach `main` with no automated verification in several ways, none
+ * of which produce a red X, an annotation, or anything else a reviewer would
  * notice:
  *
- *  - A `pull_request: branches: [main]` filter. A PR based on any other
- *    branch then matches no trigger, so the workflow never starts and its
- *    required checks are simply absent.
- *  - A `github.base_ref` job guard without `edited` in `types:`. Retargeting
- *    a PR's base fires only the `edited` activity type, which the default set
- *    omits — so when a parent merges and GitHub retargets the child onto
- *    `main`, nothing re-runs, and the child's conclusions from its old base
- *    stand. Those conclusions are `skipped`, and a skipped check satisfies a
- *    required status check.
+ *  - A `pull_request` trigger narrowed by `branches`, `branches-ignore`, or
+ *    `paths`. The workflow never starts, so its required checks are absent
+ *    rather than failing — and absent reads as "still running".
+ *  - An expensive job that *skips* on a non-`main` base. Skipped satisfies a
+ *    required status check. When the parent of a stacked PR merges, GitHub
+ *    retargets the child onto `main` automatically, and branch protection
+ *    re-reads the conclusions already sitting there. A skip becomes a merge
+ *    authorization in that window, before any new run can exist. Refusing
+ *    (exiting non-zero) keeps the PR blocked instead.
+ *  - A base guard moved *up* the `needs` graph. Gating one shared upstream job
+ *    starves every downstream job transitively while each of their own `if:`
+ *    expressions still looks innocent.
  *
- * The second is the subtle one: it is the first hole wearing the disguise of
- * a fix. That is why these are assertions and not comments in the YAML.
+ * The third is why these assertions resolve the dependency graph rather than
+ * reading each job's `if:` in isolation: an earlier version of this file
+ * passed clean against a workflow whose `changes` job carried the guard.
  */
 
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { parse } from "yaml";
 
-type Job = { if?: string };
+type Job = { if?: string; needs?: string | string[] };
 type Workflow = {
-  on?: { pull_request?: { branches?: string[]; types?: string[] } | null };
+  on?: { pull_request?: { branches?: string[]; types?: string[] } | null } | null;
   jobs?: Record<string, Job>;
 };
 
@@ -36,79 +40,103 @@ function workflow(name: string): Workflow {
   return parse(readFileSync(join(WORKFLOW_DIR, `${name}.yml`), "utf-8")) as Workflow;
 }
 
-// Adding a new PR-triggered workflow to this list is the point: it inherits
-// the invariants rather than rediscovering them.
-const PR_WORKFLOWS = ["ci", "e2e-tests", "codeql"] as const;
+/**
+ * Every workflow with a `pull_request` trigger, discovered rather than listed.
+ * A hardcoded list silently exempts the next workflow someone adds, which is
+ * the population these invariants most need to cover.
+ */
+const PR_WORKFLOWS = readdirSync(WORKFLOW_DIR)
+  .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+  .map((f) => f.replace(/\.ya?ml$/, ""))
+  .filter((name) => {
+    const on = workflow(name).on;
+    return !!on && "pull_request" in on;
+  });
 
-// Declaring `types:` REPLACES the default set rather than extending it, so
-// omitting `synchronize` would stop CI from running on pushes to an open PR —
-// a far wider hole than the one `edited` closes. Pin the whole set.
-const REQUIRED_TYPES = ["opened", "synchronize", "reopened", "edited"];
+/** Transitive `needs` closure, so a guard one level up is still visible. */
+function dependencyClosure(jobs: Record<string, Job>, start: string): string[] {
+  const seen = new Set<string>();
+  const queue = [start];
+  while (queue.length) {
+    const name = queue.pop()!;
+    if (seen.has(name)) continue;
+    seen.add(name);
+    const needs = jobs[name]?.needs;
+    for (const dep of typeof needs === "string" ? [needs] : (needs ?? [])) queue.push(dep);
+  }
+  return [...seen];
+}
 
 describe("GitHub workflow PR triggers", () => {
-  it.each(PR_WORKFLOWS)(
-    "%s.yml does not filter pull_request by base branch",
-    (name) => {
-      const pr = workflow(name).on?.pull_request;
-      // `pull_request:` with no mapping parses as null — every branch, default
-      // types. That shape is fine; a `branches:` key is not.
-      expect(pr?.branches).toBeUndefined();
-    }
-  );
+  it("finds the PR-triggered workflows by scanning, and there are some", () => {
+    expect(PR_WORKFLOWS.length).toBeGreaterThan(0);
+    // The three the base-guard design reasons about must be among them; a
+    // rename or a deleted trigger should fail here rather than shrink the
+    // suite's coverage in silence.
+    expect(PR_WORKFLOWS).toEqual(expect.arrayContaining(["ci", "e2e-tests", "codeql"]));
+  });
 
-  it.each(PR_WORKFLOWS)(
-    "%s.yml re-runs on base retarget whenever any job guards on github.base_ref",
-    (name) => {
-      const wf = workflow(name);
-      const guarded = Object.entries(wf.jobs ?? {}).filter(([, job]) =>
-        job.if?.includes("github.base_ref")
-      );
-      if (guarded.length === 0) return;
-
-      const types = wf.on?.pull_request?.types ?? [];
+  it.each(PR_WORKFLOWS)("%s.yml does not narrow its pull_request trigger", (name) => {
+    const on = workflow(name).on;
+    // Asserting `pr?.branches` alone passes vacuously when the trigger is gone
+    // entirely, or when a YAML 1.1 parser turns the `on` key into boolean true.
+    expect(on, `${name}.yml lost its \`on:\` block`).toBeTruthy();
+    const pr = on!.pull_request as Record<string, unknown> | null | undefined;
+    expect("pull_request" in on!, `${name}.yml lost its pull_request trigger`).toBe(true);
+    for (const narrowing of ["branches", "branches-ignore", "paths", "paths-ignore"]) {
       expect(
-        types,
-        `${name}.yml guards ${guarded.map(([n]) => n).join(", ")} on github.base_ref ` +
-          `but its pull_request types are [${types.join(", ")}] — a base retarget ` +
-          `fires only 'edited', so those guards would never be re-evaluated`
-      ).toEqual(REQUIRED_TYPES);
+        pr?.[narrowing],
+        `${name}.yml narrows pull_request by ${narrowing}, which starves whole PRs of this workflow`
+      ).toBeUndefined();
     }
-  );
+  });
 });
 
-describe("Expensive-job base guards", () => {
-  // The jobs whose cost scales with the depth of a stacked chain: a per-PR
-  // Cloudflare deployment, and an E2E matrix whose every shard boots a
-  // Backend-Service plus a mock tubafrenzy mirror.
-  it("gates the per-PR preview deploy on a main base", () => {
-    expect(workflow("ci").jobs?.preview?.if).toContain("github.base_ref == 'main'");
+describe("Expensive jobs refuse a non-main base rather than skipping", () => {
+  // Skipping is the trap: it satisfies branch protection, so it converts into
+  // a merge authorization the instant a stacked PR is retargeted onto `main`.
+  // Both of these must therefore leave a *failing* conclusion behind, which
+  // means neither may carry a `github.base_ref` job-level guard — a guard
+  // produces exactly the skip being avoided.
+
+  it("the preview deploy has no base guard, and refuses inside the job", () => {
+    const ci = workflow("ci");
+    expect(ci.jobs?.preview?.if ?? "").not.toContain("github.base_ref");
+    const source = readFileSync(join(WORKFLOW_DIR, "ci.yml"), "utf-8");
+    expect(source).toMatch(/BASE_REF.*!=.*"main"/s);
   });
 
-  it("gates the E2E matrix on a main base", () => {
+  it("the E2E aggregator has no base guard, and refuses inside the job", () => {
+    const e2e = workflow("e2e-tests");
+    expect(e2e.jobs?.["e2e-all"]?.if ?? "").not.toContain("github.base_ref");
+    const source = readFileSync(join(WORKFLOW_DIR, "e2e-tests.yml"), "utf-8");
+    expect(source).toMatch(/BASE_REF.*!=.*"main"/s);
+  });
+
+  // The matrix itself may skip — it is pure cost, and `e2e-all` carries the
+  // signal for it. This pins that the cost control is still in place, so a
+  // future edit doesn't quietly start booting four backends per stacked PR.
+  it("the E2E shard matrix still skips on a non-main base, for cost", () => {
     expect(workflow("e2e-tests").jobs?.e2e?.if).toContain("github.base_ref == 'main'");
-  });
-
-  // The aggregator maps a skipped matrix to success so a docs-only PR can
-  // satisfy the required check. Ungated, that mapping would report the
-  // required "E2E Tests" as *passing* on a stacked PR that ran zero shards —
-  // a check claiming verification it never performed, strictly worse than the
-  // honest skip branch protection already accepts.
-  it("repeats the guard on the E2E aggregator so a skipped matrix cannot report success", () => {
-    expect(workflow("e2e-tests").jobs?.["e2e-all"]?.if).toContain(
-      "github.base_ref == 'main'"
-    );
   });
 });
 
 describe("Cheap correctness jobs", () => {
-  // The whole point of the unfiltered trigger. If a future cost-trimming pass
-  // gates these on the base too, a stacked PR is back to running nothing.
+  // The whole point of the unfiltered trigger. Checked across the transitive
+  // `needs` closure: gating a shared upstream job like `changes` starves all
+  // of these at once while every `if:` here still reads clean.
   it.each(["typecheck", "test", "build", "script-tests"])(
-    "%s runs regardless of the PR's base branch",
+    "%s runs regardless of the PR's base branch, transitively",
     (jobName) => {
-      const job = workflow("ci").jobs?.[jobName];
-      expect(job, `ci.yml has no job named ${jobName}`).toBeDefined();
-      expect(job!.if ?? "").not.toContain("github.base_ref");
+      const jobs = workflow("ci").jobs ?? {};
+      expect(jobs[jobName], `ci.yml has no job named ${jobName}`).toBeDefined();
+      for (const dep of dependencyClosure(jobs, jobName)) {
+        expect(
+          jobs[dep]?.if ?? "",
+          `${jobName} depends on ${dep}, which gates on github.base_ref — that starves ` +
+            `${jobName} on every stacked PR even though its own \`if:\` looks unconditional`
+        ).not.toContain("github.base_ref");
+      }
     }
   );
 });

--- a/tests/unit/github-workflow-triggers.test.ts
+++ b/tests/unit/github-workflow-triggers.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Trigger and base-guard invariants for the PR workflows.
+ *
+ * Two ways a PR can reach `main` with no automated verification, neither of
+ * which produces a red X, an annotation, or anything else a reviewer would
+ * notice:
+ *
+ *  - A `pull_request: branches: [main]` filter. A PR based on any other
+ *    branch then matches no trigger, so the workflow never starts and its
+ *    required checks are simply absent.
+ *  - A `github.base_ref` job guard without `edited` in `types:`. Retargeting
+ *    a PR's base fires only the `edited` activity type, which the default set
+ *    omits — so when a parent merges and GitHub retargets the child onto
+ *    `main`, nothing re-runs, and the child's conclusions from its old base
+ *    stand. Those conclusions are `skipped`, and a skipped check satisfies a
+ *    required status check.
+ *
+ * The second is the subtle one: it is the first hole wearing the disguise of
+ * a fix. That is why these are assertions and not comments in the YAML.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse } from "yaml";
+
+type Job = { if?: string };
+type Workflow = {
+  on?: { pull_request?: { branches?: string[]; types?: string[] } | null };
+  jobs?: Record<string, Job>;
+};
+
+const WORKFLOW_DIR = join(__dirname, "..", "..", ".github", "workflows");
+
+function workflow(name: string): Workflow {
+  return parse(readFileSync(join(WORKFLOW_DIR, `${name}.yml`), "utf-8")) as Workflow;
+}
+
+// Adding a new PR-triggered workflow to this list is the point: it inherits
+// the invariants rather than rediscovering them.
+const PR_WORKFLOWS = ["ci", "e2e-tests", "codeql"] as const;
+
+// Declaring `types:` REPLACES the default set rather than extending it, so
+// omitting `synchronize` would stop CI from running on pushes to an open PR —
+// a far wider hole than the one `edited` closes. Pin the whole set.
+const REQUIRED_TYPES = ["opened", "synchronize", "reopened", "edited"];
+
+describe("GitHub workflow PR triggers", () => {
+  it.each(PR_WORKFLOWS)(
+    "%s.yml does not filter pull_request by base branch",
+    (name) => {
+      const pr = workflow(name).on?.pull_request;
+      // `pull_request:` with no mapping parses as null — every branch, default
+      // types. That shape is fine; a `branches:` key is not.
+      expect(pr?.branches).toBeUndefined();
+    }
+  );
+
+  it.each(PR_WORKFLOWS)(
+    "%s.yml re-runs on base retarget whenever any job guards on github.base_ref",
+    (name) => {
+      const wf = workflow(name);
+      const guarded = Object.entries(wf.jobs ?? {}).filter(([, job]) =>
+        job.if?.includes("github.base_ref")
+      );
+      if (guarded.length === 0) return;
+
+      const types = wf.on?.pull_request?.types ?? [];
+      expect(
+        types,
+        `${name}.yml guards ${guarded.map(([n]) => n).join(", ")} on github.base_ref ` +
+          `but its pull_request types are [${types.join(", ")}] — a base retarget ` +
+          `fires only 'edited', so those guards would never be re-evaluated`
+      ).toEqual(REQUIRED_TYPES);
+    }
+  );
+});
+
+describe("Expensive-job base guards", () => {
+  // The jobs whose cost scales with the depth of a stacked chain: a per-PR
+  // Cloudflare deployment, and an E2E matrix whose every shard boots a
+  // Backend-Service plus a mock tubafrenzy mirror.
+  it("gates the per-PR preview deploy on a main base", () => {
+    expect(workflow("ci").jobs?.preview?.if).toContain("github.base_ref == 'main'");
+  });
+
+  it("gates the E2E matrix on a main base", () => {
+    expect(workflow("e2e-tests").jobs?.e2e?.if).toContain("github.base_ref == 'main'");
+  });
+
+  // The aggregator maps a skipped matrix to success so a docs-only PR can
+  // satisfy the required check. Ungated, that mapping would report the
+  // required "E2E Tests" as *passing* on a stacked PR that ran zero shards —
+  // a check claiming verification it never performed, strictly worse than the
+  // honest skip branch protection already accepts.
+  it("repeats the guard on the E2E aggregator so a skipped matrix cannot report success", () => {
+    expect(workflow("e2e-tests").jobs?.["e2e-all"]?.if).toContain(
+      "github.base_ref == 'main'"
+    );
+  });
+});
+
+describe("Cheap correctness jobs", () => {
+  // The whole point of the unfiltered trigger. If a future cost-trimming pass
+  // gates these on the base too, a stacked PR is back to running nothing.
+  it.each(["typecheck", "test", "build", "script-tests"])(
+    "%s runs regardless of the PR's base branch",
+    (jobName) => {
+      const job = workflow("ci").jobs?.[jobName];
+      expect(job, `ci.yml has no job named ${jobName}`).toBeDefined();
+      expect(job!.if ?? "").not.toContain("github.base_ref");
+    }
+  );
+});

--- a/tests/unit/github-workflow-triggers.test.ts
+++ b/tests/unit/github-workflow-triggers.test.ts
@@ -90,6 +90,20 @@ describe("GitHub workflow PR triggers", () => {
       ).toBeUndefined();
     }
   });
+
+  // Declaring `types:` REPLACES the default set rather than extending it, so a
+  // partial list is a silent subtraction: `types: [opened]` alone would stop
+  // every push to an open PR from re-running anything. None of these workflows
+  // needs a custom set — the base guards report failure rather than skipping,
+  // so nothing here depends on `edited`.
+  it.each(PR_WORKFLOWS)("%s.yml keeps the default activity types", (name) => {
+    const pr = workflow(name).on?.pull_request as Record<string, unknown> | null | undefined;
+    expect(
+      pr?.types,
+      `${name}.yml declares pull_request types, which replaces the default set — ` +
+        `dropping 'synchronize' would stop CI running on pushes to an open PR`
+    ).toBeUndefined();
+  });
 });
 
 describe("Expensive jobs refuse a non-main base rather than skipping", () => {
@@ -99,18 +113,46 @@ describe("Expensive jobs refuse a non-main base rather than skipping", () => {
   // means neither may carry a `github.base_ref` job-level guard — a guard
   // produces exactly the skip being avoided.
 
+  // The refusal must EXIT NON-ZERO, not warn. A guard that logs and returns 0
+  // reports the required check as *passing* on a PR that deployed nothing and
+  // ran zero shards — worse than the skip this design replaced. The pattern is
+  // anchored tightly (no `s` flag, bounded gap, `exit 1` required) because a
+  // loose `/BASE_REF.*!= .*"main"/s` matches any later unrelated comparison in
+  // a 600-line file and would survive deleting the refusal outright.
+  const REFUSAL = /"\$BASE_REF" != "main" \]; then\n(?:[^\n]*\n){0,3}\s*exit 1\n/;
+
   it("the preview deploy has no base guard, and refuses inside the job", () => {
-    const ci = workflow("ci");
-    expect(ci.jobs?.preview?.if ?? "").not.toContain("github.base_ref");
-    const source = readFileSync(join(WORKFLOW_DIR, "ci.yml"), "utf-8");
-    expect(source).toMatch(/BASE_REF.*!=.*"main"/s);
+    const preview = workflow("ci").jobs?.preview;
+    expect(preview, "ci.yml has no job named preview — renaming it makes this suite vacuous").toBeDefined();
+    expect(preview!.if ?? "").not.toContain("github.base_ref");
+    expect(readFileSync(join(WORKFLOW_DIR, "ci.yml"), "utf-8")).toMatch(REFUSAL);
   });
 
   it("the E2E aggregator has no base guard, and refuses inside the job", () => {
-    const e2e = workflow("e2e-tests");
-    expect(e2e.jobs?.["e2e-all"]?.if ?? "").not.toContain("github.base_ref");
-    const source = readFileSync(join(WORKFLOW_DIR, "e2e-tests.yml"), "utf-8");
-    expect(source).toMatch(/BASE_REF.*!=.*"main"/s);
+    const aggregator = workflow("e2e-tests").jobs?.["e2e-all"];
+    expect(
+      aggregator,
+      "e2e-tests.yml has no job named e2e-all — renaming it makes this suite vacuous"
+    ).toBeDefined();
+    expect(aggregator!.if ?? "").not.toContain("github.base_ref");
+    expect(readFileSync(join(WORKFLOW_DIR, "e2e-tests.yml"), "utf-8")).toMatch(REFUSAL);
+  });
+
+  // `always()` is what lets the aggregator report at all when its matrix
+  // skipped, and on a docs-only stacked PR — where the `changes` path filter
+  // skips typecheck, unit, build and preview too — its red is the *only*
+  // required check still blocking. `success()`, a missing `if:`, or any added
+  // conjunct would make it skip instead, which branch protection reads as
+  // satisfied.
+  it("the E2E aggregator runs unconditionally", () => {
+    expect(workflow("e2e-tests").jobs?.["e2e-all"]?.if).toBe("always()");
+  });
+
+  // Hardcoding this would disarm both refusals while leaving their shell text
+  // intact for the pattern above to match.
+  it.each(["ci", "e2e-tests"])("%s.yml reads BASE_REF from github.base_ref", (name) => {
+    const source = readFileSync(join(WORKFLOW_DIR, `${name}.yml`), "utf-8");
+    expect(source).toMatch(/BASE_REF: \$\{\{ github\.base_ref \}\}/);
   });
 
   // The matrix itself may skip — it is pure cost, and `e2e-all` carries the


### PR DESCRIPTION
Closes #1226.

## The hole

`ci.yml`, `e2e-tests.yml`, and `codeql.yml` each filtered `pull_request` to `branches: [main]`. A PR based on anything else matched no trigger, so the workflow never started and its required checks were **absent** — not failing, absent. #1219 was reviewed, approved, and merged with zero automated verification on exactly that.

## The fix, and the trap inside the obvious version of it

Drop the filter, run the cheap jobs on every base, keep the expensive ones off a stacked PR for cost. The trap is *how* you keep them off.

Gating them with an `if:` makes them **skip**, and a skipped check **satisfies** a required one (#740). That matters because when a stacked PR's parent merges, GitHub retargets the child onto `main` automatically (`delete_branch_on_merge` is on) and branch protection re-reads the conclusions already sitting there. So the child arrives at `main` looking fully satisfied, before any new run can exist — and the pre-change behavior it replaced was *fail-closed*, because five absent checks read "Expected — waiting for status" and blocked the merge.

**So this PR makes a non-`main` base FAIL rather than skip.** `preview` refuses in its config-check step, which runs before any checkout — the refusal costs seconds and never touches Cloudflare. `e2e-all` runs unconditionally under `always()` and exits non-zero with the base named; the four-shard matrix still skips, so the cost control is intact and only the *reported conclusion* changes.

That keeps the property the `branches:` filter had by accident: a stacked PR cannot merge into `main` on checks that never ran. Retargeting leaves it red until someone re-runs the workflow.

| job | before this PR | after |
|---|---|---|
| `typecheck`, `test`/`unit-tests`, `build`, `script-tests`, `dependency-audit` | only on a `main`-based PR | **every PR base** |
| `preview` (per-PR Cloudflare deploy) | only on a `main`-based PR | **fails** on a non-`main` base, before checkout |
| `e2e` (4-shard matrix) | only on a `main`-based PR | skips on a non-`main` base (cost) |
| `e2e-all` (the required "E2E Tests") | `always()` | `always()`, and **fails** on a non-`main` base |
| `codeql` `analyze` | only on a `main`-based PR | **every PR base**, no base logic |

## Why there is no `edited` in `types:`

A base retarget fires only the `edited` activity type, which the default set omits — so with a *skip*-based design, `edited` is the only thing that clears the stale conclusion, and it has to arrive before anyone merges. With a *fail*-based design it is merely a convenience, and it is an expensive one: the base guard is a no-op on a `main`-based PR, where essentially every PR lives, so `edited` would re-run the four-shard E2E matrix and mint a fresh Cloudflare deployment **on every title and body edit** — roughly sixty runner-minutes per description tweak, in a repo where PR bodies get edited routinely. `cancel-in-progress` only collapses edits that land while a run is still in flight.

Fail closed, clear by hand. The cost of a manual re-run on the rare retarget is far below a full CI run on every edit.

## Compute delta

**Newly runs on a stacked PR** (previously: nothing): the `changes` job in both workflows, `Type Check`, the 3-shard unit matrix, `Unit Tests`, `Build`, `Script Tests`, `Dependency Audit`, one CodeQL analyze, and two fast refusals (`preview`, `e2e-all`) — 13 jobs, of which two exit in seconds.

**Still gated:** the 4-shard E2E matrix and the Cloudflare preview deploy — the two costs that would otherwise multiply by chain depth.

**No new cost on `main`-based PRs at all**, which is the change from the first version of this PR.

## The test earns its keep now

Mutation testing against the first draft found it green on the two likeliest ways a future editor breaks this: **moving the base gate up onto the shared `changes` job** (which starves typecheck, unit, build, script-tests and dependency-audit transitively, while every downstream `if:` still reads innocent — the #1219 hole exactly) and **adding a `paths:` filter** (the #731 class the workflow comments cite by name). It also passed with `branches-ignore: ['**']`, with codeql's trigger deleted outright, and against a newly-added workflow.

It now resolves each cheap job's **transitive `needs` closure** rather than reading one `if:` in isolation; rejects all four narrowing keys, not just `branches`; asserts the trigger exists before asserting its shape (closing a vacuous pass if a parser ever yields `on` as boolean `true`); and **discovers PR-triggered workflows by scanning the directory**, so the next one inherits the rules instead of being silently exempt.

All six previously-surviving mutations now fail. 12 assertions, green on the real tree.

## Expected findings, confirmed rather than "fixed"

- **`changes` needs nothing.** `dorny/paths-filter@v4` with no `base:` resolves the PR base via the API.
- **vitest's `--changed origin/main` stays.** `fetch-depth: 0` brings the ref on any base, and on a stacked PR the merge ref yields a *superset* of the child's diff: minutes, never a miss. If the ref failed to resolve, vitest errors and the job goes red — fail-closed.
- **Fork PRs** now run `npm ci`, build, unit tests and CodeQL against non-`main` bases where they previously ran nothing. No secrets exposure change — this is `pull_request`, not `pull_request_target`, so the token is read-only and `secrets.*` are empty for forks. Worth confirming "Require approval for all outside collaborators" is set.

## Local verification

`npm run lint` (0 errors, no new warnings), `npx tsc --noEmit`, `npx vitest run` (**336 files / 4806 tests**), plus the mutation matrix above.

## What this PR cannot demonstrate

Its own base is `main`, so its CI run exercises the unchanged path. The stacked-PR behavior is covered by the assertions; the first live proof will be the next PR opened against a non-`main` base.

## Known unrelated CI wrinkle

This PR's lockfile change busts both E2E caches at once, which timed out two shards on the first run — diagnosed in a comment below and filed as #1241.
