### PR TITLE
fix(flowsheet): keep a live update from grafting a marker's wire timestamp onto the cache

### DIFF
--- a/lib/features/flowsheet/live-updates-listener.ts
+++ b/lib/features/flowsheet/live-updates-listener.ts
@@ -239,6 +239,27 @@ export function createLiveUpdatesListenerMiddleware(
    * cached row under a key nothing reads, while the rendered `day` / `time`
    * stay pinned to whatever the last conversion produced — the same
    * `rotation_bin` → `rotation` fork, not the `add_time` exception.
+   *
+   * Two caveats on that `timestamp` reasoning, both deliberate:
+   *
+   * 1. The API contract declares the field `format: date-time`, so the
+   *    display string above is BS departing from its own schema, not the
+   *    schema. Excluding the key is correct either way — an ISO instant is
+   *    equally not a converted key — but note the latent trap if BS is ever
+   *    corrected to honour the declared format: `parseTimestamp` splits on a
+   *    comma, finds none in an ISO string, and every marker renders
+   *    `day`/`time` as "Unknown". The exclusion here does not shield that.
+   *
+   * 2. This set is a flat key list, and one member of the same class cannot
+   *    be expressed in it: `artist_name`. On the marker variants the
+   *    conversion reads it as the legacy fallback for `dj_name`
+   *    (`entry.dj_name ?? entry.artist_name`) and the converted row keeps no
+   *    `artist_name`, so merging one onto a marker forks exactly the way
+   *    `timestamp` does. On a track row it is same-name-retained enrichment
+   *    that this merge exists to deliver. Excluding it therefore requires a
+   *    rule that discriminates on `entry_type`, which a `Set<string>`
+   *    structurally cannot; adding it here would silently break track
+   *    enrichment. Left open knowingly rather than half-fixed.
    */
   const WIRE_ONLY_UPDATE_KEYS = new Set([
     "entry_type",

--- a/lib/features/flowsheet/live-updates-listener.ts
+++ b/lib/features/flowsheet/live-updates-listener.ts
@@ -226,6 +226,19 @@ export function createLiveUpdatesListenerMiddleware(
    * NOT that the value is unshared: the marker variants still derive `day` /
    * `time` / `isToday` at conversion time, and those are not recomputed here,
    * so a genuinely changed `add_time` would leave them disagreeing.
+   *
+   * `timestamp` is the opposite case, not a second instance of the `add_time`
+   * exception: it exists only on the V2 `show_start`/`show_end` wire shape
+   * (`FlowsheetV2ShowStartEntry`/`FlowsheetV2ShowEndEntry`), and the value
+   * BS puts there is a locale-formatted display string
+   * (`add_time.toLocaleString('en-US', { timeZone: 'America/New_York' })`,
+   * e.g. "8/28/2026, 2:30:00 PM") — not the ISO instant `add_time` carries.
+   * `convertV2Entry` consumes it once, at conversion time, into `day` /
+   * `time` / `isToday` and the converted row never keeps a `timestamp`
+   * field of its own. A raw merge would graft that display string onto the
+   * cached row under a key nothing reads, while the rendered `day` / `time`
+   * stay pinned to whatever the last conversion produced — the same
+   * `rotation_bin` → `rotation` fork, not the `add_time` exception.
    */
   const WIRE_ONLY_UPDATE_KEYS = new Set([
     "entry_type",
@@ -233,6 +246,7 @@ export function createLiveUpdatesListenerMiddleware(
     "radio_hour",
     "dj_name",
     "rotation_bin",
+    "timestamp",
   ]);
 
   /**

--- a/tests/unit/lib/features/flowsheet/live-updates-listener.test.ts
+++ b/tests/unit/lib/features/flowsheet/live-updates-listener.test.ts
@@ -449,12 +449,10 @@ describe("live-updates listener middleware", () => {
     // one: the merge must be safe on its own terms, not safe because BS
     // currently withholds this shape.
     //
-    // `add_time` deliberately repeats the seeded value rather than a fresh
-    // one. It is NOT wire-only, so a differing value would merge and leave
-    // the row's raw instant disagreeing with the `day`/`time` derived from
-    // the original conversion — a second, unasserted fork that would blur
-    // which key this test is actually pinning. `timestamp` is the only
-    // variable here.
+    // `add_time` must keep repeating the seeded value: it is NOT wire-only,
+    // so a fresh one would merge and fork the row's raw instant against the
+    // `day`/`time` derived from the original conversion — a second fork this
+    // test asserts nothing about. `timestamp` is the only variable.
     getLastMock()._fireMessage(
       frame({
         type: "update",

--- a/tests/unit/lib/features/flowsheet/live-updates-listener.test.ts
+++ b/tests/unit/lib/features/flowsheet/live-updates-listener.test.ts
@@ -13,6 +13,7 @@ import { makeStore } from "@/lib/store";
 import { makePublicStore } from "@/lib/store-public";
 import {
   createTestInsertWirePayload,
+  createTestV2ShowStartEntry,
   server,
   TEST_BACKEND_URL,
 } from "@/tests/helpers";
@@ -408,6 +409,75 @@ describe("live-updates listener middleware", () => {
     // `add_time` is not a wire-only key: the conversion carries it onto every
     // entry under the same name and value, so merging it forks no shape.
     expect("add_time" in patched).toBe(true);
+
+    store.dispatch(liveUpdatesConnectionReleased());
+  });
+
+  it("update event does not fork a show marker's time: timestamp is wire-only like rotation_bin, not a passthrough like add_time", async () => {
+    // `timestamp` exists only on the V2 show_start/show_end wire shape, and
+    // `convertV2Entry` consumes it once — at conversion time — into `day` /
+    // `time` / `isToday`. The converted cache row keeps no `timestamp` field
+    // of its own (pinned by conversions.test.ts), unlike `add_time`, which
+    // the conversion now carries through under the identical name and ISO
+    // value. So unlike `add_time`, a raw merge of `timestamp` is not a
+    // freshening of a shared field — it grafts a SECOND, ungoverned
+    // representation of the marker's time onto the row, one the rendered
+    // `day`/`time` never catch up to because nothing recomputes them here.
+    const store = await makeStoreWithSeededEntries([
+      createTestV2ShowStartEntry({
+        id: 9003,
+        show_id: 7000,
+        play_order: 1,
+        dj_name: "dj sue",
+        timestamp: "8/28/2026, 2:00:00 PM",
+      }),
+    ]);
+
+    const before = flowsheetApi.endpoints.getInfiniteEntries.select(undefined)(
+      store.getState()
+    ).data;
+    expect(before?.pages?.[0]?.[0]).toMatchObject({
+      id: 9003,
+      day: "8/28/2026",
+      time: "2:00:00 PM",
+    });
+
+    store.dispatch(liveUpdatesConnectionRequested());
+    // BS does not broadcast marker-row updates today (its `update` filter
+    // only reaches a terminal `metadata_status`, a track-only concept), but
+    // `nonNullWirePatch` does not discriminate on `entry_type` — it merges
+    // whatever keys the payload carries. A defensive test, not a fabricated
+    // one: the merge must be safe on its own terms, not safe because BS
+    // currently withholds this shape.
+    getLastMock()._fireMessage(
+      frame({
+        type: "update",
+        payload: {
+          id: 9003,
+          entry_type: "show_start",
+          show_id: 7000,
+          play_order: 1,
+          dj_name: "dj sue",
+          add_time: "2026-08-28T18:00:00.000Z",
+          timestamp: "8/28/2026, 5:00:00 PM",
+        },
+        timestamp: 1,
+      })
+    );
+
+    const after = flowsheetApi.endpoints.getInfiniteEntries.select(undefined)(
+      store.getState()
+    ).data;
+    const patched = after?.pages?.[0]?.[0] as Record<string, unknown>;
+
+    // The only representation of the marker's time on the cached row is
+    // day/time. Before this fix, `patched.timestamp` reads the wire's fresh
+    // "8/28/2026, 5:00:00 PM" while `patched.day`/`patched.time` still read
+    // the stale "8/28/2026"/"2:00:00 PM" from the original conversion —
+    // two disagreeing representations of the same instant on one row.
+    expect("timestamp" in patched).toBe(false);
+    expect(patched.day).toBe("8/28/2026");
+    expect(patched.time).toBe("2:00:00 PM");
 
     store.dispatch(liveUpdatesConnectionReleased());
   });

--- a/tests/unit/lib/features/flowsheet/live-updates-listener.test.ts
+++ b/tests/unit/lib/features/flowsheet/live-updates-listener.test.ts
@@ -423,15 +423,14 @@ describe("live-updates listener middleware", () => {
     // freshening of a shared field — it grafts a SECOND, ungoverned
     // representation of the marker's time onto the row, one the rendered
     // `day`/`time` never catch up to because nothing recomputes them here.
-    const store = await makeStoreWithSeededEntries([
-      createTestV2ShowStartEntry({
-        id: 9003,
-        show_id: 7000,
-        play_order: 1,
-        dj_name: "dj sue",
-        timestamp: "8/28/2026, 2:00:00 PM",
-      }),
-    ]);
+    const seeded = createTestV2ShowStartEntry({
+      id: 9003,
+      show_id: 7000,
+      play_order: 1,
+      dj_name: "dj sue",
+      timestamp: "8/28/2026, 2:00:00 PM",
+    });
+    const store = await makeStoreWithSeededEntries([seeded]);
 
     const before = flowsheetApi.endpoints.getInfiniteEntries.select(undefined)(
       store.getState()
@@ -443,12 +442,19 @@ describe("live-updates listener middleware", () => {
     });
 
     store.dispatch(liveUpdatesConnectionRequested());
-    // BS does not broadcast marker-row updates today (its `update` filter
-    // only reaches a terminal `metadata_status`, a track-only concept), but
-    // `nonNullWirePatch` does not discriminate on `entry_type` — it merges
+    // BS does not broadcast marker-row updates today — its update filter
+    // requires a terminal `metadata_status`, which marker rows never reach —
+    // but `nonNullWirePatch` does not discriminate on `entry_type`: it merges
     // whatever keys the payload carries. A defensive test, not a fabricated
     // one: the merge must be safe on its own terms, not safe because BS
     // currently withholds this shape.
+    //
+    // `add_time` deliberately repeats the seeded value rather than a fresh
+    // one. It is NOT wire-only, so a differing value would merge and leave
+    // the row's raw instant disagreeing with the `day`/`time` derived from
+    // the original conversion — a second, unasserted fork that would blur
+    // which key this test is actually pinning. `timestamp` is the only
+    // variable here.
     getLastMock()._fireMessage(
       frame({
         type: "update",
@@ -458,7 +464,7 @@ describe("live-updates listener middleware", () => {
           show_id: 7000,
           play_order: 1,
           dj_name: "dj sue",
-          add_time: "2026-08-28T18:00:00.000Z",
+          add_time: seeded.add_time,
           timestamp: "8/28/2026, 5:00:00 PM",
         },
         timestamp: 1,


### PR DESCRIPTION
Closes #1294

## The issue's premise is backwards, and the fix is the inverse

#1294 asks for `timestamp` to be "handled consistently with `add_time`." It should not be. The two look alike and are genuinely asymmetric, and treating them alike is what would break the row.

`add_time` is on **every** V2 entry type via `FlowsheetV2Base`, is a raw ISO-8601 instant, and #1288 made the conversion carry it onto the converted row under the same name and the same value. Merging it from a live update is a freshening of a shared field, so #1288 correctly **removed** it from `WIRE_ONLY_UPDATE_KEYS`.

`timestamp` is a different animal. It exists only on the `show_start` / `show_end` wire variants, and Backend-Service builds it at [`apps/backend/services/flowsheet.service.ts:2377`](https://github.com/WXYC/Backend-Service/blob/main/apps/backend/services/flowsheet.service.ts#L2377) as:

```ts
entry.add_time.toLocaleString('en-US', { timeZone: 'America/New_York' })
```

That is a lossy, locale-formatted **display string derived from `add_time`** — not a second instant. `convertV2Entry` consumes it exactly once, at conversion time, into `day` / `time` / `isToday`, and the converted row keeps no `timestamp` field of its own.

So `timestamp` belongs to the `rotation_bin` → `rotation` class, not the `add_time` class: a wire key whose value the converted row re-expresses under different names and does not itself retain. Merging it raw grafts the display string onto the cached row under a key nothing reads, while the rendered `day` / `time` stay pinned to whatever the last conversion produced — two disagreeing representations of one instant on one row. The fix is therefore to **add** `timestamp` to `WIRE_ONLY_UPDATE_KEYS`, the opposite of what #1288 did to `add_time`.

Both comments now sit side by side above the set, so a future reader meets the two decisions as one rule with two branches — "does the converted row keep this key, under this name, with this value?" — rather than as two ad-hoc patches that happen to point in opposite directions.

## Reachability, stated honestly

This is defensive against the **wire contract**, not against a bug reachable today — but the precise reason matters, and my first draft of this section got it wrong.

Backend-Service's update broadcast is gated by `matchTerminalTrackUpdate` (`apps/backend/services/metadata-broadcast/metadata-broadcast.ts`). Its `entry_type` check is `if (data.entry_type !== undefined && data.entry_type !== 'track') return null` — it fails **open** on an absent `entry_type`, so it is not the guard that excludes markers. What actually excludes them is the terminal-`metadata_status` requirement: marker rows keep `metadata_status = 'pending'` and never reach a terminal state, so none is ever broadcast. (The stricter `entry_type !== 'track'` form belongs to the *insert* matcher, not this one.) The conclusion holds — BS does not broadcast marker-row updates — but the reachability argument is looser than a reader skimming for the strict check would assume.

What makes the fix worth landing anyway is that `nonNullWirePatch` does **not** discriminate on `entry_type`. It merges whatever keys the payload carries, so the client's safety here rests entirely on the producer's current filter rather than on anything the merge itself enforces. The merge should be safe on its own terms. This does not fix an active incident and should not be read as one.

## Pre-existing, not a #1288 regression

The gap predates #1288 — `timestamp` was never in the set. It was found while reviewing the `add_time` half, which is why it reads as a follow-up. #1288 did not introduce it and did not widen it.

## The test demonstrates the fork rather than asserting it

`live-updates-listener.test.ts` seeds a converted `show_start` row (`day: "8/28/2026"`, `time: "2:00:00 PM"`), fires an SSE `update` carrying a **different** wire `timestamp` (`"8/28/2026, 5:00:00 PM"`), and asserts the cached row still has no `timestamp` key and that `day` / `time` are untouched.

Run against the pre-fix source it fails on `expect("timestamp" in patched).toBe(false)` — the raw wire string grafts on, while `day` / `time` stay stale at the original conversion's values. That is the fork itself, shown.

The payload repeats the seeded `add_time` rather than sending a fresh one. `add_time` is deliberately *not* wire-only, so a differing value merges — leaving the row's raw instant disagreeing with the `day`/`time` derived from the original conversion. That is a second, unasserted fork, and it blurred which key the test was actually pinning. `timestamp` is now the only variable.

## What else could be in this class — and the one that does not fit

The `add_time` gap and this one were each found one at a time, so I enumerated the whole V2 wire surface rather than waiting for a third to surface on its own. Two results.

**No third *display*-forking key is missing from the set.** Every wire key whose value the converted row re-expresses under a different name is now in it: `entry_type` (→ `isStart` / the row's shape), `rotation_bin` (→ `rotation`), and `timestamp` (→ `day` / `time` / `isToday`). `metadata_status` and `radio_hour` are in it as pure wire-only keys — note that dj-site's breakpoint branch derives `day` / `time` from `add_time` via `formatStationDateTime`, so nothing is derived from `radio_hour` here at all.

**But there is a fourth member of the class that this shape of fix cannot reach: `artist_name`.** On the marker variants `convertV2Entry` reads it as the legacy fallback for the DJ's name (`entry.dj_name ?? entry.artist_name`) and keeps no `artist_name` on the converted row, so merging one onto a marker forks exactly the way `timestamp` does. On a `track` row it is same-name-retained enrichment that this merge exists to deliver. A flat `Set<string>` cannot express that — adding it would silently break track enrichment — so it needs a rule that discriminates on `entry_type`, which is a mechanism change rather than a set membership. It is also the more contractually reachable of the two: `artist_name` is a declared member of `FlowsheetEntryFields`/`FlowsheetEntryResponse`, the type the update payload actually is, whereas `timestamp` is not in that type at all.

Left knowingly open and recorded in the doc comment rather than half-fixed, with the mechanism change filed as #1313. Generalizing here would have turned a two-file no-op into a redesign of the merge's contract, on a path where a regression costs live track enrichment.

The comment also now records a second caveat: api.yaml declares `timestamp` as `format: date-time`, so the locale string BS actually sends is a departure from its own schema. The exclusion is right either way, but the contradiction would otherwise read as an error in the comment, and there is a latent trap worth naming — if BS is ever corrected to honour the declared format, `parseTimestamp` splits on a comma, finds none, and every marker renders `day`/`time` as "Unknown".

One further note for scope: about fifteen track-only wire keys (`artist_id`, `track_position`, `discogs_url`, `release_year`, the five streaming-URL fields, `artist_bio`, `artist_wikipedia_url`, `genres`, `styles`, `upcoming_show`, `critic_reviews`) are dropped by `convertV2Entry` yet merged by `nonNullWirePatch`, so an updated row carries keys an inserted row never has. Inert today — none is read off a `FlowsheetEntry` anywhere in the app, and none has a differently-named converted counterpart that could go stale — and excluding them would drop enrichment the merge exists to deliver. Left alone deliberately.

## Testing

`npx vitest run` on the affected file — 40 passing. `npx tsc --noEmit` clean. `npm run lint` 0 errors.
