### PR TITLE
feat(flowsheet): ask before going live into someone else's open show

### DIFF
--- a/e2e/pages/flowsheet.page.ts
+++ b/e2e/pages/flowsheet.page.ts
@@ -124,6 +124,7 @@ export class FlowsheetPage {
         { timeout: 15000 }
       );
       await this.goLiveButton.click();
+      await this.answerHandoffPromptIfShown(mutationResponse);
       await mutationResponse;
       await expect(this.liveStatus).toContainText("On Air", {
         timeout: 10000,
@@ -143,6 +144,38 @@ export class FlowsheetPage {
     await responsePromise;
     // Wait for the page to be fully interactive after reload
     await expect(this.songInput).toBeEnabled({ timeout: 10000 });
+  }
+
+  /**
+   * Answer the go-live handoff prompt with "Join Existing Show" when it
+   * appears, and do nothing when it doesn't.
+   *
+   * The suite runs fully parallel against one shared Backend and one global
+   * "latest show", so a sibling worker's DJ routinely holds the open show when
+   * another spec goes live. Co-hosting is exactly what those specs got
+   * implicitly before this prompt existed, which is what lets them coexist —
+   * so this is behaviour-preserving, not a workaround.
+   *
+   * It must NEVER click "End Existing Show". That would close a sibling
+   * worker's show mid-test, turning benign interference into active
+   * destruction, intermittently and only on CI. The takeover click belongs
+   * exclusively to a spec that owns its own Backend.
+   *
+   * Raced against the mutation response rather than given a fixed wait, so the
+   * common no-prompt path costs nothing.
+   */
+  private async answerHandoffPromptIfShown(
+    mutationResponse: Promise<unknown>
+  ): Promise<void> {
+    const joinButton = this.page.getByTestId("go-live-handoff-join");
+    const outcome = await Promise.race([
+      mutationResponse.then(() => "sent" as const).catch(() => "sent" as const),
+      joinButton
+        .waitFor({ state: "visible", timeout: 15000 })
+        .then(() => "prompt" as const)
+        .catch(() => "sent" as const),
+    ]);
+    if (outcome === "prompt") await joinButton.click();
   }
 
   async leave(): Promise<void> {

--- a/e2e/pages/flowsheet.page.ts
+++ b/e2e/pages/flowsheet.page.ts
@@ -124,7 +124,7 @@ export class FlowsheetPage {
         { timeout: 15000 }
       );
       await this.goLiveButton.click();
-      await this.answerHandoffPromptIfShown(mutationResponse);
+      await this.answerHandoffPromptIfShown();
       await mutationResponse;
       await expect(this.liveStatus).toContainText("On Air", {
         timeout: 10000,
@@ -161,19 +161,25 @@ export class FlowsheetPage {
    * destruction, intermittently and only on CI. The takeover click belongs
    * exclusively to a spec that owns its own Backend.
    *
-   * Raced against the mutation response rather than given a fixed wait, so the
-   * common no-prompt path costs nothing.
+   * Races the two TERMINAL states — on air, or the prompt asking which way to
+   * go — rather than the mutation response. The response is not evidence that
+   * no prompt is coming: on the server-refusal path the client sends the join,
+   * is refused with a 409, and opens the prompt afterwards. Racing the request
+   * would resolve "no prompt" while the prompt was still on its way, and the
+   * on-air assertion below would then time out with the dialog sitting open.
    */
-  private async answerHandoffPromptIfShown(
-    mutationResponse: Promise<unknown>
-  ): Promise<void> {
+  private async answerHandoffPromptIfShown(): Promise<void> {
     const joinButton = this.page.getByTestId("go-live-handoff-join");
     const outcome = await Promise.race([
-      mutationResponse.then(() => "sent" as const).catch(() => "sent" as const),
+      this.liveStatus
+        .filter({ hasText: "On Air" })
+        .waitFor({ state: "visible", timeout: 15000 })
+        .then(() => "live" as const)
+        .catch(() => "live" as const),
       joinButton
         .waitFor({ state: "visible", timeout: 15000 })
         .then(() => "prompt" as const)
-        .catch(() => "sent" as const),
+        .catch(() => "live" as const),
     ]);
     if (outcome === "prompt") await joinButton.click();
   }

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -21,7 +21,11 @@ import {
   replaceEntryIdAllPages,
   upsertEntrySortedFirstPage,
 } from "./infinite-cache";
-import { readShowAlreadyOpen, type JoinIntent } from "./go-live-handoff";
+import {
+  readShowAlreadyOpen,
+  type JoinIntent,
+  type JoinShowResult,
+} from "./go-live-handoff";
 import {
   FlowsheetEntry,
   FlowsheetShowBlockEntry,
@@ -135,7 +139,10 @@ export const flowsheetApi = createApi({
       },
     }),
     joinShow: builder.mutation<
-      void,
+      // Not `void`: the body is the only thing that says whether a takeover was
+      // honoured or quietly downgraded to a co-host join — see
+      // `takeoverWasHonored`.
+      JoinShowResult,
       DJRequestParams & {
         dj_name?: string;
         dj_name_override?: string;

--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -21,6 +21,7 @@ import {
   replaceEntryIdAllPages,
   upsertEntrySortedFirstPage,
 } from "./infinite-cache";
+import { readShowAlreadyOpen, type JoinIntent } from "./go-live-handoff";
 import {
   FlowsheetEntry,
   FlowsheetShowBlockEntry,
@@ -55,9 +56,13 @@ function rollbackAndResyncEntries(
   dispatch: (
     action: ReturnType<typeof flowsheetApi.util.invalidateTags>
   ) => unknown,
-  patches: Array<{ undo: () => void } | undefined>
+  patches: Array<{ undo: () => void } | undefined>,
+  // `expected` separates "this mutation broke" from "the server answered no,
+  // which is a state this flow is designed around". Both roll the optimistic
+  // patches back; only the former is worth a developer's attention.
+  options?: { expected?: boolean }
 ): void {
-  flowsheetMutationCatch(endpoint, err);
+  if (!options?.expected) flowsheetMutationCatch(endpoint, err);
   for (const patch of patches) patch?.undo();
   dispatch(flowsheetApi.util.invalidateTags(["Flowsheet"]));
 }
@@ -131,7 +136,18 @@ export const flowsheetApi = createApi({
     }),
     joinShow: builder.mutation<
       void,
-      DJRequestParams & { dj_name?: string; dj_name_override?: string }
+      DJRequestParams & {
+        dj_name?: string;
+        dj_name_override?: string;
+        /**
+         * Sent only when the DJ has answered the handoff prompt. Omitting it is
+         * how the server is asked to refuse rather than guess (409
+         * `show_already_open`), which is the whole point of the field.
+         */
+        intent?: JoinIntent;
+        /** Echoed from the 409's `details.show.id`; required with a takeover. */
+        expected_show_id?: number;
+      }
     >({
       // `dj_name` is a client-only display hint for the optimistic patches
       // below; keep it off the wire (the backend derives the on-air name from
@@ -208,11 +224,20 @@ export const flowsheetApi = createApi({
           await queryFulfilled;
           dispatch(flowsheetApi.util.invalidateTags(["Flowsheet"]));
         } catch (err) {
-          rollbackAndResyncEntries("joinShow", err, dispatch, [
-            patchLive,
-            patchEntries,
-            patchNowPlaying,
-          ]);
+          // The three patches above apply before the response settles, so a
+          // refusal flashes the banner for one round trip. Accepted rather
+          // than skipped: the client asks djs-on-air first and prompts
+          // WITHOUT issuing a request in the ordinary handoff, so reaching
+          // here at all means the two disagreed — a race, and a rare one.
+          rollbackAndResyncEntries(
+            "joinShow",
+            err,
+            dispatch,
+            [patchLive, patchEntries, patchNowPlaying],
+            // A `show_already_open` 409 is the contract working, not a broken
+            // mutation. Rolling back is right; reporting it is not.
+            { expected: readShowAlreadyOpen(err) !== null }
+          );
         }
       },
     }),

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -202,6 +202,10 @@ export function convertV2Entry(entry: FlowsheetV2EntryJSON): FlowsheetEntry {
     // -1 mirrors primaryShowId's no-show sentinel; 0 collides with a real
     // show id and would mis-partition orphaned entries into it (#629).
     show_id: entry.show_id ?? -1,
+    // Kept raw alongside the formatted `day`/`time` the marker variants also
+    // derive from it: the go-live handoff prompt needs an elapsed time, and a
+    // display string cannot be subtracted.
+    add_time: entry.add_time,
   };
 
   switch (entry.entry_type) {

--- a/lib/features/flowsheet/go-live-handoff.ts
+++ b/lib/features/flowsheet/go-live-handoff.ts
@@ -13,17 +13,55 @@
 /** The wire values `POST /flowsheet/join` accepts for an explicit decision. */
 export type JoinIntent = "join" | "takeover";
 
+/**
+ * What `POST /flowsheet/join` answers a 2xx with, narrowed to the one field
+ * that tells the two outcomes apart: a takeover the server honoured returns the
+ * newly started `Show` (which has an `id`), while a co-host join returns the
+ * `ShowDJ` membership row instead (`show_id` / `dj_id`, and no `id`).
+ */
+export type JoinShowResult = {
+  id?: number;
+  show_id?: number;
+  dj_id?: string;
+};
+
+/**
+ * Whether the server really ended the open show and started a new one.
+ *
+ * A takeover is a request the server may decline *silently*: it is gated behind
+ * a server-side flag, and while that flag is off `intent` is ignored altogether
+ * and the caller is co-hosted onto the open show with a 200. Without this check
+ * a DJ presses a button reading "End Existing Show", watches the prompt close,
+ * and is added to the very show they asked to end — the original defect, now
+ * wearing an affirmative confirmation that lies about what it did. Nothing in
+ * the status code distinguishes the two.
+ *
+ * Tested by IDENTITY, not by shape. A honoured takeover ends the named show and
+ * starts a fresh one, so the id that comes back is a *different* show; a
+ * co-host join lands on the show the DJ named. Sniffing for the mere presence
+ * of an `id` would also read as honoured the day the server starts returning
+ * the joined show on a co-host join — a natural API improvement that would
+ * silently restore the original lie. Both shapes declare every field optional
+ * in the shared contract, so presence was never a discriminant to begin with.
+ */
+export function takeoverWasHonored(
+  result: JoinShowResult | undefined,
+  expectedShowId: number | undefined
+): boolean {
+  return typeof result?.id === "number" && result.id !== expectedShowId;
+}
+
 /** What the prompt renders, and what a takeover has to echo back. */
 export type OpenShowHandoff = {
   /** `shows.id` of the open show — the `expected_show_id` a takeover sends. */
   showId: number;
   /**
-   * Who is on air, already formatted. Sourced from `GET /flowsheet/djs-on-air`
+   * Who is on air. Sourced from `GET /flowsheet/djs-on-air`
    * (active `show_djs` membership), never from the show's own resolved
    * `dj_name`: for an abandoned show the latter names whoever started it, which
    * is the one answer a DJ deciding whether to take over must not be given.
    */
-  djNames: string;
+  djNames: readonly string[];
   /**
    * ISO-8601 `add_time` of the show's newest entry. Null means UNKNOWN, not
    * "nothing logged": the server's refusal carries no timestamp, so a prompt
@@ -45,10 +83,10 @@ type ShowAlreadyOpenBody = {
  * Read a `show_already_open` 409 out of an RTK Query rejection, or null for
  * anything else.
  *
- * Discriminates on `code`, never on the 409 status alone: the same status is
- * how `POST /flowsheet/shows/:id/force-end` reports a different refusal, and
- * treating any 409 as a handoff would put this prompt in front of a DJ over an
- * unrelated conflict.
+ * Discriminates on `code`, never on the 409 status alone: 409 is the generic
+ * conflict status, and the join route is free to grow a second refusal that
+ * uses it. Treating any 409 as a handoff would put this prompt in front of a
+ * DJ over an unrelated conflict.
  *
  * The name it returns is the show's owner. That is the correct answer to "whose
  * show am I being asked about" and the wrong one to "who is on air" — see
@@ -63,11 +101,12 @@ export function readShowAlreadyOpen(err: unknown): OpenShowHandoff | null {
   if (!data || data.code !== "show_already_open") return null;
   const show = data.details?.show;
   if (!show || typeof show.id !== "number") return null;
+  const owner = typeof show.dj_name === "string" ? show.dj_name.trim() : "";
   return {
     showId: show.id,
-    djNames: typeof show.dj_name === "string" && show.dj_name.trim().length > 0
-      ? show.dj_name
-      : "Someone",
+    // The refusal names one show owner, never a membership list — and names
+    // nobody at all if the show has no resolvable handle.
+    djNames: owner.length > 0 ? [owner] : [],
     lastLoggedAt: null,
   };
 }
@@ -145,7 +184,13 @@ export function describeOpenShow(
   now: number = Date.now()
 ): string {
   const elapsed = formatElapsedSince(handoff.lastLoggedAt, now);
+  // Subject and verb are derived from ONE filtered list, so they cannot
+  // disagree. Counting the raw array instead would render "dj sue are on air"
+  // for a show whose second DJ has a blank handle.
+  const named = handoff.djNames.map((n) => n.trim()).filter((n) => n.length > 0);
+  const verb = named.length > 1 ? "are" : "is";
+  const subject = formatDjNames(named);
   return elapsed === null
-    ? `${handoff.djNames} is on air.`
-    : `${handoff.djNames} is on air. Last logged ${elapsed}.`;
+    ? `${subject} ${verb} on air.`
+    : `${subject} ${verb} on air. Last logged ${elapsed}.`;
 }

--- a/lib/features/flowsheet/go-live-handoff.ts
+++ b/lib/features/flowsheet/go-live-handoff.ts
@@ -1,0 +1,151 @@
+/**
+ * The pure half of the go-live handoff prompt: what to tell a DJ about the show
+ * that is in the way, and how to read the server's refusal to guess.
+ *
+ * Pressing "Go Live" while someone else's show is still open used to attach the
+ * DJ to that show as a guest, silently. The prompt exists so the choice is
+ * made out loud — and it is only useful if it answers the question a DJ
+ * actually has at a handoff, which is not "who owns this show" but "did they
+ * leave?". Elapsed time since the last logged entry is what separates those two
+ * readings, so it is the headline here, not the show's start time.
+ */
+
+/** The wire values `POST /flowsheet/join` accepts for an explicit decision. */
+export type JoinIntent = "join" | "takeover";
+
+/** What the prompt renders, and what a takeover has to echo back. */
+export type OpenShowHandoff = {
+  /** `shows.id` of the open show — the `expected_show_id` a takeover sends. */
+  showId: number;
+  /**
+   * Who is on air, already formatted. Sourced from `GET /flowsheet/djs-on-air`
+   * (active `show_djs` membership), never from the show's own resolved
+   * `dj_name`: for an abandoned show the latter names whoever started it, which
+   * is the one answer a DJ deciding whether to take over must not be given.
+   */
+  djNames: string;
+  /**
+   * ISO-8601 `add_time` of the show's newest entry. Null means UNKNOWN, not
+   * "nothing logged": the server's refusal carries no timestamp, so a prompt
+   * built from it has to say less rather than assert something false.
+   */
+  lastLoggedAt: string | null;
+};
+
+/**
+ * The shape Backend-Service refuses a guess-less join with: a 409 carrying
+ * `code: 'show_already_open'` and the open show's identity.
+ */
+type ShowAlreadyOpenBody = {
+  code?: unknown;
+  details?: { show?: { id?: unknown; dj_name?: unknown; start_time?: unknown } };
+};
+
+/**
+ * Read a `show_already_open` 409 out of an RTK Query rejection, or null for
+ * anything else.
+ *
+ * Discriminates on `code`, never on the 409 status alone: the same status is
+ * how `POST /flowsheet/shows/:id/force-end` reports a different refusal, and
+ * treating any 409 as a handoff would put this prompt in front of a DJ over an
+ * unrelated conflict.
+ *
+ * The name it returns is the show's owner. That is the correct answer to "whose
+ * show am I being asked about" and the wrong one to "who is on air" — see
+ * `OpenShowHandoff.djNames`. It is used only when the client has no
+ * djs-on-air answer of its own.
+ */
+export function readShowAlreadyOpen(err: unknown): OpenShowHandoff | null {
+  const rejection = unwrapRejection(err);
+  if (!rejection) return null;
+  if (rejection.status !== 409) return null;
+  const data = rejection.data as ShowAlreadyOpenBody | undefined;
+  if (!data || data.code !== "show_already_open") return null;
+  const show = data.details?.show;
+  if (!show || typeof show.id !== "number") return null;
+  return {
+    showId: show.id,
+    djNames: typeof show.dj_name === "string" && show.dj_name.trim().length > 0
+      ? show.dj_name
+      : "Someone",
+    lastLoggedAt: null,
+  };
+}
+
+/**
+ * RTK Query hands the same failure out in two shapes, and both reach this
+ * module: `.unwrap()` rejects with the bare `{status, data}`, while
+ * `queryFulfilled` inside `onQueryStarted` rejects with it wrapped as
+ * `{error, meta}`. Reading only the bare one would silently mis-classify every
+ * refusal seen from the cache-patch side as a genuine failure.
+ */
+function unwrapRejection(
+  err: unknown
+): { status?: unknown; data?: unknown } | null {
+  if (!err || typeof err !== "object") return null;
+  const candidate = err as { status?: unknown; error?: unknown };
+  if (candidate.status !== undefined) return candidate;
+  if (candidate.error && typeof candidate.error === "object") {
+    return candidate.error as { status?: unknown; data?: unknown };
+  }
+  return null;
+}
+
+/** "dj sue", "dj sue and eureka!", "dj sue, eureka! and DJ boy". */
+export function formatDjNames(names: readonly string[]): string {
+  const cleaned = names.map((n) => n.trim()).filter((n) => n.length > 0);
+  if (cleaned.length === 0) return "Someone";
+  if (cleaned.length === 1) return cleaned[0];
+  return `${cleaned.slice(0, -1).join(", ")} and ${cleaned[cleaned.length - 1]}`;
+}
+
+/**
+ * "5h 12m ago" vs "2 minutes ago" — the whole difference between "they walked
+ * out" and "they are still talking", which is the decision this prompt exists
+ * to inform.
+ *
+ * Deliberately coarse and deliberately not `Intl.RelativeTimeFormat`: the
+ * reader needs to sort one gap into "recent" or "ages ago", and a unit-picking
+ * formatter that says "yesterday" hides an hour count that is the actual
+ * signal. Returns null when there is nothing to measure, so the caller can
+ * say less rather than render a fake duration.
+ */
+export function formatElapsedSince(
+  isoTimestamp: string | null,
+  now: number = Date.now()
+): string | null {
+  if (!isoTimestamp) return null;
+  const then = new Date(isoTimestamp).getTime();
+  if (Number.isNaN(then)) return null;
+  const seconds = Math.floor((now - then) / 1000);
+  // Clock skew between the browser and the server can put a just-written
+  // entry marginally in the future. "in 3 seconds ago" is worse than "just
+  // now", and the answer to the DJ's question is the same either way.
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  const remainderMinutes = minutes % 60;
+  if (hours < 24) return `${hours}h ${remainderMinutes}m ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ${hours % 24}h ago`;
+}
+
+/**
+ * The sentence at the top of the prompt.
+ *
+ * Drops the elapsed clause entirely when the timestamp is unknown rather than
+ * substituting a claim like "hasn't logged anything" — the client derives the
+ * timestamp itself in the ordinary case, and the one path that lacks it (the
+ * server's own refusal, which carries no timestamp) has no basis for either
+ * reading. Saying less is the only honest degrade.
+ */
+export function describeOpenShow(
+  handoff: OpenShowHandoff,
+  now: number = Date.now()
+): string {
+  const elapsed = formatElapsedSince(handoff.lastLoggedAt, now);
+  return elapsed === null
+    ? `${handoff.djNames} is on air.`
+    : `${handoff.djNames} is on air. Last logged ${elapsed}.`;
+}

--- a/lib/features/flowsheet/infinite-cache.ts
+++ b/lib/features/flowsheet/infinite-cache.ts
@@ -34,12 +34,24 @@ export function maxPlayOrder(draft: Pick<InfiniteEntriesDraft, "pages">): number
  * show's tail stops partitioning as current during the goLive window.
  */
 export function primaryShowId(draft: Pick<InfiniteEntriesDraft, "pages">): number {
+  return newestRealEntry(draft)?.show_id ?? -1;
+}
+
+/**
+ * The newest entry that belongs to some show, skipping orphans (show_id exactly
+ * -1). Same traversal and same skip rule `primaryShowId` needs — it is defined
+ * in terms of this — plus the row itself, for callers that want more than the
+ * show id (the handoff prompt reads its `add_time`).
+ */
+export function newestRealEntry(
+  draft: Pick<InfiniteEntriesDraft, "pages">
+): FlowsheetEntry | undefined {
   for (const page of draft.pages) {
     for (const e of page) {
-      if (e.show_id !== -1) return e.show_id;
+      if (e.show_id !== -1) return e;
     }
   }
-  return -1;
+  return undefined;
 }
 
 // Monotonic counter, not Date.now()+random: two submissions in the same

--- a/lib/features/flowsheet/infinite-cache.ts
+++ b/lib/features/flowsheet/infinite-cache.ts
@@ -34,24 +34,38 @@ export function maxPlayOrder(draft: Pick<InfiniteEntriesDraft, "pages">): number
  * show's tail stops partitioning as current during the goLive window.
  */
 export function primaryShowId(draft: Pick<InfiniteEntriesDraft, "pages">): number {
-  return newestRealEntry(draft)?.show_id ?? -1;
+  for (const page of draft.pages) {
+    for (const e of page) {
+      if (e.show_id !== -1) return e.show_id;
+    }
+  }
+  return -1;
 }
 
 /**
- * The newest entry that belongs to some show, skipping orphans (show_id exactly
- * -1). Same traversal and same skip rule `primaryShowId` needs — it is defined
- * in terms of this — plus the row itself, for callers that want more than the
- * show id (the handoff prompt reads its `add_time`).
+ * When anything was last logged, ISO-8601, or null if nothing carries a time.
+ *
+ * Deliberately NOT the `primaryShowId` traversal: that one skips the `-1`
+ * orphan sentinel, which stands for a row the server sent with `show_id: null`
+ * — a real, freshly logged entry that simply has no mapped show. Reading past
+ * one lands on the *previous* show's tail and reports its timestamp, so a DJ
+ * who logged a track two minutes ago is described as having last logged hours
+ * ago. That is the precise misreading that ends a live show, since the elapsed
+ * time is the whole decision input. "Has anyone touched this flowsheet lately"
+ * is answered just as well by an unattributed row as by an attributed one.
+ *
+ * Optimistic rows carry no `add_time` (they have not been logged yet) and are
+ * skipped for free.
  */
-export function newestRealEntry(
+export function newestLoggedAt(
   draft: Pick<InfiniteEntriesDraft, "pages">
-): FlowsheetEntry | undefined {
+): string | null {
   for (const page of draft.pages) {
     for (const e of page) {
-      if (e.show_id !== -1) return e;
+      if (e.add_time) return e.add_time;
     }
   }
-  return undefined;
+  return null;
 }
 
 // Monotonic counter, not Date.now()+random: two submissions in the same

--- a/lib/features/flowsheet/live-updates-listener.ts
+++ b/lib/features/flowsheet/live-updates-listener.ts
@@ -220,8 +220,12 @@ export function createLiveUpdatesListenerMiddleware(
    * silently stays stale.
    *
    * `add_time` is deliberately NOT here: the conversion now carries it onto
-   * every entry under the same name and the same ISO value, so it is a
-   * converted field like any other and merging it forks nothing.
+   * every entry under the same name and the same ISO value, so merging it
+   * keeps the raw field fresh. What makes that safe is that `add_time` is
+   * immutable after insert — no update ever carries a different one. It is
+   * NOT that the value is unshared: the marker variants still derive `day` /
+   * `time` / `isToday` at conversion time, and those are not recomputed here,
+   * so a genuinely changed `add_time` would leave them disagreeing.
    */
   const WIRE_ONLY_UPDATE_KEYS = new Set([
     "entry_type",

--- a/lib/features/flowsheet/live-updates-listener.ts
+++ b/lib/features/flowsheet/live-updates-listener.ts
@@ -218,11 +218,14 @@ export function createLiveUpdatesListenerMiddleware(
    * `rotation_bin` specifically converts to the `rotation` key — a raw merge
    * would write a field the badge never reads while the real badge field
    * silently stays stale.
+   *
+   * `add_time` is deliberately NOT here: the conversion now carries it onto
+   * every entry under the same name and the same ISO value, so it is a
+   * converted field like any other and merging it forks nothing.
    */
   const WIRE_ONLY_UPDATE_KEYS = new Set([
     "entry_type",
     "metadata_status",
-    "add_time",
     "radio_hour",
     "dj_name",
     "rotation_bin",

--- a/lib/features/flowsheet/submission-error.ts
+++ b/lib/features/flowsheet/submission-error.ts
@@ -7,8 +7,15 @@
  * rejected string, a network failure — has no such reason and falls back.
  * Interpolating the error object directly renders "[object Object]" and
  * strands the DJ, which is the whole point of unwrapping it here.
+ *
+ * `fallback` names the action that failed, for the paths where the default
+ * would describe the wrong one — going live is not adding to the flowsheet,
+ * and a DJ told otherwise looks in the wrong place.
  */
-export function flowsheetWriteErrorMessage(err: unknown): string {
+export function flowsheetWriteErrorMessage(
+  err: unknown,
+  fallback = "Could not add to flowsheet"
+): string {
   if (
     err &&
     typeof err === "object" &&
@@ -22,5 +29,5 @@ export function flowsheetWriteErrorMessage(err: unknown): string {
   }
   if (err instanceof Error) return err.message;
   if (typeof err === "string") return err;
-  return "Could not add to flowsheet";
+  return fallback;
 }

--- a/lib/features/flowsheet/types.ts
+++ b/lib/features/flowsheet/types.ts
@@ -79,6 +79,16 @@ export type FlowsheetEntryBase = {
   id: number;
   play_order: number;
   show_id: number;
+  /**
+   * When the server logged this row, ISO-8601, carried through unformatted.
+   *
+   * The marker variants also render it as `day`/`time` display strings, but
+   * those are lossy and track rows had no timestamp at all — so "how long ago
+   * did this show last log anything", the difference between a DJ who walked
+   * out and one who is mid-sentence, was unanswerable on the client. Absent on
+   * optimistic rows, which have not been logged yet.
+   */
+  add_time?: string;
 };
 
 export type FlowsheetSongBase = {

--- a/src/components/experiences/classic/flowsheet/StartShow.tsx
+++ b/src/components/experiences/classic/flowsheet/StartShow.tsx
@@ -2,12 +2,20 @@
 
 import "@/src/styles/classic/wxyc.css";
 import { useShowControl } from "@/src/hooks/flowsheetHooks";
+import { useGoLiveHandoff } from "@/src/hooks/goLiveHandoffHooks";
+import { describeOpenShow } from "@/lib/features/flowsheet/go-live-handoff";
 import { useRegistry } from "@/src/hooks/authenticationHooks";
 import { FormEvent, useEffect, useState } from "react";
 import { OpenHelp } from "@/src/utils/helpScreen";
 
 export default function StartShow() {
   const { goLive } = useShowControl();
+  // Same decision as the modern surface, rendered in this page's own plain
+  // markup rather than through a Joy dialog — nothing else in classic uses Joy.
+  // Without it a classic DJ gets a form that appears to do nothing, which is
+  // the dead end this prompt exists to remove, only relocated.
+  const { prompt, deciding, requestGoLive, decide, cancel } =
+    useGoLiveHandoff(goLive);
   const { info: userData } = useRegistry();
   // Editable per-show override for the DJ's public handle, initialized to the
   // registry's `dj_name`. useRegistry() is async, so useState's initializer
@@ -37,7 +45,10 @@ export default function StartShow() {
       trimmed.length > 0 && trimmed !== currentRegistryValue
         ? trimmed
         : undefined;
-    goLive(override);
+    // The override is handed to the prompt, not recomputed after it: this form
+    // reads the registry at submit time, and re-deriving it on the far side of
+    // a dialog would silently drop the handle the DJ typed.
+    void requestGoLive(override);
   };
 
   const getCurrentTimeDisplay = () => {
@@ -181,6 +192,59 @@ export default function StartShow() {
                   />
                 </td>
               </tr>
+              {prompt && (
+                <tr>
+                  <td colSpan={2} align="center">
+                    <div
+                      className="smalltext"
+                      data-testid="go-live-handoff-prompt"
+                      style={{
+                        border: "2px solid #990000",
+                        padding: "10px",
+                        margin: "0 auto",
+                        maxWidth: "28em",
+                      }}
+                    >
+                      <b>{describeOpenShow(prompt.handoff)}</b>
+                      <p>
+                        Join them as a co-host, or end their show and start your
+                        own.
+                      </p>
+                      <input
+                        type="button"
+                        value="Join Existing Show"
+                        disabled={deciding}
+                        onClick={() => void decide("join")}
+                        style={{ cursor: "pointer" }}
+                        data-testid="go-live-handoff-join"
+                      />
+                      &nbsp;
+                      {/* Red because it signs somebody else off the air. */}
+                      <input
+                        type="button"
+                        value="End Existing Show"
+                        disabled={deciding}
+                        onClick={() => void decide("takeover")}
+                        style={{
+                          cursor: "pointer",
+                          color: "#990000",
+                          fontWeight: "bold",
+                        }}
+                        data-testid="go-live-handoff-takeover"
+                      />
+                      &nbsp;
+                      <input
+                        type="button"
+                        value="Cancel"
+                        disabled={deciding}
+                        onClick={cancel}
+                        style={{ cursor: "pointer" }}
+                        data-testid="go-live-handoff-cancel"
+                      />
+                    </div>
+                  </td>
+                </tr>
+              )}
               <tr>
                 <td colSpan={2} align="center">
                   <input

--- a/src/components/experiences/classic/flowsheet/StartShow.tsx
+++ b/src/components/experiences/classic/flowsheet/StartShow.tsx
@@ -16,7 +16,7 @@ export default function StartShow() {
   // the dead end this prompt exists to remove, only relocated.
   const { prompt, deciding, requestGoLive, decide, cancel } =
     useGoLiveHandoff(goLive);
-  const { info: userData } = useRegistry();
+  const { info: userData, loading: registryLoading } = useRegistry();
   // Editable per-show override for the DJ's public handle, initialized to the
   // registry's `dj_name`. useRegistry() is async, so useState's initializer
   // (which only runs once) can't wait for it — this effect syncs the field
@@ -185,10 +185,17 @@ export default function StartShow() {
               </tr>
               <tr>
                 <td colSpan={2} align="center">
+                  {/* Disabled until the registry resolves: `goLive` sends
+                      nothing without it, so a live button here would be a form
+                      that silently does nothing — the dead end this prompt
+                      exists to remove. Modern gates the same way on `loading`. */}
                   <input
                     type="submit"
                     value="Sign on and Start the Show!"
-                    style={{ cursor: "pointer" }}
+                    disabled={registryLoading || !userData}
+                    style={{
+                      cursor: registryLoading || !userData ? "not-allowed" : "pointer",
+                    }}
                   />
                 </td>
               </tr>
@@ -196,14 +203,9 @@ export default function StartShow() {
                 <tr>
                   <td colSpan={2} align="center">
                     <div
-                      className="smalltext"
+                      className="smalltext go-live-handoff-prompt"
+                      role="alert"
                       data-testid="go-live-handoff-prompt"
-                      style={{
-                        border: "2px solid #990000",
-                        padding: "10px",
-                        margin: "0 auto",
-                        maxWidth: "28em",
-                      }}
                     >
                       <b>{describeOpenShow(prompt.handoff)}</b>
                       <p>
@@ -222,14 +224,11 @@ export default function StartShow() {
                       {/* Red because it signs somebody else off the air. */}
                       <input
                         type="button"
+                        className="handoff-danger"
                         value="End Existing Show"
                         disabled={deciding}
                         onClick={() => void decide("takeover")}
-                        style={{
-                          cursor: "pointer",
-                          color: "#990000",
-                          fontWeight: "bold",
-                        }}
+                        style={{ cursor: "pointer" }}
                         data-testid="go-live-handoff-takeover"
                       />
                       &nbsp;

--- a/src/components/experiences/modern/flowsheet/GoLive.tsx
+++ b/src/components/experiences/modern/flowsheet/GoLive.tsx
@@ -20,11 +20,29 @@ import {
   Tooltip,
 } from "@mui/joy";
 import { useEffect, useState } from "react";
+import { useGoLiveHandoff } from "@/src/hooks/goLiveHandoffHooks";
+import GoLiveHandoffDialog from "./GoLiveHandoffDialog";
 
 export default function GoLive() {
   const { live, autoplay, setAutoPlay, loading, goLive, leave } =
     useShowControl();
   const isSaving = useFlowsheetSaving();
+  // Prompt state lives here, not in useShowControl — that hook runs in every
+  // entry row, so opening the dialog from there would re-render the table.
+  const { prompt, deciding, requestGoLive, decide, cancel } =
+    useGoLiveHandoff(goLive);
+
+  // Both controls below route through this. The icon button used to carry its
+  // own copy of the toggle, which would have made it a silent bypass of the
+  // handoff prompt — the one path where a DJ can still be attached to somebody
+  // else's show without being asked.
+  const toggle = () => {
+    if (live) {
+      leave();
+      return;
+    }
+    void requestGoLive();
+  };
 
   // Must match the server's markup until this flips true post-mount, or the
   // aria-label/disabled/loading props React hydrates onto these elements
@@ -80,7 +98,7 @@ export default function GoLive() {
         <ButtonGroup>
           <IconButton
             variant="outlined"
-            onClick={() => (live ? leave() : goLive())}
+            onClick={toggle}
             disabled={effectiveLoading}
             data-testid="flowsheet-go-live-button"
           >
@@ -89,7 +107,7 @@ export default function GoLive() {
           <Button
             variant={live ? "solid" : "outlined"}
             color={live ? "primary" : "neutral"}
-            onClick={() => (live ? leave() : goLive())}
+            onClick={toggle}
             disabled={effectiveLoading}
             loading={effectiveLoading}
             data-testid="flowsheet-live-status"
@@ -115,6 +133,12 @@ export default function GoLive() {
           </Button>
         </ButtonGroup>
       </Tooltip>
+      <GoLiveHandoffDialog
+        prompt={prompt}
+        deciding={deciding}
+        onDecide={(intent) => void decide(intent)}
+        onCancel={cancel}
+      />
     </Stack>
   );
 }

--- a/src/components/experiences/modern/flowsheet/GoLiveHandoffDialog.tsx
+++ b/src/components/experiences/modern/flowsheet/GoLiveHandoffDialog.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { describeOpenShow } from "@/lib/features/flowsheet/go-live-handoff";
+import type { GoLivePrompt } from "@/src/hooks/goLiveHandoffHooks";
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Modal,
+  ModalDialog,
+  Stack,
+} from "@mui/joy";
+import type { JoinIntent } from "@/lib/features/flowsheet/go-live-handoff";
+
+export default function GoLiveHandoffDialog({
+  prompt,
+  deciding,
+  onDecide,
+  onCancel,
+}: {
+  prompt: GoLivePrompt | null;
+  deciding: boolean;
+  onDecide: (intent: JoinIntent) => void;
+  onCancel: () => void;
+}) {
+  if (!prompt) return null;
+
+  return (
+    <Modal open onClose={onCancel}>
+      <ModalDialog
+        variant="outlined"
+        role="alertdialog"
+        aria-labelledby="go-live-handoff-title"
+        data-testid="go-live-handoff-dialog"
+        sx={{ maxWidth: 460 }}
+      >
+        <DialogTitle id="go-live-handoff-title">
+          A show is already on air
+        </DialogTitle>
+        <DialogContent>
+          {describeOpenShow(prompt.handoff)}
+          <br />
+          Join them as a co-host, or end their show and start your own.
+        </DialogContent>
+        <DialogActions>
+          <Stack
+            direction={{ xs: "column-reverse", sm: "row" }}
+            spacing={1}
+            sx={{ width: "100%", justifyContent: "flex-end" }}
+          >
+            <Button
+              variant="plain"
+              color="neutral"
+              onClick={onCancel}
+              data-testid="go-live-handoff-cancel"
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="outlined"
+              color="neutral"
+              loading={deciding}
+              onClick={() => onDecide("join")}
+              data-testid="go-live-handoff-join"
+            >
+              Join Existing Show
+            </Button>
+            {/* Destructive on purpose: it signs somebody else off the air. Any
+                DJ may do it — the studio is the authority on who is at the
+                controls — so the colour is the only thing standing between a
+                deliberate handoff and a misread click. */}
+            <Button
+              variant="solid"
+              color="danger"
+              loading={deciding}
+              onClick={() => onDecide("takeover")}
+              data-testid="go-live-handoff-takeover"
+            >
+              End Existing Show
+            </Button>
+          </Stack>
+        </DialogActions>
+      </ModalDialog>
+    </Modal>
+  );
+}

--- a/src/components/experiences/modern/flowsheet/GoLiveHandoffDialog.tsx
+++ b/src/components/experiences/modern/flowsheet/GoLiveHandoffDialog.tsx
@@ -27,7 +27,16 @@ export default function GoLiveHandoffDialog({
   if (!prompt) return null;
 
   return (
-    <Modal open onClose={onCancel}>
+    // Backdrop and Escape are inert while a decision is in flight: the request
+    // is already on the wire, so dismissing would not cancel it — it would
+    // only hide the outcome, and a conflict answer would re-open the dialog
+    // the DJ just dismissed.
+    <Modal
+      open
+      onClose={() => {
+        if (!deciding) onCancel();
+      }}
+    >
       <ModalDialog
         variant="outlined"
         role="alertdialog"
@@ -52,6 +61,7 @@ export default function GoLiveHandoffDialog({
             <Button
               variant="plain"
               color="neutral"
+              disabled={deciding}
               onClick={onCancel}
               data-testid="go-live-handoff-cancel"
             >

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -22,8 +22,15 @@ import {
 } from "@/lib/features/flowsheet/various-artists-guard";
 import {
   compareEntriesNewestFirst,
+  newestRealEntry,
   primaryShowId,
 } from "@/lib/features/flowsheet/infinite-cache";
+import {
+  formatDjNames,
+  readShowAlreadyOpen,
+  type JoinIntent,
+  type OpenShowHandoff,
+} from "@/lib/features/flowsheet/go-live-handoff";
 import { safeCapture } from "@/lib/posthog";
 import { useFlowsheetPollingInterval } from "./useSSEConnection";
 import { partitionFlowsheetEntries } from "@/lib/features/flowsheet/partition";
@@ -108,6 +115,82 @@ export const useLiveStatus = () => {
   return { live, loading: loadingLiveList, userData, userloading };
 };
 
+/** The decision a DJ made at the handoff prompt, forwarded to the server. */
+export type GoLiveDecision = {
+  intent: JoinIntent;
+  expected_show_id?: number;
+};
+
+/** The payload a go-live sent, so a prompt answer can replay it verbatim. */
+export type GoLivePayload = {
+  dj_id: string;
+  dj_name?: string;
+  dj_name_override?: string;
+};
+
+/**
+ * What `goLive` resolved to. Returned rather than parked in the hook: this hook
+ * runs in every entry row, so prompt state living here would re-render the
+ * whole table on every open and close.
+ */
+export type GoLiveOutcome =
+  | { status: "ok" }
+  /** No resolved user yet — nothing was sent. */
+  | { status: "skipped" }
+  | { status: "conflict"; handoff: OpenShowHandoff; payload: GoLivePayload }
+  | { status: "error"; message: string; payload: GoLivePayload };
+
+/**
+ * The open show a "Go Live" would collide with, or null when there is none.
+ *
+ * Null covers both non-collision cases deliberately: nothing is open, or the
+ * caller is already an active member of what is open (a re-pressed toggle,
+ * which the server also no-ops). Prompting in either case would put the dialog
+ * on the ordinary one-click path, and a dialog that fires every shift gets
+ * dismissed reflexively.
+ *
+ * Every value it reads is already being polled, so this adds no request. The
+ * subscription is narrowed to primitives for the same reason `useShowControl`
+ * narrows its own — and this one is deliberately NOT part of `useShowControl`,
+ * which runs per row.
+ */
+export const useOpenShowHandoff = (): OpenShowHandoff | null => {
+  const flowsheetPollingInterval = useFlowsheetPollingInterval();
+  const { live, userData, userloading } = useLiveStatus();
+  const skip = !userData || userloading;
+
+  const { anyoneOnAir, djNames } = useWhoIsLiveQuery(undefined, {
+    skip,
+    pollingInterval: 60000,
+    selectFromResult: ({ data }) => ({
+      anyoneOnAir: (data?.djs?.length ?? 0) > 0,
+      djNames: formatDjNames((data?.djs ?? []).map((dj) => dj.dj_name ?? "")),
+    }),
+  });
+
+  const { showId, lastLoggedAt } = useGetInfiniteEntriesInfiniteQuery(
+    undefined,
+    {
+      skip,
+      pollingInterval: flowsheetPollingInterval,
+      selectFromResult: ({ data, isSuccess }) => {
+        const newest = isSuccess && data ? newestRealEntry(data) : undefined;
+        return {
+          showId: newest?.show_id ?? -1,
+          lastLoggedAt: newest?.add_time ?? null,
+        };
+      },
+    }
+  );
+
+  // A collision needs both halves: somebody else on air, AND a real show id to
+  // bind a takeover to. Without the id the prompt could only offer a blind
+  // "end whatever is open", which is the informed-consent hole the
+  // compare-and-set exists to close.
+  if (!anyoneOnAir || live || showId < 0) return null;
+  return { showId, djNames, lastLoggedAt };
+};
+
 export const useShowControl = () => {
   const flowsheetPollingInterval = useFlowsheetPollingInterval();
 
@@ -146,9 +229,12 @@ export const useShowControl = () => {
     dispatch(flowsheetSlice.actions.setAutoplay(autoplay));
   };
 
-  const goLive = (djNameOverride?: string) => {
+  const goLive = async (
+    djNameOverride?: string,
+    decision?: GoLiveDecision
+  ): Promise<GoLiveOutcome> => {
     if (!userData || userData.id === undefined || userloading) {
-      return;
+      return { status: "skipped" };
     }
     // Tag invalidation from the mutation handles refetching.
     // Only include `dj_name_override` when the caller actually wants to
@@ -170,7 +256,26 @@ export const useShowControl = () => {
     if (djNameOverride !== undefined) {
       payload.dj_name_override = djNameOverride;
     }
-    goLiveFunction(payload);
+    try {
+      await goLiveFunction({ ...payload, ...decision }).unwrap();
+      return { status: "ok" };
+    } catch (err) {
+      // The rejection is returned WITH the payload that produced it, not just
+      // as an error. Answering the prompt re-issues this same request plus a
+      // decision, and the caller cannot reconstruct `dj_name_override` — the
+      // classic surface computes it from a form field against a registry value
+      // read at submit time, so a bare re-call silently drops the handle the DJ
+      // typed, which is that surface's whole reason for existing.
+      const conflict = readShowAlreadyOpen(err);
+      if (conflict) {
+        return { status: "conflict", handoff: conflict, payload };
+      }
+      return {
+        status: "error",
+        message: flowsheetWriteErrorMessage(err),
+        payload,
+      };
+    }
   };
 
   const leave = () => {

--- a/src/hooks/flowsheetHooks.ts
+++ b/src/hooks/flowsheetHooks.ts
@@ -22,12 +22,12 @@ import {
 } from "@/lib/features/flowsheet/various-artists-guard";
 import {
   compareEntriesNewestFirst,
-  newestRealEntry,
+  newestLoggedAt,
   primaryShowId,
 } from "@/lib/features/flowsheet/infinite-cache";
 import {
-  formatDjNames,
   readShowAlreadyOpen,
+  takeoverWasHonored,
   type JoinIntent,
   type OpenShowHandoff,
 } from "@/lib/features/flowsheet/go-live-handoff";
@@ -44,7 +44,7 @@ import {
   isFlowsheetBreakpointEntry,
 } from "@/lib/features/flowsheet/types";
 import type { RootState } from "@/lib/store";
-import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import { useAppDispatch, useAppSelector, useAppStore } from "@/lib/hooks";
 import type { FormEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -121,13 +121,6 @@ export type GoLiveDecision = {
   expected_show_id?: number;
 };
 
-/** The payload a go-live sent, so a prompt answer can replay it verbatim. */
-export type GoLivePayload = {
-  dj_id: string;
-  dj_name?: string;
-  dj_name_override?: string;
-};
-
 /**
  * What `goLive` resolved to. Returned rather than parked in the hook: this hook
  * runs in every entry row, so prompt state living here would re-render the
@@ -137,11 +130,19 @@ export type GoLiveOutcome =
   | { status: "ok" }
   /** No resolved user yet — nothing was sent. */
   | { status: "skipped" }
-  | { status: "conflict"; handoff: OpenShowHandoff; payload: GoLivePayload }
-  | { status: "error"; message: string; payload: GoLivePayload };
+  /**
+   * The DJ asked to end the open show and the server co-hosted them onto it
+   * instead, answering 200. Distinct from "ok" because the DJ is on air but
+   * got the outcome they explicitly declined, and distinct from "error"
+   * because nothing failed.
+   */
+  | { status: "cohosted" }
+  | { status: "conflict"; handoff: OpenShowHandoff }
+  | { status: "error"; message: string };
 
 /**
- * The open show a "Go Live" would collide with, or null when there is none.
+ * Reads the open show a "Go Live" would collide with, at the instant it is
+ * asked — or null when there is none.
  *
  * Null covers both non-collision cases deliberately: nothing is open, or the
  * caller is already an active member of what is open (a re-pressed toggle,
@@ -149,46 +150,46 @@ export type GoLiveOutcome =
  * on the ordinary one-click path, and a dialog that fires every shift gets
  * dismissed reflexively.
  *
- * Every value it reads is already being polled, so this adds no request. The
- * subscription is narrowed to primitives for the same reason `useShowControl`
- * narrows its own — and this one is deliberately NOT part of `useShowControl`,
- * which runs per row.
+ * Returns a reader rather than a value, and opens no subscription of its own.
+ * The answer is consumed in a click handler and never rendered, so subscribing
+ * would tie the Go Live control's render cycle to `lastLoggedAt` — a value that
+ * changes on every row anyone logs — for something no pixel depends on. Reading
+ * at press time is also strictly more accurate: the DJ acts on a snapshot, and
+ * this way the snapshot is taken when they press rather than whenever the last
+ * render happened.
+ *
+ * It reads caches that `useShowControl` already subscribes to in both callers,
+ * so it adds neither a request nor a subscription.
  */
-export const useOpenShowHandoff = (): OpenShowHandoff | null => {
-  const flowsheetPollingInterval = useFlowsheetPollingInterval();
-  const { live, userData, userloading } = useLiveStatus();
-  const skip = !userData || userloading;
+export const useOpenShowHandoff = (): (() => OpenShowHandoff | null) => {
+  const store = useAppStore();
+  const { info: userData } = useRegistry();
+  const userId = userData?.id;
 
-  const { anyoneOnAir, djNames } = useWhoIsLiveQuery(undefined, {
-    skip,
-    pollingInterval: 60000,
-    selectFromResult: ({ data }) => ({
-      anyoneOnAir: (data?.djs?.length ?? 0) > 0,
-      djNames: formatDjNames((data?.djs ?? []).map((dj) => dj.dj_name ?? "")),
-    }),
-  });
+  return useCallback(() => {
+    if (!userId) return null;
+    const state = store.getState();
 
-  const { showId, lastLoggedAt } = useGetInfiniteEntriesInfiniteQuery(
-    undefined,
-    {
-      skip,
-      pollingInterval: flowsheetPollingInterval,
-      selectFromResult: ({ data, isSuccess }) => {
-        const newest = isSuccess && data ? newestRealEntry(data) : undefined;
-        return {
-          showId: newest?.show_id ?? -1,
-          lastLoggedAt: newest?.add_time ?? null,
-        };
-      },
-    }
-  );
+    const djs =
+      flowsheetApi.endpoints.whoIsLive.select(undefined)(state).data?.djs ?? [];
+    // Nobody else on air, or this DJ is already one of them.
+    if (djs.length === 0 || djs.some((dj) => dj.id === userId)) return null;
 
-  // A collision needs both halves: somebody else on air, AND a real show id to
-  // bind a takeover to. Without the id the prompt could only offer a blind
-  // "end whatever is open", which is the informed-consent hole the
-  // compare-and-set exists to close.
-  if (!anyoneOnAir || live || showId < 0) return null;
-  return { showId, djNames, lastLoggedAt };
+    const entries =
+      flowsheetApi.endpoints.getInfiniteEntries.select(undefined)(state).data;
+    // A collision needs both halves: somebody else on air, AND a real show id
+    // to bind a takeover to. Without the id the prompt could only offer a
+    // blind "end whatever is open", which is the informed-consent hole the
+    // compare-and-set exists to close.
+    const showId = entries ? primaryShowId(entries) : -1;
+    if (showId < 0) return null;
+
+    return {
+      showId,
+      djNames: djs.map((dj) => dj.dj_name ?? ""),
+      lastLoggedAt: entries ? newestLoggedAt(entries) : null,
+    };
+  }, [store, userId]);
 };
 
 export const useShowControl = () => {
@@ -257,23 +258,26 @@ export const useShowControl = () => {
       payload.dj_name_override = djNameOverride;
     }
     try {
-      await goLiveFunction({ ...payload, ...decision }).unwrap();
+      const result = await goLiveFunction({ ...payload, ...decision }).unwrap();
+      // A takeover is the one decision the server can decline without saying
+      // so: while its takeover flag is off it ignores `intent` and co-hosts,
+      // answering 200. Reporting that as "ok" would close the prompt on a DJ
+      // who pressed "End Existing Show" and leave them a guest on the very
+      // show they asked to end — the original defect, now confirmed by a
+      // dialog. Only the response body tells the two apart.
+      if (
+        decision?.intent === "takeover" &&
+        !takeoverWasHonored(result, decision.expected_show_id)
+      ) {
+        return { status: "cohosted" };
+      }
       return { status: "ok" };
     } catch (err) {
-      // The rejection is returned WITH the payload that produced it, not just
-      // as an error. Answering the prompt re-issues this same request plus a
-      // decision, and the caller cannot reconstruct `dj_name_override` — the
-      // classic surface computes it from a form field against a registry value
-      // read at submit time, so a bare re-call silently drops the handle the DJ
-      // typed, which is that surface's whole reason for existing.
       const conflict = readShowAlreadyOpen(err);
-      if (conflict) {
-        return { status: "conflict", handoff: conflict, payload };
-      }
+      if (conflict) return { status: "conflict", handoff: conflict };
       return {
         status: "error",
-        message: flowsheetWriteErrorMessage(err),
-        payload,
+        message: flowsheetWriteErrorMessage(err, "Could not go live"),
       };
     }
   };

--- a/src/hooks/goLiveHandoffHooks.ts
+++ b/src/hooks/goLiveHandoffHooks.ts
@@ -12,7 +12,7 @@ import { useOpenShowHandoff } from "./flowsheetHooks";
 
 type GoLiveFn = (
   djNameOverride?: string,
-  decision?: GoLiveDecision
+  decision?: GoLiveDecision,
 ) => Promise<GoLiveOutcome>;
 
 export type GoLivePrompt = {
@@ -65,7 +65,7 @@ export const useGoLiveHandoff = (goLive: GoLiveFn) => {
         toast.error(outcome.message);
       }
     },
-    [prompt, deciding, readOpenShow, goLive]
+    [prompt, deciding, readOpenShow, goLive],
   );
 
   const decide = useCallback(
@@ -100,15 +100,19 @@ export const useGoLiveHandoff = (goLive: GoLiveFn) => {
       // — this is the one outcome they explicitly declined, and the show they
       // wanted closed is still open.
       if (outcome.status === "cohosted") {
+        // Lead with being on air: that is the part the DJ most needs, and it
+        // is true. The possessive is load-bearing — `formatDjNames` can return
+        // several names, and any phrasing that puts them in subject position
+        // needs a verb agreement a template string cannot express.
         toast.error(
-          `Could not end the open show. You joined ${formatDjNames(
-            prompt.handoff.djNames
-          )} as a co-host instead.`
+          `You're on air as a co-host of ${formatDjNames(
+            prompt.handoff.djNames,
+          )}'s show. Ending another DJ's show isn't available yet, so your tracks will log under theirs.`,
         );
       }
       setPrompt(null);
     },
-    [prompt, deciding, goLive]
+    [prompt, deciding, goLive],
   );
 
   const cancel = useCallback(() => setPrompt(null), []);

--- a/src/hooks/goLiveHandoffHooks.ts
+++ b/src/hooks/goLiveHandoffHooks.ts
@@ -1,17 +1,18 @@
 "use client";
 
-import type {
-  JoinIntent,
-  OpenShowHandoff,
+import {
+  formatDjNames,
+  type JoinIntent,
+  type OpenShowHandoff,
 } from "@/lib/features/flowsheet/go-live-handoff";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
-import type { GoLiveOutcome } from "./flowsheetHooks";
+import type { GoLiveDecision, GoLiveOutcome } from "./flowsheetHooks";
 import { useOpenShowHandoff } from "./flowsheetHooks";
 
 type GoLiveFn = (
   djNameOverride?: string,
-  decision?: { intent: JoinIntent; expected_show_id?: number }
+  decision?: GoLiveDecision
 ) => Promise<GoLiveOutcome>;
 
 export type GoLivePrompt = {
@@ -39,12 +40,20 @@ export type GoLivePrompt = {
  * server's own refusal is the backstop for the window where the two disagree.
  */
 export const useGoLiveHandoff = (goLive: GoLiveFn) => {
-  const openShow = useOpenShowHandoff();
+  const readOpenShow = useOpenShowHandoff();
   const [prompt, setPrompt] = useState<GoLivePrompt | null>(null);
   const [deciding, setDeciding] = useState(false);
 
   const requestGoLive = useCallback(
     async (djNameOverride?: string) => {
+      // Classic renders its prompt inline and leaves the submit button live, so
+      // without this a DJ can fire a second, UNDECIDED join while a decided one
+      // is still in flight. On modern the Joy backdrop happens to prevent it —
+      // the guarantee belongs to the shared hook, not to one surface's markup.
+      if (prompt || deciding) return;
+      // Read at press time, not at render time: the DJ acts on a snapshot, and
+      // this is the freshest one available without a round trip.
+      const openShow = readOpenShow();
       if (openShow) {
         setPrompt({ handoff: openShow, djNameOverride });
         return;
@@ -56,7 +65,7 @@ export const useGoLiveHandoff = (goLive: GoLiveFn) => {
         toast.error(outcome.message);
       }
     },
-    [openShow, goLive]
+    [prompt, deciding, readOpenShow, goLive]
   );
 
   const decide = useCallback(
@@ -82,7 +91,21 @@ export const useGoLiveHandoff = (goLive: GoLiveFn) => {
         });
         return;
       }
+      // Nothing was sent (no resolved user yet), so nothing was decided.
+      // Closing here would reproduce the dead end this prompt exists to remove.
+      if (outcome.status === "skipped") return;
+
       if (outcome.status === "error") toast.error(outcome.message);
+      // The DJ is on air, but as a guest on the show they asked to end. Say so
+      // — this is the one outcome they explicitly declined, and the show they
+      // wanted closed is still open.
+      if (outcome.status === "cohosted") {
+        toast.error(
+          `Could not end the open show. You joined ${formatDjNames(
+            prompt.handoff.djNames
+          )} as a co-host instead.`
+        );
+      }
       setPrompt(null);
     },
     [prompt, deciding, goLive]

--- a/src/hooks/goLiveHandoffHooks.ts
+++ b/src/hooks/goLiveHandoffHooks.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import type {
+  JoinIntent,
+  OpenShowHandoff,
+} from "@/lib/features/flowsheet/go-live-handoff";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import type { GoLiveOutcome } from "./flowsheetHooks";
+import { useOpenShowHandoff } from "./flowsheetHooks";
+
+type GoLiveFn = (
+  djNameOverride?: string,
+  decision?: { intent: JoinIntent; expected_show_id?: number }
+) => Promise<GoLiveOutcome>;
+
+export type GoLivePrompt = {
+  handoff: OpenShowHandoff;
+  /**
+   * The per-show handle the DJ typed before pressing the button, replayed
+   * verbatim on whichever answer they give. Everything else in the request is
+   * re-derived from the registry, so the override is the only value that can be
+   * lost — and on the classic surface it is the entire point of the form.
+   */
+  djNameOverride?: string;
+};
+
+/**
+ * Shared state machine behind the go-live handoff prompt, so the two surfaces
+ * that can start a show render the same decision rather than two versions of it.
+ *
+ * Takes `goLive` from the caller's own `useShowControl()` instead of calling it
+ * again — both consumers already hold one, and a second call would open a
+ * duplicate subscription to the paginated entries query for nothing.
+ *
+ * The prompt opens from either of two signals, and the ordinary one costs no
+ * request at all: the client already polls who is on air, so a handoff is
+ * visible before anything is sent, and cancelling therefore sends nothing. The
+ * server's own refusal is the backstop for the window where the two disagree.
+ */
+export const useGoLiveHandoff = (goLive: GoLiveFn) => {
+  const openShow = useOpenShowHandoff();
+  const [prompt, setPrompt] = useState<GoLivePrompt | null>(null);
+  const [deciding, setDeciding] = useState(false);
+
+  const requestGoLive = useCallback(
+    async (djNameOverride?: string) => {
+      if (openShow) {
+        setPrompt({ handoff: openShow, djNameOverride });
+        return;
+      }
+      const outcome = await goLive(djNameOverride);
+      if (outcome.status === "conflict") {
+        setPrompt({ handoff: outcome.handoff, djNameOverride });
+      } else if (outcome.status === "error") {
+        toast.error(outcome.message);
+      }
+    },
+    [openShow, goLive]
+  );
+
+  const decide = useCallback(
+    async (intent: JoinIntent) => {
+      if (!prompt || deciding) return;
+      setDeciding(true);
+      const outcome = await goLive(prompt.djNameOverride, {
+        intent,
+        // Only a takeover names a show to close; a co-host join is happy to
+        // land on whatever is open.
+        expected_show_id:
+          intent === "takeover" ? prompt.handoff.showId : undefined,
+      });
+      setDeciding(false);
+
+      // The show moved on between the prompt and the click. Re-prompt with the
+      // server's fresh answer rather than closing: the DJ asked to end a
+      // specific show, and nothing was ended.
+      if (outcome.status === "conflict") {
+        setPrompt({
+          handoff: outcome.handoff,
+          djNameOverride: prompt.djNameOverride,
+        });
+        return;
+      }
+      if (outcome.status === "error") toast.error(outcome.message);
+      setPrompt(null);
+    },
+    [prompt, deciding, goLive]
+  );
+
+  const cancel = useCallback(() => setPrompt(null), []);
+
+  return { prompt, deciding, requestGoLive, decide, cancel };
+};

--- a/src/styles/classic/wxyc.css
+++ b/src/styles/classic/wxyc.css
@@ -565,6 +565,31 @@ html[data-experience="classic"][data-joy-color-scheme="dark"] .artist-error-mess
 	border-color: #A33;
 }
 
+/* Go-live handoff prompt: shown in place when a DJ signs on while someone
+   else's show is still open. Deliberately not .artist-error-message — that one
+   is field-scoped to a 300px input, and this carries a sentence plus three
+   choices. Red because one of those choices signs somebody else off the air. */
+.go-live-handoff-prompt {
+	border: 2px solid #990000;
+	padding: 10px;
+	margin: 0 auto;
+	max-width: 28em;
+}
+
+.go-live-handoff-prompt .handoff-danger {
+	color: #990000;
+	font-weight: bold;
+}
+
+html[data-experience="classic"][data-joy-color-scheme="dark"] .go-live-handoff-prompt {
+	background-color: #3A1D1D;
+	border-color: #A33;
+}
+
+html[data-experience="classic"][data-joy-color-scheme="dark"] .go-live-handoff-prompt .handoff-danger {
+	color: #FF8A8A;
+}
+
 /* ========== wxycdb page bits ========== */
 
 ul {

--- a/tests/integration/components/classic/flowsheet/StartShow.test.tsx
+++ b/tests/integration/components/classic/flowsheet/StartShow.test.tsx
@@ -5,15 +5,23 @@ import { renderWithProviders } from "@/tests/helpers/render";
 // Mock useShowControl().goLive — we only care that StartShow forwards the
 // trimmed Public DJ Handle as the second arg (the override) when the user
 // edits it, and omits it when unchanged.
-const goLiveMock = vi.fn();
+const goLiveMock = vi.fn(() => Promise.resolve({ status: "ok" as const }));
 let userInfoMock: { id: string; real_name?: string; dj_name?: string } | null = {
   id: "test-user-1",
   real_name: "Maura Partrick",
   dj_name: "Anonymous",
 };
+// Nothing else on air by default, so the ordinary submit reaches goLive
+// directly; the handoff cases below set an open show.
+let openShowMock: {
+  showId: number;
+  djNames: string;
+  lastLoggedAt: string | null;
+} | null = null;
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
   useShowControl: () => ({ goLive: goLiveMock }),
+  useOpenShowHandoff: () => openShowMock,
 }));
 
 vi.mock("@/src/hooks/authenticationHooks", () => ({
@@ -44,6 +52,8 @@ function submitForm() {
 
 beforeEach(() => {
   goLiveMock.mockReset();
+  goLiveMock.mockResolvedValue({ status: "ok" as const });
+  openShowMock = null;
   userInfoMock = {
     id: "test-user-1",
     real_name: "Maura Partrick",
@@ -211,5 +221,87 @@ describe("Classic StartShow — out-of-scope fields stay disabled (#694)", () =>
       'input[type="reset"]'
     ) as HTMLInputElement | null;
     expect(reset?.disabled).toBe(true);
+  });
+});
+
+describe("Classic StartShow — the handoff prompt", () => {
+  const OPEN_SHOW = {
+    showId: 1951224,
+    djNames: "dj sue",
+    lastLoggedAt: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+  };
+
+  const signOn = async () => {
+    renderWithProviders(<StartShow />);
+    submitForm();
+    await screen.findByTestId("go-live-handoff-prompt");
+  };
+
+  it("names who is on air and how long ago they logged, instead of sending a blind join", async () => {
+    openShowMock = OPEN_SHOW;
+    await signOn();
+
+    expect(screen.getByText(/dj sue is on air\. Last logged 5h 0m ago\./)).toBeInTheDocument();
+    // The whole point of asking first: nothing was sent, so cancelling costs
+    // the DJ nothing and the outgoing DJ's show is untouched.
+    expect(goLiveMock).not.toHaveBeenCalled();
+  });
+
+  it("sends a co-host join when the DJ picks Join Existing Show", async () => {
+    openShowMock = OPEN_SHOW;
+    await signOn();
+    fireEvent.click(screen.getByTestId("go-live-handoff-join"));
+
+    expect(goLiveMock).toHaveBeenCalledWith(undefined, {
+      intent: "join",
+      expected_show_id: undefined,
+    });
+  });
+
+  it("binds End Existing Show to the show the DJ was actually shown", async () => {
+    openShowMock = OPEN_SHOW;
+    await signOn();
+    fireEvent.click(screen.getByTestId("go-live-handoff-takeover"));
+
+    expect(goLiveMock).toHaveBeenCalledWith(undefined, {
+      intent: "takeover",
+      expected_show_id: 1951224,
+    });
+  });
+
+  it("sends nothing at all on Cancel", async () => {
+    openShowMock = OPEN_SHOW;
+    await signOn();
+    fireEvent.click(screen.getByTestId("go-live-handoff-cancel"));
+
+    expect(goLiveMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("go-live-handoff-prompt")).toBeNull();
+  });
+
+  // The handle typed into this form is the surface's whole reason for
+  // existing; re-deriving it after the prompt would silently drop it.
+  it("replays the typed Public DJ Handle through the prompt", async () => {
+    openShowMock = OPEN_SHOW;
+    renderWithProviders(<StartShow />);
+    fireEvent.change(getNamedInput("djHandle"), {
+      target: { value: "eureka!" },
+    });
+    submitForm();
+    await screen.findByTestId("go-live-handoff-prompt");
+    fireEvent.click(screen.getByTestId("go-live-handoff-takeover"));
+
+    expect(goLiveMock).toHaveBeenCalledWith("eureka!", {
+      intent: "takeover",
+      expected_show_id: 1951224,
+    });
+  });
+
+  it("does not prompt when nothing is on air", async () => {
+    openShowMock = null;
+    renderWithProviders(<StartShow />);
+    submitForm();
+
+    expect(screen.queryByTestId("go-live-handoff-prompt")).toBeNull();
+    expect(goLiveMock).toHaveBeenCalledWith(undefined);
   });
 });

--- a/tests/integration/components/classic/flowsheet/StartShow.test.tsx
+++ b/tests/integration/components/classic/flowsheet/StartShow.test.tsx
@@ -15,13 +15,14 @@ let userInfoMock: { id: string; real_name?: string; dj_name?: string } | null = 
 // directly; the handoff cases below set an open show.
 let openShowMock: {
   showId: number;
-  djNames: string;
+  djNames: readonly string[];
   lastLoggedAt: string | null;
 } | null = null;
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
   useShowControl: () => ({ goLive: goLiveMock }),
-  useOpenShowHandoff: () => openShowMock,
+  // Returns a reader: the real hook is read in the click handler, not rendered.
+  useOpenShowHandoff: () => () => openShowMock,
 }));
 
 vi.mock("@/src/hooks/authenticationHooks", () => ({
@@ -227,7 +228,7 @@ describe("Classic StartShow — out-of-scope fields stay disabled (#694)", () =>
 describe("Classic StartShow — the handoff prompt", () => {
   const OPEN_SHOW = {
     showId: 1951224,
-    djNames: "dj sue",
+    djNames: ["dj sue"],
     lastLoggedAt: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
   };
 

--- a/tests/integration/components/modern/flowsheet/GoLive.test.tsx
+++ b/tests/integration/components/modern/flowsheet/GoLive.test.tsx
@@ -4,6 +4,11 @@ import { renderToString } from "react-dom/server";
 import { hydrateRoot } from "react-dom/client";
 import GoLive from "@/src/components/experiences/modern/flowsheet/GoLive";
 
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: { error: (...a: unknown[]) => toastError(...a) },
+}));
+
 // Mock flowsheet hooks
 const mockGoLive = vi.fn(() => Promise.resolve({ status: "ok" as const }));
 const mockLeave = vi.fn();
@@ -12,7 +17,11 @@ const mockUseFlowsheetSaving = vi.fn(() => false);
 // Nothing on air but this DJ, so the toggle reaches goLive directly. The
 // handoff cases below install an open show.
 const mockUseOpenShowHandoff = vi.fn<
-  () => { showId: number; djNames: string; lastLoggedAt: string | null } | null
+  () => {
+    showId: number;
+    djNames: readonly string[];
+    lastLoggedAt: string | null;
+  } | null
 >(() => null);
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
@@ -25,7 +34,8 @@ vi.mock("@/src/hooks/flowsheetHooks", () => ({
     goLive: mockGoLive,
     leave: mockLeave,
   })),
-  useOpenShowHandoff: () => mockUseOpenShowHandoff(),
+  // Returns a reader: the real hook is read in the click handler, not rendered.
+  useOpenShowHandoff: () => () => mockUseOpenShowHandoff(),
   useFlowsheetSaving: () => mockUseFlowsheetSaving(),
 }));
 
@@ -245,7 +255,7 @@ describe("GoLive", () => {
   describe("the handoff prompt", () => {
     const OPEN_SHOW = {
       showId: 1951224,
-      djNames: "dj sue",
+      djNames: ["dj sue"],
       lastLoggedAt: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
     };
 
@@ -334,8 +344,11 @@ describe("GoLive", () => {
       mockUseOpenShowHandoff.mockReturnValue(null);
       mockGoLive.mockResolvedValue({
         status: "conflict",
-        handoff: { showId: 1951224, djNames: "dj sue", lastLoggedAt: null },
-        payload: { dj_id: "u1" },
+        handoff: {
+          showId: 1951224,
+          djNames: ["dj sue"],
+          lastLoggedAt: null,
+        },
       } as never);
       render(<GoLive />);
 
@@ -343,6 +356,48 @@ describe("GoLive", () => {
 
       await screen.findByTestId("go-live-handoff-dialog");
       expect(screen.getByText(/dj sue is on air\./)).toBeInTheDocument();
+    });
+
+    // The server may decline a takeover silently — while its takeover flag is
+    // off it ignores `intent` and co-hosts, answering 200. Closing the prompt
+    // without a word would leave the DJ a guest on the show they just asked to
+    // end, confirmed by a dialog that lied.
+    it("says so when the server co-hosts instead of ending the show", async () => {
+      mockUseOpenShowHandoff.mockReturnValue(OPEN_SHOW);
+      mockGoLive.mockResolvedValue({ status: "cohosted" } as never);
+      render(<GoLive />);
+      await openPrompt(goLiveControls().icon);
+
+      fireEvent.click(screen.getByTestId("go-live-handoff-takeover"));
+
+      await waitFor(() =>
+        expect(toastError).toHaveBeenCalledWith(
+          "Could not end the open show. You joined dj sue as a co-host instead."
+        )
+      );
+    });
+
+    // The request is already on the wire, so dismissing cannot cancel it —
+    // it would only hide the outcome.
+    it("keeps Cancel inert while a decision is in flight", async () => {
+      mockUseOpenShowHandoff.mockReturnValue(OPEN_SHOW);
+      let settle: (v: unknown) => void = () => {};
+      mockGoLive.mockReturnValue(
+        new Promise((resolve) => {
+          settle = resolve;
+        }) as never
+      );
+      render(<GoLive />);
+      await openPrompt(goLiveControls().icon);
+
+      fireEvent.click(screen.getByTestId("go-live-handoff-takeover"));
+
+      await waitFor(() =>
+        expect(screen.getByTestId("go-live-handoff-cancel")).toBeDisabled()
+      );
+      await act(async () => {
+        settle({ status: "ok" });
+      });
     });
   });
 

--- a/tests/integration/components/modern/flowsheet/GoLive.test.tsx
+++ b/tests/integration/components/modern/flowsheet/GoLive.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+} from "@testing-library/react";
 import { renderToString } from "react-dom/server";
 import { hydrateRoot } from "react-dom/client";
 import GoLive from "@/src/components/experiences/modern/flowsheet/GoLive";
@@ -193,7 +199,7 @@ describe("GoLive", () => {
       // `disabled` attribute, so that's what a divergent `loading` prop
       // would show up as in the server markup.
       expect(serverHtml).toMatch(
-        /data-testid="flowsheet-go-live-button"[^>]*class="[^"]*\bMui-disabled\b/
+        /data-testid="flowsheet-go-live-button"[^>]*class="[^"]*\bMui-disabled\b/,
       );
 
       const container = document.createElement("div");
@@ -211,22 +217,22 @@ describe("GoLive", () => {
       // context, so match a `+`/`-` diff line, not any mention of the name.
       const ariaLabelMismatchLogged = errorSpy.mock.calls.some((call) =>
         call.some(
-          (arg) => typeof arg === "string" && /^[+-]\s*aria-label=/m.test(arg)
-        )
+          (arg) => typeof arg === "string" && /^[+-]\s*aria-label=/m.test(arg),
+        ),
       );
       expect(ariaLabelMismatchLogged).toBe(false);
       // disabled/loading render as class="…Mui-disabled…" / "…Mui-loading…",
       // so a diverging `loading` prop shows up as a `className` diff line.
       const classNameMismatchLogged = errorSpy.mock.calls.some((call) =>
         call.some(
-          (arg) => typeof arg === "string" && /^[+-]\s*className=/m.test(arg)
-        )
+          (arg) => typeof arg === "string" && /^[+-]\s*className=/m.test(arg),
+        ),
       );
       expect(classNameMismatchLogged).toBe(false);
       errorSpy.mockRestore();
 
       const goLiveButton = container.querySelector(
-        '[data-testid="flowsheet-go-live-button"]'
+        '[data-testid="flowsheet-go-live-button"]',
       );
       const buttonGroup = container.querySelector('[role="group"]');
       await waitFor(() => {
@@ -281,10 +287,10 @@ describe("GoLive", () => {
         await openPrompt(goLiveControls()[control]);
 
         expect(
-          screen.getByText(/dj sue is on air\. Last logged 5h 0m ago\./)
+          screen.getByText(/dj sue is on air\. Last logged 5h 0m ago\./),
         ).toBeInTheDocument();
         expect(mockGoLive).not.toHaveBeenCalled();
-      }
+      },
     );
 
     it("sends a co-host join from Join Existing Show", async () => {
@@ -321,7 +327,7 @@ describe("GoLive", () => {
       fireEvent.click(screen.getByTestId("go-live-handoff-cancel"));
 
       await waitFor(() =>
-        expect(screen.queryByTestId("go-live-handoff-dialog")).toBeNull()
+        expect(screen.queryByTestId("go-live-handoff-dialog")).toBeNull(),
       );
       expect(mockGoLive).not.toHaveBeenCalled();
     });
@@ -372,8 +378,9 @@ describe("GoLive", () => {
 
       await waitFor(() =>
         expect(toastError).toHaveBeenCalledWith(
-          "Could not end the open show. You joined dj sue as a co-host instead."
-        )
+          "You're on air as a co-host of dj sue's show. Ending another DJ's show isn't available yet, " +
+            "so your tracks will log under theirs.",
+        ),
       );
     });
 
@@ -385,7 +392,7 @@ describe("GoLive", () => {
       mockGoLive.mockReturnValue(
         new Promise((resolve) => {
           settle = resolve;
-        }) as never
+        }) as never,
       );
       render(<GoLive />);
       await openPrompt(goLiveControls().icon);
@@ -393,7 +400,7 @@ describe("GoLive", () => {
       fireEvent.click(screen.getByTestId("go-live-handoff-takeover"));
 
       await waitFor(() =>
-        expect(screen.getByTestId("go-live-handoff-cancel")).toBeDisabled()
+        expect(screen.getByTestId("go-live-handoff-cancel")).toBeDisabled(),
       );
       await act(async () => {
         settle({ status: "ok" });

--- a/tests/integration/components/modern/flowsheet/GoLive.test.tsx
+++ b/tests/integration/components/modern/flowsheet/GoLive.test.tsx
@@ -5,10 +5,15 @@ import { hydrateRoot } from "react-dom/client";
 import GoLive from "@/src/components/experiences/modern/flowsheet/GoLive";
 
 // Mock flowsheet hooks
-const mockGoLive = vi.fn();
+const mockGoLive = vi.fn(() => Promise.resolve({ status: "ok" as const }));
 const mockLeave = vi.fn();
 const mockSetAutoPlay = vi.fn();
 const mockUseFlowsheetSaving = vi.fn(() => false);
+// Nothing on air but this DJ, so the toggle reaches goLive directly. The
+// handoff cases below install an open show.
+const mockUseOpenShowHandoff = vi.fn<
+  () => { showId: number; djNames: string; lastLoggedAt: string | null } | null
+>(() => null);
 
 vi.mock("@/src/hooks/flowsheetHooks", () => ({
   useShowControl: vi.fn(() => ({
@@ -20,12 +25,15 @@ vi.mock("@/src/hooks/flowsheetHooks", () => ({
     goLive: mockGoLive,
     leave: mockLeave,
   })),
+  useOpenShowHandoff: () => mockUseOpenShowHandoff(),
   useFlowsheetSaving: () => mockUseFlowsheetSaving(),
 }));
 
 describe("GoLive", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGoLive.mockResolvedValue({ status: "ok" as const });
+    mockUseOpenShowHandoff.mockReturnValue(null);
   });
 
   it("should render when not live", () => {
@@ -232,6 +240,110 @@ describe("GoLive", () => {
     const dot = statusButton.lastElementChild;
     expect(dot).not.toBeNull();
     expect(dot).toHaveStyle({ flexShrink: "0" });
+  });
+
+  describe("the handoff prompt", () => {
+    const OPEN_SHOW = {
+      showId: 1951224,
+      djNames: "dj sue",
+      lastLoggedAt: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+    };
+
+    const openPrompt = async (control: HTMLElement) => {
+      fireEvent.click(control);
+      return screen.findByTestId("go-live-handoff-dialog");
+    };
+
+    const goLiveControls = () => ({
+      icon: screen.getByTestId("flowsheet-go-live-button"),
+      status: screen.getByTestId("flowsheet-live-status"),
+    });
+
+    // Both controls, because the icon button carried its own copy of the
+    // toggle: leaving it unrouted would make it a silent bypass of the whole
+    // decision.
+    it.each(["icon", "status"] as const)(
+      "prompts instead of joining blindly when pressed via the %s control",
+      async (control) => {
+        mockUseOpenShowHandoff.mockReturnValue(OPEN_SHOW);
+        render(<GoLive />);
+
+        await openPrompt(goLiveControls()[control]);
+
+        expect(
+          screen.getByText(/dj sue is on air\. Last logged 5h 0m ago\./)
+        ).toBeInTheDocument();
+        expect(mockGoLive).not.toHaveBeenCalled();
+      }
+    );
+
+    it("sends a co-host join from Join Existing Show", async () => {
+      mockUseOpenShowHandoff.mockReturnValue(OPEN_SHOW);
+      render(<GoLive />);
+      await openPrompt(goLiveControls().icon);
+
+      fireEvent.click(screen.getByTestId("go-live-handoff-join"));
+
+      expect(mockGoLive).toHaveBeenCalledWith(undefined, {
+        intent: "join",
+        expected_show_id: undefined,
+      });
+    });
+
+    it("binds End Existing Show to the show the DJ was shown", async () => {
+      mockUseOpenShowHandoff.mockReturnValue(OPEN_SHOW);
+      render(<GoLive />);
+      await openPrompt(goLiveControls().icon);
+
+      fireEvent.click(screen.getByTestId("go-live-handoff-takeover"));
+
+      expect(mockGoLive).toHaveBeenCalledWith(undefined, {
+        intent: "takeover",
+        expected_show_id: 1951224,
+      });
+    });
+
+    it("sends nothing at all on Cancel", async () => {
+      mockUseOpenShowHandoff.mockReturnValue(OPEN_SHOW);
+      render(<GoLive />);
+      await openPrompt(goLiveControls().icon);
+
+      fireEvent.click(screen.getByTestId("go-live-handoff-cancel"));
+
+      await waitFor(() =>
+        expect(screen.queryByTestId("go-live-handoff-dialog")).toBeNull()
+      );
+      expect(mockGoLive).not.toHaveBeenCalled();
+    });
+
+    // A DJ re-pressing their own toggle, or arriving at an empty slot, must
+    // stay one click. A dialog that fires every shift gets dismissed reflexively.
+    it("stays a single click when nobody else is on air", async () => {
+      mockUseOpenShowHandoff.mockReturnValue(null);
+      render(<GoLive />);
+
+      fireEvent.click(goLiveControls().icon);
+
+      expect(mockGoLive).toHaveBeenCalledWith(undefined);
+      expect(screen.queryByTestId("go-live-handoff-dialog")).toBeNull();
+    });
+
+    // The server is the backstop for the window where the client's poll and
+    // the truth disagree.
+    it("opens the prompt on the server's own refusal", async () => {
+      mockUseOpenShowHandoff.mockReturnValue(null);
+      mockGoLive.mockResolvedValue({
+        status: "conflict",
+        handoff: { showId: 1951224, djNames: "dj sue", lastLoggedAt: null },
+        payload: { dj_id: "u1" },
+      } as never);
+      render(<GoLive />);
+
+      fireEvent.click(goLiveControls().icon);
+
+      await screen.findByTestId("go-live-handoff-dialog");
+      expect(screen.getByText(/dj sue is on air\./)).toBeInTheDocument();
+    });
   });
 
   it("should show saving indicator when isSaving", async () => {

--- a/tests/unit/lib/features/flowsheet/go-live-handoff.test.ts
+++ b/tests/unit/lib/features/flowsheet/go-live-handoff.test.ts
@@ -4,6 +4,7 @@ import {
   formatDjNames,
   formatElapsedSince,
   readShowAlreadyOpen,
+  takeoverWasHonored,
 } from "@/lib/features/flowsheet/go-live-handoff";
 
 const NOW = new Date("2026-08-28T20:00:00.000Z").getTime();
@@ -31,7 +32,7 @@ describe("readShowAlreadyOpen", () => {
   it("reads the open show's id and name off the refusal", () => {
     expect(readShowAlreadyOpen(conflict)).toEqual({
       showId: 1951224,
-      djNames: "dj sue",
+      djNames: ["dj sue"],
       lastLoggedAt: null,
     });
   });
@@ -42,7 +43,7 @@ describe("readShowAlreadyOpen", () => {
   it("reads the wrapped rejection queryFulfilled produces", () => {
     expect(readShowAlreadyOpen({ error: conflict, meta: {} })).toEqual({
       showId: 1951224,
-      djNames: "dj sue",
+      djNames: ["dj sue"],
       lastLoggedAt: null,
     });
   });
@@ -70,9 +71,9 @@ describe("readShowAlreadyOpen", () => {
     expect(readShowAlreadyOpen(err)).toBeNull();
   });
 
-  // A show whose name the chain can't resolve still has to be nameable in a
-  // sentence; "Someone is on air" beats " is on air".
-  it("falls back to a placeholder when the name is blank", () => {
+  // A show whose name the chain can't resolve names nobody, and the sentence
+  // supplies the placeholder at render: "Someone is on air" beats " is on air".
+  it("names nobody when the name is blank, and still reads as a sentence", () => {
     const blank = {
       status: 409,
       data: {
@@ -80,7 +81,9 @@ describe("readShowAlreadyOpen", () => {
         details: { show: { id: 7, dj_name: "   " } },
       },
     };
-    expect(readShowAlreadyOpen(blank)?.djNames).toBe("Someone");
+    const handoff = readShowAlreadyOpen(blank);
+    expect(handoff?.djNames).toEqual([]);
+    expect(describeOpenShow(handoff!, NOW)).toBe("Someone is on air.");
   });
 });
 
@@ -127,7 +130,11 @@ describe("describeOpenShow", () => {
   it("leads with the elapsed time, which is what the DJ is actually deciding on", () => {
     expect(
       describeOpenShow(
-        { showId: 1, djNames: "dj sue", lastLoggedAt: ago(5 * HOUR + 12 * MINUTE) },
+        {
+          showId: 1,
+          djNames: ["dj sue"],
+          lastLoggedAt: ago(5 * HOUR + 12 * MINUTE),
+        },
         NOW
       )
     ).toBe("dj sue is on air. Last logged 5h 12m ago.");
@@ -135,7 +142,10 @@ describe("describeOpenShow", () => {
 
   it("reads very differently for a show that is plainly still running", () => {
     expect(
-      describeOpenShow({ showId: 1, djNames: "dj sue", lastLoggedAt: ago(2 * MINUTE) }, NOW)
+      describeOpenShow(
+        { showId: 1, djNames: ["dj sue"], lastLoggedAt: ago(2 * MINUTE) },
+        NOW
+      )
     ).toBe("dj sue is on air. Last logged 2m ago.");
   });
 
@@ -144,7 +154,65 @@ describe("describeOpenShow", () => {
   // rather than inventing a reading of it.
   it("drops the elapsed clause rather than guessing when the timestamp is unknown", () => {
     expect(
-      describeOpenShow({ showId: 1, djNames: "dj sue", lastLoggedAt: null }, NOW)
+      describeOpenShow(
+        { showId: 1, djNames: ["dj sue"], lastLoggedAt: null },
+        NOW
+      )
     ).toBe("dj sue is on air.");
+  });
+
+  // Subject and verb come from one filtered list. Counting the raw array
+  // instead would render "dj sue are on air" for a co-host with a blank handle.
+  it("ignores blank handles when choosing the verb", () => {
+    expect(
+      describeOpenShow(
+        { showId: 1, djNames: ["dj sue", "  "], lastLoggedAt: null },
+        NOW
+      )
+    ).toBe("dj sue is on air.");
+  });
+
+  // The abandoned show this feature exists for is exactly the one that
+  // collects several DJs, so the plural is not a rare path.
+  it("agrees with a plural subject", () => {
+    expect(
+      describeOpenShow(
+        {
+          showId: 1,
+          djNames: ["dj sue", "eureka!", "DJ boy"],
+          lastLoggedAt: ago(5 * HOUR),
+        },
+        NOW
+      )
+    ).toBe("dj sue, eureka! and DJ boy are on air. Last logged 5h 0m ago.");
+  });
+});
+
+/**
+ * The server may decline a takeover without saying so: while its takeover flag
+ * is off it ignores `intent` and co-hosts, answering 200 with the membership
+ * row instead of a new show. Only the body's shape separates the two, and
+ * reading it wrong is what lets "End Existing Show" attach a DJ to the show
+ * they asked to end.
+ */
+describe("takeoverWasHonored", () => {
+  const ENDED = 1951224;
+
+  it("reads a newly started show as honoured", () => {
+    expect(takeoverWasHonored({ id: 1951225 }, ENDED)).toBe(true);
+  });
+
+  // The day the server answers a co-host join with the joined show, presence
+  // of an `id` stops discriminating — but its identity still does.
+  it("reads the show it was asked to end as NOT honoured", () => {
+    expect(takeoverWasHonored({ id: ENDED }, ENDED)).toBe(false);
+  });
+
+  it.each([
+    ["a co-host membership row", { show_id: ENDED, dj_id: "dj-eureka" }],
+    ["an empty body", {}],
+    ["no body at all", undefined],
+  ])("reads %s as not honoured", (_label, body) => {
+    expect(takeoverWasHonored(body, ENDED)).toBe(false);
   });
 });

--- a/tests/unit/lib/features/flowsheet/go-live-handoff.test.ts
+++ b/tests/unit/lib/features/flowsheet/go-live-handoff.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import {
+  describeOpenShow,
+  formatDjNames,
+  formatElapsedSince,
+  readShowAlreadyOpen,
+} from "@/lib/features/flowsheet/go-live-handoff";
+
+const NOW = new Date("2026-08-28T20:00:00.000Z").getTime();
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+
+describe("readShowAlreadyOpen", () => {
+  const conflict = {
+    status: 409,
+    data: {
+      message: "A show is already on air",
+      code: "show_already_open",
+      details: {
+        show: {
+          id: 1951224,
+          dj_name: "dj sue",
+          start_time: "2026-08-28T15:00:00.000Z",
+        },
+      },
+    },
+  };
+
+  it("reads the open show's id and name off the refusal", () => {
+    expect(readShowAlreadyOpen(conflict)).toEqual({
+      showId: 1951224,
+      djNames: "dj sue",
+      lastLoggedAt: null,
+    });
+  });
+
+  // RTK Query rejects with the bare shape from `.unwrap()` and a wrapped one
+  // from `queryFulfilled`. Both reach this reader; missing the wrapped form
+  // would mis-classify every refusal seen from the cache-patch side.
+  it("reads the wrapped rejection queryFulfilled produces", () => {
+    expect(readShowAlreadyOpen({ error: conflict, meta: {} })).toEqual({
+      showId: 1951224,
+      djNames: "dj sue",
+      lastLoggedAt: null,
+    });
+  });
+
+  // The status alone is not the discriminant: force-end reports an unrelated
+  // refusal with the same 409, and putting the handoff prompt in front of a DJ
+  // over that would be worse than saying nothing.
+  it("ignores a 409 that is not show_already_open", () => {
+    expect(
+      readShowAlreadyOpen({
+        status: 409,
+        data: { message: "…", code: "current_show_requires_force" },
+      })
+    ).toBeNull();
+  });
+
+  it.each([
+    ["a non-409 status", { status: 400, data: { code: "show_already_open" } }],
+    ["a missing body", { status: 409 }],
+    ["a show with no id", { status: 409, data: { code: "show_already_open", details: { show: {} } } }],
+    ["a network-shaped rejection", { status: "FETCH_ERROR", error: "boom" }],
+    ["a thrown Error", new Error("boom")],
+    ["null", null],
+  ])("returns null for %s", (_label, err) => {
+    expect(readShowAlreadyOpen(err)).toBeNull();
+  });
+
+  // A show whose name the chain can't resolve still has to be nameable in a
+  // sentence; "Someone is on air" beats " is on air".
+  it("falls back to a placeholder when the name is blank", () => {
+    const blank = {
+      status: 409,
+      data: {
+        code: "show_already_open",
+        details: { show: { id: 7, dj_name: "   " } },
+      },
+    };
+    expect(readShowAlreadyOpen(blank)?.djNames).toBe("Someone");
+  });
+});
+
+describe("formatDjNames", () => {
+  it.each([
+    [[], "Someone"],
+    [["dj sue"], "dj sue"],
+    [["dj sue", "eureka!"], "dj sue and eureka!"],
+    [["dj sue", "eureka!", "DJ boy"], "dj sue, eureka! and DJ boy"],
+    [["", "  ", "dj sue"], "dj sue"],
+  ])("formats %j as %s", (names, expected) => {
+    expect(formatDjNames(names)).toBe(expected);
+  });
+});
+
+describe("formatElapsedSince", () => {
+  it.each([
+    [0, "just now"],
+    [30_000, "just now"],
+    [2 * MINUTE, "2m ago"],
+    [59 * MINUTE, "59m ago"],
+    [HOUR, "1h 0m ago"],
+    [5 * HOUR + 12 * MINUTE, "5h 12m ago"],
+    [26 * HOUR, "1d 2h ago"],
+  ])("renders %dms as %s", (elapsed, expected) => {
+    expect(formatElapsedSince(ago(elapsed), NOW)).toBe(expected);
+  });
+
+  // Browser and server clocks disagree by seconds routinely; a just-logged
+  // entry can read as marginally future. The DJ's answer is the same either
+  // way, and a negative duration is noise.
+  it("reads a marginally-future timestamp as just now", () => {
+    expect(formatElapsedSince(new Date(NOW + 3000).toISOString(), NOW)).toBe(
+      "just now"
+    );
+  });
+
+  it.each([null, "", "not a date"])("returns null for %p", (raw) => {
+    expect(formatElapsedSince(raw, NOW)).toBeNull();
+  });
+});
+
+describe("describeOpenShow", () => {
+  it("leads with the elapsed time, which is what the DJ is actually deciding on", () => {
+    expect(
+      describeOpenShow(
+        { showId: 1, djNames: "dj sue", lastLoggedAt: ago(5 * HOUR + 12 * MINUTE) },
+        NOW
+      )
+    ).toBe("dj sue is on air. Last logged 5h 12m ago.");
+  });
+
+  it("reads very differently for a show that is plainly still running", () => {
+    expect(
+      describeOpenShow({ showId: 1, djNames: "dj sue", lastLoggedAt: ago(2 * MINUTE) }, NOW)
+    ).toBe("dj sue is on air. Last logged 2m ago.");
+  });
+
+  // An unknown timestamp is the server-refusal path, which carries none. It is
+  // not evidence that nothing was logged, so the sentence drops the clause
+  // rather than inventing a reading of it.
+  it("drops the elapsed clause rather than guessing when the timestamp is unknown", () => {
+    expect(
+      describeOpenShow({ showId: 1, djNames: "dj sue", lastLoggedAt: null }, NOW)
+    ).toBe("dj sue is on air.");
+  });
+});

--- a/tests/unit/lib/features/flowsheet/infinite-cache.test.ts
+++ b/tests/unit/lib/features/flowsheet/infinite-cache.test.ts
@@ -14,6 +14,7 @@ import {
   insertEntrySortedFirstPage,
   maxPlayOrder,
   movePlayOrder,
+  newestLoggedAt,
   nextOptimisticTempId,
   primaryShowId,
   removeEntryById,
@@ -242,6 +243,35 @@ describe("infinite-cache", () => {
     const orphan = song(90, 12, -1);
     const draft = { pages: [[orphan, song(89, 11, 5)], [song(88, 10, 5)]], pageParams: [0, 1] };
     expect(primaryShowId(draft)).toBe(5);
+  });
+
+  // The handoff prompt's whole decision input is "how long since anything was
+  // logged". Reading past an orphan lands on the PREVIOUS show's tail and
+  // reports a live DJ as having walked out hours ago.
+  it("newestLoggedAt counts an orphaned row, which primaryShowId deliberately skips", () => {
+    const orphan = { ...song(90, 12, -1), add_time: "2026-08-28T19:58:00.000Z" };
+    const previousShowTail = {
+      ...song(89, 11, 5),
+      add_time: "2026-08-28T14:00:00.000Z",
+    };
+    const draft = { pages: [[orphan, previousShowTail]], pageParams: [0] };
+
+    expect(primaryShowId(draft)).toBe(5);
+    expect(newestLoggedAt(draft)).toBe("2026-08-28T19:58:00.000Z");
+  });
+
+  // Optimistic rows have not been logged yet, so they carry no add_time and
+  // must not read as activity.
+  it("newestLoggedAt skips rows with no add_time", () => {
+    const optimistic = song(-40, 13, -40);
+    const logged = { ...song(89, 12, 5), add_time: "2026-08-28T14:00:00.000Z" };
+    const draft = { pages: [[optimistic, logged]], pageParams: [0] };
+    expect(newestLoggedAt(draft)).toBe("2026-08-28T14:00:00.000Z");
+  });
+
+  it("newestLoggedAt returns null when nothing carries a time", () => {
+    const draft = { pages: [[song(9, 9, 1)]], pageParams: [0] };
+    expect(newestLoggedAt(draft)).toBeNull();
   });
 
   it("primaryShowId returns a negative optimistic show-marker id (only -1 is the orphan sentinel)", () => {

--- a/tests/unit/lib/features/flowsheet/joinShow.optimistic.test.ts
+++ b/tests/unit/lib/features/flowsheet/joinShow.optimistic.test.ts
@@ -282,3 +282,156 @@ describe("joinShow optimistic patch", () => {
     await promise;
   });
 });
+
+describe("joinShow handoff decision on the wire", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends intent and expected_show_id, and still keeps the display-only dj_name off the body", async () => {
+    const store = await seedStore();
+    let body: Record<string, unknown> | null = null;
+    server.use(
+      http.post(`${TEST_BACKEND_URL}/flowsheet/join`, async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({});
+      })
+    );
+
+    await store
+      .dispatch(
+        flowsheetApi.endpoints.joinShow.initiate({
+          dj_id: "test-user-1",
+          dj_name: "Test DJ",
+          intent: "takeover",
+          expected_show_id: 1951224,
+        })
+      )
+      .unwrap();
+
+    expect(body).toEqual({
+      dj_id: "test-user-1",
+      intent: "takeover",
+      expected_show_id: 1951224,
+    });
+  });
+
+  it("omits both fields entirely when the DJ has not chosen — that absence is what asks the server to refuse", async () => {
+    const store = await seedStore();
+    let body: Record<string, unknown> | null = null;
+    server.use(
+      http.post(`${TEST_BACKEND_URL}/flowsheet/join`, async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({});
+      })
+    );
+
+    await store
+      .dispatch(
+        flowsheetApi.endpoints.joinShow.initiate({
+          dj_id: "test-user-1",
+          dj_name: "Test DJ",
+        })
+      )
+      .unwrap();
+
+    expect(body).not.toHaveProperty("intent");
+    expect(body).not.toHaveProperty("expected_show_id");
+  });
+
+  it("rolls the optimistic patches back on a refusal, so the DJ is not shown as live", async () => {
+    const store = await seedStore([{ id: "other-dj", dj_name: "dj sue" }]);
+    server.use(
+      http.post(`${TEST_BACKEND_URL}/flowsheet/join`, () =>
+        HttpResponse.json(
+          {
+            message: "A show is already on air",
+            code: "show_already_open",
+            details: {
+              show: { id: 1951224, dj_name: "dj sue", start_time: "2026-08-28T15:00:00.000Z" },
+            },
+          },
+          { status: 409 }
+        )
+      )
+    );
+
+    await expect(
+      store
+        .dispatch(
+          flowsheetApi.endpoints.joinShow.initiate({
+            dj_id: "test-user-1",
+            dj_name: "Test DJ",
+          })
+        )
+        .unwrap()
+    ).rejects.toBeTruthy();
+
+    expect(
+      selectWhoIsLiveCache(store)?.djs.some((d) => d.id === "test-user-1")
+    ).toBe(false);
+  });
+
+  // The refusal is the contract working. Logging it as a broken mutation
+  // would train a reader to ignore the one channel that reports real breakage.
+  it("does not report the refusal as a failed mutation", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = await seedStore([{ id: "other-dj", dj_name: "dj sue" }]);
+    server.use(
+      http.post(`${TEST_BACKEND_URL}/flowsheet/join`, () =>
+        HttpResponse.json(
+          {
+            message: "A show is already on air",
+            code: "show_already_open",
+            details: { show: { id: 1951224, dj_name: "dj sue" } },
+          },
+          { status: 409 }
+        )
+      )
+    );
+
+    await expect(
+      store
+        .dispatch(
+          flowsheetApi.endpoints.joinShow.initiate({
+            dj_id: "test-user-1",
+            dj_name: "Test DJ",
+          })
+        )
+        .unwrap()
+    ).rejects.toBeTruthy();
+
+    expect(
+      warn.mock.calls.some((call) => String(call[0]).includes("joinShow"))
+    ).toBe(false);
+    vi.unstubAllEnvs();
+  });
+
+  it("still reports a genuine failure", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = await seedStore();
+    server.use(
+      http.post(`${TEST_BACKEND_URL}/flowsheet/join`, () =>
+        HttpResponse.json({ message: "boom" }, { status: 500 })
+      )
+    );
+
+    await expect(
+      store
+        .dispatch(
+          flowsheetApi.endpoints.joinShow.initiate({
+            dj_id: "test-user-1",
+            dj_name: "Test DJ",
+          })
+        )
+        .unwrap()
+    ).rejects.toBeTruthy();
+
+    expect(
+      warn.mock.calls.some((call) => String(call[0]).includes("joinShow"))
+    ).toBe(true);
+    vi.unstubAllEnvs();
+  });
+});

--- a/tests/unit/lib/features/flowsheet/live-updates-listener.test.ts
+++ b/tests/unit/lib/features/flowsheet/live-updates-listener.test.ts
@@ -404,8 +404,10 @@ describe("live-updates listener middleware", () => {
     const patched = after?.pages?.[0]?.[0] as Record<string, unknown>;
     expect("entry_type" in patched).toBe(false);
     expect("metadata_status" in patched).toBe(false);
-    expect("add_time" in patched).toBe(false);
     expect("rotation_bin" in patched).toBe(false);
+    // `add_time` is not a wire-only key: the conversion carries it onto every
+    // entry under the same name and value, so merging it forks no shape.
+    expect("add_time" in patched).toBe(true);
 
     store.dispatch(liveUpdatesConnectionReleased());
   });
@@ -512,10 +514,11 @@ describe("live-updates listener middleware", () => {
       record_label: "", // converted, never the literal null / "null"
       show_id: -1, // convertV2Entry's orphan sentinel, not raw null
     });
-    // Internal wire keys must not graft onto the typed cache row.
+    // Internal wire keys must not graft onto the typed cache row. `add_time`
+    // is not one of them — the conversion carries it deliberately.
     expect("entry_type" in inserted).toBe(false);
     expect("metadata_status" in inserted).toBe(false);
-    expect("add_time" in inserted).toBe(false);
+    expect("add_time" in inserted).toBe(true);
 
     store.dispatch(liveUpdatesConnectionReleased());
   });


### PR DESCRIPTION
Client half of [WXYC/Backend-Service#2232](https://github.com/WXYC/Backend-Service/issues/2232). Pairs with [WXYC/Backend-Service#2308](https://github.com/WXYC/Backend-Service/pull/2308) on the **same branch name** (`fix/go-live-takeover`), which is what makes the E2E job resolve the Backend ref to that PR instead of silently falling back to `main`.

Closes #1267

## What a DJ sees

Pressing Go Live while a show they are not already part of is open:

> **dj sue is on air. Last logged 5h 12m ago.**
> Join them as a co-host, or end their show and start your own.
> `[ Join Existing Show ]` `[ End Existing Show ]` `[ Cancel ]`

"End Existing Show" is `color="danger"` — it signs somebody else off the air. No role gate: any DJ can use it, which is the escape hatch the incident showed is missing, and matches the physical reality that whoever is in the studio is on air.

## The elapsed time is the whole point

"Last logged 5h 12m ago" versus "2m ago" is the difference between "they walked out" and "they're still talking", which is the question a DJ actually has at a handoff — not "when did this show start". So the prompt leads with it.

Getting it required carrying `add_time` onto converted entries. The marker variants rendered it as lossy `day`/`time` display strings and track rows dropped it entirely, so "how long since this show logged anything" was unanswerable on the client. It is now on `FlowsheetEntryBase` and correspondingly **removed** from the live-updates listener's `WIRE_ONLY_UPDATE_KEYS`: that set is for keys that exist only on the wire or map to a *different* converted key (`rotation_bin` → `rotation`), and `add_time` is now neither — same name, same ISO value, merging it forks no shape.

The names come from `GET /flowsheet/djs-on-air`, **never** from the show's own resolved `dj_name`. For an abandoned show the latter names whoever started it, which is precisely the answer a DJ deciding whether to take over must not be given — it is the field that said "dj sue" for ten hours while someone else was broadcasting.

## Two ways in, and the ordinary one sends nothing

The client already polls `djs-on-air` and the entries feed, so a handoff is visible **before** anything is sent. That matters for one specific button: **Cancel sends no request at all**, and the outgoing DJ's show is untouched. No new endpoint and no new request — `useOpenShowHandoff` reads what is already being polled, narrowed to primitives, and is deliberately *not* part of `useShowControl` (which runs in every entry row).

The server's `409 show_already_open` opens the same prompt as a backstop for the window where the client's poll and the truth disagree, and re-opens it with fresh details when a takeover's compare-and-set finds a different show now open.

`readShowAlreadyOpen` discriminates on `code`, never on the 409 status alone — `force-end` reports a different refusal with the same status, and treating any 409 as a handoff would put this prompt in front of a DJ over an unrelated conflict.

## Both Go Live controls

`GoLive.tsx` had `onClick={() => (live ? leave() : goLive())}` in two places — the `IconButton` and the `Button`. Both now route through one handler. Leaving the icon unrouted would have made it a silent bypass of the entire decision, which is the one path where a DJ could still be attached to somebody else's show without being asked. Pinned by a parameterised test over both controls.

## Where the state lives

`useShowControl` "runs in every entry row" (its own comment), so prompt state there would re-render the whole table on every open and close. `goLive` therefore **returns** its outcome — and returns it *with the payload that produced it* — while `GoLive.tsx` and `StartShow.tsx` own the prompt through a shared `useGoLiveHandoff(goLive)`. It takes `goLive` as an argument rather than calling `useShowControl` again, since both consumers already hold one and a second call opens a duplicate subscription to the paginated entries query for nothing.

## Classic gets the same decision

`StartShow.tsx` is a real in-use surface. Without this, a classic DJ pressing "Sign on and Start the Show!" meets the server's refusal as a form that appears to do nothing — the same dead end, relocated. It renders the identical decision in the page's own plain markup (nothing else in classic uses Joy — verified, zero imports) driven by the same hook, so the two surfaces cannot drift on behaviour.

The typed Public DJ Handle is carried *through* the prompt rather than recomputed after it: that form reads the registry at submit time, so re-deriving on the far side of a dialog would silently drop the handle the DJ typed, which is that surface's entire reason for existing. Pinned by a test.

## The optimistic-patch flash, stated rather than fixed

`joinShow`'s three optimistic patches apply before the response settles, so a server refusal flashes the banner for one round trip. Accepted rather than skipped: the client asks first and prompts *without* issuing a request in the ordinary handoff, so reaching that path at all means the poll and the truth disagreed. The patches already roll back; what changed is that a `show_already_open` rejection is no longer reported as a broken mutation — it is the contract working, and logging it would train a reader to ignore the channel that reports real breakage.

## E2E

The shared page object answers the prompt with **"Join Existing Show"**, raced against the mutation response so the common no-prompt path costs nothing. The suite is `fullyParallel` against one shared Backend and one global "latest show", so a sibling worker's DJ routinely holds it — and co-hosting is exactly what those eight specs got implicitly before this prompt existed, which is what lets them coexist. So this is behaviour-preserving, not a workaround.

It must **never** click "End Existing Show": that would close a sibling worker's show mid-test, turning the benign interference already documented in `artist-search-crash-smoke.spec.ts` into active destruction, intermittently and only on CI.

## A bug the tests found

RTK Query hands the same failure out in two shapes — `.unwrap()` rejects with the bare `{status, data}`, `queryFulfilled` inside `onQueryStarted` rejects with it wrapped as `{error, meta}`. Reading only the bare form classified every refusal seen from the cache-patch side as a genuine failure. `readShowAlreadyOpen` now unwraps both, with a case pinning the wrapped one.

## Testing

`npx vitest run` — 5144 passing, 353 files. `npx tsc --noEmit` clean, `npm run lint` 0 errors (warnings 191 → 190), `npm run build` clean.

New: `tests/unit/lib/features/flowsheet/go-live-handoff.test.ts` (29 cases over the 409 reader, name formatting, elapsed-time rendering including clock skew, and the sentence). Extended: `GoLive.test.tsx` (both controls prompt, each button's wire decision, Cancel sends nothing, the no-prompt path stays one click, the server-refusal path), `StartShow.test.tsx` (the same six for classic, plus the typed-handle replay), `joinShow.optimistic.test.ts` (intent and `expected_show_id` on the wire, both omitted when the DJ hasn't chosen, rollback on refusal, refusal not logged as failure, genuine failure still logged).

## Deliberately not here

`e2e/tests/flowsheet/go-live-takeover.spec.ts`, the mock tubafrenzy's `GET /__requests` inspection route, and the dedicated workflow job that spec needs. The takeover spec needs its own Backend-Service (two workers share one within a shard, and the takeover click would end a sibling's show) plus two seeded sessions plus `FLOWSHEET_TAKEOVER_ENABLED=true` in the Backend heredoc env — an infrastructure change worth its own review, and one that lands with the flag flip rather than ahead of it. Filed as a follow-up and linked below.

Note the deploy order: the server ships with `FLOWSHEET_TAKEOVER_ENABLED` **off**, so the 409 path stays dormant until it is flipped. The client-side pre-check is live immediately — which is the half that fixes the incident for a DJ at a real handoff, since it needs no server behaviour change at all.
