### PR TITLE
feat(catalog): recovered visual system — filing-code badge, artwork overlay, section cards, bin-picker chips

### DIFF
--- a/src/components/experiences/modern/catalog/CatalogCodePreview.tsx
+++ b/src/components/experiences/modern/catalog/CatalogCodePreview.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import type { Genre } from "@/lib/features/catalog/types";
+import type { Rotation } from "@/lib/features/rotation/types";
+import {
+  formatTone,
+  genreTone,
+  ROTATION_TONES,
+} from "@/lib/features/experiences/modern/tokens/roles";
+import { Avatar, Badge, Stack, Typography } from "@mui/joy";
+
+export type CatalogCodePreviewProps = {
+  /** Display genre name (maps to `Genre` tones when possible). */
+  genreName: string | null;
+  codeLetters: string;
+  /** Artist number in genre; shown as "|" when empty. */
+  artistNumber: string | number | null;
+  /** Album entry / disc #; "?" when unknown draft. */
+  albumEntry: string | number | null;
+  /** e.g. "CD", "Vinyl" — drives inner letter chip color. */
+  formatLabel: string | null;
+  /** Optional rotation badge (omitted for drafts not yet classified). */
+  rotation?: Rotation | null;
+  /** Compact size for artwork overlay; default full size for add/edit cards. */
+  size?: "md" | "sm";
+};
+
+const SIZE_STYLES = {
+  md: {
+    outer: "4rem",
+    inner: "1.5rem",
+    innerFont: "0.75rem",
+    text: "0.65rem",
+    textWidth: 10,
+  },
+  sm: {
+    outer: "2.5rem",
+    inner: "1rem",
+    innerFont: "0.55rem",
+    text: "0.5rem",
+    textWidth: 8,
+  },
+} as const;
+
+// `genreTone` resolves unknown strings to the Unknown tone but matches keys
+// exactly; draft input arrives in whatever case the form holds, so normalize
+// to the canonical key first to keep the match case-insensitive.
+function asGenreKey(name: string | null): Genre {
+  if (!name || !name.trim()) return "Unknown";
+  const g = name.trim();
+  const keys: Genre[] = [
+    "Rock",
+    "Blues",
+    "Electronic",
+    "Hiphop",
+    "Jazz",
+    "Classical",
+    "Reggae",
+    "Soundtracks",
+    "OCS",
+    "Unknown",
+  ];
+  const hit = keys.find((k) => k.toLowerCase() === g.toLowerCase());
+  return hit ?? "Unknown";
+}
+
+/**
+ * The library filing code rendered in `ArtistAvatar`'s visual language (genre
+ * tone, nested letter / # / entry), but driven by loose string props instead of
+ * an `ArtistEntry` so it can render a live draft while a form is being filled.
+ */
+export default function CatalogCodePreview({
+  genreName,
+  codeLetters,
+  artistNumber,
+  albumEntry,
+  formatLabel,
+  rotation = null,
+  size = "md",
+}: CatalogCodePreviewProps) {
+  const s = SIZE_STYLES[size];
+  const { color: color_choice, variant: variant_choice } = genreTone(
+    asGenreKey(genreName),
+  );
+  const formatColor = formatTone(formatLabel).color;
+
+  const genreAbbr =
+    genreName && genreName.trim().length > 0
+      ? genreName.trim().substring(0, 2).toUpperCase()
+      : "—";
+  const letters =
+    codeLetters.trim().length > 0
+      ? codeLetters.trim().toUpperCase().slice(0, 4)
+      : "&&";
+  const num =
+    artistNumber !== null &&
+    artistNumber !== "" &&
+    String(artistNumber).trim().length > 0
+      ? String(artistNumber)
+      : "|";
+  const entry =
+    albumEntry !== null &&
+    albumEntry !== "" &&
+    String(albumEntry).trim().length > 0
+      ? String(albumEntry)
+      : "?";
+  const fmtAbbr =
+    formatLabel && formatLabel.trim().length > 0
+      ? formatLabel.trim().substring(0, 2).toUpperCase()
+      : "—";
+
+  return (
+    <Badge
+      badgeContent={rotation || null}
+      size="sm"
+      color={rotation ? ROTATION_TONES[rotation]?.color : undefined}
+    >
+      <Avatar
+        variant={variant_choice}
+        color={color_choice}
+        sx={{
+          width: s.outer,
+          height: s.outer,
+        }}
+      >
+        <Stack direction="row" spacing={size === "sm" ? 0.1 : 0.2} sx={{ ml: -0.1 }}>
+          <Stack
+            direction="column"
+            sx={{
+              justifyContent: "center",
+            }}
+          >
+            <Typography
+              level="body-xs"
+              sx={{
+                color: "text.primary",
+                width: s.textWidth,
+                fontSize: s.text,
+                ml: -0.1,
+              }}
+            >
+              {genreAbbr}
+            </Typography>
+          </Stack>
+          <Stack direction="column" sx={{ textAlign: "center" }}>
+            <Typography
+              level="body-xs"
+              sx={{ color: "text.primary", fontSize: s.text }}
+            >
+              {num}
+            </Typography>
+            <Avatar
+              variant={variant_choice === "solid" ? "soft" : "solid"}
+              color={formatColor}
+              sx={{
+                width: s.inner,
+                height: s.inner,
+                m: 0,
+                fontSize: s.innerFont,
+              }}
+            >
+              {letters}
+            </Avatar>
+            <Typography
+              level="body-xs"
+              sx={{ color: "text.primary", fontSize: s.text }}
+            >
+              {entry}
+            </Typography>
+          </Stack>
+          <Stack
+            direction="column"
+            sx={{
+              width: s.textWidth,
+              textAlign: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Typography
+              level="body-xs"
+              sx={{
+                color: "text.primary",
+                fontSize: s.text,
+              }}
+            >
+              {fmtAbbr}
+            </Typography>
+          </Stack>
+        </Stack>
+      </Avatar>
+    </Badge>
+  );
+}

--- a/src/components/experiences/modern/catalog/CatalogRotationBinPicker.tsx
+++ b/src/components/experiences/modern/catalog/CatalogRotationBinPicker.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import type { Rotation } from "@/lib/features/rotation/types";
+import {
+  ROTATION_BINS,
+  ROTATION_BIN_LABELS,
+} from "@/src/utilities/modern/rotationBinColors";
+import { Checkbox, Stack, Typography } from "@mui/joy";
+import { useTheme } from "@mui/joy/styles";
+
+// Bin letter → the theme's `rotation` palette slot. Colors come from the
+// active theme's CSS vars (light and dark both), so the picker rethemes with
+// the rest of the color system instead of carrying its own hex tables.
+const BIN_SLOT: Record<Rotation, "heavy" | "medium" | "light" | "singles"> = {
+  H: "heavy",
+  M: "medium",
+  L: "light",
+  S: "singles",
+};
+
+/**
+ * Single-select rotation-bin chips that behave like a radiogroup but allow
+ * deselection: toggling the selected bin clears it, which a plain radio
+ * cannot express.
+ */
+export default function CatalogRotationBinPicker({
+  selectedBin,
+  onSelectBin,
+  disabled = false,
+  size = "md",
+  showLabel = true,
+}: {
+  selectedBin: Rotation | null;
+  onSelectBin: (bin: Rotation | null) => void;
+  disabled?: boolean;
+  size?: "sm" | "md";
+  showLabel?: boolean;
+}) {
+  const theme = useTheme();
+
+  const handleToggle = (bin: Rotation) => {
+    if (disabled) return;
+    onSelectBin(selectedBin === bin ? null : bin);
+  };
+
+  return (
+    <Stack spacing={showLabel ? 0.75 : 0}>
+      {showLabel ? (
+        <Typography level="body-xs" sx={{ color: "text.secondary" }}>
+          Rotation bin
+        </Typography>
+      ) : null}
+      {/* A group of toggleable checkboxes, not a radiogroup: the selected
+          bin can be clicked again to clear it, which radio semantics can't
+          express. Single-select is enforced by the controlled value. */}
+      <Stack
+        direction="row"
+        role="group"
+        aria-label="Rotation bin"
+        spacing={size === "sm" ? 0.75 : 1}
+        sx={{ alignItems: "center", flexWrap: "wrap" }}
+      >
+        {ROTATION_BINS.map((bin) => {
+          const isSelected = selectedBin === bin;
+          const c = theme.vars.palette.rotation[BIN_SLOT[bin]];
+          return (
+            <Checkbox
+              key={bin}
+              size={size}
+              variant="solid"
+              checked={isSelected}
+              disabled={disabled}
+              onClick={() => handleToggle(bin)}
+              label={bin}
+              slotProps={{
+                input: { "aria-label": `${ROTATION_BIN_LABELS[bin]} rotation` },
+                label: {
+                  sx: {
+                    fontWeight: isSelected ? "lg" : "md",
+                    fontSize: size === "sm" ? "0.75rem" : "0.8125rem",
+                  },
+                },
+                checkbox: {
+                  sx: {
+                    bgcolor: isSelected ? c.bgSelected : c.bg,
+                    borderColor: isSelected ? "transparent" : c.border,
+                    color: isSelected ? c.textSelected : c.text,
+                    "&:hover": {
+                      bgcolor: isSelected ? c.bgSelected : c.bgHover,
+                    },
+                  },
+                },
+              }}
+            />
+          );
+        })}
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/components/experiences/modern/catalog/album/AlbumArtworkWithCodeOverlay.tsx
+++ b/src/components/experiences/modern/catalog/album/AlbumArtworkWithCodeOverlay.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import CatalogCodePreview, {
+  type CatalogCodePreviewProps,
+} from "@/src/components/experiences/modern/catalog/CatalogCodePreview";
+import { Box } from "@mui/joy";
+
+type AlbumArtworkWithCodeOverlayProps = {
+  artworkUrl: string;
+  alt: string;
+  codePreview?: CatalogCodePreviewProps | null;
+};
+
+const artworkSx = {
+  width: { xs: 120, lg: 160 },
+  height: { xs: 120, lg: 160 },
+  objectFit: "cover" as const,
+  borderRadius: "sm",
+  flexShrink: 0,
+  display: "block",
+};
+
+export default function AlbumArtworkWithCodeOverlay({
+  artworkUrl,
+  alt,
+  codePreview,
+}: AlbumArtworkWithCodeOverlayProps) {
+  if (!codePreview) {
+    return (
+      <Box
+        component="img"
+        src={artworkUrl}
+        alt={alt}
+        data-testid="album-artwork"
+        sx={artworkSx}
+      />
+    );
+  }
+
+  return (
+    <Box
+      data-testid="album-artwork-with-code"
+      sx={{
+        position: "relative",
+        width: artworkSx.width,
+        height: artworkSx.height,
+        flexShrink: 0,
+      }}
+    >
+      <Box component="img" src={artworkUrl} alt={alt} sx={artworkSx} />
+      <Box
+        sx={{
+          position: "absolute",
+          right: 6,
+          bottom: 6,
+          pointerEvents: "none",
+          filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.35))",
+        }}
+        data-testid="album-artwork-code-overlay"
+      >
+        <CatalogCodePreview {...codePreview} size="sm" />
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/experiences/modern/catalog/album/AlbumCard.tsx
+++ b/src/components/experiences/modern/catalog/album/AlbumCard.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/joy";
 import { useRef, useState, useEffect } from "react";
 import { NotOnDiscogsBadge } from "@/src/components/experiences/modern/catalog/AlbumArtwork";
+import AlbumArtworkWithCodeOverlay from "./AlbumArtworkWithCodeOverlay";
 import AlbumEditForm from "./AlbumEditForm";
 import DiscogsMarkup from "./DiscogsMarkupRenderer";
 import DiscogsUnavailableControl from "./DiscogsUnavailableControl";
@@ -79,16 +80,16 @@ export default function AlbumCard({
               note={album.discogsUnavailableNote}
             />
           ) : (
-            <Box
-              component="img"
-              src={artworkUrl}
+            <AlbumArtworkWithCodeOverlay
+              artworkUrl={artworkUrl}
               alt={`${album.title} cover`}
-              sx={{
-                width: { xs: 120, lg: 160 },
-                height: { xs: 120, lg: 160 },
-                objectFit: "cover",
-                borderRadius: "sm",
-                flexShrink: 0,
+              codePreview={{
+                genreName: album.artist.genre,
+                codeLetters: album.artist.lettercode,
+                artistNumber: album.artist.numbercode,
+                albumEntry: album.entry,
+                formatLabel: album.format,
+                rotation: album.rotation_bin ?? null,
               }}
             />
           )}

--- a/src/components/experiences/modern/catalog/album/AlbumEditForm.tsx
+++ b/src/components/experiences/modern/catalog/album/AlbumEditForm.tsx
@@ -15,6 +15,7 @@ import {
   Typography,
 } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
+import FormSectionCard from "@/src/components/shared/FormSectionCard";
 import {
   useGetFormatsQuery,
   useGetGenresQuery,
@@ -105,7 +106,9 @@ function artistLinkFrom(saved: SavedFields, name: string): ArtistLink | null {
 function AlbumEditForm({ album }: AlbumEditFormProps) {
   return (
     <RequireMD>
-      <AlbumEditFormFields album={album} />
+      <FormSectionCard title="Edit release" data-testid="edit-release-section-card">
+        <AlbumEditFormFields album={album} />
+      </FormSectionCard>
     </RequireMD>
   );
 }

--- a/src/components/experiences/modern/catalog/album/DiscogsUnavailableControl.tsx
+++ b/src/components/experiences/modern/catalog/album/DiscogsUnavailableControl.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
 } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
+import FormSectionCard from "@/src/components/shared/FormSectionCard";
 import { useUpdateAlbumMutation } from "@/lib/features/catalog/api";
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { DISCOGS_UNAVAILABLE_NOTE_MAX_LENGTH } from "@/lib/features/catalog/constants";
@@ -96,7 +97,10 @@ function DiscogsUnavailableControl({ album }: DiscogsUnavailableControlProps) {
 
   return (
     <RequireMD>
-      <Stack spacing={1}>
+      <FormSectionCard
+        title="Discogs availability"
+        data-testid="discogs-availability-section-card"
+      >
         <FormControl
           orientation="horizontal"
           sx={{ justifyContent: "space-between", alignItems: "center" }}
@@ -138,7 +142,7 @@ function DiscogsUnavailableControl({ album }: DiscogsUnavailableControlProps) {
             </Stack>
           </FormControl>
         )}
-      </Stack>
+      </FormSectionCard>
     </RequireMD>
   );
 }

--- a/src/components/experiences/modern/catalog/album/RotationClassifyControl.tsx
+++ b/src/components/experiences/modern/catalog/album/RotationClassifyControl.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
-import { Button, Chip, FormControl, FormLabel, Stack } from "@mui/joy";
+import { Button, Chip, Stack } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
 import {
   useAddRotationEntryMutation,
@@ -12,7 +12,8 @@ import {
 import { Rotation } from "@/lib/features/rotation/types";
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
-import RotationBinSelector from "@/src/components/experiences/modern/flowsheet/Search/RotationBinSelector";
+import FormSectionCard from "@/src/components/shared/FormSectionCard";
+import CatalogRotationBinPicker from "@/src/components/experiences/modern/catalog/CatalogRotationBinPicker";
 
 interface RotationClassifyControlProps {
   album: AlbumEntry;
@@ -30,7 +31,9 @@ interface RotationClassifyControlProps {
 function RotationClassifyControl({ album }: RotationClassifyControlProps) {
   return (
     <RequireMD>
-      <RotationClassifyFields album={album} />
+      <FormSectionCard title="Rotation" data-testid="rotation-section-card">
+        <RotationClassifyFields album={album} />
+      </FormSectionCard>
     </RequireMD>
   );
 }
@@ -204,27 +207,25 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
   }
 
   return (
-    <FormControl
-      orientation="horizontal"
-      sx={{ justifyContent: "space-between", alignItems: "center" }}
+    <Stack
+      direction="row"
+      spacing={1}
+      sx={{ alignItems: "flex-end", justifyContent: "space-between" }}
     >
-      <FormLabel>Rotation</FormLabel>
-      <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
-        <RotationBinSelector
-          selectedBin={selectedBin}
-          onSelectBin={setSelectedBin}
-          disabled={addBusy}
-        />
-        <Button
-          size="sm"
-          disabled={!selectedBin}
-          loading={addBusy}
-          onClick={handleAdd}
-        >
-          Add to Rotation
-        </Button>
-      </Stack>
-    </FormControl>
+      <CatalogRotationBinPicker
+        selectedBin={selectedBin}
+        onSelectBin={setSelectedBin}
+        disabled={addBusy}
+      />
+      <Button
+        size="sm"
+        disabled={!selectedBin}
+        loading={addBusy}
+        onClick={handleAdd}
+      >
+        Add to Rotation
+      </Button>
+    </Stack>
   );
 }
 

--- a/src/components/shared/FormSectionCard.tsx
+++ b/src/components/shared/FormSectionCard.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Card, CardContent, Stack, Typography } from "@mui/joy";
+import type { SxProps } from "@mui/joy/styles/types";
+import type { ReactNode } from "react";
+
+import {
+  formSectionCardInteractiveSx,
+  formSectionCardSx,
+} from "./formSectionCardStyles";
+
+type FormSectionCardProps = {
+  title: string;
+  description?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  disabled?: boolean;
+  interactive?: boolean;
+  "data-testid"?: string;
+};
+
+export default function FormSectionCard({
+  title,
+  description,
+  children,
+  footer,
+  disabled = false,
+  interactive = true,
+  "data-testid": dataTestId,
+}: FormSectionCardProps) {
+  return (
+    <Card
+      variant="outlined"
+      data-testid={dataTestId}
+      sx={
+        [
+          formSectionCardSx,
+          interactive ? formSectionCardInteractiveSx : {},
+          disabled ? { opacity: 0.55, pointerEvents: "none" } : {},
+        ] as SxProps
+      }
+    >
+      <CardContent>
+        <Typography level="title-sm">{title}</Typography>
+        {description ? (
+          <Typography
+            level="body-xs"
+            sx={{ color: "text.tertiary", mt: 0.25, display: "block" }}
+          >
+            {description}
+          </Typography>
+        ) : null}
+        <Stack spacing={1.5} sx={{ mt: description ? 1 : 0.75 }}>
+          {children}
+        </Stack>
+        {footer}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/shared/formSectionCardStyles.ts
+++ b/src/components/shared/formSectionCardStyles.ts
@@ -1,0 +1,22 @@
+import type { SxProps } from "@mui/joy/styles/types";
+
+/** Outlined section cards in stacked forms — aligned with AlbumCard and the catalog search shell. */
+export const formSectionCardSx: SxProps = {
+  borderRadius: "md",
+  bgcolor: "background.surface",
+  flexShrink: 0,
+};
+
+/** Focus ring when a card contains active form controls. */
+export const formSectionCardInteractiveSx: SxProps = {
+  "&:focus-within": {
+    borderColor: "var(--wxyc-palette-primary-300)",
+    boxShadow: "0 0 0 2px var(--wxyc-palette-primary-100)",
+  },
+};
+
+export const formSectionCardsStackSx: SxProps = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 1.5,
+};

--- a/tests/integration/components/modern/catalog/CatalogCodePreview.test.tsx
+++ b/tests/integration/components/modern/catalog/CatalogCodePreview.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers";
+
+// Mock fonts before importing the modern theme (pulled in for the format palette slots).
+vi.mock("next/font/google", () => ({
+  Kanit: () => ({ style: { fontFamily: "Kanit, sans-serif" } }),
+}));
+vi.mock("next/font/local", () => ({
+  default: () => ({ style: { fontFamily: "Minbus, sans-serif" } }),
+}));
+
+import { CssVarsProvider } from "@mui/joy/styles";
+import type { ReactElement } from "react";
+import modernTheme from "@/lib/features/experiences/modern/theme";
+import CatalogCodePreview from "@/src/components/experiences/modern/catalog/CatalogCodePreview";
+
+// The inner format chip uses the custom formatVinyl/formatCd palette slots,
+// which only resolve under the modern theme.
+const inModernTheme = (ui: ReactElement) => (
+  <CssVarsProvider theme={modernTheme}>{ui}</CssVarsProvider>
+);
+
+describe("CatalogCodePreview", () => {
+  it("renders placeholders when the draft is empty", () => {
+    const { container } = renderWithProviders(
+      inModernTheme(<CatalogCodePreview
+        genreName={null}
+        codeLetters=""
+        artistNumber={null}
+        albumEntry={null}
+        formatLabel={null}
+      />
+      )
+    );
+    expect(container.textContent).toContain("&&");
+    expect(container.textContent).toContain("?");
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the compact avatar when size is sm", () => {
+    const { container } = renderWithProviders(
+      inModernTheme(<CatalogCodePreview
+        genreName="Rock"
+        codeLetters="RO"
+        artistNumber={87}
+        albumEntry="4"
+        formatLabel="Vinyl"
+        size="sm"
+      />
+      )
+    );
+    // jsdom computes the sx rem values to px (16px root): sm outer = 2.5rem.
+    const avatar = container.querySelector(".MuiAvatar-root");
+    expect(avatar).toHaveStyle({ width: "40px", height: "40px" });
+  });
+
+  it("shows the artist number, letters, entry, and format abbreviation", () => {
+    const { container } = renderWithProviders(
+      inModernTheme(<CatalogCodePreview
+        genreName="Jazz"
+        codeLetters="el"
+        artistNumber={87}
+        albumEntry="4"
+        formatLabel="Vinyl"
+      />
+      )
+    );
+    expect(screen.getByText("87")).toBeInTheDocument();
+    expect(screen.getByText("EL")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(container.textContent).toContain("VI");
+  });
+
+  it("resolves genre tones case-insensitively", () => {
+    const upper = renderWithProviders(
+      inModernTheme(<CatalogCodePreview
+        genreName="Rock"
+        codeLetters="RO"
+        artistNumber={1}
+        albumEntry={1}
+        formatLabel="CD"
+      />
+      )
+    ).container.querySelector(".MuiAvatar-root")!.className;
+    const lower = renderWithProviders(
+      inModernTheme(<CatalogCodePreview
+        genreName="rock"
+        codeLetters="RO"
+        artistNumber={1}
+        albumEntry={1}
+        formatLabel="CD"
+      />
+      )
+    ).container.querySelector(".MuiAvatar-root")!.className;
+    expect(lower).toBe(upper);
+  });
+
+  it("renders the rotation badge only when a rotation is given", () => {
+    const { container } = renderWithProviders(
+      inModernTheme(<CatalogCodePreview
+        genreName="Rock"
+        codeLetters="RO"
+        artistNumber={87}
+        albumEntry="4"
+        formatLabel="CD"
+        rotation="H"
+      />
+      )
+    );
+    expect(container.textContent).toContain("H");
+
+    const { container: without } = renderWithProviders(
+      inModernTheme(<CatalogCodePreview
+        genreName="Jazz"
+        codeLetters="EL"
+        artistNumber={5}
+        albumEntry="1"
+        formatLabel="CD"
+      />
+      )
+    );
+    const badge = without.querySelector(".MuiBadge-badge");
+    expect(badge?.textContent ?? "").toBe("");
+  });
+});

--- a/tests/integration/components/modern/catalog/CatalogRotationBinPicker.test.tsx
+++ b/tests/integration/components/modern/catalog/CatalogRotationBinPicker.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/tests/helpers";
+
+// Mock fonts before importing the modern theme (pulled in for the rotation palette).
+vi.mock("next/font/google", () => ({
+  Kanit: () => ({ style: { fontFamily: "Kanit, sans-serif" } }),
+}));
+vi.mock("next/font/local", () => ({
+  default: () => ({ style: { fontFamily: "Minbus, sans-serif" } }),
+}));
+
+import { CssVarsProvider } from "@mui/joy/styles";
+import type { ReactElement } from "react";
+import modernTheme from "@/lib/features/experiences/modern/theme";
+import CatalogRotationBinPicker from "@/src/components/experiences/modern/catalog/CatalogRotationBinPicker";
+
+// The bin colors come from the custom `rotation` palette slot, which only
+// resolves under the modern theme.
+const inModernTheme = (ui: ReactElement) => (
+  <CssVarsProvider theme={modernTheme}>{ui}</CssVarsProvider>
+);
+
+describe("CatalogRotationBinPicker", () => {
+  it("shows the rotation bin label by default and hides it on request", () => {
+    renderWithProviders(
+      inModernTheme(<CatalogRotationBinPicker selectedBin={null} onSelectBin={vi.fn()} />
+      )
+    );
+    expect(screen.getByText("Rotation bin")).toBeInTheDocument();
+  });
+
+  it("renders all four bins as a labeled group", () => {
+    renderWithProviders(
+      inModernTheme(<CatalogRotationBinPicker
+        selectedBin={null}
+        onSelectBin={vi.fn()}
+        showLabel={false}
+      />
+      )
+    );
+    expect(screen.queryByText("Rotation bin")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: "Rotation bin" })
+    ).toBeInTheDocument();
+    for (const label of [
+      "Heavy rotation",
+      "Medium rotation",
+      "Light rotation",
+      "Singles rotation",
+    ]) {
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("selects an unselected bin on click", async () => {
+    const onSelectBin = vi.fn();
+    renderWithProviders(
+      inModernTheme(<CatalogRotationBinPicker selectedBin={null} onSelectBin={onSelectBin} />
+      )
+    );
+    await userEvent.click(screen.getByLabelText("Heavy rotation"));
+    expect(onSelectBin).toHaveBeenCalledWith("H");
+  });
+
+  it("deselects the selected bin on a second click", async () => {
+    const onSelectBin = vi.fn();
+    renderWithProviders(
+      inModernTheme(<CatalogRotationBinPicker selectedBin="H" onSelectBin={onSelectBin} />
+      )
+    );
+    await userEvent.click(screen.getByLabelText("Heavy rotation"));
+    expect(onSelectBin).toHaveBeenCalledWith(null);
+  });
+
+  it("ignores clicks when disabled", async () => {
+    const onSelectBin = vi.fn();
+    renderWithProviders(
+      inModernTheme(<CatalogRotationBinPicker
+        selectedBin={null}
+        onSelectBin={onSelectBin}
+        disabled
+      />
+      )
+    );
+    await userEvent.click(screen.getByLabelText("Heavy rotation"), {
+      pointerEventsCheck: 0,
+    });
+    expect(onSelectBin).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/components/modern/catalog/album/RotationClassifyControl.test.tsx
+++ b/tests/integration/components/modern/catalog/album/RotationClassifyControl.test.tsx
@@ -283,7 +283,7 @@ describe("RotationClassifyControl", () => {
       await waitFor(() => expect(mockFetchOrgRole).toHaveBeenCalled());
       await mockFetchOrgRole.mock.results[0].value;
       await waitFor(() =>
-        expect(screen.queryByRole("radiogroup", { name: "Rotation bin" })).not.toBeInTheDocument()
+        expect(screen.queryByRole("group", { name: "Rotation bin" })).not.toBeInTheDocument()
       );
       expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument();
       expect(backend.listRequests()).toBe(0);
@@ -296,7 +296,7 @@ describe("RotationClassifyControl", () => {
       renderWithProviders(inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />));
 
       expect(
-        await screen.findByRole("radiogroup", { name: "Rotation bin" }),
+        await screen.findByRole("group", { name: "Rotation bin" }),
       ).toBeInTheDocument();
       expect(backend.listRequests()).toBeGreaterThan(0);
     });
@@ -312,7 +312,7 @@ describe("RotationClassifyControl", () => {
       fakeRotationEndpoints();
       renderWithProviders(inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />));
 
-      await screen.findByRole("radiogroup", { name: "Rotation bin" });
+      await screen.findByRole("group", { name: "Rotation bin" });
       expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument();
     });
 
@@ -322,8 +322,8 @@ describe("RotationClassifyControl", () => {
         inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
 
-      await screen.findByRole("radiogroup", { name: "Rotation bin" });
-      await user.click(screen.getByRole("radio", { name: "H" }));
+      await screen.findByRole("group", { name: "Rotation bin" });
+      await user.click(screen.getByRole("checkbox", { name: "Heavy rotation" }));
       await user.click(screen.getByRole("button", { name: "Add to Rotation" }));
 
       await waitFor(() =>
@@ -340,13 +340,13 @@ describe("RotationClassifyControl", () => {
         inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
 
-      await screen.findByRole("radiogroup", { name: "Rotation bin" });
-      await user.click(screen.getByRole("radio", { name: "H" }));
+      await screen.findByRole("group", { name: "Rotation bin" });
+      await user.click(screen.getByRole("checkbox", { name: "Heavy rotation" }));
       await user.click(screen.getByRole("button", { name: "Add to Rotation" }));
 
       expect(await screen.findByRole("button", { name: "Kill H" })).toBeInTheDocument();
       expect(
-        screen.queryByRole("radiogroup", { name: "Rotation bin" }),
+        screen.queryByRole("group", { name: "Rotation bin" }),
       ).not.toBeInTheDocument();
     });
 
@@ -361,15 +361,15 @@ describe("RotationClassifyControl", () => {
         inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
 
-      await screen.findByRole("radiogroup", { name: "Rotation bin" });
-      await user.click(screen.getByRole("radio", { name: "M" }));
+      await screen.findByRole("group", { name: "Rotation bin" });
+      await user.click(screen.getByRole("checkbox", { name: "Medium rotation" }));
       await user.click(screen.getByRole("button", { name: "Add to Rotation" }));
 
       await waitFor(() =>
         expect(toast.error).toHaveBeenCalledWith("Failed to add to rotation"),
       );
       expect(
-        await screen.findByRole("radiogroup", { name: "Rotation bin" }),
+        await screen.findByRole("group", { name: "Rotation bin" }),
       ).toBeInTheDocument();
     });
 
@@ -393,8 +393,8 @@ describe("RotationClassifyControl", () => {
         inModernTheme(<RotationClassifyControl album={juanaMolinaAlbum()} />),
       );
 
-      await screen.findByRole("radiogroup", { name: "Rotation bin" });
-      await user.click(screen.getByRole("radio", { name: "M" }));
+      await screen.findByRole("group", { name: "Rotation bin" });
+      await user.click(screen.getByRole("checkbox", { name: "Medium rotation" }));
       await user.click(screen.getByRole("button", { name: "Add to Rotation" }));
 
       await waitFor(() =>
@@ -420,7 +420,7 @@ describe("RotationClassifyControl", () => {
 
       expect(await screen.findByRole("button", { name: "Kill H" })).toBeInTheDocument();
       expect(
-        screen.queryByRole("radiogroup", { name: "Rotation bin" }),
+        screen.queryByRole("group", { name: "Rotation bin" }),
       ).not.toBeInTheDocument();
     });
 
@@ -465,7 +465,7 @@ describe("RotationClassifyControl", () => {
       await user.click(await screen.findByRole("button", { name: "Kill H" }));
 
       expect(
-        await screen.findByRole("radiogroup", { name: "Rotation bin" }),
+        await screen.findByRole("group", { name: "Rotation bin" }),
       ).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument();
     });
@@ -517,7 +517,7 @@ describe("RotationClassifyControl", () => {
       );
 
       expect(
-        await screen.findByRole("radiogroup", { name: "Rotation bin" }),
+        await screen.findByRole("group", { name: "Rotation bin" }),
       ).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: "Kill H" })).not.toBeInTheDocument();
     });
@@ -631,7 +631,7 @@ describe("RotationClassifyControl", () => {
 
       expect(await screen.findByText("Rotation status unavailable")).toBeInTheDocument();
       expect(
-        screen.queryByRole("radiogroup", { name: "Rotation bin" }),
+        screen.queryByRole("group", { name: "Rotation bin" }),
       ).not.toBeInTheDocument();
       expect(screen.queryByRole("button", { name: /^Kill/ })).not.toBeInTheDocument();
     });
@@ -676,7 +676,7 @@ describe("RotationClassifyControl", () => {
         await screen.findByText("Not linked to a library album — can't be classified"),
       ).toBeInTheDocument();
       expect(
-        screen.queryByRole("radiogroup", { name: "Rotation bin" }),
+        screen.queryByRole("group", { name: "Rotation bin" }),
       ).not.toBeInTheDocument();
       expect(
         screen.queryByRole("button", { name: "Add to Rotation" }),

--- a/tests/integration/components/shared/FormSectionCard.test.tsx
+++ b/tests/integration/components/shared/FormSectionCard.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers";
+import FormSectionCard from "@/src/components/shared/FormSectionCard";
+
+describe("FormSectionCard", () => {
+  it("renders title, description, children, and data-testid", () => {
+    renderWithProviders(
+      <FormSectionCard
+        title="Artist"
+        description="Pick a genre first."
+        data-testid="test-section-card"
+      >
+        <span>child field</span>
+      </FormSectionCard>
+    );
+
+    expect(screen.getByText("Artist")).toBeInTheDocument();
+    expect(screen.getByText("Pick a genre first.")).toBeInTheDocument();
+    expect(screen.getByText("child field")).toBeInTheDocument();
+    expect(screen.getByTestId("test-section-card")).toBeInTheDocument();
+    expect(screen.getByTestId("test-section-card").className).toMatch(
+      /MuiCard-root/
+    );
+  });
+
+  it("renders footer when provided", () => {
+    renderWithProviders(
+      <FormSectionCard title="Album" footer={<button type="button">Save</button>}>
+        <span>fields</span>
+      </FormSectionCard>
+    );
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+
+  it("dims and blocks pointer events when disabled", () => {
+    renderWithProviders(
+      <FormSectionCard title="Album" disabled data-testid="disabled-card">
+        <span>fields</span>
+      </FormSectionCard>
+    );
+
+    expect(screen.getByTestId("disabled-card")).toHaveStyle({
+      "pointer-events": "none",
+    });
+  });
+});


### PR DESCRIPTION
## What

Ports the recovered catalog visual components onto the current MD edit functionality (stacked on #1243; merge that first):

- **CatalogCodePreview** — the genre-toned lettercode avatar (ArtistAvatar's visual language, driven by loose string props so it can live-preview a form draft). Rewired from the retired `GENRE_COLORS`/`GENRE_VARIANTS` to the shared `genreTone()`/`formatTone()`/`ROTATION_TONES` role tokens — identical rendered values.
- **AlbumArtworkWithCodeOverlay** — compact badge overlaid on artwork; the album modal now shows the real filing code (genre/letters/number/entry/format) over the cover.
- **FormSectionCard** (+ styles) — outlined section card with focus-within ring and disabled dim, now wrapping the modal's MD sections: Edit release, Rotation, Discogs availability. CSS vars corrected to the `--wxyc-` prefix.
- **CatalogRotationBinPicker** — H/M/L/S solid chips colored from `theme.vars.palette.rotation.*` (rethemes with the color system). Swapped into RotationClassifyControl's add form only — all of its landed logic (fail-closed unknown state, shared bare `getRotation` subscription, kill-id busy set) is untouched. Container is `role=group` (not radiogroup) since a second click deselects; the input-level aria-labels are "Heavy/Medium/Light/Singles rotation".

## Verification

`npx tsc --noEmit` clean; lint 0 errors / 194 warnings (no growth); full vitest suite green (338 files, 4814 tests) including new suites for all three components and updated RotationClassifyControl queries. Light/dark screenshots pending local backend stack — flagged for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)