### PR TITLE
feat(classic): build the librarian artist card

### DIFF
--- a/app/dashboard/@classic/library/artist/[id]/page.tsx
+++ b/app/dashboard/@classic/library/artist/[id]/page.tsx
@@ -1,0 +1,57 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getPageTitle } from "@/lib/utils/page-title";
+import { requireAuth, requireRole } from "@/lib/features/authentication/server-utils";
+import { Authorization } from "@/lib/features/admin/types";
+import Main from "@/src/components/experiences/classic/Layout/Main";
+import ArtistCard from "@/src/components/experiences/classic/catalog/ArtistCard";
+import { firstSearchParam } from "@/lib/utils/search-params";
+
+export const metadata: Metadata = {
+  title: getPageTitle("View an Artist Card"),
+};
+
+/**
+ * `ArtistAdminServlet:187`'s confirmation, carried onto this card after a
+ * create. Selected by a flag rather than passed as text: the JSP's message is
+ * a fixed server string, and taking it from the URL would let any link put
+ * arbitrary words in the station's own voice at the top of a catalog screen.
+ */
+const CREATED_MESSAGE = "The artist/library code below has been added to the database.";
+
+type ClassicArtistCardPageProps = {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ created?: string | string[] }>;
+};
+
+/**
+ * Reproduces `libraryAdmin/artistCardModify.jsp`, gated to `hasAdminAccess()`
+ * per `mainmenu.jsp:32-37`.
+ */
+export default async function ClassicArtistCardPage({
+  params,
+  searchParams,
+}: ClassicArtistCardPageProps) {
+  const session = await requireAuth();
+  await requireRole(session, Authorization.MD);
+
+  const { id } = await params;
+  const artistId = Number(id);
+  // A non-numeric segment would otherwise reach the card as NaN and request
+  // `/library/artists/NaN`, which the backend answers 400 -- rendering as
+  // "this card could not be loaded" for what is really a wrong URL.
+  if (!Number.isInteger(artistId) || artistId <= 0) {
+    notFound();
+  }
+
+  const created = firstSearchParam((await searchParams).created);
+
+  return (
+    <Main>
+      <ArtistCard
+        artistId={artistId}
+        message={created === "1" ? CREATED_MESSAGE : undefined}
+      />
+    </Main>
+  );
+}

--- a/app/dashboard/@classic/library/artist/[id]/view/page.tsx
+++ b/app/dashboard/@classic/library/artist/[id]/view/page.tsx
@@ -1,0 +1,40 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getPageTitle } from "@/lib/utils/page-title";
+import { requireAuth } from "@/lib/features/authentication/server-utils";
+import Main from "@/src/components/experiences/classic/Layout/Main";
+import ArtistCardView from "@/src/components/experiences/classic/catalog/ArtistCardView";
+
+export const metadata: Metadata = {
+  title: getPageTitle("View an Artist Card"),
+};
+
+type ClassicArtistViewPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+/**
+ * Reproduces `lucene/artistCardDisplay.jsp` — the destination a catalog result
+ * row's artist name opens (`artist?id=…&mode=view`).
+ *
+ * Authenticated but NOT role-gated, deliberately, and unlike the sibling modify
+ * card: the JSP carries no role check, and catalog search is the DJ-facing
+ * screen in classic, so gating here would bounce every DJ who clicked an artist.
+ */
+export default async function ClassicArtistViewPage({
+  params,
+}: ClassicArtistViewPageProps) {
+  await requireAuth();
+
+  const { id } = await params;
+  const artistId = Number(id);
+  if (!Number.isInteger(artistId) || artistId <= 0) {
+    notFound();
+  }
+
+  return (
+    <Main>
+      <ArtistCardView artistId={artistId} />
+    </Main>
+  );
+}

--- a/app/dashboard/@classic/library/release/[id]/page.tsx
+++ b/app/dashboard/@classic/library/release/[id]/page.tsx
@@ -1,0 +1,47 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getPageTitle } from "@/lib/utils/page-title";
+import { requireAuth, requireRole } from "@/lib/features/authentication/server-utils";
+import { Authorization } from "@/lib/features/admin/types";
+import Main from "@/src/components/experiences/classic/Layout/Main";
+import ReleaseCard from "@/src/components/experiences/classic/catalog/ReleaseCard";
+
+export const metadata: Metadata = {
+  title: getPageTitle("Modify a Library Release Card"),
+};
+
+type ClassicReleasePageProps = {
+  params: Promise<{ id: string }>;
+};
+
+/**
+ * Reproduces `libraryAdmin/libraryReleaseModify.jsp` — the screen a catalog
+ * result's release title opens.
+ *
+ * Admin-gated to match: the JSP renders under `body class="library-admin"` and
+ * every action on it is a librarian action. Catalog search is DJ-facing, so a
+ * DJ who follows a result row's release title lands on a screen they cannot
+ * open — which is what the legacy interface does too. An ungated read-only
+ * release view for DJs is a different screen, not a relaxation of this gate.
+ */
+export default async function ClassicReleasePage({
+  params,
+}: ClassicReleasePageProps) {
+  const session = await requireAuth();
+  await requireRole(session, Authorization.MD);
+
+  const { id } = await params;
+  const albumId = Number(id);
+  // A non-numeric segment would otherwise reach the card as NaN and request
+  // `/library/info?album_id=NaN`, rendering a load failure for what is really
+  // a wrong URL. Matches the artist card's guard.
+  if (!Number.isInteger(albumId) || albumId <= 0) {
+    notFound();
+  }
+
+  return (
+    <Main>
+      <ReleaseCard albumId={albumId} />
+    </Main>
+  );
+}

