### PR TITLE
feat(classic): compilation bucket card, the shelf's own screen

### DIFF
--- a/app/dashboard/@classic/library/various/[id]/page.tsx
+++ b/app/dashboard/@classic/library/various/[id]/page.tsx
@@ -4,11 +4,22 @@ import { getPageTitle } from "@/lib/utils/page-title";
 import { requireAuth, requireRole } from "@/lib/features/authentication/server-utils";
 import { Authorization } from "@/lib/features/admin/types";
 import Main from "@/src/components/experiences/classic/Layout/Main";
+import { firstSearchParam } from "@/lib/utils/search-params";
 import VariousArtistsCard from "@/src/components/experiences/classic/catalog/VariousArtistsCard";
 
 export const metadata: Metadata = {
   title: getPageTitle("View an Artist Card"),
 };
+
+/**
+ * `ArtistAdminServlet:187`'s confirmation, carried onto this card after a
+ * create — a compilation code is created through the same chooser as any
+ * other, and routes here rather than to the artist card. Selected by a flag
+ * rather than passed as text, for the reason the artist card page states: the
+ * JSP's message is a fixed server string, and taking it from the URL would let
+ * any link put arbitrary words in the station's own voice.
+ */
+const CREATED_MESSAGE = "The artist/library code below has been added to the database.";
 
 /**
  * Reproduces `libraryAdmin/variousArtistsCardModify.jsp`, gated to
@@ -18,8 +29,10 @@ export const metadata: Metadata = {
  */
 export default async function ClassicVariousArtistsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ created?: string | string[] }>;
 }) {
   const session = await requireAuth();
   await requireRole(session, Authorization.MD);
@@ -33,9 +46,14 @@ export default async function ClassicVariousArtistsPage({
     notFound();
   }
 
+  const created = firstSearchParam((await searchParams).created);
+
   return (
     <Main>
-      <VariousArtistsCard artistId={artistId} />
+      <VariousArtistsCard
+        artistId={artistId}
+        message={created === "1" ? CREATED_MESSAGE : undefined}
+      />
     </Main>
   );
 }

--- a/app/dashboard/@classic/library/various/[id]/page.tsx
+++ b/app/dashboard/@classic/library/various/[id]/page.tsx
@@ -1,0 +1,41 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getPageTitle } from "@/lib/utils/page-title";
+import { requireAuth, requireRole } from "@/lib/features/authentication/server-utils";
+import { Authorization } from "@/lib/features/admin/types";
+import Main from "@/src/components/experiences/classic/Layout/Main";
+import VariousArtistsCard from "@/src/components/experiences/classic/catalog/VariousArtistsCard";
+
+export const metadata: Metadata = {
+  title: getPageTitle("View an Artist Card"),
+};
+
+/**
+ * Reproduces `libraryAdmin/variousArtistsCardModify.jsp`, gated to
+ * `hasAdminAccess()` per `mainmenu.jsp:32-37` — the same authority the
+ * ordinary artist card carries, since both are reached from the add/edit block
+ * of the main menu.
+ */
+export default async function ClassicVariousArtistsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await requireAuth();
+  await requireRole(session, Authorization.MD);
+
+  const { id } = await params;
+  const artistId = Number(id);
+  // A non-numeric segment would otherwise reach the card as NaN and request
+  // `/library/artists/NaN`, which the backend answers 400 -- rendering as
+  // "this section could not be loaded" for what is really a wrong URL.
+  if (!Number.isInteger(artistId) || artistId <= 0) {
+    notFound();
+  }
+
+  return (
+    <Main>
+      <VariousArtistsCard artistId={artistId} />
+    </Main>
+  );
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,7 +77,7 @@ These reproduce tubafrenzy's `/wxycdb` screens. They are **classic-first**: the 
 | `/dashboard/library` | Entry: artist vs. Various Artists, multi-match disambiguation | `chooseLibraryCodeOrArtist.jsp`, `multipleArtistsDisplay.jsp` | MD |
 | `/dashboard/library/artist/new` | Code-miss create screen: genre/letters/numbers carried read-only from the miss branch, only the two name fields editable | `createLibraryCode.jsp` | MD |
 | `/dashboard/library/artist/[id]` | Artist card + its release list | `artistCardModify.jsp` | MD |
-| `/dashboard/library/various/[id]` | V/A bucket card, `albumArtist`, per-track credits | `variousArtistsCardModify.jsp` | MD |
+| `/dashboard/library/various/[id]` | V/A bucket card + its add-release form; per-track credits pending | `variousArtistsCardModify.jsp` | MD |
 | `/dashboard/library/release/[id]` | Release edit | `libraryReleaseModify.jsp` | MD |
 | `/dashboard/library/release/[id]/move` | Move release to another library code | `libraryReleaseModifyLibCode.jsp` | MD |
 | `/dashboard/library/release/[id]/delete` | Delete confirmation | `libraryReleaseDelete.jsp` | MD |
@@ -86,6 +86,10 @@ These reproduce tubafrenzy's `/wxycdb` screens. They are **classic-first**: the 
 | `/dashboard/rotation/new` | Add rotation release | `rotationReleaseInsert.jsp` | MD |
 | `/dashboard/rotation/[id]` | Modify rotation release | `rotationReleaseModify.jsp` | MD |
 | `/dashboard/rotation/[id]/import` | Import rotation release into the library | `rotationReleaseImport.jsp`, `rotationReleaseImportNewArtist.jsp` | MD |
+
+Which of the two artist cards a link opens is decided structurally, by `code_letters`, in `lib/features/catalog/artistCardRoute.ts` — `/wxycdb` serves both from one servlet and picks the view from the row, and that choice has to be reproduced wherever a link to an artist is built. Deciding it on the artist's *name* would drop the whole `Soundtracks - <A–Z>` sub-shelf, which carries no compilation keyword anywhere. Both cards also redirect a row that belongs on the other one, so a hand-typed or stale URL still lands on the screen that describes it.
+
+The bucket card's **Album Artist** row is display-only: `POST /library` has no parameter for it and `library.album_artist` is written solely by the nightly catalog import, so the field states that rather than offering an input that would discard what is typed. It becomes an input once a write path exists.
 
 Naming follows `/wxycdb`'s own directory split (`libraryAdmin/`, `rotation/`) rather than nesting under `/dashboard/catalog`, which would collide confusingly with the unrelated modern `/dashboard/admin/catalog` (format + genre admin).
 

--- a/lib/features/catalog/artistCardRoute.ts
+++ b/lib/features/catalog/artistCardRoute.ts
@@ -1,0 +1,25 @@
+import { isVariousArtists } from "./libraryCode";
+
+/**
+ * Which card describes this artist row.
+ *
+ * `/wxycdb` serves both cards from one `artist` servlet and picks the view
+ * from the row itself; the two are separate URLs here, so the same choice has
+ * to be made wherever a link to an artist is built. Compilation buckets get a
+ * different screen because they are a different filing model — a bucket is a
+ * shelf section with per-track credits, not a performer — so landing one on
+ * the ordinary card offers a name edit for a section heading and hides the
+ * credits entirely.
+ *
+ * The decision is structural, on `code_letters`. Deciding it on the artist's
+ * name would drop the entire `Soundtracks - <A–Z>` sub-shelf, which carries no
+ * compilation keyword anywhere in its names.
+ */
+export function artistCardHref(artist: {
+  id: number;
+  code_letters: string;
+}): string {
+  return isVariousArtists(artist.code_letters)
+    ? `/dashboard/library/various/${artist.id}`
+    : `/dashboard/library/artist/${artist.id}`;
+}

--- a/src/components/experiences/classic/catalog/ArtistCard.tsx
+++ b/src/components/experiences/classic/catalog/ArtistCard.tsx
@@ -74,9 +74,6 @@ const EMPTY_ALPHABETICAL_MESSAGE = "The alphabetical name cannot be empty.";
  *   `label`; the JSP's form has no such input. Same precedent as
  *   `NewArtistForm` adding genre and call letters/numbers because
  *   `POST /library/artists` requires them.
- * - **Release titles are plain text.** The JSP links each to
- *   `libraryReleaseModify.jsp`, a screen this experience does not have yet; a
- *   link would be a dead one.
  * - **The cross-reference blocks (`:157-232`) and the "Add Xrefs" links are
  *   absent.** Write-side cross-reference admin is deliberately not being
  *   rebuilt, and the read-only display is a separate, non-blocking screen.
@@ -541,7 +538,11 @@ export default function ArtistCard({ artistId, message }: ArtistCardProps) {
                         code_volume_letters: release.code_volume_letters,
                       })}
                     </td>
-                    <td>{release.album_title}</td>
+                    <td>
+                      <Link href={`/dashboard/library/release/${release.id}`}>
+                        {release.album_title}
+                      </Link>
+                    </td>
                     <td>{release.alternate_artist_name}</td>
                   </tr>
                 ))}

