### PR TITLE
fix(roster): let a DJ be added without an on-air handle

### DIFF
--- a/e2e/tests/admin/user-creation.spec.ts
+++ b/e2e/tests/admin/user-creation.spec.ts
@@ -155,6 +155,13 @@ test.describe("Admin User Creation", () => {
 
     // Should succeed
     await rosterPage.expectSuccessToast("Account created");
+
+    // …and the handle must actually be absent. A success toast cannot tell a
+    // NULL handle apart from one stored as the literal "Anonymous", which the
+    // backend's handle resolution treats as "no handle" — so asserting the
+    // toast alone would let that substitution pass as optional-handle support.
+    await rosterPage.expectUserInRoster(username);
+    await expect(rosterPage.getUserRow(username)).not.toContainText("Anonymous");
   });
 
   test("should show error for duplicate username", async ({ page }) => {

--- a/src/components/experiences/modern/admin/roster/ImportCSVModal.tsx
+++ b/src/components/experiences/modern/admin/roster/ImportCSVModal.tsx
@@ -117,7 +117,11 @@ export default function ImportCSVModal({ open, onClose, onComplete, organization
           organizationSlug,
           role,
           realName: row.name,
-          djName: row.djName,
+          // `|| undefined` so a blank handle is omitted from the payload
+          // rather than sent as "", matching the single-add path. The server
+          // coerces either to NULL today; keeping one wire shape means a
+          // future tightening there can't split the two import routes.
+          djName: row.djName || undefined,
         }).unwrap();
 
         results.push({

--- a/src/components/experiences/modern/admin/roster/RosterTable.tsx
+++ b/src/components/experiences/modern/admin/roster/RosterTable.tsx
@@ -72,9 +72,11 @@ export default function RosterTable({ user, organizationSlug }: { user: User; or
         const newAccount = {
           realName: formData.get("realName") as string,
           username: formData.get("username") as string,
-          djName: formData.get("djName")
-            ? (formData.get("djName") as string)
-            : "Anonymous",
+          // Blank stays blank. "Anonymous" is the literal the backend's
+          // handle resolution treats as "no handle", so writing it here
+          // manufactures the row that filter exists to absorb; `|| undefined`
+          // below drops the field, leaving auth_user.dj_name NULL instead.
+          djName: ((formData.get("djName") as string | null) ?? "").trim(),
           email: formData.get("email") as string,
           authorization: authorizationOfNewAccount,
         };

--- a/src/components/experiences/modern/admin/roster/csvImport.ts
+++ b/src/components/experiences/modern/admin/roster/csvImport.ts
@@ -127,9 +127,12 @@ export function parseCSVImport(text: string): CSVParseResult {
   const djNameIdx = findColumnIndex(headers, DJ_NAME_ALIASES);
   const emailIdx = findColumnIndex(headers, EMAIL_ALIASES);
 
+  // "DJ Name" is deliberately absent from the required set, as "Username"
+  // already is: the on-air handle is optional across the stack (nullable
+  // auth_user.dj_name, optional djName on provisionUser), so a roster export
+  // that omits the column is a valid import.
   const missingHeaders: string[] = [];
   if (nameIdx === -1) missingHeaders.push("Name");
-  if (djNameIdx === -1) missingHeaders.push("DJ Name");
   if (emailIdx === -1) missingHeaders.push("Email");
 
   if (missingHeaders.length > 0) {
@@ -160,9 +163,6 @@ export function parseCSVImport(text: string): CSVParseResult {
 
     if (!name) {
       errors.push({ row: rowNum, field: "name", message: "Name is required" });
-    }
-    if (!djName) {
-      errors.push({ row: rowNum, field: "djName", message: "DJ Name is required" });
     }
     if (!email) {
       errors.push({ row: rowNum, field: "email", message: "Email is required" });

--- a/tests/integration/components/modern/admin/roster/ImportCSVModal.test.tsx
+++ b/tests/integration/components/modern/admin/roster/ImportCSVModal.test.tsx
@@ -324,6 +324,28 @@ describe("ImportCSVModal", () => {
       expect(body.realName).toBe("Juana Molina");
     });
 
+    // A handle-less DJ is a normal roster entry, not a bad row. The importer
+    // used to reject the blank outright, so those DJs were dropped from the
+    // batch with no error surfaced against the import as a whole.
+    it("imports a row with a blank DJ name and omits djName from the payload", async () => {
+      const csv = [
+        "Name,Username,DJ Name,Email",
+        "Juana Molina,jmolina,,juana@wxyc.org",
+      ].join("\n");
+      await renderAndStartImport(csv);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      const body = JSON.parse(
+        (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body
+      );
+      expect(body).not.toHaveProperty("djName");
+      expect(body.username).toBe("jmolina");
+      expect(body.realName).toBe("Juana Molina");
+    });
+
     it("should skip rows with validation errors during import", async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
         ok: true,

--- a/tests/integration/components/modern/admin/roster/RosterTable.test.tsx
+++ b/tests/integration/components/modern/admin/roster/RosterTable.test.tsx
@@ -126,4 +126,61 @@ describe("RosterTable", () => {
     expect(init.json).not.toHaveProperty("name");
     expect(init.json.realName).toBe(MOCK_USERS.dj1.realName);
   });
+
+  // The handle input is optional, and a blank one must reach the API as an
+  // absent field so auth_user.dj_name is left NULL. It must not be sent as
+  // "Anonymous": that is the literal the backend's handle resolution treats
+  // as "no handle", so writing it manufactures the row that filter absorbs.
+  it("omits djName entirely when the handle field is left blank", async () => {
+    const store = makeStore();
+    store.dispatch(adminSlice.actions.setAdding(true));
+
+    const { user } = renderWithProviders(
+      <RosterTable user={adminUser} organizationSlug="wxyc" />,
+      { store }
+    );
+
+    await user.type(
+      screen.getByPlaceholderText("Name"),
+      MOCK_USERS.dj1.realName
+    );
+    await user.type(
+      screen.getByPlaceholderText("Username"),
+      MOCK_USERS.dj1.username
+    );
+    await user.type(
+      screen.getByPlaceholderText("Email"),
+      MOCK_USERS.dj1.email
+    );
+
+    await user.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(authFetch).toHaveBeenCalled());
+
+    const [, init] = (authFetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.json.djName).toBeUndefined();
+    expect(JSON.stringify(init.json)).not.toContain("Anonymous");
+  });
+
+  it("still forwards a handle that was filled in", async () => {
+    const store = makeStore();
+    store.dispatch(adminSlice.actions.setAdding(true));
+
+    const { user } = renderWithProviders(
+      <RosterTable user={adminUser} organizationSlug="wxyc" />,
+      { store }
+    );
+
+    await user.type(screen.getByPlaceholderText("Name"), MOCK_USERS.dj1.realName);
+    await user.type(screen.getByPlaceholderText("Username"), MOCK_USERS.dj1.username);
+    await user.type(screen.getByPlaceholderText("DJ Name (Optional)"), "DJ Juana");
+    await user.type(screen.getByPlaceholderText("Email"), MOCK_USERS.dj1.email);
+
+    await user.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(authFetch).toHaveBeenCalled());
+
+    const [, init] = (authFetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.json.djName).toBe("DJ Juana");
+  });
 });

--- a/tests/integration/components/modern/admin/roster/csvImport.test.ts
+++ b/tests/integration/components/modern/admin/roster/csvImport.test.ts
@@ -189,12 +189,27 @@ describe("parseCSVImport", () => {
       ]);
     });
 
-    it("should report error when DJ name is empty", () => {
+    // The on-air handle is optional everywhere else in the stack: the backend
+    // stores auth_user.dj_name as nullable, provisionUser() treats djName as
+    // optional, and the add form's own input is labelled "(Optional)". An
+    // importer that rejects the blank silently drops those DJs from the batch.
+    it("should accept a row with an empty DJ name", () => {
       const csv = "Name,DJ Name,Email\nJuana Molina,,juana@wxyc.org";
       const result = parseCSVImport(csv);
 
-      expect(result.errors).toEqual([
-        expect.objectContaining({ row: 1, field: "djName" }),
+      expect(result.errors).toEqual([]);
+      expect(result.rows).toEqual([
+        { name: "Juana Molina", username: "juana", djName: "", email: "juana@wxyc.org" },
+      ]);
+    });
+
+    it("should accept a CSV with no DJ Name column at all", () => {
+      const csv = "Name,Username,Email\nJuana Molina,jmolina,juana@wxyc.org";
+      const result = parseCSVImport(csv);
+
+      expect(result.errors).toEqual([]);
+      expect(result.rows).toEqual([
+        { name: "Juana Molina", username: "jmolina", djName: "", email: "juana@wxyc.org" },
       ]);
     });
 
@@ -233,7 +248,9 @@ describe("parseCSVImport", () => {
       const csv = "Name,DJ Name,Email\n,,";
       const result = parseCSVImport(csv);
 
-      expect(result.errors.length).toBeGreaterThanOrEqual(3);
+      // name + email; the blank DJ Name is no longer an error.
+      expect(result.errors.length).toBeGreaterThanOrEqual(2);
+      expect(result.errors.some((e) => e.field === "djName")).toBe(false);
       expect(result.errors.every((e) => e.row === 1)).toBe(true);
     });
 
@@ -275,11 +292,11 @@ describe("parseCSVImport", () => {
   });
 
   it("should report error when required header columns are missing", () => {
-    const csv = "Name,Email\nJuana Molina,juana@wxyc.org";
+    const csv = "Name,DJ Name\nJuana Molina,DJ Juana";
     const result = parseCSVImport(csv);
 
     expect(result.errors).toEqual([
-      expect.objectContaining({ row: 0, field: "header", message: expect.stringContaining("DJ Name") }),
+      expect.objectContaining({ row: 0, field: "header", message: expect.stringContaining("Email") }),
     ]);
     expect(result.rows).toEqual([]);
   });


### PR DESCRIPTION
Closes #1304

## What was wrong

The DJ handle is optional everywhere in the stack except the two dj-site paths that create accounts, and both mishandled a blank one — in opposite, individually-silent ways.

**CSV import dropped the DJ.** `csvImport.ts` raised a `djName` "DJ Name is required" row error, and `ImportCSVModal` filters error rows out of `validRows` before importing. A handle-less DJ was therefore omitted from the batch with no failure reported against the import as a whole — the results summary counted them as though they had never been in the file.

**The single-add form wrote a false handle.** `RosterTable.tsx` substituted the literal `"Anonymous"` for a blank one. That is the exact string the backend's handle resolution treats as "no handle", so the write manufactured the row that filter exists to absorb, and stored a fabricated handle where the column should have been NULL.

Neither matched the contract on either side. `auth_user.dj_name` is nullable and `provisionUser()` takes `djName` as optional; the add form's own input is already labelled `"DJ Name (Optional)"` with `required={false}`. Only the submit paths disagreed.

## What changed

- `csvImport.ts` — dropped the `djName` required-field error and removed `"DJ Name"` from the required-header set, so it is now an optional column exactly as `"Username"` already was.
- `RosterTable.tsx` — a blank handle stays blank and is dropped by the existing `|| undefined`, so the field is absent from the payload and the column is left NULL.
- `ImportCSVModal.tsx` — sends `djName: row.djName || undefined` so both provisioning paths put the same shape on the wire. The server coerces `""` and `undefined` identically today; sharing one shape means a future tightening there can't split the two routes.

## Why the existing tests missed it

`e2e/tests/admin/user-creation.spec.ts` already had a test named **"should allow DJ name to be optional"**. It asserted only a success toast — which `"Anonymous"` satisfies — so it passed the entire time the behaviour it names was broken. It now asserts the created roster row carries no `"Anonymous"`, which is the assertion that distinguishes the two outcomes.

Added unit coverage for the cases that were silently wrong: a blank `DJ Name` cell imports and omits `djName`; a CSV with no `DJ Name` column at all parses; the add form sends no `djName` when the field is left empty and never `"Anonymous"`; and a filled handle still forwards unchanged on both paths.

## Verification

- `npx vitest run` — 363 files / 5297 tests green.
- `npx eslint` — 0 errors (16 warnings, all pre-existing on `main` in untouched files).
- `npx tsc --noEmit` — clean.

Two earlier full-suite runs on this branch showed failures in `catalog/` files unrelated to the roster — a different file each run, both passing in isolation, and a final run fully green. A full-suite run at this branch's exact base commit was also green, and nothing here is imported by those tests; the failures are load-dependent flake in that area, not this change.

## Note for reviewers

The `"Anonymous"` filter in the backend's resolution chain stays — it defends against legacy rows and the better-auth anonymous plugin. This change only stops dj-site manufacturing new ones. The fix direction is deliberately "make the handle optional", not "make it required": optional is the intended contract, and the flowsheet resolution chain already handles a null handle by design.
