### PR TITLE
fix(e2e): authenticate and stub data for the classic catalog scroll spec

### DIFF
--- a/e2e/helpers/catalog-route.ts
+++ b/e2e/helpers/catalog-route.ts
@@ -1,0 +1,40 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Matches the legacy card-catalog search request — `useSearchCatalogQuery` →
+ * `GET <base>/library/?...`.
+ *
+ * The `/proxy/` carve-out is load-bearing: the LML proxy lives under
+ * `/proxy/library/*`, so a predicate without it would swallow both and make a
+ * catalog stub silently intercept LML traffic too.
+ */
+const isCatalogSearch = (url: URL): boolean =>
+  url.pathname.endsWith("/library/") && !url.pathname.includes("/proxy/");
+
+/**
+ * Serve `rows` for the card-catalog search, leaving every other request alone.
+ *
+ * Non-GET falls through: the same path serves catalog writes, and a spec that
+ * stubs a search must not also swallow an add.
+ *
+ * Register before the navigation that triggers the search. Interception fails
+ * open — if the route stops matching, the spec does not error, it silently
+ * falls through to the seeded database and asserts against whatever rows that
+ * happens to hold.
+ */
+export async function stubCatalogSearch(
+  page: Page,
+  rows: readonly unknown[]
+): Promise<void> {
+  await page.route(isCatalogSearch, async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(rows),
+    });
+  });
+}

--- a/e2e/tests/classic/catalog-scroll.spec.ts
+++ b/e2e/tests/classic/catalog-scroll.spec.ts
@@ -1,6 +1,10 @@
 import path from "path";
-import { wxycCanonicalArtistNames } from "@wxyc/shared/test-utils";
+import {
+  createTestAlbumSearchResult,
+  wxycCanonicalArtistNames,
+} from "@wxyc/shared/test-utils";
 import { test, expect } from "../../fixtures/auth.fixture";
+import { stubCatalogSearch } from "../../helpers/catalog-route";
 
 const authDir = path.join(__dirname, "../../.auth");
 
@@ -14,54 +18,28 @@ const authDir = path.join(__dirname, "../../.auth");
  * has none, so a result list longer than the viewport is unreachable unless the
  * classic container is itself a scrollport.
  *
