### PR TITLE
Classic: per-track artist credit entry for Various Artists releases

### DIFF
--- a/app/dashboard/@classic/library/release/[id]/tracklist/page.tsx
+++ b/app/dashboard/@classic/library/release/[id]/tracklist/page.tsx
@@ -1,0 +1,48 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getPageTitle } from "@/lib/utils/page-title";
+import { requireAuth, requireRole } from "@/lib/features/authentication/server-utils";
+import { Authorization } from "@/lib/features/admin/types";
+import Main from "@/src/components/experiences/classic/Layout/Main";
+import ReleaseTracklistEditor from "@/src/components/experiences/classic/catalog/ReleaseTracklistEditor";
+
+export const metadata: Metadata = {
+  title: getPageTitle("Modify a Library Release Card: Enter Per-Track Artist Credits"),
+};
+
+type ClassicReleaseTracklistPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+/**
+ * Per-track artist credit entry for a Various Artists release — reached from
+ * the release editor's tracklist section. No JSP renders this screen:
+ * `libraryReleaseModify.jsp`'s tracklist is read-only, so tubafrenzy never
+ * gave a librarian a way to enter these credits at all. See
+ * `ReleaseTracklistEditor` for the full account of what fills that gap.
+ *
+ * Gated to the same tier as the editor and its `/move` and `/delete`
+ * siblings: filing a per-track credit is a catalog write like any other, and
+ * Backend requires `catalog: ['write']` for the POST that carries it.
+ */
+export default async function ClassicReleaseTracklistPage({
+  params,
+}: ClassicReleaseTracklistPageProps) {
+  const session = await requireAuth();
+  await requireRole(session, Authorization.MD);
+
+  const { id } = await params;
+  const albumId = Number(id);
+  // A non-numeric segment would otherwise reach the editor as NaN and request
+  // `/library/info?album_id=NaN`, rendering a load failure for what is really
+  // a wrong URL. Matches the editor's own guard.
+  if (!Number.isInteger(albumId) || albumId <= 0) {
+    notFound();
+  }
+
+  return (
+    <Main>
+      <ReleaseTracklistEditor albumId={albumId} />
+    </Main>
+  );
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,10 +77,11 @@ These reproduce tubafrenzy's `/wxycdb` screens. They are **classic-first**: the 
 | `/dashboard/library` | Entry: artist vs. Various Artists, multi-match disambiguation | `chooseLibraryCodeOrArtist.jsp`, `multipleArtistsDisplay.jsp` | MD |
 | `/dashboard/library/artist/new` | Code-miss create screen: genre/letters/numbers carried read-only from the miss branch, only the two name fields editable | `createLibraryCode.jsp` | MD |
 | `/dashboard/library/artist/[id]` | Artist card + its release list | `artistCardModify.jsp` | MD |
-| `/dashboard/library/various/[id]` | V/A bucket card + its add-release form; per-track credits pending | `variousArtistsCardModify.jsp` | MD |
+| `/dashboard/library/various/[id]` | V/A bucket card + its add-release form | `variousArtistsCardModify.jsp` | MD |
 | `/dashboard/library/release/[id]` | Release edit | `libraryReleaseModify.jsp` | MD |
 | `/dashboard/library/release/[id]/move` | Move release to another library code | `libraryReleaseModifyLibCode.jsp` | MD |
 | `/dashboard/library/release/[id]/delete` | Delete confirmation | `libraryReleaseDelete.jsp` | MD |
+| `/dashboard/library/release/[id]/tracklist` | Per-track artist credit entry for a Various Artists release | none (the JSP's tracklist is read-only) | MD |
 | `/dashboard/library/missing` | Missing releases | `missingReleases.jsp` | **authenticated DJ** |
 | `/dashboard/rotation` | Rotation release list | `rotationReleaseList.jsp` | **authenticated DJ** |
 | `/dashboard/rotation/new` | Add rotation release | `rotationReleaseInsert.jsp` | MD |

--- a/lib/features/catalog/api.ts
+++ b/lib/features/catalog/api.ts
@@ -659,6 +659,7 @@ export const {
   useSearchArtistsInGenreQuery,
   useGetCompilationTracksQuery,
   useGetCompilationTrackSuggestionsQuery,
+  useLazyGetCompilationTrackSuggestionsQuery,
   useWriteCompilationTracksMutation,
   useGetInformationQuery,
   useGetFormatsQuery,

--- a/lib/features/catalog/compilationTrackCredits.ts
+++ b/lib/features/catalog/compilationTrackCredits.ts
@@ -1,0 +1,24 @@
+import type { CompilationTrackInput } from "./types";
+
+/**
+ * The server's uniqueness key for a per-track credit: artist and title,
+ * serialized together so `("Cat", "Power Ballad")` and `("Cat Power",
+ * "Ballad")` stay distinct — a joined plain string risks exactly that
+ * collision no matter which separator is picked, since both fields are
+ * free text a librarian can type anything into. `JSON.stringify` on the pair
+ * sidesteps the separator question entirely rather than picking one
+ * character and hoping no title ever contains it. `track_position` is
+ * deliberately excluded — it is data, not key, so two rows differing only in
+ * position are one credit to `POST /:libraryId/compilation-tracks`, and the
+ * second is skipped rather than filed.
+ *
+ * Both the modern add-release flow (`VaTracklistStep`) and classic's release
+ * tracklist editor write against this same additive-only endpoint and have to
+ * agree with its dedupe rule — to avoid offering as "new" a row the server
+ * will silently skip, or losing track of a row it will silently duplicate
+ * under a corrected spelling. One definition here rather than two
+ * independently-maintained copies of a rule that is really the backend's.
+ */
+export function compilationTrackCreditKey(track: CompilationTrackInput): string {
+  return JSON.stringify([track.artist_name.trim(), track.track_title?.trim() ?? ""]);
+}

--- a/lib/features/catalog/compilationTrackCredits.ts
+++ b/lib/features/catalog/compilationTrackCredits.ts
@@ -1,23 +1,20 @@
 import type { CompilationTrackInput } from "./types";
 
 /**
- * The server's uniqueness key for a per-track credit: artist and title,
- * serialized together so `("Cat", "Power Ballad")` and `("Cat Power",
- * "Ballad")` stay distinct — a joined plain string risks exactly that
- * collision no matter which separator is picked, since both fields are
- * free text a librarian can type anything into. `JSON.stringify` on the pair
- * sidesteps the separator question entirely rather than picking one
- * character and hoping no title ever contains it. `track_position` is
- * deliberately excluded — it is data, not key, so two rows differing only in
- * position are one credit to `POST /:libraryId/compilation-tracks`, and the
- * second is skipped rather than filed.
+ * The server's uniqueness key for a per-track credit, mirrored client-side.
+ * `POST /:libraryId/compilation-tracks` dedupes on `(artist_name,
+ * track_title)`, so `track_position` is excluded here too: two rows differing
+ * only in position are one credit to the endpoint, and the second is skipped
+ * rather than filed.
  *
- * Both the modern add-release flow (`VaTracklistStep`) and classic's release
- * tracklist editor write against this same additive-only endpoint and have to
- * agree with its dedupe rule — to avoid offering as "new" a row the server
- * will silently skip, or losing track of a row it will silently duplicate
- * under a corrected spelling. One definition here rather than two
- * independently-maintained copies of a rule that is really the backend's.
+ * Both fields are free text, so the pair is serialized rather than joined —
+ * `("Cat", "Power Ballad")` and `("Cat Power", "Ballad")` must stay distinct,
+ * and no separator character is safe to assume absent from a title.
+ *
+ * Every screen that writes to that additive-only endpoint has to agree with
+ * this rule, or it offers as new a row the server will silently skip, or loses
+ * track of one it will silently duplicate under a corrected spelling. One
+ * definition, not one per screen.
  */
 export function compilationTrackCreditKey(track: CompilationTrackInput): string {
   return JSON.stringify([track.artist_name.trim(), track.track_title?.trim() ?? ""]);

--- a/src/components/experiences/classic/catalog/ReleaseCard.tsx
+++ b/src/components/experiences/classic/catalog/ReleaseCard.tsx
@@ -51,9 +51,13 @@ import Tracklist from "./Tracklist";
  * `Tracklist` this screen already renders. No JSP offers this — the legacy
  * tracklist is display-only — so there is nothing here to diverge from; see
  * that component for why classic needs a write path for per-track credits at
- * all. Gated on `isVariousArtists(artist.lettercode)`, the same structural
- * rule `artistCardRoute` uses, not on the display-only `album_artist` field
- * `Tracklist` reads for its own, narrower purpose of showing an artist column.
+ * all.
+ *
+ * That link and the tracklist below it must agree on what a compilation is, or
+ * a credit is enterable through the one and unreadable in the other. Both use
+ * `isVariousArtists(artist.lettercode)` — never `album_artist`, which the
+ * nightly catalog import alone writes and which is therefore absent on a
+ * release filed today.
  */
 export default function ReleaseCard({ albumId }: { albumId: number }) {
   const { data, isLoading, isError } = useGetInformationQuery({ album_id: albumId });
@@ -315,7 +319,7 @@ export default function ReleaseCard({ albumId }: { albumId: number }) {
       <Tracklist
         albumId={albumId}
         legacyReleaseId={data.legacy_release_id}
-        variousArtists={!!data.album_artist}
+        variousArtists={isVariousArtists(data.artist.lettercode)}
       />
     </div>
   );

--- a/src/components/experiences/classic/catalog/ReleaseCard.tsx
+++ b/src/components/experiences/classic/catalog/ReleaseCard.tsx
@@ -8,7 +8,7 @@ import {
   useMarkMissingMutation,
   useUpdateAlbumMutation,
 } from "@/lib/features/catalog/api";
-import { formatEntireLibraryCode } from "@/lib/features/catalog/libraryCode";
+import { formatEntireLibraryCode, isVariousArtists } from "@/lib/features/catalog/libraryCode";
 import { formatStationDateTime } from "@/src/utilities/stationTime";
 import Tracklist from "./Tracklist";
 
@@ -45,6 +45,15 @@ import Tracklist from "./Tracklist";
  *    mean an untyped cast — the pattern that turns a contract gap into a
  *    silent `undefined` — and printing the add date under the JSP's label
  *    would be worse than printing it under a true one.
+ *
+ * One addition beyond the JSP, not a divergence from it: a Various Artists
+ * release gets a link to `ReleaseTracklistEditor`, right above the read-only
+ * `Tracklist` this screen already renders. No JSP offers this — the legacy
+ * tracklist is display-only — so there is nothing here to diverge from; see
+ * that component for why classic needs a write path for per-track credits at
+ * all. Gated on `isVariousArtists(artist.lettercode)`, the same structural
+ * rule `artistCardRoute` uses, not on the display-only `album_artist` field
+ * `Tracklist` reads for its own, narrower purpose of showing an artist column.
  */
 export default function ReleaseCard({ albumId }: { albumId: number }) {
   const { data, isLoading, isError } = useGetInformationQuery({ album_id: albumId });
@@ -294,6 +303,14 @@ export default function ReleaseCard({ albumId }: { albumId: number }) {
           </tbody>
         </table>
       </form>
+
+      {isVariousArtists(data.artist.lettercode) && (
+        <div className="label" style={{ textAlign: "center" }}>
+          <a href={`/dashboard/library/release/${albumId}/tracklist`}>
+            Enter Per-Track Artist Credits
+          </a>
+        </div>
+      )}
 
       <Tracklist
         albumId={albumId}

--- a/src/components/experiences/classic/catalog/ReleaseTracklistEditor.tsx
+++ b/src/components/experiences/classic/catalog/ReleaseTracklistEditor.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import { useState } from "react";
+import {
+  useGetCompilationTracksQuery,
+  useGetInformationQuery,
+  useLazyGetCompilationTrackSuggestionsQuery,
+  useWriteCompilationTracksMutation,
+} from "@/lib/features/catalog/api";
+import { compilationTrackCreditKey } from "@/lib/features/catalog/compilationTrackCredits";
+import { formatEntireLibraryCode, isVariousArtists } from "@/lib/features/catalog/libraryCode";
+import type { CompilationTrackInput } from "@/lib/features/catalog/types";
+
+type DraftRow = {
+  /** Stable across edits and removals, so React never reuses one row's DOM for another. */
+  key: number;
+  artist_name: string;
+  track_title: string;
+  track_position: string;
+};
+
+let nextRowKey = 0;
+const blankRow = (): DraftRow => ({
+  key: nextRowKey++,
+  artist_name: "",
+  track_title: "",
+  track_position: "",
+});
+
+const isBlankRow = (row: DraftRow) =>
+  row.artist_name.trim() === "" &&
+  row.track_title.trim() === "" &&
+  row.track_position.trim() === "";
+
+const rowFromSuggestion = (track: CompilationTrackInput): DraftRow => ({
+  key: nextRowKey++,
+  artist_name: track.artist_name,
+  track_title: track.track_title ?? "",
+  track_position: track.track_position ?? "",
+});
+
+/** Blank optional fields are stored as NULL, not as empty strings — matches the write endpoint's own convention. */
+const toInput = (row: DraftRow): CompilationTrackInput => ({
+  artist_name: row.artist_name.trim(),
+  track_title: row.track_title.trim() || null,
+  track_position: row.track_position.trim() || null,
+});
+
+/**
+ * "Enter per-track credits for this compilation" — the write path the
+ * release editor's read-only tracklist has never had. No JSP renders a screen
+ * like this: `libraryReleaseModify.jsp`'s tracklist is display-only
+ * (`tracklist.js` fetches Discogs and nothing posts back), so tubafrenzy never
+ * gave a librarian a way to enter per-track artists by hand. That is the gap
+ * this fills — without it, a Various Artists release filed after cutover can
+ * never receive credits, since nothing else in the product writes to
+ * `POST /:libraryId/compilation-tracks`.
+ *
+ * Reached from the release editor (`ReleaseCard`), which is where the JSP's
+ * own read-only tracklist lives; this screen continues that placement rather
+ * than inventing a second one, and is gated identically to its sibling
+ * `/move` and `/delete` sub-screens.
+ *
+ * Scoped to Backend's `library.id` (`albumId`) throughout — never
+ * `legacy_release_id`. All three compilation-track endpoints resolve their
+ * path param against `library.id`; sending the legacy id instead would not
+ * error, it would silently read or write a different, real release's rows.
+ *
+ * The V/A gate is `isVariousArtists` on `code_letters` — the same structural
+ * rule `artistCardRoute` uses to route to this shelf's own card — not the
+ * display-only `album_artist` field the read-only `Tracklist` uses to decide
+ * whether to show an artist column. `album_artist` is populated by the
+ * nightly catalog import and can lag a release's actual filing; gating a
+ * *write* affordance on it would hide this screen from a compilation that was
+ * filed today and hasn't been through an import cycle yet.
+ *
+ * Safety property, simpler than the one the modern add-release flow
+ * (`VaTracklistStep`) needs: this screen always loads the release's
+ * already-stored credits before any write is possible
+ * (`useGetCompilationTracksQuery`, never skipped — the release already
+ * exists, so the read is never wasted the way it would be moments after a
+ * brand-new release's creation). The write endpoint is additive-only — it can
+ * add a credit but never amend or remove one — so resubmitting an unchanged
+ * row is harmless (the server skips it), but resubmitting a *corrected* one
+ * after a lost response would file a second, only-slightly-different credit
+ * beside the first. Saving is therefore refused whenever the stored read has
+ * not succeeded, rather than let the librarian resubmit against an unknown
+ * base state.
+ */
+export default function ReleaseTracklistEditor({ albumId }: { albumId: number }) {
+  const { data, isLoading, isError } = useGetInformationQuery({ album_id: albumId });
+  const {
+    data: stored,
+    isError: storedError,
+    isFetching: storedFetching,
+    refetch: refetchStored,
+  } = useGetCompilationTracksQuery({ libraryId: albumId });
+  const [fetchSuggestions, { isFetching: suggestionsFetching }] =
+    useLazyGetCompilationTrackSuggestionsQuery();
+  const [writeCompilationTracks, { isLoading: saving }] = useWriteCompilationTracksMutation();
+
+  const [rows, setRows] = useState<DraftRow[]>([blankRow()]);
+  const [message, setMessage] = useState<string | null>(null);
+  const [suggestionsMessage, setSuggestionsMessage] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="label" style={{ textAlign: "center" }}>
+        Loading the release...
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div data-testid="release-tracklist-error" role="alert" className="artist-error-message">
+        This release could not be loaded, so its per-track credits can&apos;t be edited.
+      </div>
+    );
+  }
+
+  if (!isVariousArtists(data.artist.lettercode)) {
+    return (
+      <div data-testid="release-tracklist-not-various" role="status" style={{ textAlign: "center" }}>
+        This isn&apos;t a Various Artists release, so it has no per-track credits to enter.
+        <p />
+        <a href={`/dashboard/library/release/${albumId}`}>Back to this release</a>
+      </div>
+    );
+  }
+
+  const entireLibraryCode = formatEntireLibraryCode({
+    genreName: data.artist.genre,
+    code_letters: data.artist.lettercode,
+    code_artist_number: data.artist.numbercode,
+    genre_id: data.genre_id ?? 0,
+    code_number: data.entry,
+    code_volume_letters: null,
+  });
+
+  const storedTracks = stored?.tracks ?? [];
+  // Known only once the read has actually succeeded — never inferred from an
+  // empty array, which is indistinguishable from "not loaded yet" the moment
+  // this component mounts.
+  const storedKnown = !!stored && !storedError;
+
+  const updateRow = (key: number, patch: Partial<DraftRow>) =>
+    setRows((current) => current.map((row) => (row.key === key ? { ...row, ...patch } : row)));
+
+  const removeRow = (key: number) =>
+    setRows((current) => current.filter((row) => row.key !== key));
+
+  const addRow = () => setRows((current) => [...current, blankRow()]);
+
+  const handleImportFromDiscogs = async () => {
+    setSuggestionsMessage(null);
+    try {
+      const result = await fetchSuggestions({ libraryId: albumId }).unwrap();
+      const already = new Set(storedTracks.map(compilationTrackCreditKey));
+      const toImport = result.tracks.filter(
+        (track) => !already.has(compilationTrackCreditKey(track)),
+      );
+      if (toImport.length === 0) {
+        setSuggestionsMessage(
+          result.tracks.length > 0
+            ? "Every track Discogs suggested is already on file."
+            : "No Discogs tracklist matched this release. Enter credits by hand below.",
+        );
+        return;
+      }
+      setRows((current) =>
+        current.every(isBlankRow)
+          ? toImport.map(rowFromSuggestion)
+          : [...current, ...toImport.map(rowFromSuggestion)],
+      );
+      setSuggestionsMessage(
+        `Imported ${toImport.length} ${toImport.length === 1 ? "track" : "tracks"} from Discogs. Confirm or correct the per-track artists before saving.`,
+      );
+    } catch {
+      setSuggestionsMessage(
+        "Discogs tracklist lookup failed. This isn't the same as Discogs having no match — try again, or enter credits by hand below.",
+      );
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const submittable = rows.map(toInput).filter((track) => track.artist_name.length > 0);
+    if (submittable.length === 0) {
+      setMessage("Enter at least one artist credit before saving.");
+      return;
+    }
+    try {
+      const result = await writeCompilationTracks({
+        libraryId: albumId,
+        tracks: submittable,
+      }).unwrap();
+      setMessage(
+        result.skipped > 0
+          ? `Filed ${result.inserted} new credit(s); ${result.skipped} already on file.`
+          : `Filed ${result.inserted} new credit(s).`,
+      );
+      setRows([blankRow()]);
+    } catch {
+      setMessage(
+        "These credits could not be saved. Reload this page and check what's already on file before trying again — a credit can only be added here, never corrected.",
+      );
+    }
+  };
+
+  return (
+    <div id="releaseTracklistCard">
+      <div className="label" style={{ textAlign: "center" }}>
+        <a href="/dashboard/catalog">Do another search</a>
+        &nbsp;&nbsp;&nbsp;&nbsp;
+        <a href="/dashboard/library">Find and Create an Artist and/or Library Code</a>
+        <p />
+        <a href={`/dashboard/library/release/${albumId}`}>View/Modify/Delete this Library Release</a>
+      </div>
+
+      <div style={{ textAlign: "center" }}>
+        <h3>
+          LIBRARY RELEASE: &nbsp;{entireLibraryCode}&nbsp;-&nbsp;{data.title}
+        </h3>
+        <h4>Enter Per-Track Artist Credits</h4>
+      </div>
+
+      <div style={{ textAlign: "center" }}>
+        <h3 data-testid="release-tracklist-message" role="status">
+          &nbsp;{message ?? ""}&nbsp;
+        </h3>
+      </div>
+
+      {storedTracks.length > 0 && (
+        <table className="tracklist-table" data-testid="release-tracklist-stored">
+          <tbody>
+            <tr className="tracklist-header">
+              <th colSpan={3}>Already on File</th>
+            </tr>
+            {storedTracks.map((track, index) => (
+              <tr
+                key={track.id}
+                className={`tracklist-row ${
+                  index % 2 === 0 ? "tracklist-row-even" : "tracklist-row-odd"
+                }`}
+              >
+                <td className="tracklist-pos">{track.track_position ?? String(index + 1)}</td>
+                <td>{track.artist_name}</td>
+                <td>{track.track_title ?? ""}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {storedError && (
+        <div role="alert" className="artist-error-message">
+          Existing credits could not be confirmed, so saving is disabled until they can be — a
+          retry against an unknown state could file a duplicate.{" "}
+          <button type="button" disabled={storedFetching} onClick={() => refetchStored()}>
+            Try again
+          </button>
+        </div>
+      )}
+
+      <div className="label" style={{ textAlign: "center" }}>
+        <button type="button" onClick={handleImportFromDiscogs} disabled={suggestionsFetching}>
+          Check Discogs for a Tracklist
+        </button>
+        {suggestionsMessage && <p role="status">{suggestionsMessage}</p>}
+      </div>
+
+      <form name="addCompilationTracks" data-testid="release-tracklist-form" onSubmit={handleSubmit}>
+        <table cellPadding={5} style={{ margin: "0 auto" }}>
+          <tbody>
+            <tr>
+              <th style={{ textAlign: "left" }}>Position</th>
+              <th style={{ textAlign: "left" }}>Artist</th>
+              <th style={{ textAlign: "left" }}>Track Title</th>
+              <td />
+            </tr>
+            {rows.map((row, index) => (
+              <tr key={row.key}>
+                <td>
+                  <input
+                    type="text"
+                    size={5}
+                    value={row.track_position}
+                    disabled={saving}
+                    aria-label={`Position for track ${index + 1}`}
+                    onChange={(event) =>
+                      updateRow(row.key, { track_position: event.target.value })
+                    }
+                  />
+                </td>
+                <td>
+                  <input
+                    type="text"
+                    size={30}
+                    value={row.artist_name}
+                    disabled={saving}
+                    aria-label={`Artist for track ${index + 1}`}
+                    onChange={(event) => updateRow(row.key, { artist_name: event.target.value })}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="text"
+                    size={30}
+                    value={row.track_title}
+                    disabled={saving}
+                    aria-label={`Title for track ${index + 1}`}
+                    onChange={(event) => updateRow(row.key, { track_title: event.target.value })}
+                  />
+                </td>
+                <td>
+                  <button
+                    type="button"
+                    disabled={saving}
+                    aria-label={`Remove track ${index + 1}`}
+                    onClick={() => removeRow(row.key)}
+                  >
+                    Remove
+                  </button>
+                </td>
+              </tr>
+            ))}
+            <tr>
+              <td colSpan={4}>
+                <button type="button" disabled={saving} onClick={addRow}>
+                  Add track
+                </button>
+              </td>
+            </tr>
+            <tr>
+              <td colSpan={4}>
+                <input type="submit" value="Save Track Credits" disabled={saving || !storedKnown} />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+    </div>
+  );
+}

--- a/src/components/experiences/classic/catalog/ReleaseTracklistEditor.tsx
+++ b/src/components/experiences/classic/catalog/ReleaseTracklistEditor.tsx
@@ -67,25 +67,27 @@ const toInput = (row: DraftRow): CompilationTrackInput => ({
  * error, it would silently read or write a different, real release's rows.
  *
  * The V/A gate is `isVariousArtists` on `code_letters` — the same structural
- * rule `artistCardRoute` uses to route to this shelf's own card — not the
- * display-only `album_artist` field the read-only `Tracklist` uses to decide
- * whether to show an artist column. `album_artist` is populated by the
- * nightly catalog import and can lag a release's actual filing; gating a
- * *write* affordance on it would hide this screen from a compilation that was
- * filed today and hasn't been through an import cycle yet.
+ * rule `artistCardRoute` uses to route to this shelf's own card — never
+ * `album_artist`. That column is written by the catalog import mirroring the
+ * legacy MySQL and by nothing else, so it is absent on a release filed today
+ * and stops being written at all once that mirror ends. Gating a *write*
+ * affordance on it would hide this screen from exactly the compilation that
+ * needs it: the one with no credits and no other way to acquire any.
  *
- * Safety property, simpler than the one the modern add-release flow
- * (`VaTracklistStep`) needs: this screen always loads the release's
- * already-stored credits before any write is possible
- * (`useGetCompilationTracksQuery`, never skipped — the release already
- * exists, so the read is never wasted the way it would be moments after a
- * brand-new release's creation). The write endpoint is additive-only — it can
- * add a credit but never amend or remove one — so resubmitting an unchanged
- * row is harmless (the server skips it), but resubmitting a *corrected* one
- * after a lost response would file a second, only-slightly-different credit
- * beside the first. Saving is therefore refused whenever the stored read has
- * not succeeded, rather than let the librarian resubmit against an unknown
- * base state.
+ * Safety property: no write is possible against a base state this screen
+ * cannot account for. It always loads the release's already-stored credits
+ * (`useGetCompilationTracksQuery`, never skipped — the release already exists,
+ * so the read is never wasted the way it would be moments after a brand-new
+ * release's creation), and saving is refused whenever that read has not
+ * succeeded. The write endpoint is additive-only — it can add a credit but
+ * never amend or remove one — so resubmitting an unchanged row is harmless
+ * (the server skips it), while resubmitting a *corrected* one files a second,
+ * only-slightly-different credit beside the first.
+ *
+ * A failed write puts the screen in exactly that unaccountable state, which is
+ * why the refusal covers it too: a request can commit and then lose its
+ * response, so the rows on screen are no longer a truthful account of the
+ * release. The read is reissued and saving stays refused until it lands.
  */
 export default function ReleaseTracklistEditor({ albumId }: { albumId: number }) {
   const { data, isLoading, isError } = useGetInformationQuery({ album_id: albumId });
@@ -100,8 +102,12 @@ export default function ReleaseTracklistEditor({ albumId }: { albumId: number })
   const [writeCompilationTracks, { isLoading: saving }] = useWriteCompilationTracksMutation();
 
   const [rows, setRows] = useState<DraftRow[]>([blankRow()]);
-  const [message, setMessage] = useState<string | null>(null);
-  const [suggestionsMessage, setSuggestionsMessage] = useState<string | null>(null);
+  const [message, setMessage] = useState("");
+  const [suggestionsMessage, setSuggestionsMessage] = useState("");
+  // Set by a write that failed, cleared only by a stored read that succeeds
+  // afterwards. Between the two, what the release holds is unknown: the write
+  // may have committed and lost its response.
+  const [writeOutcomeUnknown, setWriteOutcomeUnknown] = useState(false);
 
   if (isLoading) {
     return (
@@ -143,6 +149,20 @@ export default function ReleaseTracklistEditor({ albumId }: { albumId: number })
   // empty array, which is indistinguishable from "not loaded yet" the moment
   // this component mounts.
   const storedKnown = !!stored && !storedError;
+  const canSave = storedKnown && !writeOutcomeUnknown;
+
+  // Both the failed-write path and the librarian's own retry go through here,
+  // so a read that succeeds always clears the refusal. A read that fails
+  // changes nothing: `storedError` is already refusing the save on its own.
+  const reconfirmStored = async () => {
+    const confirmed = await refetchStored()
+      .unwrap()
+      .then(() => true)
+      .catch(() => false);
+    if (confirmed) {
+      setWriteOutcomeUnknown(false);
+    }
+  };
 
   const updateRow = (key: number, patch: Partial<DraftRow>) =>
     setRows((current) => current.map((row) => (row.key === key ? { ...row, ...patch } : row)));
@@ -153,17 +173,23 @@ export default function ReleaseTracklistEditor({ albumId }: { albumId: number })
   const addRow = () => setRows((current) => [...current, blankRow()]);
 
   const handleImportFromDiscogs = async () => {
-    setSuggestionsMessage(null);
+    setSuggestionsMessage("");
     try {
       const result = await fetchSuggestions({ libraryId: albumId }).unwrap();
-      const already = new Set(storedTracks.map(compilationTrackCreditKey));
+      // Against the rows on screen as well as the stored ones: a second click
+      // that re-offered a row already in the form would leave two editable
+      // copies of one credit, and correcting one of them files both.
+      const already = new Set([
+        ...storedTracks.map(compilationTrackCreditKey),
+        ...rows.map((row) => compilationTrackCreditKey(toInput(row))),
+      ]);
       const toImport = result.tracks.filter(
         (track) => !already.has(compilationTrackCreditKey(track)),
       );
       if (toImport.length === 0) {
         setSuggestionsMessage(
           result.tracks.length > 0
-            ? "Every track Discogs suggested is already on file."
+            ? "Every track Discogs suggested is already on file or in the form below."
             : "No Discogs tracklist matched this release. Enter credits by hand below.",
         );
         return;
@@ -203,8 +229,10 @@ export default function ReleaseTracklistEditor({ albumId }: { albumId: number })
       setRows([blankRow()]);
     } catch {
       setMessage(
-        "These credits could not be saved. Reload this page and check what's already on file before trying again — a credit can only be added here, never corrected.",
+        "These credits could not be saved — but some may still have been filed. Check what's on file above before trying again: a credit can only be added here, never corrected.",
       );
+      setWriteOutcomeUnknown(true);
+      await reconfirmStored();
     }
   };
 
@@ -227,7 +255,7 @@ export default function ReleaseTracklistEditor({ albumId }: { albumId: number })
 
       <div style={{ textAlign: "center" }}>
         <h3 data-testid="release-tracklist-message" role="status">
-          &nbsp;{message ?? ""}&nbsp;
+          &nbsp;{message}&nbsp;
         </h3>
       </div>
 
@@ -257,7 +285,7 @@ export default function ReleaseTracklistEditor({ albumId }: { albumId: number })
         <div role="alert" className="artist-error-message">
           Existing credits could not be confirmed, so saving is disabled until they can be — a
           retry against an unknown state could file a duplicate.{" "}
-          <button type="button" disabled={storedFetching} onClick={() => refetchStored()}>
+          <button type="button" disabled={storedFetching} onClick={() => reconfirmStored()}>
             Try again
           </button>
         </div>
@@ -267,7 +295,9 @@ export default function ReleaseTracklistEditor({ albumId }: { albumId: number })
         <button type="button" onClick={handleImportFromDiscogs} disabled={suggestionsFetching}>
           Check Discogs for a Tracklist
         </button>
-        {suggestionsMessage && <p role="status">{suggestionsMessage}</p>}
+        <p role="status" data-testid="release-tracklist-suggestions-message">
+          &nbsp;{suggestionsMessage}&nbsp;
+        </p>
       </div>
 
       <form name="addCompilationTracks" data-testid="release-tracklist-form" onSubmit={handleSubmit}>
@@ -334,7 +364,7 @@ export default function ReleaseTracklistEditor({ albumId }: { albumId: number })
             </tr>
             <tr>
               <td colSpan={4}>
-                <input type="submit" value="Save Track Credits" disabled={saving || !storedKnown} />
+                <input type="submit" value="Save Track Credits" disabled={saving || !canSave} />
               </td>
             </tr>
           </tbody>

--- a/src/components/experiences/modern/catalog/AddRelease/VaTracklistStep.tsx
+++ b/src/components/experiences/modern/catalog/AddRelease/VaTracklistStep.tsx
@@ -15,6 +15,7 @@ import {
   useGetCompilationTrackSuggestionsQuery,
   useGetCompilationTracksQuery,
 } from "@/lib/features/catalog/api";
+import { compilationTrackCreditKey } from "@/lib/features/catalog/compilationTrackCredits";
 import type {
   CompilationTrack,
   CompilationTrackInput,
@@ -55,15 +56,10 @@ const toInput = (row: DraftRow): CompilationTrackInput => ({
   track_position: row.track_position.trim() || null,
 });
 
-/**
- * The server's uniqueness key for a credit: artist and title, joined by a
- * separator no title can contain, so `("Cat", "Power Ballad")` and
- * `("Cat Power", "Ballad")` stay distinct. `track_position` is deliberately
- * absent — it is data, not key, so two rows differing only in position are one
- * credit to the backend and the second is skipped.
- */
-const creditKey = (track: CompilationTrackInput) =>
-  `${track.artist_name.trim()}\u0000${track.track_title?.trim() ?? ""}`;
+// See `compilationTrackCreditKey`: this and classic's release tracklist
+// editor write against the same additive-only endpoint and must agree with
+// its dedupe rule.
+const creditKey = compilationTrackCreditKey;
 
 export type VaTracklistStepProps = {
   libraryId: number;

--- a/tests/integration/app/dashboard/@classic/library/release/tracklist-page.test.tsx
+++ b/tests/integration/app/dashboard/@classic/library/release/tracklist-page.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, vi } from "vitest";
+import {
+  setUpClassicPageAuthority,
+  setUpClassicPageAuthorityEnv,
+  assertReachesClassicPage,
+  assertDeniedClassicPage,
+} from "@/tests/helpers/classic-page-authority-harness";
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/headers", async () => {
+  const { classicPageAuthorityHeadersMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityHeadersMock();
+});
+vi.mock("next/navigation", async () => {
+  const { classicPageAuthorityNavigationMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityNavigationMock();
+});
+vi.mock("@/lib/features/authentication/server-client", async () => {
+  const { classicPageAuthorityServerClientMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityServerClientMock();
+});
+vi.mock("@/lib/features/authentication/organization-utils.server", async () => {
+  const { classicPageAuthorityOrganizationUtilsMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityOrganizationUtilsMock();
+});
+
+// The page's own responsibility under test is the auth gate, not the RTK
+// Query-backed editor content.
+vi.mock("@/src/components/experiences/classic/Layout/Main", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="classic-main">{children}</div>
+  ),
+}));
+vi.mock("@/src/components/experiences/classic/catalog/ReleaseTracklistEditor", () => ({
+  default: () => <div data-testid="release-tracklist-editor" />,
+}));
+
+import ClassicReleaseTracklistPage from "@/app/dashboard/@classic/library/release/[id]/tracklist/page";
+
+const page = () => ClassicReleaseTracklistPage({ params: Promise.resolve({ id: "53390" }) });
+
+describe("Classic /dashboard/library/release/[id]/tracklist page", () => {
+  setUpClassicPageAuthorityEnv();
+
+  it.each([
+    { role: "musicDirector" as const, label: "a music director" },
+    { role: "stationManager" as const, label: "a station manager" },
+  ])("reaches the tracklist editor for $label", async ({ role }) => {
+    setUpClassicPageAuthority(role);
+
+    await assertReachesClassicPage(page, "classic-main", "release-tracklist-editor");
+  });
+
+  it("redirects a DJ away — entering per-track credits is a catalog write like any other", async () => {
+    setUpClassicPageAuthority("dj");
+
+    await assertDeniedClassicPage(page);
+  });
+
+  it("redirects a member with no station role", async () => {
+    setUpClassicPageAuthority(undefined);
+
+    await assertDeniedClassicPage(page);
+  });
+
+  it("never grants access from the admin-plugin role column, even when it holds a WXYC tier string", async () => {
+    setUpClassicPageAuthority(undefined, "musicDirector");
+
+    await assertDeniedClassicPage(page);
+  });
+
+  it("bounces an unauthenticated visitor to login before any role resolution", async () => {
+    setUpClassicPageAuthority("unauthenticated");
+
+    await assertDeniedClassicPage(page, "/login?bounced=no-session");
+  });
+});

--- a/tests/integration/components/classic/catalog/ReleaseCard.test.tsx
+++ b/tests/integration/components/classic/catalog/ReleaseCard.test.tsx
@@ -166,4 +166,32 @@ describe("Classic ReleaseCard", () => {
     expect(fromNav.getAttribute("href")).toBe("/dashboard/library/release/53375/move");
     expect(fromArtistRow.getAttribute("href")).toBe(fromNav.getAttribute("href"));
   });
+
+  it("offers per-track credit entry for a Various Artists release", () => {
+    mockGetInformationQuery.mockReturnValue({
+      data: album({
+        artist: createTestArtist({
+          name: "Various Artists - Rock - S",
+          lettercode: "V/A",
+          numbercode: 0,
+          genre: "Rock",
+        }),
+      }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderWithProviders(<ReleaseCard albumId={53375} />);
+
+    const link = screen.getByRole("link", { name: "Enter Per-Track Artist Credits" });
+    expect(link.getAttribute("href")).toBe("/dashboard/library/release/53375/tracklist");
+  });
+
+  it("omits the per-track credit link for an ordinary, non-compilation release", () => {
+    mockGetInformationQuery.mockReturnValue({ data: album(), isLoading: false, isError: false });
+
+    renderWithProviders(<ReleaseCard albumId={53375} />);
+
+    expect(screen.queryByRole("link", { name: "Enter Per-Track Artist Credits" })).toBeNull();
+  });
 });

--- a/tests/integration/components/classic/catalog/ReleaseCard.test.tsx
+++ b/tests/integration/components/classic/catalog/ReleaseCard.test.tsx
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createTestAlbum, createTestArtist } from "@/tests/helpers";
 import { renderWithProviders } from "@/tests/helpers/render";
 
 const mockGetInformationQuery = vi.fn();
+const mockGetCompilationTracksQuery = vi.fn();
 const mockUpdateAlbum = vi.fn();
 const mockMarkMissing = vi.fn();
 const mockMarkFound = vi.fn();
@@ -14,11 +15,19 @@ vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
   return {
     ...actual,
     useGetInformationQuery: (...args: unknown[]) => mockGetInformationQuery(...args),
+    useGetCompilationTracksQuery: (...args: unknown[]) => mockGetCompilationTracksQuery(...args),
     useGetFormatsQuery: () => ({ data: [{ id: 1, format_name: "cd" }, { id: 2, format_name: "lp" }] }),
     useUpdateAlbumMutation: () => [mockUpdateAlbum, { isLoading: false }],
     useMarkMissingMutation: () => [mockMarkMissing, { isLoading: false }],
     useMarkFoundMutation: () => [mockMarkFound, { isLoading: false }],
   };
+});
+
+// The release card's tracklist has a second, Discogs-backed source. It is not
+// what these tests are about, and left live it never settles under jsdom.
+vi.mock("@/lib/features/metadata/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/metadata/api")>();
+  return { ...actual, useGetLibraryTracksQuery: () => ({ data: undefined, isLoading: false }) };
 });
 
 import ReleaseCard from "@/src/components/experiences/classic/catalog/ReleaseCard";
@@ -39,6 +48,11 @@ const album = (overrides = {}) =>
     }),
     ...overrides,
   });
+
+beforeEach(() => {
+  mockGetCompilationTracksQuery.mockReset();
+  mockGetCompilationTracksQuery.mockReturnValue({ data: undefined, isLoading: false });
+});
 
 describe("Classic ReleaseCard", () => {
   it("reproduces the JSP's heading and code row", () => {
@@ -193,5 +207,47 @@ describe("Classic ReleaseCard", () => {
     renderWithProviders(<ReleaseCard albumId={53375} />);
 
     expect(screen.queryByRole("link", { name: "Enter Per-Track Artist Credits" })).toBeNull();
+  });
+
+  // `album_artist` is written by the nightly catalog import alone, so it is
+  // absent on a compilation filed today — and on every row until that
+  // import runs. Reading the credit store through it would hide the credits a
+  // librarian had just finished entering on the very release that needed them.
+  it("shows the per-track credits of a compilation whose album_artist has not been imported yet", () => {
+    mockGetInformationQuery.mockReturnValue({
+      data: album({
+        album_artist: undefined,
+        artist: createTestArtist({
+          name: "Various Artists - Rock - S",
+          lettercode: "V/A",
+          numbercode: 0,
+          genre: "Rock",
+        }),
+      }),
+      isLoading: false,
+      isError: false,
+    });
+    mockGetCompilationTracksQuery.mockReturnValue({
+      data: {
+        library_id: 53375,
+        tracks: [
+          {
+            id: 1,
+            artist_name: "Chuquimamani-Condori",
+            track_title: "Call Your Name",
+            track_position: "A1",
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    renderWithProviders(<ReleaseCard albumId={53375} />);
+
+    expect(mockGetCompilationTracksQuery).toHaveBeenCalledWith(
+      { libraryId: 53375 },
+      { skip: false },
+    );
+    expect(screen.getByText("Chuquimamani-Condori")).toBeDefined();
   });
 });

--- a/tests/integration/components/classic/catalog/ReleaseTracklistEditor.test.tsx
+++ b/tests/integration/components/classic/catalog/ReleaseTracklistEditor.test.tsx
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createTestAlbum, createTestArtist } from "@/tests/helpers";
+import { renderWithProviders } from "@/tests/helpers/render";
+
+const mockGetInformationQuery = vi.fn();
+const mockGetCompilationTracksQuery = vi.fn();
+const mockFetchSuggestions = vi.fn();
+const mockUseLazyGetCompilationTrackSuggestionsQuery = vi.fn();
+const mockWriteCompilationTracks = vi.fn();
+const mockRefetchStored = vi.fn();
+
+vi.mock("@/lib/features/catalog/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/features/catalog/api")>();
+  return {
+    ...actual,
+    useGetInformationQuery: (...args: unknown[]) => mockGetInformationQuery(...args),
+    useGetCompilationTracksQuery: (...args: unknown[]) => mockGetCompilationTracksQuery(...args),
+    useLazyGetCompilationTrackSuggestionsQuery: (...args: unknown[]) =>
+      mockUseLazyGetCompilationTrackSuggestionsQuery(...args),
+    useWriteCompilationTracksMutation: () => [
+      mockWriteCompilationTracks,
+      { isLoading: false },
+    ],
+  };
+});
+
+import ReleaseTracklistEditor from "@/src/components/experiences/classic/catalog/ReleaseTracklistEditor";
+
+const VA_ALBUM_ID = 53390;
+
+const vaAlbum = (overrides = {}) =>
+  createTestAlbum({
+    id: VA_ALBUM_ID,
+    title: "A Freeform Sampler",
+    entry: 4,
+    format: "cd",
+    format_id: 1,
+    label: "self-released",
+    album_artist: "Various",
+    genre_id: 3,
+    artist: createTestArtist({
+      name: "Various Artists - Rock - S",
+      lettercode: "V/A",
+      numbercode: 0,
+      genre: "Rock",
+    }),
+    ...overrides,
+  });
+
+const ordinaryAlbum = (overrides = {}) =>
+  createTestAlbum({
+    id: 53375,
+    title: "Tri Repetae",
+    entry: 1,
+    format: "cd",
+    format_id: 1,
+    label: "Warp",
+    artist: createTestArtist({
+      name: "Autechre",
+      lettercode: "AU",
+      numbercode: 3,
+      genre: "Electronic",
+    }),
+    ...overrides,
+  });
+
+const emptyStored = { data: { library_id: VA_ALBUM_ID, tracks: [] }, isError: false, isFetching: false, refetch: mockRefetchStored };
+
+beforeEach(() => {
+  mockGetInformationQuery.mockReset();
+  mockGetCompilationTracksQuery.mockReset();
+  mockFetchSuggestions.mockReset();
+  mockUseLazyGetCompilationTrackSuggestionsQuery.mockReset();
+  mockWriteCompilationTracks.mockReset();
+  mockRefetchStored.mockReset();
+  mockUseLazyGetCompilationTrackSuggestionsQuery.mockReturnValue([
+    mockFetchSuggestions,
+    { isFetching: false },
+  ]);
+  mockGetCompilationTracksQuery.mockReturnValue(emptyStored);
+});
+
+describe("Classic ReleaseTracklistEditor", () => {
+  it("shows a loading state while the release loads", () => {
+    mockGetInformationQuery.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    expect(screen.getByText("Loading the release...")).toBeDefined();
+  });
+
+  it("surfaces a load failure rather than rendering an empty editor", () => {
+    mockGetInformationQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    expect(screen.getByTestId("release-tracklist-error")).toBeDefined();
+  });
+
+  it("is gated on the structural V/A code, not the display-only album_artist field", () => {
+    // album_artist is set (as VariousArtistsCard's add path would leave it
+    // unset until the nightly import runs), but the artist's own code_letters
+    // is an ordinary one — this must NOT be treated as a compilation.
+    mockGetInformationQuery.mockReturnValue({
+      data: ordinaryAlbum({ album_artist: "Various" }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={53375} />);
+
+    expect(screen.getByTestId("release-tracklist-not-various")).toBeDefined();
+    expect(screen.queryByTestId("release-tracklist-form")).toBeNull();
+  });
+
+  it("recognizes the legacy Z-<letter> spelling as a compilation", () => {
+    mockGetInformationQuery.mockReturnValue({
+      data: vaAlbum({ artist: createTestArtist({ name: "Soundtracks - S", lettercode: "Z-S", numbercode: 0, genre: "Rock" }) }),
+      isLoading: false,
+      isError: false,
+    });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    expect(screen.getByTestId("release-tracklist-form")).toBeDefined();
+  });
+
+  it("renders the already-filed credits for a compilation release", () => {
+    mockGetInformationQuery.mockReturnValue({ data: vaAlbum(), isLoading: false, isError: false });
+    mockGetCompilationTracksQuery.mockReturnValue({
+      data: {
+        library_id: VA_ALBUM_ID,
+        tracks: [
+          { id: 1, artist_name: "Chuquimamani-Condori", track_title: "Call Your Name", track_position: "A1" },
+          { id: 2, artist_name: "Nilüfer Yanya", track_title: "Stabilise", track_position: "A2" },
+        ],
+      },
+      isError: false,
+      isFetching: false,
+      refetch: mockRefetchStored,
+    });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    const stored = screen.getByTestId("release-tracklist-stored");
+    expect(stored.textContent).toContain("Chuquimamani-Condori");
+    expect(stored.textContent).toContain("Nilüfer Yanya");
+  });
+
+  it("scopes every query and the write to the Backend library.id, never the legacy release id", async () => {
+    const user = userEvent.setup();
+    mockGetInformationQuery.mockReturnValue({
+      data: vaAlbum({ legacy_release_id: 91100 }),
+      isLoading: false,
+      isError: false,
+    });
+    mockWriteCompilationTracks.mockReturnValue({ unwrap: () => Promise.resolve({ library_id: VA_ALBUM_ID, inserted: 1, skipped: 0, tracks: [] }) });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    expect(mockGetCompilationTracksQuery).toHaveBeenCalledWith({ libraryId: VA_ALBUM_ID });
+
+    await user.type(screen.getByLabelText("Artist for track 1"), "Juana Molina");
+    await user.type(screen.getByLabelText("Title for track 1"), "la paradoja");
+    await user.click(screen.getByDisplayValue("Save Track Credits"));
+
+    await waitFor(() =>
+      expect(mockWriteCompilationTracks).toHaveBeenCalledWith({
+        libraryId: VA_ALBUM_ID,
+        tracks: [{ artist_name: "Juana Molina", track_title: "la paradoja", track_position: null }],
+      }),
+    );
+  });
+
+  it("refuses to submit with no artist entered on any row", async () => {
+    const user = userEvent.setup();
+    mockGetInformationQuery.mockReturnValue({ data: vaAlbum(), isLoading: false, isError: false });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    await user.click(screen.getByDisplayValue("Save Track Credits"));
+
+    expect(mockWriteCompilationTracks).not.toHaveBeenCalled();
+    expect(screen.getByTestId("release-tracklist-message").textContent).toContain(
+      "Enter at least one artist credit",
+    );
+  });
+
+  it("reports the server's inserted/skipped counts after a successful save", async () => {
+    const user = userEvent.setup();
+    mockGetInformationQuery.mockReturnValue({ data: vaAlbum(), isLoading: false, isError: false });
+    mockWriteCompilationTracks.mockReturnValue({
+      unwrap: () => Promise.resolve({ library_id: VA_ALBUM_ID, inserted: 1, skipped: 1, tracks: [] }),
+    });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    await user.type(screen.getByLabelText("Artist for track 1"), "Stereolab");
+    await user.click(screen.getByDisplayValue("Save Track Credits"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("release-tracklist-message").textContent).toContain(
+        "Filed 1 new credit(s); 1 already on file.",
+      ),
+    );
+  });
+
+  // The additive-only write can never amend or remove a row, so a corrected
+  // resubmission after a lost response would file a duplicate rather than a
+  // correction. Saving must therefore refuse to proceed on an unknown base
+  // state, not just on a known bad one.
+  it("disables saving while the already-filed credits could not be confirmed", async () => {
+    mockGetInformationQuery.mockReturnValue({ data: vaAlbum(), isLoading: false, isError: false });
+    mockGetCompilationTracksQuery.mockReturnValue({
+      data: undefined,
+      isError: true,
+      isFetching: false,
+      refetch: mockRefetchStored,
+    });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    expect(screen.getByDisplayValue("Save Track Credits")).toHaveProperty("disabled", true);
+  });
+
+  it("imports Discogs suggestions that are not already on file", async () => {
+    const user = userEvent.setup();
+    mockGetInformationQuery.mockReturnValue({ data: vaAlbum(), isLoading: false, isError: false });
+    mockGetCompilationTracksQuery.mockReturnValue({
+      data: {
+        library_id: VA_ALBUM_ID,
+        tracks: [{ id: 1, artist_name: "Jessica Pratt", track_title: "Back, Baby", track_position: "A1" }],
+      },
+      isError: false,
+      isFetching: false,
+      refetch: mockRefetchStored,
+    });
+    mockFetchSuggestions.mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({
+          library_id: VA_ALBUM_ID,
+          discogs_release_id: 4242,
+          tracks: [
+            { artist_name: "Jessica Pratt", track_title: "Back, Baby", track_position: "A1" },
+            { artist_name: "Hermanos Gutiérrez", track_title: "Thousand Days", track_position: "A2" },
+          ],
+        }),
+    });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    await user.click(screen.getByRole("button", { name: "Check Discogs for a Tracklist" }));
+
+    await waitFor(() => expect(screen.getByLabelText("Artist for track 1")).toHaveProperty("value", "Hermanos Gutiérrez"));
+    // The already-filed Jessica Pratt credit must not be re-offered as new.
+    expect(screen.queryByDisplayValue("Jessica Pratt")).toBeNull();
+  });
+});

--- a/tests/integration/components/classic/catalog/ReleaseTracklistEditor.test.tsx
+++ b/tests/integration/components/classic/catalog/ReleaseTracklistEditor.test.tsx
@@ -225,9 +225,112 @@ describe("Classic ReleaseTracklistEditor", () => {
     expect(screen.getByDisplayValue("Save Track Credits")).toHaveProperty("disabled", true);
   });
 
-  it("imports Discogs suggestions that are not already on file", async () => {
+  // A write that fails may still have committed -- the rows land and the
+  // response is lost. The stored list on screen is then a stale account of the
+  // release, and the endpoint cannot amend, so a second save of a corrected row
+  // files it beside the original. Saving stays refused until a fresh read lands.
+  it("re-reads what is on file after a failed save, and refuses another save meanwhile", async () => {
     const user = userEvent.setup();
     mockGetInformationQuery.mockReturnValue({ data: vaAlbum(), isLoading: false, isError: false });
+    mockWriteCompilationTracks.mockReturnValue({
+      unwrap: () => Promise.reject(new Error("connection reset")),
+    });
+    mockRefetchStored.mockReturnValue({ unwrap: () => new Promise(() => {}) });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    await user.type(screen.getByLabelText("Artist for track 1"), "Juana Molina");
+    await user.click(screen.getByDisplayValue("Save Track Credits"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("release-tracklist-message").textContent).toContain(
+        "could not be saved",
+      ),
+    );
+    expect(mockRefetchStored).toHaveBeenCalled();
+    expect(screen.getByDisplayValue("Save Track Credits")).toHaveProperty("disabled", true);
+  });
+
+  it("lifts that refusal as soon as the re-read lands, rather than locking the screen", async () => {
+    const user = userEvent.setup();
+    let confirmRead: (value: unknown) => void = () => {};
+    mockGetInformationQuery.mockReturnValue({ data: vaAlbum(), isLoading: false, isError: false });
+    mockWriteCompilationTracks.mockReturnValue({
+      unwrap: () => Promise.reject(new Error("connection reset")),
+    });
+    mockRefetchStored.mockReturnValue({
+      unwrap: () => new Promise((resolve) => { confirmRead = resolve; }),
+    });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    await user.type(screen.getByLabelText("Artist for track 1"), "Juana Molina");
+    await user.click(screen.getByDisplayValue("Save Track Credits"));
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("Save Track Credits")).toHaveProperty("disabled", true),
+    );
+
+    confirmRead({ library_id: VA_ALBUM_ID, tracks: [] });
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("Save Track Credits")).toHaveProperty("disabled", false),
+    );
+  });
+
+  // Two clicks on the Discogs button must not leave two editable copies of the
+  // same track: correcting one copy and saving files the correction *and* the
+  // original, and neither can be removed afterwards.
+  it("does not re-import a suggestion already sitting in the form", async () => {
+    const user = userEvent.setup();
+    mockGetInformationQuery.mockReturnValue({ data: vaAlbum(), isLoading: false, isError: false });
+    mockFetchSuggestions.mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({
+          library_id: VA_ALBUM_ID,
+          discogs_release_id: 4242,
+          tracks: [
+            { artist_name: "Hermanos Gutiérrez", track_title: "Thousand Days", track_position: "A1" },
+          ],
+        }),
+    });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    const button = screen.getByRole("button", { name: "Check Discogs for a Tracklist" });
+    await user.click(button);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Artist for track 1")).toHaveProperty(
+        "value",
+        "Hermanos Gutiérrez",
+      ),
+    );
+    await user.click(button);
+
+    await waitFor(() =>
+      expect(screen.getAllByDisplayValue("Hermanos Gutiérrez")).toHaveLength(1),
+    );
+    expect(screen.queryByLabelText("Artist for track 2")).toBeNull();
+  });
+
+  // A live region announces only what changes inside it. Mounting the region
+  // and its first message together leaves a screen-reader user with silence
+  // where a sighted one reads an outcome.
+  it("keeps the Discogs outcome's live region mounted before there is an outcome", () => {
+    mockGetInformationQuery.mockReturnValue({ data: vaAlbum(), isLoading: false, isError: false });
+
+    renderWithProviders(<ReleaseTracklistEditor albumId={VA_ALBUM_ID} />);
+
+    expect(screen.getByTestId("release-tracklist-suggestions-message")).toBeDefined();
+  });
+
+  it("imports Discogs suggestions that are not already on file", async () => {
+    const user = userEvent.setup();
+    mockGetInformationQuery.mockReturnValue({
+      data: vaAlbum({ legacy_release_id: 91100 }),
+      isLoading: false,
+      isError: false,
+    });
     mockGetCompilationTracksQuery.mockReturnValue({
       data: {
         library_id: VA_ALBUM_ID,
@@ -253,6 +356,10 @@ describe("Classic ReleaseTracklistEditor", () => {
 
     await user.click(screen.getByRole("button", { name: "Check Discogs for a Tracklist" }));
 
+    // The suggestions read resolves its path param against `library.id` too.
+    // The legacy id is a live id in another space, so passing it would return
+    // an unrelated release's tracklist with a 200 rather than failing.
+    await waitFor(() => expect(mockFetchSuggestions).toHaveBeenCalledWith({ libraryId: VA_ALBUM_ID }));
     await waitFor(() => expect(screen.getByLabelText("Artist for track 1")).toHaveProperty("value", "Hermanos Gutiérrez"));
     // The already-filed Jessica Pratt credit must not be re-offered as new.
     expect(screen.queryByDisplayValue("Jessica Pratt")).toBeNull();

--- a/tests/unit/lib/features/catalog/compilationTrackCredits.test.ts
+++ b/tests/unit/lib/features/catalog/compilationTrackCredits.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { compilationTrackCreditKey } from "@/lib/features/catalog/compilationTrackCredits";
+
+describe("compilationTrackCreditKey", () => {
+  it("distinguishes an artist/title split that a plain-joined string would collide on", () => {
+    const splitOne = compilationTrackCreditKey({
+      artist_name: "Cat",
+      track_title: "Power Ballad",
+    });
+    const splitTwo = compilationTrackCreditKey({
+      artist_name: "Cat Power",
+      track_title: "Ballad",
+    });
+
+    expect(splitOne).not.toBe(splitTwo);
+  });
+
+  it("trims both fields before keying, matching the server's dedupe on submission", () => {
+    const untrimmed = compilationTrackCreditKey({
+      artist_name: "  Jessica Pratt  ",
+      track_title: "  Back, Baby  ",
+    });
+    const trimmed = compilationTrackCreditKey({
+      artist_name: "Jessica Pratt",
+      track_title: "Back, Baby",
+    });
+
+    expect(untrimmed).toBe(trimmed);
+  });
+
+  it("treats a null and a missing track_title identically", () => {
+    const withNull = compilationTrackCreditKey({
+      artist_name: "Chuquimamani-Condori",
+      track_title: null,
+    });
+    const withUndefined = compilationTrackCreditKey({
+      artist_name: "Chuquimamani-Condori",
+    });
+
+    expect(withNull).toBe(withUndefined);
+  });
+
+  it("distinguishes two credits for the same artist with different titles", () => {
+    const a = compilationTrackCreditKey({
+      artist_name: "Stereolab",
+      track_title: "Metronomic Underground",
+    });
+    const b = compilationTrackCreditKey({
+      artist_name: "Stereolab",
+      track_title: "Tone Burst",
+    });
+
+    expect(a).not.toBe(b);
+  });
+});

--- a/tests/unit/lib/features/catalog/compilationTrackCredits.test.ts
+++ b/tests/unit/lib/features/catalog/compilationTrackCredits.test.ts
@@ -40,6 +40,23 @@ describe("compilationTrackCreditKey", () => {
     expect(withNull).toBe(withUndefined);
   });
 
+  // The server's uniqueness index covers artist and title together. A key that
+  // dropped the artist would report a Discogs suggestion as already filed
+  // because some other artist's track shares its title, and quietly refuse to
+  // offer it.
+  it("distinguishes two credits sharing a title but crediting different artists", () => {
+    const one = compilationTrackCreditKey({
+      artist_name: "Juana Molina",
+      track_title: "Back, Baby",
+    });
+    const other = compilationTrackCreditKey({
+      artist_name: "Jessica Pratt",
+      track_title: "Back, Baby",
+    });
+
+    expect(one).not.toBe(other);
+  });
+
   it("distinguishes two credits for the same artist with different titles", () => {
     const a = compilationTrackCreditKey({
       artist_name: "Stereolab",


### PR DESCRIPTION
Second and last PR on Slice 3 of WXYC/dj-site#1163. WXYC/dj-site#1282 carried the V/A bucket card, the structural routing and the 19923 sentinel; this carries per-track artist credit entry.

## What the screen does, and why it has to exist

`/dashboard/library/release/[id]/tracklist` is a plain-HTML form that files per-track artist credits for a Various Artists release: position, artist, track title, one row per track, plus a button that pulls the release's Discogs tracklist in as pre-filled rows to confirm or correct. It is reached from the release editor, immediately above the read-only tracklist that screen already renders.

Per-track credits are what make an individual track on a compilation findable at all — release-level search is otherwise the only thing that ever matches them, and compilations are roughly 10% of the catalog. Today those rows arrive in exactly one way: the insert-only `jobs/library-etl` mirror of tubafrenzy's MySQL. **When `/wxycdb` goes dark that mirror stops, and nothing in the product writes `POST /library/:id/compilation-tracks` for a release that already exists.** Modern's `VaTracklistStep` writes it, but only inside the add-release wizard, for a release created seconds earlier — there is no way back to it for a compilation filed last week, or last decade. Classic's existing `Tracklist.tsx` is read-only. So without this screen, every compilation filed after cutover would be permanently creditless, and no existing one could ever be corrected forward.

## There is no JSP to copy

The slice's binding rule is that the JSP is the design spec. This screen has no JSP. `libraryReleaseModify.jsp`'s tracklist is display-only — `tracklist.js` fetches a tracklist from Discogs and renders it, and nothing posts back. tubafrenzy never gave a librarian a way to type a per-track artist. So there is no layout, field order, tab order, or button label to reproduce, and every choice below was made in a vacuum rather than derived from the legacy screen. Each one is therefore stated rather than assumed.

| Decision | What forced it |
|---|---|
| Placed on the release editor as a `/tracklist` sub-screen, beside `/move` and `/delete` | The read-only tracklist already lives on the release editor, so the write path for the same data belongs at the same address. The alternative — hanging it off the V/A bucket card — would put per-*release* editing on a per-*shelf* screen, and the bucket card is deliberately read-only at the bucket level. |
| Reuses classic's release-editor chrome (`.label` nav strip, `LIBRARY RELEASE: <call number> - <title>` heading, centered `<h3>` message line) rather than inventing a form idiom | The surrounding sub-screens (`libraryReleaseModifyLibCode.jsp`, `libraryReleaseDelete.jsp`) all share that chrome. Copying the nearest sibling is the only available substitute for a spec. |
| Rows are added and removed client-side, with a per-row `Remove` button; no server round trip per row | The endpoint takes a batch (`{ tracks: [...] }`, capped at 500 server-side) and reports `inserted`/`skipped` for the batch. A row-at-a-time UI would fabricate a request shape the contract does not have. |
| "Check Discogs for a Tracklist" is an explicit button, not an automatic fetch on mount | Modern fetches suggestions eagerly because its step exists only inside the add flow, where the librarian has just asked for exactly that. Here the screen is also the place you come to correct or extend an existing list, and the suggestions read triggers upstream Discogs work — firing it on every visit would spend a rate-limited upstream call on a librarian who came to add one missing credit. |
| A failed suggestions lookup says so in those words, and never falls back to "Discogs had no match" | `getCompilationTrackSuggestions` opts out of the shared non-JSON soft-fail for this exact reason: the soft-fail's `null` is indistinguishable from the upstream's genuine `discogs_release_id: null` + empty `tracks`, which is the signal that sends the librarian to hand-type a tracklist. An outage must not be able to impersonate it. |
| Discogs suggestions already on file are filtered out of the import rather than offered and skipped on save | The server dedupes on `(library_id, artist_name, track_title)` and silently absorbs a duplicate. Offering a row the server will discard reads as a lost edit. |
| Blank optional fields are sent as `null`, not `""` | The `cta_unique_null_track_idx` partial index covers `track_title IS NULL`; the server normalizes blank to null on the way in, and the client keying has to agree or the two disagree about what is already filed. |
| The screen refuses non-V/A releases with an explanatory page rather than a 404 | A librarian who follows a stale or hand-typed URL to an ordinary release has made a navigation mistake, not requested a nonexistent thing. A non-numeric path segment *is* a 404, matching the sibling pages' guard. |

## Three things worth a reviewer's attention

**1. This PR modifies a file under `experiences/modern/`, and I would like that confirmed or rejected.**

`VaTracklistStep.tsx`'s local `creditKey` helper is now `compilationTrackCreditKey` in `lib/features/catalog/compilationTrackCredits.ts`, imported by both screens. The justification: both write to the same additive-only endpoint, and the client-side notion of "this credit is already filed" has to match the server's uniqueness key exactly. If the two copies drift, one screen offers as new a row the server will silently skip, or loses track of a row it will silently duplicate under a corrected spelling — a defect that is invisible until someone compares two shelves.

Two caveats I do not want to gloss:

- **The move is not byte-identical.** The serialization changed from a NUL-joined string to `JSON.stringify` of the `[artist, title]` pair. Both are injective over the same inputs and neither key is persisted or compared across processes, so no behaviour depends on the difference; the pair form just stops the separator question from being a question. `VaTracklistStep.test.tsx` is unmodified and green.
- **WXYC/dj-site#1168 says modifying that area "breaks the epic's 'modern unchanged' criterion."** In context that sentence is about `is-compilation-artist.ts` — which is untouched here, its three exports byte-identical and all six importers untouched, as in #1282. But the criterion is stated broadly enough that this is a judgement call rather than a settled one. If the reviewer would rather modern stayed literally untouched, the alternative is a second copy of the key rule in classic, and the drift hazard above is the price. Say so and I will revert the extraction.

**2. The V/A gate is `isVariousArtists(code_letters)`, not the `album_artist` field — and the read side had to move too.**

`library.album_artist` is written by exactly one thing: the catalog import mirroring tubafrenzy's MySQL. So it lags a freshly-filed release, it stops being written at all after cutover, and today it is empty on every row in the library (Backend's `jobs/library-etl` is the only writer; `jobs/album-reviews-etl` pins the "empty on all ~64k rows" fact against a real PG). Gating a *write* affordance on it would hide this screen from precisely the release that needs it most: the compilation filed this afternoon, which has no credits and no other way to get any. `code_letters` is structural, arrives with the artist row, and selects the shelf exactly — 53 artist rows, ~6,300 releases, including the `Soundtracks - <A-Z>` sub-shelf that contains no compilation keyword anywhere. Same rule `artistCardHref` routes on.

The read side of the same round trip was still on `album_artist`: `ReleaseCard` passed `variousArtists={!!data.album_artist}` to the read-only `Tracklist`, which uses it to *skip* the credit query entirely. With that column empty, credits filed through this new screen would never have appeared on the screen that links to it — the librarian's work would have read as lost. `ReleaseCard` now passes `isVariousArtists(data.artist.lettercode)`, so both halves decide the same way. That is a one-line change to a pre-existing line, made because this PR is what turns it into a visible defect.

**3. Saving is refused until the already-filed credits are known — including after a write that failed.**

`POST /library/:id/compilation-tracks` is additive-only: it can add a credit, never amend or remove one. Existing rows matched on the uniqueness key are skipped, not mutated. So a resubmission after a *lost response* — the write committed, the response never arrived — is safe for an unchanged row and unsafe for a corrected one, which lands beside the row it was meant to replace with `skipped` as the only hint, both of them searchable forever. The screen therefore reads the stored credits on mount (never skipped — the release already exists, so unlike modern's step the read is never wasted) and disables Save whenever that read has not succeeded. An empty `tracks` array is never treated as "nothing is filed": on mount it is indistinguishable from "not loaded yet", so the flag is derived from the read having actually succeeded.

A failed write is the case that most needs this and was the one it missed. The last read had succeeded, so Save stayed enabled — against a stored list that a half-succeeded write had just made stale. A write failure now reissues the read and holds the refusal until it lands; the stored-credits banner's own retry clears the same refusal, so neither path can strand the screen.

## Also in this branch, from reviewing the above

Four defects the first pass left, each with a test that fails against the code without the fix:

- The read side of the round trip, above.
- The failed-write refusal, above.
- Discogs suggestions were deduplicated against the stored credits but not against the rows already in the form. A second lookup left two editable copies of one track; correcting one of them and saving files both, and neither can be removed here.
- The Discogs outcome's live region was mounted together with its first message. A region that appears with its content is silence to a screen reader, so the librarian who most needs the outcome read aloud is the one who does not get it. It is now always mounted, matching the save-outcome line beside it.

Plus a coverage hole rather than a defect: all four existing cases for the credit key passed with a key made of the title alone, which would report a Discogs suggestion as already filed whenever some other artist's track shared its title. Pinned.

## Tests

`tests/integration/app/dashboard/@classic/library/release/tracklist-page.test.tsx` (page authority, on the shared harness), `tests/integration/components/classic/catalog/ReleaseTracklistEditor.test.tsx` (gate, stored-credit render, id scoping, refusals, Discogs import dedupe), `tests/integration/components/classic/catalog/ReleaseCard.test.tsx` (link presence/absence), `tests/unit/lib/features/catalog/compilationTrackCredits.test.ts` (the extracted key).

Closes #1168