--- a/e2e/tests/classic/catalog-scroll.spec.ts
+++ b/e2e/tests/classic/catalog-scroll.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Drives the mouse wheel rather than scrollIntoView: an `overflow: hidden` box
+ * still has a scrollport, so programmatic scrolling succeeds on a page the user
+ * has no way to scroll. Only a real scroll container answers the wheel.
+ *
+ * The shell clips its own overflow so the dashboard can own internal scroll
+ * regions. Modern carries those inside its panels; classic is plain HTML and
+ * has none, so a result list longer than the viewport is unreachable unless the
+ * classic container is itself a scrollport.
+ */
+test.describe("Classic catalog overflow", () => {
+  test("scrolls to the last result on a short viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 500 });
+    // A query broad enough that the result table exceeds the viewport.
+    await page.goto("/dashboard/catalog?searchString=james");
+
+    const rows = page.locator("#liveResults table.entry-table tbody tr");
+    await expect(rows.first()).toBeVisible();
+    const lastRow = rows.last();
+    await expect(lastRow).not.toBeInViewport();
+
+    await page.mouse.move(512, 250);
+    await page.mouse.wheel(0, 4000);
+
+    await expect(lastRow).toBeInViewport();
+  });
+});

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -18,6 +18,9 @@ import {
   AlbumEntry,
   AlbumSearchResultJSON,
   AlbumRequestParams,
+  ArtistCard,
+  ArtistReleasesQuery,
+  ArtistReleasesResponse,
   CompilationTrackInput,
   CompilationTrackList,
   CompilationTrackSuggestions,
@@ -31,6 +34,7 @@ import {
   SearchArtistsInGenreResponse,
   SearchCatalogQueryParams,
   UpdateAlbumRequestBody,
+  UpdateArtistRequestBody,
 } from "./types";
 
 type LibraryQueryResponseJSON = {
@@ -69,7 +73,7 @@ function transformLibraryQueryResponse(
 export const catalogApi = createApi({
   reducerPath: "catalogApi",
   baseQuery: backendBaseQuery("library"),
-  tagTypes: ["Rotation", "AlbumDetail", "CatalogList", "ArtistSearch", "FormatList", "GenreList", "ArtistCodePeek", "CompilationTracks"],
+  tagTypes: ["Rotation", "AlbumDetail", "CatalogList", "ArtistSearch", "FormatList", "GenreList", "ArtistCodePeek", "CompilationTracks", "ArtistCard", "ArtistReleaseList"],
   endpoints: (builder) => ({
     searchCatalog: builder.query<AlbumEntry[], SearchCatalogQueryParams>({
       query: ({ artist_name, album_title, n, on_streaming }) => ({
@@ -146,7 +150,23 @@ export const catalogApi = createApi({
       // paginated/sorted infinite query, so a new row can't be patched into
       // the cache coherently (its correct page may be unloaded). Invalidate
       // the list instead so the panel refetches.
-      invalidatesTags: [{ type: "CatalogList", id: "LIST" }],
+      //
+      // The artist card's release table is invalidated for a second reason,
+      // not the same one: its shelf order is server-assigned. `POST /library`
+      // derives `code_number` itself (`generateAlbumCodeNumber`, max+1 for the
+      // artist), so the client cannot know where the new row lands, and the
+      // add-release form sits directly above the table it changes. Keyed by
+      // the artist the release was filed under -- when the caller identified
+      // that artist by id. A caller that sent only `artist_name` leaves the
+      // backend to resolve the id, so the specific list to refresh isn't
+      // knowable here; those invalidate the whole tag rather than guessing.
+      invalidatesTags: (_result, _error, body) => [
+        { type: "CatalogList", id: "LIST" },
+        {
+          type: "ArtistReleaseList",
+          id: body.artist_id != null ? String(body.artist_id) : "LIST",
+        },
+      ],
     }),
     updateAlbum: builder.mutation<AlbumEntry, { albumId: number; body: UpdateAlbumRequestBody }>({
       query: ({ albumId, body }) => ({
@@ -245,6 +265,56 @@ export const catalogApi = createApi({
         if (error.status !== 409) return [];
         return isArtistNameConflictData(error.data) ? [] : [codePeekTag];
       },
+    }),
+    /** The header of `/wxycdb`'s artist card (`artistCardModify.jsp`). */
+    getArtistCard: builder.query<ArtistCard, number>({
+      query: (artistId) => ({ url: `/artists/${artistId}` }),
+      // The shared base query soft-fails an unparseable body into a
+      // successful `null` payload. Here that would render as an artist card
+      // with blank names and a blank shelf code -- a screen that looks like a
+      // catalogued artist with missing data rather than like an outage, and
+      // whose add-release form would then file against an id the librarian
+      // was never shown the name of.
+      extraOptions: { surfaceNonJsonAsError: true },
+      providesTags: (_result, _error, artistId) => [
+        { type: "ArtistCard", id: String(artistId) },
+      ],
+    }),
+    /**
+     * `modifyArtist`'s one writable field. See `UpdateArtistRequestBody` for
+     * why the JSP's other four are absent.
+     */
+    updateArtistCard: builder.mutation<
+      { id: number; artist_name: string; alphabetical_name: string },
+      { artistId: number; body: UpdateArtistRequestBody }
+    >({
+      query: ({ artistId, body }) => ({
+        url: `/artists/${artistId}`,
+        method: "PATCH",
+        body,
+      }),
+      // The card refetches so the row reflects what was stored rather than
+      // what was typed -- the backend NFC-normalizes `alphabetical_name` on
+      // write, so the two can legitimately differ.
+      invalidatesTags: (_result, _error, { artistId }) => [
+        { type: "ArtistCard", id: String(artistId) },
+      ],
+    }),
+    /** The artist card's release table, in shelf order. */
+    getArtistReleases: builder.query<ArtistReleasesResponse, ArtistReleasesQuery>({
+      query: ({ artistId, page, limit }) => ({
+        url: `/artists/${artistId}/releases`,
+        params: { ...(page != null ? { page } : {}), ...(limit != null ? { limit } : {}) },
+      }),
+      // Same opt-out as the card above, for the sharper reason: soft-failing
+      // resolves to `{ releases: [] }`, which this screen renders as the JSP's
+      // "The artist does not have any library releases" -- a positive claim
+      // about the shelf. A librarian who believes it files a duplicate.
+      extraOptions: { surfaceNonJsonAsError: true },
+      providesTags: (_result, _error, { artistId }) => [
+        { type: "ArtistReleaseList", id: String(artistId) },
+        { type: "ArtistReleaseList", id: "LIST" },
+      ],
     }),
     peekArtistCode: builder.query<PeekArtistCodeResponse, PeekArtistCodeQuery>({
       query: ({ code_letters, genre_id }) => ({
@@ -454,6 +524,9 @@ export const {
   useAddAlbumMutation,
   useUpdateAlbumMutation,
   useAddArtistMutation,
+  useGetArtistCardQuery,
+  useUpdateArtistCardMutation,
+  useGetArtistReleasesQuery,
   useLazyPeekArtistCodeQuery,
   useSearchArtistsInGenreQuery,
   useGetCompilationTracksQuery,

--- a/lib/features/catalog/libraryCode.ts
+++ b/lib/features/catalog/libraryCode.ts
@@ -38,13 +38,28 @@ export type ReleaseCodeParts = {
 };
 
 /**
- * True for a Various Artists bucket. `ArtistLibraryCode.isVariousArtists()`
- * trims before testing the prefix, so a stored `" Z-X"` is a V/A bucket —
- * reproduced rather than tightened, since the legacy catalog is what supplies
- * these values.
+ * True for a Various Artists bucket.
+ *
+ * Two spellings, because two systems store this differently and only one of
+ * them is upstream of this client:
+ *
+ * - **`V/A`** is what Backend-Service actually serves. The catalog import
+ *   rewrites `Z-<letter>` to the literal `V/A` on the way in, so this is the
+ *   form every compilation on the shelf arrives in — 53 artist rows over
+ *   ~6,300 releases. Matched case- and whitespace-insensitively, since the
+ *   legacy catalog is what supplied these values.
+ * - **`Z-<letter>`** is the legacy spelling, the one
+ *   `ArtistLibraryCode.isVariousArtists()` tests. Kept so a value predating or
+ *   bypassing that rewrite still reads as a compilation rather than as an
+ *   artist whose name happens to start with `Z-`.
+ *
+ * Structural, never a test on the artist's name: the shelf holds
+ * `Various Artists`, `Various Artists - Rock - <A-Z>`, and
+ * `Soundtracks - <A-Z>`, and the last of those contains no "various" at all.
  */
 function isVariousArtists(codeLetters: string): boolean {
-  return codeLetters.trim().startsWith("Z-");
+  const trimmed = codeLetters.trim();
+  return trimmed.toUpperCase() === "V/A" || trimmed.startsWith("Z-");
 }
 
 /**
@@ -64,8 +79,19 @@ export function formatArtistCodeWithPunctuation({
   if (isVariousArtists(code_letters)) {
     const trimmed = code_letters.trim();
     // `callLetters.substring(2, 3)` — the single character after the `Z-`
-    // prefix, which is the Rock/Soundtracks sub-bucket letter.
-    const bucket = genre_id === SOUNDTRACKS_GENRE_ID ? trimmed.substring(2, 3) : "V/A";
+    // prefix, which is the Soundtracks sub-bucket letter.
+    //
+    // Reachable only on the legacy `Z-<letter>` spelling. The `V/A` form
+    // Backend-Service serves has already lost that letter — the import
+    // collapses every `Z-<letter>` to the same three characters. It survives
+    // in the artist's NAME (`Soundtracks - K`), which this screen shows in its
+    // heading, so the sub-bucket stays legible to a librarian; it is simply
+    // not recoverable from the code, and digging it back out of the name is
+    // the name-matching this file exists to avoid.
+    const bucket =
+      genre_id === SOUNDTRACKS_GENRE_ID && trimmed.startsWith("Z-")
+        ? trimmed.substring(2, 3)
+        : "V/A";
     return `${bucket}-`;
   }
   return `${code_letters.toUpperCase()} ${code_artist_number}/`;

--- a/lib/features/catalog/libraryCode.ts
+++ b/lib/features/catalog/libraryCode.ts
@@ -1,0 +1,107 @@
+/**
+ * Shelf-code rendering for the classic librarian screens, reproducing
+ * tubafrenzy's three formatters rule-for-rule:
+ *
+ * - `ArtistLibraryCode.getCallLettersAndNumbersWithPunctuation()` (`:98`)
+ * - `LibraryRelease.getCallNumbersAndLetters()` (`:122`)
+ * - `LibraryRelease.getEntireLibraryCode()` (`:129`)
+ *
+ * These are not cosmetic. The composed string is the physical call number a
+ * librarian reads off the screen and walks to the stacks with, so its
+ * punctuation is part of the catalog's meaning rather than a display choice —
+ * which is why the JSPs are the spec here rather than a starting point, and
+ * why the pieces live in `lib/` rather than inside one screen.
+ *
+ * Backend-Service serves the parts, never the composed string: the artist
+ * half's `code_letters` comes off `artists` and `code_artist_number` off
+ * `genre_artist_crossreference` (it is genre-scoped), while the release half's
+ * `code_number` and `code_volume_letters` come off `library`.
+ */
+
+/**
+ * `GenreId.SOUNDTRACKS`. Hardcoded rather than resolved by name, matching
+ * `chooserValidation.isRockCompLettersRequired`, which hardcodes the same id
+ * for the same reason: the JSPs branch on the id, and a genre rename upstream
+ * must not silently change how a shelf code renders.
+ */
+const SOUNDTRACKS_GENRE_ID = 12;
+
+export type ArtistCodeParts = {
+  code_letters: string;
+  code_artist_number: number;
+  genre_id: number;
+};
+
+export type ReleaseCodeParts = {
+  code_number: number;
+  code_volume_letters: string | null;
+};
+
+/**
+ * True for a Various Artists bucket. `ArtistLibraryCode.isVariousArtists()`
+ * trims before testing the prefix, so a stored `" Z-X"` is a V/A bucket —
+ * reproduced rather than tightened, since the legacy catalog is what supplies
+ * these values.
+ */
+function isVariousArtists(codeLetters: string): boolean {
+  return codeLetters.trim().startsWith("Z-");
+}
+
+/**
+ * The artist half of a call number, with its trailing punctuation: `MO 12/`
+ * for a named artist, `V/A-` for a compilation bucket, and the sub-bucket
+ * letter alone (`X-`) for a Soundtracks compilation.
+ *
+ * The V/A branches drop `code_artist_number` entirely — that is the Java's
+ * behavior, not an omission: a compilation bucket is filed by its letter, so
+ * the artist number never reaches the shelf.
+ */
+export function formatArtistCodeWithPunctuation({
+  code_letters,
+  code_artist_number,
+  genre_id,
+}: ArtistCodeParts): string {
+  if (isVariousArtists(code_letters)) {
+    const trimmed = code_letters.trim();
+    // `callLetters.substring(2, 3)` — the single character after the `Z-`
+    // prefix, which is the Rock/Soundtracks sub-bucket letter.
+    const bucket = genre_id === SOUNDTRACKS_GENRE_ID ? trimmed.substring(2, 3) : "V/A";
+    return `${bucket}-`;
+  }
+  return `${code_letters.toUpperCase()} ${code_artist_number}/`;
+}
+
+/**
+ * The release half of a call number: the number alone, or `NUMBER-LETTERS`
+ * when the release carries volume letters. Blank-not-empty is the Java's test
+ * (`isBlank()`), so a whitespace-only value renders as no volume letter rather
+ * than as a trailing hyphen.
+ */
+export function formatReleaseCode({
+  code_number,
+  code_volume_letters,
+}: ReleaseCodeParts): string {
+  if (!code_volume_letters || code_volume_letters.trim() === "") {
+    return String(code_number);
+  }
+  return `${code_number}-${code_volume_letters.toUpperCase()}`;
+}
+
+/**
+ * The whole call number as the artist card's release table renders it:
+ * genre name, a space, the artist half, then the release half with no
+ * separator — `getEntireLibraryCode()`.
+ *
+ * `genreName` is optional because it is resolved from the genres list, which
+ * can be in flight or unavailable. When it is missing the prefix is dropped
+ * and the rest of the code still renders: a librarian can find a record from
+ * `MO 12/5` without the genre word, and withholding the whole cell would be a
+ * worse answer than an incomplete one.
+ */
+export function formatEntireLibraryCode({
+  genreName,
+  ...parts
+}: ArtistCodeParts & ReleaseCodeParts & { genreName?: string }): string {
+  const code = `${formatArtistCodeWithPunctuation(parts)}${formatReleaseCode(parts)}`;
+  return genreName ? `${genreName} ${code}` : code;
+}

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -123,6 +123,70 @@ export type AddArtistConflict = {
   reason?: "artist_name_conflict";
 };
 
+/**
+ * GET /library/artists/:id — the header of `/wxycdb`'s artist card
+ * (`artistCardModify.jsp`).
+ *
+ * `code_artist_number` is genre-scoped (it lives on
+ * `genre_artist_crossreference`), and the endpoint collapses a multi-genre
+ * artist to its lowest `genre_id`, so `genre_id` here names which genre's code
+ * this is — not merely which genre the artist is filed under.
+ *
+ * Deliberately carries no `last_modified`: the JSP shows a "Time Last
+ * Modified" row for the artist and this endpoint does not project one.
+ */
+export type ArtistCard = {
+  artist_id: number;
+  artist_name: string;
+  alphabetical_name: string;
+  genre_id: number;
+  code_letters: string;
+  code_artist_number: number;
+};
+
+/**
+ * PATCH /library/artists/:id.
+ *
+ * One field, not the JSP's five. The backend **rejects** `artist_name`,
+ * `genre_id`, `code_letters`, and `code_artist_number` with a 400 naming why
+ * rather than dropping them silently, so widening this type would turn a
+ * compile-time constraint into a runtime rejection. `artist_name` is the one
+ * that is merely deferred: renaming an artist moves the nightly catalog
+ * import's `fold_artist_name` match key while that import is still a live
+ * cron, so it waits on the import stopping, not on a missing column.
+ */
+export type UpdateArtistRequestBody = {
+  alphabetical_name: string;
+};
+
+/** One row of the artist card's release table (GET /library/artists/:id/releases). */
+export type ArtistRelease = {
+  id: number;
+  last_modified: string;
+  format_name: string;
+  genre_id: number;
+  code_letters: string;
+  code_artist_number: number;
+  code_number: number;
+  code_volume_letters: string | null;
+  album_title: string;
+  alternate_artist_name: string | null;
+};
+
+export type ArtistReleasesQuery = {
+  artistId: number;
+  page?: number;
+  limit?: number;
+};
+
+export type ArtistReleasesResponse = {
+  artist_id: number;
+  releases: ArtistRelease[];
+  total: number;
+  page: number;
+  totalPages: number;
+};
+
 export type PeekArtistCodeQuery = {
   code_letters: string;
   genre_id: number;

--- a/src/components/experiences/classic/catalog/ArtistCard.tsx
+++ b/src/components/experiences/classic/catalog/ArtistCard.tsx
@@ -1,0 +1,558 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useId, useState } from "react";
+import {
+  useAddAlbumMutation,
+  useGetArtistCardQuery,
+  useGetArtistReleasesQuery,
+  useGetFormatsQuery,
+  useGetGenresQuery,
+  useUpdateArtistCardMutation,
+} from "@/lib/features/catalog/api";
+import {
+  formatArtistCodeWithPunctuation,
+  formatEntireLibraryCode,
+} from "@/lib/features/catalog/libraryCode";
+import type { AddAlbumRequestBody, ArtistRelease } from "@/lib/features/catalog/types";
+import {
+  formatStationDateTime,
+  formatStationLongDate,
+} from "@/src/utilities/stationTime";
+
+type ArtistCardProps = {
+  artistId: number;
+  /**
+   * The confirmation `/wxycdb` carries onto this card after a create
+   * (`ArtistAdminServlet:187`), shown once above the artist's name.
+   */
+  message?: string;
+};
+
+/** `artist-card-modify.js` `validateAddRelease`, verbatim. */
+const EMPTY_TITLE_MESSAGE = "Please enter a title before adding this release.";
+/** `shared/validate-names`, the same text `chooserValidation` reproduces. */
+const EMPTY_ALPHABETICAL_MESSAGE = "The alphabetical name cannot be empty.";
+
+/**
+ * Reproduces `libraryAdmin/artistCardModify.jsp` -- the main working screen of
+ * `/wxycdb` and the one a librarian spends the day on: the artist's details,
+ * the `modifyArtist` name-edit form (`:41`), the add-release form (`:86`), and
+ * the artist's release table (`:126-150`).
+ *
+ * Deliberate divergences, every one forced by the Backend-Service contract
+ * rather than chosen -- where both the JSP's shape and a Backend-Service call
+ * are possible, the JSP wins:
+ *
+ * - **Four of `modifyArtist`'s five fields are read-only.** `PATCH
+ *   /library/artists/:id` allowlists `alphabetical_name` alone and *rejects*
+ *   `artist_name`, `genre_id`, `code_letters`, and `code_artist_number` with a
+ *   400 naming why. Rendering them as editable inputs would offer an
+ *   edit that always fails. `artist_name` is the one that is merely deferred:
+ *   renaming an artist moves the nightly catalog import's `fold_artist_name`
+ *   match key while that import is still a live 30-minute cron, so it waits on
+ *   that import stopping. The other three have no write path anywhere in
+ *   Backend-Service.
+ * - **The genre renders as text, not the JSP's `<select>`.** Same cause: with
+ *   no write path, a dropdown would be a control that cannot commit.
+ * - **No "Time Last Modified" row for the artist.** `GET /library/artists/:id`
+ *   does not project one. Rendering a blank labelled row would read as "never
+ *   modified", which is a claim, so the row is dropped instead.
+ * - **No "Delete The Artist" link.** The JSP offers it only for an artist with
+ *   no releases and no cross-references; Backend-Service has no delete-artist
+ *   endpoint at any privilege (`DELETE /library/:id` deletes a *release*).
+ * - **The add-release form does not take the release call number or volume
+ *   letters.** `POST /library` derives `code_number` itself
+ *   (max+1 for the artist) and has no
+ *   `code_volume_letters` parameter at all, so the JSP's two inputs have
+ *   nothing to submit to. The assigned code is reported back after the save
+ *   instead, which is the fact the librarian actually needs -- it is what goes
+ *   on the sleeve.
+ * - **The add-release form gains a Label field.** `POST /library` requires
+ *   `label`; the JSP's form has no such input. Same precedent as
+ *   `NewArtistForm` adding genre and call letters/numbers because
+ *   `POST /library/artists` requires them.
+ * - **Release titles are plain text.** The JSP links each to
+ *   `libraryReleaseModify.jsp`, a screen this experience does not have yet; a
+ *   link would be a dead one.
+ * - **The cross-reference blocks (`:157-232`) and the "Add Xrefs" links are
+ *   absent.** Write-side cross-reference admin is deliberately not being
+ *   rebuilt, and the read-only display is a separate, non-blocking screen.
+ * - **No sortable column headers.** The JSP's `SortHeaderController` posts a
+ *   sort back to the servlet; `GET /library/artists/:id/releases` takes no
+ *   sort parameter and returns shelf order, which is the order the JSP itself
+ *   defaults to.
+ */
+export default function ArtistCard({ artistId, message }: ArtistCardProps) {
+  const alphabeticalNameId = useId();
+  const presentationNameId = useId();
+  const titleId = useId();
+  const altArtistId = useId();
+  const labelId = useId();
+  const formatId = useId();
+
+  const {
+    data: artist,
+    isLoading: artistLoading,
+    isError: artistError,
+  } = useGetArtistCardQuery(artistId);
+  const {
+    data: releasePage,
+    isError: releasesError,
+  } = useGetArtistReleasesQuery({ artistId });
+  const { data: genres } = useGetGenresQuery();
+  const { data: formats } = useGetFormatsQuery();
+
+  const [updateArtist, { isLoading: savingArtist }] = useUpdateArtistCardMutation();
+  const [addAlbum, { isLoading: savingRelease }] = useAddAlbumMutation();
+
+  const [alphabeticalName, setAlphabeticalName] = useState("");
+  const [artistMessage, setArtistMessage] = useState<string | null>(null);
+
+  const [title, setTitle] = useState("");
+  const [altArtistName, setAltArtistName] = useState("");
+  const [label, setLabel] = useState("");
+  const [formatIdValue, setFormatIdValue] = useState<number | null>(null);
+  const [releaseMessage, setReleaseMessage] = useState<string | null>(null);
+  const [addedCode, setAddedCode] = useState<string | null>(null);
+
+  // Seed the one editable field from the server once the card arrives, and
+  // re-seed after a save so the input shows what was stored rather than what
+  // was typed -- the backend NFC-normalizes on write.
+  useEffect(() => {
+    if (artist) setAlphabeticalName(artist.alphabetical_name);
+  }, [artist]);
+
+  const genreName = genres?.find((genre) => genre.id === artist?.genre_id)?.genre_name;
+
+  // `fn:trim(format.referenceName)` -- the JSP omits blank-named formats from
+  // its dropdown rather than offering an unlabelled option.
+  const selectableFormats = (formats ?? []).filter(
+    (format) => format.format_name.trim() !== "",
+  );
+
+  const artistCode = artist
+    ? formatArtistCodeWithPunctuation({
+        code_letters: artist.code_letters,
+        code_artist_number: artist.code_artist_number,
+        genre_id: artist.genre_id,
+      })
+    : "";
+
+  const handleModifyArtist = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!artist) return;
+
+    if (alphabeticalName.trim() === "") {
+      setArtistMessage(EMPTY_ALPHABETICAL_MESSAGE);
+      return;
+    }
+
+    setArtistMessage(null);
+    try {
+      await updateArtist({
+        artistId,
+        body: { alphabetical_name: alphabeticalName.trim() },
+      }).unwrap();
+    } catch {
+      setArtistMessage("Failed to modify the artist.");
+    }
+  };
+
+  const handleAddRelease = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!artist) return;
+    setAddedCode(null);
+
+    if (title.trim() === "") {
+      setReleaseMessage(EMPTY_TITLE_MESSAGE);
+      return;
+    }
+    if (label.trim() === "") {
+      setReleaseMessage("You must enter a label before adding this release.");
+      return;
+    }
+    if (formatIdValue == null) {
+      setReleaseMessage("You must select a format before adding this release.");
+      return;
+    }
+
+    setReleaseMessage(null);
+
+    // `artist_id`, never `artist_name`: the backend resolves a name through
+    // `artistIdFromName(name, genre_id)`, which would file the release under
+    // whichever artist that fuzzy match returns rather than under the card the
+    // librarian is looking at.
+    const body: AddAlbumRequestBody = {
+      artist_id: artistId,
+      genre_id: artist.genre_id,
+      album_title: title.trim(),
+      label: label.trim(),
+      format_id: formatIdValue,
+      ...(altArtistName.trim() !== ""
+        ? { alternate_artist_name: altArtistName.trim() }
+        : {}),
+    };
+
+    try {
+      const created = await addAlbum(body).unwrap();
+      const codeNumber = created.code_number;
+      setAddedCode(
+        typeof codeNumber === "number"
+          ? formatEntireLibraryCode({
+              genreName,
+              code_letters: artist.code_letters,
+              code_artist_number: artist.code_artist_number,
+              genre_id: artist.genre_id,
+              code_number: codeNumber,
+              code_volume_letters:
+                typeof created.code_volume_letters === "string"
+                  ? created.code_volume_letters
+                  : null,
+            })
+          : null,
+      );
+      setTitle("");
+      setAltArtistName("");
+      setLabel("");
+    } catch {
+      setReleaseMessage("Failed to add the release.");
+    }
+  };
+
+  if (artistError) {
+    return (
+      <div data-testid="artist-card-error" role="alert" className="artist-error-message">
+        This artist card could not be loaded.
+      </div>
+    );
+  }
+
+  if (artistLoading || !artist) {
+    return <div role="status">Loading…</div>;
+  }
+
+  const releases = releasePage?.releases ?? [];
+  const total = releasePage?.total ?? 0;
+
+  return (
+    <>
+      {/* `:26-27`. The third link -- "Add Cross-References From This Artist" --
+          is dropped with the xref blocks below. */}
+      <div className="label" style={{ textAlign: "center" }}>
+        <Link href="/dashboard/catalog" legacyBehavior={false}>
+          Do another search
+        </Link>
+        &nbsp;&nbsp;&nbsp;&nbsp;
+        <Link href="/dashboard/library" legacyBehavior={false}>
+          Find and Create an Artist and/or Library Code
+        </Link>
+      </div>
+
+      <div style={{ textAlign: "center" }}>
+        <h3>ARTIST:&nbsp;{artist.artist_name}&nbsp;</h3>
+      </div>
+      {message && (
+        <div style={{ textAlign: "center" }} role="status">
+          <h5>&nbsp;{message}&nbsp;</h5>
+        </div>
+      )}
+      <hr />
+
+      <form
+        name="modifyArtist"
+        data-testid="modify-artist-form"
+        onSubmit={handleModifyArtist}
+      >
+        <table cellPadding={5} style={{ margin: "0 auto" }}>
+          <tbody>
+            <tr>
+              <td />
+              <td>
+                <b>Modify the Artist:</b>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <label htmlFor={presentationNameId}>
+                  <b>Artist Presentation Name:</b>
+                </label>
+              </td>
+              <td>
+                {/* readOnly rather than removed: the name is the thing the
+                    librarian is checking against the card in their hand, so it
+                    has to stay legible -- a disabled input greys it out. */}
+                <input
+                  id={presentationNameId}
+                  type="text"
+                  size={50}
+                  value={artist.artist_name}
+                  readOnly
+                />
+                <div className="label">
+                  Renaming an artist is not available here yet — the nightly
+                  catalog import still owns this field.
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <label htmlFor={alphabeticalNameId}>
+                  <b>Artist Alphabetical Name:</b>
+                </label>
+              </td>
+              <td>
+                <input
+                  id={alphabeticalNameId}
+                  type="text"
+                  size={50}
+                  value={alphabeticalName}
+                  disabled={savingArtist}
+                  onChange={(e) => setAlphabeticalName(e.target.value)}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Genre:</b>
+              </td>
+              <td>{genreName ?? "…"}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Artist Call Letters:</b>
+              </td>
+              <td>{artist.code_letters}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Artist Call Number:</b>
+              </td>
+              <td>{artist.code_artist_number}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b># of releases:</b>
+              </td>
+              {/* The server's total, not `releases.length`: the table is
+                  paginated, so the row count is a page size. */}
+              <td>{total}</td>
+            </tr>
+            <tr>
+              <td />
+              <td>
+                <div
+                  className={`validation-message${artistMessage ? " visible" : ""}`}
+                  role={artistMessage ? "alert" : undefined}
+                >
+                  {artistMessage}
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td />
+              <td>
+                <input type="submit" value="Modify This Artist" disabled={savingArtist} />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+
+      <hr />
+
+      <form name="addRelease" data-testid="add-release-form" onSubmit={handleAddRelease}>
+        <table cellPadding={5} style={{ margin: "0 auto" }}>
+          <tbody>
+            <tr>
+              <td />
+              <td>
+                <b>Add a Library Release for This Artist:</b>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Library Code:</b>
+              </td>
+              <td>
+                {genreName ?? ""}
+                {artistCode}
+                <span className="label">
+                  &nbsp;— the release number is assigned when you save.
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <label htmlFor={titleId}>
+                  <b>Title of Release:</b>
+                </label>
+              </td>
+              <td>
+                <input
+                  id={titleId}
+                  type="text"
+                  size={50}
+                  value={title}
+                  disabled={savingRelease}
+                  onChange={(e) => setTitle(e.target.value)}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <label htmlFor={altArtistId}>
+                  <b>Alternate Artist Name:</b>
+                </label>
+              </td>
+              <td>
+                <input
+                  id={altArtistId}
+                  type="text"
+                  size={50}
+                  value={altArtistName}
+                  disabled={savingRelease}
+                  onChange={(e) => setAltArtistName(e.target.value)}
+                />
+              </td>
+            </tr>
+            {/* Not in the JSP -- POST /library requires `label`. */}
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <label htmlFor={labelId}>
+                  <b>Label:</b>
+                </label>
+              </td>
+              <td>
+                <input
+                  id={labelId}
+                  type="text"
+                  size={50}
+                  value={label}
+                  disabled={savingRelease}
+                  onChange={(e) => setLabel(e.target.value)}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <label htmlFor={formatId}>
+                  <b>Format:</b>
+                </label>
+              </td>
+              <td>
+                <select
+                  id={formatId}
+                  value={formatIdValue ?? ""}
+                  disabled={savingRelease || selectableFormats.length === 0}
+                  onChange={(e) =>
+                    setFormatIdValue(e.target.value ? Number(e.target.value) : null)
+                  }
+                >
+                  {selectableFormats.map((format) => (
+                    <option key={format.id} value={format.id}>
+                      {format.format_name}
+                    </option>
+                  ))}
+                </select>
+              </td>
+            </tr>
+            <tr>
+              <td />
+              <td>
+                <div
+                  className={`validation-message${releaseMessage ? " visible" : ""}`}
+                  role={releaseMessage ? "alert" : undefined}
+                >
+                  {releaseMessage}
+                </div>
+                {addedCode && (
+                  <div role="status">Filed as {addedCode}.</div>
+                )}
+              </td>
+            </tr>
+            <tr>
+              <td />
+              <td>
+                <input
+                  type="submit"
+                  value="Add a new Library Release"
+                  disabled={savingRelease}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+
+      <hr />
+
+      {releasesError ? (
+        <div
+          data-testid="release-table-error"
+          role="alert"
+          className="artist-error-message"
+        >
+          This artist&apos;s releases could not be loaded, so this is not a
+          complete list of what is on the shelf.
+        </div>
+      ) : (
+        <table className="entry-table" data-testid="artist-release-table">
+          <tbody>
+            {releases.length > 0 ? (
+              <>
+                <tr className="entry-header">
+                  <th style={{ textAlign: "left" }}>Time Last Modified</th>
+                  <th style={{ textAlign: "left" }}>Format</th>
+                  <th style={{ textAlign: "left" }}>Code</th>
+                  <th style={{ textAlign: "left" }}>Title of Release</th>
+                  <th style={{ textAlign: "left" }}>Alternate Artist Name</th>
+                </tr>
+                {releases.map((release: ArtistRelease, index: number) => (
+                  <tr
+                    key={release.id}
+                    className={`entry-row ${index % 2 === 0 ? "entry-row-even" : "entry-row-odd"}`}
+                  >
+                    <td style={{ textAlign: "center" }}>
+                      {formatStationDateTime(release.last_modified).time},{" "}
+                      {formatStationLongDate(release.last_modified)}
+                    </td>
+                    <td>{release.format_name}</td>
+                    <td>
+                      {formatEntireLibraryCode({
+                        genreName: genres?.find((g) => g.id === release.genre_id)
+                          ?.genre_name,
+                        code_letters: release.code_letters,
+                        code_artist_number: release.code_artist_number,
+                        genre_id: release.genre_id,
+                        code_number: release.code_number,
+                        code_volume_letters: release.code_volume_letters,
+                      })}
+                    </td>
+                    <td>{release.album_title}</td>
+                    <td>{release.alternate_artist_name}</td>
+                  </tr>
+                ))}
+              </>
+            ) : (
+              <tr className="entry-header">
+                <th colSpan={5} style={{ textAlign: "center" }}>
+                  The artist does not have any library releases
+                </th>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      )}
+
+      {/* The JSP pages this table through `queryResultsSubset`; the endpoint
+          pages too, and a librarian with more releases than one page must be
+          told rather than shown a silently truncated shelf. */}
+      {total > releases.length && (
+        <div className="label" style={{ textAlign: "center" }}>
+          Showing the first {releases.length} of {total} releases.
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/experiences/classic/catalog/ArtistCardView.tsx
+++ b/src/components/experiences/classic/catalog/ArtistCardView.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import Link from "next/link";
+import {
+  useGetArtistCardQuery,
+  useGetArtistReleasesQuery,
+  useGetGenresQuery,
+} from "@/lib/features/catalog/api";
+import {
+  formatArtistCodeWithPunctuation,
+  formatEntireLibraryCode,
+} from "@/lib/features/catalog/libraryCode";
+
+const RELEASES_PER_PAGE = 100;
+
+/**
+ * "View an Artist Card" — reproduces `lucene/artistCardDisplay.jsp`, the screen
+ * a catalog result's artist name opens.
+ *
+ * Ungated, unlike the librarian's modify card. The JSP carries no role check
+ * and catalog search is the DJ-facing screen, so a DJ who follows a result
+ * row's artist must land on something they can read. The two screens are one
+ * URL in the JSP, separated by `mode=view`; here they are two routes, because
+ * the role gate is a property of the route.
+ *
+ * Divergences:
+ *
+ *  - **Cross-reference blocks omitted.** The JSP renders them below the release
+ *    table, with each cross-referencing artist linking to another view card.
+ *    Read-only cross-reference display is owned separately, for this screen and
+ *    the modify card together.
+ *  - **No sortable column headers.** The JSP's `libcodeHeader` / `titleHeader` /
+ *    `formatHeader` ids drive a client-side sort the release endpoint does not
+ *    expose an ordering parameter for.
+ */
+export default function ArtistCardView({ artistId }: { artistId: number }) {
+  const { data: artist, isLoading, isError } = useGetArtistCardQuery(artistId);
+  const { data: genres } = useGetGenresQuery();
+  const { data: releaseData, isLoading: releasesLoading } = useGetArtistReleasesQuery({
+    artistId,
+    limit: RELEASES_PER_PAGE,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="label" style={{ textAlign: "center" }}>
+        Loading the artist card...
+      </div>
+    );
+  }
+
+  if (isError || !artist) {
+    return (
+      <div data-testid="artist-view-error" role="alert" className="artist-error-message">
+        This artist card could not be loaded.
+      </div>
+    );
+  }
+
+  const genreName = genres?.find((genre) => genre.id === artist.genre_id)?.genre_name;
+  const artistCode = formatArtistCodeWithPunctuation({
+    code_letters: artist.code_letters,
+    code_artist_number: artist.code_artist_number,
+    genre_id: artist.genre_id,
+  });
+  const releases = releaseData?.releases ?? [];
+  const total = releaseData?.total ?? 0;
+
+  return (
+    <div id="searchResultsPanel">
+      <table className="entry-table" style={{ width: "100%" }}>
+        <tbody>
+          <tr className="entry-header">
+            <th style={{ textAlign: "left" }} data-testid="artist-view-code">
+              {genreName ? `${genreName} ` : ""}
+              {artistCode.replace(/-$/, "")}
+            </th>
+            <th style={{ textAlign: "center" }}>{artist.artist_name}</th>
+            <th style={{ textAlign: "right" }}># of releases: {total}</th>
+          </tr>
+        </tbody>
+      </table>
+
+      {releasesLoading ? (
+        <div className="label" style={{ textAlign: "center" }}>
+          Loading releases...
+        </div>
+      ) : total > 0 ? (
+        <>
+          <table className="entry-table" style={{ width: "100%" }}>
+            <thead>
+              <tr className="entry-header">
+                <th style={{ textAlign: "left" }}>Library Code</th>
+                <th style={{ textAlign: "left" }}>Artist</th>
+                <th style={{ textAlign: "left" }}>Title of Release</th>
+                <th style={{ textAlign: "left" }}>Format</th>
+              </tr>
+            </thead>
+            <tbody>
+              {releases.map((release, index) => (
+                <tr
+                  key={release.id}
+                  className={`entry-row ${
+                    index % 2 === 0 ? "entry-row-even" : "entry-row-odd"
+                  }`}
+                >
+                  <td>
+                    {formatEntireLibraryCode({
+                      genreName,
+                      code_letters: release.code_letters,
+                      code_artist_number: release.code_artist_number,
+                      genre_id: release.genre_id,
+                      code_number: release.code_number,
+                      code_volume_letters: release.code_volume_letters,
+                    })}
+                  </td>
+                  {/* The JSP prints the release's own artist string, which
+                      differs from the card's artist on a compilation or an
+                      alternate-artist row. */}
+                  <td>{release.alternate_artist_name || artist.artist_name}</td>
+                  <td>
+                    <Link href={`/dashboard/library/release/${release.id}`}>
+                      {release.album_title}
+                    </Link>
+                  </td>
+                  <td>{release.format_name}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {total > releases.length ? (
+            <div className="live-results-status">
+              Showing the first {releases.length} of {total}.
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <div style={{ textAlign: "center" }}>
+          The artist does not have any library releases.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/experiences/classic/catalog/CreateLibraryCodeForm.tsx
+++ b/src/components/experiences/classic/catalog/CreateLibraryCodeForm.tsx
@@ -19,7 +19,14 @@ type CreateLibraryCodeFormProps = {
   codeNumberRaw: string;
 };
 
-const INTERIM_SUCCESS_DESTINATION = "/dashboard/library";
+/**
+ * `ArtistAdminServlet:188` -- `processAddArtistLibraryCode` lands on the new
+ * artist's card carrying "The artist/library code below has been added to the
+ * database." `created=1` selects that fixed message on the card rather than
+ * putting its text in the URL.
+ */
+const successDestination = (artistId: number) =>
+  `/dashboard/library/artist/${artistId}?created=1`;
 
 // The heading is the servlet's message, and it has two forms
 // (`ArtistAdminServlet:152-155`): a Various Artists code -- call letters
@@ -49,10 +56,6 @@ const ARTIST_HEADING =
  *   requires `code_number`, so a V/A code is filed here with the number it
  *   carried -- and a V/A link that carries none is refused rather than filed
  *   incomplete.
- * - The JSP's successful submit lands on the artist card
- *   (`goToArtistModifyCard`), which does not exist here yet, so this interim
- *   build lands where the chooser's own create path already lands today --
- *   `/dashboard/library` -- and moves to the card once that screen ships.
  *
  * Genre display follows `isGenresUnavailable`'s convention: an unissued or
  * failed genres request renders an explicit unavailable state, never a blank
@@ -158,8 +161,8 @@ export default function CreateLibraryCodeForm({
     };
 
     try {
-      await addArtist(body).unwrap();
-      router.push(INTERIM_SUCCESS_DESTINATION);
+      const created = await addArtist(body).unwrap();
+      router.push(successDestination(created.id));
     } catch (err) {
       // Same discriminant as NewArtistForm's addArtist rejection handling:
       // a taken (code_letters, genre_id, code_number) triple is fixed by

--- a/src/components/experiences/classic/catalog/NewArtistForm.tsx
+++ b/src/components/experiences/classic/catalog/NewArtistForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useId, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   useAddArtistMutation,
   useGetGenresQuery,
@@ -19,6 +20,17 @@ import type { AddArtistRequestBody, PeekArtistCodeQuery } from "@/lib/features/c
 import { useDebouncedValue } from "@/src/hooks/useDebouncedValue";
 
 const PEEK_DEBOUNCE_MS = 150;
+
+/**
+ * `ArtistAdminServlet:188`. This form posts `mode=addArtistLibraryCode`
+ * (`chooseLibraryCodeOrArtist.jsp:62`) -- the same handler
+ * `createLibraryCode.jsp` submits to -- which lands on the new artist's card
+ * carrying "The artist/library code below has been added to the database."
+ * `created=1` selects that fixed message on the card rather than putting its
+ * text in the URL.
+ */
+const successDestination = (artistId: number) =>
+  `/dashboard/library/artist/${artistId}?created=1`;
 
 /**
  * Reproduces `chooseLibraryCodeOrArtist.jsp`'s `newArtistForm`: presentation
@@ -40,6 +52,7 @@ const PEEK_DEBOUNCE_MS = 150;
  * previous genre's series instead of the one about to be submitted.
  */
 export default function NewArtistForm() {
+  const router = useRouter();
   const genreFieldId = useId();
   const presentationNameId = useId();
   const alphabeticalNameId = useId();
@@ -66,7 +79,6 @@ export default function NewArtistForm() {
   const [codeLetters, setCodeLetters] = useState("");
   const [codeNumberRaw, setCodeNumberRaw] = useState("");
   const [validationMessage, setValidationMessage] = useState<string | null>(null);
-  const [added, setAdded] = useState<{ code_letters: string; code_number: number } | null>(null);
 
   const codeNumber = parseRequiredPositiveInt(codeNumberRaw);
 
@@ -98,22 +110,12 @@ export default function NewArtistForm() {
     setValidationMessage(null);
   };
 
-  // The JSP's "Reset values" button also discards the last confirmation, but
-  // a successful submit's own field-clearing must not: it would erase the
-  // "Added as ..." message in the same render that produced it.
-  const handleResetClick = () => {
-    resetFields();
-    setAdded(null);
-  };
-
   const handleCodeLettersChange = (value: string) => {
     setCodeLetters(normalizeCodeLetters(value));
-    setAdded(null);
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setAdded(null);
 
     const nameResult = validateNewArtistNames(presentationName, alphabeticalName);
     if (!nameResult.valid) {
@@ -154,12 +156,8 @@ export default function NewArtistForm() {
     };
 
     try {
-      const result = await addArtist(body).unwrap();
-      setAdded({
-        code_letters: result.code_letters ?? body.code_letters,
-        code_number: result.code_number ?? body.code_number,
-      });
-      resetFields();
+      const created = await addArtist(body).unwrap();
+      router.push(successDestination(created.id));
     } catch (err) {
       // The 409 this endpoint sends has two distinct causes that call for
       // different remedies: a taken (code_letters, genre_id, code_number)
@@ -238,10 +236,7 @@ export default function NewArtistForm() {
                 aria-label="Genre"
                 value={genreId ?? ""}
                 disabled={isLoading || genresUnavailable}
-                onChange={(e) => {
-                  setGenreId(e.target.value ? Number(e.target.value) : null);
-                  setAdded(null);
-                }}
+                onChange={(e) => setGenreId(e.target.value ? Number(e.target.value) : null)}
               >
                 <option value="" disabled>
                   Select genre...
@@ -287,10 +282,7 @@ export default function NewArtistForm() {
                 type="text"
                 value={codeNumberRaw}
                 disabled={isLoading}
-                onChange={(e) => {
-                  setCodeNumberRaw(e.target.value);
-                  setAdded(null);
-                }}
+                onChange={(e) => setCodeNumberRaw(e.target.value)}
                 size={3}
               />
               {peekArg && (
@@ -310,19 +302,13 @@ export default function NewArtistForm() {
               >
                 {validationMessage}
               </div>
-              {added && (
-                <div role="status">
-                  Added as {added.code_letters}
-                  {added.code_number}.
-                </div>
-              )}
             </td>
           </tr>
         </tbody>
       </table>
       <input type="submit" value="Submit" disabled={isLoading} />
       &nbsp;&nbsp;&nbsp;&nbsp;
-      <input type="button" value="Reset values" onClick={handleResetClick} disabled={isLoading} />
+      <input type="button" value="Reset values" onClick={resetFields} disabled={isLoading} />
     </form>
   );
 }

--- a/src/components/experiences/classic/catalog/ReleaseCard.tsx
+++ b/src/components/experiences/classic/catalog/ReleaseCard.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  useGetFormatsQuery,
+  useGetInformationQuery,
+  useMarkFoundMutation,
+  useMarkMissingMutation,
+  useUpdateAlbumMutation,
+} from "@/lib/features/catalog/api";
+import { formatEntireLibraryCode } from "@/lib/features/catalog/libraryCode";
+import { formatStationDateTime } from "@/src/utilities/stationTime";
+import Tracklist from "./Tracklist";
+
+/**
+ * "View/Modify a Library Release" — the screen a catalog result's release title
+ * opens, reproducing `libraryAdmin/libraryReleaseModify.jsp`.
+ *
+ * Divergences, each forced by what Backend-Service serves rather than chosen:
+ *
+ *  - **Release Call Number and Release Call Letter are read-only.** The JSP
+ *    edits both. `PATCH /library/:id` accepts neither, so rendering them as
+ *    inputs would offer an edit that silently discards.
+ *  - **Album Artist is read-only**, for the same reason: not in the PATCH body.
+ *  - **No "Delete This Library Release".** There is no delete endpoint.
+ *  - **No "Change the Library Code / Artist Code of This Library Release"**, and
+ *    no "Undo Last Change" — none has an endpoint behind it.
+ *  - **Cross-reference blocks and "Add Xrefs" omitted.** Write-side
+ *    cross-reference admin is frozen; read-only display is owned separately,
+ *    for this screen and the artist card together.
+ *  - **The Artist cell is text, not a link.** The JSP links it to a card with
+ *    no role gate; ours is gated, so the link lands when the ungated view card
+ *    does.
+ *  - **"Time Last Modified" is replaced by "Date Added".** Backend returns
+ *    `last_modified`, but the published contract does not declare it and the
+ *    conversion to the client row therefore drops it. Reading it anyway would
+ *    mean an untyped cast — the pattern that turns a contract gap into a
+ *    silent `undefined` — and printing the add date under the JSP's label
+ *    would be worse than printing it under a true one.
+ */
+export default function ReleaseCard({ albumId }: { albumId: number }) {
+  const { data, isLoading, isError } = useGetInformationQuery({ album_id: albumId });
+  const { data: formats } = useGetFormatsQuery();
+  const [updateAlbum, { isLoading: saving }] = useUpdateAlbumMutation();
+  const [markMissing, { isLoading: markingMissing }] = useMarkMissingMutation();
+  const [markFound, { isLoading: markingFound }] = useMarkFoundMutation();
+
+  const [title, setTitle] = useState("");
+  const [altArtist, setAltArtist] = useState("");
+  const [formatId, setFormatId] = useState<number | "">("");
+  const [message, setMessage] = useState("");
+
+  // The form mirrors server state until the librarian edits it; re-syncing on a
+  // new row is the only reason this effect exists.
+  useEffect(() => {
+    if (!data) return;
+    setTitle(data.title);
+    setAltArtist(data.alternate_artist ?? "");
+    setFormatId(data.format_id ?? "");
+  }, [data]);
+
+  if (isLoading) {
+    return (
+      <div className="label" style={{ textAlign: "center" }}>
+        Loading the release...
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div data-testid="release-card-error" role="alert" className="artist-error-message">
+        This release could not be loaded.
+      </div>
+    );
+  }
+
+  // `code_volume_letters` is null rather than omitted: `GET /library/info` does
+  // not project it, so a multi-volume release shows `5` where the artist card's
+  // release table shows `5-A`. `genre_id` falls back to 0, which is not the
+  // Soundtracks id, so an absent genre takes the ordinary V/A branch.
+  const entireLibraryCode = formatEntireLibraryCode({
+    genreName: data.artist.genre,
+    code_letters: data.artist.lettercode,
+    code_artist_number: data.artist.numbercode,
+    genre_id: data.genre_id ?? 0,
+    code_number: data.entry,
+    code_volume_letters: null,
+  });
+
+  const displayArtist = data.album_artist ? "Various Artists" : data.artist.name;
+  const artistCode = `${data.artist.lettercode} ${data.artist.numbercode}`;
+  const missing = !!data.date_lost && !data.date_found;
+  const added = data.add_date ? formatStationDateTime(data.add_date) : undefined;
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!title.trim()) {
+      setMessage("Please enter a title for this release.");
+      return;
+    }
+    try {
+      await updateAlbum({
+        albumId,
+        body: {
+          album_title: title.trim(),
+          alternate_artist_name: altArtist.trim() === "" ? null : altArtist.trim(),
+          ...(formatId === "" ? {} : { format_id: Number(formatId) }),
+        },
+      }).unwrap();
+      setMessage("This library release has been modified.");
+    } catch {
+      setMessage("This library release could not be modified.");
+    }
+  };
+
+  const toggleMissing = async () => {
+    try {
+      if (missing) {
+        await markFound({ albumId }).unwrap();
+        setMessage("This library release has been marked as found.");
+      } else {
+        await markMissing({ albumId }).unwrap();
+        setMessage("This library release has been marked as missing.");
+      }
+    } catch {
+      setMessage("The library status could not be changed.");
+    }
+  };
+
+  return (
+    <div id="releaseCard">
+      <div className="label" style={{ textAlign: "center" }}>
+        <a href="/dashboard/catalog">Do another search</a>
+        &nbsp;&nbsp;&nbsp;&nbsp;
+        <a href="/dashboard/library">Find and Create an Artist and/or Library Code</a>
+      </div>
+
+      <div style={{ textAlign: "center" }}>
+        <h3>
+          LIBRARY RELEASE: &nbsp;{entireLibraryCode}&nbsp;-&nbsp;{displayArtist} - {data.title}
+        </h3>
+      </div>
+
+      <div style={{ textAlign: "center" }}>
+        <h3 data-testid="release-message">&nbsp;{message}&nbsp;</h3>
+      </div>
+
+      <form name="modifyRelease" onSubmit={handleSubmit}>
+        <table cellPadding={5}>
+          <tbody>
+            <tr>
+              <td></td>
+              <td>
+                <h3>View/Modify a Library Release</h3>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Entire Code For Library Release:</b>
+              </td>
+              <td data-testid="release-library-code">{entireLibraryCode}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Artist:</b>
+              </td>
+              <td>
+                {artistCode} - {displayArtist}
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Release Call Number:</b>
+              </td>
+              <td data-testid="release-call-number">{data.entry}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Album Artist:</b>
+              </td>
+              <td>{data.album_artist ?? ""}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Alternate Artist Name:</b>
+              </td>
+              <td>
+                <input
+                  type="text"
+                  name="altArtistName"
+                  size={50}
+                  aria-label="Alternate Artist Name"
+                  value={altArtist}
+                  onChange={(event) => setAltArtist(event.target.value)}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Title of Release:</b>
+              </td>
+              <td>
+                <input
+                  type="text"
+                  name="title"
+                  size={60}
+                  aria-label="Title of Release"
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Format:</b>
+              </td>
+              <td>
+                <select
+                  name="formatID"
+                  aria-label="Format"
+                  value={formatId}
+                  onChange={(event) =>
+                    setFormatId(event.target.value === "" ? "" : Number(event.target.value))
+                  }
+                >
+                  {(formats ?? []).map((format) => (
+                    <option key={format.id} value={format.id}>
+                      {format.format_name}
+                    </option>
+                  ))}
+                </select>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Date Added:</b>
+              </td>
+              <td>{added ? `${added.time} ${added.day}` : ""}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Library Status:</b>
+              </td>
+              <td data-testid="release-library-status">
+                {missing ? (
+                  <span style={{ color: "red", fontWeight: "bold" }}>
+                    Missing since {formatStationDateTime(data.date_lost as string).day}
+                  </span>
+                ) : (
+                  "In Library"
+                )}
+                &nbsp;&nbsp;
+                <button
+                  type="button"
+                  className="label"
+                  onClick={toggleMissing}
+                  disabled={markingMissing || markingFound}
+                >
+                  {missing ? "Mark as Found" : "Mark as Missing"}
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td></td>
+              <td>
+                <input
+                  type="submit"
+                  value="Modify this Library Release"
+                  disabled={saving}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+
+      <Tracklist
+        albumId={albumId}
+        legacyReleaseId={data.legacy_release_id}
+        variousArtists={!!data.album_artist}
+      />
+    </div>
+  );
+}

--- a/src/components/experiences/classic/catalog/SearchResults.tsx
+++ b/src/components/experiences/classic/catalog/SearchResults.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSearchCatalogQuery } from "@/lib/features/catalog/api";
 import { MatchedTrackChips } from "./MatchedTrackChips";
@@ -127,12 +128,52 @@ export default function SearchResults() {
                 {result.entry}
               </td>
               <td>
-                {result.album_artist
-                  ? "Various Artists"
-                  : result.artist?.name || "Unknown"}
+                {/*
+                  The artist name links to the ungated view card, mirroring
+                  `card-catalog-search`'s `<a href="artist?id=…&mode=view">` —
+                  the view card, not the librarian's modify card, because this
+                  table is DJ-facing.
+
+                  `artist.id` is only present once the search response carries
+                  `artist_id`; a row without it renders as plain text rather
+                  than a link to an unresolvable id.
+                */}
+                {result.artist?.id ? (
+                  <Link href={`/dashboard/library/artist/${result.artist.id}/view`}>
+                    {result.album_artist
+                      ? "Various Artists"
+                      : result.artist.name || "Unknown"}
+                  </Link>
+                ) : result.album_artist ? (
+                  "Various Artists"
+                ) : (
+                  result.artist?.name || "Unknown"
+                )}
               </td>
               <td>
-                {result.title}
+                {/*
+                  The release title links to the classic release view,
+                  mirroring `card-catalog-search`'s
+                  `<a href="libraryRelease?id=…">`.
+
+                  NOT `/dashboard/album/[id]`: that URL has no page in either
+                  experience slot — both fall through to `default.tsx` and
+                  render `ExperienceGap`. Its album card exists only as the
+                  `@information` slot's client-side portal, so it survives a
+                  soft navigation and breaks on reload, bookmark, or paste.
+
+                  Guarded on a positive id: `convertToAlbumEntry` synthesizes a
+                  NEGATIVE id (a hash, or a contentless counter) for a row with
+                  no Backend `library.id` behind it, and there is no album card
+                  to route to for those. They stay plain text.
+                */}
+                {result.id != null && result.id > 0 ? (
+                  <Link href={`/dashboard/library/release/${result.id}`}>
+                    {result.title}
+                  </Link>
+                ) : (
+                  result.title
+                )}
                 {result.on_streaming === false && (
                   <>
                     {" "}

--- a/src/components/experiences/classic/catalog/Tracklist.tsx
+++ b/src/components/experiences/classic/catalog/Tracklist.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useGetCompilationTracksQuery } from "@/lib/features/catalog/api";
+import { useGetLibraryTracksQuery } from "@/lib/features/metadata/api";
+
+type TracklistProps = {
+  /** Backend's `library.id` — the key the per-track credit store is keyed by. */
+  albumId: number;
+  /**
+   * The row's tubafrenzy `LIBRARY_RELEASE_ID`. A **different id space** from
+   * `albumId`, and the only one the Discogs-backed tracks endpoint accepts:
+   * it resolves the path param against `library.legacy_release_id`. The two
+   * spaces are nearly coextensive, so passing the wrong one does not fail — it
+   * returns a real but unrelated release's tracklist with a 200. `null` where
+   * the row has no legacy id, in which case that source is skipped rather than
+   * queried with a placeholder.
+   */
+  legacyReleaseId: number | null;
+  /** True for a compilation, which is the only case with per-track artists. */
+  variousArtists: boolean;
+};
+
+/**
+ * Release tracklist, reproducing `tracklist.js`'s markup and copy.
+ *
+ * Two sources, because the legacy servlet's single endpoint has no single
+ * equivalent here: per-track credits for a compilation are librarian-entered
+ * and stored locally, while an ordinary release's tracklist is resolved
+ * through Discogs. The compilation source is preferred when it has rows, since
+ * it is the only one carrying a per-track artist — the column the legacy
+ * renderer adds exactly when the release is various-artists and at least one
+ * track names an artist.
+ */
+export default function Tracklist({
+  albumId,
+  legacyReleaseId,
+  variousArtists,
+}: TracklistProps) {
+  const { data: compilation, isLoading: compilationLoading } =
+    useGetCompilationTracksQuery({ libraryId: albumId }, { skip: !variousArtists });
+
+  const { data: discogs, isLoading: discogsLoading } = useGetLibraryTracksQuery(
+    legacyReleaseId as number,
+    { skip: legacyReleaseId === null || legacyReleaseId <= 0 },
+  );
+
+  const compilationTracks = compilation?.tracks ?? [];
+  const rows =
+    compilationTracks.length > 0
+      ? compilationTracks.map((track, index) => ({
+          position: track.track_position ?? String(index + 1),
+          artist: track.artist_name ?? "",
+          title: track.track_title ?? "",
+        }))
+      : (discogs?.tracks ?? []).map((track, index) => ({
+          position: track.position || String(index + 1),
+          artist: track.artist_credit ?? "",
+          title: track.title,
+        }));
+
+  if (compilationLoading || discogsLoading) {
+    return (
+      <div id="tracklistContainer">
+        <p className="tracklist-loading">Loading tracklist...</p>
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div id="tracklistContainer">
+        <p className="tracklist-empty">No tracklist available.</p>
+      </div>
+    );
+  }
+
+  // The legacy renderer shows the artist column only when the release is
+  // various-artists AND at least one track actually names an artist — a
+  // compilation whose credits were never entered gets two columns, not a
+  // column of blanks.
+  const showArtist = variousArtists && rows.some((row) => !!row.artist);
+
+  return (
+    <div id="tracklistContainer">
+      <table className="tracklist-table">
+        <tbody>
+          <tr className="tracklist-header">
+            <th colSpan={showArtist ? 3 : 2}>Tracklist</th>
+          </tr>
+          {rows.map((row, index) => (
+            <tr
+              key={`${row.position}-${row.title}-${index}`}
+              className={`tracklist-row ${
+                index % 2 === 0 ? "tracklist-row-even" : "tracklist-row-odd"
+              }`}
+            >
+              <td className="tracklist-pos">{row.position}</td>
+              {showArtist ? <td>{row.artist}</td> : null}
+              <td>{row.title}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/styles/classic/wxyc.css
+++ b/src/styles/classic/wxyc.css
@@ -706,3 +706,60 @@ html[data-experience="classic"][data-joy-color-scheme="dark"] a:hover {
 html[data-experience="classic"][data-joy-color-scheme="dark"] a:visited {
 	color: #D0B0FF;
 }
+
+/* ========== Tracklist ========== */
+/* Ported verbatim from tubafrenzy's wxycdb.css, which the release card's
+   tracklist markup reproduces. The `.tracklist-section` rules are omitted:
+   nothing here renders that wrapper. */
+
+.tracklist-table {
+	border-collapse: collapse;
+	width: 100%;
+	font-size: 0.9em;
+	line-height: 1.4;
+	border: 1px solid #ddd;
+	margin-bottom: 20px;
+}
+
+.tracklist-header {
+	background: #444;
+	color: #fff;
+}
+
+.tracklist-header th {
+	padding: 8px;
+	text-align: left;
+	font-weight: bold;
+}
+
+.tracklist-row td {
+	padding: 6px 8px;
+	border-bottom: 1px solid #ddd;
+	text-align: left;
+}
+
+.tracklist-row-even {
+	background-color: #f9f9f9;
+}
+
+.tracklist-row-odd {
+	background-color: #fff;
+}
+
+.tracklist-row:hover {
+	background-color: #e8e8e8;
+}
+
+.tracklist-pos {
+	width: 40px;
+	text-align: center;
+	color: #666;
+}
+
+.tracklist-loading,
+.tracklist-empty {
+	text-align: center;
+	padding: 10px;
+	font-size: 0.9em;
+	color: #666;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -17,6 +17,23 @@ main {
     overflow: hidden;
 }
 
+/* Classic's scrollport.
+
+   Everything above this box clips its overflow so the dashboard can own its
+   internal scroll regions. Modern carries those regions inside its own panels;
+   classic is plain HTML with none, so without a scrollport here a result list
+   longer than the viewport is simply unreachable — it renders and cannot be
+   scrolled to.
+
+   Scoped to the shell's container rather than to a classic stylesheet on
+   purpose: this is the shell's scroll ownership, not part of Classic's look,
+   and the tubafrenzy-parity stylesheets stay the single source of truth for
+   the latter. */
+#classic-container {
+    height: 100%;
+    overflow-y: auto;
+}
+
 @keyframes scroll {
   0% { transform: translateX(100%); }
   100% { transform: translateX(-100%); }

--- a/src/utilities/stationTime.ts
+++ b/src/utilities/stationTime.ts
@@ -99,3 +99,19 @@ export function formatStationDateTime(isoString: string): {
 
   return { day, time, isToday: day === today };
 }
+
+// The long-form date `/wxycdb`'s catalog screens print beside the time, e.g.
+// "Saturday, June 15, 2024". Reproduces `DateTimeManager.DATE_FULL`
+// ("EEEE, MMMM d, yyyy", Locale.US) on the station's wall clock -- note the
+// Java method that renders it is named `getLongDateAsMMDDYY`, which describes
+// a different format than it produces; the rendered shape is what the
+// librarian reads, so that is what is reproduced here.
+export function formatStationLongDate(isoString: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: STATION_TIME_ZONE,
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(isoString));
+}

--- a/tests/integration/app/dashboard/@classic/library/artist/[id]/page.test.tsx
+++ b/tests/integration/app/dashboard/@classic/library/artist/[id]/page.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import {
+  setUpClassicPageAuthority,
+  setUpClassicPageAuthorityEnv,
+  assertReachesClassicPage,
+  assertDeniedClassicPage,
+} from "@/tests/helpers/classic-page-authority-harness";
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/headers", async () => {
+  const { classicPageAuthorityHeadersMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityHeadersMock();
+});
+const mockNotFound = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+vi.mock("next/navigation", async () => {
+  const { classicPageAuthorityNavigationMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return { ...classicPageAuthorityNavigationMock(), notFound: () => mockNotFound() };
+});
+vi.mock("@/lib/features/authentication/server-client", async () => {
+  const { classicPageAuthorityServerClientMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityServerClientMock();
+});
+vi.mock("@/lib/features/authentication/organization-utils.server", async () => {
+  const { classicPageAuthorityOrganizationUtilsMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityOrganizationUtilsMock();
+});
+
+// The page's own responsibility under test is the auth gate and what it hands
+// down, not the card's RTK Query-backed content.
+vi.mock("@/src/components/experiences/classic/Layout/Main", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="classic-main">{children}</div>,
+}));
+vi.mock("@/src/components/experiences/classic/catalog/ArtistCard", () => ({
+  default: ({ artistId, message }: { artistId: number; message?: string }) => (
+    <div data-testid="artist-card" data-artist-id={artistId}>
+      {message}
+    </div>
+  ),
+}));
+
+import ClassicArtistCardPage from "@/app/dashboard/@classic/library/artist/[id]/page";
+
+const page = (id = "42", created?: string) =>
+  ClassicArtistCardPage({
+    params: Promise.resolve({ id }),
+    searchParams: Promise.resolve(created ? { created } : {}),
+  });
+
+describe("classic /dashboard/library/artist/[id] page — artistCardModify.jsp", () => {
+  setUpClassicPageAuthorityEnv();
+
+  it.each([
+    { role: "musicDirector" as const, label: "a music director" },
+    { role: "stationManager" as const, label: "a station manager" },
+  ])("reaches the page for $label", async ({ role }) => {
+    setUpClassicPageAuthority(role);
+
+    await assertReachesClassicPage(() => page(), "classic-main", "artist-card");
+  });
+
+  it("redirects a DJ away from the artist card", async () => {
+    setUpClassicPageAuthority("dj");
+
+    await assertDeniedClassicPage(() => page());
+  });
+
+  it("never grants access from the admin-plugin role column, even when it holds a WXYC tier string", async () => {
+    setUpClassicPageAuthority(undefined, "musicDirector");
+
+    await assertDeniedClassicPage(() => page());
+  });
+
+  it("bounces an unauthenticated visitor to login, not to the dashboard home", async () => {
+    setUpClassicPageAuthority("unauthenticated");
+
+    await assertDeniedClassicPage(() => page(), "/login?bounced=no-session");
+  });
+
+  it("passes the route's id through to the card", async () => {
+    setUpClassicPageAuthority("musicDirector");
+
+    await assertReachesClassicPage(() => page("1087"), "classic-main", "artist-card");
+    expect(screen.getByTestId("artist-card").getAttribute("data-artist-id")).toBe("1087");
+  });
+
+  it("carries the create confirmation only when the URL asks for it", async () => {
+    setUpClassicPageAuthority("musicDirector");
+
+    await assertReachesClassicPage(() => page("42", "1"), "classic-main", "artist-card");
+    expect(screen.getByTestId("artist-card")).toHaveTextContent(
+      "The artist/library code below has been added to the database.",
+    );
+  });
+
+  // A non-numeric segment would otherwise reach the card as NaN and render as
+  // "this card could not be loaded", which describes a backend fault rather
+  // than a wrong URL.
+  it("404s a non-numeric artist id instead of rendering a card that cannot load", async () => {
+    setUpClassicPageAuthority("musicDirector");
+
+    await expect(page("not-an-id")).rejects.toThrow("NEXT_NOT_FOUND");
+  });
+});

--- a/tests/integration/components/classic/catalog/ArtistCard.test.tsx
+++ b/tests/integration/components/classic/catalog/ArtistCard.test.tsx
@@ -1,0 +1,335 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
+
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import(
+    "@/tests/helpers/auth-client-mock"
+  );
+  return {
+    ...createAuthClientModuleMock(),
+    getJWTToken: vi.fn(async () => "test-token"),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import ArtistCard from "@/src/components/experiences/classic/catalog/ArtistCard";
+
+const ARTIST_ID = 42;
+const GENRE_ID = 3;
+
+const artist = {
+  artist_id: ARTIST_ID,
+  artist_name: "Juana Molina",
+  alphabetical_name: "Molina, Juana",
+  genre_id: GENRE_ID,
+  code_letters: "MO",
+  code_artist_number: 12,
+};
+
+function release(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 900,
+    last_modified: "2024-06-15T19:04:05.000Z",
+    format_name: "CD",
+    genre_id: GENRE_ID,
+    code_letters: "MO",
+    code_artist_number: 12,
+    code_number: 5,
+    code_volume_letters: null,
+    album_title: "DOGA",
+    alternate_artist_name: null,
+    ...overrides,
+  };
+}
+
+function mockCard(body: unknown = artist, status = 200) {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/artists/${ARTIST_ID}`, () =>
+      HttpResponse.json(body as object, { status }),
+    ),
+  );
+}
+
+function mockReleases(releases: unknown[] = [release()], total = releases.length) {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/artists/${ARTIST_ID}/releases`, () =>
+      HttpResponse.json({
+        artist_id: ARTIST_ID,
+        releases,
+        total,
+        page: 0,
+        totalPages: Math.max(1, Math.ceil(total / 50)),
+      }),
+    ),
+  );
+}
+
+function mockGenres() {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
+      HttpResponse.json([{ id: GENRE_ID, genre_name: "Rock" }]),
+    ),
+  );
+}
+
+function mockFormats() {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/formats`, () =>
+      HttpResponse.json([
+        { id: 1, format_name: "CD" },
+        { id: 2, format_name: "  " },
+        { id: 3, format_name: "Vinyl" },
+      ]),
+    ),
+  );
+}
+
+function mockAll() {
+  mockCard();
+  mockReleases();
+  mockGenres();
+  mockFormats();
+}
+
+describe("classic ArtistCard — artistCardModify.jsp", () => {
+  beforeEach(() => {
+    mockAll();
+  });
+
+  it("heads the card with the artist's presentation name", async () => {
+    renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+    expect(
+      await screen.findByRole("heading", { name: /ARTIST:\s*Juana Molina/i }),
+    ).toBeDefined();
+  });
+
+  it("shows the artist's genre, call letters, and call number", async () => {
+    renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+    const modify = await screen.findByTestId("modify-artist-form");
+    expect(within(modify).getByText("Rock")).toBeDefined();
+    expect(within(modify).getByText("MO")).toBeDefined();
+    expect(within(modify).getByText("12")).toBeDefined();
+  });
+
+  it("reports the release count from the server's total, not the rows on this page", async () => {
+    mockReleases([release()], 137);
+    renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+    const modify = await screen.findByTestId("modify-artist-form");
+    expect(within(modify).getByText("137")).toBeDefined();
+  });
+
+  describe("modifyArtist", () => {
+    it("saves an edited alphabetical name", async () => {
+      const user = userEvent.setup();
+      const bodies: unknown[] = [];
+      server.use(
+        http.patch(
+          `${TEST_BACKEND_URL}/library/artists/${ARTIST_ID}`,
+          async ({ request }) => {
+            bodies.push(await request.json());
+            return HttpResponse.json({
+              id: ARTIST_ID,
+              artist_name: artist.artist_name,
+              alphabetical_name: "Molina, Juana C.",
+            });
+          },
+        ),
+      );
+
+      renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+      const field = await screen.findByLabelText(/Artist Alphabetical Name/i);
+      await user.clear(field);
+      await user.type(field, "Molina, Juana C.");
+      await user.click(screen.getByRole("button", { name: "Modify This Artist" }));
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toEqual({ alphabetical_name: "Molina, Juana C." });
+    });
+
+    // The backend rejects `artist_name` with a 400 rather than dropping it,
+    // so an editable field here would be an edit that always fails.
+    it("shows the presentation name without offering to edit it", async () => {
+      renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+      const field = (await screen.findByLabelText(
+        /Artist Presentation Name/i,
+      )) as HTMLInputElement;
+      expect(field.readOnly).toBe(true);
+    });
+
+    it("refuses to save an empty alphabetical name rather than sending it", async () => {
+      const user = userEvent.setup();
+      let patched = false;
+      server.use(
+        http.patch(`${TEST_BACKEND_URL}/library/artists/${ARTIST_ID}`, () => {
+          patched = true;
+          return HttpResponse.json({});
+        }),
+      );
+
+      renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+      const field = await screen.findByLabelText(/Artist Alphabetical Name/i);
+      await user.clear(field);
+      await user.click(screen.getByRole("button", { name: "Modify This Artist" }));
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        "The alphabetical name cannot be empty.",
+      );
+      expect(patched).toBe(false);
+    });
+  });
+
+  describe("the release table", () => {
+    it("renders the whole shelf code, the format, the title, and the alternate artist name", async () => {
+      mockReleases([
+        release({ code_volume_letters: "a", alternate_artist_name: "Juana" }),
+      ]);
+      renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+      const table = await screen.findByTestId("artist-release-table");
+      const row = within(table).getByText("DOGA").closest("tr")!;
+      expect(within(row).getByText("Rock MO 12/5-A")).toBeDefined();
+      expect(within(row).getByText("CD")).toBeDefined();
+      expect(within(row).getByText("Juana")).toBeDefined();
+    });
+
+    it("prints the station-local time the release was last modified", async () => {
+      renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+      const table = await screen.findByTestId("artist-release-table");
+      expect(
+        within(table).getByText("3:04:05 PM, Saturday, June 15, 2024"),
+      ).toBeDefined();
+    });
+
+    // The release-detail screen this would link to does not exist in this
+    // experience yet, so a link would be a dead one.
+    it("renders the title as plain text, not a link", async () => {
+      renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+      const table = await screen.findByTestId("artist-release-table");
+      expect(within(table).queryByRole("link", { name: "DOGA" })).toBeNull();
+    });
+
+    it("says so when the artist has no releases", async () => {
+      mockReleases([], 0);
+      renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+      expect(
+        await screen.findByText("The artist does not have any library releases"),
+      ).toBeDefined();
+    });
+
+    // Soft-failing an unreadable response into an empty list would render the
+    // line above — a positive claim that the shelf is empty, which is what
+    // makes a librarian file a duplicate.
+    it("does not claim an empty shelf when the release list could not be read", async () => {
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/artists/${ARTIST_ID}/releases`, () =>
+          HttpResponse.error(),
+        ),
+      );
+      renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+      await screen.findByTestId("modify-artist-form");
+      await waitFor(() =>
+        expect(
+          screen.queryByText("The artist does not have any library releases"),
+        ).toBeNull(),
+      );
+      expect(await screen.findByTestId("release-table-error")).toBeDefined();
+    });
+  });
+
+  describe("addRelease", () => {
+    it("files a release under this artist and names the code it was assigned", async () => {
+      const user = userEvent.setup();
+      const bodies: unknown[] = [];
+      server.use(
+        http.post(`${TEST_BACKEND_URL}/library`, async ({ request }) => {
+          bodies.push(await request.json());
+          return HttpResponse.json(
+            { id: 901, code_number: 6, code_volume_letters: null },
+            { status: 201 },
+          );
+        }),
+      );
+
+      renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+      await user.type(await screen.findByLabelText(/Title of Release/i), "Halo");
+      await user.type(screen.getByLabelText(/Alternate Artist Name/i), "J. Molina");
+      await user.type(screen.getByLabelText(/^Label/i), "Crammed Discs");
+      await user.selectOptions(screen.getByLabelText(/Format/i), "3");
+      await user.click(
+        screen.getByRole("button", { name: "Add a new Library Release" }),
+      );
+
+      await waitFor(() => expect(bodies).toHaveLength(1));
+      expect(bodies[0]).toEqual({
+        artist_id: ARTIST_ID,
+        genre_id: GENRE_ID,
+        album_title: "Halo",
+        alternate_artist_name: "J. Molina",
+        label: "Crammed Discs",
+        format_id: 3,
+      });
+      expect(await screen.findByRole("status")).toHaveTextContent("Rock MO 12/6");
+    });
+
+    it("omits the blank-named format the JSP filters out of its dropdown", async () => {
+      renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+      const select = await screen.findByLabelText(/Format/i);
+      const values = within(select).getAllByRole("option").map((o) => o.getAttribute("value"));
+      expect(values).toEqual(["1", "3"]);
+    });
+
+    it("refuses a release with no title rather than sending it", async () => {
+      const user = userEvent.setup();
+      let posted = false;
+      server.use(
+        http.post(`${TEST_BACKEND_URL}/library`, () => {
+          posted = true;
+          return HttpResponse.json({ id: 901 }, { status: 201 });
+        }),
+      );
+
+      renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+      await user.type(await screen.findByLabelText(/^Label/i), "Crammed Discs");
+      await user.click(
+        screen.getByRole("button", { name: "Add a new Library Release" }),
+      );
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        "Please enter a title before adding this release.",
+      );
+      expect(posted).toBe(false);
+    });
+  });
+
+  it("reports an unreachable card rather than rendering blank fields", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/library/artists/${ARTIST_ID}`, () =>
+        HttpResponse.error(),
+      ),
+    );
+
+    renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+    expect(await screen.findByTestId("artist-card-error")).toBeDefined();
+    expect(screen.queryByTestId("modify-artist-form")).toBeNull();
+  });
+});

--- a/tests/integration/components/classic/catalog/ArtistCardView.test.tsx
+++ b/tests/integration/components/classic/catalog/ArtistCardView.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+const mockArtistCard = vi.fn();
+const mockArtistReleases = vi.fn();
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return {
+    ...actual,
+    useGetArtistCardQuery: (...args: unknown[]) => mockArtistCard(...args),
+    useGetArtistReleasesQuery: (...args: unknown[]) => mockArtistReleases(...args),
+    useGetGenresQuery: () => ({ data: [{ id: 15, genre_name: "Electronic" }] }),
+  };
+});
+
+import ArtistCardView from "@/src/components/experiences/classic/catalog/ArtistCardView";
+
+const artist = {
+  artist_id: 19516,
+  artist_name: "Autechre",
+  alphabetical_name: "Autechre",
+  genre_id: 15,
+  code_letters: "AU",
+  code_artist_number: 3,
+};
+
+const release = (over = {}) => ({
+  id: 53375,
+  last_modified: "2016-10-29T16:28:00.254Z",
+  format_name: "cd",
+  genre_id: 15,
+  code_letters: "AU",
+  code_artist_number: 3,
+  code_number: 1,
+  code_volume_letters: null,
+  album_title: "Tri Repetae",
+  alternate_artist_name: null,
+  ...over,
+});
+
+describe("Classic ArtistCardView", () => {
+  it("renders the JSP's header: code, name, and release count", () => {
+    mockArtistCard.mockReturnValue({ data: artist, isLoading: false, isError: false });
+    mockArtistReleases.mockReturnValue({
+      data: { artist_id: 19516, releases: [release()], total: 1, page: 0, totalPages: 1 },
+      isLoading: false,
+    });
+
+    renderWithProviders(<ArtistCardView artistId={19516} />);
+
+    expect(screen.getByTestId("artist-view-code").textContent).toContain("Electronic AU 3");
+    // Twice on purpose: the card's own heading, and the release row's artist
+    // cell — which the JSP prints per-release, so they diverge on a
+    // compilation or an alternate-artist row.
+    expect(screen.getAllByText("Autechre")).toHaveLength(2);
+    expect(screen.getByText("# of releases: 1")).toBeDefined();
+  });
+
+  it("links each release title to the release screen", () => {
+    mockArtistCard.mockReturnValue({ data: artist, isLoading: false, isError: false });
+    mockArtistReleases.mockReturnValue({
+      data: { artist_id: 19516, releases: [release()], total: 1, page: 0, totalPages: 1 },
+      isLoading: false,
+    });
+
+    renderWithProviders(<ArtistCardView artistId={19516} />);
+
+    expect(screen.getByRole("link", { name: "Tri Repetae" }).getAttribute("href")).toBe(
+      "/dashboard/library/release/53375"
+    );
+  });
+
+  it("renders the JSP's empty state verbatim", () => {
+    mockArtistCard.mockReturnValue({ data: artist, isLoading: false, isError: false });
+    mockArtistReleases.mockReturnValue({
+      data: { artist_id: 19516, releases: [], total: 0, page: 0, totalPages: 0 },
+      isLoading: false,
+    });
+
+    renderWithProviders(<ArtistCardView artistId={19516} />);
+
+    expect(screen.getByText("The artist does not have any library releases.")).toBeDefined();
+  });
+
+  it("surfaces a load failure rather than an empty card", () => {
+    mockArtistCard.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    mockArtistReleases.mockReturnValue({ data: undefined, isLoading: false });
+
+    renderWithProviders(<ArtistCardView artistId={1} />);
+
+    expect(screen.getByTestId("artist-view-error")).toBeDefined();
+  });
+});

--- a/tests/integration/components/classic/catalog/CreateLibraryCodeForm.test.tsx
+++ b/tests/integration/components/classic/catalog/CreateLibraryCodeForm.test.tsx
@@ -119,7 +119,9 @@ describe("classic CreateLibraryCodeForm — createLibraryCode.jsp", () => {
 
     await waitFor(() => expect(getBodies()).toHaveLength(1));
     expect(getBodies()[0]).toMatchObject({ code_letters: "MO" });
-    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/dashboard/library"));
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith("/dashboard/library/artist/99?created=1"),
+    );
   });
 
   // The carried code is displayed verbatim, so every refusal has to name the
@@ -204,7 +206,9 @@ describe("classic CreateLibraryCodeForm — createLibraryCode.jsp", () => {
     expect(await screen.findByText("The alphabetical name cannot be empty.")).toBeInTheDocument();
   });
 
-  it("submits POST /library/artists with the carried code and typed names, then lands where the chooser's create path lands today", async () => {
+  // `processAddArtistLibraryCode` (`ArtistAdminServlet:188`) lands on the new
+  // artist's card carrying the servlet's create confirmation.
+  it("submits POST /library/artists with the carried code and typed names, then lands on the new artist's card", async () => {
     const { getBodies } = mockAddArtist(() => created());
     const { user } = renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
 
@@ -221,7 +225,7 @@ describe("classic CreateLibraryCodeForm — createLibraryCode.jsp", () => {
       genre_id: GENRE_ID,
       code_number: 12,
     });
-    expect(mockPush).toHaveBeenCalledWith("/dashboard/library");
+    expect(mockPush).toHaveBeenCalledWith("/dashboard/library/artist/99?created=1");
   });
 
   it("shows the code-conflict message on a 409 naming the artist_code_conflict reason", async () => {

--- a/tests/integration/components/classic/catalog/NewArtistForm.test.tsx
+++ b/tests/integration/components/classic/catalog/NewArtistForm.test.tsx
@@ -20,6 +20,11 @@ vi.mock("@/lib/features/authentication/client", async () => {
   };
 });
 
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
 import NewArtistForm from "@/src/components/experiences/classic/catalog/NewArtistForm";
 
 const GENRE_ID = 3;
@@ -87,6 +92,7 @@ async function selectGenre(user: ReturnType<typeof renderWithProviders>["user"],
 
 describe("classic NewArtistForm — chooseLibraryCodeOrArtist.jsp's newArtistForm", () => {
   beforeEach(() => {
+    mockPush.mockClear();
     mockGenres();
     mockPeekCode();
   });
@@ -174,8 +180,12 @@ describe("classic NewArtistForm — chooseLibraryCodeOrArtist.jsp's newArtistFor
     expect(await screen.findByText(/next code:\s*3/i)).toBeInTheDocument();
   });
 
-  it("confirms the assigned code from the server response after submit", async () => {
-    mockAddArtist(() => created({ code_letters: "MO", code_number: 12 }));
+  // `mode=addArtistLibraryCode` (`chooseLibraryCodeOrArtist.jsp:62`) is the
+  // same handler `createLibraryCode.jsp` submits to, and it lands on the new
+  // artist's card carrying the servlet's create confirmation
+  // (`ArtistAdminServlet:188`) rather than confirming in place.
+  it("lands on the new artist's card after submit", async () => {
+    mockAddArtist(() => created({ id: 99, code_letters: "MO", code_number: 12 }));
     const { user } = renderWithProviders(<NewArtistForm />);
 
     await selectGenre(user);
@@ -185,7 +195,9 @@ describe("classic NewArtistForm — chooseLibraryCodeOrArtist.jsp's newArtistFor
     await user.type(screen.getByLabelText(/call numbers/i), "12");
     await user.click(screen.getByRole("button", { name: "Submit" }));
 
-    expect(await screen.findByText(/Added as MO12/i)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith("/dashboard/library/artist/99?created=1"),
+    );
   });
 
   it("shows the code-conflict message on a 409 naming the artist_code_conflict reason", async () => {

--- a/tests/integration/components/classic/catalog/ReleaseCard.test.tsx
+++ b/tests/integration/components/classic/catalog/ReleaseCard.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createTestAlbum, createTestArtist } from "@/tests/helpers";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+const mockGetInformationQuery = vi.fn();
+const mockUpdateAlbum = vi.fn();
+const mockMarkMissing = vi.fn();
+const mockMarkFound = vi.fn();
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return {
+    ...actual,
+    useGetInformationQuery: (...args: unknown[]) => mockGetInformationQuery(...args),
+    useGetFormatsQuery: () => ({ data: [{ id: 1, format_name: "cd" }, { id: 2, format_name: "lp" }] }),
+    useUpdateAlbumMutation: () => [mockUpdateAlbum, { isLoading: false }],
+    useMarkMissingMutation: () => [mockMarkMissing, { isLoading: false }],
+    useMarkFoundMutation: () => [mockMarkFound, { isLoading: false }],
+  };
+});
+
+import ReleaseCard from "@/src/components/experiences/classic/catalog/ReleaseCard";
+
+const album = (overrides = {}) =>
+  createTestAlbum({
+    id: 53375,
+    title: "Tri Repetae",
+    entry: 1,
+    format: "cd",
+    format_id: 1,
+    label: "Warp",
+    artist: createTestArtist({
+      name: "Autechre",
+      lettercode: "AU",
+      numbercode: 3,
+      genre: "Electronic",
+    }),
+    ...overrides,
+  });
+
+describe("Classic ReleaseCard", () => {
+  it("reproduces the JSP's heading and code row", () => {
+    mockGetInformationQuery.mockReturnValue({ data: album(), isLoading: false, isError: false });
+
+    renderWithProviders(<ReleaseCard albumId={53375} />);
+
+    expect(screen.getByText("View/Modify a Library Release")).toBeDefined();
+    expect(screen.getByTestId("release-library-code").textContent).toBe("Electronic AU 3/1");
+    expect(screen.getByTestId("release-call-number").textContent).toBe("1");
+  });
+
+  it("composes a compilation's code as a V/A bucket, not a 0 artist number", () => {
+    mockGetInformationQuery.mockReturnValue({
+      data: album({
+        album_artist: "Various",
+        artist: createTestArtist({
+          name: "Various Artists",
+          lettercode: "V/A",
+          numbercode: 0,
+          genre: "Electronic",
+        }),
+      }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderWithProviders(<ReleaseCard albumId={9001} />);
+
+    // Not "Electronic V/A 0/1" — the shelf has no such call number.
+    expect(screen.getByTestId("release-library-code").textContent).toBe("Electronic V/A-1");
+  });
+
+  it("submits the fields Backend actually accepts", async () => {
+    const user = userEvent.setup();
+    mockUpdateAlbum.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    mockGetInformationQuery.mockReturnValue({ data: album(), isLoading: false, isError: false });
+
+    renderWithProviders(<ReleaseCard albumId={53375} />);
+
+    const title = screen.getByLabelText("Title of Release");
+    await user.clear(title);
+    await user.type(title, "Tri Repetae++");
+    await user.click(screen.getByDisplayValue("Modify this Library Release"));
+
+    expect(mockUpdateAlbum).toHaveBeenCalledWith({
+      albumId: 53375,
+      body: expect.objectContaining({ album_title: "Tri Repetae++" }),
+    });
+  });
+
+  it("refuses an empty title rather than sending it", async () => {
+    const user = userEvent.setup();
+    mockUpdateAlbum.mockClear();
+    mockGetInformationQuery.mockReturnValue({ data: album(), isLoading: false, isError: false });
+
+    renderWithProviders(<ReleaseCard albumId={53375} />);
+
+    await user.clear(screen.getByLabelText("Title of Release"));
+    await user.click(screen.getByDisplayValue("Modify this Library Release"));
+
+    expect(mockUpdateAlbum).not.toHaveBeenCalled();
+    expect(screen.getByTestId("release-message").textContent).toContain("enter a title");
+  });
+
+  it("offers Mark as Missing for a shelved release, and Mark as Found for a lost one", () => {
+    mockGetInformationQuery.mockReturnValue({ data: album(), isLoading: false, isError: false });
+    const { unmount } = renderWithProviders(<ReleaseCard albumId={53375} />);
+    expect(screen.getByTestId("release-library-status").textContent).toContain("In Library");
+    expect(screen.getByRole("button", { name: "Mark as Missing" })).toBeDefined();
+    unmount();
+
+    mockGetInformationQuery.mockReturnValue({
+      data: album({ date_lost: "2026-01-15T12:00:00.000Z" }),
+      isLoading: false,
+      isError: false,
+    });
+    renderWithProviders(<ReleaseCard albumId={53375} />);
+    expect(screen.getByTestId("release-library-status").textContent).toContain("Missing since");
+    expect(screen.getByRole("button", { name: "Mark as Found" })).toBeDefined();
+  });
+
+  it("surfaces a load failure rather than rendering an empty card", () => {
+    mockGetInformationQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+
+    renderWithProviders(<ReleaseCard albumId={1} />);
+
+    expect(screen.getByTestId("release-card-error")).toBeDefined();
+  });
+});

--- a/tests/integration/components/classic/catalog/SearchResults.releaseLink.test.tsx
+++ b/tests/integration/components/classic/catalog/SearchResults.releaseLink.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { createTestAlbum, createTestArtist } from "@/tests/helpers";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+const mockSearchCatalogQuery = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams("searchString=autechre"),
+}));
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return {
+    ...actual,
+    useSearchCatalogQuery: (...args: unknown[]) => mockSearchCatalogQuery(...args),
+  };
+});
+
+import SearchResults from "@/src/components/experiences/classic/catalog/SearchResults";
+
+/**
+ * The release title is the row's link to the album card, mirroring
+ * `card-catalog-search`'s `<a href="libraryRelease?id=…">`. Rows whose id was
+ * synthesized client-side (always negative — a hash of the row's content, or a
+ * contentless counter) have no Backend `library.id` to route to and must stay
+ * plain text rather than link to a URL that cannot resolve.
+ */
+describe("Classic SearchResults release link", () => {
+  it("links the release title to the classic release view", () => {
+    const album = createTestAlbum({
+      id: 9200,
+      artist: createTestArtist({ name: "Autechre", lettercode: "AU", numbercode: 3 }),
+      title: "Tri Repetae",
+    });
+    mockSearchCatalogQuery.mockReturnValue({ data: [album], isLoading: false, error: undefined });
+
+    renderWithProviders(<SearchResults />);
+
+    const link = screen.getByRole("link", { name: "Tri Repetae" });
+    expect(link.getAttribute("href")).toBe("/dashboard/library/release/9200");
+  });
+
+  it("leaves the title as plain text when the row's id was synthesized", () => {
+    const album = createTestAlbum({
+      id: -128374,
+      artist: createTestArtist({ name: "Autechre", lettercode: "AU", numbercode: 3 }),
+      title: "Untracked Release",
+    });
+    mockSearchCatalogQuery.mockReturnValue({ data: [album], isLoading: false, error: undefined });
+
+    renderWithProviders(<SearchResults />);
+
+    expect(screen.getByText("Untracked Release")).toBeDefined();
+    expect(screen.queryByRole("link", { name: "Untracked Release" })).toBeNull();
+  });
+
+  it("links the artist name to the ungated view card", () => {
+    const album = createTestAlbum({
+      id: 9200,
+      artist: createTestArtist({ name: "Autechre", lettercode: "AU", numbercode: 3, id: 19516 }),
+      title: "Tri Repetae",
+    });
+    mockSearchCatalogQuery.mockReturnValue({ data: [album], isLoading: false, error: undefined });
+
+    renderWithProviders(<SearchResults />);
+
+    const link = screen.getByRole("link", { name: "Autechre" });
+    expect(link.getAttribute("href")).toBe("/dashboard/library/artist/19516/view");
+  });
+
+  it("leaves the artist as plain text when the row carries no artist id", () => {
+    const album = createTestAlbum({
+      id: 9201,
+      artist: createTestArtist({ name: "Autechre", lettercode: "AU", numbercode: 3, id: undefined }),
+      title: "Amber",
+    });
+    mockSearchCatalogQuery.mockReturnValue({ data: [album], isLoading: false, error: undefined });
+
+    renderWithProviders(<SearchResults />);
+
+    expect(screen.queryByRole("link", { name: "Autechre" })).toBeNull();
+    expect(screen.getByText("Autechre")).toBeDefined();
+  });
+});

--- a/tests/integration/components/classic/catalog/Tracklist.test.tsx
+++ b/tests/integration/components/classic/catalog/Tracklist.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+const mockCompilationTracks = vi.fn();
+const mockLibraryTracks = vi.fn();
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return { ...actual, useGetCompilationTracksQuery: (...a: unknown[]) => mockCompilationTracks(...a) };
+});
+vi.mock("@/lib/features/metadata/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/metadata/api")>();
+  return { ...actual, useGetLibraryTracksQuery: (...a: unknown[]) => mockLibraryTracks(...a) };
+});
+
+import Tracklist from "@/src/components/experiences/classic/catalog/Tracklist";
+
+const empty = { data: undefined, isLoading: false };
+
+describe("Classic Tracklist", () => {
+  it("renders a Discogs-sourced tracklist in two columns", () => {
+    mockCompilationTracks.mockReturnValue(empty);
+    mockLibraryTracks.mockReturnValue({
+      data: {
+        library_id: 65879,
+        discogs_release_id: 41,
+        source: "discogs",
+        tracks: [
+          { position: "1", title: "Rpeg", artist_credit: "Autechre", duration_ms: null },
+          { position: "2", title: "Ccec", artist_credit: "Autechre", duration_ms: null },
+        ],
+      },
+      isLoading: false,
+    });
+
+    renderWithProviders(
+      <Tracklist albumId={53380} legacyReleaseId={65879} variousArtists={false} />
+    );
+
+    expect(screen.getByText("Tracklist")).toBeDefined();
+    expect(screen.getByText("Rpeg")).toBeDefined();
+    // Not various-artists: no artist column, so the header spans two.
+    expect(screen.getByText("Tracklist").getAttribute("colspan")).toBe("2");
+  });
+
+  it("adds the artist column only for a compilation that names artists", () => {
+    mockCompilationTracks.mockReturnValue({
+      data: {
+        library_id: 9001,
+        tracks: [
+          { id: 1, artist_name: "Chuquimamani-Condori", track_title: "Call Your Name", track_position: "A1" },
+        ],
+      },
+      isLoading: false,
+    });
+    mockLibraryTracks.mockReturnValue(empty);
+
+    renderWithProviders(
+      <Tracklist albumId={9001} legacyReleaseId={9001} variousArtists={true} />
+    );
+
+    expect(screen.getByText("Tracklist").getAttribute("colspan")).toBe("3");
+    expect(screen.getByText("Chuquimamani-Condori")).toBeDefined();
+  });
+
+  it("shows the legacy empty copy when neither source has rows", () => {
+    mockCompilationTracks.mockReturnValue(empty);
+    mockLibraryTracks.mockReturnValue({
+      data: { library_id: 65879, discogs_release_id: null, source: null, tracks: [] },
+      isLoading: false,
+    });
+
+    renderWithProviders(
+      <Tracklist albumId={53380} legacyReleaseId={65879} variousArtists={false} />
+    );
+
+    expect(screen.getByText("No tracklist available.")).toBeDefined();
+  });
+
+  it("skips the Discogs source rather than querying it with a placeholder id", () => {
+    mockCompilationTracks.mockReturnValue(empty);
+    mockLibraryTracks.mockReturnValue(empty);
+
+    renderWithProviders(
+      <Tracklist albumId={53380} legacyReleaseId={null} variousArtists={false} />
+    );
+
+    // The id spaces differ and a wrong id returns an unrelated release's
+    // tracklist with a 200, so an absent legacy id must skip, not guess.
+    expect(mockLibraryTracks).toHaveBeenCalledWith(null, expect.objectContaining({ skip: true }));
+  });
+});

--- a/tests/integration/components/modern/login/Forms/LoginFormSwitcher.passwordSwitch.test.tsx
+++ b/tests/integration/components/modern/login/Forms/LoginFormSwitcher.passwordSwitch.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+import LoginFormSwitcher from "@/src/components/experiences/modern/login/Forms/LoginFormSwitcher";
+
+/**
+ * The existing EmailOTPForm test asserts the "Sign in with password instead"
+ * link RENDERS. Nothing asserts that clicking it does anything. This drives the
+ * switch through the component that owns the decision.
+ */
+describe("LoginFormSwitcher: password fallback", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("swaps the OTP form for the password form when the fallback is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <LoginFormSwitcher welcomeQuote={["Welcome...", "to the Jungle", "Guns N' Roses"]} />
+    );
+
+    expect(screen.getByRole("button", { name: "Send login code" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Sign in with password instead" }));
+
+    expect(screen.getByPlaceholderText("Username or email")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send login code" })).toBeNull();
+  });
+});

--- a/tests/unit/lib/features/catalog/libraryCode.test.ts
+++ b/tests/unit/lib/features/catalog/libraryCode.test.ts
@@ -48,6 +48,24 @@ describe("formatArtistCodeWithPunctuation — ArtistLibraryCode.java:98", () => 
     ).toBe("X-");
   });
 
+  // Backend-Service is the source here, not tubafrenzy's MySQL, and the two
+  // spell a compilation bucket differently: the catalog import rewrites
+  // `Z-<letter>` to the literal `V/A` on the way in, so the `Z-` form never
+  // reaches this client. Every compilation on the shelf -- 53 artist rows over
+  // ~6,300 releases -- arrives as `V/A` with an artist number of 0.
+  it.each([["V/A"], ["v/a"], [" V/A "]])(
+    "treats the stored %s form as a Various Artists bucket",
+    (codeLetters) => {
+      expect(
+        formatArtistCodeWithPunctuation({
+          code_letters: codeLetters,
+          code_artist_number: 0,
+          genre_id: 11,
+        }),
+      ).toBe("V/A-");
+    },
+  );
+
   it("treats leading whitespace before Z- as a Various Artists bucket, matching isVariousArtists's trim", () => {
     expect(
       formatArtistCodeWithPunctuation({

--- a/tests/unit/lib/features/catalog/libraryCode.test.ts
+++ b/tests/unit/lib/features/catalog/libraryCode.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatArtistCodeWithPunctuation,
+  formatReleaseCode,
+  formatEntireLibraryCode,
+} from "@/lib/features/catalog/libraryCode";
+
+describe("formatArtistCodeWithPunctuation — ArtistLibraryCode.java:98", () => {
+  it("renders a regular artist code as LETTERS NUMBER/", () => {
+    expect(
+      formatArtistCodeWithPunctuation({
+        code_letters: "ABC",
+        code_artist_number: 123,
+        genre_id: 1,
+      }),
+    ).toBe("ABC 123/");
+  });
+
+  it("upper-cases the call letters", () => {
+    expect(
+      formatArtistCodeWithPunctuation({
+        code_letters: "mo",
+        code_artist_number: 12,
+        genre_id: 1,
+      }),
+    ).toBe("MO 12/");
+  });
+
+  it("renders a Various Artists bucket as V/A-, dropping the number", () => {
+    expect(
+      formatArtistCodeWithPunctuation({
+        code_letters: "Z-X",
+        code_artist_number: 4,
+        genre_id: 1,
+      }),
+    ).toBe("V/A-");
+  });
+
+  // GenreId.SOUNDTRACKS — 12, the same id chooserValidation's
+  // isRockCompLettersRequired hardcodes.
+  it("renders a Soundtracks compilation as its sub-bucket letter, not V/A", () => {
+    expect(
+      formatArtistCodeWithPunctuation({
+        code_letters: "Z-X",
+        code_artist_number: 4,
+        genre_id: 12,
+      }),
+    ).toBe("X-");
+  });
+
+  it("treats leading whitespace before Z- as a Various Artists bucket, matching isVariousArtists's trim", () => {
+    expect(
+      formatArtistCodeWithPunctuation({
+        code_letters: "  Z-X",
+        code_artist_number: 4,
+        genre_id: 1,
+      }),
+    ).toBe("V/A-");
+  });
+});
+
+describe("formatReleaseCode — LibraryRelease.java:122", () => {
+  it("renders the number alone when the release carries no volume letters", () => {
+    expect(formatReleaseCode({ code_number: 5, code_volume_letters: null })).toBe("5");
+  });
+
+  it("renders NUMBER-LETTERS when it does, upper-cased", () => {
+    expect(formatReleaseCode({ code_number: 5, code_volume_letters: "a" })).toBe("5-A");
+  });
+
+  // `isBlank()` in the Java, not `isEmpty()`: a whitespace-only value is no
+  // volume letter at all, and rendering `5-` would read as a truncated code.
+  it("treats whitespace-only volume letters as absent", () => {
+    expect(formatReleaseCode({ code_number: 5, code_volume_letters: "   " })).toBe("5");
+  });
+});
+
+describe("formatEntireLibraryCode — LibraryRelease.java:129", () => {
+  it("joins genre, the artist code, and the release code the way the release table does", () => {
+    expect(
+      formatEntireLibraryCode({
+        genreName: "Rock",
+        code_letters: "MO",
+        code_artist_number: 12,
+        genre_id: 1,
+        code_number: 5,
+        code_volume_letters: "a",
+      }),
+    ).toBe("Rock MO 12/5-A");
+  });
+
+  // The genre name is looked up from a list that may not have loaded. The
+  // shelf code is what a librarian walks to the stacks with, so the rest of
+  // it must still render rather than being withheld behind a missing prefix.
+  it("omits the genre prefix rather than the whole code when the genre name is unknown", () => {
+    expect(
+      formatEntireLibraryCode({
+        genreName: undefined,
+        code_letters: "MO",
+        code_artist_number: 12,
+        genre_id: 1,
+        code_number: 5,
+        code_volume_letters: null,
+      }),
+    ).toBe("MO 12/5");
+  });
+});

--- a/tests/unit/utilities/stationTime.test.ts
+++ b/tests/unit/utilities/stationTime.test.ts
@@ -4,6 +4,7 @@ import {
   closestStationHour,
   formatStationDateTime,
   formatStationHourLabel,
+  formatStationLongDate,
   isStationHourBreakpointPresent,
   stationBreakpointMessage,
 } from "@/src/utilities/stationTime";
@@ -113,3 +114,19 @@ describe("stationTime", () => {
     });
   });
 });
+
+describe("formatStationLongDate — DateTimeManager.DATE_FULL", () => {
+  it("renders the station-local weekday, month, day, and year", () => {
+    expect(formatStationLongDate("2024-06-15T19:04:05.000Z")).toBe(
+      "Saturday, June 15, 2024",
+    );
+  });
+
+  // 00:30 UTC on the 16th is 20:30 EDT on the 15th — the station's date, not
+  // the browser's or UTC's.
+  it("uses the station's calendar day, not UTC's", () => {
+    expect(formatStationLongDate("2024-06-16T00:30:00.000Z")).toBe(
+      "Saturday, June 15, 2024",
+    );
+  });
+})


### PR DESCRIPTION
Closes #1166 (Slice 1b of #1163).

## What this unblocks

`/wxycdb`'s artist card is its main working screen, and classic had nothing like it. Until now classic had the chooser (#1165), the code-miss create screen (#1167), and Missing Releases (#1170) — but **no way to add a release at all**, because on `/wxycdb` the add-release form lives on this card. That made it the binding gap in the epic's "minimum for the librarian validation week" set, and so in [wiki#89](https://github.com/WXYC/wiki/issues/89)'s chain step 2 behind it.

Its blocker [Backend-Service#2156](https://github.com/WXYC/Backend-Service/issues/2156) closed 2026-08-18, and per this epic's shipping note the gate is the **deploy**, not the merge — verified against prod before building: `GET /library/artists/:id` and `GET /library/artists/:id/releases` both answer 401 (route present, refusing an unauthenticated caller) rather than 404.

## The screen

`/dashboard/library/artist/[id]`, MD-gated server-side, carrying the JSP's four pieces: artist details, the `modifyArtist` name-edit form, the add-release form, and the release table in shelf order.

## Divergences — eight, all forced by the Backend contract

Each is enumerated in `ArtistCard.tsx`'s header. None is a preference:

| Divergence | Forced by |
|---|---|
| Four of `modifyArtist`'s five fields are read-only | `PATCH /library/artists/:id` allowlists `alphabetical_name` alone and **rejects** the other four with a 400 naming why. Editable inputs would offer an edit that always fails. |
| Genre renders as text, not a `<select>` | Same — no write path, so a dropdown could not commit. |
| No "Time Last Modified" row for the artist | `GET /library/artists/:id` projects none. A blank labelled row would read as "never modified". |
| No "Delete The Artist" link | No delete-artist endpoint exists at any privilege. |
| Add-release takes neither release call number nor volume letters | `POST /library` derives `code_number` itself (max+1 per artist) and has no `code_volume_letters` parameter. The assigned code is reported back after the save instead — that is the fact that goes on the sleeve. |
| Add-release gains a **Label** field | `POST /library` requires `label`; the JSP has no such input. Same precedent as `NewArtistForm` adding genre + call letters/numbers. |
| Release titles are plain text | Their destination is Slice 4 (#1169). A link would be a dead one — and #1169's AC already claims adding them. |
| Cross-reference blocks and sortable headers absent | Write-side xref admin is out of scope; the read-only display is #1211. The releases endpoint takes no sort parameter and returns shelf order, which is the JSP's own default. |

**On renaming an artist:** `artist_name` is the only rejected field that is merely deferred rather than absent. Renaming moves `jobs/library-etl`'s `fold_artist_name` match key while that ETL is still a live 30-minute cron, so the rename gets silently duplicated and reverted. It re-enables when library-etl stops ([wiki#89](https://github.com/WXYC/wiki/issues/89) step 3). The read-only field carries a plain-language note rather than a bare disabled input.

## Both parked landings claimed (this issue's last AC)

`/wxycdb`'s chooser new-artist form and its code-miss create screen post to the **same** `mode=addArtistLibraryCode` handler (`chooseLibraryCodeOrArtist.jsp:62`), which ends at `goToArtistModifyCard` carrying *"The artist/library code below has been added to the database."* (`ArtistAdminServlet:188`). Both were parked on interim landings waiting for this screen; both now land here, and #1167's divergence note is deleted rather than reworded.

`NewArtistForm`'s inline "Added as MO12" confirmation goes with it — that was the stand-in for this landing, so it is deleted rather than kept alongside.

`created=1` selects the fixed message rather than passing its text through the URL: taking it from the query string would let any link put arbitrary words in the station's own voice at the top of a catalog screen.

## Two failure modes answered by refusing rather than guessing

Both new queries opt out of the shared non-JSON soft-fail, which resolves an unreadable response into a successful empty payload:

- On the **release list** that renders as *"The artist does not have any library releases"* — a positive claim about the shelf, and the one a librarian acts on by filing a duplicate.
- On the **card** it renders blank names beside an add-release form that would then file against an id nobody was shown the name of.

The table also states the total whenever the page is short of it, so a paginated shelf is never presented as a complete one.

## `lib/features/catalog/libraryCode.ts`

Backend-Service serves the shelf code's parts, never the composed string, so composition is the client's job. Extracted to `lib/` rather than inlined because the punctuation is not cosmetic — the result is the physical call number, including the Various-Artists and Soundtracks branches that drop the artist number entirely and the `isBlank`-not-`isEmpty` volume-letter test. Ported rule-for-rule from `ArtistLibraryCode.java:98`, `LibraryRelease.java:122`, and `:129`, with the Java's own unit tests as the cases.

## Verification

- `npm run test` — **4,945 passed** (341 files), including 15 new component tests, 7 page-authority tests, 10 formatter unit tests, and 2 station-time tests
- `npm run lint` — **0 errors**; warning count went *down* by one (an unused import removed), so none added
- `npx tsc --noEmit` — clean
- `npm run build` — succeeds; `/dashboard/library/artist/[id]` appears in the route table

All of the above re-run against the worktree's own `npm ci` rather than a parent `node_modules`, so nothing here is a stale-dist result.

## Notes for review

- **Size.** ~1,490 lines, over the org's 1,000-line aim. The epic sizes slices at roughly 2× the JSP, and this JSP is its largest at 372 lines; the split is 558 lines of screen to 565 of test. Splitting the card from its own add-release form would ship a screen that cannot do the task it exists for.
- **Timestamp format.** The JSP prints `h:mm:ss a` plus `EEEE, MMMM d, yyyy` on the station's wall clock — note the Java method rendering the second is named `getLongDateAsMMDDYY` while producing neither. The rendered shape is what the librarian reads, so that is what `formatStationLongDate` reproduces.
- **Now-stale comment elsewhere, deliberately untouched:** `MissingReleases.tsx`'s divergence note says the artist cell renders as plain text because "dj-site's librarian artist/release detail screens are a later slice". Half of that is no longer true. Wiring the link needs an artist id the search row may not carry, so it is left for whoever owns that screen rather than smuggled in here.
- **Nav is unchanged.** This card is reached by searching, not from the main menu — `/wxycdb` has no main-menu link to it either. `NEXT_PUBLIC_CLASSIC_LIBRARIAN_NAV_ENABLED` stays OFF and its flip remains #1212.