- * The catalog search is stubbed rather than run against the seeded CI
- * database: the CI seed is 9 artists / 10 library rows, and no query against
- * it returns enough rows to overflow a 500px viewport. The mock returns rows
- * in the raw AlbumSearchResultJSON shape `convertToAlbumEntry` consumes (same
- * predicate as flowsheet/backend-results-cap.spec.ts and
- * flowsheet/flowsheet-track-picker.spec.ts).
+ * The search is stubbed because the seeded CI database is far too small for any
+ * query to overflow the viewport, which is the precondition the whole test rests
+ * on. A classic identity is required too: for a signed-in context the account's
+ * appSkin decides the experience, so the app_state cookie cannot reach classic.
  */
 test.describe("Classic catalog overflow", () => {
   test.use({ storageState: path.join(authDir, "classicDj.json") });
 
-  // The legacy catalog endpoint the classic search results table hits
-  // (`useSearchCatalogQuery` -> GET `<base>/library/?...`). NOT the
-  // `/proxy/library/*` LML proxy.
-  const isCatalogSearch = (url: URL) =>
-    url.pathname.endsWith("/library/") && !url.pathname.includes("/proxy/");
-
   test("scrolls to the last result on a short viewport", async ({ page }) => {
     await page.setViewportSize({ width: 1024, height: 500 });
 
-    // 40 rows, comfortably past the 500px viewport and under the search
-    // results table's n: 50 cap, drawn from the WXYC canonical artist pool
-    // rather than synthetic "Artist N" names. Each row is a stand-in WXYC
-    // session recording, tying the rows together under one shared label so
-    // the "wxyc" query below reads as a real search against them.
-    const mockRows = wxycCanonicalArtistNames.slice(0, 40).map((artist_name, i) => ({
-      id: 9000 + i,
-      album_title: `Live at WXYC, Vol. ${i + 1}`,
-      artist_name,
-      code_letters: "WX",
-      code_artist_number: i + 1,
-      code_number: 1,
-      genre_name: "Freeform",
-      format_name: "LP",
-      label: "WXYC Session Archive",
-      add_date: "2024-01-01",
-    }));
+    // Enough rows to overflow a 500px viewport several times over. Distinct
+    // ids because the results table keys rows by id.
+    const mockRows = wxycCanonicalArtistNames.slice(0, 40).map((artist_name, i) =>
+      createTestAlbumSearchResult({
+        id: 9000 + i,
+        album_title: `Live at WXYC, Vol. ${i + 1}`,
+        artist_name,
+      })
+    );
 
-    await page.route(isCatalogSearch, async (route) => {
-      if (route.request().method() === "GET") {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify(mockRows),
-        });
-      } else {
-        await route.fallback();
-      }
-    });
+    await stubCatalogSearch(page, mockRows);
 
     await page.goto("/dashboard/catalog?searchString=wxyc");
 

--- a/e2e/tests/classic/catalog-scroll.spec.ts
+++ b/e2e/tests/classic/catalog-scroll.spec.ts
@@ -1,4 +1,8 @@
-import { test, expect } from "@playwright/test";
+import path from "path";
+import { wxycCanonicalArtistNames } from "@wxyc/shared/test-utils";
+import { test, expect } from "../../fixtures/auth.fixture";
+
+const authDir = path.join(__dirname, "../../.auth");
 
 /**
  * Drives the mouse wheel rather than scrollIntoView: an `overflow: hidden` box
@@ -9,12 +13,57 @@ import { test, expect } from "@playwright/test";
  * regions. Modern carries those inside its panels; classic is plain HTML and
  * has none, so a result list longer than the viewport is unreachable unless the
  * classic container is itself a scrollport.
+ *
+ * The catalog search is stubbed rather than run against the seeded CI
+ * database: the CI seed is 9 artists / 10 library rows, and no query against
+ * it returns enough rows to overflow a 500px viewport. The mock returns rows
+ * in the raw AlbumSearchResultJSON shape `convertToAlbumEntry` consumes (same
+ * predicate as flowsheet/backend-results-cap.spec.ts and
+ * flowsheet/flowsheet-track-picker.spec.ts).
  */
 test.describe("Classic catalog overflow", () => {
+  test.use({ storageState: path.join(authDir, "classicDj.json") });
+
+  // The legacy catalog endpoint the classic search results table hits
+  // (`useSearchCatalogQuery` -> GET `<base>/library/?...`). NOT the
+  // `/proxy/library/*` LML proxy.
+  const isCatalogSearch = (url: URL) =>
+    url.pathname.endsWith("/library/") && !url.pathname.includes("/proxy/");
+
   test("scrolls to the last result on a short viewport", async ({ page }) => {
     await page.setViewportSize({ width: 1024, height: 500 });
-    // A query broad enough that the result table exceeds the viewport.
-    await page.goto("/dashboard/catalog?searchString=james");
+
+    // 40 rows, comfortably past the 500px viewport and under the search
+    // results table's n: 50 cap, drawn from the WXYC canonical artist pool
+    // rather than synthetic "Artist N" names. Each row is a stand-in WXYC
+    // session recording, tying the rows together under one shared label so
+    // the "wxyc" query below reads as a real search against them.
+    const mockRows = wxycCanonicalArtistNames.slice(0, 40).map((artist_name, i) => ({
+      id: 9000 + i,
+      album_title: `Live at WXYC, Vol. ${i + 1}`,
+      artist_name,
+      code_letters: "WX",
+      code_artist_number: i + 1,
+      code_number: 1,
+      genre_name: "Freeform",
+      format_name: "LP",
+      label: "WXYC Session Archive",
+      add_date: "2024-01-01",
+    }));
+
+    await page.route(isCatalogSearch, async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(mockRows),
+        });
+      } else {
+        await route.fallback();
+      }
+    });
+
+    await page.goto("/dashboard/catalog?searchString=wxyc");
 
     const rows = page.locator("#liveResults table.entry-table tbody tr");
     await expect(rows.first()).toBeVisible();

--- a/e2e/tests/flowsheet/backend-results-cap.spec.ts
+++ b/e2e/tests/flowsheet/backend-results-cap.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "../../fixtures/auth.fixture";
 import { FlowsheetPage } from "../../pages/flowsheet.page";
+import { stubCatalogSearch } from "../../helpers/catalog-route";
 import path from "path";
 
 const authDir = path.join(__dirname, "../../.auth");
@@ -58,13 +59,6 @@ test.describe("Flowsheet backend results — render cap", { tag: "@smoke" }, () 
     await context.close();
   });
 
-  // The legacy catalog endpoint the flowsheet's card-catalog search hits
-  // (`useSearchCatalogQuery` → GET `<base>/library/?...`). NOT the
-  // `/proxy/library/*` LML proxy — same predicate shape as the track-picker
-  // spec's isCatalogSearch.
-  const isCatalogSearch = (url: URL) =>
-    url.pathname.endsWith("/library/") && !url.pathname.includes("/proxy/");
-
   test("a 500-row backend response neither freezes the tab nor renders unbounded rows", async ({
     page,
   }) => {
@@ -87,17 +81,7 @@ test.describe("Flowsheet backend results — render cap", { tag: "@smoke" }, () 
       on_streaming: true,
     }));
 
-    await page.route(isCatalogSearch, async (route) => {
-      if (route.request().method() === "GET") {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify(rows),
-        });
-      } else {
-        await route.fallback();
-      }
-    });
+    await stubCatalogSearch(page, rows);
 
     // Suppress LML proxy results (same pattern as flowsheet-track-picker's
     // catalog suppression, inverted) so stray library-search rows can't shift

