### PR TITLE
chore(deps): @wxyc/shared ^3.5.0 -> ^4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@opennextjs/cloudflare": "^1.20.2",
         "@reduxjs/toolkit": "^2.12.0",
         "@sentry/browser": "^10.70.0",
-        "@wxyc/shared": "^3.5.0",
+        "@wxyc/shared": "^4.0.0",
         "better-auth": "^1.6.26",
         "jwt-decode": "^4.0.0",
         "motion": "^12.42.2",
@@ -7168,9 +7168,9 @@
       "license": "MIT"
     },
     "node_modules/@wxyc/shared": {
-      "version": "3.5.0",
-      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/3.5.0/7fcc3eaf9c87383cc82d2c7f90a87bbdee77becc",
-      "integrity": "sha512-R8ziGiqNbJNuhiedSWgq+xaNYRE+Wwvo9Gl2kyQG4tqS9+pA9ig/CT/F4oiIPnehV5Blvt8QbWrfgU4bExjCrQ==",
+      "version": "4.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@wxyc/shared/4.0.0/89c029ae8fe9b2b04b2acaa05e74843be3f3824b",
+      "integrity": "sha512-HniPRvft4SVm9W5gFyB1dOJDzZZ1ZpiEt/7UKSsktz7DRzm0oviuSOLbWQOgiaiDbxdxn4ic3CZuPJsowM4qcw==",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "date-fns": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@opennextjs/cloudflare": "^1.20.2",
     "@reduxjs/toolkit": "^2.12.0",
     "@sentry/browser": "^10.70.0",
-    "@wxyc/shared": "^3.5.0",
+    "@wxyc/shared": "^4.0.0",
     "better-auth": "^1.6.26",
     "jwt-decode": "^4.0.0",
     "motion": "^12.42.2",


### PR DESCRIPTION
Unblocks #1268. Manifest + lockfile only — no source file needed editing.

## Why a manifest change and not just a lockfile refresh

This repo pins `"@wxyc/shared": "^3.5.0"`. A caret range **will not accept 4.0.0**, so `npm update` alone can never pick up the types #1268 needs.

## Why 4.0.0 is a major, given the feature was additive

The operator-close contract (WXYC/wxyc-shared#388, backing WXYC/Backend-Service#2238) added two paths and two schemas and removed nothing. The major comes from two *unrelated* commits sitting unreleased between `v3.7.0` and the release — `dc86a93` and `be0f9f4`, which pruned api.yaml paths that were never actually mounted — and took exported symbols with them:

| Removed | From |
|---|---|
| `WeeklySchedule` | `src/dtos/extensions.ts` |
| `DJ`, `DayOfWeek` | generated models (phantom paths pruned) |
| `testDJ` | `src/test-utils/fixtures.ts` |
| `createTestDJ` | `src/test-utils/factories.ts` |

**Nothing in this repo imports any of them** — checked before the release went out, and the clean typecheck below is the second confirmation. They're type- and test-only, so a stale import would have surfaced as a compile error, never at runtime. The major reports the removal honestly rather than its blast radius.

## This is a three-release jump, not one

dj-site was on **3.5.0**; the upgrade crosses 3.6.0 and 3.7.0 as well. Across the entire `v3.5.0..v4.0.0` span the only changes to published source are the removals above — everything else is regenerated DTOs tracking `api.yaml`.

Worth knowing what moved in there, since it looks alarming in a path diff and isn't:

```
- /library/labels        →  + /labels
- /lookup                →  + /api/v1/lookup
- /metadata/album, /metadata/artist   (relocated)
- /djs, /djs/register, /album-reviews, /library/tracks
+ /flowsheet/open-shows, /flowsheet/shows/{id}/force-end   (the new ones)
```

Those are **operation-derived** types. This repo consumes **schema** types (`Show`, `FlowsheetEntry`, …), which is why a path relocation doesn't reach it.

## Verified against 4.0.0, not assumed

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `eslint .` | 0 errors (191 pre-existing warnings) |
| `vitest run` | **5,010 passing / 349 files** |
| `next build` | completes, all routes emitted |

## One note for the reviewer

This changes `package-lock.json`, which busts the E2E Playwright caches — expect the first CI run's shards to be slow and possibly to hit the 15-minute shard timeout. It self-heals on re-run; it is not a real failure. (Same behaviour as any other lockfile-touching PR here.)

## Related

- #1268 — the admin open-shows UI this unblocks
- WXYC/wxyc-shared#388 — the contract · WXYC/Backend-Service#2238 — the endpoints · WXYC/Backend-Service#2235
