### PR TITLE
feat(catalog): right-click context menu on catalog results

### DIFF
--- a/src/components/experiences/modern/catalog/Results/CatalogResultContextMenu.tsx
+++ b/src/components/experiences/modern/catalog/Results/CatalogResultContextMenu.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import {
+  Archive,
+  Check,
+  EditOutlined,
+  InfoOutlined,
+  Unarchive,
+} from "@mui/icons-material";
+import { ClickAwayListener } from "@mui/material";
+import Popper from "@mui/material/Popper";
+import { ListDivider, ListSubheader, MenuItem, MenuList } from "@mui/joy";
+import type { Rotation } from "@/lib/features/rotation/types";
+import {
+  ROTATION_BINS,
+  ROTATION_BIN_LABELS,
+} from "@/src/utilities/modern/rotationBinColors";
+import {
+  useAddRotationEntryMutation,
+  useKillRotationEntryMutation,
+} from "@/lib/features/rotation/api";
+import { AlbumEntry } from "@/lib/features/catalog/types";
+import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
+import { RequireMD } from "@/src/components/shared/Authorization";
+import { useAlbumRotationEntries } from "@/src/components/experiences/modern/catalog/album/useAlbumRotationEntries";
+import { useBin, useAddToBin, useDeleteFromBin } from "@/src/hooks/binHooks";
+import type { VirtualElement } from "@popperjs/core";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { toast } from "sonner";
+
+export type ContextMenuAnchor = { top: number; left: number };
+
+export type CatalogResultContextMenuState = {
+  album: AlbumEntry;
+  top: number;
+  left: number;
+};
+
+function contextMenuVirtualAnchor(top: number, left: number): VirtualElement {
+  return {
+    getBoundingClientRect: () =>
+      DOMRect.fromRect({
+        x: left,
+        y: top,
+        width: 0,
+        height: 0,
+      }),
+  };
+}
+
+/**
+ * Right-click menu on a catalog result row. Menu state is owned by the
+ * results list (one open menu at a time, unmounted when closed), so every
+ * action can simply act and close — nothing here survives dismissal.
+ */
+export default function CatalogResultContextMenu({
+  menu,
+  onClose,
+}: {
+  menu: CatalogResultContextMenuState;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const { album } = menu;
+
+  const { bin, loading: binListLoading } = useBin();
+  const { addToBin, loading: addBinLoading } = useAddToBin();
+  const { deleteFromBin, loading: deleteBinLoading } = useDeleteFromBin();
+
+  const inBin = Boolean(bin?.find((item) => item.id === album.id));
+  const binLoading = binListLoading || addBinLoading || deleteBinLoading;
+
+  const anchorEl = useMemo(
+    () => contextMenuVirtualAnchor(menu.top, menu.left),
+    [menu.top, menu.left],
+  );
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  const run = (fn: () => void) => {
+    fn();
+    onClose();
+  };
+
+  const openDetail = () => {
+    if (album.id != null) router.push(`/dashboard/album/${album.id}`);
+  };
+
+  const toggleBin = () => {
+    // Catalog rows always carry a real library.id; only LML rows go null.
+    if (album.id == null) return;
+    if (inBin) deleteFromBin(album.id);
+    else addToBin(album.id);
+  };
+
+  const content = (
+    <ClickAwayListener onClickAway={onClose}>
+      <Popper
+        open
+        anchorEl={anchorEl}
+        placement="bottom-start"
+        sx={{ zIndex: 10000 }}
+        modifiers={[{ name: "offset", options: { offset: [0, 4] } }]}
+      >
+        <MenuList
+          variant="outlined"
+          size="sm"
+          role="menu"
+          aria-label={`Actions for ${album.title}`}
+          sx={{
+            boxShadow: (theme) => theme.shadow.md,
+            bgcolor: "background.popup",
+          }}
+        >
+          <MenuItem color="neutral" onClick={() => run(openDetail)}>
+            <InfoOutlined />
+            More information
+          </MenuItem>
+          <MenuItem
+            color={inBin ? "warning" : "neutral"}
+            disabled={binLoading}
+            onClick={() => run(toggleBin)}
+          >
+            {inBin ? <Unarchive /> : <Archive />}
+            {inBin ? "Remove from mail bin" : "Add to mail bin"}
+          </MenuItem>
+          <RequireMD>
+            <MenuItem color="success" onClick={() => run(openDetail)}>
+              <EditOutlined />
+              Edit catalog entry
+            </MenuItem>
+            <RotationMenuSection album={album} onClose={onClose} />
+          </RequireMD>
+        </MenuList>
+      </Popper>
+    </ClickAwayListener>
+  );
+
+  return createPortal(content, document.body);
+}
+
+/**
+ * MD-only rotation section. Mounts inside `RequireMD` so the rotation-list
+ * subscription only runs for an authorized viewer with the menu open — and it
+ * joins the shared cache entry rather than refetching it (see
+ * `useAlbumRotationEntries`).
+ */
+function RotationMenuSection({
+  album,
+  onClose,
+}: {
+  album: AlbumEntry;
+  onClose: () => void;
+}) {
+  const { activeEntries, albumIdValid, rotationStateUnknown, rotationFetching } =
+    useAlbumRotationEntries(album);
+  const [addRotationEntry] = useAddRotationEntryMutation();
+  const [killRotationEntry] = useKillRotationEntryMutation();
+  const [mutating, setMutating] = useState(false);
+
+  if (!albumIdValid) return null;
+
+  const activeBins = new Set(activeEntries.map((entry) => entry.rotation_bin));
+
+  // Undecidable until the first rotation load lands: render the section
+  // disabled rather than offering an add against unknown membership, which
+  // could open a duplicate active entry (the backend's insert has no dedupe).
+  const busy = rotationStateUnknown || rotationFetching || mutating;
+
+  const setRotation = async (bin: Rotation | null) => {
+    setMutating(true);
+    try {
+      // Re-binning and removal both retire every active entry first; the
+      // backend keeps prior unkilled entries as genuinely active rows, so a
+      // plain add would stack a second bin on top of the first.
+      for (const entry of activeEntries) {
+        // `kill_date` is omitted so the server dates the kill itself; a
+        // browser-computed UTC date is already tomorrow during Eastern
+        // evenings and would leave the entry selectable for another day.
+        await killRotationEntry({ rotation_id: entry.rotation_id }).unwrap();
+      }
+      if (bin) {
+        // Guarded by the `albumIdValid` check above.
+        await addRotationEntry({ album_id: album.id!, rotation_bin: bin }).unwrap();
+        toast.success(`Marked for ${bin} rotation.`);
+      } else {
+        toast.success("Removed from rotation.");
+      }
+    } catch (err) {
+      if (isUnmessagedHttpError(err)) {
+        toast.error("Could not update rotation.");
+      }
+    } finally {
+      setMutating(false);
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      <ListDivider />
+      <ListSubheader sticky={false} sx={{ color: "text.tertiary" }}>
+        {rotationStateUnknown ? "Rotation — checking status…" : "Rotation"}
+      </ListSubheader>
+      {ROTATION_BINS.map((bin) => {
+        const isActive = activeBins.has(bin);
+        return (
+          <MenuItem
+            key={bin}
+            color="neutral"
+            disabled={busy}
+            onClick={() => setRotation(isActive ? null : bin)}
+          >
+            {isActive ? <Check /> : null}
+            {ROTATION_BIN_LABELS[bin]} ({bin})
+          </MenuItem>
+        );
+      })}
+      {activeBins.size > 0 && (
+        <MenuItem color="warning" disabled={busy} onClick={() => setRotation(null)}>
+          Remove from rotation
+        </MenuItem>
+      )}
+    </>
+  );
+}

--- a/src/components/experiences/modern/catalog/Results/Result.tsx
+++ b/src/components/experiences/modern/catalog/Results/Result.tsx
@@ -30,10 +30,12 @@ function CatalogResult({
   album,
   live,
   addToQueue,
+  onContextMenu,
 }: {
   album: AlbumEntry;
   live: boolean;
   addToQueue: (entry: FlowsheetQuery) => void;
+  onContextMenu?: (album: AlbumEntry, event: React.MouseEvent) => void;
 }) {
   const router = useRouter();
 
@@ -66,6 +68,9 @@ function CatalogResult({
       key={album.id}
       className={isSelected ? "row-selected" : undefined}
       onClick={openAlbumDetail}
+      onContextMenu={
+        onContextMenu ? (event) => onContextMenu(album, event) : undefined
+      }
       style={{ cursor: "pointer" }}
     >
       <td

--- a/src/components/experiences/modern/catalog/Results/Results.tsx
+++ b/src/components/experiences/modern/catalog/Results/Results.tsx
@@ -3,7 +3,11 @@
 import Button from "@mui/joy/Button";
 import Checkbox from "@mui/joy/Checkbox";
 import CircularProgress from "@mui/joy/CircularProgress";
-import { ChangeEvent } from "react";
+import { ChangeEvent, useCallback, useState } from "react";
+import { AlbumEntry } from "@/lib/features/catalog/types";
+import CatalogResultContextMenu, {
+  type CatalogResultContextMenuState,
+} from "./CatalogResultContextMenu";
 
 import { Box, Table } from "@mui/joy";
 
@@ -70,6 +74,19 @@ export default function Results({
   // its own useLiveStatus + useQueue (polling-query) subscriptions.
   const { live } = useLiveStatus();
   const { addToQueue } = useQueue();
+
+  // One state cell owns the context menu, so at most one is open and closing
+  // unmounts it (and its MD-only rotation subscription) entirely.
+  const [contextMenu, setContextMenu] =
+    useState<CatalogResultContextMenuState | null>(null);
+  const onRowContextMenu = useCallback(
+    (album: AlbumEntry, event: React.MouseEvent) => {
+      event.preventDefault();
+      setContextMenu({ album, top: event.clientY, left: event.clientX });
+    },
+    [],
+  );
+  const closeContextMenu = useCallback(() => setContextMenu(null), []);
 
   const loadMoreButton = hasMore ? (
     <Button
@@ -261,6 +278,7 @@ export default function Results({
                 album={album}
                 live={live}
                 addToQueue={addToQueue}
+                onContextMenu={onRowContextMenu}
                 key={`result-${album.id}`}
               />
             ))}
@@ -288,6 +306,9 @@ export default function Results({
         <Box data-testid="catalog-loading-overlay" sx={loadingOverlaySx(loading)}>
           <CircularProgress color="primary" size="md" />
         </Box>
+        {contextMenu && (
+          <CatalogResultContextMenu menu={contextMenu} onClose={closeContextMenu} />
+        )}
       </Box>
     </ResultsContainer>
   );

--- a/src/components/experiences/modern/catalog/album/RotationClassifyControl.tsx
+++ b/src/components/experiences/modern/catalog/album/RotationClassifyControl.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { Button, Chip, Stack } from "@mui/joy";
 import { RequireMD } from "@/src/components/shared/Authorization";
 import {
   useAddRotationEntryMutation,
-  useGetRotationQuery,
   useKillRotationEntryMutation,
 } from "@/lib/features/rotation/api";
+import { useAlbumRotationEntries } from "./useAlbumRotationEntries";
 import { Rotation } from "@/lib/features/rotation/types";
 import { AlbumEntry } from "@/lib/features/catalog/types";
 import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
@@ -52,40 +52,18 @@ function RotationClassifyFields({ album }: RotationClassifyControlProps) {
   // here — whether the album is in rotation is only answerable from the
   // active-rotation list.
   const {
-    data: rotationEntries,
-    isFetching: rotationFetching,
-    isError: rotationErrored,
-    refetch: refetchRotation,
-  } = useGetRotationQuery();
+    activeEntries,
+    albumIdValid,
+    rotationStateUnknown,
+    rotationFetching,
+    rotationErrored,
+    refetchRotation,
+  } = useAlbumRotationEntries(album);
 
   const [selectedBin, setSelectedBin] = useState<Rotation | null>(null);
   const [inFlightKillIds, setInFlightKillIds] = useState<Set<number>>(
     () => new Set(),
   );
-
-  // `synthesizeAlbumId` hands out negative ids to rows the library never
-  // linked (see conversions.ts); neither read nor write may treat one of
-  // those as a real album, so both derive from this single flag. A null id
-  // (LML row) is equally invalid here, though this panel never sees one.
-  const albumIdValid = album.id !== null && album.id > 0;
-
-  // Both reads project `library.id` as the row id, so matching on it is
-  // matching library album to library album. `getRotationFromDB` dedupes
-  // with `rotation_bin` as PART of the uniqueness key, so a re-binned album
-  // with an unkilled prior entry surfaces as more than one row here — every
-  // one of them is a genuinely active entry for this album, not a mismatch.
-  const activeEntries = useMemo(() => {
-    if (!albumIdValid || !rotationEntries) return [];
-    return rotationEntries.filter(
-      (entry): entry is AlbumEntry & { rotation_id: number } =>
-        entry.id === album.id && typeof entry.rotation_id === "number",
-    );
-  }, [rotationEntries, album.id, albumIdValid]);
-
-  // Undecidable until the first load lands. A failed first load must not
-  // fall through to the Add picker — that would offer a second insert on an
-  // album whose actual rotation membership is simply unknown, not "none".
-  const rotationStateUnknown = rotationEntries === undefined;
 
   // The add mutation invalidates the rotation list, and this control's state
   // only flips once that refetch lands, so `addBusy` stays true through the

--- a/src/components/experiences/modern/catalog/album/useAlbumRotationEntries.ts
+++ b/src/components/experiences/modern/catalog/album/useAlbumRotationEntries.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useMemo } from "react";
+import { useGetRotationQuery } from "@/lib/features/rotation/api";
+import { AlbumEntry } from "@/lib/features/catalog/types";
+
+/**
+ * An album's active rotation entries, derived from the shared active-rotation
+ * list. Subscribes with no options on purpose: `getRotation` takes a void arg,
+ * so every subscriber shares one cache entry, and any refetch option added
+ * here would fire refetches into the live flowsheet logging path's
+ * subscription as well.
+ *
+ * `rotationStateUnknown` is true until the first load lands. Callers must
+ * fail closed on it — offering an "add to rotation" affordance while
+ * membership is unknown invites a duplicate active entry, which the backend's
+ * bare insert accepts.
+ */
+export function useAlbumRotationEntries(album: AlbumEntry) {
+  const {
+    data: rotationEntries,
+    isFetching: rotationFetching,
+    isError: rotationErrored,
+    refetch: refetchRotation,
+  } = useGetRotationQuery();
+
+  // `synthesizeAlbumId` hands out negative ids to rows the library never
+  // linked; neither read nor write may treat one of those as a real album.
+  // A null id (LML row) is equally invalid here.
+  const albumIdValid = album.id !== null && album.id > 0;
+
+  // Both reads project `library.id` as the row id, so matching on it is
+  // matching library album to library album. `getRotationFromDB` dedupes with
+  // `rotation_bin` as part of the uniqueness key, so a re-binned album with an
+  // unkilled prior entry surfaces as more than one row here — every one of
+  // them is a genuinely active entry for this album, not a mismatch.
+  const activeEntries = useMemo(() => {
+    if (!albumIdValid || !rotationEntries) return [];
+    return rotationEntries.filter(
+      (entry): entry is AlbumEntry & { rotation_id: number } =>
+        entry.id === album.id && typeof entry.rotation_id === "number",
+    );
+  }, [rotationEntries, album.id, albumIdValid]);
+
+  const rotationStateUnknown = rotationEntries === undefined;
+
+  return {
+    activeEntries,
+    albumIdValid,
+    rotationStateUnknown,
+    rotationFetching,
+    rotationErrored,
+    refetchRotation,
+  };
+}

--- a/tests/integration/components/modern/catalog/Results/CatalogResultContextMenu.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/CatalogResultContextMenu.test.tsx
@@ -1,0 +1,324 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import {
+  renderWithProviders,
+  createTestAlbum,
+  createTestArtist,
+  server,
+  TEST_BACKEND_URL,
+} from "@/tests/helpers";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: vi.fn() }),
+}));
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+// No organization configured (the real production shape): the WXYC tier
+// resolves via fetchOrganizationRoleForUserClient's JWT decode, not the raw
+// session role, so every test drives that mock and awaits resolution.
+vi.mock("@/lib/features/authentication/organization-config", () => ({
+  getAppOrganizationIdClient: vi.fn(() => undefined),
+}));
+
+vi.mock("@/lib/features/authentication/organization-utils", () => ({
+  fetchOrganizationRoleForUserClient: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const mockAddToBin = vi.fn();
+const mockDeleteFromBin = vi.fn();
+let mockBinContents: { id: number }[] = [];
+vi.mock("@/src/hooks/binHooks", () => ({
+  useBin: () => ({ bin: mockBinContents, loading: false }),
+  useAddToBin: () => ({ addToBin: mockAddToBin, loading: false }),
+  useDeleteFromBin: () => ({ deleteFromBin: mockDeleteFromBin, loading: false }),
+}));
+
+import { authClient } from "@/lib/features/authentication/client";
+import { fetchOrganizationRoleForUserClient } from "@/lib/features/authentication/organization-utils";
+import { toast } from "sonner";
+import CatalogResultContextMenu from "@/src/components/experiences/modern/catalog/Results/CatalogResultContextMenu";
+
+const mockUseSession = authClient.useSession as ReturnType<typeof vi.fn>;
+const mockFetchOrgRole = fetchOrganizationRoleForUserClient as ReturnType<
+  typeof vi.fn
+>;
+
+const ALBUM_ID = 4242;
+const ROTATION_ID = 900;
+
+function sessionWithRole() {
+  return {
+    data: {
+      user: {
+        id: "user-1",
+        email: "test@wxyc.org",
+        name: "Test User",
+        username: "testuser",
+        role: null,
+        emailVerified: true,
+      },
+      session: { id: "sess-1", userId: "user-1", expiresAt: new Date() },
+    },
+    isPending: false,
+    error: null,
+  };
+}
+
+const dogaAlbum = () =>
+  createTestAlbum({
+    id: ALBUM_ID,
+    title: "DOGA",
+    artist: createTestArtist({
+      name: "Juana Molina",
+      lettercode: "MO",
+      numbercode: 12,
+      genre: "Rock",
+    }),
+    label: "Sonamos",
+  });
+
+const rotationRow = (rotationBin = "H") => ({
+  id: ALBUM_ID,
+  code_letters: "MO",
+  code_artist_number: 12,
+  code_number: 3,
+  artist_name: "Juana Molina",
+  alphabetical_name: "Juana Molina",
+  album_title: "DOGA",
+  record_label: "Sonamos",
+  genre_name: "Rock",
+  format_name: "CD",
+  rotation_id: ROTATION_ID,
+  add_date: "2026-07-01",
+  rotation_add_date: "2026-08-01",
+  rotation_bin: rotationBin,
+  rotation_kill_date: null,
+  plays: 4,
+});
+
+function fakeRotationEndpoints(initial: ReturnType<typeof rotationRow>[] = []) {
+  let rows = [...initial];
+  const received: { add?: unknown; kills: unknown[] } = { kills: [] };
+  const counters = { listRequests: 0 };
+
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/rotation`, () => {
+      counters.listRequests += 1;
+      return HttpResponse.json(rows);
+    }),
+    http.post(`${TEST_BACKEND_URL}/library/rotation`, async ({ request }) => {
+      const body = (await request.json()) as {
+        album_id: number;
+        rotation_bin: string;
+      };
+      received.add = body;
+      rows = [...rows, rotationRow(body.rotation_bin)];
+      return HttpResponse.json(
+        {
+          id: ROTATION_ID,
+          album_id: body.album_id,
+          rotation_bin: body.rotation_bin,
+          add_date: "2026-08-18",
+          kill_date: null,
+        },
+        { status: 201 },
+      );
+    }),
+    http.patch(`${TEST_BACKEND_URL}/library/rotation`, async ({ request }) => {
+      const body = (await request.json()) as { rotation_id: number };
+      received.kills.push(body);
+      rows = rows.filter((r) => r.rotation_id !== body.rotation_id);
+      return HttpResponse.json({ id: body.rotation_id, kill_date: "2026-08-18" });
+    }),
+  );
+
+  return { received, counters };
+}
+
+const menuAt = (album = dogaAlbum()) => ({ album, top: 100, left: 100 });
+
+describe("CatalogResultContextMenu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBinContents = [];
+    mockUseSession.mockReturnValue(sessionWithRole());
+    mockFetchOrgRole.mockResolvedValue("dj");
+  });
+
+  it("navigates to the album detail route from More information and closes", async () => {
+    const onClose = vi.fn();
+    renderWithProviders(
+      <CatalogResultContextMenu menu={menuAt()} onClose={onClose} />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: "More information" }),
+    );
+    expect(mockPush).toHaveBeenCalledWith(`/dashboard/album/${ALBUM_ID}`);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("adds to the mail bin when absent and removes when present", async () => {
+    const onClose = vi.fn();
+    const { unmount } = renderWithProviders(
+      <CatalogResultContextMenu menu={menuAt()} onClose={onClose} />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: "Add to mail bin" }),
+    );
+    expect(mockAddToBin).toHaveBeenCalledWith(ALBUM_ID);
+    unmount();
+
+    mockBinContents = [{ id: ALBUM_ID }];
+    renderWithProviders(
+      <CatalogResultContextMenu menu={menuAt()} onClose={vi.fn()} />,
+    );
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: "Remove from mail bin" }),
+    );
+    expect(mockDeleteFromBin).toHaveBeenCalledWith(ALBUM_ID);
+  });
+
+  it("shows no MD items for a DJ", async () => {
+    fakeRotationEndpoints();
+    renderWithProviders(
+      <CatalogResultContextMenu menu={menuAt()} onClose={vi.fn()} />,
+    );
+
+    // The role resolution is async; give the authorized branch time to appear
+    // if it (incorrectly) would.
+    await waitFor(() =>
+      expect(screen.getByRole("menuitem", { name: "More information" })).toBeInTheDocument(),
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    expect(
+      screen.queryByRole("menuitem", { name: "Edit catalog entry" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Rotation")).not.toBeInTheDocument();
+  });
+
+  it("shows Edit and the rotation section with the active bin checked for an MD", async () => {
+    mockFetchOrgRole.mockResolvedValue("musicDirector");
+    fakeRotationEndpoints([rotationRow("H")]);
+
+    renderWithProviders(
+      <CatalogResultContextMenu menu={menuAt()} onClose={vi.fn()} />,
+    );
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Edit catalog entry" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Rotation")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: "Remove from rotation" }),
+    ).toBeInTheDocument();
+
+    // The active bin row carries the check icon.
+    const heavyItem = await screen.findByRole("menuitem", {
+      name: /Heavy \(H\)/,
+    });
+    expect(heavyItem.querySelector("svg")).not.toBeNull();
+  });
+
+  it("POSTs the picked bin, toasts, and closes", async () => {
+    mockFetchOrgRole.mockResolvedValue("musicDirector");
+    const { received } = fakeRotationEndpoints();
+    const onClose = vi.fn();
+
+    renderWithProviders(
+      <CatalogResultContextMenu menu={menuAt()} onClose={onClose} />,
+    );
+
+    const mediumItem = await screen.findByRole("menuitem", {
+      name: /Medium \(M\)/,
+    });
+    await waitFor(() =>
+      expect(mediumItem).not.toHaveAttribute("aria-disabled", "true"),
+    );
+    await userEvent.click(mediumItem);
+
+    await waitFor(() =>
+      expect(received.add).toEqual({ album_id: ALBUM_ID, rotation_bin: "M" }),
+    );
+    expect(toast.success).toHaveBeenCalledWith("Marked for M rotation.");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("re-binning kills the active entry before adding the new bin", async () => {
+    mockFetchOrgRole.mockResolvedValue("musicDirector");
+    const { received } = fakeRotationEndpoints([rotationRow("H")]);
+    const onClose = vi.fn();
+
+    renderWithProviders(
+      <CatalogResultContextMenu menu={menuAt()} onClose={onClose} />,
+    );
+
+    const lightItem = await screen.findByRole("menuitem", {
+      name: /Light \(L\)/,
+    });
+    await waitFor(() =>
+      expect(lightItem).not.toHaveAttribute("aria-disabled", "true"),
+    );
+    await userEvent.click(lightItem);
+
+    await waitFor(() =>
+      expect(received.add).toEqual({ album_id: ALBUM_ID, rotation_bin: "L" }),
+    );
+    expect(received.kills).toEqual([{ rotation_id: ROTATION_ID }]);
+  });
+
+  it("fails closed while rotation membership is unknown", async () => {
+    mockFetchOrgRole.mockResolvedValue("musicDirector");
+    // A list that never resolves within the test: membership stays unknown.
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/library/rotation`, async () => {
+        await new Promise((r) => setTimeout(r, 60_000));
+        return HttpResponse.json([]);
+      }),
+    );
+
+    renderWithProviders(
+      <CatalogResultContextMenu menu={menuAt()} onClose={vi.fn()} />,
+    );
+
+    expect(
+      await screen.findByText("Rotation — checking status…"),
+    ).toBeInTheDocument();
+    const heavyItem = screen.getByRole("menuitem", {
+      name: /Heavy \(H\)/,
+    });
+    expect(heavyItem).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("does not refetch the shared rotation list across menu open/close cycles", async () => {
+    mockFetchOrgRole.mockResolvedValue("musicDirector");
+    const { counters } = fakeRotationEndpoints([rotationRow("H")]);
+
+    const first = renderWithProviders(
+      <CatalogResultContextMenu menu={menuAt()} onClose={vi.fn()} />,
+    );
+    await first.findByText("Rotation");
+    const requestsAfterFirstOpen = counters.listRequests;
+    first.unmount();
+
+    const second = renderWithProviders(
+      <CatalogResultContextMenu menu={menuAt()} onClose={vi.fn()} />,
+      { store: first.store },
+    );
+    await second.findByText("Rotation");
+    expect(counters.listRequests).toBe(requestsAfterFirstOpen);
+    expect(requestsAfterFirstOpen).toBe(1);
+  });
+});

--- a/tests/integration/components/modern/catalog/Results/Result.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/Result.test.tsx
@@ -488,6 +488,27 @@ describe("CatalogResult album detail navigation", () => {
     expect(mockPush).toHaveBeenCalledWith("/dashboard/album/42");
   });
 
+  it("reports right-clicks through onContextMenu with the album", () => {
+    const onContextMenu = vi.fn();
+    const album = createTestAlbum({ id: 42 });
+
+    renderWithProviders(
+      <table>
+        <tbody>
+          <CatalogResult
+            album={album}
+            live={false}
+            addToQueue={vi.fn()}
+            onContextMenu={onContextMenu}
+          />
+        </tbody>
+      </table>
+    );
+
+    fireEvent.contextMenu(screen.getByText(album.title));
+    expect(onContextMenu).toHaveBeenCalledWith(album, expect.anything());
+  });
+
   it("does not navigate for a row without a library id", () => {
     mockPush.mockClear();
     const album = createTestAlbum({ id: null });


### PR DESCRIPTION
## What

Restores the recovered result context menu, rewired onto today's data layer (stacked on #1244):

- **Everyone:** More information (→ album modal), Add/Remove mail bin (via the existing `binHooks`).
- **MD only** (`RequireMD` composition — no resurrected `useCanEditCatalog`): Edit catalog entry (→ album modal, where the edit form lives) and a Rotation section — Heavy/Medium/Light/Singles with a check on active bins, plus Remove from rotation.

## Design constraints honored

- Menu state is a single hoisted cell in `Results.tsx` (`{album, top, left} | null`): one menu at a time, unmounted on close — the recovered Redux menu slice was dropped.
- The rotation section subscribes to the shared `getRotation` cache entry **bare** (no `refetchOnMountOrArgChange`), inside the RequireMD child, only while the menu is open. A test pins **one list fetch across open/close cycles** — no refetch reaches flowsheet-shaped subscribers.
- Fails closed while rotation membership is unknown (items disabled, "checking status…"), because the backend insert has no dedupe.
- Re-binning kills all active entries before adding the new bin (verified by test).
- Extracted `useAlbumRotationEntries` — the active-entry derivation now lives once, shared by RotationClassifyControl and the menu.

## Verification

tsc clean; lint 0 errors / 194 warnings (no growth); full suite green (339 files, 4823 tests) incl. 8 new menu tests (navigation, bin toggle both ways, MD gating both ways, POST body, kill-then-add, fail-closed, fetch-count pin) and a row-wiring test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)