--- a/e2e/tests/flowsheet/flowsheet-track-picker.spec.ts
+++ b/e2e/tests/flowsheet/flowsheet-track-picker.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "../../fixtures/auth.fixture";
 import { FlowsheetPage } from "../../pages/flowsheet.page";
+import { stubCatalogSearch } from "../../helpers/catalog-route";
 import path from "path";
 
 const authDir = path.join(__dirname, "../../.auth");
@@ -59,13 +60,6 @@ test.describe("Flowsheet Track Picker", { tag: "@smoke" }, () => {
     await context.close();
   });
 
-  // URL predicate for the legacy /library/ catalog endpoint (NOT the
-  // /proxy/library/* LML proxy). Used to suppress card-catalog results so
-  // the LML mock row reliably lands at a known index.
-  const isCatalogSearch = (url: URL) =>
-    url.pathname.endsWith("/library/") &&
-    !url.pathname.includes("/proxy/");
-
   test("picks a tracklisted release and submits track_title + track_position; the LML write-gate withholds album_id", async ({
     page,
   }) => {
@@ -74,17 +68,7 @@ test.describe("Flowsheet Track Picker", { tag: "@smoke" }, () => {
     // Suppress card-catalog results so only the LML mock populates the
     // result list (otherwise a seeded backend could shift the positional
     // index of the picker target row).
-    await page.route(isCatalogSearch, async (route) => {
-      if (route.request().method() === "GET") {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify([]),
-        });
-      } else {
-        await route.fallback();
-      }
-    });
+    await stubCatalogSearch(page, []);
 
     // Mock library search → one Juana Molina release.
     await page.route("**/proxy/library/search**", async (route) => {
@@ -261,32 +245,22 @@ test.describe("Flowsheet Track Picker", { tag: "@smoke" }, () => {
       });
     });
 
-    await page.route(isCatalogSearch, async (route) => {
-      if (route.request().method() !== "GET") {
-        await route.fallback();
-        return;
-      }
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify([
-          {
-            id: LIBRARY_ID,
-            legacy_release_id: LEGACY_RELEASE_ID,
-            add_date: "2026-05-01T00:00:00.000Z",
-            album_title: "On Your Own Love Again",
-            artist_name: "Jessica Pratt",
-            code_letters: "PR",
-            code_artist_number: 3,
-            code_number: 1,
-            format_name: "Vinyl",
-            genre_name: "Rock",
-            label: "Drag City",
-            plays: 4,
-          },
-        ]),
-      });
-    });
+    await stubCatalogSearch(page, [
+      {
+        id: LIBRARY_ID,
+        legacy_release_id: LEGACY_RELEASE_ID,
+        add_date: "2026-05-01T00:00:00.000Z",
+        album_title: "On Your Own Love Again",
+        artist_name: "Jessica Pratt",
+        code_letters: "PR",
+        code_artist_number: 3,
+        code_number: 1,
+        format_name: "Vinyl",
+        genre_name: "Rock",
+        label: "Drag City",
+        plays: 4,
+      },
+    ]);
 
     // Both id spaces answer, with different tracklists. Stubbing only the
     // correct one would let a wrong-space read fail as an unrouted request —
