### PR TITLE
Give the public pages a scrollport

### DIFF
--- a/e2e/tests/auth/login-layout.spec.ts
+++ b/e2e/tests/auth/login-layout.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+import { LoginPage } from "../../pages/login.page";
+
+/**
+ * These drive the mouse wheel rather than scrollIntoView: an `overflow: hidden`
+ * box still has a scrollport, so programmatic scrolling succeeds on a page the
+ * user has no way to scroll. Only a real scroll container answers the wheel.
+ */
+test.describe("Login page overflow", () => {
+  test("scrolls to the footer on a short viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 500 });
+    await new LoginPage(page).goto();
+
+    // Located by tag, not by the contentinfo role: the shell nests this footer
+    // inside <main>, which strips its landmark mapping.
+    const footer = page.locator("footer");
+    await expect(footer).not.toBeInViewport();
+
+    await page.mouse.move(195, 250);
+    await page.mouse.wheel(0, 2000);
+
+    await expect(footer).toBeInViewport();
+  });
+
+  test("shows the whole page without scrolling when it fits", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await new LoginPage(page).goto();
+
+    await expect(page.locator("footer")).toBeInViewport();
+  });
+});

--- a/src/Layout/WXYCPage.tsx
+++ b/src/Layout/WXYCPage.tsx
@@ -9,8 +9,11 @@ export default function WXYCPage({
 }: {
   children: React.ReactNode;
 }) {
+  // Everything above this box clips its overflow so the dashboard can own its
+  // internal scroll regions, which leaves the public pages no scrollport unless
+  // they carry one themselves.
   return (
-    <Box sx={{ minHeight: "100%" }} className="ignoreClassic">
+    <Box sx={{ height: "100%", overflowY: "auto" }} className="ignoreClassic">
       <BackgroundBox>
         <Header />
         <Main>{children}</Main>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -12,7 +12,11 @@ body {
     overflow: hidden;
 }
 
-main {
+/* Scoped to the shell's own <main>. As a bare element selector it also matches
+   the nested content <main> that each page renders, pinning that box to the
+   viewport height so the header and footer stacked around it fall outside the
+   clipped area. */
+#root > main {
     height: 100vh;
     overflow: hidden;
 }

--- a/tests/integration/components/Layout/WXYCPage.test.tsx
+++ b/tests/integration/components/Layout/WXYCPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers";
 import WXYCPage from "@/src/Layout/WXYCPage";
 
 // Mock child components
@@ -73,6 +74,22 @@ describe("WXYCPage", () => {
     );
 
     expect(screen.getByTestId("background-image")).toBeInTheDocument();
+  });
+
+  // The app shell above this page clips its own overflow so the dashboard can
+  // own its internal scroll regions, which leaves no scrollport for the public
+  // pages. This container is theirs.
+  it("scrolls its own content when the page outgrows the viewport", () => {
+    const { container } = renderWithProviders(
+      <WXYCPage>
+        <span>Content</span>
+      </WXYCPage>
+    );
+
+    expect(container.querySelector(".ignoreClassic")).toHaveStyle({
+      height: "100%",
+      overflowY: "auto",
+    });
   });
 
   it("should have ignoreClassic class", () => {


### PR DESCRIPTION
The login page could not be scrolled — content past the fold was clipped with no way to reach it. The cause is not login-specific and not limited to short viewports: measured against a production build, the footer sat **276px below the fold at every viewport size tested** (1280x900, 1280x700, 1280x500, 390x844, 390x640, 390x500) on `/`, `/live`, `/playlists`, and `/login` alike.

## Cause

Two things stack.

**The `main` rule in `src/styles/globals.css` is a bare element selector.** It was written for the app shell's own `<main>` in `app/layout.tsx`, but it also matches the nested content `<main>` that `src/Layout/Main.tsx` renders inside every `WXYCPage`. That inner box was therefore pinned to `height: 100vh`, so the 204px header and 72px footer stacked around it fell outside the viewport by construction — regardless of how much content the page had.

**Nothing in the ancestor chain could scroll.** `html`, `body`, `#root`, and the shell `<main>` are all `overflow: hidden` on purpose, so the dashboard can own its internal scroll regions. The public pages inherited that clipping without ever getting a scrollport of their own.

## Fix

- `src/styles/globals.css`: scope the rule to `#root > main`, the shell's own element, so it stops leaking onto nested content boxes.
- `src/Layout/WXYCPage.tsx`: `minHeight: 100%` → `height: 100%; overflow-y: auto`, making the public shell its own scrollport.

The dashboard is untouched. Its content box (`src/components/experiences/modern/Main.tsx`) sets `height: 100dvh; overflow: hidden` in `sx`, so the narrowed selector is a no-op there, and `#root` / the shell `<main>` keep clipping exactly as before.

## Testing

`e2e/tests/auth/login-layout.spec.ts` (new) drives the **mouse wheel**, not `scrollIntoView`. That distinction matters: an `overflow: hidden` box still has a scrollport, so programmatic scrolling succeeded against the broken page — a `scrollIntoViewIfNeeded` test would have passed all along. Both cases were confirmed red against a production build of the unfixed shell and green after.

- short viewport (390x500): footer out of view, then in view after a wheel scroll
- tall viewport (1280x900): whole page including footer visible, no scrolling

Also verified by hand against a production build on all four public routes — footer fully visible with zero scroll at 1280x900; a real scroll container (101–169px of overflow) at 390x500 on `/`, `/playlists`, `/login`, and no overflow needed on `/live`.

Unit: `tests/integration/components/Layout/WXYCPage.test.tsx` asserts the container is a scrollport. Full suite 341 files / 4953 tests pass, `npm run lint` 0 errors with no new warnings, `npx tsc --noEmit` clean.

## Noted, not fixed

- The shell renders a `<main>` inside a `<main>`. Invalid HTML, and it strips the footer's `contentinfo` landmark — which is why the e2e locates the footer by tag. Worth its own a11y ticket.
- `src/components/shared/layouts/AppShell.tsx` and `src/components/experiences/modern/login/Layout/*` have no production importers, only their own tests.
- `/login` 500s under `next dev` on Next 16.3.0 (`TypeError: Cannot read properties of undefined (reading 'hasOwnProperty')`). Production builds serve it fine, which is why this was verified against `next build` + `next start`.

Closes #1262
