### PR TITLE
feat(classic): resolve a library code to the artist who holds it

### DIFF
--- a/app/dashboard/@classic/library/artist/new/page.tsx
+++ b/app/dashboard/@classic/library/artist/new/page.tsx
@@ -20,10 +20,12 @@ type ClassicCreateLibraryCodePageProps = {
 
 /**
  * Reproduces `createLibraryCode.jsp`: the miss branch of
- * `findOrCreateLibraryCode` (`ArtistAdminServlet:161`). URL-reachable on its
- * own route, taking the code that missed as query params, ahead of the
- * chooser's no-match branch being wired into it. Not linked in nav -- see
- * `isClassicLibrarianNavEnabled`.
+ * `findOrCreateLibraryCode` (`ArtistAdminServlet:161`), reached from
+ * `ArtistSearchForm`'s code search when `resolveArtistByCode` answers
+ * `code_not_assigned` for the searched triple. URL-reachable on its own
+ * route too, taking the code as query params -- not linked in nav itself
+ * (see `isClassicLibrarianNavEnabled`), since a librarian always arrives
+ * here carrying a specific code rather than choosing this screen directly.
  */
 export default async function ClassicCreateLibraryCodePage({
   searchParams,

--- a/app/dashboard/@classic/library/page.tsx
+++ b/app/dashboard/@classic/library/page.tsx
@@ -3,17 +3,19 @@ import { getPageTitle } from "@/lib/utils/page-title";
 import { requireAuth, requireRole } from "@/lib/features/authentication/server-utils";
 import { Authorization } from "@/lib/features/admin/types";
 import Main from "@/src/components/experiences/classic/Layout/Main";
-import ArtistSearchForm from "@/src/components/experiences/classic/catalog/ArtistSearchForm";
-import NewArtistForm from "@/src/components/experiences/classic/catalog/NewArtistForm";
+import LibraryChooser from "@/src/components/experiences/classic/catalog/LibraryChooser";
 
 export const metadata: Metadata = {
   title: getPageTitle("Find an Artist"),
 };
 
 /**
- * Reproduces `chooseLibraryCodeOrArtist.jsp`: the classic catalog's
- * artist-vs-Various-Artists entry point, gated to `hasAdminAccess()` in the
- * JSP's `mainmenu.jsp`.
+ * Reproduces `chooseLibraryCodeOrArtist.jsp` and, on a multi-match,
+ * `multipleArtistsDisplay.jsp` -- the classic catalog's
+ * artist-vs-Various-Artists entry point and its code-search resolution, both
+ * gated to `hasAdminAccess()` in the JSP's `mainmenu.jsp`. `LibraryChooser`
+ * owns which of the two screens is showing; see its doc for why that toggle
+ * lives below this one URL rather than as a separate route.
  */
 export default async function LibraryPage() {
   const session = await requireAuth();
@@ -21,9 +23,7 @@ export default async function LibraryPage() {
 
   return (
     <Main>
-      <ArtistSearchForm />
-      <hr />
-      <NewArtistForm />
+      <LibraryChooser />
     </Main>
   );
 }

--- a/lib/features/catalog/adminCreateArtistValidation.ts
+++ b/lib/features/catalog/adminCreateArtistValidation.ts
@@ -1,26 +1,30 @@
 import type { AddArtistConflict } from "./types";
 
-/** Empty or non-numeric strings must not become 0 (Number("") === 0). */
-export function parseRequiredPositiveInt(raw: string): number | null {
-  const trimmed = raw.trim();
-  // Base-10 positive integers only — reject scientific/hex (Number("1e3") === 1000).
-  if (trimmed === "" || !/^[1-9]\d*$/.test(trimmed)) return null;
-  return Number(trimmed);
-}
-
 /**
- * Same contract as `parseRequiredPositiveInt` with a floor of 0 instead of 1
- * — the floor `resolveArtistByCode` enforces on `code_number`. 0 is not a
+ * The floor `resolveArtistByCode` enforces on `code_number`. 0 is not a
  * placeholder there: it is the Various Artists filing (every compilation
- * bucket is stored at `artist_genre_code = 0`, regardless of genre), and
- * Backend-Service imposes no floor above 0 for an ordinary artist code
- * either, so a carried or typed "0" must parse rather than be read as
- * absent.
+ * bucket is stored at `artist_genre_code = 0`), and Backend-Service imposes
+ * no floor above 0 for an ordinary artist code either, so a carried or typed
+ * "0" must parse rather than be read as absent.
+ *
+ * Empty or non-numeric strings must not become 0 (`Number("") === 0`), and
+ * only base-10 integers count — `Number` accepts scientific and hex notation
+ * (`Number("1e3") === 1000`) for values no call-number field means.
  */
 export function parseRequiredNonNegativeInt(raw: string): number | null {
   const trimmed = raw.trim();
   if (trimmed === "" || !/^(?:0|[1-9]\d*)$/.test(trimmed)) return null;
   return Number(trimmed);
+}
+
+/**
+ * The same contract with a floor of 1. Expressed in terms of the function
+ * above rather than beside it: the two differ on exactly one input, and every
+ * other rule they must agree on is worth stating once.
+ */
+export function parseRequiredPositiveInt(raw: string): number | null {
+  const parsed = parseRequiredNonNegativeInt(raw);
+  return parsed === 0 ? null : parsed;
 }
 
 /**
@@ -57,6 +61,23 @@ export const CODE_NUMBER_MAX = 2147483647;
  */
 export function normalizeCodeLetters(value: string): string {
   return value.toUpperCase();
+}
+
+/**
+ * Whether a code can be *looked up* by `GET /library/artists/by-code`, which
+ * rejects anything else with a 400.
+ *
+ * Deliberately narrower than what `normalizeCodeLetters` above lets a
+ * librarian file, and the gap is real rather than an oversight: the catalog
+ * holds `??` placeholders and legacy `Z-<letter>` compilation codes, and
+ * neither is resolvable by code. Answering the narrow question here, beside
+ * the column's other rules, is what keeps a caller from re-deriving the
+ * domain — and from mistaking this for what may be stored.
+ */
+const CANONICAL_CODE_LETTERS = new RegExp(`^[A-Za-z0-9/]{1,${CODE_LETTERS_MAX_LENGTH}}$`);
+
+export function isCanonicalCodeLetters(value: string): boolean {
+  return CANONICAL_CODE_LETTERS.test(value);
 }
 
 export type NewArtistFieldValues = {

--- a/lib/features/catalog/adminCreateArtistValidation.ts
+++ b/lib/features/catalog/adminCreateArtistValidation.ts
@@ -9,6 +9,21 @@ export function parseRequiredPositiveInt(raw: string): number | null {
 }
 
 /**
+ * Same contract as `parseRequiredPositiveInt` with a floor of 0 instead of 1
+ * — the floor `resolveArtistByCode` enforces on `code_number`. 0 is not a
+ * placeholder there: it is the Various Artists filing (every compilation
+ * bucket is stored at `artist_genre_code = 0`, regardless of genre), and
+ * Backend-Service imposes no floor above 0 for an ordinary artist code
+ * either, so a carried or typed "0" must parse rather than be read as
+ * absent.
+ */
+export function parseRequiredNonNegativeInt(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (trimmed === "" || !/^(?:0|[1-9]\d*)$/.test(trimmed)) return null;
+  return Number(trimmed);
+}
+
+/**
  * Column ceilings on the rows an artist-creation form writes. Nothing between
  * these fields and the INSERT checks any of them — the handler validates only
  * that the keys are present — so an over-long or over-large value reaches

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -30,6 +30,8 @@ import {
   LibraryQueryParams,
   PeekArtistCodeQuery,
   PeekArtistCodeResponse,
+  ResolveArtistByCodeQuery,
+  ResolveArtistByCodeResponse,
   SearchArtistsInGenreParams,
   SearchArtistsInGenreResponse,
   SearchCatalogQueryParams,
@@ -325,6 +327,40 @@ export const catalogApi = createApi({
         { type: "ArtistCodePeek", id: `${genre_id}:${code_letters}` },
       ],
     }),
+    /**
+     * Resolves a fully-specified library code (`chooseLibraryCodeOrArtist.jsp`'s
+     * `artistSearchForm`, `mode=findOrCreateLibraryCode`) to the artist(s) that
+     * own it. A 200 always carries one or more owners -- more than one is the
+     * `multipleArtistsDisplay.jsp` disambiguation case, not an error; a 404
+     * distinguishes an unknown genre from a code simply not assigned in a
+     * genre that does exist (`reason: 'genre_not_found' | 'code_not_assigned'`).
+     *
+     * Same opt-out and reasoning as `searchArtistsInGenre`: the shared base
+     * query soft-fails an unparseable body (a gateway's HTML 502, Express's
+     * HTML 404) into a successful `null`, which here would read as "code not
+     * assigned" -- the one answer an unreachable backend must not give, since
+     * the chooser acts on it by routing the librarian to create a fresh
+     * artist under that exact code.
+     */
+    resolveArtistByCode: builder.query<ResolveArtistByCodeResponse, ResolveArtistByCodeQuery>({
+      query: ({ genre_id, code_letters, code_number }) => ({
+        url: "/artists/by-code",
+        params: { genre_id, code_letters, code_number },
+      }),
+      extraOptions: { surfaceNonJsonAsError: true },
+      // The chooser handles every failure shape inline (see
+      // `resolveArtistByCodeErrorReason`), including the two structured 404
+      // reasons -- neither is a surprise the shared rtk-query-error-logger
+      // middleware should also toast. Wrapping hides `data.message` from
+      // that middleware entirely, same technique as searchArtistsInGenre for
+      // the same reason: one message, from the screen that has the context
+      // to state it precisely, not two.
+      transformErrorResponse: (
+        response: FetchBaseQueryError,
+      ): { resolveArtistByCodeError: FetchBaseQueryError } => ({
+        resolveArtistByCodeError: response,
+      }),
+    }),
     searchArtistsInGenre: builder.query<
       SearchArtistsInGenreResponse,
       SearchArtistsInGenreParams
@@ -528,6 +564,7 @@ export const {
   useUpdateArtistCardMutation,
   useGetArtistReleasesQuery,
   useLazyPeekArtistCodeQuery,
+  useLazyResolveArtistByCodeQuery,
   useSearchArtistsInGenreQuery,
   useGetCompilationTracksQuery,
   useGetCompilationTrackSuggestionsQuery,

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -348,6 +348,16 @@ export const catalogApi = createApi({
         params: { genre_id, code_letters, code_number },
       }),
       extraOptions: { surfaceNonJsonAsError: true },
+      // Guards a well-formed 200 whose body omits `artists`, the same shape
+      // guard `searchArtistsInGenre` and `getCompilationTracks` apply: the
+      // caller reads `.length` to pick its branch, so a missing array would
+      // throw mid-handler and be laundered into the generic outage message.
+      // The empty array it resolves to is a shape the contract never
+      // produces, and the caller refuses to act on it for that reason.
+      transformResponse: (
+        response: ResolveArtistByCodeResponse | null,
+      ): ResolveArtistByCodeResponse =>
+        response?.artists ? response : { artists: [] },
       // The chooser handles every failure shape inline (see
       // `resolveArtistByCodeErrorReason`), including the two structured 404
       // reasons -- neither is a surprise the shared rtk-query-error-logger

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -348,12 +348,18 @@ export const catalogApi = createApi({
         params: { genre_id, code_letters, code_number },
       }),
       extraOptions: { surfaceNonJsonAsError: true },
-      // Guards a well-formed 200 whose body omits `artists`, the same shape
-      // guard `searchArtistsInGenre` and `getCompilationTracks` apply: the
-      // caller reads `.length` to pick its branch, so a missing array would
-      // throw mid-handler and be laundered into the generic outage message.
-      // The empty array it resolves to is a shape the contract never
-      // produces, and the caller refuses to act on it for that reason.
+      // Never read from cache: the trigger always refetches, and a stale
+      // `code_not_assigned` is the one answer that routes the librarian into
+      // creating a duplicate. Dropping the entry as soon as the form lets go
+      // keeps that impossible by construction rather than by the trigger's
+      // default, and is why the endpoint carries no `providesTags`.
+      keepUnusedDataFor: 0,
+      // Unlike its two models, an empty list is not a legal answer here -- an
+      // unassigned code is a 404 carrying `code_not_assigned`. So this guard
+      // is not making a missing `artists` mean "none": it is normalizing an
+      // unreadable body onto the one value the caller already refuses to act
+      // on, so both arrive at the same refusal instead of one of them
+      // throwing mid-handler.
       transformResponse: (
         response: ResolveArtistByCodeResponse | null,
       ): ResolveArtistByCodeResponse =>

--- a/lib/features/catalog/chooserValidation.ts
+++ b/lib/features/catalog/chooserValidation.ts
@@ -26,6 +26,16 @@ export type ValidationResult<Field extends string> =
   | { valid: false; field: Field; message: string };
 
 /**
+ * The JSP's own wording for the two conditions a later gate can also reach.
+ * Exported so the composition step downstream refuses in the same words: a
+ * librarian who sees one sentence for a condition and a different one for the
+ * same condition reads it as two different problems.
+ */
+export const GENRE_REQUIRED_MESSAGE = "You must select a genre.";
+export const CALL_LETTER_MODE_REQUIRED_MESSAGE =
+  "You must select one of the choices for Call Letters/Numbers.";
+
+/**
  * The rockCompLetters sub-bucket letter is required for genreID 11 AND 12 —
  * the JSP's visible label names only "Rock comps", but its own validator
  * raises a distinct message for 12 ("Soundtracks require an additional
@@ -59,7 +69,7 @@ export function validateArtistSearchForm(
       return {
         valid: false,
         field: "genreId",
-        message: "You must select a genre.",
+        message: GENRE_REQUIRED_MESSAGE,
       };
     }
     if (values.genreId === 11 && values.rockCompLetters.trim() === "") {
@@ -82,7 +92,7 @@ export function validateArtistSearchForm(
   return {
     valid: false,
     field: "callLetterMode",
-    message: "You must select one of the choices for Call Letters/Numbers.",
+    message: CALL_LETTER_MODE_REQUIRED_MESSAGE,
   };
 }
 

--- a/lib/features/catalog/libraryCode.ts
+++ b/lib/features/catalog/libraryCode.ts
@@ -1,11 +1,17 @@
 /**
  * Shelf-code rendering for the classic librarian screens, reproducing
- * tubafrenzy's four formatters rule-for-rule:
+ * tubafrenzy's four formatters:
  *
  * - `ArtistLibraryCode.getCallLettersAndNumbers()` (`:85`)
  * - `ArtistLibraryCode.getCallLettersAndNumbersWithPunctuation()` (`:98`)
  * - `LibraryRelease.getCallNumbersAndLetters()` (`:122`)
  * - `LibraryRelease.getEntireLibraryCode()` (`:129`)
+ *
+ * Rule-for-rule except where the Java recovers a Various Artists sub-bucket
+ * letter by substring-ing the legacy `Z-<letter>` spelling. That letter is
+ * gone from the data these functions are given -- see `isVariousArtists`
+ * below -- so the substring would slice the `V/A` literal itself and render
+ * a letter the shelf does not use. Each such branch names the divergence.
  *
  * These are not cosmetic. The composed string is the physical call number a
  * librarian reads off the screen and walks to the stacks with, so its
@@ -67,12 +73,15 @@ export function isVariousArtists(codeLetters: string): boolean {
  * The artist half of a call number, with no trailing punctuation: `MO 12`
  * for a named artist, `V/A` for a compilation bucket.
  *
- * Unlike `formatArtistCodeWithPunctuation`, this never recovers a
- * Rock/Soundtracks sub-bucket letter (`X-`) from the legacy `Z-<letter>`
- * spelling: `multipleArtistsDisplay.jsp`, the one screen that renders this
- * exact getter, only ever receives rows Backend-Service already collapsed to
- * the literal `V/A` — see this file's header — so there is no sub-bucket
- * letter left to recover by the time a caller here holds one.
+ * The Java splits the Various Artists case three ways off `genre_id` —
+ * `V/A <letter>` for Rock, the bare `<letter>` for Soundtracks, and `V/A` for
+ * every other genre — by taking `callLetters.substring(2, 3)` out of a
+ * `Z-<letter>` code. This takes no `genre_id` because that split has no input
+ * left: `multipleArtistsDisplay.jsp` is the one screen rendering this getter,
+ * and it only ever receives rows the catalog import already collapsed to the
+ * literal `V/A`, where `substring(2, 3)` would slice out the `A` of `V/A`.
+ * The sub-bucket survives in the artist's NAME, which this screen's own
+ * Artist Name column shows, so the librarian still tells the buckets apart.
  */
 export function formatCallLettersAndNumbers({
   code_letters,

--- a/lib/features/catalog/libraryCode.ts
+++ b/lib/features/catalog/libraryCode.ts
@@ -45,6 +45,14 @@ export type ReleaseCodeParts = {
 };
 
 /**
+ * The one code every Various Artists bucket is filed under once the catalog
+ * import has run, in every genre. The data-model fact behind the collapse
+ * documented on `isVariousArtists` below, exported so the code search and the
+ * formatters compose one literal rather than four.
+ */
+export const VARIOUS_ARTISTS_CODE_LETTERS = "V/A";
+
+/**
  * True for a Various Artists bucket.
  *
  * Two spellings, because two systems store this differently and only one of
@@ -66,7 +74,7 @@ export type ReleaseCodeParts = {
  */
 export function isVariousArtists(codeLetters: string): boolean {
   const trimmed = codeLetters.trim();
-  return trimmed.toUpperCase() === "V/A" || trimmed.startsWith("Z-");
+  return trimmed.toUpperCase() === VARIOUS_ARTISTS_CODE_LETTERS || trimmed.startsWith("Z-");
 }
 
 /**
@@ -88,7 +96,7 @@ export function formatCallLettersAndNumbers({
   code_artist_number,
 }: Pick<ArtistCodeParts, "code_letters" | "code_artist_number">): string {
   if (isVariousArtists(code_letters)) {
-    return "V/A";
+    return VARIOUS_ARTISTS_CODE_LETTERS;
   }
   return `${code_letters.toUpperCase()} ${code_artist_number}`;
 }
@@ -122,10 +130,13 @@ export function formatArtistCodeWithPunctuation({
     const bucket =
       genre_id === SOUNDTRACKS_GENRE_ID && trimmed.startsWith("Z-")
         ? trimmed.substring(2, 3)
-        : "V/A";
+        : VARIOUS_ARTISTS_CODE_LETTERS;
     return `${bucket}-`;
   }
-  return `${code_letters.toUpperCase()} ${code_artist_number}/`;
+  // The named-artist form is the same string the no-punctuation getter
+  // renders, which is how the Java relates the two -- delegated so the pair
+  // cannot drift into disagreeing about a code neither branch calls V/A.
+  return `${formatCallLettersAndNumbers({ code_letters, code_artist_number })}/`;
 }
 
 /**

--- a/lib/features/catalog/libraryCode.ts
+++ b/lib/features/catalog/libraryCode.ts
@@ -1,7 +1,8 @@
 /**
  * Shelf-code rendering for the classic librarian screens, reproducing
- * tubafrenzy's three formatters rule-for-rule:
+ * tubafrenzy's four formatters rule-for-rule:
  *
+ * - `ArtistLibraryCode.getCallLettersAndNumbers()` (`:85`)
  * - `ArtistLibraryCode.getCallLettersAndNumbersWithPunctuation()` (`:98`)
  * - `LibraryRelease.getCallNumbersAndLetters()` (`:122`)
  * - `LibraryRelease.getEntireLibraryCode()` (`:129`)
@@ -57,9 +58,30 @@ export type ReleaseCodeParts = {
  * `Various Artists`, `Various Artists - Rock - <A-Z>`, and
  * `Soundtracks - <A-Z>`, and the last of those contains no "various" at all.
  */
-function isVariousArtists(codeLetters: string): boolean {
+export function isVariousArtists(codeLetters: string): boolean {
   const trimmed = codeLetters.trim();
   return trimmed.toUpperCase() === "V/A" || trimmed.startsWith("Z-");
+}
+
+/**
+ * The artist half of a call number, with no trailing punctuation: `MO 12`
+ * for a named artist, `V/A` for a compilation bucket.
+ *
+ * Unlike `formatArtistCodeWithPunctuation`, this never recovers a
+ * Rock/Soundtracks sub-bucket letter (`X-`) from the legacy `Z-<letter>`
+ * spelling: `multipleArtistsDisplay.jsp`, the one screen that renders this
+ * exact getter, only ever receives rows Backend-Service already collapsed to
+ * the literal `V/A` — see this file's header — so there is no sub-bucket
+ * letter left to recover by the time a caller here holds one.
+ */
+export function formatCallLettersAndNumbers({
+  code_letters,
+  code_artist_number,
+}: Pick<ArtistCodeParts, "code_letters" | "code_artist_number">): string {
+  if (isVariousArtists(code_letters)) {
+    return "V/A";
+  }
+  return `${code_letters.toUpperCase()} ${code_artist_number}`;
 }
 
 /**

--- a/lib/features/catalog/libraryCodeResolution.ts
+++ b/lib/features/catalog/libraryCodeResolution.ts
@@ -1,0 +1,118 @@
+import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
+import type { CallLetterMode } from "./chooserValidation";
+import { parseRequiredNonNegativeInt } from "./adminCreateArtistValidation";
+import type { ResolveArtistByCodeQuery } from "./types";
+
+/**
+ * Composes `artistSearchForm`'s fields into `resolveArtistByCode`'s query
+ * args, once `chooserValidation.validateArtistSearchForm` has already passed
+ * -- this is a second, independent gate, not a restatement of that one.
+ *
+ * `by-code` requires a fully specified `(genre_id, code_letters,
+ * code_number)` triple; the JSP's own client-side validator
+ * (`library-code-form.js`) never required a call number at all, because the
+ * legacy servlet fell through to a genre+letters-only browse
+ * (`LibraryCodeServlet` -> `multipleArtistsDisplay.jsp`) when one was
+ * missing. That browse has no Backend-Service equivalent -- there is no
+ * "any number" query -- so a blank or unparseable call number is refused
+ * here instead of being silently treated as a miss or forwarded as an
+ * invalid request.
+ */
+export type LibraryCodeSearchValues = {
+  callLetterMode: CallLetterMode;
+  artistLettersTextbox: string;
+  artistNumbersTextbox: string;
+  genreId: number | null;
+};
+
+export type LibraryCodeSearchComposition =
+  | { ready: true; args: ResolveArtistByCodeQuery }
+  | { ready: false; message: string };
+
+/**
+ * The literal code Backend-Service's catalog import files every Various
+ * Artists bucket under, regardless of genre -- see `libraryCode.ts`'s header
+ * for the collapse this reflects. The JSP composed a genre-specific
+ * `Z-<letter>` search key from the compilation radio's `rockCompLetters`
+ * sub-bucket field for Rock/Soundtracks; that letter does not survive in
+ * Backend-Service's storage, so it cannot narrow this search. Every
+ * compilation bucket for a genre collides on this one triple, which is the
+ * disambiguation screen's actual production trigger -- `V/A`/12/0 has 27
+ * owners, `V/A`/11/0 has 26, in the current catalog.
+ */
+const VARIOUS_ARTISTS_CODE_LETTERS = "V/A";
+const VARIOUS_ARTISTS_CODE_NUMBER = 0;
+
+export function composeLibraryCodeSearchArgs(
+  values: LibraryCodeSearchValues,
+): LibraryCodeSearchComposition {
+  if (values.genreId === null) {
+    return { ready: false, message: "You must select a genre." };
+  }
+
+  if (values.callLetterMode === "compilation") {
+    return {
+      ready: true,
+      args: {
+        genre_id: values.genreId,
+        code_letters: VARIOUS_ARTISTS_CODE_LETTERS,
+        code_number: VARIOUS_ARTISTS_CODE_NUMBER,
+      },
+    };
+  }
+
+  if (values.callLetterMode === "textbox") {
+    const codeNumber = parseRequiredNonNegativeInt(values.artistNumbersTextbox);
+    if (codeNumber === null) {
+      return { ready: false, message: "You must enter a call number to look up this code." };
+    }
+    return {
+      ready: true,
+      args: {
+        genre_id: values.genreId,
+        code_letters: values.artistLettersTextbox.trim(),
+        code_number: codeNumber,
+      },
+    };
+  }
+
+  // Unreachable through the form's own submit handler --
+  // validateArtistSearchForm already rejects a null mode before this runs.
+  // Kept as an explicit, correctly-worded refusal rather than falling
+  // through, so a future caller that skips that gate fails safely instead of
+  // composing a bogus query.
+  return {
+    ready: false,
+    message: "You must select one of the choices for Call Letters/Numbers.",
+  };
+}
+
+export type ResolveArtistByCodeErrorReason = "genre_not_found" | "code_not_assigned";
+
+type WrappedResolveArtistByCodeError = { resolveArtistByCodeError: FetchBaseQueryError };
+
+function isWrappedResolveArtistByCodeError(
+  err: unknown,
+): err is WrappedResolveArtistByCodeError {
+  return !!err && typeof err === "object" && "resolveArtistByCodeError" in err;
+}
+
+/**
+ * The `reason` a structured 404 from `resolveArtistByCode` carries, or
+ * `undefined` for every other failure shape -- a 400, a 5xx, a non-JSON
+ * body, a network failure. `undefined` is the caller's one fallback branch:
+ * an outage this screen must refuse to act on, never read as an unassigned
+ * code (see the endpoint's `extraOptions` comment in `api.ts` for the
+ * consequence of getting that backwards).
+ */
+export function resolveArtistByCodeErrorReason(
+  err: unknown,
+): ResolveArtistByCodeErrorReason | undefined {
+  if (!isWrappedResolveArtistByCodeError(err)) return undefined;
+  const inner = err.resolveArtistByCodeError;
+  if (inner.status !== 404) return undefined;
+  const data = inner.data;
+  if (!data || typeof data !== "object") return undefined;
+  const reason = (data as { reason?: unknown }).reason;
+  return reason === "genre_not_found" || reason === "code_not_assigned" ? reason : undefined;
+}

--- a/lib/features/catalog/libraryCodeResolution.ts
+++ b/lib/features/catalog/libraryCodeResolution.ts
@@ -1,6 +1,15 @@
 import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import type { CallLetterMode } from "./chooserValidation";
-import { parseRequiredNonNegativeInt } from "./adminCreateArtistValidation";
+import {
+  CALL_LETTER_MODE_REQUIRED_MESSAGE,
+  GENRE_REQUIRED_MESSAGE,
+  type CallLetterMode,
+} from "./chooserValidation";
+import {
+  isCanonicalCodeLetters,
+  normalizeCodeLetters,
+  parseRequiredNonNegativeInt,
+} from "./adminCreateArtistValidation";
+import { VARIOUS_ARTISTS_CODE_LETTERS } from "./libraryCode";
 import type { ResolveArtistByCodeQuery } from "./types";
 
 export type LibraryCodeSearchValues = {
@@ -15,29 +24,18 @@ export type LibraryCodeSearchComposition =
   | { ready: false; message: string };
 
 /**
- * The one code Backend-Service's catalog import leaves every Various Artists
- * bucket filed under, in every genre -- see `libraryCode.ts`'s header for the
- * collapse this reflects. The JSP composed a genre-specific search key from
- * the compilation radio: `Z-<letter>` from `rockCompLetters` for Rock and
- * Soundtracks, the literal `Z--` for every other genre. Neither spelling
- * survives the import, so neither can narrow this search, and the sub-bucket
- * letter is left to `rockCompLetters`' JSP-parity validation alone.
+ * Every Various Artists bucket in a genre is filed at this one call number,
+ * so the compilation radio can only ever search the one pair. The JSP composed
+ * a genre-specific key instead -- `Z-<letter>` from `rockCompLetters` for Rock
+ * and Soundtracks, the literal `Z--` for every other genre -- and the catalog
+ * import preserves neither spelling, so neither can narrow this search. The
+ * sub-bucket letter is left to `rockCompLetters`' JSP-parity validation alone.
  *
  * Every compilation bucket in a genre therefore collides on this one triple,
- * which is the disambiguation screen's actual production trigger --
+ * which is the disambiguation screen's actual production trigger:
  * `V/A`/12/0 has 27 owners and `V/A`/11/0 has 26 in the current catalog.
  */
-const VARIOUS_ARTISTS_CODE_LETTERS = "V/A";
 const VARIOUS_ARTISTS_CODE_NUMBER = 0;
-
-/**
- * `artists.code_letters` is `varchar(4)` and `resolveArtistByCode` rejects
- * anything outside this set with a 400. Mirrored here so a stray character
- * refuses with a message naming the field, rather than reaching the backend
- * and coming back as the caller's unstructured-failure branch — which is
- * worded for a transient outage and invites a retry that can never succeed.
- */
-const CODE_LETTERS_PATTERN = /^[A-Za-z0-9/]{1,4}$/;
 
 /**
  * Composes `artistSearchForm`'s fields into `resolveArtistByCode`'s query
@@ -58,7 +56,7 @@ export function composeLibraryCodeSearchArgs(
   values: LibraryCodeSearchValues,
 ): LibraryCodeSearchComposition {
   if (values.genreId === null) {
-    return { ready: false, message: "You must select a genre." };
+    return { ready: false, message: GENRE_REQUIRED_MESSAGE };
   }
 
   if (values.callLetterMode === "compilation") {
@@ -73,8 +71,8 @@ export function composeLibraryCodeSearchArgs(
   }
 
   if (values.callLetterMode === "textbox") {
-    const codeLetters = values.artistLettersTextbox.trim();
-    if (!CODE_LETTERS_PATTERN.test(codeLetters)) {
+    const codeLetters = normalizeCodeLetters(values.artistLettersTextbox.trim());
+    if (!isCanonicalCodeLetters(codeLetters)) {
       return {
         ready: false,
         message: "Call letters must be letters, digits, or a slash.",
@@ -99,10 +97,7 @@ export function composeLibraryCodeSearchArgs(
   // Kept as an explicit, correctly-worded refusal rather than falling
   // through, so a future caller that skips that gate fails safely instead of
   // composing a bogus query.
-  return {
-    ready: false,
-    message: "You must select one of the choices for Call Letters/Numbers.",
-  };
+  return { ready: false, message: CALL_LETTER_MODE_REQUIRED_MESSAGE };
 }
 
 export type ResolveArtistByCodeErrorReason = "genre_not_found" | "code_not_assigned";

--- a/lib/features/catalog/libraryCodeResolution.ts
+++ b/lib/features/catalog/libraryCodeResolution.ts
@@ -3,6 +3,42 @@ import type { CallLetterMode } from "./chooserValidation";
 import { parseRequiredNonNegativeInt } from "./adminCreateArtistValidation";
 import type { ResolveArtistByCodeQuery } from "./types";
 
+export type LibraryCodeSearchValues = {
+  callLetterMode: CallLetterMode;
+  artistLettersTextbox: string;
+  artistNumbersTextbox: string;
+  genreId: number | null;
+};
+
+export type LibraryCodeSearchComposition =
+  | { ready: true; args: ResolveArtistByCodeQuery }
+  | { ready: false; message: string };
+
+/**
+ * The one code Backend-Service's catalog import leaves every Various Artists
+ * bucket filed under, in every genre -- see `libraryCode.ts`'s header for the
+ * collapse this reflects. The JSP composed a genre-specific search key from
+ * the compilation radio: `Z-<letter>` from `rockCompLetters` for Rock and
+ * Soundtracks, the literal `Z--` for every other genre. Neither spelling
+ * survives the import, so neither can narrow this search, and the sub-bucket
+ * letter is left to `rockCompLetters`' JSP-parity validation alone.
+ *
+ * Every compilation bucket in a genre therefore collides on this one triple,
+ * which is the disambiguation screen's actual production trigger --
+ * `V/A`/12/0 has 27 owners and `V/A`/11/0 has 26 in the current catalog.
+ */
+const VARIOUS_ARTISTS_CODE_LETTERS = "V/A";
+const VARIOUS_ARTISTS_CODE_NUMBER = 0;
+
+/**
+ * `artists.code_letters` is `varchar(4)` and `resolveArtistByCode` rejects
+ * anything outside this set with a 400. Mirrored here so a stray character
+ * refuses with a message naming the field, rather than reaching the backend
+ * and coming back as the caller's unstructured-failure branch — which is
+ * worded for a transient outage and invites a retry that can never succeed.
+ */
+const CODE_LETTERS_PATTERN = /^[A-Za-z0-9/]{1,4}$/;
+
 /**
  * Composes `artistSearchForm`'s fields into `resolveArtistByCode`'s query
  * args, once `chooserValidation.validateArtistSearchForm` has already passed
@@ -18,31 +54,6 @@ import type { ResolveArtistByCodeQuery } from "./types";
  * here instead of being silently treated as a miss or forwarded as an
  * invalid request.
  */
-export type LibraryCodeSearchValues = {
-  callLetterMode: CallLetterMode;
-  artistLettersTextbox: string;
-  artistNumbersTextbox: string;
-  genreId: number | null;
-};
-
-export type LibraryCodeSearchComposition =
-  | { ready: true; args: ResolveArtistByCodeQuery }
-  | { ready: false; message: string };
-
-/**
- * The literal code Backend-Service's catalog import files every Various
- * Artists bucket under, regardless of genre -- see `libraryCode.ts`'s header
- * for the collapse this reflects. The JSP composed a genre-specific
- * `Z-<letter>` search key from the compilation radio's `rockCompLetters`
- * sub-bucket field for Rock/Soundtracks; that letter does not survive in
- * Backend-Service's storage, so it cannot narrow this search. Every
- * compilation bucket for a genre collides on this one triple, which is the
- * disambiguation screen's actual production trigger -- `V/A`/12/0 has 27
- * owners, `V/A`/11/0 has 26, in the current catalog.
- */
-const VARIOUS_ARTISTS_CODE_LETTERS = "V/A";
-const VARIOUS_ARTISTS_CODE_NUMBER = 0;
-
 export function composeLibraryCodeSearchArgs(
   values: LibraryCodeSearchValues,
 ): LibraryCodeSearchComposition {
@@ -62,6 +73,13 @@ export function composeLibraryCodeSearchArgs(
   }
 
   if (values.callLetterMode === "textbox") {
+    const codeLetters = values.artistLettersTextbox.trim();
+    if (!CODE_LETTERS_PATTERN.test(codeLetters)) {
+      return {
+        ready: false,
+        message: "Call letters must be letters, digits, or a slash.",
+      };
+    }
     const codeNumber = parseRequiredNonNegativeInt(values.artistNumbersTextbox);
     if (codeNumber === null) {
       return { ready: false, message: "You must enter a call number to look up this code." };
@@ -70,7 +88,7 @@ export function composeLibraryCodeSearchArgs(
       ready: true,
       args: {
         genre_id: values.genreId,
-        code_letters: values.artistLettersTextbox.trim(),
+        code_letters: codeLetters,
         code_number: codeNumber,
       },
     };

--- a/lib/features/catalog/types.ts
+++ b/lib/features/catalog/types.ts
@@ -213,6 +213,34 @@ export type SearchArtistsInGenreResponse = {
   artists: ArtistInGenreOption[];
 };
 
+/** GET /library/artists/by-code — a fully specified library code. */
+export type ResolveArtistByCodeQuery = {
+  genre_id: number;
+  code_letters: string;
+  code_number: number;
+};
+
+/**
+ * One artist that owns a `(code_letters, genre_id, code_number)` triple.
+ * Plural because the triple is not unique -- Backend-Service's
+ * `getArtistsByCode` documents 13 production collisions, the two largest
+ * being Various-Artists sub-buckets that share one code within a genre. Every
+ * entry in a given response carries the same `genre_id`/`code_letters`/
+ * `code_number` -- that identity is what makes them collide -- so the three
+ * are still projected per-row rather than hoisted, matching the wire shape.
+ */
+export type ArtistByCodeOwner = {
+  id: number;
+  artist_name: string;
+  code_letters: string;
+  code_number: number;
+  genre_id: number;
+};
+
+export type ResolveArtistByCodeResponse = {
+  artists: ArtistByCodeOwner[];
+};
+
 /**
  * A per-track artist credit to write to a Various-Artists compilation. Only the
  * librarian-meaningful free-text fields travel on the wire: the backend derives

--- a/src/components/experiences/classic/catalog/ArtistSearchForm.tsx
+++ b/src/components/experiences/classic/catalog/ArtistSearchForm.tsx
@@ -48,21 +48,13 @@ type ArtistSearchFormProps = {
  * JSP's exact client-side rules (`library-code-form.js`).
  *
  * On submit, resolves the composed code against `resolveArtistByCode`
- * (`GET /library/artists/by-code`) and goes straight to the outcome, matching
- * the JSP's own `findOrCreateLibraryCode` -- no confirmation or results
- * screen in between:
- *
- * - One owner: the artist's card (`/dashboard/library/artist/:id`).
- * - No owner (`reason: "code_not_assigned"`): the creation flow, carrying the
- *   searched code (`/dashboard/library/artist/new`).
- * - More than one owner: `onMultiMatch`, so the caller can swap to
- *   `MultipleArtistsDisplay` -- this component itself never renders that
- *   screen, since the JSP replaces the *whole page* on a multi-match, not
- *   just this form's own subtree.
- * - An unknown genre (`reason: "genre_not_found"`) or any other failure (a
- *   validation 400, a 5xx, an outage): an inline message, and nothing is
- *   navigated to -- see `resolveArtistByCodeErrorReason`'s doc for why a
- *   backend outage must never be read as "code not assigned."
+ * (`GET /library/artists/by-code`) and goes straight to its outcome, matching
+ * the JSP's own `findOrCreateLibraryCode` -- no confirmation or results screen
+ * in between. A multi-match leaves through `onMultiMatch` rather than
+ * rendering here, because the JSP replaces the *whole page* on one, not just
+ * this form's subtree. Every answer this screen cannot trust stops it: see
+ * `resolveArtistByCodeErrorReason` for why an outage must never be read as
+ * "code not assigned."
  *
  * Three divergences from the JSP, each forced by a Backend contract that has
  * no legacy equivalent:
@@ -153,18 +145,6 @@ export default function ArtistSearchForm({ onMultiMatch }: ArtistSearchFormProps
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    // Ahead of validation, not after it: with no genre list there is no
-    // `effectiveGenreId`, and the compilation branch's genre rule would
-    // otherwise refuse with "You must select a genre" -- blaming the
-    // librarian for an outage, beside a select they cannot open. The banner
-    // by that select is the honest message, and the Search button is
-    // disabled while it stands, so reaching here means the state changed
-    // mid-submit.
-    if (genresUnavailable) {
-      setValidationMessage(null);
-      return;
-    }
-
     const result = validateArtistSearchForm({
       callLetterMode,
       artistLettersTextbox,
@@ -191,10 +171,9 @@ export default function ArtistSearchForm({ onMultiMatch }: ArtistSearchFormProps
       return;
     }
 
-    // Only the request is guarded. Routing on its answer stays outside, so a
-    // throw from `router.push` or from `onMultiMatch` surfaces as itself
-    // rather than being reported as a failed lookup the librarian should
-    // retry.
+    // Deciding what a *successful* answer means stays outside the guard, so a
+    // throw from `router.push` or `onMultiMatch` surfaces as itself rather
+    // than being reported as a lookup the librarian should retry.
     let owners: ArtistByCodeOwner[];
     try {
       owners = (await resolveArtistByCode(composed.args).unwrap()).artists;
@@ -272,7 +251,7 @@ export default function ArtistSearchForm({ onMultiMatch }: ArtistSearchFormProps
                 // the derivation above. Disabled (with nothing to select) is
                 // this list's own pre-load state, not a stand-in for the
                 // JSP's empty option.
-                disabled={!genres || genres.length === 0 || genresUnavailable}
+                disabled={!genres || genres.length === 0}
                 onChange={(e) => setGenreId(e.target.value ? Number(e.target.value) : null)}
               >
                 {(genres ?? []).map((genre) => (
@@ -377,11 +356,12 @@ export default function ArtistSearchForm({ onMultiMatch }: ArtistSearchFormProps
           <tr>
             <td />
             <td>
-              <input
-                type="submit"
-                value="Search!"
-                disabled={isResolving || genresUnavailable}
-              />
+              {/* Disabled through a genre outage rather than left to refuse
+                  on submit: with no genre list, the JSP-parity rules would
+                  answer "You must select a genre", blaming the librarian for
+                  a backend that is down beside a select they cannot open.
+                  The banner above says the true thing once. */}
+              <input type="submit" value="Search!" disabled={isResolving || genresUnavailable} />
               &nbsp;&nbsp;&nbsp;&nbsp;
               <input type="button" value="Reset values" onClick={reset} disabled={isResolving} />
             </td>

--- a/src/components/experiences/classic/catalog/ArtistSearchForm.tsx
+++ b/src/components/experiences/classic/catalog/ArtistSearchForm.tsx
@@ -1,12 +1,34 @@
 "use client";
 
 import { useId, useState } from "react";
-import { useGetGenresQuery } from "@/lib/features/catalog/api";
+import { useRouter } from "next/navigation";
+import { useGetGenresQuery, useLazyResolveArtistByCodeQuery } from "@/lib/features/catalog/api";
 import {
   isRockCompLettersRequired,
   validateArtistSearchForm,
   type CallLetterMode,
 } from "@/lib/features/catalog/chooserValidation";
+import { isGenresUnavailable } from "@/lib/features/catalog/genreAvailability";
+import {
+  composeLibraryCodeSearchArgs,
+  resolveArtistByCodeErrorReason,
+} from "@/lib/features/catalog/libraryCodeResolution";
+import type { ArtistByCodeOwner } from "@/lib/features/catalog/types";
+
+/** A code search that matched more than one artist -- `LibraryChooser` swaps to `MultipleArtistsDisplay` on this. */
+export type MultiMatchResult = {
+  genreName: string | undefined;
+  codeLetters: string;
+  codeNumber: number;
+  artists: ArtistByCodeOwner[];
+};
+
+type ArtistSearchFormProps = {
+  /** Called instead of navigating when a code search matches more than one artist. */
+  onMultiMatch?: (result: MultiMatchResult) => void;
+};
+
+const noop = () => {};
 
 /**
  * Reproduces `chooseLibraryCodeOrArtist.jsp`'s `artistSearchForm`: genre
@@ -14,20 +36,62 @@ import {
  * Rock/Soundtracks-only `rockCompLetters` sub-bucket field, validated to the
  * JSP's exact client-side rules (`library-code-form.js`).
  *
- * Divergence from the JSP, forced by the Backend contract: the JSP submits
- * `mode=findOrCreateLibraryCode` to a legacy endpoint that resolves a code to
- * an existing artist, a new-artist form, or `multipleArtistsDisplay.jsp` for
- * a multi-match. Backend-Service has no such resolve endpoint, so this form
- * validates and stops there rather than inventing a client-side scan or
- * approximating it with the unrelated name-search endpoint.
+ * On submit, resolves the composed code against `resolveArtistByCode`
+ * (`GET /library/artists/by-code`) and goes straight to the outcome, matching
+ * the JSP's own `findOrCreateLibraryCode` -- no confirmation or results
+ * screen in between:
+ *
+ * - One owner: the artist's card (`/dashboard/library/artist/:id`).
+ * - No owner (`reason: "code_not_assigned"`): the creation flow, carrying the
+ *   searched code (`/dashboard/library/artist/new`).
+ * - More than one owner: `onMultiMatch`, so the caller can swap to
+ *   `MultipleArtistsDisplay` -- this component itself never renders that
+ *   screen, since the JSP replaces the *whole page* on a multi-match, not
+ *   just this form's own subtree.
+ * - An unknown genre (`reason: "genre_not_found"`) or any other failure (a
+ *   validation 400, a 5xx, an outage): an inline message, and nothing is
+ *   navigated to -- see `resolveArtistByCodeErrorReason`'s doc for why a
+ *   backend outage must never be read as "code not assigned."
+ *
+ * Divergence from the JSP, forced by the Backend contract:
+ * `resolveArtistByCode` requires a fully specified `(genre_id, code_letters,
+ * code_number)` triple. The JSP's own client-side validator never required a
+ * call number at all -- a blank one fell through to a genre+letters-only
+ * browse (`LibraryCodeServlet` -> `multipleArtistsDisplay.jsp`) with no
+ * Backend-Service equivalent, since there is no "any number" query. This
+ * form still accepts a blank call number past `validateArtistSearchForm`
+ * (matching the JSP rule-for-rule), then refuses at submit with a message
+ * asking for one, rather than guessing a number or reintroducing a browse
+ * the API cannot back. See `composeLibraryCodeSearchArgs`.
+ *
+ * The compilation radio always searches the fixed `V/A`/0 pair for the
+ * selected genre, never a value composed from `rockCompLetters`: see
+ * `composeLibraryCodeSearchArgs`'s doc for why that field cannot narrow a
+ * Backend-Service search, even though it is still collected and validated
+ * for JSP parity.
+ *
+ * The textbox mode radio and its letters/numbers inputs are interactive from
+ * mount, matching the JSP: `library-code-form.js`'s textbox branch reads
+ * only `artistLettersTextbox`, never `genreID`, so a submit landing inside
+ * this form's client-side genre fetch passes JSP-parity validation with
+ * `genreId` still null. `composeLibraryCodeSearchArgs` is where that case is
+ * caught -- not a widening of the shared validator, which would make a
+ * JSP-faithful state read as a JSP-parity failure.
  */
-export default function ArtistSearchForm() {
+export default function ArtistSearchForm({ onMultiMatch = noop }: ArtistSearchFormProps) {
+  const router = useRouter();
   const genreFieldId = useId();
   const lettersId = useId();
   const numbersId = useId();
   const rockCompLettersId = useId();
 
-  const { data: genres } = useGetGenresQuery();
+  const genresQuery = useGetGenresQuery();
+  const { data: genres, isFetching: genresFetching, refetch: refetchGenres } = genresQuery;
+  // See isGenresUnavailable's doc for the cached-list trap: `isError` can be
+  // true while a good cached list is still on screen, so this reads
+  // absence-of-list, never the error flag.
+  const genresUnavailable = isGenresUnavailable(genresQuery);
+  const [resolveArtistByCode, { isFetching: isResolving }] = useLazyResolveArtistByCodeQuery();
 
   const [genreId, setGenreId] = useState<number | null>(null);
   const [callLetterMode, setCallLetterMode] = useState<CallLetterMode>(null);
@@ -35,7 +99,6 @@ export default function ArtistSearchForm() {
   const [artistNumbersTextbox, setArtistNumbersTextbox] = useState("");
   const [rockCompLetters, setRockCompLetters] = useState("");
   const [validationMessage, setValidationMessage] = useState<string | null>(null);
-  const [deferredNote, setDeferredNote] = useState(false);
 
   // The JSP's <select name="genreID"> carries no empty option, so the browser
   // selects the first <option> the moment the page loads — a genre is always
@@ -55,7 +118,6 @@ export default function ArtistSearchForm() {
     setArtistNumbersTextbox("");
     setRockCompLetters("");
     setValidationMessage(null);
-    setDeferredNote(false);
     // A native <input type=reset> restores a <select> to its default option
     // along with the rest of the form; mirror that by clearing the
     // librarian's explicit pick so the select falls back to the derived
@@ -63,9 +125,8 @@ export default function ArtistSearchForm() {
     setGenreId(null);
   };
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setDeferredNote(false);
 
     const result = validateArtistSearchForm({
       callLetterMode,
@@ -80,7 +141,65 @@ export default function ArtistSearchForm() {
     }
 
     setValidationMessage(null);
-    setDeferredNote(true);
+
+    // The outage banner beside the genre select already explains why; a
+    // submit that slipped past it would search under a genre the librarian
+    // cannot currently be shown the name of.
+    if (genresUnavailable) {
+      return;
+    }
+
+    const composed = composeLibraryCodeSearchArgs({
+      callLetterMode,
+      artistLettersTextbox,
+      artistNumbersTextbox,
+      genreId: effectiveGenreId,
+    });
+
+    if (!composed.ready) {
+      setValidationMessage(composed.message);
+      return;
+    }
+
+    try {
+      const response = await resolveArtistByCode(composed.args).unwrap();
+
+      if (response.artists.length === 1) {
+        router.push(`/dashboard/library/artist/${response.artists[0].id}`);
+        return;
+      }
+
+      const genreName = genres?.find((genre) => genre.id === composed.args.genre_id)?.genre_name;
+      onMultiMatch({
+        genreName,
+        codeLetters: composed.args.code_letters,
+        codeNumber: composed.args.code_number,
+        artists: response.artists,
+      });
+    } catch (err) {
+      const reason = resolveArtistByCodeErrorReason(err);
+
+      if (reason === "code_not_assigned") {
+        const params = new URLSearchParams({
+          genre_id: String(composed.args.genre_id),
+          code_letters: composed.args.code_letters,
+          code_number: String(composed.args.code_number),
+        });
+        router.push(`/dashboard/library/artist/new?${params.toString()}`);
+        return;
+      }
+
+      if (reason === "genre_not_found") {
+        setValidationMessage(
+          `No genre in the catalog has id ${composed.args.genre_id}, so this code can't be looked up.`,
+        );
+        return;
+      }
+
+      // A validation failure, a 5xx, or an outage: refuse to act rather than
+      // guess -- see resolveArtistByCodeErrorReason's doc.
+      setValidationMessage("Couldn't check whether this code exists right now. Try again.");
+    }
   };
 
   return (
@@ -106,7 +225,7 @@ export default function ArtistSearchForm() {
                 // the derivation above. Disabled (with nothing to select) is
                 // this list's own pre-load state, not a stand-in for the
                 // JSP's empty option.
-                disabled={!genres || genres.length === 0}
+                disabled={!genres || genres.length === 0 || genresUnavailable}
                 onChange={(e) => setGenreId(e.target.value ? Number(e.target.value) : null)}
               >
                 {(genres ?? []).map((genre) => (
@@ -115,6 +234,18 @@ export default function ArtistSearchForm() {
                   </option>
                 ))}
               </select>
+              {genresUnavailable && (
+                <div role="alert" className="artist-error-message">
+                  Genres are unavailable, so a code can&apos;t be looked up right now.{" "}
+                  <button
+                    type="button"
+                    disabled={genresFetching}
+                    onClick={() => refetchGenres()}
+                  >
+                    Try again
+                  </button>
+                </div>
+              )}
             </td>
           </tr>
           <tr>
@@ -194,20 +325,14 @@ export default function ArtistSearchForm() {
               >
                 {validationMessage}
               </div>
-              {deferredNote && (
-                <div role="status">
-                  Code lookup is not yet available — resolving a code to an existing artist
-                  requires Backend-Service support that is not deployed yet.
-                </div>
-              )}
             </td>
           </tr>
           <tr>
             <td />
             <td>
-              <input type="submit" value="Search!" />
+              <input type="submit" value="Search!" disabled={isResolving} />
               &nbsp;&nbsp;&nbsp;&nbsp;
-              <input type="button" value="Reset values" onClick={reset} />
+              <input type="button" value="Reset values" onClick={reset} disabled={isResolving} />
             </td>
           </tr>
         </tbody>

--- a/src/components/experiences/classic/catalog/ArtistSearchForm.tsx
+++ b/src/components/experiences/classic/catalog/ArtistSearchForm.tsx
@@ -23,12 +23,23 @@ export type MultiMatchResult = {
   artists: ArtistByCodeOwner[];
 };
 
-type ArtistSearchFormProps = {
-  /** Called instead of navigating when a code search matches more than one artist. */
-  onMultiMatch?: (result: MultiMatchResult) => void;
-};
+/**
+ * Every answer this screen cannot act on reads the same, deliberately: an
+ * outage, a malformed body, and a 400 differ in cause but not in what the
+ * librarian can do about them, and none of them means the code is free.
+ */
+const UNTRUSTWORTHY_ANSWER_MESSAGE =
+  "Couldn't check whether this code exists right now. Try again.";
 
-const noop = () => {};
+type ArtistSearchFormProps = {
+  /**
+   * Called instead of navigating when a code search matches more than one
+   * artist. Required rather than optional: a caller that omits it has no
+   * disambiguation screen to show, and the multi-match branch would leave
+   * the librarian looking at a Search button that did nothing.
+   */
+  onMultiMatch: (result: MultiMatchResult) => void;
+};
 
 /**
  * Reproduces `chooseLibraryCodeOrArtist.jsp`'s `artistSearchForm`: genre
@@ -53,16 +64,31 @@ const noop = () => {};
  *   navigated to -- see `resolveArtistByCodeErrorReason`'s doc for why a
  *   backend outage must never be read as "code not assigned."
  *
- * Divergence from the JSP, forced by the Backend contract:
- * `resolveArtistByCode` requires a fully specified `(genre_id, code_letters,
- * code_number)` triple. The JSP's own client-side validator never required a
- * call number at all -- a blank one fell through to a genre+letters-only
- * browse (`LibraryCodeServlet` -> `multipleArtistsDisplay.jsp`) with no
- * Backend-Service equivalent, since there is no "any number" query. This
- * form still accepts a blank call number past `validateArtistSearchForm`
- * (matching the JSP rule-for-rule), then refuses at submit with a message
- * asking for one, rather than guessing a number or reintroducing a browse
- * the API cannot back. See `composeLibraryCodeSearchArgs`.
+ * Three divergences from the JSP, each forced by a Backend contract that has
+ * no legacy equivalent:
+ *
+ * 1. `resolveArtistByCode` requires a fully specified `(genre_id,
+ *    code_letters, code_number)` triple. The JSP's own client-side validator
+ *    never required a call number at all -- a blank one fell through to a
+ *    genre+letters-only browse (`LibraryCodeServlet` ->
+ *    `multipleArtistsDisplay.jsp`) that Backend-Service cannot answer, since
+ *    there is no "any number" query. This form still accepts a blank call
+ *    number past `validateArtistSearchForm` (matching the JSP rule-for-rule),
+ *    then refuses at submit with a message asking for one, rather than
+ *    guessing a number or reintroducing a browse the API cannot back. See
+ *    `composeLibraryCodeSearchArgs`.
+ * 2. A fully specified code with more than one owner reaches the
+ *    disambiguation screen here. The legacy servlet's own fully-specified
+ *    lookup ends in `findFirst()` over an unordered query, so it silently
+ *    hands the librarian one arbitrary row out of a contested code and
+ *    cannot tell one match from twenty-seven. `by-code` answers a list
+ *    precisely so that guess is not forced.
+ * 3. The compilation radio's misses route to the creation flow like the
+ *    textbox radio's do. The servlet instead redirects a compilation miss
+ *    back to an empty chooser with no message at all, contradicting this
+ *    screen's own heading ("If the code does not exist, you will get the
+ *    chance to create it"). The heading is reproduced verbatim, so the
+ *    behavior it promises is reproduced with it.
  *
  * The compilation radio always searches the fixed `V/A`/0 pair for the
  * selected genre, never a value composed from `rockCompLetters`: see
@@ -70,15 +96,14 @@ const noop = () => {};
  * Backend-Service search, even though it is still collected and validated
  * for JSP parity.
  *
- * The textbox mode radio and its letters/numbers inputs are interactive from
- * mount, matching the JSP: `library-code-form.js`'s textbox branch reads
- * only `artistLettersTextbox`, never `genreID`, so a submit landing inside
- * this form's client-side genre fetch passes JSP-parity validation with
- * `genreId` still null. `composeLibraryCodeSearchArgs` is where that case is
- * caught -- not a widening of the shared validator, which would make a
- * JSP-faithful state read as a JSP-parity failure.
+ * `library-code-form.js`'s textbox branch reads only `artistLettersTextbox`,
+ * never `genreID`, so a submit landing inside this form's client-side genre
+ * fetch passes JSP-parity validation with `genreId` still null.
+ * `composeLibraryCodeSearchArgs` is where that case is caught -- not a
+ * widening of the shared validator, which would make a JSP-faithful state
+ * read as a JSP-parity failure.
  */
-export default function ArtistSearchForm({ onMultiMatch = noop }: ArtistSearchFormProps) {
+export default function ArtistSearchForm({ onMultiMatch }: ArtistSearchFormProps) {
   const router = useRouter();
   const genreFieldId = useId();
   const lettersId = useId();
@@ -128,6 +153,18 @@ export default function ArtistSearchForm({ onMultiMatch = noop }: ArtistSearchFo
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    // Ahead of validation, not after it: with no genre list there is no
+    // `effectiveGenreId`, and the compilation branch's genre rule would
+    // otherwise refuse with "You must select a genre" -- blaming the
+    // librarian for an outage, beside a select they cannot open. The banner
+    // by that select is the honest message, and the Search button is
+    // disabled while it stands, so reaching here means the state changed
+    // mid-submit.
+    if (genresUnavailable) {
+      setValidationMessage(null);
+      return;
+    }
+
     const result = validateArtistSearchForm({
       callLetterMode,
       artistLettersTextbox,
@@ -142,13 +179,6 @@ export default function ArtistSearchForm({ onMultiMatch = noop }: ArtistSearchFo
 
     setValidationMessage(null);
 
-    // The outage banner beside the genre select already explains why; a
-    // submit that slipped past it would search under a genre the librarian
-    // cannot currently be shown the name of.
-    if (genresUnavailable) {
-      return;
-    }
-
     const composed = composeLibraryCodeSearchArgs({
       callLetterMode,
       artistLettersTextbox,
@@ -161,21 +191,13 @@ export default function ArtistSearchForm({ onMultiMatch = noop }: ArtistSearchFo
       return;
     }
 
+    // Only the request is guarded. Routing on its answer stays outside, so a
+    // throw from `router.push` or from `onMultiMatch` surfaces as itself
+    // rather than being reported as a failed lookup the librarian should
+    // retry.
+    let owners: ArtistByCodeOwner[];
     try {
-      const response = await resolveArtistByCode(composed.args).unwrap();
-
-      if (response.artists.length === 1) {
-        router.push(`/dashboard/library/artist/${response.artists[0].id}`);
-        return;
-      }
-
-      const genreName = genres?.find((genre) => genre.id === composed.args.genre_id)?.genre_name;
-      onMultiMatch({
-        genreName,
-        codeLetters: composed.args.code_letters,
-        codeNumber: composed.args.code_number,
-        artists: response.artists,
-      });
+      owners = (await resolveArtistByCode(composed.args).unwrap()).artists;
     } catch (err) {
       const reason = resolveArtistByCodeErrorReason(err);
 
@@ -198,8 +220,33 @@ export default function ArtistSearchForm({ onMultiMatch = noop }: ArtistSearchFo
 
       // A validation failure, a 5xx, or an outage: refuse to act rather than
       // guess -- see resolveArtistByCodeErrorReason's doc.
-      setValidationMessage("Couldn't check whether this code exists right now. Try again.");
+      setValidationMessage(UNTRUSTWORTHY_ANSWER_MESSAGE);
+      return;
     }
+
+    // A 200 with no owners is a shape the endpoint's contract never produces
+    // -- an unassigned code is a 404 carrying `code_not_assigned`. Reaching
+    // here means the answer cannot be trusted, so it is refused like any other
+    // malformed one: routing to the creation flow would file a duplicate, and
+    // the disambiguation screen would assert the code exists with nobody
+    // holding it.
+    if (owners.length === 0) {
+      setValidationMessage(UNTRUSTWORTHY_ANSWER_MESSAGE);
+      return;
+    }
+
+    if (owners.length === 1) {
+      router.push(`/dashboard/library/artist/${owners[0].id}`);
+      return;
+    }
+
+    const genreName = genres?.find((genre) => genre.id === composed.args.genre_id)?.genre_name;
+    onMultiMatch({
+      genreName,
+      codeLetters: composed.args.code_letters,
+      codeNumber: composed.args.code_number,
+      artists: owners,
+    });
   };
 
   return (
@@ -330,7 +377,11 @@ export default function ArtistSearchForm({ onMultiMatch = noop }: ArtistSearchFo
           <tr>
             <td />
             <td>
-              <input type="submit" value="Search!" disabled={isResolving} />
+              <input
+                type="submit"
+                value="Search!"
+                disabled={isResolving || genresUnavailable}
+              />
               &nbsp;&nbsp;&nbsp;&nbsp;
               <input type="button" value="Reset values" onClick={reset} disabled={isResolving} />
             </td>

--- a/src/components/experiences/classic/catalog/CreateLibraryCodeForm.tsx
+++ b/src/components/experiences/classic/catalog/CreateLibraryCodeForm.tsx
@@ -67,6 +67,16 @@ const ARTIST_HEADING =
  *   bucket is filed at `artist_genre_code = 0`), so the carried value is
  *   parsed with a floor of 0, not 1.
  *
+ * The floor is 0 for any carried code, not only a V/A one, and that is why it
+ * differs from `NewArtistForm`'s floor of 1 on the same column. The two forms
+ * are asked different questions. There, the librarian types a code number
+ * freely beside a peeked next-free value that is never 0, so a typed 0 is a
+ * slip. Here, the number is not input at all: it is a code the resolver was
+ * already asked about and answered `code_not_assigned` for, and both
+ * `by-code` and `POST /library/artists` accept 0 for any code letters --
+ * production holds a non-V/A `UNK` filed at 0. Refusing it would strand the
+ * librarian on a screen reached by a search that succeeded.
+ *
  * Genre display follows `isGenresUnavailable`'s convention: an unissued or
  * failed genres request renders an explicit unavailable state, never a blank
  * or a guessed name, even though `genreIdRaw` itself came from the URL and

--- a/src/components/experiences/classic/catalog/CreateLibraryCodeForm.tsx
+++ b/src/components/experiences/classic/catalog/CreateLibraryCodeForm.tsx
@@ -8,9 +8,11 @@ import {
   isAddArtistConflict,
   isArtistNameConflictData,
   normalizeCodeLetters,
+  parseRequiredNonNegativeInt,
   parseRequiredPositiveInt,
 } from "@/lib/features/catalog/adminCreateArtistValidation";
 import { isGenresUnavailable } from "@/lib/features/catalog/genreAvailability";
+import { isVariousArtists } from "@/lib/features/catalog/libraryCode";
 import type { AddArtistRequestBody } from "@/lib/features/catalog/types";
 
 type CreateLibraryCodeFormProps = {
@@ -49,13 +51,21 @@ const ARTIST_HEADING =
  * - The dead `Z_` V/A auto-naming branch (`:26`, testing an underscore the
  *   servlet's own prefix `Z-` never produces) is not reproduced -- see
  *   NewArtistForm's header for the same call. The servlet's *live* V/A
- *   handling is reproduced: `Z-` letters get their own heading.
+ *   handling is reproduced: a Various Artists code gets its own heading,
+ *   matched via `isVariousArtists` rather than the servlet's own bare
+ *   `Z-` prefix test, because this screen's carrying URL can arrive with
+ *   either spelling -- `Z-<letter>` from a legacy-shaped link, or `V/A`, the
+ *   literal Backend-Service's by-code resolution actually returns (its
+ *   catalog import collapses every Rock/Soundtracks sub-bucket to that one
+ *   form; see `libraryCode.ts`'s header).
  * - The servlet forwards no `artistNumbers` on its V/A branch and
  *   `processAddArtistLibraryCode` skips call numbers for `Z-` entirely, so
  *   `/wxycdb` files V/A codes with no number at all. `POST /library/artists`
  *   requires `code_number`, so a V/A code is filed here with the number it
  *   carried -- and a V/A link that carries none is refused rather than filed
- *   incomplete.
+ *   incomplete. That number is legitimately `0` (every Various Artists
+ *   bucket is filed at `artist_genre_code = 0`), so the carried value is
+ *   parsed with a floor of 0, not 1.
  *
  * Genre display follows `isGenresUnavailable`'s convention: an unissued or
  * failed genres request renders an explicit unavailable state, never a blank
@@ -85,9 +95,9 @@ export default function CreateLibraryCodeForm({
   const [validationMessage, setValidationMessage] = useState<string | null>(null);
 
   const genreId = parseRequiredPositiveInt(genreIdRaw);
-  const codeNumber = parseRequiredPositiveInt(codeNumberRaw);
+  const codeNumber = parseRequiredNonNegativeInt(codeNumberRaw);
   const upperCodeLetters = normalizeCodeLetters(codeLetters.trim());
-  const heading = upperCodeLetters.startsWith("Z-") ? VARIOUS_ARTISTS_HEADING : ARTIST_HEADING;
+  const heading = isVariousArtists(upperCodeLetters) ? VARIOUS_ARTISTS_HEADING : ARTIST_HEADING;
 
   // Which part of the carried code is unusable, so the refusal can name it.
   // The rows below display these values verbatim like the JSP does, so a
@@ -103,7 +113,7 @@ export default function CreateLibraryCodeForm({
         : codeNumber == null
           ? codeNumberRaw.trim() === ""
             ? "This link carries no call number."
-            : `This link's call number (${codeNumberRaw}) is not a whole number above zero.`
+            : `This link's call number (${codeNumberRaw}) is not a whole number, zero or greater.`
           : null;
 
   const genreName = genres?.find((genre) => genre.id === genreId)?.genre_name;

--- a/src/components/experiences/classic/catalog/LibraryChooser.tsx
+++ b/src/components/experiences/classic/catalog/LibraryChooser.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useGetGenresQuery } from "@/lib/features/catalog/api";
 import ArtistSearchForm, { type MultiMatchResult } from "./ArtistSearchForm";
 import MultipleArtistsDisplay from "./MultipleArtistsDisplay";
 import NewArtistForm from "./NewArtistForm";
@@ -22,17 +23,16 @@ import NewArtistForm from "./NewArtistForm";
  */
 export default function LibraryChooser() {
   const [multiMatch, setMultiMatch] = useState<MultiMatchResult | null>(null);
+  // Held here, not only inside the two forms, because they both unmount for
+  // the length of the disambiguation screen. Scanning a 27-owner compilation
+  // bucket outlasts RTK Query's unsubscribed-cache window, so without a
+  // subscriber that survives the swap the librarian returns to a disabled
+  // genre select and a refetch. Deduped against the forms' identical
+  // subscription, so it costs no extra request.
+  useGetGenresQuery();
 
   if (multiMatch) {
-    return (
-      <MultipleArtistsDisplay
-        genreName={multiMatch.genreName}
-        codeLetters={multiMatch.codeLetters}
-        codeNumber={multiMatch.codeNumber}
-        artists={multiMatch.artists}
-        onChooseAgain={() => setMultiMatch(null)}
-      />
-    );
+    return <MultipleArtistsDisplay {...multiMatch} onChooseAgain={() => setMultiMatch(null)} />;
   }
 
   return (

--- a/src/components/experiences/classic/catalog/LibraryChooser.tsx
+++ b/src/components/experiences/classic/catalog/LibraryChooser.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import ArtistSearchForm, { type MultiMatchResult } from "./ArtistSearchForm";
+import MultipleArtistsDisplay from "./MultipleArtistsDisplay";
+import NewArtistForm from "./NewArtistForm";
+
+/**
+ * Owns the toggle between `chooseLibraryCodeOrArtist.jsp`'s two forms and
+ * `multipleArtistsDisplay.jsp` -- one URL (`/dashboard/library`, the Slice 0
+ * URL table's single row for both JSPs) in front of two mutually exclusive
+ * screens, matching the JSP: a code search that matches more than one
+ * artist replaces the whole page with the multi-artist list, not just the
+ * search form's own subtree, and there is no route to leave for either
+ * screen -- `multipleArtistsDisplay.jsp` has no counterpart destination of
+ * its own in `/wxycdb` either, since a librarian returns to the chooser
+ * (`chooseLibraryCodePrompt`) or picks an artist.
+ */
+export default function LibraryChooser() {
+  const [multiMatch, setMultiMatch] = useState<MultiMatchResult | null>(null);
+
+  if (multiMatch) {
+    return (
+      <MultipleArtistsDisplay
+        genreName={multiMatch.genreName}
+        codeLetters={multiMatch.codeLetters}
+        codeNumber={multiMatch.codeNumber}
+        artists={multiMatch.artists}
+        onChooseAgain={() => setMultiMatch(null)}
+      />
+    );
+  }
+
+  return (
+    <>
+      <ArtistSearchForm onMultiMatch={setMultiMatch} />
+      <hr />
+      <NewArtistForm />
+    </>
+  );
+}

--- a/src/components/experiences/classic/catalog/LibraryChooser.tsx
+++ b/src/components/experiences/classic/catalog/LibraryChooser.tsx
@@ -7,14 +7,18 @@ import NewArtistForm from "./NewArtistForm";
 
 /**
  * Owns the toggle between `chooseLibraryCodeOrArtist.jsp`'s two forms and
- * `multipleArtistsDisplay.jsp` -- one URL (`/dashboard/library`, the Slice 0
- * URL table's single row for both JSPs) in front of two mutually exclusive
- * screens, matching the JSP: a code search that matches more than one
- * artist replaces the whole page with the multi-artist list, not just the
- * search form's own subtree, and there is no route to leave for either
- * screen -- `multipleArtistsDisplay.jsp` has no counterpart destination of
- * its own in `/wxycdb` either, since a librarian returns to the chooser
- * (`chooseLibraryCodePrompt`) or picks an artist.
+ * `multipleArtistsDisplay.jsp` -- two mutually exclusive screens behind the
+ * one `/dashboard/library` URL that the dashboard URL map in
+ * `docs/architecture.md` assigns to both JSPs.
+ *
+ * A state swap rather than a second route, because the multi-match screen is
+ * not addressable by what a librarian holds. `/wxycdb` reaches it at
+ * `libraryCode?genreID=&artistLetters=`, a genre+letters browse
+ * Backend-Service cannot answer -- and the search that reaches it here is a
+ * fully specified code whose owners are a server response, not a URL. The
+ * swap is whole-page in both: the JSP replaces the chooser outright, so
+ * `NewArtistForm` goes with the search form rather than sitting under a list
+ * of artists that already own the code.
  */
 export default function LibraryChooser() {
   const [multiMatch, setMultiMatch] = useState<MultiMatchResult | null>(null);

--- a/src/components/experiences/classic/catalog/MultipleArtistsDisplay.tsx
+++ b/src/components/experiences/classic/catalog/MultipleArtistsDisplay.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import Link from "next/link";
+import { formatCallLettersAndNumbers } from "@/lib/features/catalog/libraryCode";
+import type { ArtistByCodeOwner } from "@/lib/features/catalog/types";
+
+type MultipleArtistsDisplayProps = {
+  genreName: string | undefined;
+  codeLetters: string;
+  codeNumber: number;
+  artists: ArtistByCodeOwner[];
+  /** Returns to the chooser -- `multipleArtistsDisplay.jsp`'s "Choose/Add Library Codes" link. */
+  onChooseAgain: () => void;
+};
+
+/**
+ * Reproduces `libraryAdmin/multipleArtistsDisplay.jsp`: every artist that
+ * owns the searched `(genre_id, code_letters, code_number)` triple, in the
+ * order `resolveArtistByCode` returned them (server-sorted by artist name,
+ * then id -- this component does not re-sort).
+ *
+ * Reached only from `ArtistSearchForm`'s code search matching more than one
+ * owner, which the JSP frames differently but the underlying data makes the
+ * same screen necessary either way: Backend-Service's catalog import
+ * collapses every Various Artists sub-bucket to the identical `V/A`/0 pair
+ * within a genre, so a librarian resolving a compilation code is routed here
+ * to pick the specific bucket by name -- `V/A`/12/0 alone has 27 owners in
+ * production (see `libraryCodeResolution.ts`).
+ *
+ * The JSP's "no results" branch is not reproduced: `resolveArtistByCode`
+ * never answers a 200 with zero owners (see the endpoint's doc), so it is
+ * unreachable here.
+ *
+ * Selection affordance matches the JSP exactly: each artist name links to
+ * its *view* card (`mode=view` in the JSP, `/dashboard/library/artist/:id/view`
+ * here), not the MD modify card a single-match code search lands on --
+ * `multipleArtistsDisplay.jsp` sends every row through the DJ-facing display
+ * card regardless of who is browsing it.
+ */
+export default function MultipleArtistsDisplay({
+  genreName,
+  codeLetters,
+  codeNumber,
+  artists,
+  onChooseAgain,
+}: MultipleArtistsDisplayProps) {
+  const callLettersAndNumbers = formatCallLettersAndNumbers({
+    code_letters: codeLetters,
+    code_artist_number: codeNumber,
+  });
+
+  return (
+    <div data-testid="multiple-artists-display" style={{ textAlign: "center" }}>
+      <button
+        type="button"
+        onClick={onChooseAgain}
+        style={{
+          background: "none",
+          border: "none",
+          padding: 0,
+          font: "inherit",
+          fontWeight: "bold",
+          textDecoration: "underline",
+          cursor: "pointer",
+          color: "inherit",
+        }}
+      >
+        Choose/Add Library Codes
+      </button>
+
+      <h3>
+        {genreName ? `${genreName} ` : ""}
+        {callLettersAndNumbers}
+      </h3>
+
+      <table className="entry-table" style={{ width: "95%", margin: "0 auto" }}>
+        <thead>
+          <tr className="entry-header">
+            <th colSpan={2} style={{ textAlign: "center" }}>
+              Library Code
+            </th>
+            <th style={{ textAlign: "left" }}>Artist Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {artists.map((artist, index) => (
+            <tr
+              key={artist.id}
+              className={`entry-row ${index % 2 === 0 ? "entry-row-even" : "entry-row-odd"}`}
+            >
+              <td style={{ textAlign: "right" }}>{genreName ?? ""}</td>
+              <td style={{ textAlign: "left" }}>
+                {formatCallLettersAndNumbers({
+                  code_letters: artist.code_letters,
+                  code_artist_number: artist.code_number,
+                })}
+              </td>
+              <td>
+                <Link href={`/dashboard/library/artist/${artist.id}/view`}>
+                  {artist.artist_name}
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/experiences/classic/catalog/MultipleArtistsDisplay.tsx
+++ b/src/components/experiences/classic/catalog/MultipleArtistsDisplay.tsx
@@ -17,25 +17,35 @@ type MultipleArtistsDisplayProps = {
  * Reproduces `libraryAdmin/multipleArtistsDisplay.jsp`: every artist that
  * owns the searched `(genre_id, code_letters, code_number)` triple, in the
  * order `resolveArtistByCode` returned them (server-sorted by artist name,
- * then id -- this component does not re-sort).
+ * then id -- this component does not re-sort). The JSP's own query carries no
+ * `ORDER BY` at all, so a deterministic order is the one thing here that is
+ * strictly better than the original rather than equal to it.
  *
  * Reached only from `ArtistSearchForm`'s code search matching more than one
  * owner, which the JSP frames differently but the underlying data makes the
- * same screen necessary either way: Backend-Service's catalog import
- * collapses every Various Artists sub-bucket to the identical `V/A`/0 pair
- * within a genre, so a librarian resolving a compilation code is routed here
- * to pick the specific bucket by name -- `V/A`/12/0 alone has 27 owners in
- * production (see `libraryCodeResolution.ts`).
+ * same screen necessary either way: Backend-Service's catalog import collapses
+ * every Various Artists sub-bucket to the identical `V/A`/0 pair within a
+ * genre, so a librarian resolving a compilation code is routed here to pick
+ * the specific bucket by name -- `V/A`/12/0 alone has 27 owners in production
+ * (see `libraryCodeResolution.ts`).
  *
- * The JSP's "no results" branch is not reproduced: `resolveArtistByCode`
- * never answers a 200 with zero owners (see the endpoint's doc), so it is
- * unreachable here.
+ * The JSP's "no results" branch is not reproduced: `resolveArtistByCode` never
+ * answers a 200 with zero owners (see the endpoint's doc), and the caller
+ * refuses a zero-length list rather than routing here, so it is unreachable.
  *
- * Selection affordance matches the JSP exactly: each artist name links to
- * its *view* card (`mode=view` in the JSP, `/dashboard/library/artist/:id/view`
- * here), not the MD modify card a single-match code search lands on --
- * `multipleArtistsDisplay.jsp` sends every row through the DJ-facing display
- * card regardless of who is browsing it.
+ * Every row displays the searched code rather than re-deriving one per owner.
+ * The wire shape carries `code_letters`/`code_number` on each entry, but
+ * Backend-Service projects both from the request, so they are the searched
+ * values by construction -- sharing the triple is what makes these artists
+ * collide at all.
+ *
+ * Selection affordance matches the JSP's real behavior, which its own markup
+ * misstates: the row link carries `mode=view`, but `ArtistViewServlet` never
+ * reads `mode` and forwards unconditionally to the modify card for an admin --
+ * and only an admin can reach this screen, since `LibraryCodeServlet` bounces
+ * everyone else to the DJ search. So each artist name opens the same modify
+ * card a single-match code search lands on, not the read-only view card the
+ * DJ-facing catalog results link to.
  */
 export default function MultipleArtistsDisplay({
   genreName,
@@ -51,59 +61,56 @@ export default function MultipleArtistsDisplay({
 
   return (
     <div data-testid="multiple-artists-display" style={{ textAlign: "center" }}>
-      <button
-        type="button"
-        onClick={onChooseAgain}
-        style={{
-          background: "none",
-          border: "none",
-          padding: 0,
-          font: "inherit",
-          fontWeight: "bold",
-          textDecoration: "underline",
-          cursor: "pointer",
-          color: "inherit",
-        }}
-      >
-        Choose/Add Library Codes
-      </button>
-
-      <h3>
-        {genreName ? `${genreName} ` : ""}
-        {callLettersAndNumbers}
-      </h3>
-
-      <table className="entry-table" style={{ width: "95%", margin: "0 auto" }}>
-        <thead>
-          <tr className="entry-header">
-            <th colSpan={2} style={{ textAlign: "center" }}>
-              Library Code
-            </th>
-            <th style={{ textAlign: "left" }}>Artist Name</th>
-          </tr>
-        </thead>
-        <tbody>
-          {artists.map((artist, index) => (
-            <tr
-              key={artist.id}
-              className={`entry-row ${index % 2 === 0 ? "entry-row-even" : "entry-row-odd"}`}
-            >
-              <td style={{ textAlign: "right" }}>{genreName ?? ""}</td>
-              <td style={{ textAlign: "left" }}>
-                {formatCallLettersAndNumbers({
-                  code_letters: artist.code_letters,
-                  code_artist_number: artist.code_number,
-                })}
+      <div style={{ width: "95%", margin: "0 auto" }}>
+        {/* The JSP's header is a three-cell layout table, reproduced as one
+            so the return link and the code sit on a line rather than
+            stacking. Presentational: it carries no tabular data, and leaving
+            it in the accessibility tree would announce a second table on a
+            screen whose point is the one below. */}
+        <table role="presentation" cellPadding={4} style={{ width: "100%", borderSpacing: 1 }}>
+          <tbody>
+            <tr>
+              <td className="text" style={{ width: "33%", textAlign: "center" }}>
+                <button type="button" className="link-button" onClick={onChooseAgain}>
+                  <b>Choose/Add Library Codes</b>
+                </button>
               </td>
-              <td>
-                <Link href={`/dashboard/library/artist/${artist.id}/view`}>
-                  {artist.artist_name}
-                </Link>
+              <td className="title" style={{ width: "34%", textAlign: "center" }}>
+                {genreName ? `${genreName} ` : ""}
+                {callLettersAndNumbers}
               </td>
+              <td className="text" style={{ width: "33%", textAlign: "center" }} />
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+
+        <br />
+
+        <table className="entry-table">
+          <thead>
+            <tr className="entry-header">
+              <th colSpan={2} style={{ textAlign: "center" }}>
+                Library Code
+              </th>
+              <th style={{ textAlign: "left" }}>Artist Name</th>
+            </tr>
+          </thead>
+          <tbody>
+            {artists.map((artist, index) => (
+              <tr
+                key={artist.id}
+                className={`entry-row ${index % 2 === 0 ? "entry-row-even" : "entry-row-odd"}`}
+              >
+                <td style={{ textAlign: "right" }}>{genreName ?? ""}</td>
+                <td style={{ textAlign: "left" }}>{callLettersAndNumbers}</td>
+                <td>
+                  <Link href={`/dashboard/library/artist/${artist.id}`}>{artist.artist_name}</Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/components/experiences/classic/catalog/MultipleArtistsDisplay.tsx
+++ b/src/components/experiences/classic/catalog/MultipleArtistsDisplay.tsx
@@ -2,13 +2,9 @@
 
 import Link from "next/link";
 import { formatCallLettersAndNumbers } from "@/lib/features/catalog/libraryCode";
-import type { ArtistByCodeOwner } from "@/lib/features/catalog/types";
+import type { MultiMatchResult } from "./ArtistSearchForm";
 
-type MultipleArtistsDisplayProps = {
-  genreName: string | undefined;
-  codeLetters: string;
-  codeNumber: number;
-  artists: ArtistByCodeOwner[];
+type MultipleArtistsDisplayProps = MultiMatchResult & {
   /** Returns to the chooser -- `multipleArtistsDisplay.jsp`'s "Choose/Add Library Codes" link. */
   onChooseAgain: () => void;
 };
@@ -16,22 +12,17 @@ type MultipleArtistsDisplayProps = {
 /**
  * Reproduces `libraryAdmin/multipleArtistsDisplay.jsp`: every artist that
  * owns the searched `(genre_id, code_letters, code_number)` triple, in the
- * order `resolveArtistByCode` returned them (server-sorted by artist name,
- * then id -- this component does not re-sort). The JSP's own query carries no
- * `ORDER BY` at all, so a deterministic order is the one thing here that is
- * strictly better than the original rather than equal to it.
+ * order `resolveArtistByCode` returned them -- this component does not
+ * re-sort, and the JSP's own query carries no `ORDER BY` to reproduce.
  *
- * Reached only from `ArtistSearchForm`'s code search matching more than one
- * owner, which the JSP frames differently but the underlying data makes the
- * same screen necessary either way: Backend-Service's catalog import collapses
- * every Various Artists sub-bucket to the identical `V/A`/0 pair within a
- * genre, so a librarian resolving a compilation code is routed here to pick
- * the specific bucket by name -- `V/A`/12/0 alone has 27 owners in production
- * (see `libraryCodeResolution.ts`).
+ * A compilation code is the case that makes this screen load-bearing rather
+ * than defensive: every Various Artists bucket in a genre collides on one
+ * triple, so picking the bucket by name is the only way through. See
+ * `composeLibraryCodeSearchArgs` for why.
  *
  * The JSP's "no results" branch is not reproduced: `resolveArtistByCode` never
- * answers a 200 with zero owners (see the endpoint's doc), and the caller
- * refuses a zero-length list rather than routing here, so it is unreachable.
+ * answers a 200 with zero owners, and the caller refuses a zero-length list
+ * rather than routing here, so it is unreachable.
  *
  * Every row displays the searched code rather than re-deriving one per owner.
  * The wire shape carries `code_letters`/`code_number` on each entry, but
@@ -60,57 +51,58 @@ export default function MultipleArtistsDisplay({
   });
 
   return (
-    <div data-testid="multiple-artists-display" style={{ textAlign: "center" }}>
-      <div style={{ width: "95%", margin: "0 auto" }}>
-        {/* The JSP's header is a three-cell layout table, reproduced as one
-            so the return link and the code sit on a line rather than
-            stacking. Presentational: it carries no tabular data, and leaving
-            it in the accessibility tree would announce a second table on a
-            screen whose point is the one below. */}
-        <table role="presentation" cellPadding={4} style={{ width: "100%", borderSpacing: 1 }}>
-          <tbody>
-            <tr>
-              <td className="text" style={{ width: "33%", textAlign: "center" }}>
-                <button type="button" className="link-button" onClick={onChooseAgain}>
-                  <b>Choose/Add Library Codes</b>
-                </button>
-              </td>
-              <td className="title" style={{ width: "34%", textAlign: "center" }}>
-                {genreName ? `${genreName} ` : ""}
-                {callLettersAndNumbers}
-              </td>
-              <td className="text" style={{ width: "33%", textAlign: "center" }} />
-            </tr>
-          </tbody>
-        </table>
+    <div
+      data-testid="multiple-artists-display"
+      style={{ textAlign: "center", width: "95%", margin: "0 auto" }}
+    >
+      {/* The JSP's header is a three-cell layout table, reproduced as one so
+          the return link and the code sit on a line rather than stacking.
+          Presentational: it carries no tabular data, and leaving it in the
+          accessibility tree would announce a second table on a screen whose
+          point is the one below. */}
+      <table role="presentation" cellPadding={4} style={{ width: "100%", borderSpacing: 1 }}>
+        <tbody>
+          <tr>
+            <td className="text" style={{ width: "33%", textAlign: "center" }}>
+              <button type="button" className="link-button" onClick={onChooseAgain}>
+                <b>Choose/Add Library Codes</b>
+              </button>
+            </td>
+            <td className="title" style={{ width: "34%", textAlign: "center" }}>
+              {genreName ? `${genreName} ` : ""}
+              {callLettersAndNumbers}
+            </td>
+            <td className="text" style={{ width: "33%", textAlign: "center" }} />
+          </tr>
+        </tbody>
+      </table>
 
-        <br />
+      <br />
 
-        <table className="entry-table">
-          <thead>
-            <tr className="entry-header">
-              <th colSpan={2} style={{ textAlign: "center" }}>
-                Library Code
-              </th>
-              <th style={{ textAlign: "left" }}>Artist Name</th>
+      <table className="entry-table">
+        <thead>
+          <tr className="entry-header">
+            <th colSpan={2} style={{ textAlign: "center" }}>
+              Library Code
+            </th>
+            <th style={{ textAlign: "left" }}>Artist Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {artists.map((artist, index) => (
+            <tr
+              key={artist.id}
+              className={`entry-row ${index % 2 === 0 ? "entry-row-even" : "entry-row-odd"}`}
+            >
+              <td style={{ textAlign: "right" }}>{genreName ?? ""}</td>
+              <td style={{ textAlign: "left" }}>{callLettersAndNumbers}</td>
+              <td>
+                <Link href={`/dashboard/library/artist/${artist.id}`}>{artist.artist_name}</Link>
+              </td>
             </tr>
-          </thead>
-          <tbody>
-            {artists.map((artist, index) => (
-              <tr
-                key={artist.id}
-                className={`entry-row ${index % 2 === 0 ? "entry-row-even" : "entry-row-odd"}`}
-              >
-                <td style={{ textAlign: "right" }}>{genreName ?? ""}</td>
-                <td style={{ textAlign: "left" }}>{callLettersAndNumbers}</td>
-                <td>
-                  <Link href={`/dashboard/library/artist/${artist.id}`}>{artist.artist_name}</Link>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/styles/classic/wxyc.css
+++ b/src/styles/classic/wxyc.css
@@ -192,11 +192,12 @@ html[data-experience="classic"] body {
 .entry-row a { color: #000; text-decoration: none; }
 .entry-row a:hover { color: #CC0000; text-decoration: underline; }
 
-/* A row action that performs its work in place rather than navigating. It has
-   to be a <button> — an <a href="#"> is not a control — but tubafrenzy's row
-   action was an anchor, so the native button chrome is reset back to that
-   appearance. */
-.entry-row .link-button {
+/* An action that performs its work in place rather than navigating. It has to
+   be a <button> — an <a href="#"> is not a control — but tubafrenzy's
+   counterpart was an anchor, so the native button chrome is reset back to that
+   appearance. Not scoped to .entry-row: the same substitution happens outside
+   tables, wherever a JSP anchor became an in-page state change. */
+.link-button {
 	background: none;
 	border: none;
 	padding: 0;
@@ -205,8 +206,8 @@ html[data-experience="classic"] body {
 	text-decoration: none;
 	cursor: pointer;
 }
-.entry-row .link-button:hover:enabled { color: #CC0000; text-decoration: underline; }
-.entry-row .link-button:disabled { cursor: default; opacity: 0.55; }
+.link-button:hover:enabled { color: #CC0000; text-decoration: underline; }
+.link-button:disabled { cursor: default; opacity: 0.55; }
 
 .talkset-row { background: #555; }
 .talkset-row td { padding: 8px; border-bottom: 1px solid #ddd; font-weight: bold; color: #DDDD22; }
@@ -660,7 +661,7 @@ html[data-experience="classic"][data-joy-color-scheme="dark"] .entry-row:hover {
 }
 
 html[data-experience="classic"][data-joy-color-scheme="dark"] .entry-row a,
-html[data-experience="classic"][data-joy-color-scheme="dark"] .entry-row .link-button {
+html[data-experience="classic"][data-joy-color-scheme="dark"] .link-button {
 	color: #E0E0E0;
 }
 

--- a/tests/integration/components/classic/catalog/ArtistSearchForm.test.tsx
+++ b/tests/integration/components/classic/catalog/ArtistSearchForm.test.tsx
@@ -3,10 +3,17 @@ import { screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse, delay } from "msw";
 import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
 
-vi.mock("@/lib/features/authentication/client", () => ({
-  authClient: { useSession: vi.fn() },
-  getJWTToken: vi.fn().mockResolvedValue("test-token"),
-}));
+// The real better-auth client installs listeners whose teardown is deferred a
+// second past the last subscriber; a short file finishes inside that second.
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import(
+    "@/tests/helpers/auth-client-mock"
+  );
+  return {
+    ...createAuthClientModuleMock(),
+    getJWTToken: vi.fn(async () => "test-token"),
+  };
+});
 
 const mockPush = vi.fn();
 vi.mock("next/navigation", () => ({

--- a/tests/integration/components/classic/catalog/ArtistSearchForm.test.tsx
+++ b/tests/integration/components/classic/catalog/ArtistSearchForm.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
-import { http, HttpResponse } from "msw";
+import { http, HttpResponse, delay } from "msw";
 import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
 
 vi.mock("@/lib/features/authentication/client", () => ({
@@ -8,11 +8,17 @@ vi.mock("@/lib/features/authentication/client", () => ({
   getJWTToken: vi.fn().mockResolvedValue("test-token"),
 }));
 
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
 import ArtistSearchForm from "@/src/components/experiences/classic/catalog/ArtistSearchForm";
 
 const ROCK_GENRE_ID = 11;
 const SOUNDTRACKS_GENRE_ID = 12;
 const BLUES_GENRE_ID = 3;
+const BY_CODE_URL = `${TEST_BACKEND_URL}/library/artists/by-code`;
 
 function mockGenres() {
   server.use(
@@ -31,8 +37,19 @@ async function selectGenre(user: ReturnType<typeof renderWithProviders>["user"],
   await user.selectOptions(screen.getByLabelText(/^genre/i), name);
 }
 
+async function fillTextboxCode(
+  user: ReturnType<typeof renderWithProviders>["user"],
+  letters: string,
+  numbers: string,
+) {
+  await user.click(screen.getByRole("radio", { name: /call letters:/i }));
+  await user.type(screen.getByLabelText("Call letters:"), letters);
+  await user.type(screen.getByLabelText(/call numbers:/i), numbers);
+}
+
 describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSearchForm", () => {
   beforeEach(() => {
+    mockPush.mockClear();
     mockGenres();
   });
 
@@ -169,7 +186,173 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
     ).not.toBeInTheDocument();
   });
 
-  it("notes the deferred code-resolution path once validation passes", async () => {
+  it("looks up a fully specified code and lands on the single owner's card", async () => {
+    server.use(
+      http.get(BY_CODE_URL, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("genre_id")).toBe(String(ROCK_GENRE_ID));
+        expect(url.searchParams.get("code_letters")).toBe("MO");
+        expect(url.searchParams.get("code_number")).toBe("12");
+        return HttpResponse.json({
+          artists: [
+            { id: 99, artist_name: "Juana Molina", code_letters: "MO", code_number: 12, genre_id: ROCK_GENRE_ID },
+          ],
+        });
+      }),
+    );
+    const { user } = renderWithProviders(<ArtistSearchForm />);
+    await selectGenre(user, "Rock");
+
+    await fillTextboxCode(user, "MO", "12");
+    await user.click(screen.getByRole("button", { name: "Search!" }));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/dashboard/library/artist/99"));
+  });
+
+  // 0 is a legitimate call number (the Various Artists filing, and no floor
+  // above 0 for an ordinary code either) -- not an empty field.
+  it("accepts a call number of 0 in textbox mode", async () => {
+    server.use(
+      http.get(BY_CODE_URL, () =>
+        HttpResponse.json({
+          artists: [{ id: 5, artist_name: "Unknown", code_letters: "UNK", code_number: 0, genre_id: BLUES_GENRE_ID }],
+        }),
+      ),
+    );
+    const { user } = renderWithProviders(<ArtistSearchForm />);
+
+    await fillTextboxCode(user, "UNK", "0");
+    await user.click(screen.getByRole("button", { name: "Search!" }));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/dashboard/library/artist/5"));
+  });
+
+  it("routes a code_not_assigned miss to the creation flow, carrying the searched code", async () => {
+    server.use(
+      http.get(BY_CODE_URL, () =>
+        HttpResponse.json(
+          { message: "Artist code not assigned in that genre", reason: "code_not_assigned" },
+          { status: 404 },
+        ),
+      ),
+    );
+    const { user } = renderWithProviders(<ArtistSearchForm />);
+    await selectGenre(user, "Rock");
+
+    await fillTextboxCode(user, "MO", "12");
+    await user.click(screen.getByRole("button", { name: "Search!" }));
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith(
+        `/dashboard/library/artist/new?genre_id=${ROCK_GENRE_ID}&code_letters=MO&code_number=12`,
+      ),
+    );
+  });
+
+  // Every Various Artists bucket is filed at code_number 0 under the literal
+  // code_letters "V/A" -- the rockCompLetters sub-bucket letter, still
+  // collected and validated for JSP parity, plays no part in the composed
+  // query (see composeLibraryCodeSearchArgs).
+  it("searches the compilation radio as V/A, 0 for the selected genre", async () => {
+    server.use(
+      http.get(BY_CODE_URL, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("code_letters")).toBe("V/A");
+        expect(url.searchParams.get("code_number")).toBe("0");
+        return HttpResponse.json(
+          { message: "Artist code not assigned in that genre", reason: "code_not_assigned" },
+          { status: 404 },
+        );
+      }),
+    );
+    const { user } = renderWithProviders(<ArtistSearchForm />);
+    await selectGenre(user, "Soundtracks");
+    await user.click(screen.getByRole("radio", { name: /various artists/i }));
+    await user.type(screen.getByLabelText(/rock comp/i), "K");
+
+    await user.click(screen.getByRole("button", { name: "Search!" }));
+
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith(
+        `/dashboard/library/artist/new?genre_id=${SOUNDTRACKS_GENRE_ID}&code_letters=V%2FA&code_number=0`,
+      ),
+    );
+  });
+
+  it("hands a multi-owner match to onMultiMatch instead of navigating", async () => {
+    const owners = [
+      { id: 1, artist_name: "Various Artists - Rock - A", code_letters: "V/A", code_number: 0, genre_id: ROCK_GENRE_ID },
+      { id: 2, artist_name: "Various Artists - Rock - B", code_letters: "V/A", code_number: 0, genre_id: ROCK_GENRE_ID },
+    ];
+    server.use(http.get(BY_CODE_URL, () => HttpResponse.json({ artists: owners })));
+    const onMultiMatch = vi.fn();
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={onMultiMatch} />);
+    await selectGenre(user, "Rock");
+    await user.click(screen.getByRole("radio", { name: /various artists/i }));
+    await user.type(screen.getByLabelText(/rock comp/i), "A");
+
+    await user.click(screen.getByRole("button", { name: "Search!" }));
+
+    await waitFor(() =>
+      expect(onMultiMatch).toHaveBeenCalledWith({
+        genreName: "Rock",
+        codeLetters: "V/A",
+        codeNumber: 0,
+        artists: owners,
+      }),
+    );
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes an unknown genre from an unassigned code, refusing to navigate", async () => {
+    server.use(
+      http.get(BY_CODE_URL, () =>
+        HttpResponse.json({ message: "Genre not found", reason: "genre_not_found" }, { status: 404 }),
+      ),
+    );
+    const { user } = renderWithProviders(<ArtistSearchForm />);
+    await selectGenre(user, "Rock");
+
+    await fillTextboxCode(user, "MO", "12");
+    await user.click(screen.getByRole("button", { name: "Search!" }));
+
+    expect(
+      await screen.findByText(`No genre in the catalog has id ${ROCK_GENRE_ID}, so this code can't be looked up.`),
+    ).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  // A backend outage must never be reported as "unassigned" -- that would
+  // walk the librarian into creating a duplicate of a code that already
+  // exists.
+  it.each([
+    ["a structured 500", () => HttpResponse.json({ message: "boom" }, { status: 500 })],
+    [
+      "a non-JSON gateway error",
+      () =>
+        new HttpResponse("<!DOCTYPE html><html><body>Bad Gateway</body></html>", {
+          status: 502,
+          headers: { "Content-Type": "text/html" },
+        }),
+    ],
+  ])("refuses to act on %s rather than treating it as unassigned", async (_name, respond) => {
+    server.use(http.get(BY_CODE_URL, respond));
+    const { user } = renderWithProviders(<ArtistSearchForm />);
+    await selectGenre(user, "Rock");
+
+    await fillTextboxCode(user, "MO", "12");
+    await user.click(screen.getByRole("button", { name: "Search!" }));
+
+    expect(
+      await screen.findByText("Couldn't check whether this code exists right now. Try again."),
+    ).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  // The JSP's own client validator never checks the call number field --
+  // resolveArtistByCode requires one, so a blank value is refused only once
+  // the JSP-parity rules above have already passed.
+  it("asks for a call number when textbox mode is submitted with one blank", async () => {
     const { user } = renderWithProviders(<ArtistSearchForm />);
 
     await user.click(screen.getByRole("radio", { name: /call letters:/i }));
@@ -177,8 +360,80 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
     await user.click(screen.getByRole("button", { name: "Search!" }));
 
     expect(
-      await screen.findByText(/code lookup is not yet available/i),
+      await screen.findByText("You must enter a call number to look up this code."),
     ).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  // The textbox radio and its letters/numbers inputs are interactive from
+  // mount -- faithful to the JSP, whose own client-side validator
+  // (library-code-form.js) reads only artistLettersTextbox for this branch,
+  // never genreID. A submit landing inside the client-side genre fetch's
+  // window therefore passes that JSP-parity validation with genreId still
+  // null; the guard against reaching the resolver genre-less lives at the
+  // composition step (composeLibraryCodeSearchArgs), not in the shared
+  // validator, so it fires here too.
+  it("refuses a textbox submit that lands before genres have loaded, without calling the resolver", async () => {
+    let byCodeCalls = 0;
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/library/genres`, async () => {
+        await delay(50);
+        return HttpResponse.json([{ id: BLUES_GENRE_ID, genre_name: "Blues" }]);
+      }),
+      http.get(BY_CODE_URL, () => {
+        byCodeCalls += 1;
+        return HttpResponse.json({ artists: [] });
+      }),
+    );
+    const { user } = renderWithProviders(<ArtistSearchForm />);
+
+    await fillTextboxCode(user, "MO", "12");
+    await user.click(screen.getByRole("button", { name: "Search!" }));
+
+    expect(await screen.findByText("You must select a genre.")).toBeInTheDocument();
+    expect(byCodeCalls).toBe(0);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  describe("genre outage", () => {
+    it("shows the unavailable genre state and refuses the submit without duplicating the message", async () => {
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
+          HttpResponse.json({ message: "genres unavailable" }, { status: 500 }),
+        ),
+      );
+      const { user } = renderWithProviders(<ArtistSearchForm />);
+
+      expect(await screen.findByText(/genres are unavailable/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^genre/i)).toBeDisabled();
+
+      await user.click(screen.getByRole("radio", { name: /various artists/i }));
+      await user.click(screen.getByRole("button", { name: "Search!" }));
+
+      expect(screen.getAllByText(/genres are unavailable/i)).toHaveLength(1);
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("recovers via Try again once genres are reachable", async () => {
+      let genreCalls = 0;
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/genres`, () => {
+          genreCalls += 1;
+          return genreCalls === 1
+            ? HttpResponse.json({ message: "genres unavailable" }, { status: 500 })
+            : HttpResponse.json([{ id: BLUES_GENRE_ID, genre_name: "Blues" }]);
+        }),
+      );
+      const { user } = renderWithProviders(<ArtistSearchForm />);
+
+      expect(await screen.findByText(/genres are unavailable/i)).toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: /try again/i }));
+
+      await waitFor(() =>
+        expect(screen.queryByText(/genres are unavailable/i)).not.toBeInTheDocument(),
+      );
+      expect(screen.getByLabelText(/^genre/i)).toBeEnabled();
+    });
   });
 
   it("resets the mode and fields, including the genre back to its default, on Reset values", async () => {

--- a/tests/integration/components/classic/catalog/ArtistSearchForm.test.tsx
+++ b/tests/integration/components/classic/catalog/ArtistSearchForm.test.tsx
@@ -431,8 +431,11 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
   it("refuses a textbox submit that lands before genres have loaded, without calling the resolver", async () => {
     let byCodeCalls = 0;
     server.use(
+      // Held open rather than merely slow: a fixed delay races the typing this
+      // test does first, and loses that race on a slow machine, which turns
+      // the assertion into "genres happened to be late here".
       http.get(`${TEST_BACKEND_URL}/library/genres`, async () => {
-        await delay(50);
+        await delay("infinite");
         return HttpResponse.json([{ id: BLUES_GENRE_ID, genre_name: "Blues" }]);
       }),
       http.get(BY_CODE_URL, () => {

--- a/tests/integration/components/classic/catalog/ArtistSearchForm.test.tsx
+++ b/tests/integration/components/classic/catalog/ArtistSearchForm.test.tsx
@@ -13,6 +13,8 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
 }));
 
+const mockOnMultiMatch = vi.fn();
+
 import ArtistSearchForm from "@/src/components/experiences/classic/catalog/ArtistSearchForm";
 
 const ROCK_GENRE_ID = 11;
@@ -50,11 +52,12 @@ async function fillTextboxCode(
 describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSearchForm", () => {
   beforeEach(() => {
     mockPush.mockClear();
+    mockOnMultiMatch.mockClear();
     mockGenres();
   });
 
   it("renders the JSP's copy, radio modes, and button labels", async () => {
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
 
     expect(
       await screen.findByText(/enter a library code below\. if the code exists/i),
@@ -76,7 +79,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
   });
 
   it("disables the genre select until genres load, then defaults it to the first genre with no placeholder option", async () => {
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
 
     expect(screen.getByLabelText(/^genre/i)).toBeDisabled();
 
@@ -102,14 +105,14 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
   });
 
   it("disables the letters/numbers textboxes until the textbox radio is chosen", async () => {
-    renderWithProviders(<ArtistSearchForm />);
+    renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
 
     expect(screen.getByLabelText("Call letters:")).toBeDisabled();
     expect(screen.getByLabelText(/call numbers:/i)).toBeDisabled();
   });
 
   it("enables the letters/numbers textboxes once the textbox radio is chosen", async () => {
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
 
     await user.click(screen.getByRole("radio", { name: /call letters:/i }));
 
@@ -118,7 +121,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
   });
 
   it("shows the rockCompLetters field only for genre 11 or 12 under the compilation radio", async () => {
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
     await selectGenre(user, "Blues");
 
     await user.click(screen.getByRole("radio", { name: /various artists/i }));
@@ -132,7 +135,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
   });
 
   it("shows the exact validation message when no radio is selected on submit", async () => {
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
 
     await user.click(screen.getByRole("button", { name: "Search!" }));
 
@@ -142,7 +145,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
   });
 
   it("shows the exact validation message for empty artist letters in textbox mode", async () => {
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
 
     await user.click(screen.getByRole("radio", { name: /call letters:/i }));
     await user.click(screen.getByRole("button", { name: "Search!" }));
@@ -151,7 +154,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
   });
 
   it("shows the exact Rock message for genre 11 with an empty rockCompLetters field", async () => {
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
     await selectGenre(user, "Rock");
     await user.click(screen.getByRole("radio", { name: /various artists/i }));
 
@@ -163,7 +166,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
   });
 
   it("shows the exact Soundtracks message for genre 12 with an empty rockCompLetters field", async () => {
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
     await selectGenre(user, "Soundtracks");
     await user.click(screen.getByRole("radio", { name: /various artists/i }));
 
@@ -175,7 +178,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
   });
 
   it("passes validation for the compilation radio under a non Rock/Soundtracks genre with no rockCompLetters", async () => {
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
     await selectGenre(user, "Blues");
     await user.click(screen.getByRole("radio", { name: /various artists/i }));
 
@@ -200,7 +203,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
         });
       }),
     );
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
     await selectGenre(user, "Rock");
 
     await fillTextboxCode(user, "MO", "12");
@@ -219,7 +222,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
         }),
       ),
     );
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
 
     await fillTextboxCode(user, "UNK", "0");
     await user.click(screen.getByRole("button", { name: "Search!" }));
@@ -236,7 +239,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
         ),
       ),
     );
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
     await selectGenre(user, "Rock");
 
     await fillTextboxCode(user, "MO", "12");
@@ -265,7 +268,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
         );
       }),
     );
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
     await selectGenre(user, "Soundtracks");
     await user.click(screen.getByRole("radio", { name: /various artists/i }));
     await user.type(screen.getByLabelText(/rock comp/i), "K");
@@ -285,8 +288,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
       { id: 2, artist_name: "Various Artists - Rock - B", code_letters: "V/A", code_number: 0, genre_id: ROCK_GENRE_ID },
     ];
     server.use(http.get(BY_CODE_URL, () => HttpResponse.json({ artists: owners })));
-    const onMultiMatch = vi.fn();
-    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={onMultiMatch} />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
     await selectGenre(user, "Rock");
     await user.click(screen.getByRole("radio", { name: /various artists/i }));
     await user.type(screen.getByLabelText(/rock comp/i), "A");
@@ -294,7 +296,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
     await user.click(screen.getByRole("button", { name: "Search!" }));
 
     await waitFor(() =>
-      expect(onMultiMatch).toHaveBeenCalledWith({
+      expect(mockOnMultiMatch).toHaveBeenCalledWith({
         genreName: "Rock",
         codeLetters: "V/A",
         codeNumber: 0,
@@ -310,7 +312,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
         HttpResponse.json({ message: "Genre not found", reason: "genre_not_found" }, { status: 404 }),
       ),
     );
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
     await selectGenre(user, "Rock");
 
     await fillTextboxCode(user, "MO", "12");
@@ -337,7 +339,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
     ],
   ])("refuses to act on %s rather than treating it as unassigned", async (_name, respond) => {
     server.use(http.get(BY_CODE_URL, respond));
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
     await selectGenre(user, "Rock");
 
     await fillTextboxCode(user, "MO", "12");
@@ -349,11 +351,58 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  // The contract makes an empty 200 impossible -- an unassigned code is a 404
+  // carrying code_not_assigned. If one arrives anyway the answer cannot be
+  // trusted, so it is refused: routing to the creation flow would file a
+  // duplicate, and the disambiguation screen would claim the code exists with
+  // nobody holding it.
+  it.each([
+    ["an empty owner list", { artists: [] }],
+    ["a body missing the owner list", {}],
+  ])("refuses %s rather than routing anywhere", async (_name, body) => {
+    server.use(http.get(BY_CODE_URL, () => HttpResponse.json(body)));
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
+    await selectGenre(user, "Rock");
+
+    await fillTextboxCode(user, "MO", "12");
+    await user.click(screen.getByRole("button", { name: "Search!" }));
+
+    expect(
+      await screen.findByText("Couldn't check whether this code exists right now. Try again."),
+    ).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockOnMultiMatch).not.toHaveBeenCalled();
+  });
+
+  // A code the endpoint's charset rule would 400 on is refused here, naming
+  // the field. Left to the backend it comes back as the unstructured-failure
+  // branch, whose wording invites a retry that can never succeed.
+  it("refuses call letters outside the code column's charset without calling the resolver", async () => {
+    let byCodeCalls = 0;
+    server.use(
+      http.get(BY_CODE_URL, () => {
+        byCodeCalls += 1;
+        return HttpResponse.json({ artists: [] });
+      }),
+    );
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
+    await selectGenre(user, "Rock");
+
+    await fillTextboxCode(user, "?!", "12");
+    await user.click(screen.getByRole("button", { name: "Search!" }));
+
+    expect(
+      await screen.findByText("Call letters must be letters, digits, or a slash."),
+    ).toBeInTheDocument();
+    expect(byCodeCalls).toBe(0);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
   // The JSP's own client validator never checks the call number field --
   // resolveArtistByCode requires one, so a blank value is refused only once
   // the JSP-parity rules above have already passed.
   it("asks for a call number when textbox mode is submitted with one blank", async () => {
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
 
     await user.click(screen.getByRole("radio", { name: /call letters:/i }));
     await user.type(screen.getByLabelText("Call letters:"), "MO");
@@ -365,14 +414,13 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
     expect(mockPush).not.toHaveBeenCalled();
   });
 
-  // The textbox radio and its letters/numbers inputs are interactive from
-  // mount -- faithful to the JSP, whose own client-side validator
-  // (library-code-form.js) reads only artistLettersTextbox for this branch,
-  // never genreID. A submit landing inside the client-side genre fetch's
-  // window therefore passes that JSP-parity validation with genreId still
-  // null; the guard against reaching the resolver genre-less lives at the
-  // composition step (composeLibraryCodeSearchArgs), not in the shared
-  // validator, so it fires here too.
+  // The JSP's own client-side validator (library-code-form.js) reads only
+  // artistLettersTextbox for the textbox branch, never genreID. A submit
+  // landing inside the client-side genre fetch's window therefore passes that
+  // JSP-parity validation with genreId still null; the guard against reaching
+  // the resolver genre-less lives at the composition step
+  // (composeLibraryCodeSearchArgs), not in the shared validator, so it fires
+  // here too.
   it("refuses a textbox submit that lands before genres have loaded, without calling the resolver", async () => {
     let byCodeCalls = 0;
     server.use(
@@ -385,7 +433,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
         return HttpResponse.json({ artists: [] });
       }),
     );
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
 
     await fillTextboxCode(user, "MO", "12");
     await user.click(screen.getByRole("button", { name: "Search!" }));
@@ -396,21 +444,27 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
   });
 
   describe("genre outage", () => {
-    it("shows the unavailable genre state and refuses the submit without duplicating the message", async () => {
+    // The outage owns the message. Neither the select's own JSP-parity rule
+    // ("You must select a genre") nor a second copy of the banner may stand
+    // in for it: one blames the librarian for a backend that is down, the
+    // other says the same thing twice.
+    it("disables the search and refuses the submit without blaming the librarian", async () => {
       server.use(
         http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
           HttpResponse.json({ message: "genres unavailable" }, { status: 500 }),
         ),
       );
-      const { user } = renderWithProviders(<ArtistSearchForm />);
+      const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
 
       expect(await screen.findByText(/genres are unavailable/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/^genre/i)).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Search!" })).toBeDisabled();
 
       await user.click(screen.getByRole("radio", { name: /various artists/i }));
       await user.click(screen.getByRole("button", { name: "Search!" }));
 
       expect(screen.getAllByText(/genres are unavailable/i)).toHaveLength(1);
+      expect(screen.queryByText("You must select a genre.")).not.toBeInTheDocument();
       expect(mockPush).not.toHaveBeenCalled();
     });
 
@@ -424,7 +478,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
             : HttpResponse.json([{ id: BLUES_GENRE_ID, genre_name: "Blues" }]);
         }),
       );
-      const { user } = renderWithProviders(<ArtistSearchForm />);
+      const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
 
       expect(await screen.findByText(/genres are unavailable/i)).toBeInTheDocument();
       await user.click(screen.getByRole("button", { name: /try again/i }));
@@ -437,7 +491,7 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
   });
 
   it("resets the mode and fields, including the genre back to its default, on Reset values", async () => {
-    const { user } = renderWithProviders(<ArtistSearchForm />);
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
 
     await selectGenre(user, "Rock");
     await user.click(screen.getByRole("radio", { name: /call letters:/i }));

--- a/tests/integration/components/classic/catalog/CreateLibraryCodeForm.test.tsx
+++ b/tests/integration/components/classic/catalog/CreateLibraryCodeForm.test.tsx
@@ -85,21 +85,28 @@ describe("classic CreateLibraryCodeForm — createLibraryCode.jsp", () => {
     expect(screen.getByRole("button", { name: "Reset" })).toBeInTheDocument();
   });
 
-  // ArtistAdminServlet picks the heading off the call letters: a `Z-` code is
-  // a Various Artists shelf bucket and gets its own shorter wording, so a
+  // ArtistAdminServlet picks the heading off the call letters: a Various
+  // Artists code is a shelf bucket and gets its own shorter wording, so a
   // librarian filing a compilation is not told to associate a named artist.
-  it("shows the Various Artists heading for a Z- code and the artist heading otherwise", async () => {
-    const { unmount } = renderWithProviders(
-      <CreateLibraryCodeForm {...defaultProps} codeLetters="z-ro" />,
-    );
+  // Both spellings route to the same heading -- `Z-<letter>` is the legacy
+  // spelling this form's carrying URL could still name, `V/A` is what
+  // Backend-Service's by-code resolution actually returns (see
+  // `libraryCode.ts`'s `isVariousArtists`) -- so this is the one URL both
+  // paths funnel through.
+  it.each([["z-ro"], ["V/A"], ["v/a"]])(
+    "shows the Various Artists heading for a %j code",
+    async (codeLetters) => {
+      renderWithProviders(<CreateLibraryCodeForm {...defaultProps} codeLetters={codeLetters} />);
 
-    expect(
-      await screen.findByText(
-        "This 'Various Artists' library code does not currently exist in the database. To create it, click 'Add!'",
-      ),
-    ).toBeInTheDocument();
-    unmount();
+      expect(
+        await screen.findByText(
+          "This 'Various Artists' library code does not currently exist in the database. To create it, click 'Add!'",
+        ),
+      ).toBeInTheDocument();
+    },
+  );
 
+  it("shows the artist heading for an ordinary code", async () => {
     renderWithProviders(<CreateLibraryCodeForm {...defaultProps} />);
     expect(
       await screen.findByText(
@@ -134,7 +141,11 @@ describe("classic CreateLibraryCodeForm — createLibraryCode.jsp", () => {
     [{ codeNumberRaw: "" }, "This link carries no call number."],
     [
       { codeNumberRaw: "012" },
-      "This link's call number (012) is not a whole number above zero.",
+      "This link's call number (012) is not a whole number, zero or greater.",
+    ],
+    [
+      { codeNumberRaw: "-1" },
+      "This link's call number (-1) is not a whole number, zero or greater.",
     ],
   ])("names the unusable part of the carried code (%o)", async (override, message) => {
     const { user } = renderWithProviders(
@@ -146,6 +157,26 @@ describe("classic CreateLibraryCodeForm — createLibraryCode.jsp", () => {
     await user.click(screen.getByRole("button", { name: "Add!" }));
 
     expect(await screen.findByText(message)).toBeInTheDocument();
+  });
+
+  // 0 is the Various Artists filing (artist_genre_code = 0), not a missing
+  // value -- the by-code resolution this screen is reached from searches V/A
+  // codes at exactly this number, so a code carried with "0" must file, not
+  // be refused as though the link were incomplete.
+  it("accepts and files a carried call number of 0", async () => {
+    const { getBodies } = mockAddArtist(() => created({ code_number: 0 }));
+    const { user } = renderWithProviders(
+      <CreateLibraryCodeForm {...defaultProps} codeLetters="V/A" codeNumberRaw="0" />,
+    );
+
+    await screen.findByText("Blues");
+    expect(screen.getByText("0")).toBeInTheDocument();
+    await user.type(screen.getByLabelText(/artist presentation name/i), "Various Artists - Rock - A");
+    await user.type(screen.getByLabelText(/artist alphabetical name/i), "Various Artists - Rock - A");
+    await user.click(screen.getByRole("button", { name: "Add!" }));
+
+    await waitFor(() => expect(getBodies()).toHaveLength(1));
+    expect(getBodies()[0]).toMatchObject({ code_letters: "V/A", code_number: 0 });
   });
 
   // The pending window must not borrow the missing-value rendering: "no genre

--- a/tests/integration/components/classic/catalog/LibraryChooser.test.tsx
+++ b/tests/integration/components/classic/catalog/LibraryChooser.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { act, screen } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+let capturedOnMultiMatch: ((result: unknown) => void) | undefined;
+vi.mock("@/src/components/experiences/classic/catalog/ArtistSearchForm", () => ({
+  default: ({ onMultiMatch }: { onMultiMatch: (result: unknown) => void }) => {
+    capturedOnMultiMatch = onMultiMatch;
+    return <div data-testid="artist-search-form" />;
+  },
+}));
+vi.mock("@/src/components/experiences/classic/catalog/NewArtistForm", () => ({
+  default: () => <div data-testid="new-artist-form" />,
+}));
+vi.mock("@/src/components/experiences/classic/catalog/MultipleArtistsDisplay", () => ({
+  default: ({ onChooseAgain }: { onChooseAgain: () => void }) => (
+    <div data-testid="multiple-artists-display">
+      <button type="button" onClick={onChooseAgain}>
+        back
+      </button>
+    </div>
+  ),
+}));
+
+import LibraryChooser from "@/src/components/experiences/classic/catalog/LibraryChooser";
+
+const MULTI_MATCH = {
+  genreName: "Rock",
+  codeLetters: "V/A",
+  codeNumber: 0,
+  artists: [
+    { id: 1, artist_name: "Various Artists - Rock - A", code_letters: "V/A", code_number: 0, genre_id: 11 },
+    { id: 2, artist_name: "Various Artists - Rock - B", code_letters: "V/A", code_number: 0, genre_id: 11 },
+  ],
+};
+
+describe("classic LibraryChooser — chooseLibraryCodeOrArtist.jsp + multipleArtistsDisplay.jsp, one URL", () => {
+  it("renders both chooser forms by default", () => {
+    renderWithProviders(<LibraryChooser />);
+
+    expect(screen.getByTestId("artist-search-form")).toBeInTheDocument();
+    expect(screen.getByTestId("new-artist-form")).toBeInTheDocument();
+    expect(screen.queryByTestId("multiple-artists-display")).not.toBeInTheDocument();
+  });
+
+  it("replaces both forms with the disambiguation screen on a multi-match, matching the JSP's full-page swap", async () => {
+    const { user } = renderWithProviders(<LibraryChooser />);
+    expect(capturedOnMultiMatch).toBeDefined();
+
+    act(() => capturedOnMultiMatch!(MULTI_MATCH));
+
+    expect(await screen.findByTestId("multiple-artists-display")).toBeInTheDocument();
+    expect(screen.queryByTestId("artist-search-form")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("new-artist-form")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "back" }));
+
+    expect(await screen.findByTestId("artist-search-form")).toBeInTheDocument();
+    expect(screen.getByTestId("new-artist-form")).toBeInTheDocument();
+  });
+});

--- a/tests/integration/components/classic/catalog/LibraryChooser.test.tsx
+++ b/tests/integration/components/classic/catalog/LibraryChooser.test.tsx
@@ -2,10 +2,17 @@ import { describe, it, expect, vi } from "vitest";
 import { act, screen } from "@testing-library/react";
 import { renderWithProviders } from "@/tests/helpers";
 
-vi.mock("@/lib/features/authentication/client", () => ({
-  authClient: { useSession: vi.fn() },
-  getJWTToken: vi.fn().mockResolvedValue("test-token"),
-}));
+// The real better-auth client installs listeners whose teardown is deferred a
+// second past the last subscriber; a short file finishes inside that second.
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import(
+    "@/tests/helpers/auth-client-mock"
+  );
+  return {
+    ...createAuthClientModuleMock(),
+    getJWTToken: vi.fn(async () => "test-token"),
+  };
+});
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),

--- a/tests/integration/components/classic/catalog/MultipleArtistsDisplay.test.tsx
+++ b/tests/integration/components/classic/catalog/MultipleArtistsDisplay.test.tsx
@@ -2,10 +2,17 @@ import { describe, it, expect, vi } from "vitest";
 import { screen, within } from "@testing-library/react";
 import { renderWithProviders } from "@/tests/helpers";
 
-vi.mock("@/lib/features/authentication/client", () => ({
-  authClient: { useSession: vi.fn() },
-  getJWTToken: vi.fn().mockResolvedValue("test-token"),
-}));
+// The real better-auth client installs listeners whose teardown is deferred a
+// second past the last subscriber; a short file finishes inside that second.
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import(
+    "@/tests/helpers/auth-client-mock"
+  );
+  return {
+    ...createAuthClientModuleMock(),
+    getJWTToken: vi.fn(async () => "test-token"),
+  };
+});
 
 import MultipleArtistsDisplay from "@/src/components/experiences/classic/catalog/MultipleArtistsDisplay";
 

--- a/tests/integration/components/classic/catalog/MultipleArtistsDisplay.test.tsx
+++ b/tests/integration/components/classic/catalog/MultipleArtistsDisplay.test.tsx
@@ -71,7 +71,11 @@ describe("classic MultipleArtistsDisplay — multipleArtistsDisplay.jsp", () => 
     expect(screen.getAllByText("KU 7")).toHaveLength(2);
   });
 
-  it("links each artist name to its read-only view card -- the JSP's selection affordance", () => {
+  // The JSP's row link says `mode=view`, but ArtistViewServlet never reads
+  // `mode` and forwards to the modify card for an admin -- the only role that
+  // can reach this screen. So the affordance is the same destination a
+  // single-match code search lands on, not the DJ-facing display card.
+  it("links each artist name to the modify card the JSP's own servlet forwards to", () => {
     renderWithProviders(
       <MultipleArtistsDisplay
         genreName="Rock"
@@ -83,9 +87,9 @@ describe("classic MultipleArtistsDisplay — multipleArtistsDisplay.jsp", () => 
     );
 
     const link = screen.getByRole("link", { name: "Various Artists - Rock - A" });
-    expect(link).toHaveAttribute("href", "/dashboard/library/artist/1/view");
+    expect(link).toHaveAttribute("href", "/dashboard/library/artist/1");
     const other = screen.getByRole("link", { name: "Various Artists - Rock - B" });
-    expect(other).toHaveAttribute("href", "/dashboard/library/artist/2/view");
+    expect(other).toHaveAttribute("href", "/dashboard/library/artist/2");
   });
 
   it("returns to the chooser via the Choose/Add Library Codes affordance", async () => {

--- a/tests/integration/components/classic/catalog/MultipleArtistsDisplay.test.tsx
+++ b/tests/integration/components/classic/catalog/MultipleArtistsDisplay.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, within } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  authClient: { useSession: vi.fn() },
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+import MultipleArtistsDisplay from "@/src/components/experiences/classic/catalog/MultipleArtistsDisplay";
+
+const OWNERS = [
+  {
+    id: 2,
+    artist_name: "Various Artists - Rock - B",
+    code_letters: "V/A",
+    code_number: 0,
+    genre_id: 11,
+  },
+  {
+    id: 1,
+    artist_name: "Various Artists - Rock - A",
+    code_letters: "V/A",
+    code_number: 0,
+    genre_id: 11,
+  },
+];
+
+describe("classic MultipleArtistsDisplay — multipleArtistsDisplay.jsp", () => {
+  it("renders the Library Code / Artist Name columns in the order the response provided", () => {
+    renderWithProviders(
+      <MultipleArtistsDisplay
+        genreName="Rock"
+        codeLetters="V/A"
+        codeNumber={0}
+        artists={OWNERS}
+        onChooseAgain={vi.fn()}
+      />,
+    );
+
+    const table = screen.getByRole("table");
+    expect(within(table).getByRole("columnheader", { name: /library code/i })).toBeInTheDocument();
+    expect(within(table).getByRole("columnheader", { name: /artist name/i })).toBeInTheDocument();
+
+    const rows = within(table).getAllByRole("row").slice(1); // drop the header row
+    expect(rows).toHaveLength(2);
+    // Ordering is the response's own order (server-sorted by artist_name,
+    // then id) -- this component does not re-sort.
+    expect(within(rows[0]).getByText("Various Artists - Rock - B")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("Various Artists - Rock - A")).toBeInTheDocument();
+
+    // Genre name + the no-punctuation call letters/numbers, per row.
+    expect(within(rows[0]).getByText("Rock")).toBeInTheDocument();
+    expect(within(rows[0]).getByText("V/A")).toBeInTheDocument();
+  });
+
+  it("renders an ordinary code's letters and number, not the V/A form", () => {
+    renderWithProviders(
+      <MultipleArtistsDisplay
+        genreName="Rock"
+        codeLetters="KU"
+        codeNumber={7}
+        artists={[
+          { id: 10, artist_name: "Kurt Vile", code_letters: "KU", code_number: 7, genre_id: 11 },
+          { id: 11, artist_name: "Kurupt", code_letters: "KU", code_number: 7, genre_id: 11 },
+        ]}
+        onChooseAgain={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText("KU 7")).toHaveLength(2);
+  });
+
+  it("links each artist name to its read-only view card -- the JSP's selection affordance", () => {
+    renderWithProviders(
+      <MultipleArtistsDisplay
+        genreName="Rock"
+        codeLetters="V/A"
+        codeNumber={0}
+        artists={OWNERS}
+        onChooseAgain={vi.fn()}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "Various Artists - Rock - A" });
+    expect(link).toHaveAttribute("href", "/dashboard/library/artist/1/view");
+    const other = screen.getByRole("link", { name: "Various Artists - Rock - B" });
+    expect(other).toHaveAttribute("href", "/dashboard/library/artist/2/view");
+  });
+
+  it("returns to the chooser via the Choose/Add Library Codes affordance", async () => {
+    const onChooseAgain = vi.fn();
+    const { user } = renderWithProviders(
+      <MultipleArtistsDisplay
+        genreName="Rock"
+        codeLetters="V/A"
+        codeNumber={0}
+        artists={OWNERS}
+        onChooseAgain={onChooseAgain}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /choose\/add library codes/i }));
+
+    expect(onChooseAgain).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/lib/features/catalog/adminCreateArtistValidation.test.ts
+++ b/tests/unit/lib/features/catalog/adminCreateArtistValidation.test.ts
@@ -5,6 +5,7 @@ import {
   CODE_NUMBER_MAX,
   isArtistNameConflictData,
   normalizeCodeLetters,
+  parseRequiredNonNegativeInt,
   parseRequiredPositiveInt,
   validateNewArtistFields,
 } from "@/lib/features/catalog/adminCreateArtistValidation";
@@ -34,6 +35,33 @@ describe("parseRequiredPositiveInt", () => {
 
   it("rejects leading-zero decimals (not valid code-number literals)", () => {
     expect(parseRequiredPositiveInt("007")).toBeNull();
+  });
+});
+
+describe("parseRequiredNonNegativeInt", () => {
+  it.each([
+    ["0", 0],
+    ["42", 42],
+    ["  99  ", 99],
+  ])("accepts decimal non-negative integer %j → %i", (raw, expected) => {
+    expect(parseRequiredNonNegativeInt(raw)).toBe(expected);
+  });
+
+  it.each([
+    "",
+    "   ",
+    "-1",
+    "1.5",
+    "1e3",
+    "0x10",
+    "abc",
+    "12abc",
+  ])("rejects non-decimal or negative input %j", (raw) => {
+    expect(parseRequiredNonNegativeInt(raw)).toBeNull();
+  });
+
+  it("rejects leading-zero decimals", () => {
+    expect(parseRequiredNonNegativeInt("007")).toBeNull();
   });
 });
 

--- a/tests/unit/lib/features/catalog/api.test.tsx
+++ b/tests/unit/lib/features/catalog/api.test.tsx
@@ -28,6 +28,7 @@ describe("catalogApi", () => {
       "getFormats",
       "getGenres",
       "peekArtistCode",
+      "resolveArtistByCode",
       "searchArtistsInGenre",
       "getCompilationTracks",
       "getCompilationTrackSuggestions",

--- a/tests/unit/lib/features/catalog/libraryCode.test.ts
+++ b/tests/unit/lib/features/catalog/libraryCode.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
   formatArtistCodeWithPunctuation,
+  formatCallLettersAndNumbers,
   formatReleaseCode,
   formatEntireLibraryCode,
+  isVariousArtists,
 } from "@/lib/features/catalog/libraryCode";
 
 describe("formatArtistCodeWithPunctuation — ArtistLibraryCode.java:98", () => {
@@ -75,6 +77,43 @@ describe("formatArtistCodeWithPunctuation — ArtistLibraryCode.java:98", () => 
       }),
     ).toBe("V/A-");
   });
+});
+
+describe("isVariousArtists", () => {
+  it.each([["V/A"], ["v/a"], [" V/A "], ["Z-X"], ["Z--"]])(
+    "treats %j as a Various Artists bucket",
+    (codeLetters) => {
+      expect(isVariousArtists(codeLetters)).toBe(true);
+    },
+  );
+
+  it.each([["MO"], ["ZOO"], [""]])(
+    "treats %j as an ordinary artist code",
+    (codeLetters) => {
+      expect(isVariousArtists(codeLetters)).toBe(false);
+    },
+  );
+});
+
+describe("formatCallLettersAndNumbers — ArtistLibraryCode.java:85, no trailing punctuation", () => {
+  it("renders a regular artist code as LETTERS NUMBER", () => {
+    expect(
+      formatCallLettersAndNumbers({ code_letters: "mo", code_artist_number: 12 }),
+    ).toBe("MO 12");
+  });
+
+  // Backend-Service's collapsed `V/A` storage has already lost the
+  // Rock/Soundtracks sub-bucket letter the JSP's own getter recovers by
+  // substring-ing the legacy `Z-<letter>` spelling (see this file's header) --
+  // every Various Artists bucket renders identically here regardless of genre.
+  it.each([["V/A"], ["Z-X"], ["Z--"]])(
+    "renders a Various Artists bucket (%j) as V/A, dropping the number",
+    (codeLetters) => {
+      expect(
+        formatCallLettersAndNumbers({ code_letters: codeLetters, code_artist_number: 0 }),
+      ).toBe("V/A");
+    },
+  );
 });
 
 describe("formatReleaseCode — LibraryRelease.java:122", () => {

--- a/tests/unit/lib/features/catalog/libraryCodeResolution.test.ts
+++ b/tests/unit/lib/features/catalog/libraryCodeResolution.test.ts
@@ -80,6 +80,37 @@ describe("composeLibraryCodeSearchArgs", () => {
     });
   });
 
+  // Mirrors the endpoint's own `^[A-Za-z0-9/]{1,4}$` rule so a code it would
+  // 400 on is named here instead of arriving as the caller's
+  // unstructured-failure branch, which reads as "try again".
+  it.each([["?!"], ["A-"], ["A B"], ["ABCDE"], [""], ["   "]])(
+    "refuses call letters outside the code column's charset (%j)",
+    (raw) => {
+      expect(
+        composeLibraryCodeSearchArgs({
+          callLetterMode: "textbox",
+          artistLettersTextbox: raw,
+          artistNumbersTextbox: "12",
+          genreId: ROCK_GENRE_ID,
+        }),
+      ).toEqual({ ready: false, message: "Call letters must be letters, digits, or a slash." });
+    },
+  );
+
+  it.each([["MO"], ["V/A"], ["A1"], ["9"]])("composes an in-charset code (%j)", (raw) => {
+    expect(
+      composeLibraryCodeSearchArgs({
+        callLetterMode: "textbox",
+        artistLettersTextbox: raw,
+        artistNumbersTextbox: "12",
+        genreId: ROCK_GENRE_ID,
+      }),
+    ).toEqual({
+      ready: true,
+      args: { genre_id: ROCK_GENRE_ID, code_letters: raw, code_number: 12 },
+    });
+  });
+
   it("refuses to compose without a resolved genre", () => {
     expect(
       composeLibraryCodeSearchArgs({

--- a/tests/unit/lib/features/catalog/libraryCodeResolution.test.ts
+++ b/tests/unit/lib/features/catalog/libraryCodeResolution.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+  composeLibraryCodeSearchArgs,
+  resolveArtistByCodeErrorReason,
+} from "@/lib/features/catalog/libraryCodeResolution";
+
+const ROCK_GENRE_ID = 11;
+
+describe("composeLibraryCodeSearchArgs", () => {
+  it("composes a textbox search from trimmed letters and a parsed call number", () => {
+    expect(
+      composeLibraryCodeSearchArgs({
+        callLetterMode: "textbox",
+        artistLettersTextbox: " mo ",
+        artistNumbersTextbox: "12",
+        genreId: ROCK_GENRE_ID,
+      }),
+    ).toEqual({
+      ready: true,
+      args: { genre_id: ROCK_GENRE_ID, code_letters: "mo", code_number: 12 },
+    });
+  });
+
+  // 0 is a legitimate call number -- the Various Artists filing, and no
+  // floor above 0 applies to an ordinary artist code either.
+  it("accepts a call number of 0 in textbox mode", () => {
+    expect(
+      composeLibraryCodeSearchArgs({
+        callLetterMode: "textbox",
+        artistLettersTextbox: "MO",
+        artistNumbersTextbox: "0",
+        genreId: ROCK_GENRE_ID,
+      }),
+    ).toEqual({
+      ready: true,
+      args: { genre_id: ROCK_GENRE_ID, code_letters: "MO", code_number: 0 },
+    });
+  });
+
+  // The JSP's own client-side validator (library-code-form.js) never checks
+  // artistNumbersTextbox at all -- a blank call number reached the servlet,
+  // which forwarded the browser to a genre+letters-only browse
+  // (LibraryCodeServlet -> multipleArtistsDisplay.jsp) with no floor on how
+  // many numbers could come back. `by-code` requires a fully specified
+  // triple and cannot browse by letters alone, so this is a forced
+  // divergence: the form asks for the call number that JSP-parity validation
+  // itself never required.
+  it.each([
+    ["", "You must enter a call number to look up this code."],
+    ["abc", "You must enter a call number to look up this code."],
+    ["-1", "You must enter a call number to look up this code."],
+  ])("refuses to compose a textbox search with an unparseable call number %j", (raw, message) => {
+    expect(
+      composeLibraryCodeSearchArgs({
+        callLetterMode: "textbox",
+        artistLettersTextbox: "MO",
+        artistNumbersTextbox: raw,
+        genreId: ROCK_GENRE_ID,
+      }),
+    ).toEqual({ ready: false, message });
+  });
+
+  // Every Various Artists bucket is filed at code_number 0 under the literal
+  // code_letters "V/A", regardless of genre -- Backend-Service's catalog
+  // import collapses the JSP's Rock/Soundtracks-only `Z-<letter>` sub-bucket
+  // spelling to that one form (see libraryCode.ts's header), so the letter
+  // the librarian enters into rockCompLetters cannot narrow this search; it
+  // is validated for JSP parity but plays no part in the composed query.
+  it("composes a compilation search as the fixed V/A, 0 pair for the selected genre", () => {
+    expect(
+      composeLibraryCodeSearchArgs({
+        callLetterMode: "compilation",
+        artistLettersTextbox: "",
+        artistNumbersTextbox: "",
+        genreId: ROCK_GENRE_ID,
+      }),
+    ).toEqual({
+      ready: true,
+      args: { genre_id: ROCK_GENRE_ID, code_letters: "V/A", code_number: 0 },
+    });
+  });
+
+  it("refuses to compose without a resolved genre", () => {
+    expect(
+      composeLibraryCodeSearchArgs({
+        callLetterMode: "textbox",
+        artistLettersTextbox: "MO",
+        artistNumbersTextbox: "12",
+        genreId: null,
+      }),
+    ).toEqual({ ready: false, message: "You must select a genre." });
+  });
+
+  it("refuses to compose with no call letter mode selected", () => {
+    expect(
+      composeLibraryCodeSearchArgs({
+        callLetterMode: null,
+        artistLettersTextbox: "",
+        artistNumbersTextbox: "",
+        genreId: ROCK_GENRE_ID,
+      }),
+    ).toEqual({
+      ready: false,
+      message: "You must select one of the choices for Call Letters/Numbers.",
+    });
+  });
+});
+
+describe("resolveArtistByCodeErrorReason", () => {
+  it.each([["genre_not_found"], ["code_not_assigned"]] as const)(
+    "reads the %s reason off a wrapped 404",
+    (reason) => {
+      expect(
+        resolveArtistByCodeErrorReason({
+          resolveArtistByCodeError: {
+            status: 404,
+            data: { message: "nope", reason },
+          },
+        }),
+      ).toBe(reason);
+    },
+  );
+
+  it("returns undefined for a 404 with no recognized reason", () => {
+    expect(
+      resolveArtistByCodeErrorReason({
+        resolveArtistByCodeError: { status: 404, data: { message: "nope" } },
+      }),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ["a 400 validation failure", { status: 400, data: { message: "bad genre_id" } }],
+    ["a 500", { status: 500, data: { message: "boom" } }],
+    ["a network failure", { status: "FETCH_ERROR", error: "Failed to fetch" }],
+    ["a non-JSON body", { status: "PARSING_ERROR", originalStatus: 502, data: "<html>", error: "SyntaxError" }],
+  ])("returns undefined for %s -- the caller's outage fallback, never an unassigned code", (_name, inner) => {
+    expect(resolveArtistByCodeErrorReason({ resolveArtistByCodeError: inner })).toBeUndefined();
+  });
+
+  it("returns undefined for an error this endpoint didn't wrap", () => {
+    expect(resolveArtistByCodeErrorReason({ status: 404, data: { reason: "code_not_assigned" } })).toBeUndefined();
+    expect(resolveArtistByCodeErrorReason(undefined)).toBeUndefined();
+    expect(resolveArtistByCodeErrorReason(null)).toBeUndefined();
+  });
+});

--- a/tests/unit/lib/features/catalog/libraryCodeResolution.test.ts
+++ b/tests/unit/lib/features/catalog/libraryCodeResolution.test.ts
@@ -7,7 +7,10 @@ import {
 const ROCK_GENRE_ID = 11;
 
 describe("composeLibraryCodeSearchArgs", () => {
-  it("composes a textbox search from trimmed letters and a parsed call number", () => {
+  // Normalized at this edge like every other code-letters write path, so the
+  // create-flow URL a miss redirects to carries the casing the catalog is
+  // filed under rather than whatever the librarian typed.
+  it("composes a textbox search from normalized letters and a parsed call number", () => {
     expect(
       composeLibraryCodeSearchArgs({
         callLetterMode: "textbox",
@@ -17,7 +20,7 @@ describe("composeLibraryCodeSearchArgs", () => {
       }),
     ).toEqual({
       ready: true,
-      args: { genre_id: ROCK_GENRE_ID, code_letters: "mo", code_number: 12 },
+      args: { genre_id: ROCK_GENRE_ID, code_letters: "MO", code_number: 12 },
     });
   });
 
@@ -45,20 +48,22 @@ describe("composeLibraryCodeSearchArgs", () => {
   // triple and cannot browse by letters alone, so this is a forced
   // divergence: the form asks for the call number that JSP-parity validation
   // itself never required.
-  it.each([
-    ["", "You must enter a call number to look up this code."],
-    ["abc", "You must enter a call number to look up this code."],
-    ["-1", "You must enter a call number to look up this code."],
-  ])("refuses to compose a textbox search with an unparseable call number %j", (raw, message) => {
-    expect(
-      composeLibraryCodeSearchArgs({
-        callLetterMode: "textbox",
-        artistLettersTextbox: "MO",
-        artistNumbersTextbox: raw,
-        genreId: ROCK_GENRE_ID,
-      }),
-    ).toEqual({ ready: false, message });
-  });
+  it.each([[""], ["abc"], ["-1"]])(
+    "refuses to compose a textbox search with an unparseable call number %j",
+    (raw) => {
+      expect(
+        composeLibraryCodeSearchArgs({
+          callLetterMode: "textbox",
+          artistLettersTextbox: "MO",
+          artistNumbersTextbox: raw,
+          genreId: ROCK_GENRE_ID,
+        }),
+      ).toEqual({
+        ready: false,
+        message: "You must enter a call number to look up this code.",
+      });
+    },
+  );
 
   // Every Various Artists bucket is filed at code_number 0 under the literal
   // code_letters "V/A", regardless of genre -- Backend-Service's catalog

--- a/tests/unit/lib/features/catalog/resolveArtistByCode.test.ts
+++ b/tests/unit/lib/features/catalog/resolveArtistByCode.test.ts
@@ -66,6 +66,20 @@ describe("resolveArtistByCode", () => {
     expect(result.data?.artists).toHaveLength(2);
   });
 
+  // The caller reads `.length` to pick its branch, so a body missing
+  // `artists` must resolve to a shape it can read rather than throwing
+  // mid-handler, where the throw would be caught and reported as a
+  // retryable outage.
+  it("resolves a body missing the owner list to an empty list", async () => {
+    server.use(http.get(BY_CODE_URL, () => HttpResponse.json({})));
+
+    const store = createTestStore();
+    const result = await store.dispatch(initiate());
+
+    expect(result.isError).toBe(false);
+    expect(result.data).toEqual({ artists: [] });
+  });
+
   it("surfaces a genre_not_found 404 as an error", async () => {
     server.use(
       http.get(BY_CODE_URL, () =>

--- a/tests/unit/lib/features/catalog/resolveArtistByCode.test.ts
+++ b/tests/unit/lib/features/catalog/resolveArtistByCode.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server, TEST_BACKEND_URL, createTestStore } from "@/tests/helpers";
+import { catalogApi } from "@/lib/features/catalog/api";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const ROCK_GENRE_ID = 11;
+const BY_CODE_URL = `${TEST_BACKEND_URL}/library/artists/by-code`;
+
+const initiate = (
+  overrides: Partial<{ genre_id: number; code_letters: string; code_number: number }> = {},
+) =>
+  catalogApi.endpoints.resolveArtistByCode.initiate({
+    genre_id: ROCK_GENRE_ID,
+    code_letters: "MO",
+    code_number: 12,
+    ...overrides,
+  });
+
+describe("resolveArtistByCode", () => {
+  it("resolves a single owner", async () => {
+    server.use(
+      http.get(BY_CODE_URL, () =>
+        HttpResponse.json({
+          artists: [
+            { id: 12, artist_name: "Juana Molina", code_letters: "MO", code_number: 12, genre_id: ROCK_GENRE_ID },
+          ],
+        }),
+      ),
+    );
+
+    const store = createTestStore();
+    const result = await store.dispatch(initiate());
+
+    expect(result.isError).toBe(false);
+    expect(result.data?.artists).toEqual([
+      { id: 12, artist_name: "Juana Molina", code_letters: "MO", code_number: 12, genre_id: ROCK_GENRE_ID },
+    ]);
+  });
+
+  it("resolves multiple owners of a collided triple", async () => {
+    server.use(
+      http.get(BY_CODE_URL, () =>
+        HttpResponse.json({
+          artists: [
+            { id: 1, artist_name: "Various Artists - Rock - A", code_letters: "V/A", code_number: 0, genre_id: ROCK_GENRE_ID },
+            { id: 2, artist_name: "Various Artists - Rock - B", code_letters: "V/A", code_number: 0, genre_id: ROCK_GENRE_ID },
+          ],
+        }),
+      ),
+    );
+
+    const store = createTestStore();
+    const result = await store.dispatch(
+      initiate({ code_letters: "V/A", code_number: 0 }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.data?.artists).toHaveLength(2);
+  });
+
+  it("surfaces a genre_not_found 404 as an error", async () => {
+    server.use(
+      http.get(BY_CODE_URL, () =>
+        HttpResponse.json({ message: "Genre not found", reason: "genre_not_found" }, { status: 404 }),
+      ),
+    );
+
+    const store = createTestStore();
+    const result = await store.dispatch(initiate());
+
+    expect(result.isError).toBe(true);
+    expect(result.data).toBeUndefined();
+  });
+
+  it("surfaces a code_not_assigned 404 as an error", async () => {
+    server.use(
+      http.get(BY_CODE_URL, () =>
+        HttpResponse.json(
+          { message: "Artist code not assigned in that genre", reason: "code_not_assigned" },
+          { status: 404 },
+        ),
+      ),
+    );
+
+    const store = createTestStore();
+    const result = await store.dispatch(initiate());
+
+    expect(result.isError).toBe(true);
+  });
+
+  // A non-JSON body (a gateway's HTML 502, Express's HTML 404) must not
+  // soft-fail into a successful `null` -- this lookup backs the create-flow
+  // decision, and a false "unassigned" would walk the librarian into filing
+  // a duplicate of a code that already exists.
+  it.each([
+    ["a gateway HTML error page", 502],
+    ["the framework's HTML 404", 404],
+  ])("surfaces %s as an error rather than a soft-failed null", async (_name, status) => {
+    server.use(
+      http.get(
+        BY_CODE_URL,
+        () =>
+          new HttpResponse("<!DOCTYPE html><html><body>Not Found</body></html>", {
+            status,
+            headers: { "Content-Type": "text/html" },
+          }),
+      ),
+    );
+
+    const store = createTestStore();
+    const result = await store.dispatch(initiate());
+
+    expect(result.isError).toBe(true);
+    expect(result.data).toBeUndefined();
+  });
+
+  // Every failure shape here is handled inline by the chooser (see
+  // resolveArtistByCodeErrorReason), so none of them should also land as a
+  // second, generic banner from the shared rtk-query-error-logger
+  // middleware -- same technique, and the same reasoning, as
+  // searchArtistsInGenre.
+  it.each([
+    ["a gateway HTML error page (PARSING_ERROR opt-out)", () =>
+      new HttpResponse("<!DOCTYPE html><html><body>Bad Gateway</body></html>", {
+        status: 502,
+        headers: { "Content-Type": "text/html" },
+      }),
+    ],
+    ["a structured JSON 404", () =>
+      HttpResponse.json({ message: "Artist code not assigned in that genre", reason: "code_not_assigned" }, { status: 404 }),
+    ],
+  ])("keeps %s out of the global toast", async (_name, respond) => {
+    const { toast } = await import("sonner");
+    vi.mocked(toast.error).mockClear();
+    server.use(http.get(BY_CODE_URL, respond));
+
+    const store = createTestStore();
+    const result = await store.dispatch(initiate());
+
+    expect(result.isError).toBe(true);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What this does

`chooseLibraryCodeOrArtist.jsp`'s `artistSearchForm` has rendered and validated since Slice 1a, but its promise — *"Enter a library code below. If the code exists, you will be taken to the appropriate page"* — had nothing behind it, because Backend-Service could not answer "does this code already exist, and whose is it". `GET /library/artists/by-code` now can, so the form resolves the composed code and goes straight to the outcome, with no screen in between:

| Answer | Destination |
|---|---|
| One owner | that artist's card, `/dashboard/library/artist/:id` |
| More than one owner | `multipleArtistsDisplay.jsp`, built here as `MultipleArtistsDisplay` |
| `404 code_not_assigned` | the creation flow, carrying the searched code |
| `404 genre_not_found` | an inline message naming the stale genre; nothing is navigated to |
| Anything else | an inline refusal; nothing is navigated to |

The last row is the one that matters most. A lookup that soft-fails reads as "this code is free", and the screen acts on that answer by walking the librarian into filing a duplicate of a code that already exists. So `resolveArtistByCode` opts into `extraOptions: { surfaceNonJsonAsError: true }` — the same opt-out `searchArtistsInGenre` carries, for the same reason — and every failure shape that is not one of the two structured 404 reasons lands on a refusal instead of a decision.

The multi-match screen exists because of the data, not just the contract. The catalog import collapses every Various Artists sub-bucket to the literal `V/A` at call number 0, so `V/A`/12/0 has 27 owners in production and `V/A`/11/0 has 26. A librarian resolving a compilation code has to pick the bucket by name, and there is nowhere else to do it.

## Divergences from `/wxycdb`

The epic's rule is that the JSP is the design spec, and any divergence forced by the Backend contract is enumerated with a reason. Four, each verified against the tubafrenzy source rather than inferred:

**1. A blank call number is refused instead of browsing.** The JSP's own client-side validator (`library-code-form.ts`) never reads `artistNumbersTextbox` at all — despite the function being named `validateArtistNumber` — so a blank number submitted, and `ArtistAdminServlet:142-145` redirected to `libraryCode?genreID=…&artistLetters=…`, a genre+letters-only browse that forwards to `multipleArtistsDisplay.jsp`. `by-code` requires all three parameters and there is no "any number" query anywhere in the API, so that browse cannot be reproduced. The form still accepts a blank number past `validateArtistSearchForm` — that validator stays a rule-for-rule port — and refuses at submit with a message asking for one, rather than guessing a number or inventing a client-side scan.

**2. A fully specified code with several owners reaches the disambiguation screen.** The legacy servlet's fully-specified lookup ends in `findFirst()` over a query with no `ORDER BY` (`ArtistLibraryCodeRepositoryImpl:95`), so it hands the librarian one arbitrary row and cannot tell one match from twenty-seven. `by-code` answers a list precisely so that guess is not forced. This is the ticket's own acceptance criterion, and it means the JSP and this screen reach `multipleArtistsDisplay.jsp` by different routes: the JSP by a browse we cannot reproduce, this by a code search the JSP could not disambiguate.

**3. A compilation miss routes to the creation flow.** `ArtistAdminServlet:135-138` redirects a compilation-radio miss back to an empty chooser with no message at all, contradicting the heading two lines above it on the same page. The heading is reproduced verbatim here, so the behaviour it promises is reproduced with it — the textbox radio's miss already behaved this way in the JSP.

**4. The disambiguation screen is a state swap at `/dashboard/library`, not its own route.** The dashboard URL map in `docs/architecture.md` already assigns that one URL to both JSPs. `/wxycdb` reaches the screen at `libraryCode?genreID=&artistLetters=`, an address composed of the browse in divergence 1 — a query this API cannot serve. The search that reaches it here is a fully specified code whose owners are a server response, not a URL. Accepted cost, stated rather than hidden: browser Back leaves `/dashboard/library` instead of returning to the chooser, where the JSP's Back would return to it. The JSP's own "Choose/Add Library Codes" return affordance is reproduced and does that job.

Two smaller notes, both about the same collapse. The compilation radio always searches the fixed `V/A`/0 pair: the JSP composed `Z-<letter>` from `rockCompLetters` for Rock and Soundtracks and the literal `Z--` for every other genre, and the import preserves neither, so that letter cannot narrow the search. It is still collected and validated for genres 11 and 12, JSP-faithfully, including the JSP's own incomplete on-screen label. And `formatCallLettersAndNumbers` does not reproduce `ArtistLibraryCode.getCallLettersAndNumbers()`'s three-way genre split, because that split works by slicing the sub-bucket letter out of `Z-<letter>`, and against the collapsed `V/A` the same slice returns the `A` of `V/A`. The sub-bucket survives in the artist's name, which this screen's own Artist Name column shows.

## Scope expansion: `CreateLibraryCodeForm`

This PR changes a form that shipped in Slice 2, deliberately, because this PR is what first sends traffic to it that it cannot handle. Both fixes are load-bearing for the compilation path added here rather than drive-by improvements — splitting them out would land this PR with its own V/A create branch broken:

- **V/A detection tested a bare `Z-` prefix.** That is the servlet's own test (`ArtistAdminServlet:152`), and it was right when the only links into this screen were legacy-shaped. This PR starts routing compilation misses here with `code_letters=V/A` — the literal the by-code resolution actually returns — which `startsWith("Z-")` never matches, so the librarian filing a compilation would have been told to associate a named artist. Now matched via the existing `isVariousArtists`, which knows both spellings.
- **The call-number floor was 1.** Every Various Artists bucket is filed at `artist_genre_code = 0`, and this PR routes exactly that number here on a compilation miss, so the screen would have refused its own caller with "not a whole number above zero". Parsed with a floor of 0 now.

The floor stays 0 for any carried code, not only a V/A one, which is why it differs from `NewArtistForm`'s floor of 1 on the same column. The two forms are asked different questions: there the number is typed freely beside a peeked next-free value that is never 0, so a typed 0 is a slip; here it is not input at all but a code the resolver was already asked about and answered `code_not_assigned` for. Both `by-code` and `POST /library/artists` accept 0 for any code letters, and production holds a non-V/A `UNK` filed at 0.

Non-test delta is roughly 600 lines; the rest is tests.

## What review changed

`/code-review` and four `/simplify` passes ran over the branch. Substantive changes made in response:

- **The disambiguation rows opened the wrong card.** The first pass read the affordance off `multipleArtistsDisplay.jsp:48`'s `artist?id=…&mode=view` and linked to the read-only view card. `ArtistViewServlet` never reads `mode` — it forwards unconditionally to the modify card, and only an admin can reach this screen, since `LibraryCodeServlet` bounces everyone else to the DJ search. The read-only card is what a non-admin would have got, and no non-admin gets here. Rows now open `/dashboard/library/artist/:id`, which is also what makes the two paths agree: disambiguating a contested code should not cost the librarian the ability to edit the card they picked.
- **A 200 with no owners drew an empty disambiguation table** under a heading asserting the code exists. The contract never produces that shape, so it is refused rather than acted on, and a `transformResponse` shape guard keeps a body missing `artists` from throwing mid-handler and being laundered into the same message by accident — the guard `searchArtistsInGenre` and `getCompilationTracks` already carry.
- **A 400 was reported as a transient outage.** Call letters outside `^[A-Za-z0-9/]{1,4}$` are now refused by name, so the librarian is not invited to retry something that can never succeed.
- **A genre outage is caught ahead of validation, not after it.** Behind it, the compilation branch's genre rule fired first and blamed the librarian for a backend that was down, beside a select they could not open. Search is disabled while the banner stands, so the click is no longer silent either.
- **`onMultiMatch` is required.** Optional-with-a-noop-default turned a caller that forgot it into a Search button that silently did nothing.
- **Routing moved outside the `try`**, so a throw from `router.push` or `onMultiMatch` surfaces as itself rather than as a failed lookup.
- **Layout and reuse:** the JSP's three-cell header row replaces a stacked heading; the return button uses the existing classic `.link-button` rule instead of restating it inline (that rule loses its `.entry-row` scope, which no caller depended on); the call letters are computed once rather than per row, since Backend-Service projects `code_letters`/`code_number` onto every owner from the request and they are the searched values by construction.
- **Doc accuracy:** a JSDoc block was attached to a type rather than the function it described; `libraryCode.ts`'s header claimed "rule-for-rule" for a formatter that deliberately diverges; and a process-artifact reference pointed at a table under a name `docs/architecture.md` does not use.

The `/simplify` round then gave four restated rules one owner each: the `V/A` literal (four copies across two modules, for one data-model fact) now exports from `libraryCode.ts`, which documents the collapse that produces it; the two JSP refusal messages export from `chooserValidation.ts`, so the second gate refuses in the same words as the first rather than in a copy of them; the code-letters domain moved to `adminCreateArtistValidation.ts` as `isCanonicalCodeLetters`, built from the `CODE_LETTERS_MAX_LENGTH` that had been duplicated as a regex quantifier and sited beside `normalizeCodeLetters` so the gap between what may be *filed* and what may be *looked up* is visible where both live; and `parseRequiredPositiveInt` is now expressed in terms of `parseRequiredNonNegativeInt`, since the two differ on one input and every rule they must agree on was documented on one and asserted by neither. `formatArtistCodeWithPunctuation` delegates its named-artist branch to `formatCallLettersAndNumbers` for the same reason. Composed call letters now run through `normalizeCodeLetters` like every other code-letters path, so a miss redirects carrying the casing the catalog is filed under.

It also deleted two things the review round had just added that could not fire — the submit handler's genre-outage guard, made unreachable by the disabled submit control in the same change, and a `genresUnavailable` clause on the select's `disabled` that `!genres` already covered — moved the genres subscription up to `LibraryChooser` (both forms unmount for the length of the disambiguation screen, and scanning a 27-owner bucket outlasts RTK Query's unsubscribed-cache window, so the librarian was returning to a disabled select and a refetch), collapsed the four-props-then-reassemble shape into the bundle it already was, added `keepUnusedDataFor: 0` so a stale `code_not_assigned` is impossible by construction rather than by the trigger's default, and switched the three catalog test files onto `createAuthClientModuleMock`.

Four findings were raised and deliberately not taken here, all for the same reason — they are clean refactors that are not load-bearing for this feature, and folding them in would repeat the scope expansion above without its justification: extracting the genres-unavailable banner now that it has three copies (two of them pre-existing); generalizing the `transformErrorResponse` middleware-evasion trick, which is now on its third endpoint with a third bespoke key name; giving `ArtistByCodeOwner` a projection narrower than the wire shape; and moving `CODE_NUMBER_MAX` into the parsers so every path through that column gets a ceiling as well as a floor.

## Acceptance criteria

All eleven are met, so this closes the ticket. The two worth pointing at: a backend outage is covered from three directions — a structured 5xx, a non-JSON body, and a 200 whose owner list is unusable — and each lands on a refusal rather than on "unassigned"; and MD authority stays server-side in `app/dashboard/@classic/library/page.tsx`, with `LibraryChooser` doing no gating of its own.

Note that `NEXT_PUBLIC_CLASSIC_LIBRARIAN_NAV_ENABLED` went on in the commit this branch was cut from, so this screen is linked in the classic nav rather than URL-only.

Closes #1198
