### PR TITLE
feat(classic): artist and release screens, and wire catalog search results to them

### DIFF
--- a/app/dashboard/@classic/library/artist/[id]/view/page.tsx
+++ b/app/dashboard/@classic/library/artist/[id]/view/page.tsx
@@ -1,0 +1,40 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getPageTitle } from "@/lib/utils/page-title";
+import { requireAuth } from "@/lib/features/authentication/server-utils";
+import Main from "@/src/components/experiences/classic/Layout/Main";
+import ArtistCardView from "@/src/components/experiences/classic/catalog/ArtistCardView";
+
+export const metadata: Metadata = {
+  title: getPageTitle("View an Artist Card"),
+};
+
+type ClassicArtistViewPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+/**
+ * Reproduces `lucene/artistCardDisplay.jsp` — the destination a catalog result
+ * row's artist name opens (`artist?id=…&mode=view`).
+ *
+ * Authenticated but NOT role-gated, deliberately, and unlike the sibling modify
+ * card: the JSP carries no role check, and catalog search is the DJ-facing
+ * screen in classic, so gating here would bounce every DJ who clicked an artist.
+ */
+export default async function ClassicArtistViewPage({
+  params,
+}: ClassicArtistViewPageProps) {
+  await requireAuth();
+
+  const { id } = await params;
+  const artistId = Number(id);
+  if (!Number.isInteger(artistId) || artistId <= 0) {
+    notFound();
+  }
+
+  return (
+    <Main>
+      <ArtistCardView artistId={artistId} />
+    </Main>
+  );
+}

--- a/app/dashboard/@classic/library/release/[id]/page.tsx
+++ b/app/dashboard/@classic/library/release/[id]/page.tsx
@@ -1,0 +1,47 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getPageTitle } from "@/lib/utils/page-title";
+import { requireAuth, requireRole } from "@/lib/features/authentication/server-utils";
+import { Authorization } from "@/lib/features/admin/types";
+import Main from "@/src/components/experiences/classic/Layout/Main";
+import ReleaseCard from "@/src/components/experiences/classic/catalog/ReleaseCard";
+
+export const metadata: Metadata = {
+  title: getPageTitle("Modify a Library Release Card"),
+};
+
+type ClassicReleasePageProps = {
+  params: Promise<{ id: string }>;
+};
+
+/**
+ * Reproduces `libraryAdmin/libraryReleaseModify.jsp` — the screen a catalog
+ * result's release title opens.
+ *
+ * Admin-gated to match: the JSP renders under `body class="library-admin"` and
+ * every action on it is a librarian action. Catalog search is DJ-facing, so a
+ * DJ who follows a result row's release title lands on a screen they cannot
+ * open — which is what the legacy interface does too. An ungated read-only
+ * release view for DJs is a different screen, not a relaxation of this gate.
+ */
+export default async function ClassicReleasePage({
+  params,
+}: ClassicReleasePageProps) {
+  const session = await requireAuth();
+  await requireRole(session, Authorization.MD);
+
+  const { id } = await params;
+  const albumId = Number(id);
+  // A non-numeric segment would otherwise reach the card as NaN and request
+  // `/library/info?album_id=NaN`, rendering a load failure for what is really
+  // a wrong URL. Matches the artist card's guard.
+  if (!Number.isInteger(albumId) || albumId <= 0) {
+    notFound();
+  }
+
+  return (
+    <Main>
+      <ReleaseCard albumId={albumId} />
+    </Main>
+  );
+}

--- a/e2e/tests/classic/catalog-scroll.spec.ts
+++ b/e2e/tests/classic/catalog-scroll.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Drives the mouse wheel rather than scrollIntoView: an `overflow: hidden` box
+ * still has a scrollport, so programmatic scrolling succeeds on a page the user
+ * has no way to scroll. Only a real scroll container answers the wheel.
+ *
+ * The shell clips its own overflow so the dashboard can own internal scroll
+ * regions. Modern carries those inside its panels; classic is plain HTML and
+ * has none, so a result list longer than the viewport is unreachable unless the
+ * classic container is itself a scrollport.
+ */
+test.describe("Classic catalog overflow", () => {
+  test("scrolls to the last result on a short viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 500 });
+    // A query broad enough that the result table exceeds the viewport.
+    await page.goto("/dashboard/catalog?searchString=james");
+
+    const rows = page.locator("#liveResults table.entry-table tbody tr");
+    await expect(rows.first()).toBeVisible();
+    const lastRow = rows.last();
+    await expect(lastRow).not.toBeInViewport();
+
+    await page.mouse.move(512, 250);
+    await page.mouse.wheel(0, 4000);
+
+    await expect(lastRow).toBeInViewport();
+  });
+});

