### PR TITLE
fix(ci): key the Playwright cache on the Playwright version, not the lockfile

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -273,12 +273,39 @@ jobs:
           timeout 5 bash -c 'until curl -sf -X POST -H "Content-Type: application/json" --data "{}" http://localhost:9091/ >/dev/null; do sleep 0.1; done'
           echo "Mock tubafrenzy ready"
 
+      # Read the RESOLVED version out of the lockfile rather than the `^1.62.1`
+      # range in package.json: the range is stable across the patch bumps that
+      # actually change the browser build, so keying on it would serve stale
+      # binaries. `-re` makes jq exit non-zero if the path is missing, which
+      # fails this step loudly — an empty version would collapse every
+      # Playwright release into one cache entry, the exact hazard this avoids.
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          set -euo pipefail
+          version=$(jq -re '.packages["node_modules/@playwright/test"].version' dj-site/package-lock.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Resolved @playwright/test $version"
+
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ hashFiles('dj-site/package-lock.json') }}
+          # Keyed on the Playwright version, NOT the whole lockfile hash. The
+          # browser binaries depend on the Playwright release and nothing else,
+          # so hashing the entire dependency graph meant one unrelated
+          # devDependency bump re-downloaded Chromium on all four shards at
+          # once -- which, combined with a simultaneously-cold Next build, is
+          # what pushed shards past `timeout-minutes: 15`.
+          #
+          # No `restore-keys` here on purpose. A partial restore would leave a
+          # browser set from a different release in place, and the install step
+          # below skips work on `cache-hit == 'true'`, which is only set by an
+          # EXACT key match. Adding restore-keys would therefore never save the
+          # install anyway, and would only make what is on disk harder to
+          # reason about. A version change should download; that is correct.
+          key: playwright-${{ steps.playwright-version.outputs.version }}
 
       - name: Install dependencies
         env:


### PR DESCRIPTION
Closes #1241.

## What changed

The Playwright browser cache is now keyed on the resolved `@playwright/test` version instead of `hashFiles('dj-site/package-lock.json')`. A new preceding step reads that version out of the lockfile and exposes it as an output.

```yaml
key: playwright-${{ steps.playwright-version.outputs.version }}
```

The **resolved** version, not the `^1.62.1` range in `package.json` — the range stays put across exactly the patch bumps that change the browser build, so keying on it would serve stale binaries.

## Which half of the ticket this takes, and why only one

The ticket offers two independent halves. This takes the Playwright half only.

The Next build cache keeps its lockfile-prefixed `restore-keys`, because relaxing them is a correctness hazard rather than a tuning question: a build produced against a different lockfile, served as-is while `node_modules` changed underneath it, is wrong in a way that is hard to see. The workflow-file hash stays in the key for the same class of reason — the `NEXT_PUBLIC_*` env block is inlined into the build, so flipping a flag must invalidate it.

The Playwright half has no such hazard, and it is the half that fires on *every* lockfile-touching PR including dependabot's. After this change a lockfile-only PR pays a cold Next build but no Chromium download, on any shard.

## Two details worth a reviewer's eye

**`jq -re` is load-bearing.** It exits non-zero when the path is missing, failing the step loudly. An empty version string would collapse every Playwright release into one cache entry and serve stale browsers silently — a worse failure than the timeout this fixes.

**No `restore-keys` on the Playwright cache, on purpose.** The install step skips work on `cache-hit == 'true'`, which is set only by an exact key match. A partial restore would therefore never save the install; it would just leave a browser set from a different release on disk. A version change should download.

## Measurement — and a correction

This section originally claimed this PR's own run would be a both-caches-cold shard. **That was wrong**, and the cache registry says so plainly.

The Playwright half *was* cold: `playwright-1.62.1` did not exist and this run created it. But the Next build cache was **warm**. Its primary key missed (the workflow-file hash changed), yet `restore-keys` entry #2 — `e2e-nextjs-<lockfile>-<next.config>-` — matched, because this PR does not touch `package-lock.json`. A partial restore is exactly what those keys are for; I just failed to reason it through before writing the claim.

Measured on shard 1 (cold Playwright, warm Next):

| | |
|---|---|
| Whole shard | **6m21s** |
| `Build and start services` | **82s** |
| `Run E2E tests` | 222s |
| `Install dependencies` | 38s |

The useful finding is in that 82 seconds. On #1240 the same step ran past 15 minutes. Here it absorbs a **completely cold Chromium download plus `--with-deps` apt-get** and still finishes in under a minute and a half, because it runs in parallel with a build that had a warm `.next/` to start from.

That reframes the ticket's diagnosis. The Playwright download is not what blows the 15-minute budget — **the fully-cold Next build is.** On a lockfile-touching PR both went cold together, and this change removes only one of them.

So this PR is worth landing on its own terms: it deletes a needless 268MB Chromium re-download from every lockfile-touching PR including dependabot's, and `playwright-1.62.1` is now a stable key that survives dependency churn. But it should not be described as fixing the timeout, and I am not claiming the acceptance criterion about a both-cold shard is met — the post-fix worst case (Playwright warm, Next fully cold) is still unmeasured.

Getting that number needs a run whose `package-lock.json` actually changes. There is a real one waiting: `package-lock.json`'s `license` field still says `MIT` while `package.json` says `PolyForm-Noncommercial-1.0.0`, so every `npm install` regenerates that one-line diff. Committing that fix is wanted anyway and would produce the missing measurement as a side effect. Left out of this PR deliberately — different concern, and it belongs where its own CI run can be read cleanly.