--- a/src/components/experiences/classic/catalog/ArtistCard.tsx
+++ b/src/components/experiences/classic/catalog/ArtistCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useId, useState } from "react";
 import {
   useAddAlbumMutation,
@@ -13,6 +14,7 @@ import {
 import {
   formatArtistCodeWithPunctuation,
   formatEntireLibraryCode,
+  isVariousArtists,
 } from "@/lib/features/catalog/libraryCode";
 import type { AddAlbumRequestBody, ArtistRelease } from "@/lib/features/catalog/types";
 import {
@@ -84,6 +86,7 @@ const EMPTY_ALPHABETICAL_MESSAGE = "The alphabetical name cannot be empty.";
  *   defaults to.
  */
 export default function ArtistCard({ artistId, message }: ArtistCardProps) {
+  const router = useRouter();
   const alphabeticalNameId = useId();
   const presentationNameId = useId();
   const titleId = useId();
@@ -122,6 +125,15 @@ export default function ArtistCard({ artistId, message }: ArtistCardProps) {
   useEffect(() => {
     if (artist) setAlphabeticalName(artist.alphabetical_name);
   }, [artist]);
+
+  // `/wxycdb` picks this card or the compilation bucket card from the row
+  // itself. A shelf row reaching this URL -- a hand-typed id, a stale
+  // bookmark -- would otherwise be offered a name edit for what is a shelf
+  // section, and shown none of its per-track credits.
+  const isShelfRow = !!artist && isVariousArtists(artist.code_letters);
+  useEffect(() => {
+    if (isShelfRow) router.replace(`/dashboard/library/various/${artistId}`);
+  }, [isShelfRow, router, artistId]);
 
   const genreName = genres?.find((genre) => genre.id === artist?.genre_id)?.genre_name;
 
@@ -228,7 +240,7 @@ export default function ArtistCard({ artistId, message }: ArtistCardProps) {
     );
   }
 
-  if (artistLoading || !artist) {
+  if (artistLoading || !artist || isShelfRow) {
     return <div role="status">Loading…</div>;
   }
 

--- a/src/components/experiences/classic/catalog/ArtistSearchForm.tsx
+++ b/src/components/experiences/classic/catalog/ArtistSearchForm.tsx
@@ -3,6 +3,7 @@
 import { useId, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useGetGenresQuery, useLazyResolveArtistByCodeQuery } from "@/lib/features/catalog/api";
+import { artistCardHref } from "@/lib/features/catalog/artistCardRoute";
 import {
   isRockCompLettersRequired,
   validateArtistSearchForm,
@@ -215,7 +216,7 @@ export default function ArtistSearchForm({ onMultiMatch }: ArtistSearchFormProps
     }
 
     if (owners.length === 1) {
-      router.push(`/dashboard/library/artist/${owners[0].id}`);
+      router.push(artistCardHref(owners[0]));
       return;
     }
 

--- a/src/components/experiences/classic/catalog/CreateLibraryCodeForm.tsx
+++ b/src/components/experiences/classic/catalog/CreateLibraryCodeForm.tsx
@@ -2,6 +2,7 @@
 
 import { useId, useState } from "react";
 import { useRouter } from "next/navigation";
+import { artistCardHref } from "@/lib/features/catalog/artistCardRoute";
 import { useAddArtistMutation, useGetGenresQuery } from "@/lib/features/catalog/api";
 import { validateNewArtistNames } from "@/lib/features/catalog/chooserValidation";
 import {
@@ -27,8 +28,12 @@ type CreateLibraryCodeFormProps = {
  * database." `created=1` selects that fixed message on the card rather than
  * putting its text in the URL.
  */
-const successDestination = (artistId: number) =>
-  `/dashboard/library/artist/${artistId}?created=1`;
+// Routed by `code_letters`, not hard-coded to the artist card: a
+// compilation code created here is a V/A row, and the artist card would
+// only redirect to the bucket card — dropping the `created` flag, and with
+// it the confirmation this push exists to deliver.
+const successDestination = (artistId: number, codeLetters: string) =>
+  `${artistCardHref({ id: artistId, code_letters: codeLetters })}?created=1`;
 
 // The heading is the servlet's message, and it has two forms
 // (`ArtistAdminServlet:152-155`): a Various Artists code -- call letters
@@ -182,7 +187,7 @@ export default function CreateLibraryCodeForm({
 
     try {
       const created = await addArtist(body).unwrap();
-      router.push(successDestination(created.id));
+      router.push(successDestination(created.id, body.code_letters));
     } catch (err) {
       // Same discriminant as NewArtistForm's addArtist rejection handling:
       // a taken (code_letters, genre_id, code_number) triple is fixed by

--- a/src/components/experiences/classic/catalog/MultipleArtistsDisplay.tsx
+++ b/src/components/experiences/classic/catalog/MultipleArtistsDisplay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { artistCardHref } from "@/lib/features/catalog/artistCardRoute";
 import { formatCallLettersAndNumbers } from "@/lib/features/catalog/libraryCode";
 import type { MultiMatchResult } from "./ArtistSearchForm";
 
@@ -18,7 +19,9 @@ type MultipleArtistsDisplayProps = MultiMatchResult & {
  * A compilation code is the case that makes this screen load-bearing rather
  * than defensive: every Various Artists bucket in a genre collides on one
  * triple, so picking the bucket by name is the only way through. See
- * `composeLibraryCodeSearchArgs` for why.
+ * `composeLibraryCodeSearchArgs` for why. Those rows are also the reason each
+ * link is built by `artistCardHref` rather than hard-coded: a bucket is filed
+ * and edited as a shelf section, on a different card from a performer.
  *
  * The JSP's "no results" branch is not reproduced: `resolveArtistByCode` never
  * answers a 200 with zero owners, and the caller refuses a zero-length list
@@ -97,7 +100,7 @@ export default function MultipleArtistsDisplay({
               <td style={{ textAlign: "right" }}>{genreName ?? ""}</td>
               <td style={{ textAlign: "left" }}>{callLettersAndNumbers}</td>
               <td>
-                <Link href={`/dashboard/library/artist/${artist.id}`}>{artist.artist_name}</Link>
+                <Link href={artistCardHref(artist)}>{artist.artist_name}</Link>
               </td>
             </tr>
           ))}

--- a/src/components/experiences/classic/catalog/NewArtistForm.tsx
+++ b/src/components/experiences/classic/catalog/NewArtistForm.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useId, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { artistCardHref } from "@/lib/features/catalog/artistCardRoute";
 import {
   useAddArtistMutation,
   useGetGenresQuery,
@@ -29,8 +30,12 @@ const PEEK_DEBOUNCE_MS = 150;
  * `created=1` selects that fixed message on the card rather than putting its
  * text in the URL.
  */
-const successDestination = (artistId: number) =>
-  `/dashboard/library/artist/${artistId}?created=1`;
+// Routed by `code_letters`, not hard-coded to the artist card: a
+// compilation code created here is a V/A row, and the artist card would
+// only redirect to the bucket card — dropping the `created` flag, and with
+// it the confirmation this push exists to deliver.
+const successDestination = (artistId: number, codeLetters: string) =>
+  `${artistCardHref({ id: artistId, code_letters: codeLetters })}?created=1`;
 
 /**
  * Reproduces `chooseLibraryCodeOrArtist.jsp`'s `newArtistForm`: presentation
@@ -157,7 +162,7 @@ export default function NewArtistForm() {
 
     try {
       const created = await addArtist(body).unwrap();
-      router.push(successDestination(created.id));
+      router.push(successDestination(created.id, body.code_letters));
     } catch (err) {
       // The 409 this endpoint sends has two distinct causes that call for
       // different remedies: a taken (code_letters, genre_id, code_number)

--- a/src/components/experiences/classic/catalog/VariousArtistsCard.tsx
+++ b/src/components/experiences/classic/catalog/VariousArtistsCard.tsx
@@ -23,6 +23,8 @@ import {
 
 type VariousArtistsCardProps = {
   artistId: number;
+  /** The servlet's fixed post-create confirmation, when the librarian arrived from a create. */
+  message?: string;
 };
 
 /**
@@ -31,6 +33,17 @@ type VariousArtistsCardProps = {
  * sub-shelf, so filing a *new* release into it would put the release somewhere
  * no librarian can find it on the physical shelf. Reading it stays available —
  * what is already in there has to remain visible.
+ *
+ * The literal is the JSP's own (`variousArtistsCardModify.jsp:46` tests
+ * `artist.ID != 19923`), not a value chosen here, so it is reproduced rather
+ * than replaced by a derived rule — the shelf has no other property that marks
+ * the umbrella, and inventing one would diverge from the spec on the one row
+ * it governs. It is a serial, though, so it identifies the umbrella only in a
+ * database whose `artists` rows came from the tubafrenzy catalog: production
+ * and its clones. Against a freshly seeded local database the id simply does
+ * not exist, so the guard never fires and every bucket shows the form; that
+ * is the failure mode to expect there, and it is not a filing hazard in a
+ * database with no real shelf behind it.
  */
 const UMBRELLA_BUCKET_ARTIST_ID = 19923;
 
@@ -73,7 +86,7 @@ const EMPTY_TITLE_MESSAGE = "Please enter a title before adding this release.";
  *   servlet; `GET /library/artists/:id/releases` takes no sort parameter and
  *   returns shelf order, which is the order the JSP itself defaults to.
  */
-export default function VariousArtistsCard({ artistId }: VariousArtistsCardProps) {
+export default function VariousArtistsCard({ artistId, message }: VariousArtistsCardProps) {
   const router = useRouter();
   const titleId = useId();
   const altArtistId = useId();
@@ -217,6 +230,16 @@ export default function VariousArtistsCard({ artistId }: VariousArtistsCardProps
     <>
       {navigationLinks}
 
+      {/* The post-create confirmation, carried here rather than left on the
+          artist card: a compilation code created through the chooser is a V/A
+          row, so it routes straight to this screen and would otherwise arrive
+          with the servlet's own "has been added to the database" dropped on
+          the floor. */}
+      {message && (
+        <div style={{ textAlign: "center" }} role="status">
+          <h5>&nbsp;{message}&nbsp;</h5>
+        </div>
+      )}
       <div
         className={`validation-message${releaseMessage ? " visible" : ""}`}
         role={releaseMessage ? "alert" : undefined}
@@ -437,6 +460,19 @@ export default function VariousArtistsCard({ artistId }: VariousArtistsCardProps
             )}
           </tbody>
         </table>
+      )}
+
+      {/* The endpoint pages, and this is the shelf where paging always bites:
+          a compilation bucket is the largest kind of section in the catalog,
+          so the table above is truncated as a matter of course while the
+          header two rows up prints the server's true total. A librarian who
+          scans a silently-cut list and doesn't find the compilation files a
+          duplicate — which is the whole failure this screen exists to
+          prevent. Same notice the artist card carries, for the same reason. */}
+      {total > releases.length && (
+        <div className="label" style={{ textAlign: "center" }}>
+          Showing the first {releases.length} of {total} releases.
+        </div>
       )}
 
       <hr />

--- a/src/components/experiences/classic/catalog/VariousArtistsCard.tsx
+++ b/src/components/experiences/classic/catalog/VariousArtistsCard.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useId, useState } from "react";
+import {
+  useAddAlbumMutation,
+  useGetArtistCardQuery,
+  useGetArtistReleasesQuery,
+  useGetFormatsQuery,
+  useGetGenresQuery,
+} from "@/lib/features/catalog/api";
+import {
+  formatArtistCodeWithPunctuation,
+  formatEntireLibraryCode,
+  isVariousArtists,
+} from "@/lib/features/catalog/libraryCode";
+import type { AddAlbumRequestBody, ArtistRelease } from "@/lib/features/catalog/types";
+import {
+  formatStationDateTime,
+  formatStationLongDate,
+} from "@/src/utilities/stationTime";
+
+type VariousArtistsCardProps = {
+  artistId: number;
+};
+
+/**
+ * The umbrella bucket. `/wxycdb` hides the add-release form for this one row
+ * alone: it is a catch-all that collects releases which belong to no lettered
+ * sub-shelf, so filing a *new* release into it would put the release somewhere
+ * no librarian can find it on the physical shelf. Reading it stays available —
+ * what is already in there has to remain visible.
+ */
+const UMBRELLA_BUCKET_ARTIST_ID = 19923;
+
+/** `artist-card-modify.js` `validateAddRelease`, verbatim. */
+const EMPTY_TITLE_MESSAGE = "Please enter a title before adding this release.";
+
+/**
+ * Reproduces `libraryAdmin/variousArtistsCardModify.jsp` — the compilation
+ * shelf's bucket page. The shelf is one `code_letters = 'V/A'` code subdivided
+ * by letter across 53 artist rows, and each row is its own physical section;
+ * this screen is that section's card.
+ *
+ * The bucket header is read-only by design, not by omission: the JSP wraps its
+ * two rows in a `modifyArtist` form that carries no editable input and no
+ * submit button, so it renders as a table here. Preserving the subdivision is
+ * a filing invariant — the letter split *is* the shelf organization, so the 52
+ * lettered rows must never be collapsed into one bucket.
+ *
+ * Deliberate divergences, each forced by the Backend-Service contract rather
+ * than chosen — where both the JSP's shape and a Backend-Service call are
+ * possible, the JSP wins:
+ *
+ * - **The Album Artist field cannot be written.** The JSP's V/A-specific
+ *   `albumArtist` input is the one field this screen has that the ordinary
+ *   artist card does not, and `POST /library` has no parameter for it:
+ *   `library.album_artist` is populated only by the nightly catalog import.
+ *   The row is kept, with its purpose stated, rather than rendered as an input
+ *   that silently discards what the librarian types — the credited album
+ *   artist is the field compilations are filed against, so dropping the value
+ *   without saying so would lose exactly the information this screen exists to
+ *   capture. It becomes an input once a write path exists.
+ * - **The two library-code inputs are dropped.** `POST /library` derives
+ *   `code_number` itself (max+1 for the bucket) and has no
+ *   `code_volume_letters` parameter, so the JSP's `releaseCallNumbers` and
+ *   `releaseCallLetters` boxes have nothing to submit to. The assigned code is
+ *   reported after the save instead, which is the fact that goes on the sleeve.
+ * - **The form gains a Label field.** `POST /library` requires `label` and the
+ *   JSP's form has no such input; same precedent as the ordinary artist card.
+ * - **No sort form.** The JSP posts `sortColumn`/`sortOrder` back to the
+ *   servlet; `GET /library/artists/:id/releases` takes no sort parameter and
+ *   returns shelf order, which is the order the JSP itself defaults to.
+ */
+export default function VariousArtistsCard({ artistId }: VariousArtistsCardProps) {
+  const router = useRouter();
+  const titleId = useId();
+  const altArtistId = useId();
+  const labelId = useId();
+  const formatId = useId();
+
+  const {
+    data: artist,
+    isLoading: artistLoading,
+    isError: artistError,
+  } = useGetArtistCardQuery(artistId);
+  const { data: releasePage, isError: releasesError } = useGetArtistReleasesQuery({
+    artistId,
+  });
+  const { data: genres } = useGetGenresQuery();
+  const { data: formats } = useGetFormatsQuery();
+
+  const [addAlbum, { isLoading: savingRelease }] = useAddAlbumMutation();
+
+  const [title, setTitle] = useState("");
+  const [altArtistName, setAltArtistName] = useState("");
+  const [label, setLabel] = useState("");
+  const [formatIdValue, setFormatIdValue] = useState<number | null>(null);
+  const [releaseMessage, setReleaseMessage] = useState<string | null>(null);
+  const [addedCode, setAddedCode] = useState<string | null>(null);
+
+  // `/wxycdb` picks this view or the ordinary artist card from the row itself,
+  // so an id that is not a shelf row is the wrong screen rather than an error:
+  // send it to the card that does describe it. Navigation is a side effect on
+  // an external system (the router), which is why it is an effect and not a
+  // render-time redirect.
+  const misrouted = !!artist && !isVariousArtists(artist.code_letters);
+  useEffect(() => {
+    if (misrouted) router.replace(`/dashboard/library/artist/${artistId}`);
+  }, [misrouted, router, artistId]);
+
+  const genreName = genres?.find((genre) => genre.id === artist?.genre_id)?.genre_name;
+
+  // `fn:trim(format.referenceName)` — the JSP omits blank-named formats rather
+  // than offering an unlabelled option.
+  const selectableFormats = (formats ?? []).filter(
+    (format) => format.format_name.trim() !== "",
+  );
+
+  const bucketCode = artist
+    ? formatArtistCodeWithPunctuation({
+        code_letters: artist.code_letters,
+        code_artist_number: artist.code_artist_number,
+        genre_id: artist.genre_id,
+      })
+    : "";
+
+  const handleAddRelease = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!artist) return;
+    setAddedCode(null);
+
+    if (title.trim() === "") {
+      setReleaseMessage(EMPTY_TITLE_MESSAGE);
+      return;
+    }
+    if (label.trim() === "") {
+      setReleaseMessage("You must enter a label before adding this release.");
+      return;
+    }
+    if (formatIdValue == null) {
+      setReleaseMessage("You must select a format before adding this release.");
+      return;
+    }
+
+    setReleaseMessage(null);
+
+    // `artist_id`, never `artist_name`: a name goes through
+    // `artistIdFromName(name, genre_id)`, whose fuzzy match would file the
+    // release under whichever *other* V/A sub-bucket it landed on — every one
+    // of the 53 shares this code, so the collision is the normal case here,
+    // not an edge one.
+    const body: AddAlbumRequestBody = {
+      artist_id: artistId,
+      genre_id: artist.genre_id,
+      album_title: title.trim(),
+      label: label.trim(),
+      format_id: formatIdValue,
+      ...(altArtistName.trim() !== ""
+        ? { alternate_artist_name: altArtistName.trim() }
+        : {}),
+    };
+
+    try {
+      const created = await addAlbum(body).unwrap();
+      const codeNumber = created.code_number;
+      setAddedCode(
+        typeof codeNumber === "number"
+          ? formatEntireLibraryCode({
+              genreName,
+              code_letters: artist.code_letters,
+              code_artist_number: artist.code_artist_number,
+              genre_id: artist.genre_id,
+              code_number: codeNumber,
+              code_volume_letters:
+                typeof created.code_volume_letters === "string"
+                  ? created.code_volume_letters
+                  : null,
+            })
+          : null,
+      );
+      setTitle("");
+      setAltArtistName("");
+      setLabel("");
+    } catch {
+      setReleaseMessage("Failed to add the release.");
+    }
+  };
+
+  if (artistError) {
+    return (
+      <div data-testid="various-artists-card-error" role="alert" className="artist-error-message">
+        This Various Artists section could not be loaded.
+      </div>
+    );
+  }
+
+  if (artistLoading || !artist || misrouted) {
+    return <div role="status">Loading…</div>;
+  }
+
+  const releases = releasePage?.releases ?? [];
+  const total = releasePage?.total ?? 0;
+  const isUmbrellaBucket = artistId === UMBRELLA_BUCKET_ARTIST_ID;
+
+  const navigationLinks = (
+    <div className="label" style={{ textAlign: "center" }}>
+      <Link href="/dashboard/catalog">Do another search</Link>
+      &nbsp;&nbsp;&nbsp;&nbsp;
+      <Link href="/dashboard/library">Find and Create an Artist and/or Library Code</Link>
+      &nbsp;&nbsp;&nbsp;&nbsp;
+    </div>
+  );
+
+  return (
+    <>
+      {navigationLinks}
+
+      <div
+        className={`validation-message${releaseMessage ? " visible" : ""}`}
+        role={releaseMessage ? "alert" : undefined}
+      >
+        {releaseMessage}
+      </div>
+      <hr />
+
+      <table cellPadding={5} style={{ margin: "0 auto" }} data-testid="va-bucket-header">
+        <tbody>
+          <tr>
+            <td colSpan={2} style={{ textAlign: "right" }}>
+              {artist.alphabetical_name}
+            </td>
+          </tr>
+          <tr>
+            <td style={{ textAlign: "right" }}>
+              <b># of releases:</b>
+            </td>
+            {/* The server's total, not `releases.length`: the table below is
+                paginated, so the row count is a page size. */}
+            <td>{total}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <hr />
+
+      {!isUmbrellaBucket && (
+        <>
+          <form
+            name="addRelease"
+            data-testid="va-add-release-form"
+            onSubmit={handleAddRelease}
+          >
+            <table cellPadding={5} style={{ margin: "0 auto" }}>
+              <tbody>
+                <tr>
+                  <td />
+                  <td>
+                    <b>Add a Library Release for This Section:</b>
+                  </td>
+                </tr>
+                <tr>
+                  <td style={{ textAlign: "right" }}>
+                    <b>Library Code:</b>
+                  </td>
+                  <td>
+                    {genreName ?? ""}&nbsp;{bucketCode}
+                    <span className="label">
+                      &nbsp;— the release number is assigned when you save.
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td style={{ textAlign: "right" }}>
+                    <label htmlFor={titleId}>
+                      <b>Title of Release:</b>
+                    </label>
+                  </td>
+                  <td>
+                    <input
+                      id={titleId}
+                      type="text"
+                      size={50}
+                      value={title}
+                      disabled={savingRelease}
+                      onChange={(e) => setTitle(e.target.value)}
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td style={{ textAlign: "right" }}>
+                    <label htmlFor={altArtistId}>
+                      <b>Alternate Artist Name:</b>
+                    </label>
+                  </td>
+                  <td>
+                    <input
+                      id={altArtistId}
+                      type="text"
+                      size={50}
+                      value={altArtistName}
+                      disabled={savingRelease}
+                      onChange={(e) => setAltArtistName(e.target.value)}
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td style={{ textAlign: "right" }}>
+                    <b>Album Artist:</b>
+                  </td>
+                  <td>
+                    <span className="label" data-testid="va-album-artist-unavailable">
+                      The credited album artist is filled in by the nightly catalog
+                      import and cannot be set here yet.
+                    </span>
+                  </td>
+                </tr>
+                {/* Not in the JSP — POST /library requires `label`. */}
+                <tr>
+                  <td style={{ textAlign: "right" }}>
+                    <label htmlFor={labelId}>
+                      <b>Label:</b>
+                    </label>
+                  </td>
+                  <td>
+                    <input
+                      id={labelId}
+                      type="text"
+                      size={50}
+                      value={label}
+                      disabled={savingRelease}
+                      onChange={(e) => setLabel(e.target.value)}
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td style={{ textAlign: "right" }}>
+                    <label htmlFor={formatId}>
+                      <b>Format:</b>
+                    </label>
+                  </td>
+                  <td>
+                    <select
+                      id={formatId}
+                      value={formatIdValue ?? ""}
+                      disabled={savingRelease || selectableFormats.length === 0}
+                      onChange={(e) =>
+                        setFormatIdValue(e.target.value ? Number(e.target.value) : null)
+                      }
+                    >
+                      {selectableFormats.map((format) => (
+                        <option key={format.id} value={format.id}>
+                          {format.format_name}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                </tr>
+                <tr>
+                  <td />
+                  <td>{addedCode && <div role="status">Filed as {addedCode}.</div>}</td>
+                </tr>
+                <tr>
+                  <td />
+                  <td>
+                    <input
+                      type="submit"
+                      value="Add a new Library Release"
+                      disabled={savingRelease}
+                    />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </form>
+          <hr />
+        </>
+      )}
+
+      {releasesError ? (
+        <div
+          data-testid="va-release-table-error"
+          role="alert"
+          className="artist-error-message"
+        >
+          This section&apos;s releases could not be loaded, so this is not a complete
+          list of what is on the shelf.
+        </div>
+      ) : (
+        <table className="entry-table" data-testid="va-release-table">
+          <tbody>
+            {releases.length > 0 ? (
+              <>
+                <tr className="entry-header">
+                  <th style={{ textAlign: "left" }}>Time Last Modified</th>
+                  <th style={{ textAlign: "left" }}>Format</th>
+                  <th style={{ textAlign: "left" }}>Code</th>
+                  <th style={{ textAlign: "left" }}>Title of Release</th>
+                  <th style={{ textAlign: "left" }}>Alternate Artist Name</th>
+                </tr>
+                {releases.map((release: ArtistRelease, index: number) => (
+                  <tr
+                    key={release.id}
+                    className={`entry-row ${index % 2 === 0 ? "entry-row-even" : "entry-row-odd"}`}
+                  >
+                    <td style={{ textAlign: "center" }}>
+                      {formatStationDateTime(release.last_modified).time},{" "}
+                      {formatStationLongDate(release.last_modified)}
+                    </td>
+                    <td>{release.format_name}</td>
+                    <td>
+                      {formatEntireLibraryCode({
+                        genreName,
+                        code_letters: release.code_letters,
+                        code_artist_number: release.code_artist_number,
+                        genre_id: release.genre_id,
+                        code_number: release.code_number,
+                        code_volume_letters: release.code_volume_letters,
+                      })}
+                    </td>
+                    <td>
+                      <Link href={`/dashboard/library/release/${release.id}`}>
+                        {release.album_title}
+                      </Link>
+                    </td>
+                    <td>{release.alternate_artist_name ?? ""}</td>
+                  </tr>
+                ))}
+              </>
+            ) : (
+              <tr className="entry-header">
+                <th colSpan={5} style={{ textAlign: "center" }}>
+                  The artist does not have any library releases
+                </th>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      )}
+
+      <hr />
+
+      {navigationLinks}
+    </>
+  );
+}

--- a/src/components/experiences/classic/catalog/VariousArtistsCard.tsx
+++ b/src/components/experiences/classic/catalog/VariousArtistsCard.tsx
@@ -434,7 +434,15 @@ export default function VariousArtistsCard({ artistId, message }: VariousArtists
                     <td>{release.format_name}</td>
                     <td>
                       {formatEntireLibraryCode({
-                        genreName,
+                        // The release's own genre, not the card's. A bucket
+                        // crossreferenced in more than one genre reports the
+                        // lowest as its card genre, while each release carries
+                        // the genre it is actually filed under — and this
+                        // string is the call number a librarian walks to the
+                        // stacks with, so the word and the id have to come
+                        // from the same row.
+                        genreName: genres?.find((genre) => genre.id === release.genre_id)
+                          ?.genre_name,
                         code_letters: release.code_letters,
                         code_artist_number: release.code_artist_number,
                         genre_id: release.genre_id,

--- a/tests/integration/app/dashboard/@classic/library/various/page.test.tsx
+++ b/tests/integration/app/dashboard/@classic/library/various/page.test.tsx
@@ -37,7 +37,11 @@ vi.mock("@/src/components/experiences/classic/catalog/VariousArtistsCard", () =>
 
 import ClassicVariousArtistsPage from "@/app/dashboard/@classic/library/various/[id]/page";
 
-const page = () => ClassicVariousArtistsPage({ params: Promise.resolve({ id: "4211" }) });
+const page = (created?: string) =>
+  ClassicVariousArtistsPage({
+    params: Promise.resolve({ id: "4211" }),
+    searchParams: Promise.resolve(created ? { created } : {}),
+  });
 
 describe("Classic /dashboard/library/various/[id] page — variousArtistsCardModify.jsp", () => {
   setUpClassicPageAuthorityEnv();

--- a/tests/integration/app/dashboard/@classic/library/various/page.test.tsx
+++ b/tests/integration/app/dashboard/@classic/library/various/page.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, vi } from "vitest";
+import {
+  setUpClassicPageAuthority,
+  setUpClassicPageAuthorityEnv,
+  assertReachesClassicPage,
+  assertDeniedClassicPage,
+} from "@/tests/helpers/classic-page-authority-harness";
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/headers", async () => {
+  const { classicPageAuthorityHeadersMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityHeadersMock();
+});
+vi.mock("next/navigation", async () => {
+  const { classicPageAuthorityNavigationMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityNavigationMock();
+});
+vi.mock("@/lib/features/authentication/server-client", async () => {
+  const { classicPageAuthorityServerClientMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityServerClientMock();
+});
+vi.mock("@/lib/features/authentication/organization-utils.server", async () => {
+  const { classicPageAuthorityOrganizationUtilsMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityOrganizationUtilsMock();
+});
+
+// The page's own responsibility under test is the auth gate, not the RTK
+// Query-backed card content.
+vi.mock("@/src/components/experiences/classic/Layout/Main", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="classic-main">{children}</div>
+  ),
+}));
+vi.mock("@/src/components/experiences/classic/catalog/VariousArtistsCard", () => ({
+  default: () => <div data-testid="various-artists-card" />,
+}));
+
+import ClassicVariousArtistsPage from "@/app/dashboard/@classic/library/various/[id]/page";
+
+const page = () => ClassicVariousArtistsPage({ params: Promise.resolve({ id: "4211" }) });
+
+describe("Classic /dashboard/library/various/[id] page — variousArtistsCardModify.jsp", () => {
+  setUpClassicPageAuthorityEnv();
+
+  it.each([
+    { role: "musicDirector" as const, label: "a music director" },
+    { role: "stationManager" as const, label: "a station manager" },
+  ])("reaches the compilation bucket card for $label", async ({ role }) => {
+    setUpClassicPageAuthority(role);
+
+    await assertReachesClassicPage(page, "classic-main", "various-artists-card");
+  });
+
+  it("redirects a DJ away — this is an add/edit screen, gated with the rest of the catalog editor", async () => {
+    setUpClassicPageAuthority("dj");
+
+    await assertDeniedClassicPage(page);
+  });
+
+  it("redirects a member with no station role", async () => {
+    setUpClassicPageAuthority(undefined);
+
+    await assertDeniedClassicPage(page);
+  });
+
+  it("never grants access from the admin-plugin role column, even when it holds a WXYC tier string", async () => {
+    setUpClassicPageAuthority(undefined, "musicDirector");
+
+    await assertDeniedClassicPage(page);
+  });
+
+  it("bounces an unauthenticated visitor to login before any role resolution", async () => {
+    setUpClassicPageAuthority("unauthenticated");
+
+    await assertDeniedClassicPage(page, "/login?bounced=no-session");
+  });
+});

--- a/tests/integration/components/classic/catalog/ArtistCard.test.tsx
+++ b/tests/integration/components/classic/catalog/ArtistCard.test.tsx
@@ -14,8 +14,9 @@ vi.mock("@/lib/features/authentication/client", async () => {
   };
 });
 
+const mockReplace = vi.fn();
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: vi.fn(), replace: mockReplace }),
 }));
 
 import ArtistCard from "@/src/components/experiences/classic/catalog/ArtistCard";
@@ -99,7 +100,28 @@ function mockAll() {
 
 describe("classic ArtistCard — artistCardModify.jsp", () => {
   beforeEach(() => {
+    mockReplace.mockClear();
     mockAll();
+  });
+
+  // `/wxycdb` picks the card from the row. A compilation bucket reaching this
+  // URL would otherwise be offered a name edit for a shelf section and shown
+  // none of its per-track credits.
+  it("sends a compilation bucket on to the bucket card", async () => {
+    mockCard({ ...artist, artist_name: "Soundtracks - L", code_letters: "V/A" });
+    renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith(`/dashboard/library/various/${ARTIST_ID}`),
+    );
+    expect(screen.queryByTestId("modify-artist-form")).toBeNull();
+  });
+
+  it("leaves an ordinary artist on this card", async () => {
+    renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
+
+    await screen.findByTestId("modify-artist-form");
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 
   it("heads the card with the artist's presentation name", async () => {

--- a/tests/integration/components/classic/catalog/ArtistCard.test.tsx
+++ b/tests/integration/components/classic/catalog/ArtistCard.test.tsx
@@ -235,13 +235,16 @@ describe("classic ArtistCard — artistCardModify.jsp", () => {
       ).toBeDefined();
     });
 
-    // The release-detail screen this would link to does not exist in this
-    // experience yet, so a link would be a dead one.
-    it("renders the title as plain text, not a link", async () => {
+    // The JSP links each title to `libraryReleaseModify.jsp`, and this
+    // experience has that screen: both cards reach the release editor from
+    // the title, so a librarian scanning a shelf section can open any row.
+    it("opens the release editor from the title, as the JSP does", async () => {
       renderWithProviders(<ArtistCard artistId={ARTIST_ID} />);
 
       const table = await screen.findByTestId("artist-release-table");
-      expect(within(table).queryByRole("link", { name: "DOGA" })).toBeNull();
+      expect(
+        within(table).getByRole("link", { name: "DOGA" }).getAttribute("href"),
+      ).toBe("/dashboard/library/release/900");
     });
 
     it("says so when the artist has no releases", async () => {

--- a/tests/integration/components/classic/catalog/ArtistSearchForm.test.tsx
+++ b/tests/integration/components/classic/catalog/ArtistSearchForm.test.tsx
@@ -219,6 +219,33 @@ describe("classic ArtistSearchForm — chooseLibraryCodeOrArtist.jsp's artistSea
     await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/dashboard/library/artist/99"));
   });
 
+  // A sole compilation bucket at a code goes to the bucket card, not the
+  // artist card: the bucket is a shelf section with per-track credits, and the
+  // artist card offers neither those nor anything a section can be edited by.
+  it("routes a lone compilation bucket to the bucket card", async () => {
+    server.use(
+      http.get(BY_CODE_URL, () =>
+        HttpResponse.json({
+          artists: [
+            {
+              id: 4211,
+              artist_name: "Soundtracks - L",
+              code_letters: "V/A",
+              code_number: 0,
+              genre_id: SOUNDTRACKS_GENRE_ID,
+            },
+          ],
+        }),
+      ),
+    );
+    const { user } = renderWithProviders(<ArtistSearchForm onMultiMatch={mockOnMultiMatch} />);
+
+    await fillTextboxCode(user, "V/A", "0");
+    await user.click(screen.getByRole("button", { name: "Search!" }));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/dashboard/library/various/4211"));
+  });
+
   // 0 is a legitimate call number (the Various Artists filing, and no floor
   // above 0 for an ordinary code either) -- not an empty field.
   it("accepts a call number of 0 in textbox mode", async () => {

--- a/tests/integration/components/classic/catalog/CreateLibraryCodeForm.test.tsx
+++ b/tests/integration/components/classic/catalog/CreateLibraryCodeForm.test.tsx
@@ -131,6 +131,25 @@ describe("classic CreateLibraryCodeForm — createLibraryCode.jsp", () => {
     );
   });
 
+  it("lands a compilation code on the bucket card, keeping the create confirmation with it", async () => {
+    mockAddArtist(() => created());
+    const { user } = renderWithProviders(
+      <CreateLibraryCodeForm {...defaultProps} codeLetters="V/A" codeNumberRaw="0" />,
+    );
+
+    await screen.findByText("V/A");
+    await user.type(screen.getByLabelText(/artist presentation name/i), "Warp 10th Anniversary");
+    await user.type(screen.getByLabelText(/artist alphabetical name/i), "Warp 10th Anniversary");
+    await user.click(screen.getByRole("button", { name: "Add!" }));
+
+    // Not the artist card: that screen only redirects a V/A row here, and the
+    // redirect drops `created`, so the librarian would never see the
+    // servlet's own confirmation for a bucket they just made.
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith("/dashboard/library/various/99?created=1"),
+    );
+  });
+
   // The carried code is displayed verbatim, so every refusal has to name the
   // part that is wrong: a message about something "missing" beside a row
   // showing that very value reads as a broken screen, not a bad link.

--- a/tests/integration/components/classic/catalog/MultipleArtistsDisplay.test.tsx
+++ b/tests/integration/components/classic/catalog/MultipleArtistsDisplay.test.tsx
@@ -81,8 +81,11 @@ describe("classic MultipleArtistsDisplay — multipleArtistsDisplay.jsp", () => 
   // The JSP's row link says `mode=view`, but ArtistViewServlet never reads
   // `mode` and forwards to the modify card for an admin -- the only role that
   // can reach this screen. So the affordance is the same destination a
-  // single-match code search lands on, not the DJ-facing display card.
-  it("links each artist name to the modify card the JSP's own servlet forwards to", () => {
+  // single-match code search lands on, not the DJ-facing display card. Which
+  // modify card it forwards to is decided by the row: these owners collide on
+  // one code precisely because they are compilation buckets, and a bucket is
+  // edited as a shelf section rather than as a performer.
+  it("links each compilation bucket to the bucket card its filing model belongs to", () => {
     renderWithProviders(
       <MultipleArtistsDisplay
         genreName="Rock"
@@ -94,9 +97,28 @@ describe("classic MultipleArtistsDisplay — multipleArtistsDisplay.jsp", () => 
     );
 
     const link = screen.getByRole("link", { name: "Various Artists - Rock - A" });
-    expect(link).toHaveAttribute("href", "/dashboard/library/artist/1");
+    expect(link).toHaveAttribute("href", "/dashboard/library/various/1");
     const other = screen.getByRole("link", { name: "Various Artists - Rock - B" });
-    expect(other).toHaveAttribute("href", "/dashboard/library/artist/2");
+    expect(other).toHaveAttribute("href", "/dashboard/library/various/2");
+  });
+
+  it("links an ordinary artist sharing a code to the artist card instead", () => {
+    renderWithProviders(
+      <MultipleArtistsDisplay
+        genreName="Rock"
+        codeLetters="KU"
+        codeNumber={7}
+        artists={[
+          { id: 31, artist_name: "Stereolab", code_letters: "KU", code_number: 7, genre_id: 3 },
+        ]}
+        onChooseAgain={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Stereolab" })).toHaveAttribute(
+      "href",
+      "/dashboard/library/artist/31",
+    );
   });
 
   it("returns to the chooser via the Choose/Add Library Codes affordance", async () => {

--- a/tests/integration/components/classic/catalog/VariousArtistsCard.test.tsx
+++ b/tests/integration/components/classic/catalog/VariousArtistsCard.test.tsx
@@ -1,0 +1,333 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
+
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import(
+    "@/tests/helpers/auth-client-mock"
+  );
+  return {
+    ...createAuthClientModuleMock(),
+    getJWTToken: vi.fn(async () => "test-token"),
+  };
+});
+
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace }),
+}));
+
+import VariousArtistsCard from "@/src/components/experiences/classic/catalog/VariousArtistsCard";
+
+const BUCKET_ID = 4211;
+const UMBRELLA_BUCKET_ID = 19923;
+const GENRE_ID = 3;
+
+const bucket = {
+  artist_id: BUCKET_ID,
+  artist_name: "Soundtracks - L",
+  alphabetical_name: "Soundtracks - L",
+  genre_id: GENRE_ID,
+  code_letters: "V/A",
+  code_artist_number: 0,
+};
+
+function release(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 900,
+    last_modified: "2024-06-15T19:04:05.000Z",
+    format_name: "CD",
+    genre_id: GENRE_ID,
+    code_letters: "V/A",
+    code_artist_number: 0,
+    code_number: 5,
+    code_volume_letters: null,
+    album_title: "Edits",
+    alternate_artist_name: null,
+    ...overrides,
+  };
+}
+
+function mockCard(artistId: number, body: unknown = bucket, status = 200) {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/artists/${artistId}`, () =>
+      HttpResponse.json(body as object, { status }),
+    ),
+  );
+}
+
+function mockReleases(
+  artistId: number,
+  releases: unknown[] = [release()],
+  total = releases.length,
+) {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/artists/${artistId}/releases`, () =>
+      HttpResponse.json({
+        artist_id: artistId,
+        releases,
+        total,
+        page: 0,
+        totalPages: Math.max(1, Math.ceil(total / 50)),
+      }),
+    ),
+  );
+}
+
+function mockGenres() {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
+      HttpResponse.json([{ id: GENRE_ID, genre_name: "Rock" }]),
+    ),
+  );
+}
+
+function mockFormats() {
+  server.use(
+    http.get(`${TEST_BACKEND_URL}/library/formats`, () =>
+      HttpResponse.json([
+        { id: 1, format_name: "CD" },
+        { id: 2, format_name: "  " },
+        { id: 3, format_name: "Vinyl" },
+      ]),
+    ),
+  );
+}
+
+function mockAll(artistId = BUCKET_ID) {
+  mockCard(artistId);
+  mockReleases(artistId);
+  mockGenres();
+  mockFormats();
+}
+
+describe("classic VariousArtistsCard — variousArtistsCardModify.jsp", () => {
+  beforeEach(() => {
+    replace.mockClear();
+    mockAll();
+  });
+
+  it("heads the section with the bucket's alphabetical name", async () => {
+    renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+    const header = await screen.findByTestId("va-bucket-header");
+    expect(within(header).getByText("Soundtracks - L")).toBeDefined();
+  });
+
+  it("reports the release count from the server's total, not the rows on this page", async () => {
+    mockReleases(BUCKET_ID, [release()], 137);
+    renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+    const header = await screen.findByTestId("va-bucket-header");
+    expect(within(header).getByText("137")).toBeDefined();
+  });
+
+  it("offers no name edit — the bucket header is a shelf section, not a performer", async () => {
+    renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+    await screen.findByTestId("va-bucket-header");
+    expect(screen.queryByRole("button", { name: /modify this artist/i })).toBeNull();
+    expect(screen.queryByDisplayValue("Soundtracks - L")).toBeNull();
+  });
+
+  describe("add-release form", () => {
+    it("carries the JSP's fields in order, with Album Artist between the alternate name and the format", async () => {
+      renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+      const form = await screen.findByTestId("va-add-release-form");
+      const labels = within(form)
+        .getAllByRole("cell")
+        .map((cell) => cell.textContent?.trim())
+        .filter((text): text is string => !!text && text.endsWith(":"));
+
+      expect(labels).toEqual([
+        "Add a Library Release for This Section:",
+        "Library Code:",
+        "Title of Release:",
+        "Alternate Artist Name:",
+        "Album Artist:",
+        "Label:",
+        "Format:",
+      ]);
+    });
+
+    it("states that Album Artist cannot be set here rather than offering an input that discards it", async () => {
+      renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+      const note = await screen.findByTestId("va-album-artist-unavailable");
+      expect(note.textContent).toMatch(/cannot be set here/i);
+      expect(screen.queryByLabelText(/album artist/i)).toBeNull();
+    });
+
+    it("refuses an empty title with the legacy validation message", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+      const form = await screen.findByTestId("va-add-release-form");
+      await user.click(within(form).getByRole("button", { name: /add a new library release/i }));
+
+      expect(
+        await screen.findByText("Please enter a title before adding this release."),
+      ).toBeDefined();
+    });
+
+    it("files the release against the bucket's own id, never its name", async () => {
+      const user = userEvent.setup();
+      let posted: Record<string, unknown> | undefined;
+      server.use(
+        http.post(`${TEST_BACKEND_URL}/library`, async ({ request }) => {
+          posted = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({ id: 1, code_number: 12, code_volume_letters: null });
+        }),
+      );
+
+      renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+      const form = await screen.findByTestId("va-add-release-form");
+
+      await user.type(within(form).getByLabelText(/title of release/i), "Edits");
+      await user.type(within(form).getByLabelText(/^label:/i), "self-released");
+      await user.selectOptions(within(form).getByLabelText(/format/i), "1");
+      await user.click(within(form).getByRole("button", { name: /add a new library release/i }));
+
+      await waitFor(() => expect(posted).toBeDefined());
+      expect(posted?.artist_id).toBe(BUCKET_ID);
+      expect(posted).not.toHaveProperty("artist_name");
+    });
+
+    it("reports the code the release was filed under once it is assigned", async () => {
+      const user = userEvent.setup();
+      server.use(
+        http.post(`${TEST_BACKEND_URL}/library`, () =>
+          HttpResponse.json({ id: 1, code_number: 12, code_volume_letters: null }),
+        ),
+      );
+
+      renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+      const form = await screen.findByTestId("va-add-release-form");
+
+      await user.type(within(form).getByLabelText(/title of release/i), "Edits");
+      await user.type(within(form).getByLabelText(/^label:/i), "self-released");
+      await user.selectOptions(within(form).getByLabelText(/format/i), "1");
+      await user.click(within(form).getByRole("button", { name: /add a new library release/i }));
+
+      expect(await screen.findByText(/Filed as .*12/)).toBeDefined();
+    });
+
+    it("omits blank-named formats from the dropdown", async () => {
+      renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+      const form = await screen.findByTestId("va-add-release-form");
+      const options = within(form)
+        .getAllByRole("option")
+        .map((option) => option.textContent);
+      expect(options).toEqual(["CD", "Vinyl"]);
+    });
+  });
+
+  describe("the umbrella bucket", () => {
+    it("hides the add-release form, because a release filed there sits on no lettered shelf", async () => {
+      mockAll(UMBRELLA_BUCKET_ID);
+      mockCard(UMBRELLA_BUCKET_ID, {
+        ...bucket,
+        artist_id: UMBRELLA_BUCKET_ID,
+        artist_name: "Various Artists",
+        alphabetical_name: "Various Artists",
+      });
+
+      renderWithProviders(<VariousArtistsCard artistId={UMBRELLA_BUCKET_ID} />);
+
+      await screen.findByTestId("va-bucket-header");
+      expect(screen.queryByTestId("va-add-release-form")).toBeNull();
+    });
+
+    it("still lists what is already filed there", async () => {
+      mockAll(UMBRELLA_BUCKET_ID);
+      mockCard(UMBRELLA_BUCKET_ID, {
+        ...bucket,
+        artist_id: UMBRELLA_BUCKET_ID,
+        alphabetical_name: "Various Artists",
+      });
+
+      renderWithProviders(<VariousArtistsCard artistId={UMBRELLA_BUCKET_ID} />);
+
+      const table = await screen.findByTestId("va-release-table");
+      expect(within(table).getByText("Edits")).toBeDefined();
+    });
+  });
+
+  describe("release table", () => {
+    it("renders the JSP's five columns", async () => {
+      renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+      const table = await screen.findByTestId("va-release-table");
+      const headers = within(table)
+        .getAllByRole("columnheader")
+        .map((header) => header.textContent);
+      expect(headers).toEqual([
+        "Time Last Modified",
+        "Format",
+        "Code",
+        "Title of Release",
+        "Alternate Artist Name",
+      ]);
+    });
+
+    it("links each title to its release screen", async () => {
+      renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+      const table = await screen.findByTestId("va-release-table");
+      expect(within(table).getByRole("link", { name: "Edits" })).toHaveAttribute(
+        "href",
+        "/dashboard/library/release/900",
+      );
+    });
+
+    it("shows the JSP's empty-shelf message rather than a bare table", async () => {
+      mockReleases(BUCKET_ID, [], 0);
+      renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+      expect(
+        await screen.findByText("The artist does not have any library releases"),
+      ).toBeDefined();
+    });
+
+    it("says the list is incomplete when the releases cannot be loaded, rather than showing an empty shelf", async () => {
+      server.use(
+        http.get(`${TEST_BACKEND_URL}/library/artists/${BUCKET_ID}/releases`, () =>
+          HttpResponse.json({ message: "boom" }, { status: 500 }),
+        ),
+      );
+      renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+      const error = await screen.findByTestId("va-release-table-error");
+      expect(error.textContent).toMatch(/not a complete list/i);
+      expect(screen.queryByText("The artist does not have any library releases")).toBeNull();
+    });
+  });
+
+  it("sends an ordinary artist reaching this URL on to the artist card", async () => {
+    mockCard(BUCKET_ID, {
+      ...bucket,
+      artist_name: "Juana Molina",
+      alphabetical_name: "Molina, Juana",
+      code_letters: "MO",
+      code_artist_number: 12,
+    });
+
+    renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith(`/dashboard/library/artist/${BUCKET_ID}`),
+    );
+    expect(screen.queryByTestId("va-add-release-form")).toBeNull();
+  });
+
+  it("says the section could not be loaded when the card request fails", async () => {
+    mockCard(BUCKET_ID, { message: "boom" }, 500);
+    renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+    expect(await screen.findByTestId("various-artists-card-error")).toBeDefined();
+  });
+});

--- a/tests/integration/components/classic/catalog/VariousArtistsCard.test.tsx
+++ b/tests/integration/components/classic/catalog/VariousArtistsCard.test.tsx
@@ -330,4 +330,45 @@ describe("classic VariousArtistsCard — variousArtistsCardModify.jsp", () => {
 
     expect(await screen.findByTestId("various-artists-card-error")).toBeDefined();
   });
+
+  it("says the shelf is cut short rather than showing a silently truncated list", async () => {
+    mockCard(BUCKET_ID);
+    // A compilation bucket is the largest kind of section in the catalog, so
+    // this is the ordinary case here, not an edge one: the header prints the
+    // server's true total while the table shows one page. A librarian who
+    // scans the short list without being told files a duplicate.
+    mockReleases(BUCKET_ID, [release()], 214);
+
+    renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+    expect(await screen.findByText("Showing the first 1 of 214 releases.")).toBeDefined();
+  });
+
+  it("says nothing about truncation when the whole shelf is on screen", async () => {
+    mockCard(BUCKET_ID);
+    mockReleases(BUCKET_ID, [release()], 1);
+
+    renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+    await screen.findByTestId("va-release-table");
+    expect(screen.queryByText(/Showing the first/)).toBeNull();
+  });
+
+  it("carries the post-create confirmation, which routes here for a compilation code", async () => {
+    mockCard(BUCKET_ID);
+    mockReleases(BUCKET_ID);
+
+    renderWithProviders(
+      <VariousArtistsCard
+        artistId={BUCKET_ID}
+        message="The artist/library code below has been added to the database."
+      />,
+    );
+
+    expect(
+      await screen.findByText(
+        "The artist/library code below has been added to the database.",
+      ),
+    ).toBeDefined();
+  });
 });

--- a/tests/integration/components/classic/catalog/VariousArtistsCard.test.tsx
+++ b/tests/integration/components/classic/catalog/VariousArtistsCard.test.tsx
@@ -24,6 +24,7 @@ import VariousArtistsCard from "@/src/components/experiences/classic/catalog/Var
 const BUCKET_ID = 4211;
 const UMBRELLA_BUCKET_ID = 19923;
 const GENRE_ID = 3;
+const SOUNDTRACKS_GENRE_ID = 12;
 
 const bucket = {
   artist_id: BUCKET_ID,
@@ -79,7 +80,10 @@ function mockReleases(
 function mockGenres() {
   server.use(
     http.get(`${TEST_BACKEND_URL}/library/genres`, () =>
-      HttpResponse.json([{ id: GENRE_ID, genre_name: "Rock" }]),
+      HttpResponse.json([
+        { id: GENRE_ID, genre_name: "Rock" },
+        { id: SOUNDTRACKS_GENRE_ID, genre_name: "Soundtracks" },
+      ]),
     ),
   );
 }
@@ -329,6 +333,23 @@ describe("classic VariousArtistsCard — variousArtistsCardModify.jsp", () => {
     renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
 
     expect(await screen.findByTestId("various-artists-card-error")).toBeDefined();
+  });
+
+  it("prints each release's own genre, not the bucket's", async () => {
+    mockCard(BUCKET_ID);
+    // A bucket crossreferenced in more than one genre reports the lowest as
+    // its card genre, while a release carries the genre it is actually filed
+    // under. This string is the call number a librarian walks to the stacks
+    // with, so the word and the id have to come from the same row.
+    mockReleases(BUCKET_ID, [
+      release({ genre_id: SOUNDTRACKS_GENRE_ID, code_number: 7, album_title: "Paris, Texas" }),
+    ]);
+
+    renderWithProviders(<VariousArtistsCard artistId={BUCKET_ID} />);
+
+    const table = await screen.findByTestId("va-release-table");
+    expect(within(table).getByText("Soundtracks V/A-7")).toBeDefined();
+    expect(within(table).queryByText("Rock V/A-7")).toBeNull();
   });
 
   it("says the shelf is cut short rather than showing a silently truncated list", async () => {

--- a/tests/unit/lib/features/catalog/artistCardRoute.test.ts
+++ b/tests/unit/lib/features/catalog/artistCardRoute.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+
+import { artistCardHref } from "@/lib/features/catalog/artistCardRoute";
+
+describe("artistCardHref", () => {
+  it.each([
+    ["Various Artists", "V/A"],
+    ["Various Artists - Rock - A", "V/A"],
+    ["Soundtracks - L", "V/A"],
+    // The legacy spelling, for a row that predates or bypassed the catalog
+    // import's rewrite.
+    ["Various Artists - Rock - B", "Z-B"],
+  ])("sends the compilation shelf row %j, filed under %j, to the bucket card", (
+    _artistName,
+    code_letters,
+  ) => {
+    expect(artistCardHref({ id: 4211, code_letters })).toBe(
+      "/dashboard/library/various/4211",
+    );
+  });
+
+  it.each([
+    ["Juana Molina", "MOLI"],
+    ["Stereolab", "STER"],
+    // Keyword in the name, filed as an ordinary artist: the name must not
+    // pull it onto the compilation shelf.
+    ["The Soundtrack of Our Lives", "SOUN"],
+    ["Various Production", "VARI"],
+  ])("sends the ordinary artist %j, filed under %j, to the artist card", (
+    _artistName,
+    code_letters,
+  ) => {
+    expect(artistCardHref({ id: 4211, code_letters })).toBe(
+      "/dashboard/library/artist/4211",
+    );
+  });
+});

--- a/tests/unit/lib/features/catalog/libraryCode.test.ts
+++ b/tests/unit/lib/features/catalog/libraryCode.test.ts
@@ -93,34 +93,6 @@ describe("isVariousArtists", () => {
       expect(isVariousArtists(codeLetters)).toBe(false);
     },
   );
-
-  // The shelf is one code with three filed name forms, and the soundtrack
-  // sub-buckets carry no compilation keyword anywhere. They are the case that
-  // makes this check structural rather than a name test: matching on the name
-  // would drop that entire sub-shelf silently, leaving those releases unable
-  // to receive per-track credits with no error to notice.
-  // Every shelf row, paired with the call letters it is actually filed under.
-  // The soundtrack sub-buckets are the case that makes this structural rather
-  // than a name test: they carry no compilation keyword anywhere, so a name
-  // match would drop that whole sub-shelf silently, leaving those releases
-  // unable to receive per-track credits with no error to notice. The last two
-  // rows are the mirror case — a keyword in the name, filed as an ordinary
-  // artist.
-  it.each([
-    ["Various Artists", "V/A", true],
-    ["Various Artists - Rock - A", "V/A", true],
-    ["Various Artists - Rock - Z", "V/A", true],
-    ["Soundtracks - A", "V/A", true],
-    ["Soundtracks - L", "V/A", true],
-    ["Soundtracks - Z", "V/A", true],
-    ["The Soundtrack of Our Lives", "SOUN", false],
-    ["Various Production", "VARI", false],
-  ])(
-    "files %j under %j, so the compilation shelf check answers %j",
-    (_artistName, codeLetters, isShelfRow) => {
-      expect(isVariousArtists(codeLetters)).toBe(isShelfRow);
-    },
-  );
 });
 
 describe("formatCallLettersAndNumbers — ArtistLibraryCode.java:85, no trailing punctuation", () => {

--- a/tests/unit/lib/features/catalog/libraryCode.test.ts
+++ b/tests/unit/lib/features/catalog/libraryCode.test.ts
@@ -93,6 +93,34 @@ describe("isVariousArtists", () => {
       expect(isVariousArtists(codeLetters)).toBe(false);
     },
   );
+
+  // The shelf is one code with three filed name forms, and the soundtrack
+  // sub-buckets carry no compilation keyword anywhere. They are the case that
+  // makes this check structural rather than a name test: matching on the name
+  // would drop that entire sub-shelf silently, leaving those releases unable
+  // to receive per-track credits with no error to notice.
+  // Every shelf row, paired with the call letters it is actually filed under.
+  // The soundtrack sub-buckets are the case that makes this structural rather
+  // than a name test: they carry no compilation keyword anywhere, so a name
+  // match would drop that whole sub-shelf silently, leaving those releases
+  // unable to receive per-track credits with no error to notice. The last two
+  // rows are the mirror case — a keyword in the name, filed as an ordinary
+  // artist.
+  it.each([
+    ["Various Artists", "V/A", true],
+    ["Various Artists - Rock - A", "V/A", true],
+    ["Various Artists - Rock - Z", "V/A", true],
+    ["Soundtracks - A", "V/A", true],
+    ["Soundtracks - L", "V/A", true],
+    ["Soundtracks - Z", "V/A", true],
+    ["The Soundtrack of Our Lives", "SOUN", false],
+    ["Various Production", "VARI", false],
+  ])(
+    "files %j under %j, so the compilation shelf check answers %j",
+    (_artistName, codeLetters, isShelfRow) => {
+      expect(isVariousArtists(codeLetters)).toBe(isShelfRow);
+    },
+  );
 });
 
 describe("formatCallLettersAndNumbers — ArtistLibraryCode.java:85, no trailing punctuation", () => {


### PR DESCRIPTION
Part of WXYC/dj-site#1163 (Slice 3). This is the first of two PRs on that slice; per-track credit entry follows in a second, so this one stays reviewable.

## What this adds

`/dashboard/library/various/[id]`, a xerox of `libraryAdmin/variousArtistsCardModify.jsp` — the compilation shelf's bucket card. MD-gated server-side, per `mainmenu.jsp:32-37`.

Compilations file on one Z-prefixed, letter-subdivided shelf: 53 artist rows carrying `code_letters = 'V/A'`, over roughly 6,300 releases, in three filed forms (`Various Artists` plain, `Various Artists - Rock - <A–Z>`, `Soundtracks - <A–Z>`). Before this, every one of those buckets landed on the ordinary artist card, which offers a name edit for what is really a shelf section.

The umbrella bucket (artist 19923) keeps its release list and loses its add-release form, matching the JSP's `<c:if test="${artist.ID != 19923}">` — a release filed there would sit on no lettered shelf.

## Routing

Which of the two artist cards a link opens is now one rule — `artistCardHref` in `lib/features/catalog/artistCardRoute.ts` — decided structurally on `code_letters`. `/wxycdb` serves both cards from one servlet and picks the view from the row; that choice has to be reproduced wherever a link to an artist is built.

Deciding it on the artist's **name** would silently drop the whole `Soundtracks - <A–Z>` sub-shelf, which contains no compilation keyword anywhere — 1,194 releases, no error, just a shelf that quietly cannot be reached. Both cards also redirect a row that belongs on the other, so a hand-typed or stale URL still lands on the screen that describes it.

## Divergences from the JSP

Both forced by the Backend-Service contract, not chosen. Where both the JSP's shape and a Backend call were possible, the JSP won.

| JSP | Here | Why |
|---|---|---|
| `albumArtist` text input | Display-only row stating it cannot be set here | `POST /library` has no `album_artist` parameter — `NewAlbumRequest` omits it, and `library.album_artist` is written solely by the nightly catalog import. Rendering an input would discard what the librarian types. This is the field V/A add has that the ordinary artist form does not, so it is the one worth being loud about. It becomes an input once a write path exists (WXYC/Backend-Service#2004). |
| `releaseCallNumbers` + `releaseCallLetters` inputs | Dropped; assigned code reported after the save | `POST /library` derives `code_number` itself (max+1 for the bucket) and has no `code_volume_letters` parameter. Same divergence the ordinary artist card already carries. |
| No Label field | Label field added | `POST /library` requires `label`. Same precedent as the artist card. |
| `sortColumn`/`sortOrder` form | Dropped | `GET /library/artists/:id/releases` takes no sort parameter and returns shelf order — the order the JSP itself defaults to. |
| `modifyArtist` `<form>` wrapper | Plain table | The JSP's form carries no editable input and no submit button; it is inert markup. The bucket header is read-only either way, and the letter subdivision must not become editable — it *is* the physical shelf organization. |

## One deviation from the issue's acceptance criteria

The issue asks for a fourth export on `is-compilation-artist.ts`. That instruction is stale: `isVariousArtists` landed in `libraryCode.ts` on 2026-08-25, eleven days after the issue was last updated, and already owns exactly this rule — plus the legacy `Z-<letter>` spelling the issue's proposed check would have missed.

Adding a second predicate beside it would have given one rule two owners, which is what `refactor(catalog): give the code-resolution rules one owner each` just finished undoing. So `is-compilation-artist.ts` is **untouched** (its three exports byte-identical, all six importers untouched — the stated intent of that criterion), and the structural gate reuses `isVariousArtists`. The AC's testing requirement is met where the rule lives: `libraryCode.test.ts` gains the table over all three filed shelf forms plus the two keyword-named ordinary artists.

## Testing

- `libraryCode.test.ts` — table-driven over every shelf name form paired with its real call letters, including all three `Soundtracks - <L>` cases and the two mirror cases (a compilation keyword in the name, filed as an ordinary artist).
- `artistCardRoute.test.ts` — the dispatch, both directions, including the legacy `Z-<letter>` spelling.
- `VariousArtistsCard.test.tsx` — 17 tests naming `variousArtistsCardModify.jsp`: field order, the Album Artist note, the umbrella-bucket behaviour (form hidden, list still rendered), the five columns, the empty-shelf message, the releases-outage message, and that the add posts `artist_id` and never `artist_name` — every one of the 53 buckets shares a code, so a name would fuzzy-match onto a sibling bucket.
- Page-authority test on the shared classic harness: MD and SM reach it, DJ and role-less members are redirected, the admin-plugin role column never grants access, unauthenticated bounces to login.
- `ArtistCard` / `ArtistSearchForm` / `MultipleArtistsDisplay` gain dispatch assertions. `MultipleArtistsDisplay`'s existing link assertion is updated — a V/A row linking to the ordinary card is the behaviour this PR changes.

Local gate before pushing: `npm run lint` 0 errors (no new warnings), `tsc --noEmit` clean, full vitest suite 5140 passing.

Closes part of WXYC/dj-site#1168.