### PR TITLE
ci(e2e): raise the shard timeout to 20 minutes to fit the observed build tail

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -124,7 +124,21 @@ jobs:
       github.event_name != 'pull_request'
       || (needs.changes.outputs.app_source == 'true' && github.base_ref == 'main')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 20, not 15. The cap has to cover the slowest healthy shard, and "healthy"
+    # spans a wider range than the old number assumed: in a single run, with all
+    # four shards on identical cache state, `Build and start services` took 82s,
+    # 123s, 129s and 740s. The 740s shard was not cold and not on a branch that
+    # touches `package-lock.json` -- it just built nine times slower than its
+    # siblings for reasons we cannot yet name. At 15 minutes that shard has
+    # ~160s left for the tests and gets cancelled, and a cancelled shard reports
+    # no failed step and no annotation, so it reads as an infrastructure shrug
+    # rather than a signal.
+    #
+    # This is a bandaid over unexplained build variance, not a tuned number.
+    # Raising it trades a slower kill on a genuinely hung shard for not paying a
+    # full four-shard rerun every time the tail lands long. Narrowing the
+    # variance itself is the real fix.
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -297,7 +311,7 @@ jobs:
           # so hashing the entire dependency graph meant one unrelated
           # devDependency bump re-downloaded Chromium on all four shards at
           # once -- which, combined with a simultaneously-cold Next build, is
-          # what pushed shards past `timeout-minutes: 15`.
+          # what pushed shards past the job timeout.
           #
           # No `restore-keys` here on purpose. A partial restore would leave a
           # browser set from a different release in place, and the install step


### PR DESCRIPTION
Closes #1241.

## What changed

`timeout-minutes` on the E2E shard job: **15 -> 20**, with the reasoning inline so it does not have to be re-derived. Also drops a now-stale `timeout-minutes: 15` reference from the Playwright cache comment, which would otherwise contradict the value fourteen lines above it.

That is the whole diff: 16 insertions, 2 deletions, all in `.github/workflows/e2e-tests.yml`, of which 14 lines are the comment.

## Why 20, and why the ticket's own reasoning was wrong

#1241 said: a lockfile change busts both caches, the cold build overruns the cap, the shard is cancelled. #1247 fixed the Playwright half of that and it holds.

But that model does not explain the worst shard. In one run, all four shards on **identical cache state**, `Build and start services` measured:

| Shard | Duration |
|---|---|
| 1 | 82s |
| 2 | 123s |
| 3 | 129s |
| 4 | **740s** |

Shard 4 was warm, on a branch that does not touch `package-lock.json`. Neither cause the cap was blamed on was present. It had ~160s of its 900s budget left for the tests and was cancelled.

So the cap is not mainly undersized for cold builds. It is undersized for a warm build that runs nine times slower than its siblings on the same inputs.

## What this is honestly not

**It does not satisfy #1241's second acceptance criterion as written.** That criterion asks for a measured *cold* shard duration; no genuinely-cold shard was measured. The number comes from the warm tail instead, which is the larger of the two costs actually observed. Flagging that rather than quietly reinterpreting the criterion to match what I have.

**It is a bandaid, and the comment in the workflow says so.** Raising a cap to fit unexplained variance strictly worsens one side of the trade: a genuinely hung shard now burns 20 minutes across four shards before the kill. What it buys is not paying a full four-shard rerun every time the tail lands long — and a cancelled shard is the expensive kind of red, because `gh run view --log-failed` returns nothing for it and there is no annotation, so the reflex response is to rerun the matrix and learn nothing.

The real work is #1257: instrument per-shard timing, runner fingerprint and cache-restore level, collect across real runs, then set the cap from a measured distribution instead of from the worst thing anyone happened to see.

## Verification

Workflow-only change, so the source test suites are not the relevant gate.

- `actionlint` reports **7 shellcheck findings on this branch and 7 on `origin/main`** — identical set, all in `run:` blocks this diff does not touch. Nothing introduced.
- YAML parses, and `jobs.e2e.timeout-minutes` reads back as `20`.
- No hardcoded `15` left anywhere in the file.
- `.github/workflows/e2e-tests.yml` is in the `app_source` paths filter, so this PR's own matrix does run and exercises the new cap. Expect it to sit one Next restore-key deep by design: editing this file invalidates the primary cache key, because the `NEXT_PUBLIC_*` env block is inlined into the build.
