### PR TITLE
Classic rotation list + free-text rotation add

### DIFF
--- a/app/dashboard/@classic/rotation/new/page.tsx
+++ b/app/dashboard/@classic/rotation/new/page.tsx
@@ -1,0 +1,27 @@
+import { Metadata } from "next";
+import { getPageTitle } from "@/lib/utils/page-title";
+import { requireAuth, requireRole } from "@/lib/features/authentication/server-utils";
+import { Authorization } from "@/lib/features/admin/types";
+import Main from "@/src/components/experiences/classic/Layout/Main";
+import RotationReleaseInsert from "@/src/components/experiences/classic/rotation/RotationReleaseInsert";
+
+export const metadata: Metadata = {
+  title: getPageTitle("Add Rotation Release"),
+};
+
+// MD-gated, though `mainmenu.jsp` does not admin-gate the "Add Rotation
+// Release" link: Backend requires `catalog: ['write']` for
+// `POST /library/rotation`, so an ungated page would render a full add form
+// to a DJ and fail at submit. Matches `/dashboard/rotation/[id]` and
+// `/dashboard/rotation/[id]/import` in `docs/architecture.md`'s URL map,
+// both also MD for the same reason.
+export default async function ClassicRotationInsertPage() {
+  const session = await requireAuth();
+  await requireRole(session, Authorization.MD);
+
+  return (
+    <Main>
+      <RotationReleaseInsert />
+    </Main>
+  );
+}

--- a/app/dashboard/@classic/rotation/page.tsx
+++ b/app/dashboard/@classic/rotation/page.tsx
@@ -1,0 +1,52 @@
+import { Metadata } from "next";
+import { getPageTitle } from "@/lib/utils/page-title";
+import { requireAuth, requireRole } from "@/lib/features/authentication/server-utils";
+import { Authorization } from "@/lib/features/admin/types";
+import Main from "@/src/components/experiences/classic/Layout/Main";
+import RotationReleaseList from "@/src/components/experiences/classic/rotation/RotationReleaseList";
+import { firstSearchParam } from "@/lib/utils/search-params";
+import { DEFAULT_ROTATION_STATUS_FILTER, type RotationStatusFilter } from "@/lib/features/rotation/types";
+
+export const metadata: Metadata = {
+  title: getPageTitle("Rotation Releases"),
+};
+
+const VALID_STATUS_FILTERS: readonly RotationStatusFilter[] = ["all", "active", "killed", "uncataloged"];
+
+function parseStatusFilter(raw: string | undefined): RotationStatusFilter {
+  return (VALID_STATUS_FILTERS as readonly string[]).includes(raw ?? "")
+    ? (raw as RotationStatusFilter)
+    : DEFAULT_ROTATION_STATUS_FILTER;
+}
+
+type ClassicRotationListPageProps = {
+  searchParams: Promise<{ status?: string | string[] }>;
+};
+
+// Gated at authenticated-DJ, never MD: `mainmenu.jsp` places both rotation
+// links outside its hasAdminAccess() block, and Backend agrees --
+// `GET /library/rotation` and `GET /library/rotation/uncatalogued` are
+// gated at `catalog: ['read']`, while every rotation write requires
+// `catalog: ['write']`. Reading the list (and its Awaiting Cataloging
+// facet) is DJ-accessible; only `/dashboard/rotation/new` -- the write
+// surface -- is MD.
+//
+// `status` is read server-side and passed down, matching
+// `ClassicCreateLibraryCodePage` -> `CreateLibraryCodeForm`'s convention:
+// the JSP's own facet chips are real links to a new `status=` value (a full
+// navigation, not a client-side tab), so a URL is the single source of
+// truth for which facet is showing -- an unrecognized or absent value
+// silently falls back to the default (active-only) rather than erroring.
+export default async function ClassicRotationListPage({ searchParams }: ClassicRotationListPageProps) {
+  const session = await requireAuth();
+  await requireRole(session, Authorization.DJ);
+
+  const params = await searchParams;
+  const statusFilter = parseStatusFilter(firstSearchParam(params.status));
+
+  return (
+    <Main>
+      <RotationReleaseList statusFilter={statusFilter} />
+    </Main>
+  );
+}

--- a/e2e/tests/classic/rotation-authority.spec.ts
+++ b/e2e/tests/classic/rotation-authority.spec.ts
@@ -1,0 +1,70 @@
+import path from "path";
+import { test, expect } from "../../fixtures/auth.fixture";
+
+const authDir = path.join(__dirname, "../../.auth");
+
+/**
+ * Asserts the authority split rotationReleaseList.jsp / rotationReleaseInsert.jsp
+ * carry over: the classic rotation list is DJ-readable, the free-text add
+ * form is MD-gated. `mainmenu.jsp` places both rotation links outside its
+ * hasAdminAccess() block, but Backend requires catalog:['write'] for every
+ * rotation write, so the list and the insert form are gated at different
+ * authorities -- this spec is what actually exercises that split end to
+ * end, rather than trusting the two page-authority unit tests never to
+ * disagree about it.
+ *
+ * Uses the dedicated classicDj/classicMd identities (provisioned in
+ * e2e/auth.setup.ts's "provision classic-preference identity" step) rather
+ * than the app_state cookie: `setExperienceCookie` is inert on a signed-in
+ * context (the account's own appSkin wins on every request once a session
+ * resolves), so a real classic-preference account is the only way to reach
+ * these pages' classic slot at all.
+ */
+test.describe("Classic rotation authority split", () => {
+  test.describe("DJ", () => {
+    test.use({ storageState: path.join(authDir, "classicDj.json") });
+
+    test("reaches the rotation list", async ({ page }) => {
+      await page.goto("/dashboard/rotation");
+
+      await expect(page.locator("#classic-container")).toBeVisible({ timeout: 15000 });
+      await expect(page.getByRole("heading", { name: "Rotation Releases" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Add Rotation Release" })).toBeVisible();
+    });
+
+    test("is denied the free-text add form", async ({ page }) => {
+      await page.goto("/dashboard/rotation/new");
+
+      // The deny redirect can arrive as a streaming-SSR client redirect (the
+      // shell flushes at the gated URL first, the router soft-navigates
+      // after hydration) -- poll for the final URL rather than sampling
+      // immediately after `goto` resolves, mirroring
+      // DashboardPage.expectRedirectedToDefaultDashboard.
+      await page.waitForURL(
+        (u) => {
+          const url = u.toString();
+          return !url.includes("/dashboard/rotation/new") && !url.includes("/login");
+        },
+        { timeout: 15000 },
+      );
+      expect(page.url()).not.toContain("/dashboard/rotation/new");
+    });
+  });
+
+  test.describe("Music Director", () => {
+    test.use({ storageState: path.join(authDir, "classicMd.json") });
+
+    test("reaches the free-text add form", async ({ page }) => {
+      await page.goto("/dashboard/rotation/new");
+
+      await expect(page.locator("#classic-container")).toBeVisible({ timeout: 15000 });
+      await expect(page.getByRole("button", { name: "Add this record" })).toBeVisible();
+    });
+
+    test("also reaches the rotation list", async ({ page }) => {
+      await page.goto("/dashboard/rotation");
+
+      await expect(page.getByRole("heading", { name: "Rotation Releases" })).toBeVisible();
+    });
+  });
+});

--- a/lib/features/rotation/addErrorMessage.ts
+++ b/lib/features/rotation/addErrorMessage.ts
@@ -1,0 +1,33 @@
+/**
+ * The message to show an MD when `POST /library/rotation` (the free-text
+ * add) is refused.
+ *
+ * Mirrors `flowsheetWriteErrorMessage`'s shape-unwrapping, kept as its own
+ * copy rather than a shared import: the two live in different features and
+ * their fallback copy is feature-specific ("add rotation release" vs "add to
+ * flowsheet"). Backend-Service's `addRotation` controller (the free-text
+ * relaxation of `POST /library/rotation` for a release with no catalogued
+ * album) reports every refusal -- a missing `rotation_bin`, a missing
+ * artist/title pair, a snapshot field over the 128-character limit -- as a
+ * `WxycError`, which serializes to `{ message }`. That string is precise
+ * enough to act on and is rendered inline (see `RotationReleaseInsert`'s
+ * `validationMessage`, matching the JSP's own div of the same name), so this
+ * only falls back to a generic sentence for shapes that carry no such
+ * message at all.
+ */
+export function rotationAddErrorMessage(err: unknown): string {
+  if (
+    err &&
+    typeof err === "object" &&
+    "data" in err &&
+    err.data &&
+    typeof err.data === "object" &&
+    "message" in err.data &&
+    typeof (err.data as { message: unknown }).message === "string"
+  ) {
+    return (err.data as { message: string }).message;
+  }
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "Failed to add rotation release.";
+}

--- a/lib/features/rotation/api.ts
+++ b/lib/features/rotation/api.ts
@@ -1,4 +1,5 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
+import type { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import type { RootState } from "@/lib/store";
 import { backendBaseQuery } from "../backend";
 import { convertToAlbumEntry } from "../catalog/conversions";
@@ -9,6 +10,11 @@ import type {
   KillRotationRequest,
   RotationEntry,
 } from "@wxyc/shared";
+import type {
+  FreeTextRotationAddRequest,
+  RotationListRow,
+  UncataloguedRotationRow,
+} from "./types";
 
 export const rotationApi = createApi({
   reducerPath: "rotationApi",
@@ -100,6 +106,87 @@ export const rotationApi = createApi({
         url: `/${rotationId}/tracks`,
       }),
     }),
+    // The classic list's Active facet. Distinct from `getRotation` above,
+    // which converts the same `GET /library/rotation` response into
+    // `AlbumEntry[]` for the modern add-to-rotation picker and drops every
+    // field that conversion doesn't read (`rotation_id`, `rotation_bin`,
+    // `rotation_add_date`, `rotation_kill_date`) -- exactly the fields the
+    // classic list's Type/Added/Killed columns and Kill/Unkill actions need.
+    // A second endpoint against the same URL costs a second request when a
+    // page uses both shapes; no page does today.
+    // Opts out of the shared soft-JSON-failure handling
+    // (`surfaceNonJsonAsError`), matching `getUncataloguedRotation` below: a
+    // query-fed list must never render an unissued or failed request as "there
+    // are none", and the Active facet reading a backend outage as "no
+    // releases are active" is exactly that failure.
+    getRotationList: builder.query<RotationListRow[], void>({
+      query: () => ({ url: "" }),
+      extraOptions: { surfaceNonJsonAsError: true },
+      providesTags: ["Rotation"],
+    }),
+    // The Awaiting Cataloging queue (`GET /library/rotation/uncatalogued`, the
+    // cataloging-backlog read Backend's relaxed rotation-add path pairs with).
+    // `limit`/`offset` are passed straight through as query params; omitting
+    // the arg omits both, which Backend treats as "the default page"
+    // (`UNCATALOGUED_ROTATION_MAX_LIMIT`, currently 500) rather than "no
+    // rows" -- there is no arg shape here that could send `limit=0`.
+    //
+    // Opts out of the shared soft-JSON-failure handling
+    // (`surfaceNonJsonAsError`), matching `labelsApi.searchLabels`: an empty
+    // rotation queue is exactly the state a query-fed list must never render
+    // an outage as, and the shared base query's default behavior for a
+    // non-JSON body is exactly a silent empty list.
+    getUncataloguedRotation: builder.query<
+      UncataloguedRotationRow[],
+      { limit?: number; offset?: number } | void
+    >({
+      query: (args) => ({ url: "/uncatalogued", params: args ?? undefined }),
+      extraOptions: { surfaceNonJsonAsError: true },
+      providesTags: ["Rotation"],
+    }),
+    // `POST /library/rotation` for a release with no catalogued album (the
+    // free-text path Backend added alongside the cataloging-backlog read
+    // above) -- distinct from `addRotationEntry` above,
+    // which is typed against the published `AddRotationRequest` and requires
+    // `album_id`. The response is the full raw `rotation` row, a superset of
+    // `UncataloguedRotationRow`'s fields.
+    //
+    // Every refusal from this endpoint (missing rotation_bin, missing
+    // artist_name/album_title, an over-length snapshot field) carries a
+    // message precise enough to act on, and the caller renders it inline
+    // (`RotationReleaseInsert`'s validationMessage, matching the JSP's own
+    // div of that name) -- so, like `labelsApi.searchLabels`, the message is
+    // nested under a key the shared rejected-query middleware's
+    // `payload.data.message` lookup does not recognize, keeping one refusal
+    // from being reported twice.
+    addFreeTextRotationEntry: builder.mutation<UncataloguedRotationRow, FreeTextRotationAddRequest>({
+      query: (body) => ({ url: "", method: "POST", body }),
+      transformErrorResponse: (
+        response: FetchBaseQueryError,
+      ): { rotationAddError: FetchBaseQueryError } => ({
+        rotationAddError: response,
+      }),
+      invalidatesTags: ["Rotation"],
+    }),
+    // Unkill: `PATCH /library/rotation/:id`, the field-level rotation editor,
+    // with `kill_date: null` clears a kill date. Distinct from
+    // `killRotationEntry` above, which
+    // hits the *other* rotation PATCH route (`PATCH /library/rotation`, no
+    // `:id`) that only ever sets a kill date -- there is no bodied "clear"
+    // shape on that route, so Unkill has to be the field-level editor
+    // instead. A kill_date-only PATCH never touches the artist_name /
+    // album_title / record_label snapshot trio, so it can never hit that
+    // route's linked-row 409 -- this mutation's response type is the
+    // same eight-field projection every `/library/rotation/:id` PATCH
+    // returns.
+    unkillRotationEntry: builder.mutation<UncataloguedRotationRow, { rotation_id: number }>({
+      query: ({ rotation_id }) => ({
+        url: `/${rotation_id}`,
+        method: "PATCH",
+        body: { kill_date: null },
+      }),
+      invalidatesTags: ["Rotation"],
+    }),
   }),
 });
 
@@ -115,5 +202,9 @@ export const {
   useAddRotationEntryMutation,
   useKillRotationEntryMutation,
   useGetRotationTracksQuery,
+  useGetRotationListQuery,
+  useGetUncataloguedRotationQuery,
+  useAddFreeTextRotationEntryMutation,
+  useUnkillRotationEntryMutation,
   usePrefetch: useRotationPrefetch,
 } = rotationApi;

--- a/lib/features/rotation/api.ts
+++ b/lib/features/rotation/api.ts
@@ -186,6 +186,33 @@ export const rotationApi = createApi({
         body: { kill_date: null },
       }),
       invalidatesTags: ["Rotation"],
+      async onQueryStarted(_arg, { dispatch, getState, queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          // The mirror image of `killRotationEntry`'s patch, and not
+          // optional: that handler writes a per-album "no rotation" override
+          // into the catalog slice, which shadows the server's own value on
+          // every later read. Without this, unkilling a release the same
+          // session killed leaves the catalog search results claiming it is
+          // out of rotation for as long as the tab is open -- a refetch does
+          // not clear the override, only another write to it does.
+          // `album_id` is null on a rotation row that never linked to a
+          // library album; there is nothing in the catalog to patch for one.
+          if (typeof data.album_id !== "number") return;
+          patchCatalogSearchRotation(
+            dispatch,
+            getState as () => RootState,
+            data.album_id,
+            { rotation_bin: data.rotation_bin, rotation_id: data.id },
+          );
+        } catch {
+          // A rejected `queryFulfilled` (mutation failure or the cache patch
+          // itself throwing) must not escape this handler: RTK Query treats
+          // an onQueryStarted rejection as an unhandled promise rejection,
+          // and the caller's own `.unwrap()` already owns surfacing the
+          // failure to the user (toast).
+        }
+      },
     }),
   }),
 });

