### PR TITLE
docs: tubafrenzy cutover is 2026-09-07, not 2026-08-31

### DIFF
--- a/docs/plans/catalog-filing-bench.md
+++ b/docs/plans/catalog-filing-bench.md
@@ -60,7 +60,7 @@ That is not a reason to change course. Library-first is the only shape expressib
 
 **Two process gaps found while checking this** — neither caused by this work, both worth fixing:
 
-- **#2109 and [#2113](https://github.com/WXYC/Backend-Service/issues/2113) are on no project board.** Both carry the `tubafrenzy` label, both gate workflows that die at the 8/31 cutover, and neither appears among the 77 items on the [Tubafrenzy decommissioning board](https://github.com/orgs/WXYC/projects/36). A cutover dependency tracked only by a label is a dependency nobody is watching.
+- **#2109 and [#2113](https://github.com/WXYC/Backend-Service/issues/2113) are on no project board.** Both carry the `tubafrenzy` label, both gate workflows that die at the 9/7 cutover, and neither appears among the 77 items on the [Tubafrenzy decommissioning board](https://github.com/orgs/WXYC/projects/36). A cutover dependency tracked only by a label is a dependency nobody is watching.
 - **#2113** — "Rotation releases cannot be edited: no field-level update endpoint" — is the backend half of the re-bin gap this plan defers. It also records that the allowlist comment quoted above is *already* stale: wiki#88 Phase 3 flipped `rotation` to Backend-canonical, so "tubafrenzy is the only legitimate source for the snapshot columns" no longer holds, and every rotation release created since is uneditable. A typo in an artist name is unfixable today.
 
 For context on what this bench builds on: the [MD catalog-edit UI epic](https://github.com/WXYC/dj-site/issues/1071) and all nine of its children are **closed** — that work shipped 2026-08-05 and is what PR 4 later deletes. This chain is its successor, not a duplicate of open work.


### PR DESCRIPTION
Milestone 1 of the [tubafrenzy decommissioning](https://github.com/orgs/WXYC/projects/36) moved from **2026-08-31 to 2026-09-07** on 2026-08-28.

Not an engineering slip. **24 DJs currently on the schedule have either never created a Backend account or never finished the account-creation flow**, and Phase 6a darkens the classic flowsheet UI — the only surface those DJs can log a show on. Reaching them is a management task and management is absorbed in hiring the incoming DJ class. Every Phase 6a code gate had already closed.

Comment- and doc-only.

Tracking: WXYC/wiki#125 · plan PR WXYC/wiki#126