@@ -370,17 +344,7 @@ test.describe("Flowsheet Track Picker", { tag: "@smoke" }, () => {
     const LIBRARY_ID = 54321;
 
     // Suppress card-catalog results (see comment on the previous test).
-    await page.route(isCatalogSearch, async (route) => {
-      if (route.request().method() === "GET") {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify([]),
-        });
-      } else {
-        await route.fallback();
-      }
-    });
+    await stubCatalogSearch(page, []);
 
     await page.route("**/proxy/library/search**", async (route) => {
       await route.fulfill({


### PR DESCRIPTION
Closes #1271

`E2E Tests` has been red on `main` since #1259 merged on 2026-08-21. One spec fails, deterministically: `e2e/tests/classic/catalog-scroll.spec.ts` › "Classic catalog overflow › scrolls to the last result on a short viewport".

## Root cause

Not a rendering regression in the #1259 range, and not flake. The accessibility snapshot in the failing run's Playwright artifact shows the **login page**, and it is byte-identical across the retry — so the spec never reached the catalog at all. Three causes were stacked, each of which alone is sufficient to fail the test:

1. **No authentication.** The spec set no `storageState` — it was the only spec under `e2e/tests/` without one. `app/dashboard/layout.tsx` gates the dashboard through `resolveAuthGate()`, which redirects to `/login?bounced=no-session` when there is no session, so `#liveResults` never rendered in any of its four branches. This is why the failure is `element(s) not found` rather than the empty-results branch the issue hypothesized.
2. **Wrong experience.** CI runs with `NEXT_PUBLIC_DEFAULT_EXPERIENCE=modern`. For a signed-in context the account's `appSkin` beats the `app_state` cookie, so merely authenticating is not enough — only the dedicated classic identities (`classicMd.json` / `classicDj.json`, provisioned in `e2e/auth.setup.ts`) land on the classic slot.
3. **No matching data.** `searchString=james` matched nothing. The CI E2E database is seeded from Backend-Service `dev_env/seed_db.sql` — 9 artists / 10 library rows, zero "James". The James rows exist only in `dev_env/seed-clone.sql`, an untracked prod clone gated behind `LOAD_CLONE_FIXTURE=true`, which neither the CI workflow nor `scripts/e2e-local.sh` sets. So even a correctly-authenticated classic session had no result set that could overflow a 500px viewport.

The issue's stated hypothesis (the empty-results branch) was the right instinct about the data, but the auth redirect preempts it — the component never mounted. Both are fixed here regardless, because fixing only the data would have left the spec passing for the wrong reason on a future config change.

## The fix

No product code changes — nothing in the app was broken. The fix itself is one file, `e2e/tests/classic/catalog-scroll.spec.ts`; a second commit consolidates the route stub it uses (see "Review follow-ups" below).

- `test.use({ storageState: classicDj.json })`, matching how `e2e/tests/rbac/role-access.spec.ts` pins its classic assertions. DJ authority is the correct floor here: catalog search is DJ-readable, so the spec does not need the MD identity.
- A stub of `GET <base>/library/` returning 40 rows in the `AlbumSearchResultJSON` shape `convertToAlbumEntry` consumes, built with the shared `createTestAlbumSearchResult` factory so the stubbed wire shape stays tied to the DTO. The route predicate deliberately excludes `/proxy/library/*` (the LML proxy) and falls through on non-GET, so it intercepts exactly the one call `useSearchCatalogQuery` makes and nothing else.
- Rows are drawn from `wxycCanonicalArtistNames` rather than synthetic "Artist N" strings, per the repo's real-catalog-data fixture rule. 40 rows overflows a 500px viewport several times over, which is the only bound that matters — the ids are distinct because the results table keys rows by id.

Stubbing rather than seeding is the deliberate choice: it makes overflow a property of the test rather than of whichever seed file the environment happens to load, which is precisely the coupling that let this spec assert against data it was never guaranteed.

## Review follow-ups

A second commit, `refactor(e2e): share the card-catalog search stub`, came out of review. The same route stub — match `GET <base>/library/` with a `/proxy/` carve-out, fulfill JSON on GET, fall through otherwise — was independently re-implemented at five call sites across three specs, in two spellings of the same guard. It is now `stubCatalogSearch(page, rows)` in `e2e/helpers/catalog-route.ts`.

That consolidation is on-theme rather than incidental: the interception fails open. A stub that stops matching does not error — it lets the spec fall through to the seeded database and assert against whatever rows that happens to hold, which is exactly the silent, data-dependent pass this PR is fixing. One helper means that failure mode can only be introduced in one place. Net effect on the three specs is a line reduction.

The two flowsheet specs it touches (`backend-results-cap`, `flowsheet-track-picker`) were already green, so they were re-run locally in the real harness alongside the target spec — all 12 tests pass. Worth knowing for reviewers: the root `tsconfig.json` **excludes** `e2e/`, so CI's `Type Check` job does not cover these files; `npx playwright test --list` (which transpiles all 30 spec files) is the actual compile gate, and it is clean.

## The test still proves the original property

This was an explicit acceptance criterion, so to be concrete about what did **not** change: the `page.mouse.move` / `page.mouse.wheel(0, 4000)` drive and the `toBeInViewport` assertions are untouched. The spec still asserts the last row is out of view, drives a real wheel event, and asserts it comes into view.

That distinction is load-bearing and the reason the wheel is not collapsed into `scrollIntoView`: an `overflow: hidden` box still has a scrollport and still answers *programmatic* scrolling, so `scrollIntoView` would pass on a page a user has no way to scroll. Only a real scroll container answers the wheel. The property under test — that `#classic-container` is a genuine scrollport — is intact; what changed is only that the test now reliably reaches a page where that property can be observed.

## Verification

Run against the real harness, not just a headless assertion. Scoped to every spec this PR touches, since the refactor reaches two previously-green flowsheet specs:

```
BACKEND_DIR=../Backend-Service ./scripts/e2e-local.sh \
  --grep "Classic catalog overflow|Flowsheet backend results|Flowsheet Track Picker"
```

→ **12 passed**: the target spec, the render-cap spec, and all three track-picker tests.

Also clean locally: `npm run lint` at 0 errors / 191 warnings (the existing baseline — no new warnings), `npx tsc --noEmit`, the full unit suite (349 files / 5010 tests), and `npx playwright test --list` (all 30 spec files transpile).

## On the fourth acceptance criterion: required checks

The issue asked for a decision on whether `E2E Tests` should be a required check, on the reasoning that it not being one is what let this reach `main`. That premise turns out to be wrong, and the real gap is one step over — worth stating precisely so the decision lands in the right place.

`E2E Tests` **is already a required status check** on `main`. Current required contexts: `Preview URL smoke check`, `Type Check`, `Build`, `E2E Tests`, `Unit Tests`. The check is also already shard-rename-proof: `e2e-tests.yml` carries a dedicated aggregator job (`e2e-all`) named exactly `E2E Tests`, precisely so the protection rule survives changes to the shard count.

It reported `failure` on #1259's head SHA `696581ff`, and the PR merged anyway. The mechanism is `enforce_admins: false` on the branch protection rule, which lets an administrator merge past a failing required check.

So the open decision is **not** whether to make the check required — it already is — but whether to enable `enforce_admins`. My recommendation is to enable it: a required check an admin can wave through is an advisory check, and this incident is the demonstration, with two unrelated PRs inheriting the red main afterwards. The counter-argument worth weighing is that `enforce_admins` also removes the escape hatch for a genuine CI-infrastructure outage, where merging past a red check is the correct call; on a repo this size that trade may still favor enabling it, with the escape hatch being a temporary toggle rather than a standing exemption.

**No repository settings or branch protection were changed in this PR** — that is the repo owner's call, not something to slip into a test fix.