--- a/lib/features/rotation/classicList.ts
+++ b/lib/features/rotation/classicList.ts
@@ -25,6 +25,13 @@ function localTodayISO(now: Date): string {
  * /library/rotation/uncatalogued`) is deliberately NOT status-filtered
  * server-side and mixes active and killed rows in one response.
  *
+ * Distinct from "has a kill date", which is what the JSP's Killed column,
+ * its Kill/Unkill choice and its Import affordance all key on
+ * (`release.killDate == 0`). A future-dated kill is both: still in rotation
+ * today, but already scheduled to leave. Conflating the two hides a
+ * scheduled kill date behind a green "Active" and offers a Kill button for
+ * a row that has already been killed.
+ *
  * Plain string comparison on `YYYY-MM-DD`, not a `Date` parse: a date-only
  * string has no timezone to get wrong, and lexicographic comparison of two
  * zero-padded ISO dates is exactly calendar-day comparison.
@@ -52,12 +59,12 @@ export type RotationLibraryStatus = "cataloged" | "uncataloged" | "unknown";
 /**
  * The JSP's Library column: Cataloged when linked (regardless of kill
  * status), Uncataloged when killed and never linked, and an em-dash
- * ("unknown" here) for a still-active, never-catalogued row -- it hasn't
+ * ("unknown" here) for a never-killed, never-catalogued row -- it hasn't
  * been through a cataloging decision yet.
  */
-export function rotationLibraryStatus(isLinked: boolean, isKilled: boolean): RotationLibraryStatus {
+export function rotationLibraryStatus(isLinked: boolean, hasKillDate: boolean): RotationLibraryStatus {
   if (isLinked) return "cataloged";
-  return isKilled ? "uncataloged" : "unknown";
+  return hasKillDate ? "uncataloged" : "unknown";
 }
 
 /** One row of the classic list's table, regardless of which endpoint produced it. */
@@ -66,48 +73,46 @@ export type RotationDisplayRow = {
   artistName: string;
   title: string;
   label: string;
-  binLabel: RotationBin;
+  /** The bin's own letter, which is what the JSP's Type column prints. */
+  bin: RotationBin;
   formatName: string;
   addedDisplay: string;
-  killed: boolean;
-  killedDisplay: string;
+  /**
+   * The kill date as `MM/DD/YY`, or `null` for a row that has never been
+   * killed. One value rather than a flag beside a string, so "killed with
+   * no date" and "not killed but carrying one" are both unrepresentable.
+   */
+  killedDisplay: string | null;
+  /** Whether the row still counts as in rotation today (a future kill hasn't landed). */
+  active: boolean;
   libraryStatus: RotationLibraryStatus;
-  showImport: boolean;
 };
 
-const EM_DASH = "—";
-
-function killedDisplay(killDate: string | null): string {
-  return killDate == null ? "Active" : formatRotationDate(killDate);
-}
+const EM_DASH = "\u2014";
 
 /**
- * Projects a `GET /library/rotation` row (catalogued or uncatalogued,
- * active-only by construction) into the shared display shape.
+ * Projects a `GET /library/rotation` row (catalogued or uncatalogued) into
+ * the shared display shape.
  *
  * `id` is `library.id` from Backend's LEFT JOIN and is the linkage
  * indicator -- `null` on an unlinked row. Checked with `hasLinkedAlbumId`
- * (its `> 0` guard) rather than a bare nullish check: the unlinked sentinel
- * is both `0` (tubafrenzy's convention) and `NULL` (Backend's), and while a
- * `library.id` can never actually be `0` (it's a `serial` starting at 1),
- * asserting that here would be trusting the invariant instead of checking
- * it.
+ * (its `> 0` guard) rather than a bare nullish check: while a `library.id`
+ * can never actually be `0` (it is a `serial` starting at 1), asserting
+ * that here would be trusting an invariant this client cannot see instead
+ * of checking it.
  */
 export function toDisplayRowFromList(row: RotationListRow, now: Date = new Date()): RotationDisplayRow {
-  const isLinked = hasLinkedAlbumId(row.id);
-  const active = isRotationRowActive(row.rotation_kill_date, now);
   return {
     rotationId: row.rotation_id,
     artistName: row.artist_name ?? "",
     title: row.album_title ?? "",
     label: row.record_label ?? "",
-    binLabel: row.rotation_bin,
+    bin: row.rotation_bin,
     formatName: row.format_name ?? EM_DASH,
     addedDisplay: formatRotationDate(row.rotation_add_date),
-    killed: !active,
-    killedDisplay: killedDisplay(row.rotation_kill_date),
-    libraryStatus: rotationLibraryStatus(isLinked, !active),
-    showImport: !active && !isLinked,
+    killedDisplay: row.rotation_kill_date == null ? null : formatRotationDate(row.rotation_kill_date),
+    active: isRotationRowActive(row.rotation_kill_date, now),
+    libraryStatus: rotationLibraryStatus(hasLinkedAlbumId(row.id), row.rotation_kill_date != null),
   };
 }
 
@@ -124,51 +129,78 @@ export function toDisplayRowFromUncatalogued(
   row: UncataloguedRotationRow,
   now: Date = new Date(),
 ): RotationDisplayRow {
-  const isLinked = hasLinkedAlbumId(row.album_id);
-  const active = isRotationRowActive(row.kill_date, now);
   return {
     rotationId: row.id,
     artistName: row.artist_name ?? "",
     title: row.album_title ?? "",
     label: row.record_label ?? "",
-    binLabel: row.rotation_bin,
+    bin: row.rotation_bin,
     formatName: EM_DASH,
     addedDisplay: formatRotationDate(row.add_date),
-    killed: !active,
-    killedDisplay: killedDisplay(row.kill_date),
-    libraryStatus: rotationLibraryStatus(isLinked, !active),
-    showImport: !active && !isLinked,
+    killedDisplay: row.kill_date == null ? null : formatRotationDate(row.kill_date),
+    active: isRotationRowActive(row.kill_date, now),
+    libraryStatus: rotationLibraryStatus(hasLinkedAlbumId(row.album_id), row.kill_date != null),
   };
 }
 
-/** A dedupe key from an artist/title pair: folded to collapse case and stray whitespace. */
+/**
+ * A dedupe key from an artist/title pair, folded to collapse case and stray
+ * whitespace.
+ *
+ * The two halves are encoded as a JSON array rather than joined by a
+ * separator character. Any separator an artist name or album title could
+ * itself contain makes `("Sun", "Ra Arkestra")` and `("Sun Ra",
+ * "Arkestra")` one key, silently dropping one of the two releases from the
+ * list; the separators that cannot appear in a title are all invisible
+ * control characters, which no reader or diff can verify by eye.
+ */
 function dedupeKey(artistName: string | null, albumTitle: string | null): string {
   const fold = (value: string | null) => (value ?? "").normalize("NFC").trim().toLowerCase();
-  return `${fold(artistName)} ${fold(albumTitle)}`;
+  return JSON.stringify([fold(artistName), fold(albumTitle)]);
 }
 
 /**
- * Collapses rotation rows that share an artist and title, keeping the first
- * occurrence. Rotation rows genuinely duplicate in production --
- * `LOS THUTHANAKA / Wak'a` appears three times across two days -- and
- * Backend's own `DISTINCT ON` in `getRotationFromDB` only collapses same
- * `(album, bin)` pairs, not a re-add under a different bin.
+ * Most-recently-added first, tie-broken on the lowest rotation id so the
+ * order is total. This is `rotationReleaseList.jsp`'s own Active-facet
+ * order (`ORDER BY RR.ROTATION_ADD_DATE DESC` in `RotationReleaseServlet`),
+ * and it is not the order the rows arrive in: `getRotationFromDB` orders by
+ * its `DISTINCT ON` partition key first -- an `album_id`, or a `hashtext`
+ * of the artist/title snapshot -- so the response reaches this client
+ * grouped by a hash, with `add_date` only breaking ties inside a group.
+ */
+function byMostRecentlyAdded(left: RotationListRow, right: RotationListRow): number {
+  if (left.rotation_add_date !== right.rotation_add_date) {
+    return left.rotation_add_date < right.rotation_add_date ? 1 : -1;
+  }
+  return left.rotation_id - right.rotation_id;
+}
+
+/**
+ * Sorts rotation rows most-recently-added first and collapses rows sharing
+ * an artist and title, keeping the most recent of each group.
  *
- * Callers pass rows already ordered most-recent-first (Backend's own
- * `ORDER BY add_date DESC, id ASC`), so "first occurrence" is "most
- * recent" without this function needing to know about dates at all.
+ * Rotation rows genuinely duplicate in production -- `LOS THUTHANAKA /
+ * Wak'a` appears three times across two days -- and Backend's own
+ * `DISTINCT ON` in `getRotationFromDB` only collapses same `(album, bin)`
+ * pairs, so a re-add under a different bin still arrives twice. The sort
+ * belongs here rather than to the caller because "keep the first
+ * occurrence" is only "keep the most recent" if the order is guaranteed,
+ * and the response's own order guarantees the opposite: inside a duplicate
+ * group the rows arrive ordered by bin letter, so taking the first would
+ * pin the list to whichever bin sorts earliest -- showing a release still
+ * in Heavy months after it moved to Light.
  *
  * Deliberately applied to the Active facet only, never to the Awaiting
- * Cataloging queue: `getUncataloguedRotationFromDB`'s own doc comment states
- * the opposite rule for that endpoint on purpose -- "two physically distinct
- * promos sharing an artist and title are two separate rows a librarian has
- * to catalogue" -- and re-collapsing them here would reintroduce the exact
- * bug (#862) that comment describes fixing.
+ * Cataloging queue: `getUncataloguedRotationFromDB`'s own doc comment
+ * states the opposite rule for that endpoint on purpose -- "two physically
+ * distinct promos sharing an artist and title are two separate rows a
+ * librarian has to catalogue" -- and re-collapsing them here would re-hide
+ * one of them from the person whose job is to catalogue it.
  */
 export function dedupeRotationListByArtistTitle(rows: RotationListRow[]): RotationListRow[] {
   const seen = new Set<string>();
   const result: RotationListRow[] = [];
-  for (const row of rows) {
+  for (const row of [...rows].sort(byMostRecentlyAdded)) {
     const key = dedupeKey(row.artist_name, row.album_title);
     if (seen.has(key)) continue;
     seen.add(key);

--- a/lib/features/rotation/classicList.ts
+++ b/lib/features/rotation/classicList.ts
@@ -1,0 +1,178 @@
+import { hasLinkedAlbumId } from "../flowsheet/linkage";
+import type { RotationBin, RotationListRow, UncataloguedRotationRow } from "./types";
+
+/**
+ * The viewer's local calendar day as `YYYY-MM-DD`. Deliberately local, not
+ * UTC: `rotation.kill_date`/`rotation.add_date` are plain SQL `date` columns
+ * with no time component, and the station's DJs and the database both live
+ * in Eastern time -- comparing against a UTC "today" would misclassify a row
+ * killed earlier today as still-active for however many hours UTC runs
+ * ahead of the viewer's evening (the same trap `rotationApi`'s
+ * `killRotationEntry` comment documents for the write side).
+ */
+function localTodayISO(now: Date): string {
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * A rotation row is active when it has never been killed, or its kill date
+ * hasn't arrived yet -- mirrors `getRotationFromDB`'s own
+ * `kill_date IS NULL OR kill_date > CURRENT_DATE` predicate, reproduced
+ * client-side because the Awaiting Cataloging queue (`GET
+ * /library/rotation/uncatalogued`) is deliberately NOT status-filtered
+ * server-side and mixes active and killed rows in one response.
+ *
+ * Plain string comparison on `YYYY-MM-DD`, not a `Date` parse: a date-only
+ * string has no timezone to get wrong, and lexicographic comparison of two
+ * zero-padded ISO dates is exactly calendar-day comparison.
+ */
+export function isRotationRowActive(killDate: string | null, now: Date = new Date()): boolean {
+  if (killDate == null) return true;
+  return killDate > localTodayISO(now);
+}
+
+/**
+ * `MM/DD/YY`, matching `rotationReleaseList.jsp`'s
+ * `DateTimeManager.getLongDateAsMMDDYY`. Reads the ISO string's own digits
+ * rather than round-tripping through `Date` -- a date-only string parsed
+ * with `new Date(...)` is UTC midnight, which a viewer west of UTC renders
+ * as the previous calendar day.
+ */
+export function formatRotationDate(iso: string | null): string {
+  if (!iso) return "";
+  const [year, month, day] = iso.split("-");
+  return `${month}/${day}/${year.slice(2)}`;
+}
+
+export type RotationLibraryStatus = "cataloged" | "uncataloged" | "unknown";
+
+/**
+ * The JSP's Library column: Cataloged when linked (regardless of kill
+ * status), Uncataloged when killed and never linked, and an em-dash
+ * ("unknown" here) for a still-active, never-catalogued row -- it hasn't
+ * been through a cataloging decision yet.
+ */
+export function rotationLibraryStatus(isLinked: boolean, isKilled: boolean): RotationLibraryStatus {
+  if (isLinked) return "cataloged";
+  return isKilled ? "uncataloged" : "unknown";
+}
+
+/** One row of the classic list's table, regardless of which endpoint produced it. */
+export type RotationDisplayRow = {
+  rotationId: number;
+  artistName: string;
+  title: string;
+  label: string;
+  binLabel: RotationBin;
+  formatName: string;
+  addedDisplay: string;
+  killed: boolean;
+  killedDisplay: string;
+  libraryStatus: RotationLibraryStatus;
+  showImport: boolean;
+};
+
+const EM_DASH = "—";
+
+function killedDisplay(killDate: string | null): string {
+  return killDate == null ? "Active" : formatRotationDate(killDate);
+}
+
+/**
+ * Projects a `GET /library/rotation` row (catalogued or uncatalogued,
+ * active-only by construction) into the shared display shape.
+ *
+ * `id` is `library.id` from Backend's LEFT JOIN and is the linkage
+ * indicator -- `null` on an unlinked row. Checked with `hasLinkedAlbumId`
+ * (its `> 0` guard) rather than a bare nullish check: the unlinked sentinel
+ * is both `0` (tubafrenzy's convention) and `NULL` (Backend's), and while a
+ * `library.id` can never actually be `0` (it's a `serial` starting at 1),
+ * asserting that here would be trusting the invariant instead of checking
+ * it.
+ */
+export function toDisplayRowFromList(row: RotationListRow, now: Date = new Date()): RotationDisplayRow {
+  const isLinked = hasLinkedAlbumId(row.id);
+  const active = isRotationRowActive(row.rotation_kill_date, now);
+  return {
+    rotationId: row.rotation_id,
+    artistName: row.artist_name ?? "",
+    title: row.album_title ?? "",
+    label: row.record_label ?? "",
+    binLabel: row.rotation_bin,
+    formatName: row.format_name ?? EM_DASH,
+    addedDisplay: formatRotationDate(row.rotation_add_date),
+    killed: !active,
+    killedDisplay: killedDisplay(row.rotation_kill_date),
+    libraryStatus: rotationLibraryStatus(isLinked, !active),
+    showImport: !active && !isLinked,
+  };
+}
+
+/**
+ * Projects a `GET /library/rotation/uncatalogued` row into the shared
+ * display shape. Every row from this endpoint is unlinked by construction
+ * (`album_id IS NULL` is the query's whole predicate), so `libraryStatus`
+ * can only ever read `uncataloged` or `unknown` here -- `album_id` is still
+ * checked with `hasLinkedAlbumId` rather than assumed, so a future change to
+ * the endpoint's predicate would show as a Cataloged row here instead of
+ * silently mislabeling one as Uncataloged.
+ */
+export function toDisplayRowFromUncatalogued(
+  row: UncataloguedRotationRow,
+  now: Date = new Date(),
+): RotationDisplayRow {
+  const isLinked = hasLinkedAlbumId(row.album_id);
+  const active = isRotationRowActive(row.kill_date, now);
+  return {
+    rotationId: row.id,
+    artistName: row.artist_name ?? "",
+    title: row.album_title ?? "",
+    label: row.record_label ?? "",
+    binLabel: row.rotation_bin,
+    formatName: EM_DASH,
+    addedDisplay: formatRotationDate(row.add_date),
+    killed: !active,
+    killedDisplay: killedDisplay(row.kill_date),
+    libraryStatus: rotationLibraryStatus(isLinked, !active),
+    showImport: !active && !isLinked,
+  };
+}
+
+/** A dedupe key from an artist/title pair: folded to collapse case and stray whitespace. */
+function dedupeKey(artistName: string | null, albumTitle: string | null): string {
+  const fold = (value: string | null) => (value ?? "").normalize("NFC").trim().toLowerCase();
+  return `${fold(artistName)} ${fold(albumTitle)}`;
+}
+
+/**
+ * Collapses rotation rows that share an artist and title, keeping the first
+ * occurrence. Rotation rows genuinely duplicate in production --
+ * `LOS THUTHANAKA / Wak'a` appears three times across two days -- and
+ * Backend's own `DISTINCT ON` in `getRotationFromDB` only collapses same
+ * `(album, bin)` pairs, not a re-add under a different bin.
+ *
+ * Callers pass rows already ordered most-recent-first (Backend's own
+ * `ORDER BY add_date DESC, id ASC`), so "first occurrence" is "most
+ * recent" without this function needing to know about dates at all.
+ *
+ * Deliberately applied to the Active facet only, never to the Awaiting
+ * Cataloging queue: `getUncataloguedRotationFromDB`'s own doc comment states
+ * the opposite rule for that endpoint on purpose -- "two physically distinct
+ * promos sharing an artist and title are two separate rows a librarian has
+ * to catalogue" -- and re-collapsing them here would reintroduce the exact
+ * bug (#862) that comment describes fixing.
+ */
+export function dedupeRotationListByArtistTitle(rows: RotationListRow[]): RotationListRow[] {
+  const seen = new Set<string>();
+  const result: RotationListRow[] = [];
+  for (const row of rows) {
+    const key = dedupeKey(row.artist_name, row.album_title);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(row);
+  }
+  return result;
+}

--- a/lib/features/rotation/types.ts
+++ b/lib/features/rotation/types.ts
@@ -97,3 +97,12 @@ export type FreeTextRotationAddRequest = {
 export type RotationStatusFilter = "all" | "active" | "killed" | "uncataloged";
 
 export const DEFAULT_ROTATION_STATUS_FILTER: RotationStatusFilter = "active";
+
+/**
+ * Rows per request for the Awaiting Cataloging queue. Mirrors Backend's own
+ * ceiling on `GET /library/rotation/uncatalogued?limit=` -- ask for it
+ * explicitly rather than relying on the server's default so a page that
+ * comes back this full can be reported as truncated against a number this
+ * client actually chose.
+ */
+export const UNCATALOGUED_ROTATION_PAGE_SIZE = 500;

--- a/lib/features/rotation/types.ts
+++ b/lib/features/rotation/types.ts
@@ -10,3 +10,90 @@ export type RotationFrontendState = {
   orderBy: "title" | "artist" | "album";
   orderDirection: "asc" | "desc";
 };
+
+/** Radio-button label for each rotation bin, matching `rotationReleaseInsert.jsp`'s wording verbatim. */
+export const ROTATION_BIN_LABELS: Record<RotationBin, string> = {
+  [RotationBin.H]: "Heavy",
+  [RotationBin.M]: "Medium",
+  [RotationBin.L]: "Light",
+  [RotationBin.S]: "Singles",
+};
+
+/**
+ * Wire shape of a `GET /library/rotation` row — Backend's `Rotation`
+ * interface (`apps/backend/services/library.service.ts`), hand-mirrored
+ * rather than imported from `@wxyc/shared`. The published `Rotation` DTO
+ * there predates the LEFT JOIN rework that lets an unlinked rotation row
+ * surface alongside a linked one, and carries a different, narrower field
+ * set (`play_freq` instead of `rotation_bin`, no
+ * `rotation_add_date`/`rotation_kill_date` split, no `id`/`legacy_release_id`
+ * linkage pair). dj-site's pre-existing `getRotation` query works around the
+ * drift by treating the response as an `AlbumSearchResultJSON` for its
+ * overlapping field names and dropping the rest -- this screen needs exactly
+ * the fields that drops: `rotation_id` (the row Kill/Unkill/Edit act on, not
+ * `id`, which is the library row and is `null` on an unlinked release),
+ * `rotation_bin`, `rotation_add_date`, `rotation_kill_date`.
+ */
+export type RotationListRow = {
+  id: number | null;
+  code_letters: string | null;
+  code_artist_number: number | null;
+  code_number: number | null;
+  artist_name: string | null;
+  alphabetical_name: string | null;
+  album_title: string | null;
+  record_label: string | null;
+  label_id: number | null;
+  genre_name: string | null;
+  format_name: string | null;
+  rotation_id: number;
+  add_date: string | null;
+  rotation_add_date: string;
+  rotation_bin: RotationBin;
+  rotation_kill_date: string | null;
+  plays: number | null;
+  legacy_release_id: number | null;
+};
+
+/**
+ * Wire shape of a `GET /library/rotation/uncatalogued` row -- Backend's
+ * `UncataloguedRotationRow` (`UNCATALOGUED_ROTATION_PROJECTION`,
+ * `apps/backend/services/library.service.ts`). Not yet published to
+ * `@wxyc/shared`, whose own maintainer notes intend to transcribe this shape
+ * once the endpoint stabilizes; this is a local wire mirror until it lands.
+ */
+export type UncataloguedRotationRow = {
+  id: number;
+  album_id: number | null;
+  rotation_bin: RotationBin;
+  add_date: string | null;
+  kill_date: string | null;
+  artist_name: string | null;
+  album_title: string | null;
+  record_label: string | null;
+};
+
+/**
+ * `POST /library/rotation` body for a release with no catalogued album --
+ * Backend relaxed the endpoint to accept `artist_name` + `album_title` in
+ * place of `album_id`. Deliberately not the published `@wxyc/shared`
+ * `AddRotationRequest`: that type still requires `album_id: number` and has
+ * not been widened for the free-text path (see `pickAddRotationFields` in
+ * `apps/backend/controllers/library.controller.ts`).
+ */
+export type FreeTextRotationAddRequest = {
+  rotation_bin: RotationBin;
+  artist_name: string;
+  album_title: string;
+  record_label?: string;
+};
+
+/**
+ * The four facets `rotationReleaseList.jsp`'s chip bar offers, spelled
+ * exactly as the JSP's own `status=` query values (including its
+ * single-L "uncataloged" -- distinct from the Backend route path
+ * `/library/rotation/uncatalogued`, which is not renamable to match).
+ */
+export type RotationStatusFilter = "all" | "active" | "killed" | "uncataloged";
+
+export const DEFAULT_ROTATION_STATUS_FILTER: RotationStatusFilter = "active";

--- a/src/components/experiences/classic/catalog/LibraryChooser.tsx
+++ b/src/components/experiences/classic/catalog/LibraryChooser.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useGetGenresQuery } from "@/lib/features/catalog/api";
 import ArtistSearchForm, { type MultiMatchResult } from "./ArtistSearchForm";
 import MultipleArtistsDisplay from "./MultipleArtistsDisplay";
@@ -20,6 +21,18 @@ import NewArtistForm from "./NewArtistForm";
  * swap is whole-page in both: the JSP replaces the chooser outright, so
  * `NewArtistForm` goes with the search form rather than sitting under a list
  * of artists that already own the code.
+ *
+ * The rotation block + `<hr>` above `ArtistSearchForm` reproduce
+ * `chooseLibraryCodeOrArtist.jsp:16-21` verbatim: "Import a killed rotation
+ * release into the library:" and a link to the Awaiting Cataloging facet of
+ * the classic rotation list. An earlier slice of this chooser dropped the
+ * block as a deferred divergence, because its destination -- the Awaiting
+ * Cataloging facet -- didn't exist yet; the classic rotation list slice
+ * builds that destination and restores the block here, including the JSP's
+ * own `<hr>` position (between the rotation block and `artistSearchForm` --
+ * the JSP has no second `<hr>` between the two forms below it, so the one
+ * this component used to render there is retired along with the
+ * divergence, not duplicated).
  */
 export default function LibraryChooser() {
   const [multiMatch, setMultiMatch] = useState<MultiMatchResult | null>(null);
@@ -37,8 +50,25 @@ export default function LibraryChooser() {
 
   return (
     <>
-      <ArtistSearchForm onMultiMatch={setMultiMatch} />
+      <table cellPadding={10}>
+        <tbody>
+          <tr>
+            <td colSpan={2}>
+              <h3>Import a killed rotation release into the library:</h3>
+            </td>
+          </tr>
+          <tr>
+            <td>&nbsp;&nbsp;</td>
+            <td>
+              <Link href="/dashboard/rotation?status=uncataloged">
+                <b>View Rotation Releases Awaiting Cataloging</b>
+              </Link>
+            </td>
+          </tr>
+        </tbody>
+      </table>
       <hr />
+      <ArtistSearchForm onMultiMatch={setMultiMatch} />
       <NewArtistForm />
     </>
   );

--- a/src/components/experiences/classic/rotation/CompanyAutocomplete.tsx
+++ b/src/components/experiences/classic/rotation/CompanyAutocomplete.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useId, useMemo } from "react";
+import { useSearchLabelsQuery } from "@/lib/features/labels/api";
+import type { Label } from "@/lib/features/labels/types";
+import { useDebouncedValue } from "@/src/hooks/useDebouncedValue";
+
+const DEBOUNCE_MS = 300;
+const MIN_QUERY_LENGTH = 2;
+const RESULT_LIMIT = 10;
+
+/**
+ * Classic equivalent of `rotationReleaseInsert.jsp`'s `companyName` field,
+ * which wires `setUpCompanyAutocomplete({url: 'companyAutocomplete'})`
+ * (`autocomplete-wrappers.ts`) -- a plain `<input list>` bound to a
+ * `<datalist>` the JSP populates from a fetch, with a hidden `companyID`
+ * field the browser fills in on an exact text match. That is deliberately
+ * the interaction model reproduced here (`Do not modernize interactions`):
+ * a native input/datalist pair, not the modern `LabelSearchTypeahead`'s
+ * custom listbox (MUI, keyboard-navigable, arrow-key highlight) -- that
+ * component exists because its caller needs a `label_id` on the wire
+ * (`AddReleasePanel`); the free-text rotation add this feeds submits
+ * `record_label` as a plain string, so there is no id to carry and no
+ * reason to import the heavier interaction it was built for.
+ *
+ * One deliberate divergence from the JSP, forced by this codebase's own
+ * outage-rendering convention: `autocomplete-wrappers.ts`'s fetch failure
+ * path is a bare `console.error` -- an outage there silently reads as "no
+ * matches yet", indistinguishable from an MD who simply hasn't typed enough
+ * of the name. `searchLabels` opts out of the shared backend query's
+ * soft-JSON-failure handling for exactly this reason (see its own doc
+ * comment), so a failed search surfaces here as `isError` rather than an
+ * empty option list, and this component renders a `role="alert"` panel
+ * distinct from "still typing" or "no existing label" for it.
+ *
+ * `onSelect`/`onSelectionCleared` mirror `LabelSearchTypeaheadProps`'s shape
+ * even though this caller only needs `value`/`onChange` -- the next classic
+ * rotation slice (`rotationReleaseModify.jsp`'s identical companyName
+ * wiring) is expected to reuse this component as-is, so the richer
+ * interface is kept rather than reshaped later.
+ */
+export interface CompanyAutocompleteProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSelect: (label: Label) => void;
+  onSelectionCleared: () => void;
+  disabled?: boolean;
+}
+
+export default function CompanyAutocomplete({
+  value,
+  onChange,
+  onSelect,
+  onSelectionCleared,
+  disabled,
+}: CompanyAutocompleteProps) {
+  const datalistId = useId();
+
+  const trimmed = value.trim();
+  const debouncedQuery = useDebouncedValue(trimmed, DEBOUNCE_MS);
+  const hasValidQuery = debouncedQuery.length >= MIN_QUERY_LENGTH;
+  const skip = Boolean(disabled) || !hasValidQuery;
+
+  const {
+    data,
+    isError,
+    isFetching,
+    refetch,
+  } = useSearchLabelsQuery({ q: debouncedQuery, limit: RESULT_LIMIT }, { skip });
+
+  // Memoized so the post-fetch re-check effect below only re-runs when the
+  // search result actually changes, not on every render -- `data ?? []`
+  // would otherwise hand that effect a fresh array identity every time.
+  const labels = useMemo(() => data ?? [], [data]);
+  const showError = hasValidQuery && !skip && isError;
+
+  function exactMatch(text: string, candidates: Label[]): Label | undefined {
+    const folded = text.trim().toLowerCase();
+    return candidates.find((label) => label.label_name.trim().toLowerCase() === folded);
+  }
+
+  const handleChange = (next: string) => {
+    onChange(next);
+    // Mirrors `DatalistAutocomplete.handleInput`'s exact-match check: the
+    // JSP's hidden companyID field is set only when the typed text matches a
+    // loaded option exactly (case-insensitive, trimmed), and cleared
+    // otherwise.
+    const match = exactMatch(next, labels);
+    if (match) {
+      onSelect(match);
+    } else {
+      onSelectionCleared();
+    }
+  };
+
+  // Mirrors `DatalistAutocomplete.handleInput`'s post-fetch re-check: typing
+  // finishes, and only after the debounce + request settle does the search
+  // result exist to compare against -- a keystroke that exactly typed an
+  // existing label's name can't discover the match at keystroke time, since
+  // `labels` for that name hasn't loaded yet. This synchronizes the
+  // confirmed selection with the external search result once it arrives, an
+  // external system (the search response) this component has no other way
+  // to learn about.
+  useEffect(() => {
+    if (skip) return;
+    const match = exactMatch(value, labels);
+    if (match) onSelect(match);
+  }, [labels, value, skip, onSelect]);
+
+  return (
+    <span style={{ display: "inline-block" }}>
+      <input
+        type="text"
+        aria-label="Record Label"
+        list={datalistId}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => handleChange(e.target.value)}
+        size={50}
+        autoComplete="off"
+      />
+      <datalist id={datalistId}>
+        {labels.map((label) => (
+          <option key={label.id} value={label.label_name} />
+        ))}
+      </datalist>
+      {showError && (
+        <span role="alert" className="artist-error-message">
+          Label search is unavailable, so existing labels can&apos;t be checked right now.{" "}
+          <button type="button" disabled={isFetching} onClick={() => refetch()}>
+            Try again
+          </button>
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/components/experiences/classic/rotation/CompanyAutocomplete.tsx
+++ b/src/components/experiences/classic/rotation/CompanyAutocomplete.tsx
@@ -8,6 +8,8 @@ import { useDebouncedValue } from "@/src/hooks/useDebouncedValue";
 const DEBOUNCE_MS = 300;
 const MIN_QUERY_LENGTH = 2;
 const RESULT_LIMIT = 10;
+// Stable identity so an empty result does not re-run the exact-match effect.
+const NO_LABELS: Label[] = [];
 
 /**
  * Classic equivalent of `rotationReleaseInsert.jsp`'s `companyName` field,
@@ -33,17 +35,18 @@ const RESULT_LIMIT = 10;
  * empty option list, and this component renders a `role="alert"` panel
  * distinct from "still typing" or "no existing label" for it.
  *
- * `onSelect`/`onSelectionCleared` mirror `LabelSearchTypeaheadProps`'s shape
- * even though this caller only needs `value`/`onChange` -- the next classic
- * rotation slice (`rotationReleaseModify.jsp`'s identical companyName
- * wiring) is expected to reuse this component as-is, so the richer
- * interface is kept rather than reshaped later.
+ * `onSelect` fires when the typed text names a label that already exists,
+ * which is how the caller canonicalizes "sonamos" to the stored "Sonamos"
+ * before submitting it as free text. There is no matching "selection
+ * cleared" callback because there is no selection to clear: the JSP's
+ * hidden `companyID` has no counterpart on `POST /library/rotation`, whose
+ * uncatalogued path takes `record_label` as a string and no label id, so
+ * the typed text is always already the value that will be sent.
  */
 export interface CompanyAutocompleteProps {
   value: string;
   onChange: (value: string) => void;
   onSelect: (label: Label) => void;
-  onSelectionCleared: () => void;
   disabled?: boolean;
 }
 
@@ -51,7 +54,6 @@ export default function CompanyAutocomplete({
   value,
   onChange,
   onSelect,
-  onSelectionCleared,
   disabled,
 }: CompanyAutocompleteProps) {
   const datalistId = useId();
@@ -61,17 +63,18 @@ export default function CompanyAutocomplete({
   const hasValidQuery = debouncedQuery.length >= MIN_QUERY_LENGTH;
   const skip = Boolean(disabled) || !hasValidQuery;
 
+  // `currentData`, not `data`: `data` holds the last result for ANY args, so
+  // between keystrokes it still carries the previous query's labels. The
+  // datalist would go on offering them for a prefix that no longer matches,
+  // and the exact-match check below would run against a stale list.
   const {
-    data,
+    currentData: data,
     isError,
     isFetching,
     refetch,
   } = useSearchLabelsQuery({ q: debouncedQuery, limit: RESULT_LIMIT }, { skip });
 
-  // Memoized so the post-fetch re-check effect below only re-runs when the
-  // search result actually changes, not on every render -- `data ?? []`
-  // would otherwise hand that effect a fresh array identity every time.
-  const labels = useMemo(() => data ?? [], [data]);
+  const labels = useMemo(() => data ?? NO_LABELS, [data]);
   const showError = hasValidQuery && !skip && isError;
 
   function exactMatch(text: string, candidates: Label[]): Label | undefined {
@@ -82,15 +85,10 @@ export default function CompanyAutocomplete({
   const handleChange = (next: string) => {
     onChange(next);
     // Mirrors `DatalistAutocomplete.handleInput`'s exact-match check: the
-    // JSP's hidden companyID field is set only when the typed text matches a
-    // loaded option exactly (case-insensitive, trimmed), and cleared
-    // otherwise.
+    // JSP treats the typed text as naming an existing company only when it
+    // matches a loaded option exactly (case-insensitive, trimmed).
     const match = exactMatch(next, labels);
-    if (match) {
-      onSelect(match);
-    } else {
-      onSelectionCleared();
-    }
+    if (match) onSelect(match);
   };
 
   // Mirrors `DatalistAutocomplete.handleInput`'s post-fetch re-check: typing

--- a/src/components/experiences/classic/rotation/RotationReleaseInsert.tsx
+++ b/src/components/experiences/classic/rotation/RotationReleaseInsert.tsx
@@ -208,13 +208,10 @@ export default function RotationReleaseInsert() {
                 <CompanyAutocomplete
                   value={recordLabel}
                   onChange={setRecordLabel}
+                  // Typing a name an existing label already has canonicalizes
+                  // to that label's own spelling, so "sonamos" and "Sonamos"
+                  // do not become two different `record_label` strings.
                   onSelect={(label) => setRecordLabel(label.label_name)}
-                  onSelectionCleared={() => {
-                    // The JSP resets the hidden companyID to its "no id"
-                    // sentinel here; this form submits no id at all, so
-                    // there is nothing to reset -- the typed text is
-                    // already the value that will be sent.
-                  }}
                   disabled={isLoading}
                 />
                 <span style={{ fontSize: "x-small" }}>
@@ -233,9 +230,14 @@ export default function RotationReleaseInsert() {
             <tr>
               <td />
               <td colSpan={2}>
+                {/* The live region is always in the DOM, empty until there is
+                    something to say. Adding role="alert" at the same moment
+                    the text appears is unreliable across screen readers --
+                    the region has to exist before its content changes for
+                    the change to be announced. */}
                 <div
                   className={`validation-message${validationMessage ? " visible" : ""}`}
-                  role={validationMessage ? "alert" : undefined}
+                  role="alert"
                 >
                   {validationMessage}
                 </div>

--- a/src/components/experiences/classic/rotation/RotationReleaseInsert.tsx
+++ b/src/components/experiences/classic/rotation/RotationReleaseInsert.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useId, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { RotationBin, ROTATION_BIN_LABELS, type FreeTextRotationAddRequest } from "@/lib/features/rotation/types";
+import { useAddFreeTextRotationEntryMutation } from "@/lib/features/rotation/api";
+import { rotationAddErrorMessage } from "@/lib/features/rotation/addErrorMessage";
+import CompanyAutocomplete from "./CompanyAutocomplete";
+
+const ROTATION_BINS: RotationBin[] = [RotationBin.H, RotationBin.M, RotationBin.L, RotationBin.S];
+const DEFAULT_BIN = RotationBin.H;
+
+/**
+ * Reproduces `rotationReleaseInsert.jsp` -- free-text rotation add, against
+ * Backend's relaxed `POST /library/rotation` for a release with no
+ * catalogued album.
+ *
+ * Six of the JSP's fields have no home on Backend's `rotation` table at all
+ * (`shared/database/src/schema.ts`: `id`, `album_id`, `rotation_bin`,
+ * `add_date`, `kill_date`, `artist_name`, `album_title`, `record_label`, and
+ * a handful of server-derived Discogs/LML columns -- nothing else), and are
+ * dropped here rather than rendered inert:
+ *
+ * - **Artist's Alphabetical Name.** No column. On a catalogued row this
+ *   value comes from `artists.alphabetical_name`; on an uncatalogued row
+ *   there is no `artists` row to hold it, and `PATCH /library/rotation/:id`
+ *   explicitly rejects it (`ROTATION_NO_COLUMN_FIELDS` in
+ *   `apps/backend/controllers/library.controller.ts`) for exactly that
+ *   reason.
+ * - **Format + "Additional size info".** No column -- format lives on
+ *   `library.format_id`, which only exists once a release is catalogued.
+ * - **Date Added To Rotation** (the JSP's 23-days-back picker). `add_date`
+ *   has a column, but `pickAddRotationFields` never reads it from the
+ *   request body on `POST`: the controller's own comment states
+ *   `add_date` is "post-creation-only" because `POST` always mints a fresh
+ *   row and the server stamps `defaultNow()`. There is no field here that
+ *   would do anything if rendered.
+ * - **CMJ Genres** (hiphop/jazz/loudrock/newworld/rpm) and **Comments**. No
+ *   column of any kind ever existed for these on `rotation` -- they are
+ *   tubafrenzy-only fields with nowhere to land.
+ *
+ * The JSP's two "Clear ... Artist ... Field(s)" links are dropped with the
+ * alphabetical-name field they only make sense beside.
+ *
+ * Everything else matches the JSP verbatim: field order, labels, the V/A
+ * shortcut, the rotation-type radios (Heavy default), the record-label
+ * autocomplete + self-released link, and the validationMessage div's role as
+ * the one place a refusal is shown.
+ *
+ * On success there is nowhere JSP-faithful to land: `rotationRelease?mode=
+ * addRotationRelease`'s own destination is the record it just created, and
+ * that screen (`rotationReleaseModify.jsp`) is a later classic rotation
+ * slice, not yet built. This redirects to the list instead.
+ */
+export default function RotationReleaseInsert() {
+  const router = useRouter();
+  const presentationNameId = useId();
+  const titleId = useId();
+
+  const [artistPresentationName, setArtistPresentationName] = useState("");
+  const [title, setTitle] = useState("");
+  const [rotationBin, setRotationBin] = useState<RotationBin>(DEFAULT_BIN);
+  const [recordLabel, setRecordLabel] = useState("");
+  const [validationMessage, setValidationMessage] = useState<string | null>(null);
+
+  const [addFreeTextRotationEntry, { isLoading }] = useAddFreeTextRotationEntryMutation();
+
+  const resetFields = () => {
+    setArtistPresentationName("");
+    setTitle("");
+    setRotationBin(DEFAULT_BIN);
+    setRecordLabel("");
+    setValidationMessage(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (artistPresentationName.trim() === "") {
+      setValidationMessage("Please enter a presentation name.");
+      return;
+    }
+    if (title.trim() === "") {
+      setValidationMessage("Please enter a title.");
+      return;
+    }
+
+    setValidationMessage(null);
+
+    const trimmedLabel = recordLabel.trim();
+    const body: FreeTextRotationAddRequest = {
+      rotation_bin: rotationBin,
+      artist_name: artistPresentationName.trim(),
+      album_title: title.trim(),
+      // Omitted, not sent as "" -- `pickAddRotationFields` only skips a
+      // NULL/absent record_label; an empty string would be picked and
+      // written as a blank label rather than leaving the row unlabeled,
+      // which is what "self-released" (an empty field) means.
+      ...(trimmedLabel !== "" ? { record_label: trimmedLabel } : {}),
+    };
+
+    try {
+      await addFreeTextRotationEntry(body).unwrap();
+      router.push("/dashboard/rotation");
+    } catch (err) {
+      // `addFreeTextRotationEntry`'s `transformErrorResponse` nests the real
+      // error under `rotationAddError` (mirroring `labelsApi.searchLabels`)
+      // so the shared rejected-query middleware's `payload.data.message`
+      // lookup does not find it and double-toast; `.unwrap()` throws exactly
+      // that transformed shape, so it is unwrapped one level here before
+      // `rotationAddErrorMessage` reads the server's actual message back out.
+      const original =
+        err && typeof err === "object" && "rotationAddError" in err
+          ? (err as { rotationAddError?: unknown }).rotationAddError
+          : err;
+      setValidationMessage(rotationAddErrorMessage(original));
+    }
+  };
+
+  return (
+    <div>
+      <div className="label" style={{ textAlign: "center" }}>
+        <Link href="/dashboard/rotation">Rotation Release List</Link>
+      </div>
+
+      <form name="recordInfo" onSubmit={handleSubmit}>
+        <table cellPadding={5}>
+          <tbody>
+            <tr>
+              <td />
+              <td className="title">
+                <h3>Add a Release to the rotation database:</h3>
+              </td>
+            </tr>
+            <tr>
+              <td />
+              <td>
+                <span style={{ fontSize: "x-small" }}>
+                  <a
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setArtistPresentationName("Various Artists");
+                    }}
+                  >
+                    Click here to input &apos;Various Artists&apos;
+                  </a>
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td className="redlabel" style={{ textAlign: "right" }}>
+                <label htmlFor={presentationNameId}>Artist&apos;s Presentation Name:</label>
+              </td>
+              <td colSpan={3}>
+                <input
+                  id={presentationNameId}
+                  type="text"
+                  value={artistPresentationName}
+                  disabled={isLoading}
+                  onChange={(e) => setArtistPresentationName(e.target.value)}
+                  size={50}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td className="redlabel" style={{ textAlign: "right" }}>
+                <label htmlFor={titleId}>Title of Release:</label>
+              </td>
+              <td colSpan={3}>
+                <input
+                  id={titleId}
+                  type="text"
+                  value={title}
+                  disabled={isLoading}
+                  onChange={(e) => setTitle(e.target.value)}
+                  size={100}
+                />
+              </td>
+            </tr>
+            <tr>
+              <td className="redlabel" style={{ textAlign: "right" }}>
+                <b>Rotation:</b>
+              </td>
+              <td colSpan={3}>
+                {ROTATION_BINS.map((bin) => (
+                  <span key={bin}>
+                    <input
+                      type="radio"
+                      name="rotationType"
+                      value={bin}
+                      aria-label={ROTATION_BIN_LABELS[bin]}
+                      checked={rotationBin === bin}
+                      disabled={isLoading}
+                      onChange={() => setRotationBin(bin)}
+                    />
+                    &nbsp;&nbsp;{ROTATION_BIN_LABELS[bin]}&nbsp;&nbsp;
+                  </span>
+                ))}
+              </td>
+            </tr>
+            <tr>
+              <td className="redlabel" style={{ textAlign: "right" }}>
+                Record Label:
+              </td>
+              <td className="label">
+                <CompanyAutocomplete
+                  value={recordLabel}
+                  onChange={setRecordLabel}
+                  onSelect={(label) => setRecordLabel(label.label_name)}
+                  onSelectionCleared={() => {
+                    // The JSP resets the hidden companyID to its "no id"
+                    // sentinel here; this form submits no id at all, so
+                    // there is nothing to reset -- the typed text is
+                    // already the value that will be sent.
+                  }}
+                  disabled={isLoading}
+                />
+                <span style={{ fontSize: "x-small" }}>
+                  <a
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setRecordLabel("");
+                    }}
+                  >
+                    self-released
+                  </a>
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td />
+              <td colSpan={2}>
+                <div
+                  className={`validation-message${validationMessage ? " visible" : ""}`}
+                  role={validationMessage ? "alert" : undefined}
+                >
+                  {validationMessage}
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td />
+              <td colSpan={2}>
+                <input type="submit" value="Add this record" disabled={isLoading} />
+                <input
+                  type="button"
+                  value="Reset to default values"
+                  onClick={resetFields}
+                  disabled={isLoading}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </form>
+    </div>
+  );
+}

--- a/src/components/experiences/classic/rotation/RotationReleaseList.tsx
+++ b/src/components/experiences/classic/rotation/RotationReleaseList.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  useGetRotationListQuery,
+  useGetUncataloguedRotationQuery,
+  useKillRotationEntryMutation,
+  useUnkillRotationEntryMutation,
+} from "@/lib/features/rotation/api";
+import {
+  dedupeRotationListByArtistTitle,
+  toDisplayRowFromList,
+  toDisplayRowFromUncatalogued,
+  type RotationDisplayRow,
+} from "@/lib/features/rotation/classicList";
+import type { RotationStatusFilter } from "@/lib/features/rotation/types";
+import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
+
+const FACETS: { value: RotationStatusFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "killed", label: "Killed" },
+  { value: "uncataloged", label: "Awaiting Cataloging" },
+];
+
+function facetHref(status: RotationStatusFilter): string {
+  return `/dashboard/rotation?status=${status}`;
+}
+
+/** A query-fed list must never render an unissued or failed request as "there are none". */
+function OutagePanel({ onRetry, retrying }: { onRetry: () => void; retrying: boolean }) {
+  return (
+    <p role="alert" className="artist-error-message" style={{ textAlign: "center" }}>
+      Rotation releases are unavailable right now.{" "}
+      <button type="button" disabled={retrying} onClick={onRetry}>
+        Try again
+      </button>
+    </p>
+  );
+}
+
+function EmptyState() {
+  return <p className="live-results-empty">No rotation releases found for this filter.</p>;
+}
+
+/**
+ * The nine-column table body shared by every facet that has real rows to
+ * show (Active, Awaiting Cataloging). Column set and order match
+ * `rotationReleaseList.jsp` exactly: Actions, Artist, Title, Label, Type,
+ * Format, Added, Killed, Library.
+ */
+function RotationTable({
+  rows,
+  onKill,
+  onUnkill,
+  pendingRotationIds,
+}: {
+  rows: RotationDisplayRow[];
+  onKill: (rotationId: number) => void;
+  onUnkill: (rotationId: number) => void;
+  pendingRotationIds: ReadonlySet<number>;
+}) {
+  if (rows.length === 0) return <EmptyState />;
+
+  return (
+    <table className="entry-table" style={{ maxWidth: 1100, margin: "0 auto" }}>
+      <thead>
+        <tr className="entry-header">
+          <th style={{ textAlign: "center" }}>Actions</th>
+          <th style={{ textAlign: "left" }}>Artist</th>
+          <th style={{ textAlign: "left" }}>Title</th>
+          <th style={{ textAlign: "left" }}>Label</th>
+          <th style={{ textAlign: "center" }}>Type</th>
+          <th style={{ textAlign: "center" }}>Format</th>
+          <th style={{ textAlign: "center" }}>Added</th>
+          <th style={{ textAlign: "center" }}>Killed</th>
+          <th style={{ textAlign: "center" }}>Library</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, index) => {
+          const pending = pendingRotationIds.has(row.rotationId);
+          return (
+            <tr
+              key={row.rotationId}
+              className={`entry-row ${index % 2 === 0 ? "entry-row-even" : "entry-row-odd"}`}
+            >
+              <td style={{ textAlign: "center", whiteSpace: "nowrap" }}>
+                <Link href={`/dashboard/rotation/${row.rotationId}`}>Edit</Link>
+                &nbsp;
+                {row.killed ? (
+                  <button type="button" className="link-button" disabled={pending} onClick={() => onUnkill(row.rotationId)}>
+                    Unkill
+                  </button>
+                ) : (
+                  <button type="button" className="link-button" disabled={pending} onClick={() => onKill(row.rotationId)}>
+                    Kill
+                  </button>
+                )}
+                {row.showImport && (
+                  <>
+                    &nbsp;
+                    <Link
+                      href={`/dashboard/rotation/${row.rotationId}/import`}
+                      style={{ color: "#CC0000", fontWeight: "bold" }}
+                    >
+                      Import
+                    </Link>
+                  </>
+                )}
+              </td>
+              <td>{row.artistName}</td>
+              <td>{row.title}</td>
+              <td>{row.label}</td>
+              <td style={{ textAlign: "center" }}>{row.binLabel}</td>
+              <td style={{ textAlign: "center" }}>{row.formatName}</td>
+              <td style={{ textAlign: "center" }}>{row.addedDisplay}</td>
+              <td style={{ textAlign: "center" }}>
+                {row.killed ? row.killedDisplay : <span style={{ color: "#090" }}>Active</span>}
+              </td>
+              <td style={{ textAlign: "center" }}>
+                {row.libraryStatus === "cataloged" ? (
+                  <span style={{ color: "#090" }}>Cataloged</span>
+                ) : row.libraryStatus === "uncataloged" ? (
+                  <span style={{ color: "#CC0000" }}>Uncataloged</span>
+                ) : (
+                  "—"
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+/**
+ * The Active facet: `GET /library/rotation`. Backend already restricts this
+ * to active rows (`kill_date IS NULL OR kill_date > CURRENT_DATE`) and
+ * DISTINCT-collapses same-(album, bin) duplicates; deduping again here on
+ * artist + title catches a re-add under a *different* bin, which Backend's
+ * own collapse does not reach.
+ */
+function ActiveFacet({
+  onKill,
+  onUnkill,
+  pendingRotationIds,
+}: {
+  onKill: (rotationId: number) => void;
+  onUnkill: (rotationId: number) => void;
+  pendingRotationIds: ReadonlySet<number>;
+}) {
+  const { data, isLoading, isFetching, isError, refetch } = useGetRotationListQuery();
+
+  // Absence-of-list, not the error flag: a background refetch can leave
+  // isError true while the last-good rows are still on screen, and a
+  // request that never went out reports neither.
+  const hasNothingToShow = isError && data == null;
+
+  if (isLoading) return <p style={{ textAlign: "center" }}>Loading...</p>;
+  if (hasNothingToShow) return <OutagePanel onRetry={refetch} retrying={isFetching} />;
+
+  const rows = dedupeRotationListByArtistTitle(data ?? []).map((row) => toDisplayRowFromList(row));
+  return <RotationTable rows={rows} onKill={onKill} onUnkill={onUnkill} pendingRotationIds={pendingRotationIds} />;
+}
+
+/**
+ * The Awaiting Cataloging facet: `GET /library/rotation/uncatalogued`.
+ * Defaults to the active-only subset (~164 rows measured at ticket time)
+ * with an opt-in toggle for the full killed-and-uncatalogued backlog
+ * (~3,673) -- "all 3,837 by default is a graveyard, not a worklist."
+ *
+ * Deliberately NOT deduped: `getUncataloguedRotationFromDB`'s own doc
+ * comment states two physically distinct promos sharing an artist and title
+ * are two separate rows a librarian has to catalogue, and collapsing them
+ * would re-hide one (the exact bug its own DISTINCT ON removal fixed for
+ * this endpoint).
+ *
+ * Backend returns at most one page (`UNCATALOGUED_ROTATION_MAX_LIMIT`, 500)
+ * per request, sorted most-recently-added first; this reads that single
+ * page rather than walking every page by default, matching the
+ * `MissingReleases` precedent (state the cap, do not silently show a
+ * partial list as complete).
+ */
+function UncataloguedFacet({
+  onKill,
+  onUnkill,
+  pendingRotationIds,
+}: {
+  onKill: (rotationId: number) => void;
+  onUnkill: (rotationId: number) => void;
+  pendingRotationIds: ReadonlySet<number>;
+}) {
+  const [showKilled, setShowKilled] = useState(false);
+  const { data, isLoading, isFetching, isError, refetch } = useGetUncataloguedRotationQuery();
+
+  const hasNothingToShow = isError && data == null;
+
+  if (isLoading) return <p style={{ textAlign: "center" }}>Loading...</p>;
+  if (hasNothingToShow) return <OutagePanel onRetry={refetch} retrying={isFetching} />;
+
+  const allRows = (data ?? []).map((row) => toDisplayRowFromUncatalogued(row));
+  const rows = showKilled ? allRows : allRows.filter((row) => !row.killed);
+
+  return (
+    <>
+      <p style={{ textAlign: "center" }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={showKilled}
+            onChange={(e) => setShowKilled(e.target.checked)}
+          />
+          &nbsp;Show killed releases too (the cataloging backlog)
+        </label>
+      </p>
+      <RotationTable rows={rows} onKill={onKill} onUnkill={onUnkill} pendingRotationIds={pendingRotationIds} />
+    </>
+  );
+}
+
+/**
+ * "All" and "Killed" render this instead of a table: Backend has no read
+ * path for a catalogued rotation row that has been killed.
+ * `getRotationFromDB` (`GET /library/rotation`) restricts itself to active
+ * rows via its own `WHERE kill_date IS NULL OR kill_date > CURRENT_DATE`,
+ * and `getUncataloguedRotationFromDB` (`GET /library/rotation/uncatalogued`)
+ * answers every status but only for `album_id IS NULL` rows. Between them
+ * there is no query that returns a catalogued, killed rotation row -- so
+ * these two JSP facets cannot be built against the current contract without
+ * fabricating a partial answer and presenting it as complete, which the
+ * outage-rendering convention this screen otherwise follows forbids doing
+ * silently. Rather than hide the chips (a JSP facet with no equivalent
+ * button at all would be its own, less honest, divergence), they render and
+ * say so.
+ */
+function UnavailableFacet() {
+  return (
+    <p className="live-results-empty" style={{ textAlign: "center" }}>
+      This filter needs data Backend-Service doesn&apos;t expose yet: there is no endpoint for a
+      catalogued rotation release that has been killed. The Awaiting Cataloging facet&apos;s
+      &quot;Show killed releases too&quot; toggle covers the uncatalogued half of this backlog.
+    </p>
+  );
+}
+
+/**
+ * Reproduces `rotationReleaseList.jsp` -- see the module-level facet
+ * components above for how each of the JSP's four facets maps onto
+ * Backend's actual read surface, and `lib/features/rotation/classicList.ts`
+ * for the 0-and-NULL unlinked sentinel and the active/killed date logic
+ * shared with the free-text add screen.
+ *
+ * Two more divergences, neither forced by the Backend contract:
+ *
+ * - "Main Menu" carries the JSP's own label but points at `/dashboard/
+ *   catalog` -- dj-site's classic catalog search, the DJ-facing entry point
+ *   `searchCardCatalog` names in tubafrenzy. There is no dj-site route named
+ *   after the servlet path itself.
+ * - "Format Tallysheets" is dropped entirely, matching `MissingReleases`'
+ *   precedent for a JSP link with no dj-site destination: no tallysheet
+ *   screen exists here, so the alternative would be a dead link rather than
+ *   a working one under a different name.
+ */
+export default function RotationReleaseList({ statusFilter }: { statusFilter: RotationStatusFilter }) {
+  const [killRotationEntry] = useKillRotationEntryMutation();
+  const [unkillRotationEntry] = useUnkillRotationEntryMutation();
+  const [pendingRotationIds, setPendingRotationIds] = useState<ReadonlySet<number>>(() => new Set());
+
+  const withPending = async (rotationId: number, run: () => Promise<unknown>, failureVerb: string) => {
+    setPendingRotationIds((prev) => new Set(prev).add(rotationId));
+    try {
+      await run();
+    } catch (err) {
+      if (isUnmessagedHttpError(err)) {
+        toast.error(`Couldn't ${failureVerb} this rotation release. Please try again.`);
+      }
+    } finally {
+      setPendingRotationIds((prev) => {
+        const next = new Set(prev);
+        next.delete(rotationId);
+        return next;
+      });
+    }
+  };
+
+  const handleKill = (rotationId: number) =>
+    withPending(rotationId, () => killRotationEntry({ rotation_id: rotationId }).unwrap(), "kill");
+  const handleUnkill = (rotationId: number) =>
+    withPending(rotationId, () => unkillRotationEntry({ rotation_id: rotationId }).unwrap(), "unkill");
+
+  return (
+    <div>
+      <div className="label" style={{ textAlign: "center", padding: "10px 0" }}>
+        <Link href="/dashboard/rotation/new">Add Rotation Release</Link>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        <Link href="/dashboard/catalog">Main Menu</Link>
+      </div>
+
+      <h3 style={{ textAlign: "center", margin: "5px 0 15px 0" }}>Rotation Releases</h3>
+
+      <div style={{ textAlign: "center", marginBottom: 15 }}>
+        <div className="facet-bar">
+          {FACETS.map((facet) => (
+            <Link
+              key={facet.value}
+              href={facetHref(facet.value)}
+              className={`facet-chip${statusFilter === facet.value ? " active" : ""}`}
+            >
+              {facet.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {statusFilter === "active" && (
+        <ActiveFacet onKill={handleKill} onUnkill={handleUnkill} pendingRotationIds={pendingRotationIds} />
+      )}
+      {statusFilter === "uncataloged" && (
+        <UncataloguedFacet onKill={handleKill} onUnkill={handleUnkill} pendingRotationIds={pendingRotationIds} />
+      )}
+      {(statusFilter === "all" || statusFilter === "killed") && <UnavailableFacet />}
+    </div>
+  );
+}

--- a/src/components/experiences/classic/rotation/RotationReleaseList.tsx
+++ b/src/components/experiences/classic/rotation/RotationReleaseList.tsx
@@ -15,7 +15,10 @@ import {
   toDisplayRowFromUncatalogued,
   type RotationDisplayRow,
 } from "@/lib/features/rotation/classicList";
-import type { RotationStatusFilter } from "@/lib/features/rotation/types";
+import {
+  UNCATALOGUED_ROTATION_PAGE_SIZE,
+  type RotationStatusFilter,
+} from "@/lib/features/rotation/types";
 import { isUnmessagedHttpError } from "@/lib/rtk-query-error-logger";
 
 const FACETS: { value: RotationStatusFilter; label: string }[] = [
@@ -50,6 +53,12 @@ function EmptyState() {
  * show (Active, Awaiting Cataloging). Column set and order match
  * `rotationReleaseList.jsp` exactly: Actions, Artist, Title, Label, Type,
  * Format, Added, Killed, Library.
+ *
+ * Kill/Unkill, the Killed column and the Library column all key on whether
+ * the row carries a kill date at all, never on whether that date has
+ * arrived -- `release.killDate == 0` is the JSP's own test. A kill dated
+ * next week leaves the row in rotation today and is still a kill, so it
+ * shows its date and offers Unkill.
  */
 function RotationTable({
   rows,
@@ -88,37 +97,24 @@ function RotationTable({
               className={`entry-row ${index % 2 === 0 ? "entry-row-even" : "entry-row-odd"}`}
             >
               <td style={{ textAlign: "center", whiteSpace: "nowrap" }}>
-                <Link href={`/dashboard/rotation/${row.rotationId}`}>Edit</Link>
-                &nbsp;
-                {row.killed ? (
-                  <button type="button" className="link-button" disabled={pending} onClick={() => onUnkill(row.rotationId)}>
-                    Unkill
-                  </button>
-                ) : (
+                {row.killedDisplay == null ? (
                   <button type="button" className="link-button" disabled={pending} onClick={() => onKill(row.rotationId)}>
                     Kill
                   </button>
-                )}
-                {row.showImport && (
-                  <>
-                    &nbsp;
-                    <Link
-                      href={`/dashboard/rotation/${row.rotationId}/import`}
-                      style={{ color: "#CC0000", fontWeight: "bold" }}
-                    >
-                      Import
-                    </Link>
-                  </>
+                ) : (
+                  <button type="button" className="link-button" disabled={pending} onClick={() => onUnkill(row.rotationId)}>
+                    Unkill
+                  </button>
                 )}
               </td>
               <td>{row.artistName}</td>
               <td>{row.title}</td>
               <td>{row.label}</td>
-              <td style={{ textAlign: "center" }}>{row.binLabel}</td>
+              <td style={{ textAlign: "center" }}>{row.bin}</td>
               <td style={{ textAlign: "center" }}>{row.formatName}</td>
               <td style={{ textAlign: "center" }}>{row.addedDisplay}</td>
               <td style={{ textAlign: "center" }}>
-                {row.killed ? row.killedDisplay : <span style={{ color: "#090" }}>Active</span>}
+                {row.killedDisplay ?? <span style={{ color: "#090" }}>Active</span>}
               </td>
               <td style={{ textAlign: "center" }}>
                 {row.libraryStatus === "cataloged" ? (
@@ -179,11 +175,12 @@ function ActiveFacet({
  * would re-hide one (the exact bug its own DISTINCT ON removal fixed for
  * this endpoint).
  *
- * Backend returns at most one page (`UNCATALOGUED_ROTATION_MAX_LIMIT`, 500)
- * per request, sorted most-recently-added first; this reads that single
- * page rather than walking every page by default, matching the
- * `MissingReleases` precedent (state the cap, do not silently show a
- * partial list as complete).
+ * Backend serves at most one page per request, sorted most-recently-added
+ * first; this reads that single page rather than walking every page, and
+ * says so whenever the page comes back full. The backlog runs to thousands
+ * of rows against a page of 500, and a truncated queue that does not
+ * announce itself reads as a finished one -- the `MissingReleases`
+ * precedent for the same situation.
  */
 function UncataloguedFacet({
   onKill,
@@ -195,15 +192,22 @@ function UncataloguedFacet({
   pendingRotationIds: ReadonlySet<number>;
 }) {
   const [showKilled, setShowKilled] = useState(false);
-  const { data, isLoading, isFetching, isError, refetch } = useGetUncataloguedRotationQuery();
+  const { data, isLoading, isFetching, isError, refetch } = useGetUncataloguedRotationQuery({
+    limit: UNCATALOGUED_ROTATION_PAGE_SIZE,
+  });
 
   const hasNothingToShow = isError && data == null;
 
   if (isLoading) return <p style={{ textAlign: "center" }}>Loading...</p>;
   if (hasNothingToShow) return <OutagePanel onRetry={refetch} retrying={isFetching} />;
 
-  const allRows = (data ?? []).map((row) => toDisplayRowFromUncatalogued(row));
-  const rows = showKilled ? allRows : allRows.filter((row) => !row.killed);
+  const page = data ?? [];
+  const allRows = page.map((row) => toDisplayRowFromUncatalogued(row));
+  const rows = showKilled ? allRows : allRows.filter((row) => row.active);
+  // A full page is indistinguishable from a complete backlog, so it is
+  // reported as what it is. The backlog runs to thousands of rows against a
+  // 500-row cap, and a silently truncated queue reads as a finished one.
+  const isTruncated = page.length >= UNCATALOGUED_ROTATION_PAGE_SIZE;
 
   return (
     <>
@@ -217,6 +221,13 @@ function UncataloguedFacet({
           &nbsp;Show killed releases too (the cataloging backlog)
         </label>
       </p>
+      {isTruncated && (
+        <p className="live-results-empty" style={{ textAlign: "center" }}>
+          This queue is drawn from the {page.length} most recently added releases awaiting cataloging
+          &mdash; the rotation API serves at most that many per request, so older entries in the backlog
+          are not listed here.
+        </p>
+      )}
       <RotationTable rows={rows} onKill={onKill} onUnkill={onUnkill} pendingRotationIds={pendingRotationIds} />
     </>
   );
@@ -251,10 +262,10 @@ function UnavailableFacet() {
  * Reproduces `rotationReleaseList.jsp` -- see the module-level facet
  * components above for how each of the JSP's four facets maps onto
  * Backend's actual read surface, and `lib/features/rotation/classicList.ts`
- * for the 0-and-NULL unlinked sentinel and the active/killed date logic
- * shared with the free-text add screen.
+ * for the unlinked-id check and the active/killed date logic shared with
+ * the free-text add screen.
  *
- * Two more divergences, neither forced by the Backend contract:
+ * Three more divergences, none forced by the Backend contract:
  *
  * - "Main Menu" carries the JSP's own label but points at `/dashboard/
  *   catalog` -- dj-site's classic catalog search, the DJ-facing entry point
@@ -264,6 +275,14 @@ function UnavailableFacet() {
  *   precedent for a JSP link with no dj-site destination: no tallysheet
  *   screen exists here, so the alternative would be a dead link rather than
  *   a working one under a different name.
+ * - The row's "Edit" and "Import" links are dropped for the same reason.
+ *   Their destinations (`/dashboard/rotation/[id]` and
+ *   `/dashboard/rotation/[id]/import` in `docs/architecture.md`'s URL map)
+ *   are later slices, and no route answers either path today, so rendering
+ *   them would put a 404 under every row -- and under the exact affordance
+ *   the catalog chooser's "Import a killed rotation release into the
+ *   library" block funnels a librarian toward. Kill and Unkill stay: both
+ *   act in place through endpoints that exist.
  */
 export default function RotationReleaseList({ statusFilter }: { statusFilter: RotationStatusFilter }) {
   const [killRotationEntry] = useKillRotationEntryMutation();
@@ -309,6 +328,7 @@ export default function RotationReleaseList({ statusFilter }: { statusFilter: Ro
               key={facet.value}
               href={facetHref(facet.value)}
               className={`facet-chip${statusFilter === facet.value ? " active" : ""}`}
+              aria-current={statusFilter === facet.value ? "page" : undefined}
             >
               {facet.label}
             </Link>

--- a/src/components/experiences/classic/rotation/RotationReleaseList.tsx
+++ b/src/components/experiences/classic/rotation/RotationReleaseList.tsx
@@ -97,12 +97,27 @@ function RotationTable({
               className={`entry-row ${index % 2 === 0 ? "entry-row-even" : "entry-row-odd"}`}
             >
               <td style={{ textAlign: "center", whiteSpace: "nowrap" }}>
+                {/* Named per row, matching `MissingReleases`: a table of up to
+                    500 buttons all reading "Kill" tells a screen-reader user
+                    nothing about which release they are about to act on. */}
                 {row.killedDisplay == null ? (
-                  <button type="button" className="link-button" disabled={pending} onClick={() => onKill(row.rotationId)}>
+                  <button
+                    type="button"
+                    className="link-button"
+                    disabled={pending}
+                    aria-label={`Kill: ${row.title}`}
+                    onClick={() => onKill(row.rotationId)}
+                  >
                     Kill
                   </button>
                 ) : (
-                  <button type="button" className="link-button" disabled={pending} onClick={() => onUnkill(row.rotationId)}>
+                  <button
+                    type="button"
+                    className="link-button"
+                    disabled={pending}
+                    aria-label={`Unkill: ${row.title}`}
+                    onClick={() => onUnkill(row.rotationId)}
+                  >
                     Unkill
                   </button>
                 )}

--- a/tests/integration/app/dashboard/@classic/rotation/new-page.test.tsx
+++ b/tests/integration/app/dashboard/@classic/rotation/new-page.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, vi } from "vitest";
+import {
+  setUpClassicPageAuthority,
+  setUpClassicPageAuthorityEnv,
+  assertReachesClassicPage,
+  assertDeniedClassicPage,
+} from "@/tests/helpers/classic-page-authority-harness";
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/headers", async () => {
+  const { classicPageAuthorityHeadersMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityHeadersMock();
+});
+vi.mock("next/navigation", async () => {
+  const { classicPageAuthorityNavigationMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityNavigationMock();
+});
+vi.mock("@/lib/features/authentication/server-client", async () => {
+  const { classicPageAuthorityServerClientMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityServerClientMock();
+});
+vi.mock("@/lib/features/authentication/organization-utils.server", async () => {
+  const { classicPageAuthorityOrganizationUtilsMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityOrganizationUtilsMock();
+});
+
+vi.mock("@/src/components/experiences/classic/rotation/RotationReleaseInsert", () => ({
+  default: () => <div data-testid="rotation-release-insert" />,
+}));
+vi.mock("@/src/components/experiences/classic/Navigation", () => ({
+  default: () => <nav data-testid="classic-nav" />,
+}));
+
+import ClassicRotationInsertPage from "@/app/dashboard/@classic/rotation/new/page";
+
+// Backend requires catalog:['write'] for POST /library/rotation, so an
+// ungated page would render a full add form to a DJ and fail at submit --
+// gating this page at MD, unlike its DJ-readable list sibling, is the
+// honest surface (docs/architecture.md's "Authority is per screen").
+describe("Classic /dashboard/rotation/new page — rotationReleaseInsert.jsp, MD-gated", () => {
+  setUpClassicPageAuthorityEnv();
+
+  it.each([
+    { role: "musicDirector" as const, label: "a music director" },
+    { role: "stationManager" as const, label: "a station manager" },
+  ])("reaches the insert form for $label", async ({ role }) => {
+    setUpClassicPageAuthority(role);
+
+    await assertReachesClassicPage(ClassicRotationInsertPage, "rotation-release-insert", "classic-nav");
+  });
+
+  it("redirects a plain DJ away from the insert form", async () => {
+    setUpClassicPageAuthority("dj");
+
+    await assertDeniedClassicPage(ClassicRotationInsertPage);
+  });
+
+  it("never grants access from the admin-plugin role column, even when it holds a WXYC tier string", async () => {
+    setUpClassicPageAuthority(undefined, "musicDirector");
+
+    await assertDeniedClassicPage(ClassicRotationInsertPage);
+  });
+
+  it("bounces an unauthenticated visitor to login, not to the dashboard home", async () => {
+    setUpClassicPageAuthority("unauthenticated");
+
+    await assertDeniedClassicPage(ClassicRotationInsertPage, "/login?bounced=no-session");
+  });
+});

--- a/tests/integration/app/dashboard/@classic/rotation/page.test.tsx
+++ b/tests/integration/app/dashboard/@classic/rotation/page.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/tests/helpers";
+import {
+  setUpClassicPageAuthority,
+  setUpClassicPageAuthorityEnv,
+  assertReachesClassicPage,
+  assertDeniedClassicPage,
+} from "@/tests/helpers/classic-page-authority-harness";
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/headers", async () => {
+  const { classicPageAuthorityHeadersMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityHeadersMock();
+});
+vi.mock("next/navigation", async () => {
+  const { classicPageAuthorityNavigationMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityNavigationMock();
+});
+vi.mock("@/lib/features/authentication/server-client", async () => {
+  const { classicPageAuthorityServerClientMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityServerClientMock();
+});
+vi.mock("@/lib/features/authentication/organization-utils.server", async () => {
+  const { classicPageAuthorityOrganizationUtilsMock } = await import("@/tests/helpers/classic-page-authority-harness");
+  return classicPageAuthorityOrganizationUtilsMock();
+});
+
+vi.mock("@/src/components/experiences/classic/rotation/RotationReleaseList", () => ({
+  default: ({ statusFilter }: { statusFilter: string }) => (
+    <div data-testid="rotation-release-list" data-status-filter={statusFilter} />
+  ),
+}));
+vi.mock("@/src/components/experiences/classic/Navigation", () => ({
+  default: () => <nav data-testid="classic-nav" />,
+}));
+
+import ClassicRotationListPage from "@/app/dashboard/@classic/rotation/page";
+
+const noStatus = Promise.resolve({});
+
+// Both rotation links sit outside mainmenu.jsp's hasAdminAccess() block, and
+// Backend gates GET /library/rotation (and /library/rotation/uncatalogued)
+// at catalog:['read'] -- the list is DJ-readable, not MD-only. Asserting a
+// plain DJ reaches it is the point of this test, matching the precedent
+// missing/page.test.tsx sets for the sibling DJ-accessible screen.
+describe("Classic /dashboard/rotation page — rotationReleaseList.jsp, DJ-readable not MD-gated", () => {
+  setUpClassicPageAuthorityEnv();
+
+  it.each([
+    { role: "dj" as const, label: "a plain DJ session — the non-negotiable authority constraint" },
+    { role: "musicDirector" as const, label: "a music director" },
+  ])("reaches the rotation list for $label", async ({ role }) => {
+    setUpClassicPageAuthority(role);
+
+    await assertReachesClassicPage(
+      () => ClassicRotationListPage({ searchParams: noStatus }),
+      "rotation-release-list",
+      "classic-nav",
+    );
+  });
+
+  it("redirects a member with no station role (below DJ)", async () => {
+    setUpClassicPageAuthority(undefined);
+
+    await assertDeniedClassicPage(() => ClassicRotationListPage({ searchParams: noStatus }));
+  });
+
+  it("never grants access from the admin-plugin role column, even when it holds a WXYC tier string", async () => {
+    setUpClassicPageAuthority(undefined, "musicDirector");
+
+    await assertDeniedClassicPage(() => ClassicRotationListPage({ searchParams: noStatus }));
+  });
+
+  it("bounces an unauthenticated visitor to login, not to the dashboard home", async () => {
+    setUpClassicPageAuthority("unauthenticated");
+
+    await assertDeniedClassicPage(
+      () => ClassicRotationListPage({ searchParams: noStatus }),
+      "/login?bounced=no-session",
+    );
+  });
+});
+
+describe("Classic /dashboard/rotation page — ?status= parsing", () => {
+  setUpClassicPageAuthorityEnv();
+
+  it("defaults to the active facet when no status is given", async () => {
+    setUpClassicPageAuthority("dj");
+    const result = await ClassicRotationListPage({ searchParams: noStatus });
+    renderWithProviders(result);
+
+    expect(screen.getByTestId("rotation-release-list")).toHaveAttribute("data-status-filter", "active");
+  });
+
+  it.each(["all", "active", "killed", "uncataloged"])("passes through a recognized status=%s", async (status) => {
+    setUpClassicPageAuthority("dj");
+    const result = await ClassicRotationListPage({ searchParams: Promise.resolve({ status }) });
+    renderWithProviders(result);
+
+    expect(screen.getByTestId("rotation-release-list")).toHaveAttribute("data-status-filter", status);
+  });
+
+  it("falls back to the active facet for an unrecognized status value", async () => {
+    setUpClassicPageAuthority("dj");
+    const result = await ClassicRotationListPage({
+      searchParams: Promise.resolve({ status: "bogus" }),
+    });
+    renderWithProviders(result);
+
+    expect(screen.getByTestId("rotation-release-list")).toHaveAttribute("data-status-filter", "active");
+  });
+});

--- a/tests/integration/components/classic/catalog/LibraryChooser.test.tsx
+++ b/tests/integration/components/classic/catalog/LibraryChooser.test.tsx
@@ -59,6 +59,32 @@ describe("classic LibraryChooser — chooseLibraryCodeOrArtist.jsp + multipleArt
     expect(screen.queryByTestId("multiple-artists-display")).not.toBeInTheDocument();
   });
 
+  // An earlier chooser slice deferred this block as a divergence from the
+  // JSP, because its destination didn't exist yet; the classic rotation
+  // list slice builds that destination (the Awaiting Cataloging facet) and
+  // restores it here, closing that divergence.
+  it("restores the chooser's rotation block, above the <hr>, linking to the Awaiting Cataloging facet", () => {
+    const { container } = renderWithProviders(<LibraryChooser />);
+
+    expect(screen.getByText(/Import a killed rotation release into the library/i)).toBeInTheDocument();
+    const rotationLink = screen.getByRole("link", { name: /View Rotation Releases Awaiting Cataloging/i });
+    expect(rotationLink).toHaveAttribute("href", "/dashboard/rotation?status=uncataloged");
+
+    // JSP order: rotation block, <hr>, artistSearchForm, newArtistForm --
+    // with no second <hr> between the two forms.
+    const html = container.innerHTML;
+    const rotationBlockIndex = html.indexOf("Import a killed rotation release");
+    const hrIndex = html.indexOf("<hr");
+    const artistFormIndex = html.indexOf('data-testid="artist-search-form"');
+    const newArtistFormIndex = html.indexOf('data-testid="new-artist-form"');
+
+    expect(rotationBlockIndex).toBeGreaterThanOrEqual(0);
+    expect(hrIndex).toBeGreaterThan(rotationBlockIndex);
+    expect(artistFormIndex).toBeGreaterThan(hrIndex);
+    expect(newArtistFormIndex).toBeGreaterThan(artistFormIndex);
+    expect((html.match(/<hr/g) ?? []).length).toBe(1);
+  });
+
   it("replaces both forms with the disambiguation screen on a multi-match, matching the JSP's full-page swap", async () => {
     const { user } = renderWithProviders(<LibraryChooser />);
     expect(capturedOnMultiMatch).toBeDefined();

--- a/tests/integration/components/classic/rotation/CompanyAutocomplete.test.tsx
+++ b/tests/integration/components/classic/rotation/CompanyAutocomplete.test.tsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
+import CompanyAutocomplete from "@/src/components/experiences/classic/rotation/CompanyAutocomplete";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+function Harness({
+  initialValue = "",
+  onSelect = vi.fn(),
+  onSelectionCleared = vi.fn(),
+}: {
+  initialValue?: string;
+  onSelect?: (label: { id: number; label_name: string }) => void;
+  onSelectionCleared?: () => void;
+}) {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <CompanyAutocomplete
+      value={value}
+      onChange={setValue}
+      onSelect={onSelect}
+      onSelectionCleared={onSelectionCleared}
+    />
+  );
+}
+
+describe("classic CompanyAutocomplete — the companyName field's setUpCompanyAutocomplete wiring", () => {
+  it("renders a plain text input wired to a datalist, matching the JSP's native input[list] pattern", async () => {
+    renderWithProviders(<Harness />);
+    const input = screen.getByRole("combobox", { name: /record label/i });
+    expect(input).toHaveAttribute("list");
+  });
+
+  it("populates the datalist with search results once the query reaches the minimum length", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/labels/search`, ({ request }) => {
+        const q = new URL(request.url).searchParams.get("q");
+        expect(q).toBe("Son");
+        return HttpResponse.json([{ id: 5, label_name: "Sonamos" }]);
+      }),
+    );
+
+    const { user, container } = renderWithProviders(<Harness />);
+    const input = screen.getByRole("combobox", { name: /record label/i });
+    await user.type(input, "Son");
+
+    // jsdom does not expose <datalist><option> through the accessibility
+    // tree the way <select><option> is (no ARIA "option" role here), so this
+    // reads the plain DOM the browser's native autocomplete would drive.
+    await waitFor(() => {
+      expect(container.querySelector('datalist option[value="Sonamos"]')).not.toBeNull();
+    });
+  });
+
+  it("calls onSelect once typed text exactly matches a loaded label, case- and whitespace-insensitively", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/labels/search`, () =>
+        HttpResponse.json([{ id: 5, label_name: "Sonamos" }]),
+      ),
+    );
+    const onSelect = vi.fn();
+    const onSelectionCleared = vi.fn();
+
+    const { user } = renderWithProviders(
+      <Harness onSelect={onSelect} onSelectionCleared={onSelectionCleared} />,
+    );
+    const input = screen.getByRole("combobox", { name: /record label/i });
+    await user.type(input, "sonamos");
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith({ id: 5, label_name: "Sonamos" });
+    });
+  });
+
+  it("calls onSelectionCleared when the typed text no longer matches a loaded label", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/labels/search`, () =>
+        HttpResponse.json([{ id: 5, label_name: "Sonamos" }]),
+      ),
+    );
+    const onSelect = vi.fn();
+    const onSelectionCleared = vi.fn();
+
+    const { user } = renderWithProviders(
+      <Harness onSelect={onSelect} onSelectionCleared={onSelectionCleared} />,
+    );
+    const input = screen.getByRole("combobox", { name: /record label/i });
+    await user.type(input, "Sonamos");
+    await waitFor(() => expect(onSelect).toHaveBeenCalled());
+
+    onSelectionCleared.mockClear();
+    await user.type(input, "z");
+
+    expect(onSelectionCleared).toHaveBeenCalled();
+  });
+
+  it("does not search below the minimum query length", async () => {
+    let called = false;
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/labels/search`, () => {
+        called = true;
+        return HttpResponse.json([]);
+      }),
+    );
+
+    const { user } = renderWithProviders(<Harness />);
+    const input = screen.getByRole("combobox", { name: /record label/i });
+    await user.type(input, "S");
+
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    expect(called).toBe(false);
+  });
+
+  it("renders an outage message distinct from 'no matches' when the search fails", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/labels/search`, () =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      ),
+    );
+
+    const { user } = renderWithProviders(<Harness />);
+    const input = screen.getByRole("combobox", { name: /record label/i });
+    await user.type(input, "Sonamos");
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/unavailable/i);
+  });
+
+  it("disables the input and skips the search when disabled", () => {
+    const onSelect = vi.fn();
+    const onSelectionCleared = vi.fn();
+    renderWithProviders(
+      <CompanyAutocomplete
+        value=""
+        onChange={vi.fn()}
+        onSelect={onSelect}
+        onSelectionCleared={onSelectionCleared}
+        disabled
+      />,
+    );
+    expect(screen.getByRole("combobox", { name: /record label/i })).toBeDisabled();
+  });
+});

--- a/tests/integration/components/classic/rotation/CompanyAutocomplete.test.tsx
+++ b/tests/integration/components/classic/rotation/CompanyAutocomplete.test.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { describe, it, expect, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
-import { http, HttpResponse } from "msw";
+import { delay, http, HttpResponse } from "msw";
 import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
 import CompanyAutocomplete from "@/src/components/experiences/classic/rotation/CompanyAutocomplete";
 
@@ -12,21 +12,12 @@ vi.mock("@/lib/features/authentication/client", () => ({
 function Harness({
   initialValue = "",
   onSelect = vi.fn(),
-  onSelectionCleared = vi.fn(),
 }: {
   initialValue?: string;
   onSelect?: (label: { id: number; label_name: string }) => void;
-  onSelectionCleared?: () => void;
 }) {
   const [value, setValue] = useState(initialValue);
-  return (
-    <CompanyAutocomplete
-      value={value}
-      onChange={setValue}
-      onSelect={onSelect}
-      onSelectionCleared={onSelectionCleared}
-    />
-  );
+  return <CompanyAutocomplete value={value} onChange={setValue} onSelect={onSelect} />;
 }
 
 describe("classic CompanyAutocomplete — the companyName field's setUpCompanyAutocomplete wiring", () => {
@@ -64,11 +55,8 @@ describe("classic CompanyAutocomplete — the companyName field's setUpCompanyAu
       ),
     );
     const onSelect = vi.fn();
-    const onSelectionCleared = vi.fn();
 
-    const { user } = renderWithProviders(
-      <Harness onSelect={onSelect} onSelectionCleared={onSelectionCleared} />,
-    );
+    const { user } = renderWithProviders(<Harness onSelect={onSelect} />);
     const input = screen.getByRole("combobox", { name: /record label/i });
     await user.type(input, "sonamos");
 
@@ -77,26 +65,50 @@ describe("classic CompanyAutocomplete — the companyName field's setUpCompanyAu
     });
   });
 
-  it("calls onSelectionCleared when the typed text no longer matches a loaded label", async () => {
+  it("stops reporting a match once the typed text no longer names a loaded label", async () => {
     server.use(
       http.get(`${TEST_BACKEND_URL}/labels/search`, () =>
         HttpResponse.json([{ id: 5, label_name: "Sonamos" }]),
       ),
     );
     const onSelect = vi.fn();
-    const onSelectionCleared = vi.fn();
 
-    const { user } = renderWithProviders(
-      <Harness onSelect={onSelect} onSelectionCleared={onSelectionCleared} />,
-    );
+    const { user } = renderWithProviders(<Harness onSelect={onSelect} />);
     const input = screen.getByRole("combobox", { name: /record label/i });
     await user.type(input, "Sonamos");
     await waitFor(() => expect(onSelect).toHaveBeenCalled());
 
-    onSelectionCleared.mockClear();
+    onSelect.mockClear();
     await user.type(input, "z");
 
-    expect(onSelectionCleared).toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  // `data` holds the last result for ANY args, so a widened query that is
+  // still in flight would go on offering the previous query's labels as
+  // matches for a prefix they no longer match.
+  it("stops offering the previous query's labels while a widened query is still in flight", async () => {
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/labels/search`, async ({ request }) => {
+        const q = new URL(request.url).searchParams.get("q") ?? "";
+        if (q === "Son") return HttpResponse.json([{ id: 5, label_name: "Sonamos" }]);
+        await delay("infinite");
+        return HttpResponse.json([]);
+      }),
+    );
+
+    const { user, container } = renderWithProviders(<Harness />);
+    const input = screen.getByRole("combobox", { name: /record label/i });
+    await user.type(input, "Son");
+    await waitFor(() => {
+      expect(container.querySelector('datalist option[value="Sonamos"]')).not.toBeNull();
+    });
+
+    await user.type(input, "x");
+
+    await waitFor(() => {
+      expect(container.querySelector('datalist option[value="Sonamos"]')).toBeNull();
+    });
   });
 
   it("does not search below the minimum query length", async () => {
@@ -130,18 +142,20 @@ describe("classic CompanyAutocomplete — the companyName field's setUpCompanyAu
     expect(await screen.findByRole("alert")).toHaveTextContent(/unavailable/i);
   });
 
-  it("disables the input and skips the search when disabled", () => {
-    const onSelect = vi.fn();
-    const onSelectionCleared = vi.fn();
-    renderWithProviders(
-      <CompanyAutocomplete
-        value=""
-        onChange={vi.fn()}
-        onSelect={onSelect}
-        onSelectionCleared={onSelectionCleared}
-        disabled
-      />,
+  it("disables the input and issues no search when disabled", async () => {
+    let called = false;
+    server.use(
+      http.get(`${TEST_BACKEND_URL}/labels/search`, () => {
+        called = true;
+        return HttpResponse.json([]);
+      }),
     );
+    renderWithProviders(
+      <CompanyAutocomplete value="Sonamos" onChange={vi.fn()} onSelect={vi.fn()} disabled />,
+    );
+
     expect(screen.getByRole("combobox", { name: /record label/i })).toBeDisabled();
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    expect(called).toBe(false);
   });
 });

--- a/tests/integration/components/classic/rotation/RotationReleaseInsert.test.tsx
+++ b/tests/integration/components/classic/rotation/RotationReleaseInsert.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
+
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import("@/tests/helpers/auth-client-mock");
+  return {
+    ...createAuthClientModuleMock(),
+    getJWTToken: vi.fn(async () => "test-token"),
+  };
+});
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// CompanyAutocomplete has its own dedicated test coverage; here it is
+// replaced with a bare labelled input so this form's own submit/validation
+// logic is under test, not the label search widget.
+vi.mock("@/src/components/experiences/classic/rotation/CompanyAutocomplete", () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <input
+      aria-label="Record Label"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+import RotationReleaseInsert from "@/src/components/experiences/classic/rotation/RotationReleaseInsert";
+
+const BASE = `${TEST_BACKEND_URL}/library/rotation`;
+
+describe("classic RotationReleaseInsert — rotationReleaseInsert.jsp", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it("renders the JSP's field order and labels for every Backend-supportable field", () => {
+    renderWithProviders(<RotationReleaseInsert />);
+
+    expect(screen.getByText(/Add a Release to the rotation database/i)).toBeInTheDocument();
+    expect(screen.getByText(/Click here to input 'Various Artists'/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Artist's Presentation Name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Title of Release/i)).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Heavy" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Medium" })).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: "Light" })).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: "Singles" })).not.toBeChecked();
+    expect(screen.getByLabelText("Record Label")).toBeInTheDocument();
+    expect(screen.getByText(/self-released/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add this record" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reset to default values" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Rotation Release List/i })).toHaveAttribute(
+      "href",
+      "/dashboard/rotation",
+    );
+  });
+
+  it("fills the presentation name via the Various Artists shortcut", async () => {
+    const { user } = renderWithProviders(<RotationReleaseInsert />);
+    await user.click(screen.getByText(/Click here to input 'Various Artists'/i));
+    expect(screen.getByLabelText(/Artist's Presentation Name/i)).toHaveValue("Various Artists");
+  });
+
+  it("clears the record label via the self-released link", async () => {
+    const { user } = renderWithProviders(<RotationReleaseInsert />);
+    const labelField = screen.getByLabelText("Record Label");
+    await user.type(labelField, "Sonamos");
+    expect(labelField).toHaveValue("Sonamos");
+
+    await user.click(screen.getByText(/self-released/i));
+    expect(labelField).toHaveValue("");
+  });
+
+  it("refuses to submit with no presentation name", async () => {
+    const { user } = renderWithProviders(<RotationReleaseInsert />);
+    await user.type(screen.getByLabelText(/Title of Release/i), "DOGA");
+    await user.click(screen.getByRole("button", { name: "Add this record" }));
+
+    expect(await screen.findByText("Please enter a presentation name.")).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("refuses to submit with no title", async () => {
+    const { user } = renderWithProviders(<RotationReleaseInsert />);
+    await user.type(screen.getByLabelText(/Artist's Presentation Name/i), "Juana Molina");
+    await user.click(screen.getByRole("button", { name: "Add this record" }));
+
+    expect(await screen.findByText("Please enter a title.")).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("submits rotation_bin, artist_name, and album_title, omitting record_label when blank", async () => {
+    let requestBody: unknown;
+    server.use(
+      http.post(BASE, async ({ request }) => {
+        requestBody = await request.json();
+        return HttpResponse.json(
+          { id: 9001, album_id: null, rotation_bin: "H", add_date: "2026-08-29", kill_date: null },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const { user } = renderWithProviders(<RotationReleaseInsert />);
+    await user.type(screen.getByLabelText(/Artist's Presentation Name/i), "Juana Molina");
+    await user.type(screen.getByLabelText(/Title of Release/i), "DOGA");
+    await user.click(screen.getByRole("button", { name: "Add this record" }));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/dashboard/rotation"));
+    expect(requestBody).toEqual({
+      rotation_bin: "H",
+      artist_name: "Juana Molina",
+      album_title: "DOGA",
+    });
+  });
+
+  it("includes record_label when the field is filled in", async () => {
+    let requestBody: unknown;
+    server.use(
+      http.post(BASE, async ({ request }) => {
+        requestBody = await request.json();
+        return HttpResponse.json(
+          { id: 9001, album_id: null, rotation_bin: "M", add_date: "2026-08-29", kill_date: null },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const { user } = renderWithProviders(<RotationReleaseInsert />);
+    await user.type(screen.getByLabelText(/Artist's Presentation Name/i), "Juana Molina");
+    await user.type(screen.getByLabelText(/Title of Release/i), "DOGA");
+    await user.type(screen.getByLabelText("Record Label"), "Sonamos");
+    await user.click(screen.getByRole("radio", { name: "Medium" }));
+    await user.click(screen.getByRole("button", { name: "Add this record" }));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalled());
+    expect(requestBody).toEqual({
+      rotation_bin: "M",
+      artist_name: "Juana Molina",
+      album_title: "DOGA",
+      record_label: "Sonamos",
+    });
+  });
+
+  it("renders the server's refusal message inline, matching the JSP's validationMessage div", async () => {
+    server.use(
+      http.post(BASE, () =>
+        HttpResponse.json({ message: "Invalid Parameter: artist_name exceeds the 128-character limit" }, { status: 400 }),
+      ),
+    );
+
+    const { user } = renderWithProviders(<RotationReleaseInsert />);
+    await user.type(screen.getByLabelText(/Artist's Presentation Name/i), "Juana Molina");
+    await user.type(screen.getByLabelText(/Title of Release/i), "DOGA");
+    await user.click(screen.getByRole("button", { name: "Add this record" }));
+
+    expect(
+      await screen.findByText("Invalid Parameter: artist_name exceeds the 128-character limit"),
+    ).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("resets every field to its default on Reset", async () => {
+    const { user } = renderWithProviders(<RotationReleaseInsert />);
+    await user.type(screen.getByLabelText(/Artist's Presentation Name/i), "Juana Molina");
+    await user.type(screen.getByLabelText(/Title of Release/i), "DOGA");
+    await user.click(screen.getByRole("radio", { name: "Light" }));
+
+    await user.click(screen.getByRole("button", { name: "Reset to default values" }));
+
+    expect(screen.getByLabelText(/Artist's Presentation Name/i)).toHaveValue("");
+    expect(screen.getByLabelText(/Title of Release/i)).toHaveValue("");
+    expect(screen.getByRole("radio", { name: "Heavy" })).toBeChecked();
+  });
+});

--- a/tests/integration/components/classic/rotation/RotationReleaseInsert.test.tsx
+++ b/tests/integration/components/classic/rotation/RotationReleaseInsert.test.tsx
@@ -81,6 +81,13 @@ describe("classic RotationReleaseInsert — rotationReleaseInsert.jsp", () => {
     expect(labelField).toHaveValue("");
   });
 
+  // The live region has to be in the DOM before its content changes, or the
+  // refusal is announced unreliably (or not at all).
+  it("keeps an empty live region on screen before there is anything to refuse", () => {
+    renderWithProviders(<RotationReleaseInsert />);
+    expect(screen.getByRole("alert")).toHaveTextContent("");
+  });
+
   it("refuses to submit with no presentation name", async () => {
     const { user } = renderWithProviders(<RotationReleaseInsert />);
     await user.type(screen.getByLabelText(/Title of Release/i), "DOGA");

--- a/tests/integration/components/classic/rotation/RotationReleaseList.test.tsx
+++ b/tests/integration/components/classic/rotation/RotationReleaseList.test.tsx
@@ -120,11 +120,11 @@ describe("classic RotationReleaseList — rotationReleaseList.jsp", () => {
       expect(within(juanaRow).getByText("08/01/26")).toBeInTheDocument();
       expect(within(juanaRow).getByText("Active")).toBeInTheDocument();
       expect(within(juanaRow).getByText("Cataloged")).toBeInTheDocument();
-      expect(within(juanaRow).getByRole("button", { name: "Kill" })).toBeInTheDocument();
+      expect(within(juanaRow).getByRole("button", { name: /^Kill: / })).toBeInTheDocument();
 
       const chuquiRow = screen.getByText("Chuquimamani-Condori").closest("tr") as HTMLElement;
       expect(within(chuquiRow).getByText("Uncataloged")).toBeInTheDocument();
-      expect(within(chuquiRow).getByRole("button", { name: "Unkill" })).toBeInTheDocument();
+      expect(within(chuquiRow).getByRole("button", { name: /^Unkill: / })).toBeInTheDocument();
     });
 
     // Both destinations are later slices and no route answers either path,
@@ -147,8 +147,8 @@ describe("classic RotationReleaseList — rotationReleaseList.jsp", () => {
       renderWithProviders(<RotationReleaseList statusFilter="active" />);
 
       const row = (await screen.findByText("Juana Molina")).closest("tr") as HTMLElement;
-      expect(within(row).getByRole("button", { name: "Unkill" })).toBeInTheDocument();
-      expect(within(row).queryByRole("button", { name: "Kill" })).not.toBeInTheDocument();
+      expect(within(row).getByRole("button", { name: /^Unkill: / })).toBeInTheDocument();
+      expect(within(row).queryByRole("button", { name: /^Kill: / })).not.toBeInTheDocument();
       expect(within(row).queryByText("Active")).not.toBeInTheDocument();
     });
 
@@ -172,10 +172,10 @@ describe("classic RotationReleaseList — rotationReleaseList.jsp", () => {
 
       const { user } = renderWithProviders(<RotationReleaseList statusFilter="active" />);
       await screen.findByText("Juana Molina");
-      await user.click(screen.getByRole("button", { name: "Kill" }));
+      await user.click(screen.getByRole("button", { name: /^Kill: / }));
 
       await waitFor(() => expect(toast.error).toHaveBeenCalled());
-      expect(screen.getByRole("button", { name: "Kill" })).toBeEnabled();
+      expect(screen.getByRole("button", { name: /^Kill: / })).toBeEnabled();
     });
 
     it("dedupes rows sharing an artist and title, keeping the first", async () => {
@@ -227,7 +227,7 @@ describe("classic RotationReleaseList — rotationReleaseList.jsp", () => {
 
       const { user } = renderWithProviders(<RotationReleaseList statusFilter="active" />);
       await screen.findByText("Juana Molina");
-      await user.click(screen.getByRole("button", { name: "Kill" }));
+      await user.click(screen.getByRole("button", { name: /^Kill: / }));
 
       await waitFor(() => expect(killedBody).toEqual({ rotation_id: 5001 }));
     });
@@ -246,7 +246,7 @@ describe("classic RotationReleaseList — rotationReleaseList.jsp", () => {
 
       const { user } = renderWithProviders(<RotationReleaseList statusFilter="active" />);
       await screen.findByText("Chuquimamani-Condori");
-      await user.click(screen.getByRole("button", { name: "Unkill" }));
+      await user.click(screen.getByRole("button", { name: /^Unkill: / }));
 
       await waitFor(() => {
         expect(unkilledUrl).toBe("5002");

--- a/tests/integration/components/classic/rotation/RotationReleaseList.test.tsx
+++ b/tests/integration/components/classic/rotation/RotationReleaseList.test.tsx
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, server, TEST_BACKEND_URL } from "@/tests/helpers";
+
+vi.mock("@/lib/features/authentication/client", async () => {
+  const { createAuthClientModuleMock } = await import("@/tests/helpers/auth-client-mock");
+  return {
+    ...createAuthClientModuleMock(),
+    getJWTToken: vi.fn(async () => "test-token"),
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import RotationReleaseList from "@/src/components/experiences/classic/rotation/RotationReleaseList";
+
+const BASE = `${TEST_BACKEND_URL}/library/rotation`;
+
+const JUANA = {
+  id: 42,
+  code_letters: "MOL",
+  code_artist_number: 1,
+  code_number: 1,
+  artist_name: "Juana Molina",
+  alphabetical_name: "Molina, Juana",
+  album_title: "DOGA",
+  record_label: "Sonamos",
+  label_id: 5,
+  genre_name: "Rock",
+  format_name: "CD",
+  rotation_id: 5001,
+  add_date: "2026-08-01",
+  rotation_add_date: "2026-08-01",
+  rotation_bin: "H",
+  rotation_kill_date: null,
+  plays: 3,
+  legacy_release_id: 7001,
+};
+
+const CHUQUI_UNLINKED = {
+  id: null,
+  code_letters: null,
+  code_artist_number: null,
+  code_number: null,
+  artist_name: "Chuquimamani-Condori",
+  alphabetical_name: "Chuquimamani-Condori",
+  album_title: "Edits",
+  record_label: "self-released",
+  label_id: null,
+  genre_name: null,
+  format_name: null,
+  rotation_id: 5002,
+  add_date: null,
+  rotation_add_date: "2026-08-02",
+  rotation_bin: "M",
+  rotation_kill_date: "2026-01-01",
+  plays: null,
+  legacy_release_id: null,
+};
+
+function mockActiveList(rows: unknown[]) {
+  server.use(http.get(BASE, () => HttpResponse.json(rows)));
+}
+
+function mockUncatalogued(rows: unknown[]) {
+  server.use(http.get(`${BASE}/uncatalogued`, () => HttpResponse.json(rows)));
+}
+
+describe("classic RotationReleaseList — rotationReleaseList.jsp", () => {
+  beforeEach(() => {
+    mockActiveList([]);
+    mockUncatalogued([]);
+  });
+
+  it("renders the JSP's header links, heading, and facet chip bar", () => {
+    renderWithProviders(<RotationReleaseList statusFilter="active" />);
+
+    expect(screen.getByRole("link", { name: "Add Rotation Release" })).toHaveAttribute(
+      "href",
+      "/dashboard/rotation/new",
+    );
+    expect(screen.getByRole("link", { name: "Main Menu" })).toHaveAttribute("href", "/dashboard/catalog");
+    expect(screen.getByRole("heading", { name: "Rotation Releases" })).toBeInTheDocument();
+
+    expect(screen.getByRole("link", { name: "All" })).toHaveAttribute("href", "/dashboard/rotation?status=all");
+    expect(screen.getByRole("link", { name: "Active" })).toHaveAttribute(
+      "href",
+      "/dashboard/rotation?status=active",
+    );
+    expect(screen.getByRole("link", { name: "Killed" })).toHaveAttribute(
+      "href",
+      "/dashboard/rotation?status=killed",
+    );
+    expect(screen.getByRole("link", { name: "Awaiting Cataloging" })).toHaveAttribute(
+      "href",
+      "/dashboard/rotation?status=uncataloged",
+    );
+  });
+
+  it("marks the current facet's chip active", () => {
+    renderWithProviders(<RotationReleaseList statusFilter="uncataloged" />);
+    expect(screen.getByRole("link", { name: "Awaiting Cataloging" })).toHaveClass("active");
+    expect(screen.getByRole("link", { name: "Active" })).not.toHaveClass("active");
+  });
+
+  describe("Active facet", () => {
+    it("renders the JSP's nine columns for a linked and an unlinked row", async () => {
+      mockActiveList([JUANA, CHUQUI_UNLINKED]);
+      renderWithProviders(<RotationReleaseList statusFilter="active" />);
+
+      expect(await screen.findByText("Juana Molina")).toBeInTheDocument();
+      const juanaRow = screen.getByText("Juana Molina").closest("tr") as HTMLElement;
+      expect(within(juanaRow).getByText("DOGA")).toBeInTheDocument();
+      expect(within(juanaRow).getByText("Sonamos")).toBeInTheDocument();
+      expect(within(juanaRow).getByText("H")).toBeInTheDocument();
+      expect(within(juanaRow).getByText("CD")).toBeInTheDocument();
+      expect(within(juanaRow).getByText("08/01/26")).toBeInTheDocument();
+      expect(within(juanaRow).getByText("Active")).toBeInTheDocument();
+      expect(within(juanaRow).getByText("Cataloged")).toBeInTheDocument();
+      expect(within(juanaRow).getByRole("link", { name: "Edit" })).toHaveAttribute(
+        "href",
+        "/dashboard/rotation/5001",
+      );
+      expect(within(juanaRow).getByRole("button", { name: "Kill" })).toBeInTheDocument();
+
+      const chuquiRow = screen.getByText("Chuquimamani-Condori").closest("tr") as HTMLElement;
+      expect(within(chuquiRow).getByText("Uncataloged")).toBeInTheDocument();
+      // Killed and unlinked -- the Import link only appears for this combination.
+      expect(within(chuquiRow).getByRole("link", { name: "Import" })).toHaveAttribute(
+        "href",
+        "/dashboard/rotation/5002/import",
+      );
+      expect(within(chuquiRow).getByRole("button", { name: "Unkill" })).toBeInTheDocument();
+    });
+
+    it("dedupes rows sharing an artist and title, keeping the first", async () => {
+      mockActiveList([
+        { ...JUANA, rotation_id: 1 },
+        { ...JUANA, rotation_id: 2 },
+      ]);
+      renderWithProviders(<RotationReleaseList statusFilter="active" />);
+
+      await screen.findByText("Juana Molina");
+      expect(screen.getAllByText("Juana Molina")).toHaveLength(1);
+    });
+
+    it("shows the JSP's empty-state message for a genuinely empty result", async () => {
+      mockActiveList([]);
+      renderWithProviders(<RotationReleaseList statusFilter="active" />);
+
+      expect(await screen.findByText("No rotation releases found for this filter.")).toBeInTheDocument();
+    });
+
+    // A query-fed list must never render an unissued or failed request as
+    // "there are none".
+    it("never renders the empty-state message on an outage", async () => {
+      server.use(
+        http.get(
+          BASE,
+          () =>
+            new HttpResponse("<!DOCTYPE html><html><body>Bad Gateway</body></html>", {
+              status: 502,
+              headers: { "Content-Type": "text/html" },
+            }),
+        ),
+      );
+      renderWithProviders(<RotationReleaseList statusFilter="active" />);
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(/unavailable/i);
+      expect(screen.queryByText("No rotation releases found for this filter.")).not.toBeInTheDocument();
+    });
+
+    it("kills an active row", async () => {
+      mockActiveList([JUANA]);
+      let killedBody: unknown;
+      server.use(
+        http.patch(BASE, async ({ request }) => {
+          killedBody = await request.json();
+          return HttpResponse.json({ ...JUANA, rotation_kill_date: "2026-08-29" });
+        }),
+      );
+
+      const { user } = renderWithProviders(<RotationReleaseList statusFilter="active" />);
+      await screen.findByText("Juana Molina");
+      await user.click(screen.getByRole("button", { name: "Kill" }));
+
+      await waitFor(() => expect(killedBody).toEqual({ rotation_id: 5001 }));
+    });
+
+    it("unkills a killed row", async () => {
+      mockActiveList([CHUQUI_UNLINKED]);
+      let unkilledUrl: string | undefined;
+      let unkilledBody: unknown;
+      server.use(
+        http.patch(`${BASE}/:id`, async ({ request, params }) => {
+          unkilledUrl = params.id as string;
+          unkilledBody = await request.json();
+          return HttpResponse.json({ ...CHUQUI_UNLINKED, kill_date: null });
+        }),
+      );
+
+      const { user } = renderWithProviders(<RotationReleaseList statusFilter="active" />);
+      await screen.findByText("Chuquimamani-Condori");
+      await user.click(screen.getByRole("button", { name: "Unkill" }));
+
+      await waitFor(() => {
+        expect(unkilledUrl).toBe("5002");
+        expect(unkilledBody).toEqual({ kill_date: null });
+      });
+    });
+  });
+
+  describe("Awaiting Cataloging facet", () => {
+    const ACTIVE_UNCATALOGUED = {
+      id: 6001,
+      album_id: null,
+      rotation_bin: "M",
+      add_date: "2026-08-10",
+      kill_date: null,
+      artist_name: "LOS THUTHANAKA",
+      album_title: "Wak'a",
+      record_label: "self-released",
+    };
+    const KILLED_UNCATALOGUED = {
+      id: 6002,
+      album_id: null,
+      rotation_bin: "L",
+      add_date: "2026-01-10",
+      kill_date: "2026-02-01",
+      artist_name: "ear",
+      album_title: "Rumspringa",
+      record_label: null,
+    };
+
+    it("defaults to active-only, hiding the killed backlog", async () => {
+      mockUncatalogued([ACTIVE_UNCATALOGUED, KILLED_UNCATALOGUED]);
+      renderWithProviders(<RotationReleaseList statusFilter="uncataloged" />);
+
+      expect(await screen.findByText("LOS THUTHANAKA")).toBeInTheDocument();
+      expect(screen.queryByText("ear")).not.toBeInTheDocument();
+    });
+
+    it("reveals the killed backlog when the toggle is switched on", async () => {
+      mockUncatalogued([ACTIVE_UNCATALOGUED, KILLED_UNCATALOGUED]);
+      const { user } = renderWithProviders(<RotationReleaseList statusFilter="uncataloged" />);
+      await screen.findByText("LOS THUTHANAKA");
+
+      await user.click(screen.getByRole("checkbox", { name: /show killed/i }));
+
+      expect(await screen.findByText("ear")).toBeInTheDocument();
+      expect(screen.getByText("LOS THUTHANAKA")).toBeInTheDocument();
+    });
+
+    it("does NOT dedupe by artist and title -- every uncatalogued row is real cataloging work", async () => {
+      mockUncatalogued([
+        { ...ACTIVE_UNCATALOGUED, id: 1 },
+        { ...ACTIVE_UNCATALOGUED, id: 2 },
+      ]);
+      renderWithProviders(<RotationReleaseList statusFilter="uncataloged" />);
+
+      expect(await screen.findAllByText("LOS THUTHANAKA")).toHaveLength(2);
+    });
+
+    it("never renders the empty-state message on an outage", async () => {
+      server.use(
+        http.get(
+          `${BASE}/uncatalogued`,
+          () =>
+            new HttpResponse("<!DOCTYPE html><html><body>Bad Gateway</body></html>", {
+              status: 502,
+              headers: { "Content-Type": "text/html" },
+            }),
+        ),
+      );
+      renderWithProviders(<RotationReleaseList statusFilter="uncataloged" />);
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(/unavailable/i);
+      expect(screen.queryByText("No rotation releases found for this filter.")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("All and Killed facets — no Backend source for catalogued+killed rotation rows", () => {
+    it.each(["all", "killed"] as const)(
+      "states the Backend gap honestly for status=%s rather than rendering wrong data",
+      (statusFilter) => {
+        renderWithProviders(<RotationReleaseList statusFilter={statusFilter} />);
+        expect(screen.getByText(/doesn't expose|does not expose/i)).toBeInTheDocument();
+      },
+    );
+  });
+});

--- a/tests/integration/components/classic/rotation/RotationReleaseList.test.tsx
+++ b/tests/integration/components/classic/rotation/RotationReleaseList.test.tsx
@@ -120,20 +120,62 @@ describe("classic RotationReleaseList — rotationReleaseList.jsp", () => {
       expect(within(juanaRow).getByText("08/01/26")).toBeInTheDocument();
       expect(within(juanaRow).getByText("Active")).toBeInTheDocument();
       expect(within(juanaRow).getByText("Cataloged")).toBeInTheDocument();
-      expect(within(juanaRow).getByRole("link", { name: "Edit" })).toHaveAttribute(
-        "href",
-        "/dashboard/rotation/5001",
-      );
       expect(within(juanaRow).getByRole("button", { name: "Kill" })).toBeInTheDocument();
 
       const chuquiRow = screen.getByText("Chuquimamani-Condori").closest("tr") as HTMLElement;
       expect(within(chuquiRow).getByText("Uncataloged")).toBeInTheDocument();
-      // Killed and unlinked -- the Import link only appears for this combination.
-      expect(within(chuquiRow).getByRole("link", { name: "Import" })).toHaveAttribute(
-        "href",
-        "/dashboard/rotation/5002/import",
-      );
       expect(within(chuquiRow).getByRole("button", { name: "Unkill" })).toBeInTheDocument();
+    });
+
+    // Both destinations are later slices and no route answers either path,
+    // so rendering the JSP's row links would put a 404 under every row.
+    it("renders no Edit or Import link while their destinations do not exist", async () => {
+      mockActiveList([JUANA, CHUQUI_UNLINKED]);
+      renderWithProviders(<RotationReleaseList statusFilter="active" />);
+
+      await screen.findByText("Juana Molina");
+      expect(screen.queryByRole("link", { name: "Edit" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: "Import" })).not.toBeInTheDocument();
+    });
+
+    // The JSP keys Kill/Unkill and its Killed column on `killDate == 0`, not
+    // on whether the kill has landed. A kill scheduled for next week is
+    // already a kill.
+    it("shows a future kill date and offers Unkill, not a green Active and Kill", async () => {
+      const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+      mockActiveList([{ ...JUANA, rotation_kill_date: future }]);
+      renderWithProviders(<RotationReleaseList statusFilter="active" />);
+
+      const row = (await screen.findByText("Juana Molina")).closest("tr") as HTMLElement;
+      expect(within(row).getByRole("button", { name: "Unkill" })).toBeInTheDocument();
+      expect(within(row).queryByRole("button", { name: "Kill" })).not.toBeInTheDocument();
+      expect(within(row).queryByText("Active")).not.toBeInTheDocument();
+    });
+
+    it("orders rows most-recently-added first, matching the JSP, not the order the response arrives in", async () => {
+      mockActiveList([
+        { ...JUANA, rotation_id: 1, artist_name: "Jessica Pratt", album_title: "On Your Own Love Again", rotation_add_date: "2026-08-01" },
+        { ...JUANA, rotation_id: 2, artist_name: "Stereolab", album_title: "Dots and Loops", rotation_add_date: "2026-08-20" },
+      ]);
+      renderWithProviders(<RotationReleaseList statusFilter="active" />);
+
+      await screen.findByText("Stereolab");
+      const artists = screen.getAllByRole("row").slice(1).map((row) => row.children[1]?.textContent);
+      expect(artists).toEqual(["Stereolab", "Jessica Pratt"]);
+    });
+
+    it("reports a failed kill instead of leaving the row looking killed", async () => {
+      const { toast } = await import("sonner");
+      vi.mocked(toast.error).mockClear();
+      mockActiveList([JUANA]);
+      server.use(http.patch(BASE, () => new HttpResponse(null, { status: 503 })));
+
+      const { user } = renderWithProviders(<RotationReleaseList statusFilter="active" />);
+      await screen.findByText("Juana Molina");
+      await user.click(screen.getByRole("button", { name: "Kill" }));
+
+      await waitFor(() => expect(toast.error).toHaveBeenCalled());
+      expect(screen.getByRole("button", { name: "Kill" })).toBeEnabled();
     });
 
     it("dedupes rows sharing an artist and title, keeping the first", async () => {
@@ -252,6 +294,26 @@ describe("classic RotationReleaseList — rotationReleaseList.jsp", () => {
 
       expect(await screen.findByText("ear")).toBeInTheDocument();
       expect(screen.getByText("LOS THUTHANAKA")).toBeInTheDocument();
+    });
+
+    it("says so when the response fills a whole page, rather than showing a partial backlog as complete", async () => {
+      const full = Array.from({ length: 500 }, (_, index) => ({
+        ...ACTIVE_UNCATALOGUED,
+        id: index + 1,
+        artist_name: `Artist ${index}`,
+      }));
+      mockUncatalogued(full);
+      renderWithProviders(<RotationReleaseList statusFilter="uncataloged" />);
+
+      expect(await screen.findByText(/older entries in the backlog are not listed here/i)).toBeInTheDocument();
+    });
+
+    it("says nothing about truncation for a short page", async () => {
+      mockUncatalogued([ACTIVE_UNCATALOGUED]);
+      renderWithProviders(<RotationReleaseList statusFilter="uncataloged" />);
+
+      await screen.findByText("LOS THUTHANAKA");
+      expect(screen.queryByText(/older entries in the backlog are not listed here/i)).not.toBeInTheDocument();
     });
 
     it("does NOT dedupe by artist and title -- every uncatalogued row is real cataloging work", async () => {

--- a/tests/unit/lib/features/rotation/addErrorMessage.test.ts
+++ b/tests/unit/lib/features/rotation/addErrorMessage.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { rotationAddErrorMessage } from "@/lib/features/rotation/addErrorMessage";
+
+describe("rotationAddErrorMessage", () => {
+  it("surfaces the server's message from an RTK Query error", () => {
+    const err = { data: { message: "Missing Parameters: album_id, or artist_name and album_title" } };
+    expect(rotationAddErrorMessage(err)).toBe(
+      "Missing Parameters: album_id, or artist_name and album_title",
+    );
+  });
+
+  it("falls back to a generic message for a thrown Error", () => {
+    expect(rotationAddErrorMessage(new Error("network down"))).toBe("network down");
+  });
+
+  it("falls back to a generic message for a plain string rejection", () => {
+    expect(rotationAddErrorMessage("boom")).toBe("boom");
+  });
+
+  it("falls back to a generic message when nothing usable is present", () => {
+    expect(rotationAddErrorMessage({ status: 500 })).toBe("Failed to add rotation release.");
+  });
+
+  it("falls back to a generic message for a non-string server message", () => {
+    expect(rotationAddErrorMessage({ data: { message: 42 } })).toBe("Failed to add rotation release.");
+  });
+});

--- a/tests/unit/lib/features/rotation/classicApi.test.ts
+++ b/tests/unit/lib/features/rotation/classicApi.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi } from "vitest";
+import { configureStore } from "@reduxjs/toolkit";
+import { http, HttpResponse } from "msw";
+import { rotationApi } from "@/lib/features/rotation/api";
+import { rtkQueryErrorLogger } from "@/lib/rtk-query-error-logger";
+import { describeApi, server, TEST_BACKEND_URL } from "@/tests/helpers";
+
+vi.mock("@/lib/features/authentication/client", () => ({
+  getJWTToken: vi.fn().mockResolvedValue("test-token"),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+function rotationStore() {
+  return configureStore({
+    reducer: { [rotationApi.reducerPath]: rotationApi.reducer },
+    middleware: (gdm) => gdm().concat(rotationApi.middleware),
+  });
+}
+
+function rotationStoreWithErrorLogger() {
+  return configureStore({
+    reducer: { [rotationApi.reducerPath]: rotationApi.reducer },
+    middleware: (gdm) => gdm().concat(rtkQueryErrorLogger).concat(rotationApi.middleware),
+  });
+}
+
+const BASE = `${TEST_BACKEND_URL}/library/rotation`;
+
+describe("rotationApi — classic list + free-text add additions", () => {
+  describeApi(rotationApi, {
+    queries: ["getRotationList", "getUncataloguedRotation"],
+    mutations: ["addFreeTextRotationEntry", "unkillRotationEntry"],
+    reducerPath: "rotationApi",
+  });
+
+  describe("getRotationList", () => {
+    it("asks GET /library/rotation for the full row shape, unconverted", async () => {
+      let requested: URL | undefined;
+      server.use(
+        http.get(BASE, ({ request }) => {
+          requested = new URL(request.url);
+          return HttpResponse.json([{ id: null, rotation_id: 5001, rotation_bin: "H" }]);
+        }),
+      );
+
+      const store = rotationStore();
+      const result = await store.dispatch(rotationApi.endpoints.getRotationList.initiate());
+
+      expect(requested?.pathname).toBe("/library/rotation");
+      expect(result.data).toEqual([{ id: null, rotation_id: 5001, rotation_bin: "H" }]);
+    });
+  });
+
+  describe("getUncataloguedRotation", () => {
+    it("asks GET /library/rotation/uncatalogued with limit/offset params", async () => {
+      let requested: URL | undefined;
+      server.use(
+        http.get(`${BASE}/uncatalogued`, ({ request }) => {
+          requested = new URL(request.url);
+          return HttpResponse.json([]);
+        }),
+      );
+
+      const store = rotationStore();
+      await store.dispatch(
+        rotationApi.endpoints.getUncataloguedRotation.initiate({ limit: 500, offset: 500 }),
+      );
+
+      expect(requested?.pathname).toBe("/library/rotation/uncatalogued");
+      expect(requested?.searchParams.get("limit")).toBe("500");
+      expect(requested?.searchParams.get("offset")).toBe("500");
+    });
+
+    it("omits params entirely when called with no args", async () => {
+      let requested: URL | undefined;
+      server.use(
+        http.get(`${BASE}/uncatalogued`, ({ request }) => {
+          requested = new URL(request.url);
+          return HttpResponse.json([]);
+        }),
+      );
+
+      const store = rotationStore();
+      await store.dispatch(rotationApi.endpoints.getUncataloguedRotation.initiate());
+
+      expect(requested?.searchParams.has("limit")).toBe(false);
+      expect(requested?.searchParams.has("offset")).toBe(false);
+    });
+
+    // The Awaiting Cataloging queue must never read as "there are no
+    // uncatalogued releases" on an outage -- this endpoint opts out of the
+    // shared backend query's non-JSON soft-handle for that reason, matching
+    // labelsApi.searchLabels.
+    it("surfaces a non-JSON response as an error rather than an empty list", async () => {
+      server.use(
+        http.get(
+          `${BASE}/uncatalogued`,
+          () =>
+            new HttpResponse("<!DOCTYPE html><html><body>Bad Gateway</body></html>", {
+              status: 502,
+              headers: { "Content-Type": "text/html" },
+            }),
+        ),
+      );
+
+      const store = rotationStore();
+      const result = await store.dispatch(rotationApi.endpoints.getUncataloguedRotation.initiate());
+
+      expect(result.isError).toBe(true);
+      expect(result.data).toBeUndefined();
+    });
+  });
+
+  describe("addFreeTextRotationEntry", () => {
+    it("POSTs the free-text body to /library/rotation", async () => {
+      let requestBody: unknown;
+      server.use(
+        http.post(BASE, async ({ request }) => {
+          requestBody = await request.json();
+          return HttpResponse.json(
+            { id: 9001, album_id: null, rotation_bin: "H", add_date: "2026-08-29", kill_date: null },
+            { status: 201 },
+          );
+        }),
+      );
+
+      const store = rotationStore();
+      const result = await store.dispatch(
+        rotationApi.endpoints.addFreeTextRotationEntry.initiate({
+          rotation_bin: "H" as never,
+          artist_name: "Csillagrablók",
+          album_title: "Test Album",
+        }),
+      );
+
+      expect(requestBody).toEqual({
+        rotation_bin: "H",
+        artist_name: "Csillagrablók",
+        album_title: "Test Album",
+      });
+      expect(result.data).toMatchObject({ id: 9001 });
+    });
+
+    // The caller renders every refusal from this mutation inline (matching
+    // the JSP's own validationMessage div), so the shared rejected-query
+    // middleware toasting the identical string a second time would report
+    // one refusal twice. Nested the same way labelsApi.searchLabels nests
+    // its error, under a key the middleware's `payload.data.message` lookup
+    // does not recognize.
+    it("keeps its rejection message out of the global toast", async () => {
+      const { toast } = await import("sonner");
+      vi.mocked(toast.error).mockClear();
+      server.use(
+        http.post(BASE, () =>
+          HttpResponse.json({ message: "Missing Parameters: rotation_bin" }, { status: 400 }),
+        ),
+      );
+
+      const store = rotationStoreWithErrorLogger();
+      const result = await store.dispatch(
+        rotationApi.endpoints.addFreeTextRotationEntry.initiate({
+          rotation_bin: "H" as never,
+          artist_name: "Csillagrablók",
+          album_title: "Test Album",
+        }),
+      );
+
+      expect("error" in result).toBe(true);
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it("invalidates a cached Rotation-tagged query on success", async () => {
+      server.use(
+        http.get(BASE, () => HttpResponse.json([])),
+        http.post(BASE, () =>
+          HttpResponse.json(
+            { id: 9001, album_id: null, rotation_bin: "H", add_date: "2026-08-29", kill_date: null },
+            { status: 201 },
+          ),
+        ),
+      );
+
+      const store = rotationStore();
+      // `selectInvalidatedBy` reports cache entries whose *currently
+      // provided* tags intersect the given ones -- it has nothing to report
+      // until something is actually cached, so the read side is populated
+      // first.
+      await store.dispatch(rotationApi.endpoints.getRotationList.initiate());
+      await store.dispatch(
+        rotationApi.endpoints.addFreeTextRotationEntry.initiate({
+          rotation_bin: "H" as never,
+          artist_name: "Csillagrablók",
+          album_title: "Test Album",
+        }),
+      );
+
+      expect(
+        rotationApi.util.selectInvalidatedBy(store.getState(), [{ type: "Rotation" }]),
+      ).toEqual([expect.objectContaining({ endpointName: "getRotationList" })]);
+    });
+  });
+
+  describe("unkillRotationEntry", () => {
+    it("PATCHes /library/rotation/:id with kill_date: null", async () => {
+      let requestBody: unknown;
+      let requestUrl: URL | undefined;
+      server.use(
+        http.patch(`${BASE}/:id`, async ({ request, params }) => {
+          requestUrl = new URL(request.url);
+          requestBody = await request.json();
+          return HttpResponse.json({
+            id: Number(params.id),
+            album_id: null,
+            rotation_bin: "H",
+            add_date: "2026-08-01",
+            kill_date: null,
+          });
+        }),
+      );
+
+      const store = rotationStore();
+      const result = await store.dispatch(
+        rotationApi.endpoints.unkillRotationEntry.initiate({ rotation_id: 5001 }),
+      );
+
+      expect(requestUrl?.pathname).toBe("/library/rotation/5001");
+      expect(requestBody).toEqual({ kill_date: null });
+      expect(result.data).toMatchObject({ kill_date: null });
+    });
+
+    it("invalidates a cached Rotation-tagged query on success", async () => {
+      server.use(
+        http.get(BASE, () => HttpResponse.json([])),
+        http.patch(`${BASE}/:id`, () =>
+          HttpResponse.json({
+            id: 5001,
+            album_id: null,
+            rotation_bin: "H",
+            add_date: "2026-08-01",
+            kill_date: null,
+          }),
+        ),
+      );
+
+      const store = rotationStore();
+      await store.dispatch(rotationApi.endpoints.getRotationList.initiate());
+      await store.dispatch(rotationApi.endpoints.unkillRotationEntry.initiate({ rotation_id: 5001 }));
+
+      expect(
+        rotationApi.util.selectInvalidatedBy(store.getState(), [{ type: "Rotation" }]),
+      ).toEqual([expect.objectContaining({ endpointName: "getRotationList" })]);
+    });
+  });
+});

--- a/tests/unit/lib/features/rotation/classicApi.test.ts
+++ b/tests/unit/lib/features/rotation/classicApi.test.ts
@@ -13,6 +13,12 @@ vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
 
+const patchCatalogSearchRotation = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/features/catalog/patchSearchCaches", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/features/catalog/patchSearchCaches")>()),
+  patchCatalogSearchRotation,
+}));
+
 function rotationStore() {
   return configureStore({
     reducer: { [rotationApi.reducerPath]: rotationApi.reducer },
@@ -229,6 +235,56 @@ describe("rotationApi — classic list + free-text add additions", () => {
       expect(requestUrl?.pathname).toBe("/library/rotation/5001");
       expect(requestBody).toEqual({ kill_date: null });
       expect(result.data).toMatchObject({ kill_date: null });
+    });
+
+    // `killRotationEntry` writes a per-album "no rotation" override into the
+    // catalog slice, and that override shadows the server's value on every
+    // later read -- a refetch does not clear it. Unkilling has to write the
+    // restored bin back or the catalog goes on reporting the release as out
+    // of rotation for the life of the tab.
+    it("restores the catalog's rotation badge for a library-linked row", async () => {
+      patchCatalogSearchRotation.mockClear();
+      server.use(
+        http.patch(`${BASE}/:id`, () =>
+          HttpResponse.json({
+            id: 5001,
+            album_id: 42,
+            rotation_bin: "M",
+            add_date: "2026-08-01",
+            kill_date: null,
+          }),
+        ),
+      );
+
+      const store = rotationStore();
+      await store.dispatch(rotationApi.endpoints.unkillRotationEntry.initiate({ rotation_id: 5001 }));
+
+      expect(patchCatalogSearchRotation).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        42,
+        { rotation_bin: "M", rotation_id: 5001 },
+      );
+    });
+
+    it("patches nothing for a row that never linked to a library album", async () => {
+      patchCatalogSearchRotation.mockClear();
+      server.use(
+        http.patch(`${BASE}/:id`, () =>
+          HttpResponse.json({
+            id: 5001,
+            album_id: null,
+            rotation_bin: "M",
+            add_date: "2026-08-01",
+            kill_date: null,
+          }),
+        ),
+      );
+
+      const store = rotationStore();
+      await store.dispatch(rotationApi.endpoints.unkillRotationEntry.initiate({ rotation_id: 5001 }));
+
+      expect(patchCatalogSearchRotation).not.toHaveBeenCalled();
     });
 
     it("invalidates a cached Rotation-tagged query on success", async () => {

--- a/tests/unit/lib/features/rotation/classicList.test.ts
+++ b/tests/unit/lib/features/rotation/classicList.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import {
+  isRotationRowActive,
+  formatRotationDate,
+  rotationLibraryStatus,
+  dedupeRotationListByArtistTitle,
+  toDisplayRowFromList,
+  toDisplayRowFromUncatalogued,
+} from "@/lib/features/rotation/classicList";
+import { RotationBin, type RotationListRow, type UncataloguedRotationRow } from "@/lib/features/rotation/types";
+
+const NOW = new Date("2026-08-29T12:00:00.000Z");
+
+function listRow(overrides: Partial<RotationListRow> = {}): RotationListRow {
+  return {
+    id: 1001,
+    code_letters: "MOL",
+    code_artist_number: 1,
+    code_number: 1,
+    artist_name: "Juana Molina",
+    alphabetical_name: "Molina, Juana",
+    album_title: "DOGA",
+    record_label: "Sonamos",
+    label_id: 5,
+    genre_name: "Rock",
+    format_name: "CD",
+    rotation_id: 5001,
+    add_date: "2026-08-01",
+    rotation_add_date: "2026-08-01",
+    rotation_bin: RotationBin.H,
+    rotation_kill_date: null,
+    plays: 3,
+    legacy_release_id: 7001,
+    ...overrides,
+  };
+}
+
+function uncataloguedRow(overrides: Partial<UncataloguedRotationRow> = {}): UncataloguedRotationRow {
+  return {
+    id: 6001,
+    album_id: null,
+    rotation_bin: RotationBin.M,
+    add_date: "2026-08-10",
+    kill_date: null,
+    artist_name: "LOS THUTHANAKA",
+    album_title: "Wak'a",
+    record_label: "self-released",
+    ...overrides,
+  };
+}
+
+describe("isRotationRowActive", () => {
+  it("treats a null kill_date as active", () => {
+    expect(isRotationRowActive(null, NOW)).toBe(true);
+  });
+
+  it("treats a future kill_date as active", () => {
+    expect(isRotationRowActive("2026-09-01", NOW)).toBe(true);
+  });
+
+  it("treats today's kill_date as killed, not active", () => {
+    expect(isRotationRowActive("2026-08-29", NOW)).toBe(false);
+  });
+
+  it("treats a past kill_date as killed", () => {
+    expect(isRotationRowActive("2026-01-01", NOW)).toBe(false);
+  });
+});
+
+describe("formatRotationDate", () => {
+  it("formats an ISO date as MM/DD/YY, matching DateTimeManager.getLongDateAsMMDDYY", () => {
+    expect(formatRotationDate("2026-08-01")).toBe("08/01/26");
+  });
+
+  it("returns an empty string for a null date", () => {
+    expect(formatRotationDate(null)).toBe("");
+  });
+
+  it("never shifts the calendar day through a Date/timezone conversion", () => {
+    // A naive `new Date("2026-01-01")` interprets the string as UTC midnight,
+    // which renders as 2025-12-31 in any timezone west of UTC. This must
+    // read the digits directly instead.
+    expect(formatRotationDate("2026-01-01")).toBe("01/01/26");
+  });
+});
+
+describe("rotationLibraryStatus", () => {
+  it("reports cataloged for a linked row regardless of kill status", () => {
+    expect(rotationLibraryStatus(true, false)).toBe("cataloged");
+    expect(rotationLibraryStatus(true, true)).toBe("cataloged");
+  });
+
+  it("reports uncataloged for an unlinked, killed row", () => {
+    expect(rotationLibraryStatus(false, true)).toBe("uncataloged");
+  });
+
+  it("reports unknown for an unlinked, active row (the JSP's em-dash)", () => {
+    expect(rotationLibraryStatus(false, false)).toBe("unknown");
+  });
+});
+
+describe("toDisplayRowFromList", () => {
+  it("treats a 0 library id the same as null -- the 0-and-NULL unlinked sentinel", () => {
+    // tubafrenzy historically wrote a literal 0 for "unlinked"; Backend
+    // writes NULL. `id` here is `library.id` from a LEFT JOIN, which Postgres
+    // can never populate with a literal 0 (library.id is a serial starting at
+    // 1) -- but the predicate must not assume that and must reject 0 as a
+    // linked id defensively, matching `hasLinkedAlbumId`'s `> 0` guard.
+    const zero = toDisplayRowFromList(listRow({ id: 0 }), NOW);
+    const nullId = toDisplayRowFromList(listRow({ id: null }), NOW);
+    expect(zero.libraryStatus).toBe(nullId.libraryStatus);
+    expect(zero.libraryStatus).not.toBe("cataloged");
+  });
+
+  it("reports cataloged for a positive library id", () => {
+    const row = toDisplayRowFromList(listRow({ id: 42 }), NOW);
+    expect(row.libraryStatus).toBe("cataloged");
+  });
+
+  it("shows Import only for a killed, unlinked row", () => {
+    const activeUnlinked = toDisplayRowFromList(listRow({ id: null, rotation_kill_date: null }), NOW);
+    const killedUnlinked = toDisplayRowFromList(
+      listRow({ id: null, rotation_kill_date: "2026-01-01" }),
+      NOW,
+    );
+    const killedLinked = toDisplayRowFromList(listRow({ id: 42, rotation_kill_date: "2026-01-01" }), NOW);
+    expect(activeUnlinked.showImport).toBe(false);
+    expect(killedUnlinked.showImport).toBe(true);
+    expect(killedLinked.showImport).toBe(false);
+  });
+
+  it("carries the rotation row's own id for Edit/Kill/Unkill, not the library id", () => {
+    const row = toDisplayRowFromList(listRow({ rotation_id: 5001, id: 42 }), NOW);
+    expect(row.rotationId).toBe(5001);
+  });
+});
+
+describe("toDisplayRowFromUncatalogued", () => {
+  it("is always uncataloged when killed and unknown when active -- rows here are unlinked by construction", () => {
+    const active = toDisplayRowFromUncatalogued(uncataloguedRow({ kill_date: null }), NOW);
+    const killed = toDisplayRowFromUncatalogued(uncataloguedRow({ kill_date: "2026-01-01" }), NOW);
+    expect(active.libraryStatus).toBe("unknown");
+    expect(killed.libraryStatus).toBe("uncataloged");
+  });
+
+  it("treats an album_id of 0 the same as null -- defensive against the tubafrenzy sentinel", () => {
+    const zero = toDisplayRowFromUncatalogued(uncataloguedRow({ album_id: 0 }), NOW);
+    expect(zero.libraryStatus).not.toBe("cataloged");
+  });
+});
+
+describe("dedupeRotationListByArtistTitle", () => {
+  it("collapses rows sharing an artist and title, keeping the first (most recent)", () => {
+    const rows = [
+      listRow({ rotation_id: 1, artist_name: "LOS THUTHANAKA", album_title: "Wak'a", rotation_add_date: "2026-08-03" }),
+      listRow({ rotation_id: 2, artist_name: "LOS THUTHANAKA", album_title: "Wak'a", rotation_add_date: "2026-08-02" }),
+      listRow({ rotation_id: 3, artist_name: "LOS THUTHANAKA", album_title: "Wak'a", rotation_add_date: "2026-08-01" }),
+    ];
+
+    const deduped = dedupeRotationListByArtistTitle(rows);
+
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0]?.rotation_id).toBe(1);
+  });
+
+  it("is case- and whitespace-insensitive on both artist and title", () => {
+    const rows = [
+      listRow({ rotation_id: 1, artist_name: "ear", album_title: "Rumspringa" }),
+      listRow({ rotation_id: 2, artist_name: "  Ear  ", album_title: "rumspringa" }),
+    ];
+
+    expect(dedupeRotationListByArtistTitle(rows)).toHaveLength(1);
+  });
+
+  it("keeps rows with distinct artist/title pairs", () => {
+    const rows = [
+      listRow({ rotation_id: 1, artist_name: "Jessica Pratt", album_title: "On Your Own Love Again" }),
+      listRow({ rotation_id: 2, artist_name: "Chuquimamani-Condori", album_title: "Edits" }),
+    ];
+
+    expect(dedupeRotationListByArtistTitle(rows)).toHaveLength(2);
+  });
+
+  it("treats a null artist or title as its own key rather than crashing", () => {
+    const rows = [
+      listRow({ rotation_id: 1, artist_name: null, album_title: null }),
+      listRow({ rotation_id: 2, artist_name: null, album_title: null }),
+    ];
+
+    expect(dedupeRotationListByArtistTitle(rows)).toHaveLength(1);
+  });
+});

--- a/tests/unit/lib/features/rotation/classicList.test.ts
+++ b/tests/unit/lib/features/rotation/classicList.test.ts
@@ -117,16 +117,33 @@ describe("toDisplayRowFromList", () => {
     expect(row.libraryStatus).toBe("cataloged");
   });
 
-  it("shows Import only for a killed, unlinked row", () => {
+  it("reports uncataloged only for an unlinked row that carries a kill date", () => {
     const activeUnlinked = toDisplayRowFromList(listRow({ id: null, rotation_kill_date: null }), NOW);
     const killedUnlinked = toDisplayRowFromList(
       listRow({ id: null, rotation_kill_date: "2026-01-01" }),
       NOW,
     );
     const killedLinked = toDisplayRowFromList(listRow({ id: 42, rotation_kill_date: "2026-01-01" }), NOW);
-    expect(activeUnlinked.showImport).toBe(false);
-    expect(killedUnlinked.showImport).toBe(true);
-    expect(killedLinked.showImport).toBe(false);
+    expect(activeUnlinked.libraryStatus).toBe("unknown");
+    expect(killedUnlinked.libraryStatus).toBe("uncataloged");
+    expect(killedLinked.libraryStatus).toBe("cataloged");
+  });
+
+  // The JSP keys its Killed column, its Kill/Unkill choice and its Library
+  // column on `release.killDate == 0`, not on whether the kill date has
+  // arrived. A row killed as of next week is still in rotation today and is
+  // already killed.
+  it("keeps a future kill date visible while still reporting the row as active", () => {
+    const row = toDisplayRowFromList(listRow({ id: null, rotation_kill_date: "2026-09-05" }), NOW);
+    expect(row.killedDisplay).toBe("09/05/26");
+    expect(row.active).toBe(true);
+    expect(row.libraryStatus).toBe("uncataloged");
+  });
+
+  it("carries no kill display at all for a row that was never killed", () => {
+    const row = toDisplayRowFromList(listRow({ rotation_kill_date: null }), NOW);
+    expect(row.killedDisplay).toBeNull();
+    expect(row.active).toBe(true);
   });
 
   it("carries the rotation row's own id for Edit/Kill/Unkill, not the library id", () => {
@@ -136,11 +153,17 @@ describe("toDisplayRowFromList", () => {
 });
 
 describe("toDisplayRowFromUncatalogued", () => {
-  it("is always uncataloged when killed and unknown when active -- rows here are unlinked by construction", () => {
+  it("is always uncataloged when killed and unknown when never killed -- rows here are unlinked by construction", () => {
     const active = toDisplayRowFromUncatalogued(uncataloguedRow({ kill_date: null }), NOW);
     const killed = toDisplayRowFromUncatalogued(uncataloguedRow({ kill_date: "2026-01-01" }), NOW);
     expect(active.libraryStatus).toBe("unknown");
     expect(killed.libraryStatus).toBe("uncataloged");
+  });
+
+  it("keeps a future kill date visible while still reporting the row as active", () => {
+    const row = toDisplayRowFromUncatalogued(uncataloguedRow({ kill_date: "2026-09-05" }), NOW);
+    expect(row.killedDisplay).toBe("09/05/26");
+    expect(row.active).toBe(true);
   });
 
   it("treats an album_id of 0 the same as null -- defensive against the tubafrenzy sentinel", () => {
@@ -188,5 +211,49 @@ describe("dedupeRotationListByArtistTitle", () => {
     ];
 
     expect(dedupeRotationListByArtistTitle(rows)).toHaveLength(1);
+  });
+});
+
+describe("dedupeRotationListByArtistTitle — ordering and key separation", () => {
+  it("keeps the most recently added row regardless of the order it is handed", () => {
+    const rows = [
+      listRow({ rotation_id: 3, artist_name: "LOS THUTHANAKA", album_title: "Wak'a", rotation_add_date: "2026-08-01", rotation_bin: RotationBin.H }),
+      listRow({ rotation_id: 1, artist_name: "LOS THUTHANAKA", album_title: "Wak'a", rotation_add_date: "2026-08-03", rotation_bin: RotationBin.L }),
+      listRow({ rotation_id: 2, artist_name: "LOS THUTHANAKA", album_title: "Wak'a", rotation_add_date: "2026-08-02", rotation_bin: RotationBin.M }),
+    ];
+
+    const deduped = dedupeRotationListByArtistTitle(rows);
+
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0]?.rotation_id).toBe(1);
+    expect(deduped[0]?.rotation_bin).toBe(RotationBin.L);
+  });
+
+  it("orders the surviving rows most-recently-added first, matching the JSP's own ORDER BY", () => {
+    const rows = [
+      listRow({ rotation_id: 1, artist_name: "Jessica Pratt", album_title: "On Your Own Love Again", rotation_add_date: "2026-08-01" }),
+      listRow({ rotation_id: 2, artist_name: "Chuquimamani-Condori", album_title: "Edits", rotation_add_date: "2026-08-20" }),
+      listRow({ rotation_id: 3, artist_name: "Stereolab", album_title: "Dots and Loops", rotation_add_date: "2026-08-10" }),
+    ];
+
+    expect(dedupeRotationListByArtistTitle(rows).map((row) => row.rotation_id)).toEqual([2, 3, 1]);
+  });
+
+  it("breaks an identical add-date tie on the lowest rotation id, so the order is deterministic", () => {
+    const rows = [
+      listRow({ rotation_id: 9, artist_name: "Cat Power", album_title: "Moon Pix", rotation_add_date: "2026-08-05" }),
+      listRow({ rotation_id: 4, artist_name: "Juana Molina", album_title: "DOGA", rotation_add_date: "2026-08-05" }),
+    ];
+
+    expect(dedupeRotationListByArtistTitle(rows).map((row) => row.rotation_id)).toEqual([4, 9]);
+  });
+
+  it("does not collapse a pair whose artist/title split differs but whose concatenation matches", () => {
+    const rows = [
+      listRow({ rotation_id: 1, artist_name: "Sun", album_title: "Ra Arkestra" }),
+      listRow({ rotation_id: 2, artist_name: "Sun Ra", album_title: "Arkestra" }),
+    ];
+
+    expect(dedupeRotationListByArtistTitle(rows)).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Why this screen exists

The station's intake is rotation-first. A promo arrives, the MD puts it into rotation that week, and it gets catalogued later — often after it has already been killed. Classic could do neither half of that: there was no way to see what is in rotation and no way to add a release to rotation before it exists in the library. dj-site as a whole could only do the reverse — attach rotation to an *already catalogued* album. This adds the two `/wxycdb` screens that close the loop: the rotation release list (`rotation/rotationReleaseList.jsp`) and the free-text rotation add (`rotation/rotationReleaseInsert.jsp`).

It also restores the chooser block that points at the list. `chooseLibraryCodeOrArtist.jsp` opens with "Import a killed rotation release into the library:" above its `<hr>`; the earlier chooser slice dropped that block because its destination did not exist. This slice builds the destination, so the block and the JSP's `<hr>` position come back and that divergence closes.

## What is here

- `/dashboard/rotation` — the list, DJ-readable, with the JSP's four facet chips, its nine columns in the JSP's order, and the JSP's own Kill / Unkill affordances. The Awaiting Cataloging facet defaults to the active-only subset with an opt-in toggle for the killed backlog.
- `/dashboard/rotation/new` — the free-text add form, MD-gated.
- `CompanyAutocomplete` — a plain `<input list>` + `<datalist>` pair backed by label search, the classic equivalent of the JSP's `setUpCompanyAutocomplete({url: 'companyAutocomplete'})` wiring on `companyName`. No MUI, no custom listbox.
- The rotation data layer: `getRotationList`, `getUncataloguedRotation`, `addFreeTextRotationEntry`, `unkillRotationEntry`.

## Divergences from the JSP, and the reason for each

| JSP | Here | Forced by |
|---|---|---|
| Four facets: All / Active / Killed / Awaiting Cataloging | Active and Awaiting Cataloging render tables; **All and Killed render an explicit "Backend doesn't expose this yet" message** | No Backend read path returns a catalogued *and* killed rotation row. `GET /library/rotation` restricts itself to active rows (`kill_date IS NULL OR kill_date > CURRENT_DATE`); `GET /library/rotation/uncatalogued` answers every status but only for `album_id IS NULL`. Those are the only two rotation GET routes that exist. Faking either facet from the other would present a partial answer as a complete one. |
| Insert form: Artist's Alphabetical Name | Dropped | No column on `rotation`. On a catalogued row the value comes from `artists.alphabetical_name`; an uncatalogued row has no `artists` row to hold it, and `PATCH /library/rotation/:id` rejects the field outright for that reason. |
| Insert form: Format select + "Additional size info" | Dropped | No column. Format lives on `library.format_id`, which only exists once a release is catalogued. |
| Insert form: "Date Added To Rotation" (23-days-back picker) | Dropped | `add_date` has a column but `POST /library/rotation` never reads it from the body — the server always stamps now. A rendered picker would do nothing. |
| Insert form: CMJ Genres checkboxes (hiphop / jazz / loudrock / newworld / rpm) | Dropped | No column of any kind. tubafrenzy-only fields with nowhere to land. |
| Insert form: Comments | Dropped | No column. |
| Insert form: "Clear Both Artist Text Fields" / "Clear Artist Alphabetical Name" | Dropped | They only operate on the alphabetical-name field, which is gone. |
| Insert form: hidden `companyID` set by the autocomplete | No id is submitted | `POST /library/rotation` takes `record_label` as free text on an uncatalogued row; there is no `label_id` on the wire, so there is no id to carry. |
| List and insert header: "Format Tallysheets" | Dropped | No tallysheet screen exists in dj-site; the alternative is a dead link. |
| List header: "Main Menu" → `searchCardCatalog` | Points at `/dashboard/catalog` | Same destination under dj-site's own route name; there is no route named after the servlet path. |
| Row actions: "Edit" → `rotationReleaseModify.jsp`, "Import" → `rotationReleaseImportPrompt` | Dropped for now | Both destinations (`/dashboard/rotation/[id]`, `/dashboard/rotation/[id]/import`) are later slices. This follows the precedent `MissingReleases` set for the same situation — a JSP link whose dj-site destination is a later slice renders as no link rather than as a dead one. |
| Success lands on the record just created (`rotationReleaseModify.jsp`) | Redirects to the list | That screen is a later slice. |
| The list renders every row the servlet selected | Awaiting Cataloging says so when its page comes back full | `GET /library/rotation/uncatalogued` serves at most 500 rows per request against a backlog of thousands. A truncated queue that does not announce itself reads as a finished one — the same disclosure `MissingReleases` makes for the catalog query's cap. |

Only `rotation_bin`, `artist_name`, `album_title` and `record_label` are storable on an uncatalogued rotation row. Every dropped field above is a field with no home, not a field left for later.

## Dedupe is scoped to the Active facet on purpose

The acceptance criterion asks for dedupe on artist + title. That is applied to the Active facet and **deliberately not** to Awaiting Cataloging. `getUncataloguedRotationFromDB`'s own doc comment states the opposite rule for that endpoint, and states it as a fix: "two physically distinct promos sharing an artist and title are two separate rows a librarian has to catalogue" — collapsing them there re-hides real physical promos from the person whose job is to catalogue them. Following the criterion literally would reintroduce the bug that endpoint's `DISTINCT ON` removal fixed. The Active facet has no such problem: it is a status view, not a worklist, and Backend's own collapse there only reaches same-`(album, bin)` pairs, so a re-add under a different bin still arrives twice.

## A correction to the issue: the `0`-and-`NULL` instruction is wrong for this column

The issue says "The unlinked sentinel is both `0` and `NULL` (tubafrenzy writes `0`, Backend writes `NULL`). Any 'is it catalogued' predicate must `COALESCE`." The duality is real, but it belongs to `legacy_library_release_id` — a different column.

For `rotation.album_id` Backend explicitly considered and rejected a `COALESCE(album_id, 0) = 0` draft. The evidence is in the doc comment on `getUncataloguedRotationFromDB` in `apps/backend/services/library.service.ts`: `rotation.album_id` carries `rotation_album_id_library_id_fk → library.id`; `library.id` is a `serial` starting at 1, so a stored `0` would violate the FK; the webhook writer normalizes its raw upstream id with `rawLibraryId || null` before `resolveAlbumId`; the seed clone holds **0** rows at `album_id = 0` out of 21,625; and `IS NULL` is sargable against `album_id_idx` where `COALESCE(...)` is not. `addRotation` (400 on `album_id: 0`) and `linkRotationToAlbum` (`isNull(rotation.album_id)`) both agree with that reading.

This implementation checks linkage with `hasLinkedAlbumId`'s `> 0` guard, which is harmless either way and is the right shape for a client that should not be trusting a database invariant it cannot see. But the stated rationale needed correcting so the next reader does not carry the `COALESCE` instruction into a query where it would cost an index scan.

## Authority

The split is load-bearing and is asserted at both levels separately. `mainmenu.jsp` places both rotation links outside its `hasAdminAccess()` block, and Backend agrees: `GET /library/rotation` and `GET /library/rotation/uncatalogued` are gated at `catalog: ['read']`, while every rotation write requires `catalog: ['write']`. So the list is gated at authenticated DJ and the insert form at MD. Blanket-gating the pair at MD would take the list away from the DJs the JSP gives it to.

Page tests assert each level on its own (a plain DJ reaches the list and is redirected from the insert form; an MD reaches both; a member below DJ and an unauthenticated visitor are bounced from both). The e2e spec asserts the same split with the two classic identities.

## Testing

Unit and integration tests cover the display projections, the dedupe, the API layer's request shapes and cache invalidation, both page authorities, both components, and the restored chooser block. Both source JSPs are named in the integration tests.

**The e2e spec is written but has not been executed.** It needs the Docker Compose Backend-Service stack; it will run for the first time in CI on this PR. Do not read it as a passing assertion yet.

## Acceptance criteria

`Part of #1171` rather than `Closes`, because the first criterion is only partly met:

- [x] The list defaults to active-only, has an opt-in for the killed backlog, and dedupes on artist + title.
- [ ] **The list renders the JSP's facets** — two of the four render a "Backend doesn't expose this yet" message instead of a table. Building All and Killed needs a Backend read for catalogued-and-killed rotation rows, which does not exist.
- [x] `0` and `NULL` both count as unlinked (with the correction above).
- [x] An MD can create a rotation release with no catalogued album.
- [x] List readable at DJ authority; insert gated at MD; page tests assert both; the e2e spec asserts the split — **written, not yet executed**.
- [x] The chooser's rotation block and `<hr>` position are restored.
- [x] `companyName` has the classic autocomplete equivalent, backed by label search.
- [x] Query-fed selects and lists follow the outage-rendering convention.
- [x] Integration tests naming both source JSPs.

## Row order, kill dates, and the `DISTINCT ON` the response arrives in

Two things the JSP gets for free and this client has to reconstruct, both worth knowing before reading the diff.

`rotationReleaseList.jsp`'s Active facet is `ORDER BY RR.ROTATION_ADD_DATE DESC`. `getRotationFromDB` orders by its `DISTINCT ON` partition key first — an `album_id`, or a `hashtext` of the artist/title snapshot — so the response reaches the client grouped by a hash, with `add_date` only breaking ties inside a group. The sort is therefore done client-side, and it lives inside the dedupe rather than beside it: "keep the first occurrence" is only "keep the most recent" if the order is guaranteed, and the response's own order guarantees the opposite — inside a duplicate group the rows arrive ordered by bin letter, so taking the first pins the list to whichever bin sorts earliest and shows a release still in Heavy months after it moved to Light.

The dedupe key encodes its two halves as a JSON array rather than joining them with a separator. Any separator an artist name or album title could itself contain makes `("Sun", "Ra Arkestra")` and `("Sun Ra", "Arkestra")` one key; the separators a title cannot contain are all invisible control characters, which no diff or reader can verify by eye.

Kill/Unkill, the Killed column and the Library column all key on whether a row carries a kill date at all, never on whether that date has arrived — `release.killDate == 0` is the JSP's own test, and `GET /library/rotation` deliberately returns future-dated kills. A row scheduled to leave rotation next week is still in rotation today and is already killed. "Active" (the Awaiting Cataloging toggle's question) and "has a kill date" (every display question) are separate values for that reason.

Remaining for a follow-up: a Backend read that can answer "catalogued and killed", and the `/dashboard/rotation/[id]` and `/dashboard/rotation/[id]/import` screens that the Edit and Import row actions point at in the JSP.

Part of #1171
