### PR TITLE
fix(admin): stop reading or sending user.name as a real-name fallback

### DIFF
--- a/lib/features/admin/api.ts
+++ b/lib/features/admin/api.ts
@@ -19,10 +19,13 @@ import { Account, ROSTER_FETCH_CHUNK_SIZE, ROSTER_MEMBER_CHUNK_SIZE } from "./ty
 type RosterArgs = { organizationSlug: string };
 type RosterResult = { accounts: Account[] };
 
+// No `name` field: better-auth's `user.name` column is not the display
+// handle it sounds like — it has been silently duplicating DJs' legal names,
+// so provisioning must never populate it from realName or username. Requires
+// the auth provision route to accept a name-less body.
 type ProvisionUserArgs = {
   email: string;
   username: string;
-  name: string;
   organizationSlug: string;
   role: string;
   realName?: string;

--- a/lib/features/admin/conversions-better-auth.ts
+++ b/lib/features/admin/conversions-better-auth.ts
@@ -24,8 +24,8 @@ export function convertBetterAuthToAccountResult(
 ): Account {
   return {
     id: user.id,
-    userName: user.username || user.name,
-    realName: user.realName || user.name || "No Real Name",
+    userName: user.username ?? "",
+    realName: user.realName || "No Real Name",
     djName: user.djName || undefined,
     authorization: roleToAuthorization(user.role),
     authType: user.emailVerified

--- a/src/components/experiences/modern/admin/roster/ImportCSVModal.tsx
+++ b/src/components/experiences/modern/admin/roster/ImportCSVModal.tsx
@@ -107,10 +107,13 @@ export default function ImportCSVModal({ open, onClose, onComplete, organization
       const row = validRows[i];
 
       try {
+        // No `name` field: better-auth's `user.name` column is not the
+        // display handle it sounds like — it has been silently duplicating
+        // DJs' legal names. Requires the auth provision route to accept a
+        // name-less body — do not deploy this ahead of that change.
         const provisioned = await provisionUser({
           email: row.email,
           username: row.username,
-          name: row.name,
           organizationSlug,
           role,
           realName: row.name,

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -86,10 +86,13 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
 
         const role = authorizationToRole(authorizationOfNewAccount);
 
+        // No `name` field: better-auth's `user.name` column is not the
+        // display handle it sounds like — it has been silently duplicating
+        // DJs' legal names. Requires the auth provision route to accept a
+        // name-less body — do not deploy this ahead of that change.
         const provisioned = await provisionUser({
           email: newAccount.email,
           username: newAccount.username,
-          name: newAccount.realName || newAccount.username,
           organizationSlug,
           role,
           realName: newAccount.realName || undefined,

--- a/tests/integration/components/modern/admin/roster/ImportCSVModal.test.tsx
+++ b/tests/integration/components/modern/admin/roster/ImportCSVModal.test.tsx
@@ -306,6 +306,24 @@ describe("ImportCSVModal", () => {
       expect(screen.getByText(/Email already exists/)).toBeInTheDocument();
     });
 
+    // better-auth's `user.name` column has been a hidden second copy of the
+    // legal name; dj-site must stop writing it, on either provisioning path.
+    // Deployment is gated on the auth provision route accepting a name-less
+    // body.
+    it("does not send a name field in the provision payload", async () => {
+      await renderAndStartImport();
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalled();
+      });
+
+      const body = JSON.parse(
+        (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body
+      );
+      expect(body).not.toHaveProperty("name");
+      expect(body.realName).toBe("Juana Molina");
+    });
+
     it("should skip rows with validation errors during import", async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
         ok: true,

--- a/tests/integration/components/modern/admin/roster/RosterTable.test.tsx
+++ b/tests/integration/components/modern/admin/roster/RosterTable.test.tsx
@@ -6,6 +6,7 @@ import { adminSlice } from "@/lib/features/admin/frontend";
 import { Authorization } from "@/lib/features/admin/types";
 import type { User } from "@/lib/features/authentication/types";
 import RosterTable from "@/src/components/experiences/modern/admin/roster/RosterTable";
+import { authFetch } from "@/lib/features/authentication/client";
 
 const mockRefetch = vi.fn();
 vi.mock("@/src/hooks/adminHooks", () => ({
@@ -90,5 +91,39 @@ describe("RosterTable", () => {
       "Test DJ"
     );
     expect(adminSlice.selectors.getPage(store.getState())).toBe(2);
+  });
+
+  // better-auth's `user.name` column has been a hidden second copy of the
+  // legal name; dj-site must stop writing it. Deployment is gated on the
+  // auth provision route accepting a name-less body.
+  it("does not send a name field in the provision payload", async () => {
+    const store = makeStore();
+    store.dispatch(adminSlice.actions.setAdding(true));
+
+    const { user } = renderWithProviders(
+      <RosterTable user={adminUser} organizationSlug="wxyc" />,
+      { store }
+    );
+
+    await user.type(
+      screen.getByPlaceholderText("Name"),
+      MOCK_USERS.dj1.realName
+    );
+    await user.type(
+      screen.getByPlaceholderText("Username"),
+      MOCK_USERS.dj1.username
+    );
+    await user.type(
+      screen.getByPlaceholderText("Email"),
+      MOCK_USERS.dj1.email
+    );
+
+    await user.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(authFetch).toHaveBeenCalled());
+
+    const [, init] = (authFetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.json).not.toHaveProperty("name");
+    expect(init.json.realName).toBe(MOCK_USERS.dj1.realName);
   });
 });

--- a/tests/unit/lib/features/admin/conversions-better-auth.test.ts
+++ b/tests/unit/lib/features/admin/conversions-better-auth.test.ts
@@ -54,6 +54,28 @@ describe("convertBetterAuthToAccountResult", () => {
     expect(account.email).toBe("cat@wxyc.org");
   });
 
+  // better-auth's `name` column has been silently duplicating DJs' legal
+  // names; it must never surface through userName or realName, which
+  // display data an admin reads as the handle and the legal name
+  // respectively.
+  it("should not fall back to name for userName when username is absent", () => {
+    const user = createTestBetterAuthUser({
+      username: undefined,
+      name: "Legal Name Should Not Leak",
+    });
+    const account = convertBetterAuthToAccountResult(user);
+    expect(account.userName).toBe("");
+  });
+
+  it("should not fall back to name for realName when realName is absent", () => {
+    const user = createTestBetterAuthUser({
+      realName: undefined,
+      name: "Legal Name Should Not Leak",
+    });
+    const account = convertBetterAuthToAccountResult(user);
+    expect(account.realName).toBe("No Real Name");
+  });
+
   it("should map role to authorization", () => {
     const user = createTestBetterAuthUser({ role: "stationManager" });
     const account = convertBetterAuthToAccountResult(user);


### PR DESCRIPTION
> **DRAFT — do not merge until both boxes are checked.** The first gate is hard: merging ahead of it breaks admin provisioning outright. **CI has already demonstrated it** — see "CI status" below.

## Deployment gates

- [ ] **BLOCKING — WXYC/Backend-Service's provision route accepts a `name`-less body.** Branch `task/auth-user-name-unscrew` ("PR 3" of `plans/dj-name-pii-safeguards.md`, Track 2c) must be merged and deployed first. `name` is **currently a required field** on that route's validation and non-optional in `ProvisionUserInput`. If this PR lands first, every provision call from dj-site — the single-add roster form *and* CSV bulk import — fails on submit.
- [ ] **ORDERING — Backend's "preserve-first" data step (plan step 2a) has run.** That step copies legal names out of `auth_user.name` into `real_name` where `real_name` is empty. Until it has, any row whose legal name exists *only* in `name` will render "No Real Name" in the admin roster, because this PR removes the fallback that was quietly covering for it. No data is at risk — the display just stops laundering a value it should never have shown — but merging after 2a avoids the cosmetic churn.

Gate 2 is an ordering preference; gate 1 is a hard block. Neither is satisfiable from this repo.

## CI status

**Unit CI, CodeQL, and Charset Corpus Drift: green. E2E: red, and expected to be red — it is gate 1, observed.**

The E2E stack builds Backend-Service at `BACKEND_PINNED_REF: main`, where `name` is still required on the provision route. `e2e/auth.setup.ts`'s `ensureClassicIdentityAccountExists` drives the *real* roster add-account form through the browser, so it now posts the `name`-less payload this PR introduces, the auth service rejects it, and no roster row appears:

```
[setup] › e2e/auth.setup.ts:445:6 › provision classic-preference identity (music director)
[setup] › e2e/auth.setup.ts:455:6 › provision classic-preference identity (dj)

Error: expect(locator).toBeVisible() failed
Locator: locator('tr:has-text("test_classic_dj")')
Timeout: 10000ms — element(s) not found
```

Two setup tests fail; the rest of each shard is skipped as a consequence (`56 did not run`), so the shard totals are cascade, not breadth of breakage. **This is the gate proving itself against a live stack rather than only on paper** — it is the strongest available evidence that merging ahead of the Backend change breaks admin provisioning, and it is not fixable from this repo. Re-running it changes nothing, so it has not been retried.

**How this gets verified green**, once `task/auth-user-name-unscrew` is pushed to Backend-Service: the E2E workflow takes a `backend_ref` `workflow_dispatch` input, so dispatch it against that branch and the same two setup steps should pass. That branch does not exist on the Backend remote yet (verified: 404), so the run cannot be made today. After the Backend change merges to Backend `main`, the ordinary `pull_request` E2E run goes green on its own with no change here.

## What

better-auth's `user.name` column has been a hidden second copy of DJs' legal names since provisioning started filling it with `realName || username`. dj-site sits on both ends of that: it injects the duplicate on provision, and reads it back out as a real-name fallback in the admin roster.

**Writers — drop `name` from both provision payloads:**

- `RosterTable.tsx` (single-add form) — was `name: newAccount.realName || newAccount.username`
- `ImportCSVModal.tsx` (CSV bulk import) — was `name: row.name`, sent right beside `realName: row.name`

`ProvisionUserArgs` in `lib/features/admin/api.ts` loses the field entirely, so a third call site cannot reintroduce it without a deliberate type edit. Both call sites keep a comment explaining what `user.name` actually is and that the deploy is gated.

**Reader — drop both fallbacks in `conversions-better-auth.ts`:**

```diff
-    userName: user.username || user.name,
-    realName: user.realName || user.name || "No Real Name",
+    userName: user.username ?? "",
+    realName: user.realName || "No Real Name",
```

`lib/features/authentication/utilities.ts`'s `session.user.name` mappings are **intentionally untouched**. They feed dj-site's `username` field, which is already documented as a username duplicate; after the auth-side derivation lands, that value is the intended handle/username display data, not a real name. Changing them would be a different bug, not a smaller version of this one.

## Why

Two harms pointing in opposite directions, which is what makes the fallback worth removing rather than outrunning:

1. **Today** `auth_user.name` is a stale duplicate of the legal name — written once at provisioning, never maintained (roster edits go straight to better-auth's `admin.updateUser` and touch `realName`/`djName` only). Every `.name` read is a latent PII leak onto a surface never meant to carry one.
2. **After the Backend program** redefines `auth_user.name` as *on-air handle, else username*, the read-back fallback inverts into a different bug: the roster's **"Real Name" column would display a handle or username** for any DJ with an empty `real_name`, with nothing marking it as not-their-real-name. A data backfill alone does not fix that — the fallback has to go.

## The `ImportCSVModal` discovery

The upstream plan's fact-finding recorded **one** injection site (`RosterTable.tsx:92`) and asserted "exactly one place". Implementing the change turned up a **second**: `ImportCSVModal.tsx:113`, the CSV bulk-import path, sending `name: row.name` directly alongside `realName: row.name` — one CSV column fanning out into two database columns.

It matters beyond the line count. Bulk import is the high-volume path — it is how a whole semester's roster gets provisioned at once — so the majority of duplicated legal names in `auth_user.name` most likely arrived through the site the plan had not seen. The plan's Facts section has been corrected. Dropping the field from `ProvisionUserArgs` (rather than only from the two payload literals) is the structural answer to "the grep missed one".

## Test coverage

Three new tests, one per site touched:

| Test | Site | Asserts |
|---|---|---|
| `RosterTable.test.tsx` — "does not send a name field in the provision payload" | single-add writer | fills the add form, submits, reads the captured `authFetch` body: `expect(init.json).not.toHaveProperty("name")` and `realName` still carries through |
| `ImportCSVModal.test.tsx` — "does not send a name field in the provision payload" | CSV writer | runs an import, parses the captured `fetch` body: `expect(body).not.toHaveProperty("name")` and `realName` still carries through |
| `conversions-better-auth.test.ts` — two cases | reader | plants a sentinel string in `name` with `username`/`realName` absent in turn, asserts `userName` is `""` and `realName` is `"No Real Name"` — the sentinel reaches neither |

The two writer tests assert on the actual serialized request body rather than on a mocked argument object, so they fail if the field returns by any route. Each test carries a comment explaining the PII reasoning, so a future reader who sees it fail knows why it exists before deciding to "fix" it.

## Local gate results

Run in the worktree at this commit, all green:

```
$ npx tsc --noEmit
TSC_EXIT=0            (no output)

$ npm run lint
✖ 191 problems (0 errors, 191 warnings)
LINT_EXIT=0           (all 191 warnings pre-existing, unrelated to this branch)

$ npx vitest run
 Test Files  353 passed (353)
      Tests  5099 passed (5099)
VITEST_EXIT=0
```

Branch is rebased on `origin/main` (`22e78cc6`) and is a single commit.

## Related

The dj-site half of the cross-repo DJ real-name PII program planned in Backend-Service, `plans/dj-name-pii-safeguards.md` — Track **2c** (provision route stops trusting a client-supplied `name`; dj-site drops the field) and Track **2e** (drop the `|| user.name` fallbacks in `conversions-better-auth.ts:27-28`). Both appear in that plan's acceptance criteria.

Closes #1278