--- a/src/components/experiences/classic/catalog/ArtistCardView.tsx
+++ b/src/components/experiences/classic/catalog/ArtistCardView.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import Link from "next/link";
+import {
+  useGetArtistCardQuery,
+  useGetArtistReleasesQuery,
+  useGetGenresQuery,
+} from "@/lib/features/catalog/api";
+import {
+  formatArtistCodeWithPunctuation,
+  formatEntireLibraryCode,
+} from "@/lib/features/catalog/libraryCode";
+
+const RELEASES_PER_PAGE = 100;
+
+/**
+ * "View an Artist Card" — reproduces `lucene/artistCardDisplay.jsp`, the screen
+ * a catalog result's artist name opens.
+ *
+ * Ungated, unlike the librarian's modify card. The JSP carries no role check
+ * and catalog search is the DJ-facing screen, so a DJ who follows a result
+ * row's artist must land on something they can read. The two screens are one
+ * URL in the JSP, separated by `mode=view`; here they are two routes, because
+ * the role gate is a property of the route.
+ *
+ * Divergences:
+ *
+ *  - **Cross-reference blocks omitted.** The JSP renders them below the release
+ *    table, with each cross-referencing artist linking to another view card.
+ *    Read-only cross-reference display is owned separately, for this screen and
+ *    the modify card together.
+ *  - **No sortable column headers.** The JSP's `libcodeHeader` / `titleHeader` /
+ *    `formatHeader` ids drive a client-side sort the release endpoint does not
+ *    expose an ordering parameter for.
+ */
+export default function ArtistCardView({ artistId }: { artistId: number }) {
+  const { data: artist, isLoading, isError } = useGetArtistCardQuery(artistId);
+  const { data: genres } = useGetGenresQuery();
+  const { data: releaseData, isLoading: releasesLoading } = useGetArtistReleasesQuery({
+    artistId,
+    limit: RELEASES_PER_PAGE,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="label" style={{ textAlign: "center" }}>
+        Loading the artist card...
+      </div>
+    );
+  }
+
+  if (isError || !artist) {
+    return (
+      <div data-testid="artist-view-error" role="alert" className="artist-error-message">
+        This artist card could not be loaded.
+      </div>
+    );
+  }
+
+  const genreName = genres?.find((genre) => genre.id === artist.genre_id)?.genre_name;
+  const artistCode = formatArtistCodeWithPunctuation({
+    code_letters: artist.code_letters,
+    code_artist_number: artist.code_artist_number,
+    genre_id: artist.genre_id,
+  });
+  const releases = releaseData?.releases ?? [];
+  const total = releaseData?.total ?? 0;
+
+  return (
+    <div id="searchResultsPanel">
+      <table className="entry-table" style={{ width: "100%" }}>
+        <tbody>
+          <tr className="entry-header">
+            <th style={{ textAlign: "left" }} data-testid="artist-view-code">
+              {genreName ? `${genreName} ` : ""}
+              {artistCode.replace(/-$/, "")}
+            </th>
+            <th style={{ textAlign: "center" }}>{artist.artist_name}</th>
+            <th style={{ textAlign: "right" }}># of releases: {total}</th>
+          </tr>
+        </tbody>
+      </table>
+
+      {releasesLoading ? (
+        <div className="label" style={{ textAlign: "center" }}>
+          Loading releases...
+        </div>
+      ) : total > 0 ? (
+        <>
+          <table className="entry-table" style={{ width: "100%" }}>
+            <thead>
+              <tr className="entry-header">
+                <th style={{ textAlign: "left" }}>Library Code</th>
+                <th style={{ textAlign: "left" }}>Artist</th>
+                <th style={{ textAlign: "left" }}>Title of Release</th>
+                <th style={{ textAlign: "left" }}>Format</th>
+              </tr>
+            </thead>
+            <tbody>
+              {releases.map((release, index) => (
+                <tr
+                  key={release.id}
+                  className={`entry-row ${
+                    index % 2 === 0 ? "entry-row-even" : "entry-row-odd"
+                  }`}
+                >
+                  <td>
+                    {formatEntireLibraryCode({
+                      genreName,
+                      code_letters: release.code_letters,
+                      code_artist_number: release.code_artist_number,
+                      genre_id: release.genre_id,
+                      code_number: release.code_number,
+                      code_volume_letters: release.code_volume_letters,
+                    })}
+                  </td>
+                  {/* The JSP prints the release's own artist string, which
+                      differs from the card's artist on a compilation or an
+                      alternate-artist row. */}
+                  <td>{release.alternate_artist_name || artist.artist_name}</td>
+                  <td>
+                    <Link href={`/dashboard/library/release/${release.id}`}>
+                      {release.album_title}
+                    </Link>
+                  </td>
+                  <td>{release.format_name}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {total > releases.length ? (
+            <div className="live-results-status">
+              Showing the first {releases.length} of {total}.
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <div style={{ textAlign: "center" }}>
+          The artist does not have any library releases.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/experiences/classic/catalog/ReleaseCard.tsx
+++ b/src/components/experiences/classic/catalog/ReleaseCard.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  useGetFormatsQuery,
+  useGetInformationQuery,
+  useMarkFoundMutation,
+  useMarkMissingMutation,
+  useUpdateAlbumMutation,
+} from "@/lib/features/catalog/api";
+import { formatEntireLibraryCode } from "@/lib/features/catalog/libraryCode";
+import { formatStationDateTime } from "@/src/utilities/stationTime";
+import Tracklist from "./Tracklist";
+
+/**
+ * "View/Modify a Library Release" — the screen a catalog result's release title
+ * opens, reproducing `libraryAdmin/libraryReleaseModify.jsp`.
+ *
+ * Divergences, each forced by what Backend-Service serves rather than chosen:
+ *
+ *  - **Release Call Number and Release Call Letter are read-only.** The JSP
+ *    edits both. `PATCH /library/:id` accepts neither, so rendering them as
+ *    inputs would offer an edit that silently discards.
+ *  - **Album Artist is read-only**, for the same reason: not in the PATCH body.
+ *  - **No "Delete This Library Release".** There is no delete endpoint.
+ *  - **No "Change the Library Code / Artist Code of This Library Release"**, and
+ *    no "Undo Last Change" — none has an endpoint behind it.
+ *  - **Cross-reference blocks and "Add Xrefs" omitted.** Write-side
+ *    cross-reference admin is frozen; read-only display is owned separately,
+ *    for this screen and the artist card together.
+ *  - **The Artist cell is text, not a link.** The JSP links it to a card with
+ *    no role gate; ours is gated, so the link lands when the ungated view card
+ *    does.
+ *  - **"Time Last Modified" is replaced by "Date Added".** Backend returns
+ *    `last_modified`, but the published contract does not declare it and the
+ *    conversion to the client row therefore drops it. Reading it anyway would
+ *    mean an untyped cast — the pattern that turns a contract gap into a
+ *    silent `undefined` — and printing the add date under the JSP's label
+ *    would be worse than printing it under a true one.
+ */
+export default function ReleaseCard({ albumId }: { albumId: number }) {
+  const { data, isLoading, isError } = useGetInformationQuery({ album_id: albumId });
+  const { data: formats } = useGetFormatsQuery();
+  const [updateAlbum, { isLoading: saving }] = useUpdateAlbumMutation();
+  const [markMissing, { isLoading: markingMissing }] = useMarkMissingMutation();
+  const [markFound, { isLoading: markingFound }] = useMarkFoundMutation();
+
+  const [title, setTitle] = useState("");
+  const [altArtist, setAltArtist] = useState("");
+  const [formatId, setFormatId] = useState<number | "">("");
+  const [message, setMessage] = useState("");
+
+  // The form mirrors server state until the librarian edits it; re-syncing on a
+  // new row is the only reason this effect exists.
+  useEffect(() => {
+    if (!data) return;
+    setTitle(data.title);
+    setAltArtist(data.alternate_artist ?? "");
+    setFormatId(data.format_id ?? "");
+  }, [data]);
+
+  if (isLoading) {
+    return (
+      <div className="label" style={{ textAlign: "center" }}>
+        Loading the release...
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div data-testid="release-card-error" role="alert" className="artist-error-message">
+        This release could not be loaded.
+      </div>
+    );
+  }
+
+  // `code_volume_letters` is null rather than omitted: `GET /library/info` does
+  // not project it, so a multi-volume release shows `5` where the artist card's
+  // release table shows `5-A`. `genre_id` falls back to 0, which is not the
+  // Soundtracks id, so an absent genre takes the ordinary V/A branch.
+  const entireLibraryCode = formatEntireLibraryCode({
+    genreName: data.artist.genre,
+    code_letters: data.artist.lettercode,
+    code_artist_number: data.artist.numbercode,
+    genre_id: data.genre_id ?? 0,
+    code_number: data.entry,
+    code_volume_letters: null,
+  });
+
+  const displayArtist = data.album_artist ? "Various Artists" : data.artist.name;
+  const artistCode = `${data.artist.lettercode} ${data.artist.numbercode}`;
+  const missing = !!data.date_lost && !data.date_found;
+  const added = data.add_date ? formatStationDateTime(data.add_date) : undefined;
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!title.trim()) {
+      setMessage("Please enter a title for this release.");
+      return;
+    }
+    try {
+      await updateAlbum({
+        albumId,
+        body: {
+          album_title: title.trim(),
+          alternate_artist_name: altArtist.trim() === "" ? null : altArtist.trim(),
+          ...(formatId === "" ? {} : { format_id: Number(formatId) }),
+        },
+      }).unwrap();
+      setMessage("This library release has been modified.");
+    } catch {
+      setMessage("This library release could not be modified.");
+    }
+  };
+
+  const toggleMissing = async () => {
+    try {
+      if (missing) {
+        await markFound({ albumId }).unwrap();
+        setMessage("This library release has been marked as found.");
+      } else {
+        await markMissing({ albumId }).unwrap();
+        setMessage("This library release has been marked as missing.");
+      }
+    } catch {
+      setMessage("The library status could not be changed.");
+    }
+  };
+
+  return (
+    <div id="releaseCard">
+      <div className="label" style={{ textAlign: "center" }}>
+        <a href="/dashboard/catalog">Do another search</a>
+        &nbsp;&nbsp;&nbsp;&nbsp;
+        <a href="/dashboard/library">Find and Create an Artist and/or Library Code</a>
+      </div>
+
+      <div style={{ textAlign: "center" }}>
+        <h3>
+          LIBRARY RELEASE: &nbsp;{entireLibraryCode}&nbsp;-&nbsp;{displayArtist} - {data.title}
+        </h3>
+      </div>
+
+      <div style={{ textAlign: "center" }}>
+        <h3 data-testid="release-message">&nbsp;{message}&nbsp;</h3>
+      </div>
+
+      <form name="modifyRelease" onSubmit={handleSubmit}>
+        <table cellPadding={5}>
+          <tbody>
+            <tr>
+              <td></td>
+              <td>
+                <h3>View/Modify a Library Release</h3>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Entire Code For Library Release:</b>
+              </td>
+              <td data-testid="release-library-code">{entireLibraryCode}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Artist:</b>
+              </td>
+              <td>
+                {artistCode} - {displayArtist}
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Release Call Number:</b>
+              </td>
+              <td data-testid="release-call-number">{data.entry}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Album Artist:</b>
+              </td>
+              <td>{data.album_artist ?? ""}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Alternate Artist Name:</b>
+              </td>
+              <td>
+                <input
+                  type="text"
+                  name="altArtistName"
+                  size={50}
+                  aria-label="Alternate Artist Name"
+                  value={altArtist}
+                  onChange={(event) => setAltArtist(event.target.value)}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Title of Release:</b>
+              </td>
+              <td>
+                <input
+                  type="text"
+                  name="title"
+                  size={60}
+                  aria-label="Title of Release"
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Format:</b>
+              </td>
+              <td>
+                <select
+                  name="formatID"
+                  aria-label="Format"
+                  value={formatId}
+                  onChange={(event) =>
+                    setFormatId(event.target.value === "" ? "" : Number(event.target.value))
+                  }
+                >
+                  {(formats ?? []).map((format) => (
+                    <option key={format.id} value={format.id}>
+                      {format.format_name}
+                    </option>
+                  ))}
+                </select>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Date Added:</b>
+              </td>
+              <td>{added ? `${added.time} ${added.day}` : ""}</td>
+            </tr>
+            <tr>
+              <td style={{ textAlign: "right" }}>
+                <b>Library Status:</b>
+              </td>
+              <td data-testid="release-library-status">
+                {missing ? (
+                  <span style={{ color: "red", fontWeight: "bold" }}>
+                    Missing since {formatStationDateTime(data.date_lost as string).day}
+                  </span>
+                ) : (
+                  "In Library"
+                )}
+                &nbsp;&nbsp;
+                <button
+                  type="button"
+                  className="label"
+                  onClick={toggleMissing}
+                  disabled={markingMissing || markingFound}
+                >
+                  {missing ? "Mark as Found" : "Mark as Missing"}
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td></td>
+              <td>
+                <input
+                  type="submit"
+                  value="Modify this Library Release"
+                  disabled={saving}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+
+      <Tracklist
+        albumId={albumId}
+        legacyReleaseId={data.legacy_release_id}
+        variousArtists={!!data.album_artist}
+      />
+    </div>
+  );
+}

--- a/src/components/experiences/classic/catalog/SearchResults.tsx
+++ b/src/components/experiences/classic/catalog/SearchResults.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSearchCatalogQuery } from "@/lib/features/catalog/api";
 import { MatchedTrackChips } from "./MatchedTrackChips";
@@ -127,12 +128,52 @@ export default function SearchResults() {
                 {result.entry}
               </td>
               <td>
-                {result.album_artist
-                  ? "Various Artists"
-                  : result.artist?.name || "Unknown"}
+                {/*
+                  The artist name links to the ungated view card, mirroring
+                  `card-catalog-search`'s `<a href="artist?id=…&mode=view">` —
+                  the view card, not the librarian's modify card, because this
+                  table is DJ-facing.
+
+                  `artist.id` is only present once the search response carries
+                  `artist_id`; a row without it renders as plain text rather
+                  than a link to an unresolvable id.
+                */}
+                {result.artist?.id ? (
+                  <Link href={`/dashboard/library/artist/${result.artist.id}/view`}>
+                    {result.album_artist
+                      ? "Various Artists"
+                      : result.artist.name || "Unknown"}
+                  </Link>
+                ) : result.album_artist ? (
+                  "Various Artists"
+                ) : (
+                  result.artist?.name || "Unknown"
+                )}
               </td>
               <td>
-                {result.title}
+                {/*
+                  The release title links to the classic release view,
+                  mirroring `card-catalog-search`'s
+                  `<a href="libraryRelease?id=…">`.
+
+                  NOT `/dashboard/album/[id]`: that URL has no page in either
+                  experience slot — both fall through to `default.tsx` and
+                  render `ExperienceGap`. Its album card exists only as the
+                  `@information` slot's client-side portal, so it survives a
+                  soft navigation and breaks on reload, bookmark, or paste.
+
+                  Guarded on a positive id: `convertToAlbumEntry` synthesizes a
+                  NEGATIVE id (a hash, or a contentless counter) for a row with
+                  no Backend `library.id` behind it, and there is no album card
+                  to route to for those. They stay plain text.
+                */}
+                {result.id != null && result.id > 0 ? (
+                  <Link href={`/dashboard/library/release/${result.id}`}>
+                    {result.title}
+                  </Link>
+                ) : (
+                  result.title
+                )}
                 {result.on_streaming === false && (
                   <>
                     {" "}

--- a/src/components/experiences/classic/catalog/Tracklist.tsx
+++ b/src/components/experiences/classic/catalog/Tracklist.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useGetCompilationTracksQuery } from "@/lib/features/catalog/api";
+import { useGetLibraryTracksQuery } from "@/lib/features/metadata/api";
+
+type TracklistProps = {
+  /** Backend's `library.id` — the key the per-track credit store is keyed by. */
+  albumId: number;
+  /**
+   * The row's tubafrenzy `LIBRARY_RELEASE_ID`. A **different id space** from
+   * `albumId`, and the only one the Discogs-backed tracks endpoint accepts:
+   * it resolves the path param against `library.legacy_release_id`. The two
+   * spaces are nearly coextensive, so passing the wrong one does not fail — it
+   * returns a real but unrelated release's tracklist with a 200. `null` where
+   * the row has no legacy id, in which case that source is skipped rather than
+   * queried with a placeholder.
+   */
+  legacyReleaseId: number | null;
+  /** True for a compilation, which is the only case with per-track artists. */
+  variousArtists: boolean;
+};
+
+/**
+ * Release tracklist, reproducing `tracklist.js`'s markup and copy.
+ *
+ * Two sources, because the legacy servlet's single endpoint has no single
+ * equivalent here: per-track credits for a compilation are librarian-entered
+ * and stored locally, while an ordinary release's tracklist is resolved
+ * through Discogs. The compilation source is preferred when it has rows, since
+ * it is the only one carrying a per-track artist — the column the legacy
+ * renderer adds exactly when the release is various-artists and at least one
+ * track names an artist.
+ */
+export default function Tracklist({
+  albumId,
+  legacyReleaseId,
+  variousArtists,
+}: TracklistProps) {
+  const { data: compilation, isLoading: compilationLoading } =
+    useGetCompilationTracksQuery({ libraryId: albumId }, { skip: !variousArtists });
+
+  const { data: discogs, isLoading: discogsLoading } = useGetLibraryTracksQuery(
+    legacyReleaseId as number,
+    { skip: legacyReleaseId === null || legacyReleaseId <= 0 },
+  );
+
+  const compilationTracks = compilation?.tracks ?? [];
+  const rows =
+    compilationTracks.length > 0
+      ? compilationTracks.map((track, index) => ({
+          position: track.track_position ?? String(index + 1),
+          artist: track.artist_name ?? "",
+          title: track.track_title ?? "",
+        }))
+      : (discogs?.tracks ?? []).map((track, index) => ({
+          position: track.position || String(index + 1),
+          artist: track.artist_credit ?? "",
+          title: track.title,
+        }));
+
+  if (compilationLoading || discogsLoading) {
+    return (
+      <div id="tracklistContainer">
+        <p className="tracklist-loading">Loading tracklist...</p>
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div id="tracklistContainer">
+        <p className="tracklist-empty">No tracklist available.</p>
+      </div>
+    );
+  }
+
+  // The legacy renderer shows the artist column only when the release is
+  // various-artists AND at least one track actually names an artist — a
+  // compilation whose credits were never entered gets two columns, not a
+  // column of blanks.
+  const showArtist = variousArtists && rows.some((row) => !!row.artist);
+
+  return (
+    <div id="tracklistContainer">
+      <table className="tracklist-table">
+        <tbody>
+          <tr className="tracklist-header">
+            <th colSpan={showArtist ? 3 : 2}>Tracklist</th>
+          </tr>
+          {rows.map((row, index) => (
+            <tr
+              key={`${row.position}-${row.title}-${index}`}
+              className={`tracklist-row ${
+                index % 2 === 0 ? "tracklist-row-even" : "tracklist-row-odd"
+              }`}
+            >
+              <td className="tracklist-pos">{row.position}</td>
+              {showArtist ? <td>{row.artist}</td> : null}
+              <td>{row.title}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/styles/classic/wxyc.css
+++ b/src/styles/classic/wxyc.css
@@ -706,3 +706,60 @@ html[data-experience="classic"][data-joy-color-scheme="dark"] a:hover {
 html[data-experience="classic"][data-joy-color-scheme="dark"] a:visited {
 	color: #D0B0FF;
 }
+
+/* ========== Tracklist ========== */
+/* Ported verbatim from tubafrenzy's wxycdb.css, which the release card's
+   tracklist markup reproduces. The `.tracklist-section` rules are omitted:
+   nothing here renders that wrapper. */
+
+.tracklist-table {
+	border-collapse: collapse;
+	width: 100%;
+	font-size: 0.9em;
+	line-height: 1.4;
+	border: 1px solid #ddd;
+	margin-bottom: 20px;
+}
+
+.tracklist-header {
+	background: #444;
+	color: #fff;
+}
+
+.tracklist-header th {
+	padding: 8px;
+	text-align: left;
+	font-weight: bold;
+}
+
+.tracklist-row td {
+	padding: 6px 8px;
+	border-bottom: 1px solid #ddd;
+	text-align: left;
+}
+
+.tracklist-row-even {
+	background-color: #f9f9f9;
+}
+
+.tracklist-row-odd {
+	background-color: #fff;
+}
+
+.tracklist-row:hover {
+	background-color: #e8e8e8;
+}
+
+.tracklist-pos {
+	width: 40px;
+	text-align: center;
+	color: #666;
+}
+
+.tracklist-loading,
+.tracklist-empty {
+	text-align: center;
+	padding: 10px;
+	font-size: 0.9em;
+	color: #666;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -17,6 +17,23 @@ main {
     overflow: hidden;
 }
 
+/* Classic's scrollport.
+
+   Everything above this box clips its overflow so the dashboard can own its
+   internal scroll regions. Modern carries those regions inside its own panels;
+   classic is plain HTML with none, so without a scrollport here a result list
+   longer than the viewport is simply unreachable — it renders and cannot be
+   scrolled to.
+
+   Scoped to the shell's container rather than to a classic stylesheet on
+   purpose: this is the shell's scroll ownership, not part of Classic's look,
+   and the tubafrenzy-parity stylesheets stay the single source of truth for
+   the latter. */
+#classic-container {
+    height: 100%;
+    overflow-y: auto;
+}
+
 @keyframes scroll {
   0% { transform: translateX(100%); }
   100% { transform: translateX(-100%); }

--- a/tests/integration/components/classic/catalog/ArtistCardView.test.tsx
+++ b/tests/integration/components/classic/catalog/ArtistCardView.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+const mockArtistCard = vi.fn();
+const mockArtistReleases = vi.fn();
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return {
+    ...actual,
+    useGetArtistCardQuery: (...args: unknown[]) => mockArtistCard(...args),
+    useGetArtistReleasesQuery: (...args: unknown[]) => mockArtistReleases(...args),
+    useGetGenresQuery: () => ({ data: [{ id: 15, genre_name: "Electronic" }] }),
+  };
+});
+
+import ArtistCardView from "@/src/components/experiences/classic/catalog/ArtistCardView";
+
+const artist = {
+  artist_id: 19516,
+  artist_name: "Autechre",
+  alphabetical_name: "Autechre",
+  genre_id: 15,
+  code_letters: "AU",
+  code_artist_number: 3,
+};
+
+const release = (over = {}) => ({
+  id: 53375,
+  last_modified: "2016-10-29T16:28:00.254Z",
+  format_name: "cd",
+  genre_id: 15,
+  code_letters: "AU",
+  code_artist_number: 3,
+  code_number: 1,
+  code_volume_letters: null,
+  album_title: "Tri Repetae",
+  alternate_artist_name: null,
+  ...over,
+});
+
+describe("Classic ArtistCardView", () => {
+  it("renders the JSP's header: code, name, and release count", () => {
+    mockArtistCard.mockReturnValue({ data: artist, isLoading: false, isError: false });
+    mockArtistReleases.mockReturnValue({
+      data: { artist_id: 19516, releases: [release()], total: 1, page: 0, totalPages: 1 },
+      isLoading: false,
+    });
+
+    renderWithProviders(<ArtistCardView artistId={19516} />);
+
+    expect(screen.getByTestId("artist-view-code").textContent).toContain("Electronic AU 3");
+    // Twice on purpose: the card's own heading, and the release row's artist
+    // cell — which the JSP prints per-release, so they diverge on a
+    // compilation or an alternate-artist row.
+    expect(screen.getAllByText("Autechre")).toHaveLength(2);
+    expect(screen.getByText("# of releases: 1")).toBeDefined();
+  });
+
+  it("links each release title to the release screen", () => {
+    mockArtistCard.mockReturnValue({ data: artist, isLoading: false, isError: false });
+    mockArtistReleases.mockReturnValue({
+      data: { artist_id: 19516, releases: [release()], total: 1, page: 0, totalPages: 1 },
+      isLoading: false,
+    });
+
+    renderWithProviders(<ArtistCardView artistId={19516} />);
+
+    expect(screen.getByRole("link", { name: "Tri Repetae" }).getAttribute("href")).toBe(
+      "/dashboard/library/release/53375"
+    );
+  });
+
+  it("renders the JSP's empty state verbatim", () => {
+    mockArtistCard.mockReturnValue({ data: artist, isLoading: false, isError: false });
+    mockArtistReleases.mockReturnValue({
+      data: { artist_id: 19516, releases: [], total: 0, page: 0, totalPages: 0 },
+      isLoading: false,
+    });
+
+    renderWithProviders(<ArtistCardView artistId={19516} />);
+
+    expect(screen.getByText("The artist does not have any library releases.")).toBeDefined();
+  });
+
+  it("surfaces a load failure rather than an empty card", () => {
+    mockArtistCard.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    mockArtistReleases.mockReturnValue({ data: undefined, isLoading: false });
+
+    renderWithProviders(<ArtistCardView artistId={1} />);
+
+    expect(screen.getByTestId("artist-view-error")).toBeDefined();
+  });
+});

--- a/tests/integration/components/classic/catalog/ReleaseCard.test.tsx
+++ b/tests/integration/components/classic/catalog/ReleaseCard.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createTestAlbum, createTestArtist } from "@/tests/helpers";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+const mockGetInformationQuery = vi.fn();
+const mockUpdateAlbum = vi.fn();
+const mockMarkMissing = vi.fn();
+const mockMarkFound = vi.fn();
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return {
+    ...actual,
+    useGetInformationQuery: (...args: unknown[]) => mockGetInformationQuery(...args),
+    useGetFormatsQuery: () => ({ data: [{ id: 1, format_name: "cd" }, { id: 2, format_name: "lp" }] }),
+    useUpdateAlbumMutation: () => [mockUpdateAlbum, { isLoading: false }],
+    useMarkMissingMutation: () => [mockMarkMissing, { isLoading: false }],
+    useMarkFoundMutation: () => [mockMarkFound, { isLoading: false }],
+  };
+});
+
+import ReleaseCard from "@/src/components/experiences/classic/catalog/ReleaseCard";
+
+const album = (overrides = {}) =>
+  createTestAlbum({
+    id: 53375,
+    title: "Tri Repetae",
+    entry: 1,
+    format: "cd",
+    format_id: 1,
+    label: "Warp",
+    artist: createTestArtist({
+      name: "Autechre",
+      lettercode: "AU",
+      numbercode: 3,
+      genre: "Electronic",
+    }),
+    ...overrides,
+  });
+
+describe("Classic ReleaseCard", () => {
+  it("reproduces the JSP's heading and code row", () => {
+    mockGetInformationQuery.mockReturnValue({ data: album(), isLoading: false, isError: false });
+
+    renderWithProviders(<ReleaseCard albumId={53375} />);
+
+    expect(screen.getByText("View/Modify a Library Release")).toBeDefined();
+    expect(screen.getByTestId("release-library-code").textContent).toBe("Electronic AU 3/1");
+    expect(screen.getByTestId("release-call-number").textContent).toBe("1");
+  });
+
+  it("composes a compilation's code as a V/A bucket, not a 0 artist number", () => {
+    mockGetInformationQuery.mockReturnValue({
+      data: album({
+        album_artist: "Various",
+        artist: createTestArtist({
+          name: "Various Artists",
+          lettercode: "V/A",
+          numbercode: 0,
+          genre: "Electronic",
+        }),
+      }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderWithProviders(<ReleaseCard albumId={9001} />);
+
+    // Not "Electronic V/A 0/1" — the shelf has no such call number.
+    expect(screen.getByTestId("release-library-code").textContent).toBe("Electronic V/A-1");
+  });
+
+  it("submits the fields Backend actually accepts", async () => {
+    const user = userEvent.setup();
+    mockUpdateAlbum.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+    mockGetInformationQuery.mockReturnValue({ data: album(), isLoading: false, isError: false });
+
+    renderWithProviders(<ReleaseCard albumId={53375} />);
+
+    const title = screen.getByLabelText("Title of Release");
+    await user.clear(title);
+    await user.type(title, "Tri Repetae++");
+    await user.click(screen.getByDisplayValue("Modify this Library Release"));
+
+    expect(mockUpdateAlbum).toHaveBeenCalledWith({
+      albumId: 53375,
+      body: expect.objectContaining({ album_title: "Tri Repetae++" }),
+    });
+  });
+
+  it("refuses an empty title rather than sending it", async () => {
+    const user = userEvent.setup();
+    mockUpdateAlbum.mockClear();
+    mockGetInformationQuery.mockReturnValue({ data: album(), isLoading: false, isError: false });
+
+    renderWithProviders(<ReleaseCard albumId={53375} />);
+
+    await user.clear(screen.getByLabelText("Title of Release"));
+    await user.click(screen.getByDisplayValue("Modify this Library Release"));
+
+    expect(mockUpdateAlbum).not.toHaveBeenCalled();
+    expect(screen.getByTestId("release-message").textContent).toContain("enter a title");
+  });
+
+  it("offers Mark as Missing for a shelved release, and Mark as Found for a lost one", () => {
+    mockGetInformationQuery.mockReturnValue({ data: album(), isLoading: false, isError: false });
+    const { unmount } = renderWithProviders(<ReleaseCard albumId={53375} />);
+    expect(screen.getByTestId("release-library-status").textContent).toContain("In Library");
+    expect(screen.getByRole("button", { name: "Mark as Missing" })).toBeDefined();
+    unmount();
+
+    mockGetInformationQuery.mockReturnValue({
+      data: album({ date_lost: "2026-01-15T12:00:00.000Z" }),
+      isLoading: false,
+      isError: false,
+    });
+    renderWithProviders(<ReleaseCard albumId={53375} />);
+    expect(screen.getByTestId("release-library-status").textContent).toContain("Missing since");
+    expect(screen.getByRole("button", { name: "Mark as Found" })).toBeDefined();
+  });
+
+  it("surfaces a load failure rather than rendering an empty card", () => {
+    mockGetInformationQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+
+    renderWithProviders(<ReleaseCard albumId={1} />);
+
+    expect(screen.getByTestId("release-card-error")).toBeDefined();
+  });
+});

--- a/tests/integration/components/classic/catalog/SearchResults.releaseLink.test.tsx
+++ b/tests/integration/components/classic/catalog/SearchResults.releaseLink.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { createTestAlbum, createTestArtist } from "@/tests/helpers";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+const mockSearchCatalogQuery = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams("searchString=autechre"),
+}));
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return {
+    ...actual,
+    useSearchCatalogQuery: (...args: unknown[]) => mockSearchCatalogQuery(...args),
+  };
+});
+
+import SearchResults from "@/src/components/experiences/classic/catalog/SearchResults";
+
+/**
+ * The release title is the row's link to the album card, mirroring
+ * `card-catalog-search`'s `<a href="libraryRelease?id=…">`. Rows whose id was
+ * synthesized client-side (always negative — a hash of the row's content, or a
+ * contentless counter) have no Backend `library.id` to route to and must stay
+ * plain text rather than link to a URL that cannot resolve.
+ */
+describe("Classic SearchResults release link", () => {
+  it("links the release title to the classic release view", () => {
+    const album = createTestAlbum({
+      id: 9200,
+      artist: createTestArtist({ name: "Autechre", lettercode: "AU", numbercode: 3 }),
+      title: "Tri Repetae",
+    });
+    mockSearchCatalogQuery.mockReturnValue({ data: [album], isLoading: false, error: undefined });
+
+    renderWithProviders(<SearchResults />);
+
+    const link = screen.getByRole("link", { name: "Tri Repetae" });
+    expect(link.getAttribute("href")).toBe("/dashboard/library/release/9200");
+  });
+
+  it("leaves the title as plain text when the row's id was synthesized", () => {
+    const album = createTestAlbum({
+      id: -128374,
+      artist: createTestArtist({ name: "Autechre", lettercode: "AU", numbercode: 3 }),
+      title: "Untracked Release",
+    });
+    mockSearchCatalogQuery.mockReturnValue({ data: [album], isLoading: false, error: undefined });
+
+    renderWithProviders(<SearchResults />);
+
+    expect(screen.getByText("Untracked Release")).toBeDefined();
+    expect(screen.queryByRole("link", { name: "Untracked Release" })).toBeNull();
+  });
+
+  it("links the artist name to the ungated view card", () => {
+    const album = createTestAlbum({
+      id: 9200,
+      artist: createTestArtist({ name: "Autechre", lettercode: "AU", numbercode: 3, id: 19516 }),
+      title: "Tri Repetae",
+    });
+    mockSearchCatalogQuery.mockReturnValue({ data: [album], isLoading: false, error: undefined });
+
+    renderWithProviders(<SearchResults />);
+
+    const link = screen.getByRole("link", { name: "Autechre" });
+    expect(link.getAttribute("href")).toBe("/dashboard/library/artist/19516/view");
+  });
+
+  it("leaves the artist as plain text when the row carries no artist id", () => {
+    const album = createTestAlbum({
+      id: 9201,
+      artist: createTestArtist({ name: "Autechre", lettercode: "AU", numbercode: 3, id: undefined }),
+      title: "Amber",
+    });
+    mockSearchCatalogQuery.mockReturnValue({ data: [album], isLoading: false, error: undefined });
+
+    renderWithProviders(<SearchResults />);
+
+    expect(screen.queryByRole("link", { name: "Autechre" })).toBeNull();
+    expect(screen.getByText("Autechre")).toBeDefined();
+  });
+});

--- a/tests/integration/components/classic/catalog/Tracklist.test.tsx
+++ b/tests/integration/components/classic/catalog/Tracklist.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+const mockCompilationTracks = vi.fn();
+const mockLibraryTracks = vi.fn();
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return { ...actual, useGetCompilationTracksQuery: (...a: unknown[]) => mockCompilationTracks(...a) };
+});
+vi.mock("@/lib/features/metadata/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/metadata/api")>();
+  return { ...actual, useGetLibraryTracksQuery: (...a: unknown[]) => mockLibraryTracks(...a) };
+});
+
+import Tracklist from "@/src/components/experiences/classic/catalog/Tracklist";
+
+const empty = { data: undefined, isLoading: false };
+
+describe("Classic Tracklist", () => {
+  it("renders a Discogs-sourced tracklist in two columns", () => {
+    mockCompilationTracks.mockReturnValue(empty);
+    mockLibraryTracks.mockReturnValue({
+      data: {
+        library_id: 65879,
+        discogs_release_id: 41,
+        source: "discogs",
+        tracks: [
+          { position: "1", title: "Rpeg", artist_credit: "Autechre", duration_ms: null },
+          { position: "2", title: "Ccec", artist_credit: "Autechre", duration_ms: null },
+        ],
+      },
+      isLoading: false,
+    });
+
+    renderWithProviders(
+      <Tracklist albumId={53380} legacyReleaseId={65879} variousArtists={false} />
+    );
+
+    expect(screen.getByText("Tracklist")).toBeDefined();
+    expect(screen.getByText("Rpeg")).toBeDefined();
+    // Not various-artists: no artist column, so the header spans two.
+    expect(screen.getByText("Tracklist").getAttribute("colspan")).toBe("2");
+  });
+
+  it("adds the artist column only for a compilation that names artists", () => {
+    mockCompilationTracks.mockReturnValue({
+      data: {
+        library_id: 9001,
+        tracks: [
+          { id: 1, artist_name: "Chuquimamani-Condori", track_title: "Call Your Name", track_position: "A1" },
+        ],
+      },
+      isLoading: false,
+    });
+    mockLibraryTracks.mockReturnValue(empty);
+
+    renderWithProviders(
+      <Tracklist albumId={9001} legacyReleaseId={9001} variousArtists={true} />
+    );
+
+    expect(screen.getByText("Tracklist").getAttribute("colspan")).toBe("3");
+    expect(screen.getByText("Chuquimamani-Condori")).toBeDefined();
+  });
+
+  it("shows the legacy empty copy when neither source has rows", () => {
+    mockCompilationTracks.mockReturnValue(empty);
+    mockLibraryTracks.mockReturnValue({
+      data: { library_id: 65879, discogs_release_id: null, source: null, tracks: [] },
+      isLoading: false,
+    });
+
+    renderWithProviders(
+      <Tracklist albumId={53380} legacyReleaseId={65879} variousArtists={false} />
+    );
+
+    expect(screen.getByText("No tracklist available.")).toBeDefined();
+  });
+
+  it("skips the Discogs source rather than querying it with a placeholder id", () => {
+    mockCompilationTracks.mockReturnValue(empty);
+    mockLibraryTracks.mockReturnValue(empty);
+
+    renderWithProviders(
+      <Tracklist albumId={53380} legacyReleaseId={null} variousArtists={false} />
+    );
+
+    // The id spaces differ and a wrong id returns an unrelated release's
+    // tracklist with a 200, so an absent legacy id must skip, not guess.
+    expect(mockLibraryTracks).toHaveBeenCalledWith(null, expect.objectContaining({ skip: true }));
+  });
+});

--- a/tests/integration/components/modern/login/Forms/LoginFormSwitcher.passwordSwitch.test.tsx
+++ b/tests/integration/components/modern/login/Forms/LoginFormSwitcher.passwordSwitch.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+import LoginFormSwitcher from "@/src/components/experiences/modern/login/Forms/LoginFormSwitcher";
+
+/**
+ * The existing EmailOTPForm test asserts the "Sign in with password instead"
+ * link RENDERS. Nothing asserts that clicking it does anything. This drives the
+ * switch through the component that owns the decision.
+ */
+describe("LoginFormSwitcher: password fallback", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("swaps the OTP form for the password form when the fallback is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <LoginFormSwitcher welcomeQuote={["Welcome...", "to the Jungle", "Guns N' Roses"]} />
+    );
+
+    expect(screen.getByRole("button", { name: "Send login code" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Sign in with password instead" }));
+
+    expect(screen.getByPlaceholderText("Username or email")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send login code" })).toBeNull();
+  });
+});


### PR DESCRIPTION
Classic catalog search results were **inert** — plain table cells with no handler and no link — where `card-catalog-search` links two cells of every row. This builds both destinations and wires the links, plus the scrollport the classic dashboard never had.

> **Stacked on WXYC/dj-site#1259.** Base is `feat/classic-artist-card`, not `main`; review that one first. The diff shown here is only this branch's work.

## What lands

| | |
|---|---|
| **View an Artist Card** | `lucene/artistCardDisplay.jsp` — three-cell header, four-column release table, verbatim empty state. **Ungated.** |
| **View/Modify a Library Release** | `libraryAdmin/libraryReleaseModify.jsp` — label table in JSP order, editable title / alternate artist / format, Library Status with Mark as Missing / Found. **Admin-gated.** |
| **Tracklist** | `tracklist.js` markup and copy, including its column rule |
| **Row links** | artist → view card, release title → release screen |
| **Classic scrollport** | the dashboard could not scroll at all in classic |

## Decisions worth reviewing

**The two artist cards have opposite gates, deliberately.** The JSP expresses them as one URL split by `mode=view`; here they are two routes, because the role gate is a property of the route. The view card is ungated because the JSP carries no role check and catalog search is DJ-facing — gating it would bounce every DJ who clicked an artist. The release screen *is* admin-gated, because its JSP renders under `body class="library-admin"` and every action on it is a librarian action. The consequence is real and matches the legacy interface: a DJ following a release title lands on a screen they cannot open. An ungated read-only release view is a different screen, not a relaxation of this gate.

**Neither cell links to `/dashboard/album/[id]`.** That was the obvious target and it is wrong: the URL has no page in *either* experience slot — both fall through to `default.tsx` and render the experience-gap screen. Its album card exists only as the `@information` slot's client-side portal, so it survives a soft navigation and breaks on reload, bookmark, or paste.

**The artist link degrades rather than breaking before the Backend deploy.** It needs `artist_id` on search rows (WXYC/Backend-Service#2227, merged but **not yet deployed** to api.wxyc.org). Until it is, rows arrive without the field and render as plain text rather than linking to an unresolvable id. Same guard shape on the release link, which skips rows whose id was synthesized client-side — always negative, a content hash or a contentless counter.

**The tracklist's id argument is the sharp edge.** The Discogs-backed source takes a `legacy_release_id`, not a `library.id`. The two spaces are nearly coextensive, so a wrong id does not fail — it returns a real but unrelated release's tracklist with a 200. The component takes both ids explicitly and skips that query rather than guessing when the legacy id is absent.

## Divergences from the JSPs

Each is forced by what Backend serves, and each is enumerated in the component that carries it:

- Release Call Number, Release Call Letter and Album Artist are read-only — `PATCH /library/:id` accepts none of them, so an editable input would silently discard
- No Delete, no Change Library Code, no Undo — none has an endpoint
- Cross-reference blocks omitted on both cards; read-only display is owned separately for the two together
- No sortable column headers — the releases endpoint exposes no ordering parameter
- Multi-volume releases show `5` where the artist card shows `5-A` — `GET /library/info` does not project `code_volume_letters`
- The JSP's **Time Last Modified** is replaced by **Date Added**. Backend returns `last_modified`, but the published contract does not declare it and the client conversion drops it. Reading it anyway needs an untyped cast — the pattern that turns a contract gap into a silent `undefined` — and printing the add date under the JSP's label would be a quieter lie than an honest divergence.

## Verification

`npm run lint` 0 errors, `tsc --noEmit` clean, full `vitest` run. 19 new tests in 5 files.

**One pre-existing failure, confirmed not from this branch.** `tests/integration/components/modern/catalog/AddRelease/VaTracklistStep.test.tsx` times out on one case in the full suite (that file takes ~60s) while passing in isolation. It fails **identically on the base branch** with this branch's commits absent — controlled by running the full suite on `feat/classic-artist-card` itself. Every file this branch touches is classic- or login-scoped except `src/styles/globals.css`, which is CSS and cannot time out a jsdom test.

The classic scroll fix is covered by an e2e spec that drives **the mouse wheel** rather than `scrollIntoView`: an `overflow: hidden` box still has a scrollport, so programmatic scrolling succeeds on a page a person has no way to scroll. Only a real scroll container answers a wheel event.

## Not verifiable locally

Tracklists render the legacy empty copy in a local stack, from both sources: the Discogs path needs `LIBRARY_METADATA_URL`, and the seed clone carries zero `compilation_track_artist` rows. The rendering is covered by tests; the data path needs a stack with LML configured.

## Related

- WXYC/dj-site#1259 — the base branch; merge first
- WXYC/dj-site#1163 — the classic `/wxycdb` xerox epic
- WXYC/dj-site#1169 — Slice 4 owns the rest of the release screen (delete, move-to-code)
- WXYC/dj-site#1211 — owns cross-reference display, now with two consumers
- WXYC/Backend-Service#2227 — supplies the `artist_id` the artist link needs

Closes #1264
Closes #1266
