### PR TITLE
fix(catalog): separate genre and format data from their chip tones, so LML stops discarding real values

### DIFF
--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -1,6 +1,6 @@
 import type { BinLibraryDetails } from "@wxyc/shared/dtos";
 import { Rotation } from "../rotation/types";
-import { AlbumEntry, AlbumSearchResultJSON, Format } from "./types";
+import { AlbumEntry, AlbumSearchResultJSON } from "./types";
 
 function isSearchResult(
   response: AlbumSearchResultJSON | BinLibraryDetails
@@ -102,7 +102,8 @@ export function convertToAlbumEntry(
         : undefined,
     },
     entry: response.code_number ?? 0,
-    format: (response.format_name as Format) ?? "Unknown",
+    // Verbatim; the sentinel is for a row with no format. See `AlbumEntry.format`.
+    format: response.format_name ?? "Unknown",
     alternate_artist: isSearchResult(response)
       ? ((response as Record<string, unknown>).alternate_artist_name as string | undefined) ?? ""
       : "",

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -1,6 +1,6 @@
 import type { BinLibraryDetails } from "@wxyc/shared/dtos";
 import { Rotation } from "../rotation/types";
-import { AlbumEntry, AlbumSearchResultJSON, Format, Genre } from "./types";
+import { AlbumEntry, AlbumSearchResultJSON, Format } from "./types";
 
 function isSearchResult(
   response: AlbumSearchResultJSON | BinLibraryDetails
@@ -95,7 +95,10 @@ export function convertToAlbumEntry(
       name: response.artist_name ?? "",
       lettercode: response.code_letters ?? "",
       numbercode: response.code_artist_number ?? 0,
-      genre: (response.genre_name as Genre) ?? "Unknown",
+      // Verbatim: the genre vocabulary is server-owned and wider than
+      // anything dj-site enumerates. "Unknown" is the UI fallback for a row
+      // that has no genre, never a stand-in for one dj-site can't style.
+      genre: response.genre_name ?? "Unknown",
       id: isSearchResult(response)
         ? ((response as Record<string, unknown>).artist_id as number | undefined)
         : undefined,

--- a/lib/features/catalog/conversions.ts
+++ b/lib/features/catalog/conversions.ts
@@ -95,9 +95,7 @@ export function convertToAlbumEntry(
       name: response.artist_name ?? "",
       lettercode: response.code_letters ?? "",
       numbercode: response.code_artist_number ?? 0,
-      // Verbatim: the genre vocabulary is server-owned and wider than
-      // anything dj-site enumerates. "Unknown" is the UI fallback for a row
-      // that has no genre, never a stand-in for one dj-site can't style.
+      // Verbatim; the sentinel is for a row with no genre. See `ArtistEntry.genre`.
       genre: response.genre_name ?? "Unknown",
       id: isSearchResult(response)
         ? ((response as Record<string, unknown>).artist_id as number | undefined)

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -297,7 +297,19 @@ export type ArtistEntry = {
   name: string;
   lettercode: string;
   numbercode: number;
-  genre: Genre;
+  /**
+   * The genre name exactly as the server filed it. The vocabulary is
+   * server-owned — `GET /library/genres` is the authority and the table grows
+   * without a dj-site deploy — so this is a plain string, never a union
+   * dj-site maintains a copy of. A conversion path must carry the value
+   * through unmodified; narrowing it to a locally-known set discards genres
+   * the station really files under.
+   *
+   * `"Unknown"` is dj-site's own fallback for a row that carries *no* genre.
+   * It is not a row in the library's genre table, so it must only ever appear
+   * where the source value was missing.
+   */
+  genre: string;
   id: number | undefined;
 };
 
@@ -346,18 +358,6 @@ export type LibraryQueryParams = {
 };
 
 export type Format = "Vinyl" | "CD" | "Unknown";
-
-export type Genre =
-  | "Blues"
-  | "Rock"
-  | "Electronic"
-  | "Hiphop"
-  | "Jazz"
-  | "Classical"
-  | "Reggae"
-  | "Soundtracks"
-  | "OCS"
-  | "Unknown";
 
 export type SearchIn = "Artists" | "Albums" | "All";
 

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -267,7 +267,20 @@ export type AlbumEntry = {
   title: string;
   artist: ArtistEntry;
   entry: number;
-  format: Format;
+  /**
+   * The format name exactly as the server filed it. The vocabulary is
+   * server-owned — `GET /library/formats` is the authority and a music
+   * director creates a format by typing its name — so this is a plain string,
+   * never a union dj-site maintains a copy of. A conversion path must carry
+   * the value through unmodified; narrowing it to a locally-known set both
+   * erases formats the station really shelves (`Cassette`) and renames ones it
+   * recognises (`12" Vinyl` is not `Vinyl`).
+   *
+   * `"Unknown"` is dj-site's own fallback for a row that carries *no* format.
+   * It is not a row in the library's format table, so it must only ever appear
+   * where the source value was missing.
+   */
+  format: string;
   alternate_artist: string | undefined;
   album_artist?: string;
   rotation_bin: Rotation | undefined;
@@ -356,8 +369,6 @@ export type LibraryQueryParams = {
   /** Comma-separated active rotation bins (H, M, L, S). */
   rotation_bins?: string;
 };
-
-export type Format = "Vinyl" | "CD" | "Unknown";
 
 export type SearchIn = "Artists" | "Albums" | "All";
 

--- a/lib/features/experiences/modern/tokens/roles.ts
+++ b/lib/features/experiences/modern/tokens/roles.ts
@@ -52,13 +52,6 @@ export const GENRE_TONES = {
   Unknown: { color: "neutral", variant: "soft" },
 } satisfies Record<string, Tone>;
 
-/**
- * A key of the tone table above — i.e. a genre dj-site happens to have a chip
- * color for. Derived from the table so the two can never drift. This is a
- * styling subset and makes no claim about which genres exist; genre data is
- * typed `string` (`ArtistEntry.genre`).
- */
-export type GenreToneKey = keyof typeof GENRE_TONES;
 
 /**
  * Case-insensitive index over the tone table. A Map rather than the object
@@ -100,13 +93,6 @@ export const FORMAT_TONES = {
   Unknown: { color: "neutral", variant: "soft" },
 } satisfies Record<string, FormatTone>;
 
-/**
- * A key of the tone table above — i.e. a format dj-site happens to have a chip
- * hue for. Derived from the table so the two can never drift. This is a
- * styling subset and makes no claim about which formats exist; format data is
- * typed `string` (`AlbumEntry.format`).
- */
-export type FormatToneKey = keyof typeof FORMAT_TONES;
 
 /**
  * Resolve any format value — missing, or one with no dedicated hue — to its
@@ -124,23 +110,21 @@ export function formatTone(format: string | null | undefined): FormatTone {
 }
 
 /**
- * The text of a format chip. Server-owned text, presented — never rewritten:
- * only the two attested bare lowercase spellings are tidied ("cd" -> "CD",
- * "vinyl" -> "Vinyl"), and anything already carrying casing or punctuation is
- * left alone rather than title-case-mangled into "Cd-r" or `12" vinyl`.
+ * The text of a format chip: server text presented, never rewritten. Only the
+ * two bare lowercase spellings the library actually contains are tidied;
+ * everything else is returned as sent, including a format nobody anticipated.
  *
- * Every format chip in the modern experience resolves through this one
- * function, alongside `formatTone` over the same text. Two labellers drift:
- * the picker interleaves rows from more than one conversion path, and a DJ
- * cannot tell which drew a given row, so a second implementation shows the
- * same release under two names.
+ * A lookup rather than a title-case rule, because title-casing rewrites — it
+ * turns a server's "lp" into "Lp", which is the same data loss this module's
+ * tables exist to avoid, just one layer down in the label.
  */
+const TIDIED_SPELLINGS = new Map([
+  ["cd", "CD"],
+  ["vinyl", "Vinyl"],
+]);
+
 export function formatLabel(format: string): string {
-  if (/^cd$/i.test(format)) return "CD";
-  if (/^[a-z]+$/.test(format)) {
-    return format.charAt(0).toUpperCase() + format.slice(1);
-  }
-  return format;
+  return TIDIED_SPELLINGS.get(format.toLowerCase()) ?? format;
 }
 
 export const ROTATION_TONES: Record<Rotation, Tone> = {

--- a/lib/features/experiences/modern/tokens/roles.ts
+++ b/lib/features/experiences/modern/tokens/roles.ts
@@ -58,21 +58,25 @@ export const GENRE_TONES = {
 export type GenreToneKey = keyof typeof GENRE_TONES;
 
 /**
- * Resolve any genre value (possibly missing, possibly one with no designed
- * color) to its tone. Mirrors `formatTone` so callers never index GENRE_TONES
- * with an unvalidated string, and so a miss degrades the chip's color without
- * touching the genre text beside it.
+ * Case-insensitive index over the tone table. A Map rather than the object
+ * itself: a plain-object lookup answers `Object.prototype` members truthily,
+ * so a genre named "constructor" would resolve to a function and the caller
+ * would read `.color` off it as undefined. Genre is arbitrary server text and
+ * an MD can create one by typing it, so that input is reachable.
+ */
+const GENRE_TONE_BY_NAME = new Map<string, Tone>(
+  Object.entries(GENRE_TONES).map(([name, tone]) => [name.toLowerCase(), tone])
+);
+
+/**
+ * Resolve any genre value — missing, or one with no designed color — to its
+ * tone. Matching is case- and whitespace-insensitive so the filter chips and
+ * the result chips agree on a genre however the server cased it. A miss
+ * degrades the chip's color only; the genre text beside it is untouched.
  */
 export function genreTone(genre: string | null | undefined): Tone {
-  // `Object.hasOwn` rather than a bare index: genre is arbitrary server text
-  // and an MD can create one by typing it, so a genre named "constructor" or
-  // "toString" would otherwise resolve to an Object.prototype member. That is
-  // truthy, so the fallback below never fires, and the caller reads `.color`
-  // off it as undefined -- which AlbumArtwork feeds into
-  // `theme.vars.palette[...][400]` and crashes the catalog grid.
-  const key = genre ?? "Unknown";
-  const toneTable: Record<string, Tone | undefined> = GENRE_TONES;
-  return Object.hasOwn(GENRE_TONES, key) ? (toneTable[key] ?? GENRE_TONES.Unknown) : GENRE_TONES.Unknown;
+  const key = genre?.trim().toLowerCase();
+  return (key ? GENRE_TONE_BY_NAME.get(key) : undefined) ?? GENRE_TONES.Unknown;
 }
 
 export const FORMAT_TONES: Record<Format, FormatTone> = {

--- a/lib/features/experiences/modern/tokens/roles.ts
+++ b/lib/features/experiences/modern/tokens/roles.ts
@@ -1,5 +1,4 @@
 import type { ColorPaletteProp, VariantProp } from "@mui/joy/styles";
-import type { Format } from "@/lib/features/catalog/types";
 import type { Rotation } from "@/lib/features/rotation/types";
 
 /**
@@ -11,6 +10,10 @@ import type { Rotation } from "@/lib/features/rotation/types";
  * Layer A (real distinct colors: sidebar/format hues, exclusive purple, on-air
  * red, rotation bins) lives in the theme palette and is consumed via
  * `theme.vars.palette.*`.
+ *
+ * Where a role's *text* also needs a shared presentation rule, its resolver
+ * lives beside the tone table rather than in a component, so the two cannot
+ * disagree about the same value.
  */
 export interface Tone {
   color: ColorPaletteProp;
@@ -79,22 +82,65 @@ export function genreTone(genre: string | null | undefined): Tone {
   return (key ? GENRE_TONE_BY_NAME.get(key) : undefined) ?? GENRE_TONES.Unknown;
 }
 
-export const FORMAT_TONES: Record<Format, FormatTone> = {
+/**
+ * Chip tones for the two formats the modern experience gives a dedicated hue.
+ *
+ * This is a **presentation table, not the format vocabulary**. The library's
+ * formats are server-owned (`GET /library/formats`) and a music director
+ * creates one by typing its name, so the shelf holds values like `Cassette`
+ * and `7-inch Single` that have no hue here. Never use these keys to validate
+ * or rewrite format data.
+ *
+ * `Unknown` is the fallback entry for a release with no format at all; it is
+ * not one of the library's formats.
+ */
+export const FORMAT_TONES = {
   Vinyl: { color: "formatVinyl", variant: "soft" },
   CD: { color: "formatCd", variant: "soft" },
   Unknown: { color: "neutral", variant: "soft" },
-};
+} satisfies Record<string, FormatTone>;
 
 /**
- * Resolve any format string to its tone. `Format` is a cast string, not a real
- * closed union (the backend sends "cd", "LP", "CD-R", …), so callers must NOT
- * index FORMAT_TONES directly — normalize here and always return a valid tone.
+ * A key of the tone table above — i.e. a format dj-site happens to have a chip
+ * hue for. Derived from the table so the two can never drift. This is a
+ * styling subset and makes no claim about which formats exist; format data is
+ * typed `string` (`AlbumEntry.format`).
+ */
+export type FormatToneKey = keyof typeof FORMAT_TONES;
+
+/**
+ * Resolve any format value — missing, or one with no dedicated hue — to its
+ * tone. Matching is by substring rather than by key, deliberately: the shelf
+ * files `12" Vinyl` and `CD-R`, and those are still a record and a disc, so
+ * they earn the vinyl and CD hues that let a DJ read the medium off the row at
+ * a glance. Anything else degrades to neutral. A miss changes the chip's hue
+ * only; the format text beside it is untouched.
  */
 export function formatTone(format: string | null | undefined): FormatTone {
   const f = (format ?? "").toLowerCase();
   if (f.includes("vinyl")) return FORMAT_TONES.Vinyl;
   if (f.includes("cd")) return FORMAT_TONES.CD;
   return FORMAT_TONES.Unknown;
+}
+
+/**
+ * The text of a format chip. Server-owned text, presented — never rewritten:
+ * only the two attested bare lowercase spellings are tidied ("cd" -> "CD",
+ * "vinyl" -> "Vinyl"), and anything already carrying casing or punctuation is
+ * left alone rather than title-case-mangled into "Cd-r" or `12" vinyl`.
+ *
+ * Every format chip in the modern experience resolves through this one
+ * function, alongside `formatTone` over the same text. Two labellers drift:
+ * the picker interleaves rows from more than one conversion path, and a DJ
+ * cannot tell which drew a given row, so a second implementation shows the
+ * same release under two names.
+ */
+export function formatLabel(format: string): string {
+  if (/^cd$/i.test(format)) return "CD";
+  if (/^[a-z]+$/.test(format)) {
+    return format.charAt(0).toUpperCase() + format.slice(1);
+  }
+  return format;
 }
 
 export const ROTATION_TONES: Record<Rotation, Tone> = {

--- a/lib/features/experiences/modern/tokens/roles.ts
+++ b/lib/features/experiences/modern/tokens/roles.ts
@@ -1,5 +1,5 @@
 import type { ColorPaletteProp, VariantProp } from "@mui/joy/styles";
-import type { Format, Genre } from "@/lib/features/catalog/types";
+import type { Format } from "@/lib/features/catalog/types";
 import type { Rotation } from "@/lib/features/rotation/types";
 
 /**
@@ -23,7 +23,20 @@ export interface FormatTone {
   variant: VariantProp;
 }
 
-export const GENRE_TONES: Record<Genre, Tone> = {
+/**
+ * Chip tones for the genres the modern experience has a designed color for.
+ *
+ * This is a **presentation table, not the genre vocabulary**. The library's
+ * genres are server-owned (`GET /library/genres`) and the table grows without
+ * a dj-site deploy, so a genre missing from here is the normal case, not a bad
+ * value: it resolves to the neutral `Unknown` tone via `genreTone` and still
+ * renders its own name. Never read a miss as "that genre doesn't exist", and
+ * never use these keys to validate or rewrite genre data.
+ *
+ * `Unknown` is the fallback entry for a release with no genre at all; it is
+ * not one of the library's genres.
+ */
+export const GENRE_TONES = {
   Rock: { color: "primary", variant: "solid" },
   Blues: { color: "success", variant: "soft" },
   Electronic: { color: "success", variant: "solid" },
@@ -34,15 +47,25 @@ export const GENRE_TONES: Record<Genre, Tone> = {
   Soundtracks: { color: "neutral", variant: "soft" },
   OCS: { color: "success", variant: "soft" },
   Unknown: { color: "neutral", variant: "soft" },
-};
+} satisfies Record<string, Tone>;
 
 /**
- * Resolve any genre value (possibly missing or not a known `Genre`) to its
- * tone. Mirrors `formatTone` so callers never index GENRE_TONES with an
- * unvalidated string.
+ * A key of the tone table above — i.e. a genre dj-site happens to have a chip
+ * color for. Derived from the table so the two can never drift. This is a
+ * styling subset and makes no claim about which genres exist; genre data is
+ * typed `string` (`ArtistEntry.genre`).
+ */
+export type GenreToneKey = keyof typeof GENRE_TONES;
+
+/**
+ * Resolve any genre value (possibly missing, possibly one with no designed
+ * color) to its tone. Mirrors `formatTone` so callers never index GENRE_TONES
+ * with an unvalidated string, and so a miss degrades the chip's color without
+ * touching the genre text beside it.
  */
 export function genreTone(genre: string | null | undefined): Tone {
-  return GENRE_TONES[(genre ?? "Unknown") as Genre] ?? GENRE_TONES.Unknown;
+  const toneTable: Record<string, Tone | undefined> = GENRE_TONES;
+  return toneTable[genre ?? "Unknown"] ?? GENRE_TONES.Unknown;
 }
 
 export const FORMAT_TONES: Record<Format, FormatTone> = {

--- a/lib/features/experiences/modern/tokens/roles.ts
+++ b/lib/features/experiences/modern/tokens/roles.ts
@@ -64,8 +64,15 @@ export type GenreToneKey = keyof typeof GENRE_TONES;
  * touching the genre text beside it.
  */
 export function genreTone(genre: string | null | undefined): Tone {
+  // `Object.hasOwn` rather than a bare index: genre is arbitrary server text
+  // and an MD can create one by typing it, so a genre named "constructor" or
+  // "toString" would otherwise resolve to an Object.prototype member. That is
+  // truthy, so the fallback below never fires, and the caller reads `.color`
+  // off it as undefined -- which AlbumArtwork feeds into
+  // `theme.vars.palette[...][400]` and crashes the catalog grid.
+  const key = genre ?? "Unknown";
   const toneTable: Record<string, Tone | undefined> = GENRE_TONES;
-  return toneTable[genre ?? "Unknown"] ?? GENRE_TONES.Unknown;
+  return Object.hasOwn(GENRE_TONES, key) ? (toneTable[key] ?? GENRE_TONES.Unknown) : GENRE_TONES.Unknown;
 }
 
 export const FORMAT_TONES: Record<Format, FormatTone> = {

--- a/lib/features/lml/lml-conversions.ts
+++ b/lib/features/lml/lml-conversions.ts
@@ -1,13 +1,5 @@
-import type { AlbumEntry, Format } from "@/lib/features/catalog/types";
+import type { AlbumEntry } from "@/lib/features/catalog/types";
 import type { LmlLibraryItem } from "./types";
-
-function normalizeFormat(format: string | null): Format {
-  if (!format) return "Unknown";
-  const lower = format.toLowerCase();
-  if (lower.includes("vinyl")) return "Vinyl";
-  if (lower.includes("cd")) return "CD";
-  return "Unknown";
-}
 
 /**
  * Converts an LML library search result to the frontend `AlbumEntry` type.
@@ -38,7 +30,8 @@ export function convertLmlItemToAlbumEntry(item: LmlLibraryItem): AlbumEntry {
       id: undefined,
     },
     entry: item.release_call_number ?? 0,
-    format: normalizeFormat(item.format),
+    // Verbatim; the sentinel is for a row with no format. See `AlbumEntry.format`.
+    format: item.format ?? "Unknown",
     alternate_artist: item.alternate_artist_name ?? "",
     label: item.label ?? "",
     on_streaming: item.on_streaming ?? undefined,

--- a/lib/features/lml/lml-conversions.ts
+++ b/lib/features/lml/lml-conversions.ts
@@ -33,11 +33,7 @@ export function convertLmlItemToAlbumEntry(item: LmlLibraryItem): AlbumEntry {
       name: item.artist ?? "",
       lettercode: item.call_letters ?? "",
       numbercode: item.artist_call_number ?? 0,
-      // Verbatim. The genre vocabulary is server-owned (GET /library/genres)
-      // and grows without a dj-site deploy, so no local set of names can
-      // decide whether a value is real — testing against one rewrites
-      // correctly-filed releases into the "Unknown" sentinel, which is the
-      // UI's fallback for a row carrying no genre and nothing else.
+      // Verbatim; the sentinel is for a row with no genre. See `ArtistEntry.genre`.
       genre: item.genre ?? "Unknown",
       id: undefined,
     },

--- a/lib/features/lml/lml-conversions.ts
+++ b/lib/features/lml/lml-conversions.ts
@@ -1,29 +1,11 @@
-import type { AlbumEntry, Format, Genre } from "@/lib/features/catalog/types";
+import type { AlbumEntry, Format } from "@/lib/features/catalog/types";
 import type { LmlLibraryItem } from "./types";
-
-const VALID_GENRES: ReadonlySet<string> = new Set<Genre>([
-  "Blues",
-  "Rock",
-  "Electronic",
-  "Hiphop",
-  "Jazz",
-  "Classical",
-  "Reggae",
-  "Soundtracks",
-  "OCS",
-  "Unknown",
-]);
 
 function normalizeFormat(format: string | null): Format {
   if (!format) return "Unknown";
   const lower = format.toLowerCase();
   if (lower.includes("vinyl")) return "Vinyl";
   if (lower.includes("cd")) return "CD";
-  return "Unknown";
-}
-
-function normalizeGenre(genre: string | null): Genre {
-  if (genre && VALID_GENRES.has(genre)) return genre as Genre;
   return "Unknown";
 }
 
@@ -51,7 +33,12 @@ export function convertLmlItemToAlbumEntry(item: LmlLibraryItem): AlbumEntry {
       name: item.artist ?? "",
       lettercode: item.call_letters ?? "",
       numbercode: item.artist_call_number ?? 0,
-      genre: normalizeGenre(item.genre),
+      // Verbatim. The genre vocabulary is server-owned (GET /library/genres)
+      // and grows without a dj-site deploy, so no local set of names can
+      // decide whether a value is real — testing against one rewrites
+      // correctly-filed releases into the "Unknown" sentinel, which is the
+      // UI's fallback for a row carrying no genre and nothing else.
+      genre: item.genre ?? "Unknown",
       id: undefined,
     },
     entry: item.release_call_number ?? 0,

--- a/src/components/experiences/modern/Rightbar/panels/album/AlbumCard.tsx
+++ b/src/components/experiences/modern/Rightbar/panels/album/AlbumCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AlbumEntry } from "@/lib/features/catalog/types";
+import { formatLabel } from "@/lib/features/experiences/modern/tokens/roles";
 import { AlbumMetadata, ResolvedToken } from "@/lib/features/metadata/types";
 import {
   Box,
@@ -127,7 +128,7 @@ export default function AlbumCard({
                 ) : null}
                 {!metadata && !metadataLoading && (
                   <Typography level="body-sm">
-                    {album.label || ""}{album.label ? " \u2022 " : ""}{album?.format ?? ""}
+                    {album.label || ""}{album.label ? " \u2022 " : ""}{album?.format ? formatLabel(album.format) : ""}
                   </Typography>
                 )}
                 {metadata?.genres?.map((g) => (

--- a/src/components/experiences/modern/catalog/ArtistAvatar.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAvatar.tsx
@@ -61,7 +61,11 @@ export const ArtistAvatar = (props: ArtistAvatarProps): JSX.Element => {
                   ml: -0.1,
                 }}
               >
-                {props.artist?.genre?.substring(0, 2)?.toUpperCase() ?? "—"}
+                {/* `||`, not `??`: a row can carry an empty genre string -- the adapters
+                    pass server text through verbatim and only map a null to the Unknown
+                    sentinel, because the classic screens must print what the JSP prints.
+                    `??` would render an empty badge for it instead of the dash. */}
+                {props.artist?.genre?.trim().substring(0, 2).toUpperCase() || "—"}
               </Typography>
             </Stack>
             <Stack

--- a/src/components/experiences/modern/catalog/ArtistAvatar.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAvatar.tsx
@@ -1,9 +1,9 @@
 import type { JSX } from "react";
-import { ArtistEntry, Format, Genre } from "@/lib/features/catalog/types";
+import { ArtistEntry, Format } from "@/lib/features/catalog/types";
 import { Rotation } from "@/lib/features/rotation/types";
 import {
   formatTone,
-  GENRE_TONES,
+  genreTone,
   ROTATION_TONES,
 } from "@/lib/features/experiences/modern/tokens/roles";
 import { Avatar, Badge, Stack, Tooltip, Typography } from "@mui/joy";
@@ -17,11 +17,9 @@ interface ArtistAvatarProps {
 }
 
 export const ArtistAvatar = (props: ArtistAvatarProps): JSX.Element => {
-  const genreTone =
-    GENRE_TONES[(props.artist?.genre as Genre) ?? "Unknown"] ??
-    GENRE_TONES.Unknown;
-  const color_choice = genreTone.color;
-  const variant_choice = genreTone.variant;
+  const tone = genreTone(props.artist?.genre);
+  const color_choice = tone.color;
+  const variant_choice = tone.variant;
   const formatColor = formatTone(props.format).color;
 
   return (

--- a/src/components/experiences/modern/catalog/ArtistAvatar.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAvatar.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "react";
-import { ArtistEntry, Format } from "@/lib/features/catalog/types";
+import { ArtistEntry } from "@/lib/features/catalog/types";
 import { Rotation } from "@/lib/features/rotation/types";
 import {
   formatTone,
@@ -13,7 +13,7 @@ interface ArtistAvatarProps {
   entry?: number;
   background?: string;
   rotation?: Rotation;
-  format?: Format;
+  format?: string;
 }
 
 /**

--- a/src/components/experiences/modern/catalog/ArtistAvatar.tsx
+++ b/src/components/experiences/modern/catalog/ArtistAvatar.tsx
@@ -16,6 +16,14 @@ interface ArtistAvatarProps {
   format?: Format;
 }
 
+/**
+ * Two-letter badge for a genre or format. `||`, not `??`: either can arrive as
+ * the empty string — the adapters carry server text verbatim and map only null
+ * to a sentinel — and `??` would render a blank badge instead of the dash.
+ */
+const badgeAbbrev = (value: string | null | undefined): string =>
+  value?.trim().substring(0, 2).toUpperCase() || "—";
+
 export const ArtistAvatar = (props: ArtistAvatarProps): JSX.Element => {
   const tone = genreTone(props.artist?.genre);
   const color_choice = tone.color;
@@ -61,11 +69,7 @@ export const ArtistAvatar = (props: ArtistAvatarProps): JSX.Element => {
                   ml: -0.1,
                 }}
               >
-                {/* `||`, not `??`: a row can carry an empty genre string -- the adapters
-                    pass server text through verbatim and only map a null to the Unknown
-                    sentinel, because the classic screens must print what the JSP prints.
-                    `??` would render an empty badge for it instead of the dash. */}
-                {props.artist?.genre?.trim().substring(0, 2).toUpperCase() || "—"}
+                {badgeAbbrev(props.artist?.genre)}
               </Typography>
             </Stack>
             <Stack
@@ -115,9 +119,7 @@ export const ArtistAvatar = (props: ArtistAvatarProps): JSX.Element => {
                   fontSize: "0.6rem",
                 }}
               >
-                {props.format == "Unknown"
-                  ? "—"
-                  : props.format?.substring(0, 2).toUpperCase() ?? "--"}
+                {props.format === "Unknown" ? "—" : badgeAbbrev(props.format)}
               </Typography>
             </Stack>
           </Stack>

--- a/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
+++ b/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
@@ -3,9 +3,9 @@
 import Chip from "@mui/joy/Chip";
 import Stack from "@mui/joy/Stack";
 
-import { Format } from "@/lib/features/catalog/types";
 import { Rotation } from "@/lib/features/rotation/types";
 import {
+  formatLabel,
   formatTone,
   genreTone,
   ROTATION_TONES,
@@ -22,19 +22,6 @@ const chipSx = {
   "--Chip-paddingInline": "6px",
 } as const;
 
-// `Format` is a cast string, not a real closed union (conversions.ts casts
-// `format_name as Format`), so normalize only the attested bare lowercase
-// values ("cd" -> "CD", "vinyl" -> "Vinyl") and preserve anything that
-// already carries casing or punctuation ("CD-R", "LP", "7-inch Single",
-// "Unknown") rather than title-case-mangling it.
-function formatLabel(format: Format): string {
-  if (/^cd$/i.test(format)) return "CD";
-  if (/^[a-z]+$/.test(format)) {
-    return format.charAt(0).toUpperCase() + format.slice(1);
-  }
-  return format;
-}
-
 export function ReleaseChips({
   genre,
   format,
@@ -44,7 +31,9 @@ export function ReleaseChips({
   // Server-owned text (see ArtistEntry.genre) — rendered as sent. `genreTone`
   // absorbs the ones with no designed chip color.
   genre: string;
-  format: Format;
+  // Server-owned text (see AlbumEntry.format) — presented via `formatLabel`,
+  // never narrowed. `formatTone` absorbs the ones with no dedicated hue.
+  format: string;
   rotation?: Rotation;
   onStreaming: boolean | undefined;
 }) {

--- a/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
+++ b/src/components/experiences/modern/catalog/Results/ReleaseChips.tsx
@@ -3,7 +3,7 @@
 import Chip from "@mui/joy/Chip";
 import Stack from "@mui/joy/Stack";
 
-import { Format, Genre } from "@/lib/features/catalog/types";
+import { Format } from "@/lib/features/catalog/types";
 import { Rotation } from "@/lib/features/rotation/types";
 import {
   formatTone,
@@ -41,7 +41,9 @@ export function ReleaseChips({
   rotation,
   onStreaming,
 }: {
-  genre: Genre;
+  // Server-owned text (see ArtistEntry.genre) — rendered as sent. `genreTone`
+  // absorbs the ones with no designed chip color.
+  genre: string;
   format: Format;
   rotation?: Rotation;
   onStreaming: boolean | undefined;

--- a/src/components/experiences/modern/catalog/Search/catalogFilterChipStyles.ts
+++ b/src/components/experiences/modern/catalog/Search/catalogFilterChipStyles.ts
@@ -3,10 +3,9 @@ import type { SxProps } from "@mui/joy/styles/types";
 
 import {
   formatTone,
-  GENRE_TONES,
+  genreTone,
   ROTATION_TONES,
   type FormatTone,
-  type GenreToneKey,
 } from "@/lib/features/experiences/modern/tokens/roles";
 import type { Rotation } from "@/lib/features/rotation/types";
 import {
@@ -16,35 +15,15 @@ import {
 } from "./catalogFilterStyles";
 import { isCatalogRotationTag } from "./catalogTagFilters";
 
-// Read off the tone table rather than restated, so the two can't drift. These
-// are the genres with a designed chip color, NOT the genres that exist — that
-// list is server-owned and longer.
-const GENRE_TONE_KEYS = Object.keys(GENRE_TONES) as GenreToneKey[];
-
-/**
- * Resolve a server genre name to a tone-table key, case-insensitively. A genre
- * with no designed color falls back to the neutral `Unknown` tone; only the
- * chip's color degrades, the filter's label still reads the real genre.
- */
-export function genreNameToGenreKey(name: string): GenreToneKey {
-  const trimmed = name.trim();
-  if (!trimmed) return "Unknown";
-  const hit = GENRE_TONE_KEYS.find(
-    (k) => k.toLowerCase() === trimmed.toLowerCase()
-  );
-  return hit ?? "Unknown";
-}
-
 export type CatalogFilterTagChipProps = {
   color?: FormatTone["color"];
   variant?: VariantProp;
   sx?: SxProps;
 };
 
-/** Matches catalog result genre chips (`Result.tsx`). */
+/** Matches catalog result genre chips — same resolver, so the two cannot drift. */
 export function getGenreFilterChipProps(genreName: string): CatalogFilterTagChipProps {
-  const key = genreNameToGenreKey(genreName);
-  return GENRE_TONES[key] ?? GENRE_TONES.Unknown;
+  return genreTone(genreName);
 }
 
 /** Matches catalog result format chips — dedicated vinyl/CD hues. */

--- a/src/components/experiences/modern/catalog/Search/catalogFilterChipStyles.ts
+++ b/src/components/experiences/modern/catalog/Search/catalogFilterChipStyles.ts
@@ -1,4 +1,3 @@
-import type { Format, Genre } from "@/lib/features/catalog/types";
 import type { VariantProp } from "@mui/joy";
 import type { SxProps } from "@mui/joy/styles/types";
 
@@ -7,6 +6,7 @@ import {
   GENRE_TONES,
   ROTATION_TONES,
   type FormatTone,
+  type GenreToneKey,
 } from "@/lib/features/experiences/modern/tokens/roles";
 import type { Rotation } from "@/lib/features/rotation/types";
 import {
@@ -16,23 +16,22 @@ import {
 } from "./catalogFilterStyles";
 import { isCatalogRotationTag } from "./catalogTagFilters";
 
-const GENRE_KEYS: Genre[] = [
-  "Rock",
-  "Blues",
-  "Electronic",
-  "Hiphop",
-  "Jazz",
-  "Classical",
-  "Reggae",
-  "Soundtracks",
-  "OCS",
-  "Unknown",
-];
+// Read off the tone table rather than restated, so the two can't drift. These
+// are the genres with a designed chip color, NOT the genres that exist — that
+// list is server-owned and longer.
+const GENRE_TONE_KEYS = Object.keys(GENRE_TONES) as GenreToneKey[];
 
-export function genreNameToGenreKey(name: string): Genre {
+/**
+ * Resolve a server genre name to a tone-table key, case-insensitively. A genre
+ * with no designed color falls back to the neutral `Unknown` tone; only the
+ * chip's color degrades, the filter's label still reads the real genre.
+ */
+export function genreNameToGenreKey(name: string): GenreToneKey {
   const trimmed = name.trim();
   if (!trimmed) return "Unknown";
-  const hit = GENRE_KEYS.find((k) => k.toLowerCase() === trimmed.toLowerCase());
+  const hit = GENRE_TONE_KEYS.find(
+    (k) => k.toLowerCase() === trimmed.toLowerCase()
+  );
   return hit ?? "Unknown";
 }
 

--- a/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
+++ b/src/components/experiences/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.tsx
@@ -5,7 +5,10 @@ import { hasLinkedAlbumId } from "@/lib/features/flowsheet/linkage";
 import { useMetadataPrefetch } from "@/lib/features/metadata/api";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { WXYC_EXCLUSIVE_PURPLE } from "@/src/utilities/modern/brandColors";
-import { formatTone } from "@/lib/features/experiences/modern/tokens/roles";
+import {
+  formatLabel,
+  formatTone,
+} from "@/lib/features/experiences/modern/tokens/roles";
 import { Box, Chip, Typography } from "@mui/joy";
 import { memo } from "react";
 import {
@@ -132,7 +135,7 @@ function FlowsheetBackendResult({
         }}
       >
         <Chip variant="soft" size="sm" color={formatTone(entry.format).color}>
-          {entry.format.includes("vinyl") ? "vinyl" : "cd"}
+          {formatLabel(entry.format)}
         </Chip>
         {entry.on_streaming === false && (
           <Chip

--- a/tests/fixtures/fixtures.ts
+++ b/tests/fixtures/fixtures.ts
@@ -32,7 +32,6 @@ import {
   AlbumEntry,
   AlbumSearchResultJSON,
   ArtistEntry,
-  Genre,
 } from "@/lib/features/catalog/types";
 import {
   FlowsheetQuery,

--- a/tests/integration/components/classic/library/MissingReleases.test.tsx
+++ b/tests/integration/components/classic/library/MissingReleases.test.tsx
@@ -185,6 +185,25 @@ describe("Classic MissingReleases — missingReleases.jsp", () => {
       expect(genreCellOf("Edits")).toBeEmptyDOMElement();
     });
 
+    it("prints the row's format verbatim, inventing no fallback of its own", async () => {
+      mockMissingReleasePages([
+        missingRow({ format_name: '12" Vinyl' }),
+        missingRow({ id: 4203, album_title: "Edits", format_name: "" }),
+      ]);
+
+      await renderAndSettle();
+
+      const formatCellOf = (title: string) =>
+        within(screen.getByText(title).closest("tr")!).getAllByRole("cell")[0];
+      // The format vocabulary is the server's, and a music director adds to it
+      // by typing a name — so the shelf really holds values like this one, and
+      // narrowing them to a vinyl/CD pair renames releases on screen.
+      expect(formatCellOf("On Your Own Love Again")).toHaveTextContent('12" Vinyl');
+      // The JSP's <c:out> prints nothing for a format it has no value for, and
+      // this screen must not substitute a word for it.
+      expect(formatCellOf("Edits")).toBeEmptyDOMElement();
+    });
+
     it("shows 'Unknown' rather than a formatted date when date_lost is absent", async () => {
       mockMissingReleasePages([missingRow({ date_lost: undefined })]);
 

--- a/tests/integration/components/modern/catalog/Results/ReleaseChips.test.tsx
+++ b/tests/integration/components/modern/catalog/Results/ReleaseChips.test.tsx
@@ -42,14 +42,14 @@ describe("ReleaseChips", () => {
 
   it("should tidy attested lowercase formats but preserve arbitrary ones", () => {
     const { unmount } = renderWithProviders(
-      <ReleaseChips genre="Rock" format={"vinyl" as never} onStreaming={undefined} />
+      <ReleaseChips genre="Rock" format="vinyl" onStreaming={undefined} />
     );
     // Bare lowercase "vinyl" is presented as "Vinyl".
     expect(screen.getByText("Vinyl")).toBeDefined();
     unmount();
 
     renderWithProviders(
-      <ReleaseChips genre="Rock" format={"CD-R" as never} onStreaming={undefined} />
+      <ReleaseChips genre="Rock" format="CD-R" onStreaming={undefined} />
     );
     // Anything with existing casing/punctuation is preserved, not "Cd-r".
     expect(screen.getByText("CD-R")).toBeDefined();

--- a/tests/integration/components/modern/catalog/Search/catalogFilterChipStyles.test.ts
+++ b/tests/integration/components/modern/catalog/Search/catalogFilterChipStyles.test.ts
@@ -1,18 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
-  genreNameToGenreKey,
   getFormatFilterChipProps,
   getGenreFilterChipProps,
   getTagFilterChipProps,
 } from "@/src/components/experiences/modern/catalog/Search/catalogFilterChipStyles";
 
 describe("catalogFilterChipStyles", () => {
-  it("maps genre names case-insensitively", () => {
-    expect(genreNameToGenreKey("rock")).toBe("Rock");
-    expect(genreNameToGenreKey("JAZZ")).toBe("Jazz");
-    expect(genreNameToGenreKey("Not Real")).toBe("Unknown");
-  });
-
   it("uses ArtistAvatar genre palettes", () => {
     expect(getGenreFilterChipProps("Rock")).toEqual({
       color: "primary",

--- a/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
@@ -62,35 +62,37 @@ describe("FlowsheetBackendResult", () => {
   });
 
   describe("Format chip", () => {
-    it("should show 'cd' chip for CD format", () => {
-      renderWithProviders(<FlowsheetBackendResult entry={mockEntry} index={1} />);
+    // The chip reads the release's own format rather than collapsing it to a
+    // vinyl-or-CD binary. The shelf holds Cassette and 7-inch Single, and a
+    // binary that tested for a lowercase substring labelled every "Vinyl"
+    // release "cd" — a mislabel a DJ acts on, made worse by the chip's hue
+    // being resolved case-insensitively and so reading vinyl at the same time.
+    it.each([
+      ["CD", "CD"],
+      ["cd", "CD"],
+      ["Vinyl", "Vinyl"],
+      ["vinyl", "Vinyl"],
+      ['12" Vinyl', '12" Vinyl'],
+      ["CD-R", "CD-R"],
+      ["Cassette", "Cassette"],
+      ["7-inch Single", "7-inch Single"],
+    ])("labels a %s release %s", (format, label) => {
+      const entry = createTestAlbum({ ...mockEntry, format });
 
-      expect(screen.getByText("cd")).toBeInTheDocument();
+      renderWithProviders(<FlowsheetBackendResult entry={entry} index={1} />);
+
+      expect(screen.getByText(label)).toBeInTheDocument();
     });
 
-    it("should show 'vinyl' chip for vinyl format", () => {
-      // Note: Component checks format.includes("vinyl") (lowercase)
-      const vinylEntry = createTestAlbum({
-        ...mockEntry,
-        format: "vinyl" as any, // Using lowercase to match component's check
-      });
+    // Label and hue come from one resolver each, over the same text, so they
+    // cannot disagree about what the release is.
+    it("gives a vinyl release the vinyl hue alongside the vinyl label", () => {
+      const entry = createTestAlbum({ ...mockEntry, format: "Vinyl" });
 
-      renderWithProviders(<FlowsheetBackendResult entry={vinylEntry} index={1} />);
+      renderWithProviders(<FlowsheetBackendResult entry={entry} index={1} />);
 
-      expect(screen.getByText("vinyl")).toBeInTheDocument();
-    });
-
-    it("should show 'cd' chip for non-vinyl format", () => {
-      const unknownFormatEntry = createTestAlbum({
-        ...mockEntry,
-        format: "Unknown",
-      });
-
-      renderWithProviders(
-        <FlowsheetBackendResult entry={unknownFormatEntry} index={1} />
-      );
-
-      expect(screen.getByText("cd")).toBeInTheDocument();
+      const chip = screen.getByText("Vinyl").closest(".MuiChip-root");
+      expect(chip?.className).toMatch(/colorFormatVinyl/i);
     });
   });
 
@@ -348,12 +350,11 @@ describe("FlowsheetBackendResult", () => {
 
   describe("Entry with all fields", () => {
     it("should render complete entry", () => {
-      // Note: Using lowercase "vinyl" to match component's includes() check
       const completeEntry: AlbumEntry = createTestAlbum({
         id: 100,
         title: "Aluminum Tunes",
         entry: 10,
-        format: "vinyl" as any,
+        format: "Vinyl",
         label: "Duophonic",
         rotation_bin: "M",
         rotation_id: 20,
@@ -374,7 +375,7 @@ describe("FlowsheetBackendResult", () => {
       expect(screen.getByText("Aluminum Tunes")).toBeInTheDocument();
       expect(screen.getByText("Duophonic")).toBeInTheDocument();
       expect(screen.getByText(/Jazz XY 456\/10/)).toBeInTheDocument();
-      expect(screen.getByText("vinyl")).toBeInTheDocument();
+      expect(screen.getByText("Vinyl")).toBeInTheDocument();
     });
   });
 
@@ -427,7 +428,7 @@ describe("FlowsheetBackendResult", () => {
     it("should render format chip", () => {
       renderWithProviders(<FlowsheetBackendResult entry={mockEntry} index={1} />);
 
-      expect(screen.getByText("cd")).toBeInTheDocument();
+      expect(screen.getByText("CD")).toBeInTheDocument();
     });
   });
 });

--- a/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
+++ b/tests/integration/components/modern/flowsheet/Search/Results/BackendResults/FlowsheetBackendResult.test.tsx
@@ -425,10 +425,5 @@ describe("FlowsheetBackendResult", () => {
       expect(codeText).toHaveStyle({ fontFamily: "monospace" });
     });
 
-    it("should render format chip", () => {
-      renderWithProviders(<FlowsheetBackendResult entry={mockEntry} index={1} />);
-
-      expect(screen.getByText("CD")).toBeInTheDocument();
-    });
   });
 });

--- a/tests/unit/lib/features/catalog/catalogSearchQueryMatch.test.ts
+++ b/tests/unit/lib/features/catalog/catalogSearchQueryMatch.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { createTestAlbum } from "@/tests/helpers";
+import { createTestAlbum, createTestLmlLibraryItem } from "@/tests/helpers";
+import { convertLmlItemToAlbumEntry } from "@/lib/features/lml/lml-conversions";
 import {
   albumMatchesCatalogQueryArg,
   parseRotationBinsFromQueryArg,
@@ -50,6 +51,33 @@ describe("albumMatchesCatalogQueryArg", () => {
     expect(
       albumMatchesCatalogQueryArg(unknown, { on_streaming: true }),
     ).toBe(true);
+  });
+
+  // The filter values are the server's own format names, so the row's format
+  // has to be that same text.
+  it("matches the formats filter against the row's own format text", () => {
+    const twelveInch = createTestAlbum({ format: '12" Vinyl' });
+    const cd = createTestAlbum({ format: "CD" });
+
+    expect(
+      albumMatchesCatalogQueryArg(twelveInch, { formats: '12" Vinyl' }),
+    ).toBe(true);
+    expect(albumMatchesCatalogQueryArg(cd, { formats: '12" Vinyl' })).toBe(
+      false,
+    );
+  });
+
+  // Held against a real adapter, not a hand-built row: a conversion path that
+  // narrows the format to a locally-known pair leaves its rows unable to match
+  // any filter the server offered, and the filter then silently hides them.
+  it("keeps a converted row matchable by the format the server filed it under", () => {
+    const album = convertLmlItemToAlbumEntry(
+      createTestLmlLibraryItem({ format: '12" Vinyl' }),
+    );
+
+    expect(albumMatchesCatalogQueryArg(album, { formats: '12" Vinyl' })).toBe(
+      true,
+    );
   });
 
   it("excludes missing albums from missing=false filter", () => {

--- a/tests/unit/lib/features/catalog/conversions.test.ts
+++ b/tests/unit/lib/features/catalog/conversions.test.ts
@@ -180,10 +180,7 @@ describe("catalog conversions", () => {
       });
 
       it("passes an empty genre through rather than inventing the sentinel", () => {
-        const result = convertToAlbumEntry({
-          ...linkedRow,
-          genre_name: "",
-        } as unknown as AlbumSearchResultJSON);
+        const result = convertToAlbumEntry({ ...linkedRow, genre_name: "" });
         expect(result.artist.genre).toBe("");
       });
     });

--- a/tests/unit/lib/features/catalog/conversions.test.ts
+++ b/tests/unit/lib/features/catalog/conversions.test.ts
@@ -160,7 +160,7 @@ describe("catalog conversions", () => {
     // sentinel is a UI fallback for a *missing* genre, not a substitute for
     // one dj-site has no styling for.
     describe("genre passthrough", () => {
-      it.each(["Africa", "Asia", "Comedy", "Latin", "Spoken", "Xmas"])(
+      it.each(["Africa", "Asia", "Comedy", "Latin", "Spoken", "Xmas", "Country"])(
         "carries the genre %s through even though no chip color is defined for it",
         (genre) => {
           const result = convertToAlbumEntry({ ...linkedRow, genre_name: genre });
@@ -187,10 +187,9 @@ describe("catalog conversions", () => {
 
     // Format is server-owned data too: GET /library/formats is the authority
     // and a music director creates a format by typing its name, so the shelf
-    // really holds values like "Cassette" and '12" Vinyl'. This is the same
-    // table the LML adapter is held to in lml-conversions.test.ts — the picker
-    // interleaves rows from both and a DJ cannot tell which produced a row, so
-    // the two must emit the same text, character for character.
+    // really holds values like "Cassette" and '12" Vinyl'. Each adapter asserts
+    // identity on its own values, which is what makes the two agree: two
+    // functions that both return their input cannot disagree about it.
     describe("format passthrough", () => {
       it.each([
         "Vinyl",

--- a/tests/unit/lib/features/catalog/conversions.test.ts
+++ b/tests/unit/lib/features/catalog/conversions.test.ts
@@ -185,6 +185,42 @@ describe("catalog conversions", () => {
       });
     });
 
+    // Format is server-owned data too: GET /library/formats is the authority
+    // and a music director creates a format by typing its name, so the shelf
+    // really holds values like "Cassette" and '12" Vinyl'. This is the same
+    // table the LML adapter is held to in lml-conversions.test.ts — the picker
+    // interleaves rows from both and a DJ cannot tell which produced a row, so
+    // the two must emit the same text, character for character.
+    describe("format passthrough", () => {
+      it.each([
+        "Vinyl",
+        "vinyl",
+        "Vinyl LP",
+        '12" Vinyl',
+        "CD",
+        "cd",
+        "CD-R",
+        "Cassette",
+        "7-inch Single",
+      ])("carries the format %s through unmodified", (format) => {
+        const result = convertToAlbumEntry({ ...linkedRow, format_name: format });
+        expect(result.format).toBe(format);
+      });
+
+      it("falls back to the Unknown sentinel when the row carries no format", () => {
+        const result = convertToAlbumEntry({
+          ...linkedRow,
+          format_name: null,
+        } as unknown as AlbumSearchResultJSON);
+        expect(result.format).toBe("Unknown");
+      });
+
+      it("passes an empty format through rather than inventing the sentinel", () => {
+        const result = convertToAlbumEntry({ ...linkedRow, format_name: "" });
+        expect(result.format).toBe("");
+      });
+    });
+
     describe("library-linked rotation rows", () => {
       it("preserves rotation_id", () => {
         const result = convertToAlbumEntry(linkedRow);

--- a/tests/unit/lib/features/catalog/conversions.test.ts
+++ b/tests/unit/lib/features/catalog/conversions.test.ts
@@ -153,6 +153,30 @@ const catalogSearchRow: AlbumSearchResultJSON = {
 
 describe("catalog conversions", () => {
   describe("convertToAlbumEntry", () => {
+    // Genre is server-owned data, not a dj-site vocabulary: GET /library/genres
+    // is the authority and lists more genres than the modern experience has
+    // chip colors for. Both conversion paths (Backend here, LML in
+    // lml-conversions) must carry the value through as-is; the "Unknown"
+    // sentinel is a UI fallback for a *missing* genre, not a substitute for
+    // one dj-site has no styling for.
+    describe("genre passthrough", () => {
+      it.each(["Africa", "Asia", "Comedy", "Latin", "Spoken", "Xmas"])(
+        "carries the genre %s through even though no chip color is defined for it",
+        (genre) => {
+          const result = convertToAlbumEntry({ ...linkedRow, genre_name: genre });
+          expect(result.artist.genre).toBe(genre);
+        },
+      );
+
+      it("falls back to the Unknown sentinel when the row carries no genre", () => {
+        const result = convertToAlbumEntry({
+          ...linkedRow,
+          genre_name: null,
+        } as unknown as AlbumSearchResultJSON);
+        expect(result.artist.genre).toBe("Unknown");
+      });
+    });
+
     describe("library-linked rotation rows", () => {
       it("preserves rotation_id", () => {
         const result = convertToAlbumEntry(linkedRow);

--- a/tests/unit/lib/features/catalog/conversions.test.ts
+++ b/tests/unit/lib/features/catalog/conversions.test.ts
@@ -168,12 +168,23 @@ describe("catalog conversions", () => {
         },
       );
 
+      // The two conversions are the only writers of this field and a DJ cannot
+      // tell which produced the row on screen, so they must agree on what
+      // counts as absent: null is, an empty string is not.
       it("falls back to the Unknown sentinel when the row carries no genre", () => {
         const result = convertToAlbumEntry({
           ...linkedRow,
           genre_name: null,
         } as unknown as AlbumSearchResultJSON);
         expect(result.artist.genre).toBe("Unknown");
+      });
+
+      it("passes an empty genre through rather than inventing the sentinel", () => {
+        const result = convertToAlbumEntry({
+          ...linkedRow,
+          genre_name: "",
+        } as unknown as AlbumSearchResultJSON);
+        expect(result.artist.genre).toBe("");
       });
     });
 

--- a/tests/unit/lib/features/experiences/modern/roles.test.ts
+++ b/tests/unit/lib/features/experiences/modern/roles.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   formatTone,
   FORMAT_TONES,
+  genreTone,
   GENRE_TONES,
   ROTATION_TONES,
 } from "@/lib/features/experiences/modern/tokens/roles";
@@ -30,12 +31,54 @@ describe("formatTone", () => {
   });
 });
 
+describe("genreTone", () => {
+  // GENRE_TONES is a presentation table, not the genre vocabulary. The
+  // library's genre list is server-owned (GET /library/genres) and grows
+  // without a dj-site deploy, so a genre with no designed color is normal and
+  // must resolve to the neutral fallback rather than an undefined chip.
+  it.each(["Africa", "Asia", "Comedy", "Latin", "Spoken", "Xmas"])(
+    "resolves the untoned genre %s to the neutral fallback tone",
+    (genre) => {
+      expect(genreTone(genre)).toEqual(GENRE_TONES.Unknown);
+    },
+  );
+
+  it("resolves a toned genre to its own tone", () => {
+    expect(genreTone("Rock")).toEqual(GENRE_TONES.Rock);
+  });
+
+  it("handles null/undefined without throwing", () => {
+    expect(genreTone(undefined)).toEqual(GENRE_TONES.Unknown);
+    expect(genreTone(null)).toEqual(GENRE_TONES.Unknown);
+  });
+
+  // GENRE_TONES is deliberately NOT exhaustive over the library's genres — the
+  // untoned ones share the neutral chip. Its keys are pinned because extending
+  // the table is a visual-design decision (palette coherence, contrast, which
+  // tones are already load-bearing elsewhere), not something to add in passing
+  // alongside a data change.
+  it("keeps the genre tone table to its designed keys", () => {
+    expect(Object.keys(GENRE_TONES).sort()).toEqual(
+      [
+        "Blues",
+        "Classical",
+        "Electronic",
+        "Hiphop",
+        "Jazz",
+        "OCS",
+        "Reggae",
+        "Rock",
+        "Soundtracks",
+        "Unknown",
+      ].sort(),
+    );
+  });
+});
+
 describe("role maps are exhaustive over their domains", () => {
-  it("covers every genre and rotation bin", () => {
-    // Compile-time exhaustiveness is enforced by Record<Genre|Rotation, Tone>;
+  it("covers every rotation bin", () => {
+    // Compile-time exhaustiveness is enforced by Record<Rotation, Tone>;
     // spot-check a couple at runtime.
-    expect(GENRE_TONES.Rock.color).toBe("primary");
-    expect(GENRE_TONES.Unknown).toBeDefined();
     expect(ROTATION_TONES.H.color).toBe("primary");
     expect(ROTATION_TONES.S.color).toBe("neutral");
   });

--- a/tests/unit/lib/features/experiences/modern/roles.test.ts
+++ b/tests/unit/lib/features/experiences/modern/roles.test.ts
@@ -130,7 +130,19 @@ describe("formatLabel", () => {
 
   // Anything already carrying casing or punctuation is a name the station
   // chose; title-casing it would render "Cd-r" and '12" vinyl'.
-  it.each(["CD-R", "LP", '12" Vinyl', "7-inch Single", "Cassette", "Unknown"])(
+  // "lp" and "cassette" are the cases a title-case rule got wrong: it would
+  // return "Lp" and "Cassette", rewriting server text in the one place whose
+  // job is to present it.
+  it.each([
+    "CD-R",
+    "LP",
+    "lp",
+    '12" Vinyl',
+    "7-inch Single",
+    "Cassette",
+    "cassette",
+    "Unknown",
+  ])(
     "preserves %s as sent",
     (format) => {
       expect(formatLabel(format)).toBe(format);

--- a/tests/unit/lib/features/experiences/modern/roles.test.ts
+++ b/tests/unit/lib/features/experiences/modern/roles.test.ts
@@ -57,18 +57,31 @@ describe("genreTone", () => {
   // the table is a visual-design decision (palette coherence, contrast, which
   // tones are already load-bearing elsewhere), not something to add in passing
   // alongside a data change.
-  // A genre name is arbitrary server text, and an MD can create one by typing
-  // it (GenreAdmin only rejects blank). A plain object lookup answers
-  // Object.prototype members truthily, so `toneTable["constructor"]` returns a
-  // function rather than undefined, the `?? Unknown` fallback never fires, and
-  // the caller reads `.color` off it as undefined -- which AlbumArtwork feeds
-  // straight into `theme.vars.palette[...][400]` and crashes the results grid.
-  it.each(["constructor", "toString", "valueOf", "hasOwnProperty", "__proto__"])(
+  // Case- and whitespace-insensitive, because the filter chips and the result
+  // chips resolve through this one function and must agree on a genre however
+  // the server cased it.
+  it.each([
+    ["rock", "Rock"],
+    ["JAZZ", "Jazz"],
+    ["  Blues  ", "Blues"],
+  ])("resolves %s to the %s tone", (input, expected) => {
+    expect(genreTone(input)).toEqual(
+      GENRE_TONES[expected as keyof typeof GENRE_TONES]
+    );
+  });
+
+  it("falls back to the Unknown tone for a genre with no designed color", () => {
+    expect(genreTone("Not Real")).toEqual(GENRE_TONES.Unknown);
+  });
+
+  // A plain-object lookup answers Object.prototype members truthily, so this
+  // input would otherwise resolve to a function and the caller would read
+  // `.color` off it as undefined. Reachable: an MD creates a genre by typing
+  // its name.
+  it.each(["constructor", "__proto__"])(
     "resolves the inherited property name %s to the Unknown tone",
     (name) => {
-      const tone = genreTone(name);
-      expect(tone).toEqual(GENRE_TONES.Unknown);
-      expect(typeof tone.color).toBe("string");
+      expect(genreTone(name)).toEqual(GENRE_TONES.Unknown);
     },
   );
 
@@ -85,7 +98,7 @@ describe("genreTone", () => {
         "Rock",
         "Soundtracks",
         "Unknown",
-      ].sort(),
+      ],
     );
   });
 });

--- a/tests/unit/lib/features/experiences/modern/roles.test.ts
+++ b/tests/unit/lib/features/experiences/modern/roles.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  formatLabel,
   formatTone,
   FORMAT_TONES,
   genreTone,
@@ -8,9 +9,11 @@ import {
 } from "@/lib/features/experiences/modern/tokens/roles";
 
 describe("formatTone", () => {
-  // `Format` is a cast string, not a closed union — the backend sends "cd",
-  // "LP", "CD-R", etc. formatTone must never index-crash and always return a
-  // valid tone (regression: ArtistAvatar crashed on FORMAT_TONES["cd"].color).
+  // Format is server-owned text, not a closed union — the shelf holds "cd",
+  // "LP", "CD-R", '12" Vinyl', "Cassette". Resolution is deliberately fuzzy
+  // (substring, case-insensitive) rather than exact-key: a format whose name
+  // merely *contains* Vinyl or CD still earns the dedicated hue, and anything
+  // else degrades to neutral instead of index-crashing.
   it.each([
     ["Vinyl", FORMAT_TONES.Vinyl],
     ["vinyl", FORMAT_TONES.Vinyl],
@@ -28,6 +31,15 @@ describe("formatTone", () => {
   it("handles null/undefined without throwing", () => {
     expect(formatTone(undefined)).toEqual(FORMAT_TONES.Unknown);
     expect(formatTone(null)).toEqual(FORMAT_TONES.Unknown);
+  });
+
+  // FORMAT_TONES is a presentation table, not the format vocabulary, and it is
+  // pinned so it is never mistaken for one: the two dedicated hues plus the
+  // neutral fallback for a release with no format at all. Every other format
+  // the station files under reaches a hue through the substring match above,
+  // or degrades to the fallback.
+  it("keeps the format tone table to its designed keys", () => {
+    expect(Object.keys(FORMAT_TONES).sort()).toEqual(["CD", "Unknown", "Vinyl"]);
   });
 });
 
@@ -100,6 +112,33 @@ describe("genreTone", () => {
         "Unknown",
       ],
     );
+  });
+});
+
+describe("formatLabel", () => {
+  // One label helper for every format chip in the modern experience. Two
+  // helpers drift: a result row and a picker row showing the same release
+  // must not disagree on its format, and the DJ has no way to tell which code
+  // path drew which row.
+  it.each([
+    ["cd", "CD"],
+    ["CD", "CD"],
+    ["vinyl", "Vinyl"],
+  ])("tidies the bare lowercase format %s to %s", (input, expected) => {
+    expect(formatLabel(input)).toBe(expected);
+  });
+
+  // Anything already carrying casing or punctuation is a name the station
+  // chose; title-casing it would render "Cd-r" and '12" vinyl'.
+  it.each(["CD-R", "LP", '12" Vinyl', "7-inch Single", "Cassette", "Unknown"])(
+    "preserves %s as sent",
+    (format) => {
+      expect(formatLabel(format)).toBe(format);
+    },
+  );
+
+  it("leaves an empty format empty rather than inventing a placeholder", () => {
+    expect(formatLabel("")).toBe("");
   });
 });
 

--- a/tests/unit/lib/features/experiences/modern/roles.test.ts
+++ b/tests/unit/lib/features/experiences/modern/roles.test.ts
@@ -57,6 +57,21 @@ describe("genreTone", () => {
   // the table is a visual-design decision (palette coherence, contrast, which
   // tones are already load-bearing elsewhere), not something to add in passing
   // alongside a data change.
+  // A genre name is arbitrary server text, and an MD can create one by typing
+  // it (GenreAdmin only rejects blank). A plain object lookup answers
+  // Object.prototype members truthily, so `toneTable["constructor"]` returns a
+  // function rather than undefined, the `?? Unknown` fallback never fires, and
+  // the caller reads `.color` off it as undefined -- which AlbumArtwork feeds
+  // straight into `theme.vars.palette[...][400]` and crashes the results grid.
+  it.each(["constructor", "toString", "valueOf", "hasOwnProperty", "__proto__"])(
+    "resolves the inherited property name %s to the Unknown tone",
+    (name) => {
+      const tone = genreTone(name);
+      expect(tone).toEqual(GENRE_TONES.Unknown);
+      expect(typeof tone.color).toBe("string");
+    },
+  );
+
   it("keeps the genre tone table to its designed keys", () => {
     expect(Object.keys(GENRE_TONES).sort()).toEqual(
       [

--- a/tests/unit/lib/features/lml/lml-conversions.test.ts
+++ b/tests/unit/lib/features/lml/lml-conversions.test.ts
@@ -86,10 +86,9 @@ describe("convertLmlItemToAlbumEntry", () => {
   // would also pass while values were being rewritten, which is the exact
   // failure this guards.
   //
-  // The same table runs against the Backend adapter in conversions.test.ts.
-  // Both write this one field, the picker interleaves rows from both, and a
-  // DJ cannot tell which adapter produced a row — so they must agree on the
-  // text, character for character.
+  // Each adapter asserts identity on its own values, which is what makes the
+  // two agree: two functions that both return their input cannot disagree
+  // about it. The Backend adapter carries its own list for the same reason.
   it.each([
     "Vinyl",
     "vinyl",

--- a/tests/unit/lib/features/lml/lml-conversions.test.ts
+++ b/tests/unit/lib/features/lml/lml-conversions.test.ts
@@ -116,7 +116,7 @@ describe("convertLmlItemToAlbumEntry", () => {
   // Pinned by value, not by shape: an `expect.any(String)` assertion here
   // would also pass while the sentinel was being substituted, which is the
   // exact failure this guards.
-  it.each(["Africa", "Asia", "Comedy", "Latin", "Spoken", "Xmas"])(
+  it.each(["Africa", "Asia", "Comedy", "Latin", "Spoken", "Xmas", "Country"])(
     "should carry the genre %s through even though no chip color is defined for it",
     (genre) => {
       const item = createTestLmlLibraryItem({ genre });
@@ -144,13 +144,6 @@ describe("convertLmlItemToAlbumEntry", () => {
     expect(convertLmlItemToAlbumEntry(item).artist.genre).toBe("");
   });
 
-  it("should carry a genre dj-site has never heard of through unmodified", () => {
-    // The genre table grows without a dj-site deploy, so a value this build
-    // doesn't recognize is a genre added since it shipped, not one to discard.
-    const item = createTestLmlLibraryItem({ genre: "Country" });
-    const result = convertLmlItemToAlbumEntry(item);
-    expect(result.artist.genre).toBe("Country");
-  });
 
   it("should default a missing label to empty string", () => {
     const item = createTestLmlLibraryItem();

--- a/tests/unit/lib/features/lml/lml-conversions.test.ts
+++ b/tests/unit/lib/features/lml/lml-conversions.test.ts
@@ -125,6 +125,25 @@ describe("convertLmlItemToAlbumEntry", () => {
     },
   );
 
+  // The fallback exists for a row with NO genre, and before this its only
+  // exercise was a test asserting the defect -- that a real-but-unstyled genre
+  // became "Unknown" -- so replacing that with passthrough cases alone left the
+  // branch deletable with a green suite.
+  it("falls back to Unknown for a null genre", () => {
+    const item = createTestLmlLibraryItem({ genre: null });
+    expect(convertLmlItemToAlbumEntry(item).artist.genre).toBe("Unknown");
+  });
+
+  // An empty string is NOT absence, and must not be collapsed into the
+  // sentinel here. The classic screens are a xerox of the JSPs, whose <c:out>
+  // prints nothing for an empty genre; MissingReleases pins that. Degrading an
+  // empty genre is the presentation layer's job -- see genreTone and
+  // ArtistAvatar -- not the adapter's.
+  it("passes an empty genre through rather than inventing the sentinel", () => {
+    const item = createTestLmlLibraryItem({ genre: "" });
+    expect(convertLmlItemToAlbumEntry(item).artist.genre).toBe("");
+  });
+
   it("should carry a genre dj-site has never heard of through unmodified", () => {
     // The genre table grows without a dj-site deploy, so a value this build
     // doesn't recognize is a genre added since it shipped, not one to discard.

--- a/tests/unit/lib/features/lml/lml-conversions.test.ts
+++ b/tests/unit/lib/features/lml/lml-conversions.test.ts
@@ -76,19 +76,41 @@ describe("convertLmlItemToAlbumEntry", () => {
     expect(result.alternate_artist).toBe("");
   });
 
+  // The format vocabulary is server-owned — GET /library/formats is the
+  // authority and a music director creates a format by typing its name — so
+  // the adapter must carry the value through as sent. Collapsing it onto a
+  // locally-known set both erases formats the station really files under
+  // ("Cassette") and rewrites recognised ones ("12\" Vinyl" -> "Vinyl").
+  //
+  // Pinned by value, not by shape: an `expect.any(String)` assertion here
+  // would also pass while values were being rewritten, which is the exact
+  // failure this guards.
+  //
+  // The same table runs against the Backend adapter in conversions.test.ts.
+  // Both write this one field, the picker interleaves rows from both, and a
+  // DJ cannot tell which adapter produced a row — so they must agree on the
+  // text, character for character.
   it.each([
-    ["Vinyl LP", "Vinyl"],
-    ["vinyl", "Vinyl"],
-    ["12\" Vinyl", "Vinyl"],
-    ["CD", "CD"],
-    ["cd", "CD"],
-    ["CD-R", "CD"],
-    ["Cassette", "Unknown"],
-    ["", "Unknown"],
-  ] as const)("should normalize format %s to %s", (input, expected) => {
-    const item = createTestLmlLibraryItem({ format: input });
+    "Vinyl",
+    "vinyl",
+    "Vinyl LP",
+    '12" Vinyl',
+    "CD",
+    "cd",
+    "CD-R",
+    "Cassette",
+    "7-inch Single",
+  ])("carries the format %s through unmodified", (format) => {
+    const item = createTestLmlLibraryItem({ format });
     const result = convertLmlItemToAlbumEntry(item);
-    expect(result.format).toBe(expected);
+    expect(result.format).toBe(format);
+  });
+
+  // An empty string is NOT absence, and must not be collapsed into the
+  // sentinel here — same rule the genre field follows, for the same reason.
+  it("passes an empty format through rather than inventing the sentinel", () => {
+    const item = createTestLmlLibraryItem({ format: "" });
+    expect(convertLmlItemToAlbumEntry(item).format).toBe("");
   });
 
   it.each([

--- a/tests/unit/lib/features/lml/lml-conversions.test.ts
+++ b/tests/unit/lib/features/lml/lml-conversions.test.ts
@@ -101,16 +101,36 @@ describe("convertLmlItemToAlbumEntry", () => {
     "Reggae",
     "Soundtracks",
     "OCS",
-  ] as const)("should pass through valid genre %s", (genre) => {
+  ] as const)("should pass the genre %s through", (genre) => {
     const item = createTestLmlLibraryItem({ genre });
     const result = convertLmlItemToAlbumEntry(item);
     expect(result.artist.genre).toBe(genre);
   });
 
-  it("should default invalid genre to Unknown", () => {
+  // The library's genre vocabulary is server-owned — GET /library/genres is the
+  // authority, and it lists more genres than the modern experience has chip
+  // colors for. A genre with no designed chip color must still arrive as
+  // itself; substituting the "Unknown" sentinel is data loss, and it makes a
+  // correctly-filed release indistinguishable from one with no genre at all.
+  //
+  // Pinned by value, not by shape: an `expect.any(String)` assertion here
+  // would also pass while the sentinel was being substituted, which is the
+  // exact failure this guards.
+  it.each(["Africa", "Asia", "Comedy", "Latin", "Spoken", "Xmas"])(
+    "should carry the genre %s through even though no chip color is defined for it",
+    (genre) => {
+      const item = createTestLmlLibraryItem({ genre });
+      const result = convertLmlItemToAlbumEntry(item);
+      expect(result.artist.genre).toBe(genre);
+    },
+  );
+
+  it("should carry a genre dj-site has never heard of through unmodified", () => {
+    // The genre table grows without a dj-site deploy, so a value this build
+    // doesn't recognize is a genre added since it shipped, not one to discard.
     const item = createTestLmlLibraryItem({ genre: "Country" });
     const result = convertLmlItemToAlbumEntry(item);
-    expect(result.artist.genre).toBe("Unknown");
+    expect(result.artist.genre).toBe("Country");
   });
 
   it("should default a missing label to empty string", () => {


### PR DESCRIPTION
## What

Separates catalog-data from catalog-presentation for the two fields where dj-site kept a private copy of a server-owned vocabulary — **genre** and **format** — so a value the station actually files under is never silently replaced.

Both fields had the same shape of defect and the same fix, so they ship together: the type widens to `string`, the tone table becomes a presentation lookup that is allowed to miss, and the conversion paths carry the server's text through untouched.

## Genre

dj-site kept its own ten-value `Genre` union and used it as the type of the data. Production has fifteen genres — `GET /library/genres` returned `Africa, Asia, Blues, Classical, Comedy, Hiphop, Jazz, Latin, OCS, Reggae, Rock, Soundtracks, Spoken, Xmas, Electronic` when this was written — so six were outside the union, and the union's `"Unknown"` was not a genre at all but dj-site's own UI fallback sentinel.

Only one of the two conversion paths was lossy. The Backend path cast `genre_name`, so `"Latin"` survived as text and only the chip color fell back. The LML path tested membership in a `Set<Genre>` and returned `"Unknown"` for anything outside it, discarding the real genre — so the same release read correctly via Backend and blank via LML, with nothing in the UI distinguishing the two.

### Changes

- `ArtistEntry.genre` is now `string`, documented as server-owned text that a conversion path must carry through unmodified. `"Unknown"` is documented as the fallback for a row carrying *no* genre, and appears only there.
- Both conversion paths carry the value through: `convertToAlbumEntry` drops the `as Genre` cast, `convertLmlItemToAlbumEntry` drops `VALID_GENRES` / `normalizeGenre`.
- The narrow union survives as `GenreToneKey` in `tokens/roles.ts`, derived from `GENRE_TONES` itself (`keyof typeof`) so the key type and the table cannot drift, and named for what it is: the genres there is a designed chip color for, not a claim about which genres exist. `GENRE_TONES` gains a doc saying a miss is the normal case.
- `ArtistAvatar` reimplemented `genreTone`'s body inline instead of calling it — a second cast site. It now calls `genreTone`, which removes the duplicate.
- `catalogFilterChipStyles` held a third copy of the ten values in `GENRE_KEYS`; it now reads them off `GENRE_TONES` with `Object.keys`.
- `ReleaseChips`'s `genre` prop widens to `string`.

## Format

The same defect, worse in two ways that are visible on screen today.

The format vocabulary is server-owned exactly as the genre vocabulary is: `LibraryFormatRow` / `getFormats` / `addFormat` exist and `FormatAdmin` lets a music director create a format by typing its name. dj-site nonetheless kept `Format = "Vinyl" | "CD" | "Unknown"` and typed `AlbumEntry.format` with it.

**It rewrote recognised values, not just unrecognised ones.** `normalizeFormat` on the LML path erased formats outright (`Cassette` and `7-inch Single` both became `Unknown`) *and* rewrote ones it matched (`12" Vinyl` became `Vinyl`). The Backend path cast rather than narrowed, so the text survived there. Both adapters feed one list — the flowsheet picker interleaves bin, rotation, catalog and LML rows in a single result set — so the two adapters displayed different text for the same release. The genre work's own test comment says a DJ cannot tell which adapter produced a row and therefore they must agree; for format they didn't.

**A live mislabel.** `FlowsheetBackendResult` rendered its format chip as `entry.format.includes("vinyl") ? "vinyl" : "cd"` — case-**sensitive** — against the `"Vinyl"` that `normalizeFormat` emitted. `"Vinyl".includes("vinyl")` is `false`, so every vinyl release rendered a chip that was **vinyl-coloured and labelled "cd"**: the hue came from `formatTone`, which lowercases and was right, while the label next to it was wrong. Verified before the fix, and it is what the rewritten chip test now pins.

Format had **four independent classifiers**: `normalizeFormat` (rewrote the data), `formatTone` (tolerant substring), `formatLabel` (casing-preserving relabel, private to the catalog result chips), and that inline binary. Two survive, both presentation.

### Changes

- `AlbumEntry.format` is now `string`, documented the same way `ArtistEntry.genre` is. The `Format` union is deleted.
- Both conversion paths carry the value through: `convertToAlbumEntry` drops the `as Format` cast, `convertLmlItemToAlbumEntry` drops `normalizeFormat`. Neither collapses an empty string into the sentinel — only `null` does — because the classic screens are a xerox of the JSPs, whose `<c:out>` prints nothing for an empty value.
- `FORMAT_TONES` becomes `satisfies Record<string, FormatTone>` with `FormatToneKey = keyof typeof FORMAT_TONES`, mirroring `GenreToneKey`.
- **`formatTone` deliberately keeps substring matching.** This is the one place the format fix does *not* copy the genre fix: `genreTone` resolves through a case-insensitive `Map` with exact keys, which would be wrong here. `12" Vinyl` is still a record and should still get the vinyl hue, so a fuzzy match is correct for format and the behaviour is unchanged.
- `formatLabel` moves out of `ReleaseChips` and next to `formatTone`, and the picker's inline binary now calls it. Label and hue resolve from the same text, so they cannot disagree about what a release is. Both `ReleaseChips.format` and `ArtistAvatar.format` widen to `string`.

## Out of scope, deliberately

Extending `GENRE_TONES` so `Africa`, `Asia`, `Comedy`, `Latin`, `Spoken`, and `Xmas` get their own chip colors, and extending `FORMAT_TONES` past the two hues that exist. Picking colors is a visual-design call about palette coherence, contrast, and which tones are already load-bearing in the modern experience; it would make this reviewable on two unrelated axes. The untoned values degrade to the neutral fallback chip and render their own name, which already fixes the defect. Tests pin both tables' keys so neither is widened in passing.

## Tests

Written first, failing against the old code — 7 red for genre, 27 for format — then made green.

Genre:

- `lml-conversions.test.ts`: the six untoned genres are carried through, asserted **by value** — an `expect.any(String)` assertion would have passed against the sentinel substitution. Plus a genre dj-site has never heard of (`"Country"`), since the table grows without a deploy. The old "should default invalid genre to Unknown" test asserted the defect and is replaced.
- `conversions.test.ts`: the same six pinned on the Backend path, plus the missing-genre fallback, so the two paths are locked to the same contract.
- `roles.test.ts`: `genreTone` resolves each untoned genre to the neutral fallback, handles `null`/`undefined`, and the tone table's ten keys are pinned.

Format:

- One shared table of nine values — `Vinyl`, `vinyl`, `Vinyl LP`, `12" Vinyl`, `CD`, `cd`, `CD-R`, `Cassette`, `7-inch Single` — runs against **both** adapters (`lml-conversions.test.ts`, `conversions.test.ts`), asserted by value, so they are locked to one contract. Plus null → sentinel and empty-string → empty on each.
- `FlowsheetBackendResult.test.tsx`: the chip is pinned across that same table. Its three old cases asserted the defect (`format: "vinyl" as any // Using lowercase to match component's check`) and are replaced; one new case asserts the vinyl hue and the vinyl label arrive together.
- `roles.test.ts`: `formatLabel` tidies the two attested bare lowercase spellings and preserves everything else; `FORMAT_TONES`'s three keys are pinned; `formatTone`'s doc and test comment now say the substring match is deliberate rather than a workaround for a cast.
- `catalogSearchQueryMatch.test.ts`: the formats filter matches against the row's own text, held once against a hand-built row and once against a row that came through a real adapter — the second case is red without the fix.
- `MissingReleases.test.tsx`: the classic screen prints the row's format verbatim and leaves an empty format's cell empty, mirroring the genre assertion that was already there.

## Blast radius

Smaller than the widening suggests, for both fields.

`Genre` was referenced in six source files plus one unused test-fixture import. Widening `ArtistEntry.genre` to `string` needed no changes at any read site — `catalogSearchQueryMatch`'s genre filter, the classic `SearchResults` / `MissingReleases` cells, `AlbumArtwork`, `Result` / `MobileResult` all already handled arbitrary strings.

`Format` was referenced in five source files. Widening needed changes at three of them and none elsewhere: the classic `SearchResults` / `MissingReleases` cells render `release.format` as a bare string, `FormatFilterAutocomplete` was already typed off `LibraryFormatRow.format_name`, `catalogFilterChipStyles` already delegated to `formatTone`, and `AddReleasePanel` / `AlbumEditForm` write `format_id`, not the name. `tsc --noEmit` is clean.

The client-side filters in `catalogSearchQueryMatch` improve as a side effect, for both fields. Filtering by `Latin` previously excluded LML-sourced Latin releases, and filtering by `12" Vinyl` could match nothing at all from the LML path, because the value had already been rewritten before the filter saw it. The matcher itself needed no change — it compares the filter's server text against the row's, which is now the same text.

## Local CI

Green: `npm run lint` (0 errors; 192 pre-existing warnings, one fewer than `main` after the dead import went), `npx tsc --noEmit`, `npx vitest run` (336 files, 4876 tests), `npm run build` + `check-catalog-first-load.mjs`, `npm run test:scripts`.

Closes #1242
