### PR TITLE
Truncate the welcome quote to its greeting

### DIFF
--- a/src/components/experiences/modern/login/Quotes/Welcome.tsx
+++ b/src/components/experiences/modern/login/Quotes/Welcome.tsx
@@ -33,15 +33,15 @@ export function pickWelcomeQuote(): WelcomeQuote {
   ];
 }
 
+// Only the greeting is rendered; each quote's fragment and artist are deliberately
+// retained in the table above so the full couplet can be restored without re-sourcing it.
 export default function WelcomeQuotes({ quote }: { quote: WelcomeQuote }) {
-  const [greeting, fragment, artist] = quote;
+  const [greeting] = quote;
 
   return (
     <div>
-      <Typography level="h1">{greeting}</Typography>
-      <Typography level="h1">{fragment}</Typography>
-      <Typography level="body-md" sx={{ my: 1, mb: 3, textAlign: "right" }}>
-        - {artist}
+      <Typography level="h1" sx={{ mb: 3 }}>
+        {greeting}
       </Typography>
     </div>
   );

--- a/tests/integration/components/modern/login/Quotes/Welcome.test.tsx
+++ b/tests/integration/components/modern/login/Quotes/Welcome.test.tsx
@@ -34,13 +34,16 @@ describe("pickWelcomeQuote", () => {
 });
 
 describe("WelcomeQuotes", () => {
-  it("renders the provided greeting, fragment, and artist", () => {
-    render(
-      <WelcomeQuotes quote={["Hello...", "", "Erykah Badu ft. André 3000"]} />
-    );
+  it("renders the greeting", () => {
+    render(<WelcomeQuotes quote={["Hello...", "", "Erykah Badu ft. André 3000"]} />);
     expect(screen.getByText("Hello...")).toBeInTheDocument();
-    expect(
-      screen.getByText("- Erykah Badu ft. André 3000")
-    ).toBeInTheDocument();
+  });
+
+  it("renders neither the fragment nor the artist attribution", () => {
+    render(
+      <WelcomeQuotes quote={["Welcome...", "to the Jungle", "Guns N' Roses"]} />
+    );
+    expect(screen.queryByText("to the Jungle")).not.toBeInTheDocument();
+    expect(screen.queryByText("- Guns N' Roses")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Renders only the greeting of the pre-auth music quote. `WelcomeQuotes` previously stacked three lines — an `h1` greeting ("Welcome..."), an `h1` song-title fragment ("to the Jungle"), and a right-aligned attribution ("- Guns N' Roses") — drawn at random from a 20-entry table.

**Both surfaces move together.** The component is shared: the home page mounts it once (`app/page.tsx:32`), and `LoginFormSwitcher` mounts it in all three `/login` auth stages. A bare greeting on home beside a full couplet on login would read as a rendering bug, so the truncation lives in the component rather than at one call site.

**The strings are preserved.** `greetingsAndArtists`, the `WelcomeQuote` tuple type, and `pickWelcomeQuote()` are untouched — all 20 fragments and artists stay in the source, so the full couplet can be restored without re-sourcing the list. A comment in the file says so, otherwise a later reader deletes the table as dead data.

The attribution line carried the `mb: 3` that spaced the quote off the divider on home and off the form on `/login`; that margin moves to the greeting so the layout below is unchanged.

The greeting itself still varies — 18 entries read "Welcome...", one "Hello..." (Erykah Badu ft. André 3000), one "Come On..." (Broadcast). Pinning it to a single string was not in scope.

`Quotes/HoldOn.tsx` and `Quotes/Forgot.tsx` use the same three-part shape on other screens and are deliberately untouched.

## Testing

- New case in `tests/integration/components/modern/login/Quotes/Welcome.test.tsx` asserts that neither the fragment nor the `- Artist` line renders for a quote carrying both. Confirmed red against the previous component, green against this one.
- Full unit suite: 341 files / 4952 tests pass.
- `npm run lint` — 0 errors, no new warnings. `npx tsc --noEmit` — clean.
- No E2E test asserts the quote text.

Closes #1260
