### PR TITLE
test(flowsheet): go-live takeover E2E spec, its own Backend job, and an observable mock tubafrenzy

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -542,13 +542,35 @@ jobs:
       github.event_name != 'pull_request'
       || (needs.changes.outputs.app_source == 'true' && github.base_ref == 'main')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 20, matching the sharded job, for the same reason its own cap documents:
+    # `Build and start services` has been observed at 82s, 123s, 129s and 740s
+    # in a single run on identical cache state. This job is structurally more
+    # exposed than that, not less — its build cache key and every restore-key
+    # carry an `e2e-takeover-` prefix, so it can never fall back to the sharded
+    # job's entry and pays a full Next build on each new branch. A cancel here
+    # now fails `e2e-all`, so an infrastructure shrug would read as a red
+    # required check.
+    timeout-minutes: 20
+    env:
+      # Publishes the `chromium-takeover` Playwright project (and the setup
+      # steps that provision its two identities). Unset everywhere else, so no
+      # unscoped run — the sharded matrix, `npm run test:e2e`, a bare
+      # `npx playwright test` — can schedule the one spec that clicks "End
+      # Existing Show" onto a Backend-Service it doesn't own.
+      E2E_TAKEOVER_PROJECT: "1"
 
     services:
       postgres:
         image: postgres:18.0-alpine
         env:
-          POSTGRES_PASSWORD: 'RadioIsEpic$1100'
+          # Deliberately inert-looking, and deliberately free of shell
+          # metacharacters: this value is written into an env file below, and
+          # `$1100` in the older literal is a positional-parameter expansion
+          # that anything sourcing that file would read as `100`. This job
+          # provisions its own Postgres here rather than through
+          # docker-compose.e2e.yml, so the only requirement is that this and
+          # the heredoc's DB_PASSWORD agree with each other.
+          POSTGRES_PASSWORD: e2e-throwaway-not-a-secret
           POSTGRES_USER: wxyc_admin
           POSTGRES_DB: wxyc_db
         ports:
@@ -636,7 +658,7 @@ jobs:
           DB_PORT=5434
           DB_NAME=wxyc_db
           DB_USERNAME=wxyc_admin
-          DB_PASSWORD='RadioIsEpic$1100'
+          DB_PASSWORD=e2e-throwaway-not-a-secret
           BETTER_AUTH_SECRET=e2e-auth-secret-for-testing-min-32-chars
           BETTER_AUTH_URL=http://localhost:8084/auth
           BETTER_AUTH_JWKS_URL=http://localhost:8084/auth/jwks

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -515,19 +515,329 @@ jobs:
           kill $(cat /tmp/backend.pid 2>/dev/null) 2>/dev/null || true
           kill $(cat /tmp/mock-tubafrenzy.pid 2>/dev/null) 2>/dev/null || true
 
+  # e2e/tests/flowsheet/go-live-takeover.spec.ts in its own job, on its own
+  # Backend-Service, running the dedicated `chromium-takeover` Playwright
+  # project (see e2e/playwright.config.ts) with --workers=1.
+  #
+  # Three things the sharded matrix above cannot give this spec:
+  #   1. FLOWSHEET_TAKEOVER_ENABLED=true. Off, `POST /flowsheet/join` ignores
+  #      `intent` and co-hosts every collision — the pre-#2233 behavior this
+  #      spec exists to pin against regressing. The matrix's Backend runs
+  #      with the flag unset (default false) on purpose: those specs rely on
+  #      the OLD silent co-host to coexist with sibling workers sharing one
+  #      Backend (see flowsheet.page.ts's answerHandoffPromptIfShown).
+  #   2. A Backend-Service nobody else's tests touch. This spec is the only
+  #      one in the suite allowed to click "End Existing Show" — on the
+  #      shared matrix Backend, two workers within a shard share one process,
+  #      and a takeover would end a sibling worker's show mid-test.
+  #   3. `workers=1`. `mode: "serial"` inside the spec only serializes within
+  #      its own describe block; `fullyParallel: true` plus more than one
+  #      worker would still let Playwright schedule this file's tests
+  #      alongside a second run of itself (e.g. a retry) or interleave with
+  #      whatever else the project matches.
+  e2e-takeover:
+    name: E2E Tests (go-live takeover)
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request'
+      || (needs.changes.outputs.app_source == 'true' && github.base_ref == 'main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:18.0-alpine
+        env:
+          POSTGRES_PASSWORD: 'RadioIsEpic$1100'
+          POSTGRES_USER: wxyc_admin
+          POSTGRES_DB: wxyc_db
+        ports:
+          - 5434:5432
+        options: >-
+          --health-cmd "pg_isready -U wxyc_admin -d wxyc_db"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout dj-site
+        uses: actions/checkout@v7
+        with:
+          path: dj-site
+
+      # Same paired-branch convention as the sharded job above: a
+      # same-named Backend-Service branch is used when one exists, so a
+      # cross-repo change can be tested as a unit. FLOWSHEET_TAKEOVER_ENABLED
+      # itself needs no pairing — the gate it guards shipped to Backend
+      # `main` ahead of this spec — but the resolver is shared so this job
+      # doesn't silently drift onto a different Backend ref than its sibling.
+      - name: Resolve Backend-Service ref
+        id: backend-ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_BACKEND_REF: ${{ github.event.inputs.backend_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          resolve() {
+            gh api "repos/${OWNER}/Backend-Service/git/ref/heads/$1" >/dev/null 2>&1 && return 0
+            gh api "repos/${OWNER}/Backend-Service/commits/$1" >/dev/null 2>&1 && return 0
+            return 1
+          }
+
+          REF="$INPUT_BACKEND_REF"
+          if [ -z "$REF" ] && [ "$EVENT_NAME" = "pull_request" ]; then
+            REF="$HEAD_REF"
+          fi
+
+          if [ -n "$REF" ] && resolve "$REF"; then
+            echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+            echo "Using Backend-Service ref: ${REF}"
+            exit 0
+          fi
+
+          if [ -n "$INPUT_BACKEND_REF" ]; then
+            echo "::error::backend_ref '${INPUT_BACKEND_REF}' is not a branch or commit in ${OWNER}/Backend-Service."
+            exit 1
+          fi
+
+          if ! resolve "$BACKEND_PINNED_REF"; then
+            echo "::error::BACKEND_PINNED_REF '${BACKEND_PINNED_REF}' is not a branch or commit in ${OWNER}/Backend-Service."
+            exit 1
+          fi
+          echo "ref=${BACKEND_PINNED_REF}" >> "$GITHUB_OUTPUT"
+          echo "Using Backend-Service ref: ${BACKEND_PINNED_REF} (default)"
+
+      - name: Checkout Backend-Service
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.repository_owner }}/Backend-Service
+          ref: ${{ steps.backend-ref.outputs.ref }}
+          path: Backend-Service
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: |
+            dj-site/package-lock.json
+            Backend-Service/package-lock.json
+
+      - name: Create Backend .env file
+        working-directory: Backend-Service
+        run: |
+          cat > .env << 'EOF'
+          DB_HOST=localhost
+          DB_PORT=5434
+          DB_NAME=wxyc_db
+          DB_USERNAME=wxyc_admin
+          DB_PASSWORD='RadioIsEpic$1100'
+          BETTER_AUTH_SECRET=e2e-auth-secret-for-testing-min-32-chars
+          BETTER_AUTH_URL=http://localhost:8084/auth
+          BETTER_AUTH_JWKS_URL=http://localhost:8084/auth/jwks
+          BETTER_AUTH_TRUSTED_ORIGINS=http://localhost:3000,http://localhost:3001
+          FRONTEND_SOURCE=http://localhost:3000
+          DEFAULT_ORG_SLUG=test-org
+          DEFAULT_ORG_NAME='Test Organization'
+          APP_ORGANIZATION_ID=test-org-id-0000000000000000001
+          E2E_DB_PORT=5434
+          E2E_AUTH_PORT=8084
+          E2E_BACKEND_PORT=8085
+          COOKIE_SAME_SITE=lax
+          NODE_ENV=test
+          EMAIL_ENABLED=false
+          TUBAFRENZY_URL=http://localhost:9091
+          MIRROR_API_KEY=e2e-mirror-noop-key
+          CDC_SECRET=e2e-cdc-secret-not-used-by-tests
+          ETL_NOTIFY_KEY=e2e-etl-notify-key
+          # The one line this job exists to set. Must land in THIS heredoc —
+          # the Backend-Service process reads its config from .env, not from
+          # this workflow's top-level `env:` block, which never reaches a
+          # child process spawned by `node apps/backend/dist/app.js`. Without
+          # it the join route silently ignores `intent` and co-hosts every
+          # collision: the client's handoff prompt (go-live-takeover.spec.ts
+          # beat 2) would still render — its pre-check is flag-independent —
+          # but beats 3-5 would exercise no server routing at all, and the
+          # spec would pass while testing nothing.
+          FLOWSHEET_TAKEOVER_ENABLED=true
+          EOF
+
+      - name: Start mock tubafrenzy mirror
+        working-directory: dj-site
+        run: |
+          node e2e/scripts/mock-tubafrenzy.mjs > /tmp/mock-tubafrenzy.log 2>&1 &
+          echo $! > /tmp/mock-tubafrenzy.pid
+          timeout 5 bash -c 'until curl -sf -X POST -H "Content-Type: application/json" --data "{}" http://localhost:9091/ >/dev/null; do sleep 0.1; done'
+          echo "Mock tubafrenzy ready"
+
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          set -euo pipefail
+          version=$(jq -re '.packages["node_modules/@playwright/test"].version' dj-site/package-lock.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Resolved @playwright/test $version"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install dependencies
+        env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          (cd Backend-Service && npm ci) &
+          PID_BS=$!
+          (cd dj-site && npm ci) &
+          PID_DJ=$!
+          wait $PID_BS || exit 1
+          wait $PID_DJ || exit 1
+
+      - name: Cache dj-site build
+        id: nextjs-build-cache
+        uses: actions/cache@v6
+        with:
+          path: dj-site/.next
+          # Own key, distinct from the sharded job's cache: both jobs build
+          # from identical inputs (same workflow-level env, same source), so
+          # the ONLY reason not to share the sharded job's key is that two
+          # jobs in the same workflow run would race a write to it. A
+          # redundant build costs about a minute; a torn cache entry is a
+          # worse trade.
+          key: e2e-takeover-nextjs-${{ hashFiles('dj-site/package-lock.json') }}-${{ hashFiles('dj-site/next.config.*') }}-${{ hashFiles('dj-site/.github/workflows/e2e-tests.yml') }}-${{ hashFiles('dj-site/app/**', 'dj-site/src/**', 'dj-site/lib/**') }}
+          restore-keys: |
+            e2e-takeover-nextjs-${{ hashFiles('dj-site/package-lock.json') }}-${{ hashFiles('dj-site/next.config.*') }}-${{ hashFiles('dj-site/.github/workflows/e2e-tests.yml') }}-
+            e2e-takeover-nextjs-${{ hashFiles('dj-site/package-lock.json') }}-${{ hashFiles('dj-site/next.config.*') }}-
+            e2e-takeover-nextjs-${{ hashFiles('dj-site/package-lock.json') }}-
+
+      - name: Build and start services
+        env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXTJS_BUILD_CACHE_HIT: ${{ steps.nextjs-build-cache.outputs.cache-hit }}
+          PLAYWRIGHT_CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
+        run: |
+          (
+            cd Backend-Service
+            set -a; source .env; set +a
+
+            npm run build
+            node dev_env/init-db.mjs
+
+            AUTH_PORT=8084 node apps/auth/dist/app.js > /tmp/auth.log 2>&1 &
+            echo $! > /tmp/auth.pid
+            echo "Waiting for auth service..."
+            timeout 60 bash -c 'until curl -sf http://localhost:8084/healthcheck; do sleep 1; done'
+
+            PORT=8085 \
+            BETTER_AUTH_ISSUER=http://localhost:8084 \
+            BETTER_AUTH_AUDIENCE=http://localhost:8084 \
+            node apps/backend/dist/app.js > /tmp/backend.log 2>&1 &
+            echo $! > /tmp/backend.pid
+            echo "Waiting for backend service..."
+            timeout 60 bash -c 'until curl -sf http://localhost:8085/healthcheck; do sleep 1; done'
+
+            npm run setup:e2e-users
+          ) &
+          PID_BACKEND=$!
+
+          if [ "$PLAYWRIGHT_CACHE_HIT" = "true" ]; then
+            echo "Playwright browser cache hit — skipping install"
+          else
+            (cd dj-site && npx playwright install --with-deps chromium) &
+            PID_PW=$!
+          fi
+
+          # No broken-auth second build here — that build exists solely for
+          # e2e/tests/auth/server-session-via-docker.spec.ts, which this
+          # job's `chromium-takeover` project doesn't match.
+          if [ "$NEXTJS_BUILD_CACHE_HIT" = "true" ]; then
+            echo "dj-site build cache hit — skipping build"
+          else
+            (cd dj-site && npm run build) &
+            PID_BUILD=$!
+          fi
+
+          wait $PID_BACKEND || exit 1
+          if [ -n "$PID_PW" ]; then wait $PID_PW || exit 1; fi
+          if [ -n "$PID_BUILD" ]; then wait $PID_BUILD || exit 1; fi
+
+      - name: Start dj-site
+        working-directory: dj-site
+        run: |
+          npm run start > /tmp/frontend.log 2>&1 &
+          echo $! > /tmp/frontend.pid
+          echo "Waiting for frontend..."
+          timeout 60 bash -c 'until curl -sf http://localhost:3000; do sleep 2; done'
+
+      - name: Run go-live takeover E2E spec
+        working-directory: dj-site
+        run: |
+          npm run test:e2e -- \
+            "--project=chromium-takeover" \
+            "--workers=1" \
+            "--reporter=html" \
+            "--reporter=github"
+
+      - name: Show service logs on failure
+        if: failure()
+        run: |
+          echo "=== Auth Service Logs ==="
+          cat /tmp/auth.log 2>/dev/null || echo "No auth log"
+          echo ""
+          echo "=== Backend Service Logs ==="
+          cat /tmp/backend.log 2>/dev/null || echo "No backend log"
+          echo ""
+          echo "=== Frontend Logs ==="
+          cat /tmp/frontend.log 2>/dev/null || echo "No frontend log"
+          echo ""
+          echo "=== Mock Tubafrenzy Logs ==="
+          cat /tmp/mock-tubafrenzy.log 2>/dev/null || echo "No mock-tubafrenzy log"
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report-takeover
+          path: dj-site/playwright-report/
+          retention-days: 30
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: test-results-takeover
+          path: dj-site/test-results/
+          retention-days: 7
+
+      - name: Cleanup
+        if: always()
+        run: |
+          kill $(cat /tmp/frontend.pid 2>/dev/null) 2>/dev/null || true
+          kill $(cat /tmp/auth.pid 2>/dev/null) 2>/dev/null || true
+          kill $(cat /tmp/backend.pid 2>/dev/null) 2>/dev/null || true
+          kill $(cat /tmp/mock-tubafrenzy.pid 2>/dev/null) 2>/dev/null || true
+
   # Single stable check for branch protection. With the matrix above, individual
   # shard jobs are named "E2E Tests (shard N/M)" — that name shifts if we ever
   # change the shard count. This aggregator stays "E2E Tests" so the required-
   # status-check rule doesn't need touching.
   #
-  # `skipped` is treated as success because the e2e matrix is gated by the
-  # `changes` job's path filter (issue #731). On a PR that doesn't touch app
-  # source, the matrix skips and we should pass — not fail — so workflow-only
-  # PRs can satisfy the required check.
+  # `skipped` is treated as success because both e2e and e2e-takeover are
+  # gated by the `changes` job's path filter (issue #731). On a PR that
+  # doesn't touch app source, both skip and we should pass — not fail — so
+  # workflow-only PRs can satisfy the required check.
   #
   # That skipped->success mapping is also why a non-`main` base has to be
   # FAILED here rather than skipped, and why this job stays ungated so it can
-  # do the failing. The matrix skips on a stacked PR to avoid booting four
+  # do the failing. Both jobs skip on a stacked PR to avoid booting five
   # backends for a base that isn't shipping — but if this aggregator skipped
   # too, "E2E Tests" would sit satisfied on a PR that ran zero shards, and
   # GitHub's automatic retarget onto `main` when the parent merges would hand
@@ -535,14 +845,15 @@ jobs:
   # blocked until the suite actually runs against `main`.
   e2e-all:
     name: E2E Tests
-    needs: e2e
+    needs: [e2e, e2e-takeover]
     if: always()
     runs-on: ubuntu-latest
     env:
       BASE_REF: ${{ github.base_ref }}
       MATRIX_RESULT: ${{ needs.e2e.result }}
+      TAKEOVER_RESULT: ${{ needs.e2e-takeover.result }}
     steps:
-      - name: Verify all shards passed
+      - name: Verify all shards and the takeover job passed
         run: |
           # `github.base_ref` is empty on `push`; the event-name check is what
           # keeps a push to `main` from failing on "" != "main".
@@ -557,6 +868,16 @@ jobs:
               ;;
             *)
               echo "One or more E2E shards failed: ${MATRIX_RESULT}"
+              exit 1
+              ;;
+          esac
+
+          case "$TAKEOVER_RESULT" in
+            success|skipped)
+              echo "E2E takeover job result: ${TAKEOVER_RESULT}"
+              ;;
+            *)
+              echo "The go-live takeover E2E job failed: ${TAKEOVER_RESULT}"
               exit 1
               ;;
           esac

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -70,7 +70,20 @@ npx playwright test -g "login"
 
 # Run only the protected fast subset (results cap, track picker, crash smoke)
 npm run test:e2e -- --grep @smoke
+
+# Run the go-live takeover spec (see "Go-live takeover" below)
+E2E_TAKEOVER_PROJECT=1 npm run test:e2e -- --project=chromium-takeover --workers=1
 ```
+
+### Go-live takeover
+
+`tests/flowsheet/go-live-takeover.spec.ts` is the only spec that clicks "End Existing Show", so it must never run against a Backend-Service another test shares — a takeover closes whatever show is open, including a sibling worker's. Three things keep that from happening, each covering a case the others don't:
+
+- `testIgnore` on the `chromium` project keeps the file out of the ordinary suite.
+- The `chromium-takeover` and `setup-takeover` projects exist only when `E2E_TAKEOVER_PROJECT=1`, so no unscoped run (`npm run test:e2e`, `scripts/e2e-local.sh`, a bare `npx playwright test`) can schedule them.
+- In CI the spec gets its own workflow job, `E2E Tests (go-live takeover)`, with its own Postgres, auth service, Backend-Service, and mock tubafrenzy, at `--workers=1`. That job's Backend is also the only one running with `FLOWSHEET_TAKEOVER_ENABLED=true`.
+
+Running it locally therefore points at whatever stack you already have up; expect it to end any show open there.
 
 ## Test Users
 
@@ -87,8 +100,10 @@ Seeded test users all use the password: `testpassword123`. `test_classic_md` and
 | `test_deletable_user` | dj | User for deletion tests |
 | `test_promotable_user` | member | User for role promotion tests |
 | `test_demotable_sm` | stationManager | User for role demotion tests |
-| `test_classic_md` | musicDirector | Not seeded — created by `auth.setup.ts`'s `provisionClassicIdentity` factory via the admin roster. Its account `appSkin` is switched to classic once at setup time, so classic-experience specs on authenticated dashboard URLs (`e2e/tests/rbac/role-access.spec.ts`) have a dedicated identity instead of racing a shared seeded user's preference. Password is `TestClassicMd1`, not the shared `testpassword123` — it's set through the onboarding form, which requires `isStrongPassword` |
+| `test_classic_md` | musicDirector | Not seeded — created by `auth.setup.ts`'s `provisionIdentity` factory via the admin roster. Its account `appSkin` is switched to classic once at setup time, so classic-experience specs on authenticated dashboard URLs (`e2e/tests/rbac/role-access.spec.ts`) have a dedicated identity instead of racing a shared seeded user's preference. Password is `TestClassicMd1`, not the shared `testpassword123` — it's set through the onboarding form, which requires `isStrongPassword` |
 | `test_classic_dj` | dj | Not seeded — the DJ-authority counterpart to `test_classic_md`, provisioned by the same factory. Exists so classic-librarian specs can assert the DJ-readable / MD-gated authority split without racing a shared seeded user's preference. Password is `TestClassicDj1` |
+| `test_takeover_a` | dj | Not seeded — provisioned by the same factory, left at the modern default. Used only by `tests/flowsheet/go-live-takeover.spec.ts`, which is the only spec allowed to click "End Existing Show" and so needs a pair no other spec shares. Password is `TestTakeoverA1` |
+| `test_takeover_b` | dj | Not seeded — the second half of that pair, so two sessions can be on air at once. Password is `TestTakeoverB1` |
 
 ## Test Structure
 

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,6 +1,8 @@
 import { test as setup, expect, request, Browser } from "@playwright/test";
 import {
   TEST_USERS,
+  TAKEOVER_DJ_A as TAKEOVER_DJ_A_DATA,
+  TAKEOVER_DJ_B as TAKEOVER_DJ_B_DATA,
   getAuthServiceBaseUrl,
   completeOnboardingWithInviteToken,
 } from "./fixtures/auth.fixture";
@@ -184,7 +186,16 @@ setup("authenticate as station manager", async ({ page }) => {
   );
 });
 
-interface ClassicIdentity {
+/**
+ * Shape shared by every dedicated identity this file provisions itself
+ * (through the live admin roster + real onboarding flow) rather than reusing
+ * a row seeded by Backend-Service's dev_env/setup-e2e-test-users.ts. Named
+ * for the first consumers (the classic-preference pair below), but generic —
+ * {@link provisionIdentity} takes a target experience as its own argument, so
+ * a modern-preference identity (see the go-live takeover pair further down)
+ * uses the exact same shape and machinery.
+ */
+interface ProvisionedIdentity {
   username: string;
   password: string;
   email: string;
@@ -203,14 +214,14 @@ interface ClassicIdentity {
  * the admin specs exercise, and its appSkin is set through the app's own
  * experience-switch flow rather than a raw API call, so the fixture never
  * predicts an internal endpoint shape it doesn't own. Both are provisioned by
- * {@link provisionClassicIdentity}.
+ * {@link provisionIdentity}.
  *
  * The classic-librarian screens are authority-split (rotation list is
  * DJ-readable, rotation insert and catalog admin are MD-gated), so specs that
  * assert that split need identities at both authorities — hence two entries
  * rather than one.
  */
-const CLASSIC_MD_USER: ClassicIdentity = {
+const CLASSIC_MD_USER: ProvisionedIdentity = {
   username: "test_classic_md",
   // Set through the onboarding form (unlike TEST_USERS, which are seeded
   // directly into the database), so it must satisfy isStrongPassword —
@@ -224,7 +235,7 @@ const CLASSIC_MD_USER: ClassicIdentity = {
   statePath: `${authDir}/classicMd.json`,
 };
 
-const CLASSIC_DJ_USER: ClassicIdentity = {
+const CLASSIC_DJ_USER: ProvisionedIdentity = {
   username: "test_classic_dj",
   password: "TestClassicDj1",
   email: "test_classic_dj@wxyc.org",
@@ -232,6 +243,33 @@ const CLASSIC_DJ_USER: ClassicIdentity = {
   djName: "Test Classic DJ",
   role: "dj",
   statePath: `${authDir}/classicDj.json`,
+};
+
+/**
+ * Dedicated pair for the go-live takeover spec
+ * (e2e/tests/flowsheet/go-live-takeover.spec.ts). That spec is the one place
+ * in the suite allowed to click "End Existing Show" — it owns a private
+ * Backend-Service in its own workflow job, so nothing else shares state with
+ * it — and it needs two sessions on air at once. Borrowing from the shared
+ * pool (musicDirector.json 13 specs, dj.json 5, dj2.json 10, …) would inherit
+ * whichever off-air assumption the session's other consumers depend on; a
+ * takeover run against one of those on a shared CI backend would end a
+ * sibling spec's show mid-run. Provisioned the same way as the
+ * classic-preference pair above (live admin roster + real onboarding), left
+ * at the modern default since the takeover spec never touches classic.
+ *
+ * The identity DATA (username, djName, …) lives in auth.fixture.ts, not
+ * here, so the spec can import it directly without importing this file's
+ * top-level `setup()` registrations.
+ */
+const TAKEOVER_DJ_A: ProvisionedIdentity = {
+  ...TAKEOVER_DJ_A_DATA,
+  statePath: `${authDir}/${TAKEOVER_DJ_A_DATA.stateFile}`,
+};
+
+const TAKEOVER_DJ_B: ProvisionedIdentity = {
+  ...TAKEOVER_DJ_B_DATA,
+  statePath: `${authDir}/${TAKEOVER_DJ_B_DATA.stateFile}`,
 };
 
 const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
@@ -262,19 +300,19 @@ function isLoopbackHostname(hostname: string): boolean {
 }
 
 /**
- * Gates every write a "provision classic-preference identity" step can make
- * against whatever `E2E_BASE_URL` (and `NEXT_PUBLIC_BETTER_AUTH_URL`) point
- * at: `ensureClassicIdentityAccountExists` creates an account through the
- * live admin roster, and `setExperienceViaAccount` flips that account's
- * `appSkin` through the live switch flow. Every other setup step only logs
- * in. Called at the top of that step's body — not just inside
- * `ensureClassicIdentityAccountExists` — because a successful login skips
+ * Gates every write a "provision <identity>" step can make against whatever
+ * `E2E_BASE_URL` (and `NEXT_PUBLIC_BETTER_AUTH_URL`) point at:
+ * `ensureRosterAccountExists` creates an account through the live admin
+ * roster, and (for the classic-preference pair) `setExperienceViaAccount`
+ * flips that account's `appSkin` through the live switch flow. Every other
+ * setup step only logs in. Called at the top of that step's body — not just
+ * inside `ensureRosterAccountExists` — because a successful login skips
  * account creation entirely and would otherwise reach the appSkin write
  * unguarded. Without this, a mistyped or inherited env var pointed at a
  * shared environment has no structural guard between it and a real account
  * there.
  */
-function assertLocalWriteTarget(identity: ClassicIdentity): void {
+function assertLocalWriteTarget(identity: ProvisionedIdentity): void {
   const targets: Array<[envVar: string, value: string | undefined]> = [
     ["E2E_BASE_URL", process.env.E2E_BASE_URL || "http://localhost:3000"],
     ["NEXT_PUBLIC_BETTER_AUTH_URL", process.env.NEXT_PUBLIC_BETTER_AUTH_URL],
@@ -306,9 +344,9 @@ function assertLocalWriteTarget(identity: ClassicIdentity): void {
  * runs. Filtering through the roster's search input, which matches every
  * account the admin fetched, is unambiguous regardless of roster size.
  */
-async function classicIdentityAccountExists(
+async function rosterAccountExists(
   rosterPage: RosterPage,
-  identity: ClassicIdentity
+  identity: ProvisionedIdentity
 ): Promise<boolean> {
   await rosterPage.searchInput.fill(identity.realName);
   return await rosterPage
@@ -324,9 +362,9 @@ async function classicIdentityAccountExists(
  * so a prior run's account must be reconciled with, not recreated (which
  * would surface as a duplicate-username error toast).
  */
-async function ensureClassicIdentityAccountExists(
+async function ensureRosterAccountExists(
   browser: Browser,
-  identity: ClassicIdentity
+  identity: ProvisionedIdentity
 ): Promise<void> {
   assertLocalWriteTarget(identity);
 
@@ -348,7 +386,7 @@ async function ensureClassicIdentityAccountExists(
     await adminPage.goto("/dashboard/admin/roster");
     await rosterPage.waitForTableLoaded();
 
-    if (await classicIdentityAccountExists(rosterPage, identity)) {
+    if (await rosterAccountExists(rosterPage, identity)) {
       console.log(`[auth] ${identity.username} already provisioned, skipping creation`);
       return;
     }
@@ -363,7 +401,7 @@ async function ensureClassicIdentityAccountExists(
     });
     // The row, not the toast: sonner auto-dismisses on its own timer, so a
     // slow local stack can outlast it between submit and this check. The row
-    // appearing is the same reconciliation signal `classicIdentityAccountExists`
+    // appearing is the same reconciliation signal `rosterAccountExists`
     // reads above (the search filter is still applied from that check).
     await rosterPage.expectUserInRoster(identity.username);
   } finally {
@@ -372,25 +410,32 @@ async function ensureClassicIdentityAccountExists(
 }
 
 /**
- * Provisions a classic-preference identity: reconciles its roster account
- * (creating it only if absent), completes onboarding on first run, and
- * switches its appSkin to classic through the live switch flow. Shared by
- * every "provision classic-preference identity" setup test below, so a
- * second identity at a different authority costs a declaration plus one
- * `setup()` call, not a copy of this whole body.
+ * Provisions a dedicated identity this file owns end to end: reconciles its
+ * roster account (creating it only if absent), completes onboarding on first
+ * run, and — only when `switchToClassic` is true — switches its appSkin to
+ * classic through the live switch flow. Left `false` this leaves the account
+ * at its fresh-onboarding default, which `NEXT_PUBLIC_DEFAULT_EXPERIENCE`
+ * resolves to modern in every environment this suite runs against; that is
+ * what the go-live takeover pair wants, and matches the plain seeded
+ * TEST_USERS (dj1, dj2, …), none of which switch either.
+ *
+ * Shared by every "provision <identity>" setup test below, so a second
+ * identity at a different authority (or a different target experience) costs
+ * a declaration plus one `setup()` call, not a copy of this whole body.
  */
-async function provisionClassicIdentity(
+async function provisionIdentity(
   page: import("@playwright/test").Page,
   browser: Browser,
-  identity: ClassicIdentity
+  identity: ProvisionedIdentity,
+  switchToClassic: boolean
 ): Promise<void> {
   // Gates every write below (account creation AND the appSkin switch), not
   // just the account-creation branch — see assertLocalWriteTarget's doc.
   assertLocalWriteTarget(identity);
 
   // First-run path chains an admin roster creation, an invite-token
-  // onboarding, and a full-page experience-switch reload — comfortably past
-  // the file's 20s default on a cold local stack.
+  // onboarding, and (for the classic pair) a full-page experience-switch
+  // reload — comfortably past the file's 20s default on a cold local stack.
   setup.setTimeout(60_000);
 
   const statePath = identity.statePath;
@@ -410,30 +455,35 @@ async function provisionClassicIdentity(
 
   if (!loggedIn) {
     console.log(`[auth] logging in ${identity.username} failed, provisioning account`);
-    await ensureClassicIdentityAccountExists(browser, identity);
-    await completeOnboardingWithInviteToken(page, identity.email, identity.password);
+    await ensureRosterAccountExists(browser, identity);
+    await completeOnboardingWithInviteToken(page, identity.email, identity.password, {
+      realName: identity.realName,
+      djName: identity.djName,
+    });
   }
 
-  // /dashboard/help is classic-only, so the modern slot (the account's
-  // fresh default) renders ExperienceGap there and offers the real switch
-  // flow this identity exists to have already taken.
-  await setExperienceViaAccount(page, "classic", "/dashboard/help");
+  if (switchToClassic) {
+    // /dashboard/help is classic-only, so the modern slot (the account's
+    // fresh default) renders ExperienceGap there and offers the real switch
+    // flow this identity exists to have already taken.
+    await setExperienceViaAccount(page, "classic", "/dashboard/help");
 
-  // The switch flow also sets the app_state cookie to classic (see
-  // useExperienceSwitch) AND the wxyc_app_skin localStorage key (see
-  // writeLocalAppSkin), so by this point the cookie, localStorage, and the
-  // account field all agree and any one alone would render the classic slot.
-  // useThemePreferenceSync (mounted unconditionally in the root layout) falls
-  // back to localStorage whenever the cookie is absent, re-persisting the
-  // cookie and reloading — so dropping only the cookie leaves localStorage as
-  // a live second lever that reproduces the classic render without the
-  // account's appSkin ever being consulted. Strip both from what gets
-  // persisted so the specs that assert against this identity are
-  // demonstrably exercising the account's appSkin field alone — if appSkin
-  // ever became nullable, a persisted cookie or localStorage entry would
-  // silently keep those specs passing for the wrong reason.
-  await page.context().clearCookies({ name: "app_state" });
-  await page.evaluate((key) => localStorage.removeItem(key), APP_SKIN_STORAGE_KEY);
+    // The switch flow also sets the app_state cookie to classic (see
+    // useExperienceSwitch) AND the wxyc_app_skin localStorage key (see
+    // writeLocalAppSkin), so by this point the cookie, localStorage, and the
+    // account field all agree and any one alone would render the classic slot.
+    // useThemePreferenceSync (mounted unconditionally in the root layout) falls
+    // back to localStorage whenever the cookie is absent, re-persisting the
+    // cookie and reloading — so dropping only the cookie leaves localStorage as
+    // a live second lever that reproduces the classic render without the
+    // account's appSkin ever being consulted. Strip both from what gets
+    // persisted so the specs that assert against this identity are
+    // demonstrably exercising the account's appSkin field alone — if appSkin
+    // ever became nullable, a persisted cookie or localStorage entry would
+    // silently keep those specs passing for the wrong reason.
+    await page.context().clearCookies({ name: "app_state" });
+    await page.evaluate((key) => localStorage.removeItem(key), APP_SKIN_STORAGE_KEY);
+  }
   await page.context().storageState({ path: statePath });
   fs.writeFileSync(seedSidecarPath(statePath), seedKey());
 }
@@ -443,17 +493,29 @@ async function provisionClassicIdentity(
  * Used by classic-experience specs on authenticated dashboard URLs.
  */
 setup("provision classic-preference identity (music director)", async ({ page, browser }) => {
-  await provisionClassicIdentity(page, browser, CLASSIC_MD_USER);
+  await provisionIdentity(page, browser, CLASSIC_MD_USER, true);
 });
 
 /**
  * Setup authentication state for the classic-preference DJ identity. Exists
  * so classic-experience specs can assert the DJ-vs-MD authority split on the
  * upcoming classic librarian screens without racing a shared seeded user's
- * appSkin (see provisionClassicIdentity's doc).
+ * appSkin (see provisionIdentity's doc).
  */
 setup("provision classic-preference identity (dj)", async ({ page, browser }) => {
-  await provisionClassicIdentity(page, browser, CLASSIC_DJ_USER);
+  await provisionIdentity(page, browser, CLASSIC_DJ_USER, true);
+});
+
+/**
+ * Setup authentication state for the go-live takeover spec's dedicated pair.
+ * Left at the modern default — see TAKEOVER_DJ_A/B's doc.
+ */
+setup("provision go-live takeover identity (dj A)", async ({ page, browser }) => {
+  await provisionIdentity(page, browser, TAKEOVER_DJ_A, false);
+});
+
+setup("provision go-live takeover identity (dj B)", async ({ page, browser }) => {
+  await provisionIdentity(page, browser, TAKEOVER_DJ_B, false);
 });
 
 /**

--- a/e2e/fixtures/auth.fixture.ts
+++ b/e2e/fixtures/auth.fixture.ts
@@ -6,6 +6,38 @@ export const TEST_USERS = MOCK_USERS;
 export type TestUserKey = MockUserKey;
 export type TestUser = MockUser;
 
+/**
+ * Identity data for the go-live takeover spec's dedicated pair
+ * (e2e/tests/flowsheet/go-live-takeover.spec.ts). Data only — declared here
+ * rather than in auth.setup.ts (which owns provisioning) so the spec can
+ * import the username/djName/statePath fields it needs without importing a
+ * file whose top-level module code registers Playwright `setup()` tests.
+ *
+ * Not in MOCK_USERS / dev_env/setup-e2e-test-users.ts: that spec is the only
+ * one in the suite allowed to click "End Existing Show", so it needs a pair
+ * nothing else touches, provisioned via the live admin roster the same way
+ * as the classic-preference identities in auth.setup.ts.
+ */
+export const TAKEOVER_DJ_A = {
+  username: "test_takeover_a",
+  password: "TestTakeoverA1",
+  email: "test_takeover_a@wxyc.org",
+  realName: "Test Takeover A",
+  djName: "Test Takeover A",
+  role: "dj" as const,
+  stateFile: "takeoverDjA.json",
+};
+
+export const TAKEOVER_DJ_B = {
+  username: "test_takeover_b",
+  password: "TestTakeoverB1",
+  email: "test_takeover_b@wxyc.org",
+  realName: "Test Takeover B",
+  djName: "Test Takeover B",
+  role: "dj" as const,
+  stateFile: "takeoverDjB.json",
+};
+
 export async function login(
   page: Page,
   user: TestUser | { username: string; password: string }
@@ -175,7 +207,17 @@ export async function getVerificationToken(identifier: string): Promise<{ token:
 export async function completeOnboardingWithInviteToken(
   page: Page,
   email: string,
-  password: string
+  password: string,
+  // The roster's own createAccount({ realName, djName }) only seeds a
+  // suggestion the onboarding form pre-fills; it is NOT the account's final
+  // value. Onboarding always makes the final choice, so a caller whose
+  // identity's realName/djName is load-bearing (an assertion reads it, or —
+  // as here — two identities must be distinguishable by it) must pass its
+  // own values rather than trust the filler fallback below. An explicit
+  // override always wins over whatever the form pre-filled, since a caller
+  // that named a value did so because it needs exactly that value, not "any
+  // non-empty one".
+  overrides?: { realName?: string; djName?: string }
 ): Promise<void> {
   const tokenData = await getVerificationToken(email);
   if (!tokenData?.token) {
@@ -189,7 +231,9 @@ export async function completeOnboardingWithInviteToken(
   const realNameInput = page.locator('input[name="realName"]');
   if (await realNameInput.isVisible()) {
     const existingRealName = await realNameInput.inputValue();
-    if (!existingRealName.trim()) {
+    if (overrides?.realName !== undefined) {
+      await realNameInput.fill(overrides.realName);
+    } else if (!existingRealName.trim()) {
       await realNameInput.fill("E2E Test User");
     }
   }
@@ -197,7 +241,9 @@ export async function completeOnboardingWithInviteToken(
   const djNameInput = page.locator('input[name="djName"]');
   if (await djNameInput.isVisible()) {
     const existingDjName = await djNameInput.inputValue();
-    if (!existingDjName.trim()) {
+    if (overrides?.djName !== undefined) {
+      await djNameInput.fill(overrides.djName);
+    } else if (!existingDjName.trim()) {
       await djNameInput.fill("E2E DJ");
     }
   }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -71,6 +71,29 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
       dependencies: ["setup"],
       testMatch: /tests\/.+\.spec\.ts/,
+      // go-live-takeover.spec.ts runs in its own workflow job against its
+      // own Backend-Service (see chromium-takeover below and that job in
+      // .github/workflows/e2e-tests.yml) — it must never also run here.
+      // `mode: "serial"` inside that spec only serializes within its own
+      // describe block; this config's `fullyParallel: true` plus 2 CI
+      // workers would still schedule it alongside every other file in this
+      // project, and within a shard two workers share one Backend-Service.
+      // A takeover from that shared Backend would end a sibling worker's
+      // show mid-test.
+      testIgnore: /tests\/flowsheet\/go-live-takeover\.spec\.ts/,
+    },
+
+    /* go-live-takeover.spec.ts only. A dedicated project alone would not be
+     * enough isolation — `workers` is a TestConfig-level option, not a
+     * TestProject one, so project-level `fullyParallel: false` would still
+     * let Playwright schedule this project's tests across this run's worker
+     * pool. Its own workflow job invokes this project with `--workers=1` on
+     * the CLI, which is what actually gives it a Backend-Service to itself. */
+    {
+      name: "chromium-takeover",
+      use: { ...devices["Desktop Chrome"] },
+      dependencies: ["setup"],
+      testMatch: /tests\/flowsheet\/go-live-takeover\.spec\.ts/,
     },
   ],
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -4,6 +4,27 @@ import path from "path";
 const authDir = path.join(__dirname, ".auth");
 
 /**
+ * Publishes the go-live takeover projects. Off by default, and set only by the
+ * dedicated `e2e-takeover` workflow job.
+ *
+ * `testIgnore` on `chromium` keeps the takeover spec out of that project, but a
+ * project is still a schedulable unit in its own right: every unscoped
+ * invocation runs *all* projects, and neither the sharded job
+ * (`npm run test:e2e -- --shard=N/4`) nor `scripts/e2e-local.sh` passes
+ * `--project`. Without this gate the spec lands in a shard — on a
+ * Backend-Service without FLOWSHEET_TAKEOVER_ENABLED, shared with a sibling
+ * worker whose show its "End Existing Show" click is free to close.
+ *
+ * A gate rather than a `--project` flag at each call site because the property
+ * that has to hold is "nothing schedules this by accident", and every new
+ * invocation site would otherwise have to remember.
+ */
+const takeoverProjectsEnabled = process.env.E2E_TAKEOVER_PROJECT === "1";
+
+/** Titles of the setup steps that provision the takeover spec's identity pair. */
+const takeoverSetupTitle = /go-live takeover identity/;
+
+/**
  * E2E Test Configuration for dj-site
  *
  * Uses authenticated storage state to speed up tests:
@@ -63,6 +84,12 @@ export default defineConfig({
       name: "setup",
       testMatch: /auth\.setup\.ts/,
       fullyParallel: false,
+      // The takeover pair's provisioning is a live admin-roster creation plus a
+      // full onboarding flow, and this project is a dependency of `chromium`,
+      // so leaving those two steps here makes all four shards pay for — and be
+      // able to fail on — identities no test in `chromium` uses. They move to
+      // `setup-takeover` below, which only exists when the takeover job asks.
+      grepInvert: takeoverSetupTitle,
     },
 
     /* Main test project - uses storageState where configured in test files */
@@ -83,18 +110,29 @@ export default defineConfig({
       testIgnore: /tests\/flowsheet\/go-live-takeover\.spec\.ts/,
     },
 
-    /* go-live-takeover.spec.ts only. A dedicated project alone would not be
-     * enough isolation — `workers` is a TestConfig-level option, not a
-     * TestProject one, so project-level `fullyParallel: false` would still
-     * let Playwright schedule this project's tests across this run's worker
-     * pool. Its own workflow job invokes this project with `--workers=1` on
-     * the CLI, which is what actually gives it a Backend-Service to itself. */
-    {
-      name: "chromium-takeover",
-      use: { ...devices["Desktop Chrome"] },
-      dependencies: ["setup"],
-      testMatch: /tests\/flowsheet\/go-live-takeover\.spec\.ts/,
-    },
+    /* go-live-takeover.spec.ts only, and only when E2E_TAKEOVER_PROJECT asks
+     * for it. A dedicated project alone would not be enough isolation —
+     * `workers` is a TestConfig-level option, not a TestProject one, so
+     * project-level `fullyParallel: false` would still let Playwright schedule
+     * this project's tests across this run's worker pool. Its own workflow job
+     * invokes this project with `--workers=1` on the CLI, which is what
+     * actually gives it a Backend-Service to itself. */
+    ...(takeoverProjectsEnabled
+      ? [
+          {
+            name: "setup-takeover",
+            testMatch: /auth\.setup\.ts/,
+            fullyParallel: false,
+            grep: takeoverSetupTitle,
+          },
+          {
+            name: "chromium-takeover",
+            use: { ...devices["Desktop Chrome"] },
+            dependencies: ["setup", "setup-takeover"],
+            testMatch: /tests\/flowsheet\/go-live-takeover\.spec\.ts/,
+          },
+        ]
+      : []),
   ],
 
   /* 20s per test — 15s is too tight for CI runners */

--- a/e2e/scripts/mock-tubafrenzy.mjs
+++ b/e2e/scripts/mock-tubafrenzy.mjs
@@ -26,6 +26,13 @@
  *     connection alive). EventSource stays connected, no reconnect storm.
  *   - Any other request → 200 + JSON `{id}` (the mirror's createShow and
  *     createEntry read `.id`; updateEntry and signoff don't read the body).
+ *   - GET /__requests → 200 + JSON array of every non-SSE request captured
+ *     above (bounded to the last MAX_REQUESTS), each recording method, url,
+ *     the parsed JSON body, and the `id` this mock assigned it. The go-live
+ *     takeover spec (e2e/tests/flowsheet/go-live-takeover.spec.ts) is the one
+ *     consumer: it needs to see which show the mirror actually signed off and
+ *     which it created, and the ordinary shapes above give it no way to ask.
+ *     Not itself recorded.
  *
  * See WXYC/dj-site#567. Bound to 127.0.0.1 only. Port via
  * $MOCK_TUBAFRENZY_PORT or 9091.
@@ -33,8 +40,17 @@
 import { createServer } from 'node:http';
 
 const PORT = Number(process.env.MOCK_TUBAFRENZY_PORT ?? 9091);
+const MAX_REQUESTS = 500;
 let nextId = 1;
 const sseClients = new Set();
+const requests = [];
+
+function recordRequest(entry) {
+  requests.push(entry);
+  // Ring buffer, not an unbounded log — this process outlives the whole
+  // job, and nothing ever drains the array otherwise.
+  if (requests.length > MAX_REQUESTS) requests.shift();
+}
 
 const server = createServer((req, res) => {
   // SSE endpoint — keep the connection open so playlist-proxy's EventSource
@@ -52,13 +68,32 @@ const server = createServer((req, res) => {
     return;
   }
 
-  // Everything else (mirror writes) — JSON {id} works for createShow,
-  // createEntry, updateEntry, signoff.
-  req.on('data', () => {});
-  req.on('end', () => {
+  if (req.method === 'GET' && req.url === '/__requests') {
     res.statusCode = 200;
     res.setHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify({ id: nextId++ }));
+    res.end(JSON.stringify(requests));
+    return;
+  }
+
+  // Everything else (mirror writes) — JSON {id} works for createShow,
+  // createEntry, updateEntry, signoff.
+  const chunks = [];
+  req.on('data', (chunk) => chunks.push(chunk));
+  req.on('end', () => {
+    const raw = Buffer.concat(chunks).toString('utf8');
+    let body = null;
+    if (raw) {
+      try {
+        body = JSON.parse(raw);
+      } catch {
+        body = raw;
+      }
+    }
+    const id = nextId++;
+    recordRequest({ method: req.method, url: req.url, body, id, timestamp: Date.now() });
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ id }));
   });
 });
 

--- a/e2e/tests/flowsheet/go-live-takeover.spec.ts
+++ b/e2e/tests/flowsheet/go-live-takeover.spec.ts
@@ -1,0 +1,366 @@
+import { test, expect, type BrowserContext, type Page } from "@playwright/test";
+import path from "path";
+import { FlowsheetPage } from "../../pages/flowsheet.page";
+import { TAKEOVER_DJ_A, TAKEOVER_DJ_B } from "../../fixtures/auth.fixture";
+
+const authDir = path.join(__dirname, "../../.auth");
+const MOCK_TUBAFRENZY_URL = process.env.MOCK_TUBAFRENZY_URL || "http://localhost:9091";
+
+/**
+ * Go-live takeover: two DJs, one open show, and the decision a DJ makes when
+ * they collide.
+ *
+ * This file is deliberately the only place in the suite that clicks "End
+ * Existing Show". `e2e/pages/flowsheet.page.ts`'s shared
+ * `answerHandoffPromptIfShown` always clicks "Join Existing Show" and must
+ * never be taught to take over: within a shard, two Playwright workers share
+ * one Backend-Service, so a takeover from the shared page object would end a
+ * sibling worker's show mid-test. This spec avoids that by owning its own
+ * Backend-Service in its own workflow job (see .github/workflows/e2e-tests.yml's
+ * `e2e-takeover` job) and its own dedicated pair of sessions
+ * (TAKEOVER_DJ_A / TAKEOVER_DJ_B, provisioned in e2e/auth.setup.ts) — nothing
+ * else in the suite runs against this Backend or these accounts.
+ *
+ * Also depends on `FLOWSHEET_TAKEOVER_ENABLED=true` reaching that
+ * Backend-Service process. Without it, the prompt in beat 2 still renders —
+ * the client-side pre-check that opens it (`useOpenShowHandoff`) never asks
+ * the server — but the server ignores `intent` entirely and co-hosts, so
+ * beats 3-5 would exercise nothing. Beat 3 asserts the response shape that
+ * only a flag-on server can produce, which is this spec's proof the flag
+ * actually reached the running process rather than just the checked-in .env.
+ */
+test.describe("Go-live takeover", () => {
+  test.describe.configure({ mode: "serial" });
+  test.setTimeout(60_000);
+
+  let contextA: BrowserContext;
+  let contextB: BrowserContext;
+  let pageA: Page;
+  let pageB: Page;
+  let flowsheetA: FlowsheetPage;
+  let flowsheetB: FlowsheetPage;
+
+  test.beforeAll(async ({ browser }) => {
+    const baseURL = process.env.E2E_BASE_URL || "http://localhost:3000";
+    contextA = await browser.newContext({
+      baseURL,
+      storageState: path.join(authDir, TAKEOVER_DJ_A.stateFile),
+    });
+    contextB = await browser.newContext({
+      baseURL,
+      storageState: path.join(authDir, TAKEOVER_DJ_B.stateFile),
+    });
+    pageA = await contextA.newPage();
+    pageB = await contextB.newPage();
+    flowsheetA = new FlowsheetPage(pageA);
+    flowsheetB = new FlowsheetPage(pageB);
+
+    await flowsheetA.goto();
+    await flowsheetA.waitForEntriesLoaded();
+    await flowsheetB.goto();
+    await flowsheetB.waitForEntriesLoaded();
+
+    // This job's Backend-Service is freshly initialized per CI run, but a
+    // local rerun against a stale DB could leave either DJ live from a
+    // previous attempt.
+    await flowsheetA.ensureOffAir();
+    await flowsheetB.ensureOffAir();
+  });
+
+  test.afterAll(async () => {
+    await contextA?.close().catch(() => {});
+    await contextB?.close().catch(() => {});
+  });
+
+  test("1. DJ A goes live and the banner names only A", async () => {
+    await goLiveNoCollision(flowsheetA);
+
+    const state = await fetchLiveState(flowsheetA);
+    expect(state.djsOnAir.map((dj) => dj.dj_name)).toEqual([TAKEOVER_DJ_A.djName]);
+    expect(state.onAir?.dj_name).toBe(TAKEOVER_DJ_A.djName);
+  });
+
+  test("2. DJ B pressing Go Live sees the prompt naming A", async () => {
+    // Refetch B's own view before pressing so the client-side pre-check
+    // (useOpenShowHandoff) has a chance to see A's show without a round
+    // trip. Not load-bearing for the prompt itself — the server's 409
+    // backstop opens the identical prompt — only for which of the two paths
+    // this run happens to exercise.
+    await flowsheetB.goto();
+    await flowsheetB.waitForEntriesLoaded();
+
+    await expect(flowsheetB.goLiveButton).toBeEnabled({ timeout: 10000 });
+    await flowsheetB.goLiveButton.click();
+
+    const dialog = pageB.getByTestId("go-live-handoff-dialog");
+    await expect(dialog).toBeVisible({ timeout: 15000 });
+    await expect(dialog).toContainText(TAKEOVER_DJ_A.djName);
+  });
+
+  test("3. B ends A's show and takes over", async () => {
+    const decision = await decideHandoff(flowsheetB, "go-live-handoff-takeover");
+
+    expect(decision.ok).toBe(true);
+    expect(decision.intent).toBe("takeover");
+    expect(typeof decision.expectedShowId).toBe("number");
+    // The load-bearing assertion for "the flag reached the server": with
+    // FLOWSHEET_TAKEOVER_ENABLED off, the route ignores `intent` altogether
+    // and co-hosts, answering with a ShowDJ (`show_id`/`dj_id`, never a
+    // numeric `id`) — see lib/features/flowsheet/go-live-handoff.ts's
+    // takeoverWasHonored. A numeric `id` that differs from the
+    // `expected_show_id` this request sent is only possible when the server
+    // actually closed A's show and opened a new one for B.
+    expect(typeof decision.body.id).toBe("number");
+    expect(decision.body.id).not.toBe(decision.expectedShowId);
+
+    await expect(flowsheetB.liveStatus).toContainText("On Air", { timeout: 10000 });
+
+    await flowsheetA.goto();
+    await flowsheetA.waitForEntriesLoaded();
+    await expect(flowsheetA.liveStatus).toContainText("Off Air", { timeout: 10000 });
+
+    const state = await fetchLiveState(flowsheetB);
+    expect(state.djsOnAir.map((dj) => dj.dj_name)).toEqual([TAKEOVER_DJ_B.djName]);
+    expect(state.onAir?.dj_name).toBe(TAKEOVER_DJ_B.djName);
+  });
+
+  test("4. B joins as co-host instead; banner shows both, A remains primary", async () => {
+    // Fresh collision: B signs off the show it took over, A starts a new
+    // one, and this time B answers "Join Existing Show".
+    await flowsheetB.leave();
+    await goLiveNoCollision(flowsheetA);
+
+    await flowsheetB.goto();
+    await flowsheetB.waitForEntriesLoaded();
+    await expect(flowsheetB.goLiveButton).toBeEnabled({ timeout: 10000 });
+    await flowsheetB.goLiveButton.click();
+    const dialog = pageB.getByTestId("go-live-handoff-dialog");
+    await expect(dialog).toBeVisible({ timeout: 15000 });
+
+    const decision = await decideHandoff(flowsheetB, "go-live-handoff-join");
+    expect(decision.ok).toBe(true);
+    expect(decision.intent).toBe("join");
+    // A co-host join lands on the show it named rather than starting a new
+    // one, so its response is the ShowDJ shape — no numeric `id` (mirrors
+    // the inverse check in beat 3).
+    expect(typeof decision.body.id).not.toBe("number");
+
+    await expect(flowsheetB.liveStatus).toContainText("On Air", { timeout: 10000 });
+
+    const state = await fetchLiveState(flowsheetB);
+    expect(state.djsOnAir.map((dj) => dj.dj_name).sort()).toEqual(
+      [TAKEOVER_DJ_A.djName, TAKEOVER_DJ_B.djName].sort()
+    );
+    // A started the show B joined, so A stays the primary DJ the banner
+    // names — a co-host join must not reassign it.
+    expect(state.onAir?.dj_name).toBe(TAKEOVER_DJ_A.djName);
+  });
+
+  test("5. the tubafrenzy mirror signs A's show off and creates B's — targeting, not sequence", async () => {
+    // Ordering across the two mirror taps is unenforceable: the route
+    // registers the start tap's `res.once('finish')` before the controller
+    // runs, and both taps then await independent PostHog round-trips before
+    // reaching the mock. This waits for the mock to have SEEN both, and
+    // checks which show each request named — never their relative order.
+    await expect(async () => {
+      const response = await pageA.request.get(`${MOCK_TUBAFRENZY_URL}/__requests`);
+      expect(response.ok()).toBe(true);
+      const requests = (await response.json()) as MirrorRequest[];
+
+      const aCreate = requests.find(
+        (r) =>
+          r.url === "/playlists/api/radioShow" &&
+          isRecord(r.body) &&
+          r.body.djHandle === TAKEOVER_DJ_A.djName
+      );
+      expect(aCreate, "mock never saw a create request for A's show").toBeTruthy();
+
+      const bCreate = requests.find(
+        (r) =>
+          r.url === "/playlists/api/radioShow" &&
+          isRecord(r.body) &&
+          r.body.djHandle === TAKEOVER_DJ_B.djName
+      );
+      expect(bCreate, "mock never saw a create request for B's show").toBeTruthy();
+
+      // Targeting: a sign-off whose radioShowId is the tubafrenzy id THIS
+      // MOCK assigned to A's create — not merely "a signoff happened".
+      const aSignoff = requests.find(
+        (r) =>
+          r.url === "/playlists/api/radioShow/signoff" &&
+          isRecord(r.body) &&
+          r.body.radioShowId === aCreate!.id
+      );
+      expect(
+        aSignoff,
+        "mock never saw a signoff targeting the tubafrenzy id it assigned A's show"
+      ).toBeTruthy();
+    }).toPass({ timeout: 15000, intervals: [500] });
+  });
+
+  test("6. regression guard: a clean handoff still needs no prompt", async () => {
+    await flowsheetB.leave();
+    await flowsheetA.leave();
+    await expect(flowsheetA.liveStatus).toContainText("Off Air", { timeout: 10000 });
+
+    await flowsheetB.goto();
+    await flowsheetB.waitForEntriesLoaded();
+    await expect(flowsheetB.goLiveButton).toBeEnabled({ timeout: 10000 });
+    await flowsheetB.goLiveButton.click();
+
+    // No open show to collide with, so the ordinary one-click path must
+    // stay one click — this is the regression guard for the incident this
+    // whole feature exists to fix.
+    await expect(pageB.getByTestId("go-live-handoff-dialog")).not.toBeVisible({
+      timeout: 3000,
+    });
+    await expect(flowsheetB.liveStatus).toContainText("On Air", { timeout: 10000 });
+
+    await flowsheetB.leave();
+  });
+});
+
+type RawOnAirDj = { id: string | null; dj_name: string };
+
+type LiveState = {
+  djsOnAir: RawOnAirDj[];
+  onAir: { dj_name: string } | null;
+};
+
+type MirrorRequest = {
+  method: string;
+  url: string;
+  body: unknown;
+  id: number;
+  timestamp: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Click Go Live and require it to succeed with no handoff — a defensive
+ * check that the scenario each test sets up really is collision-free, not
+ * merely a click that this helper hides a prompt behind.
+ *
+ * Reloads first. `useOpenShowHandoff`'s pre-check reads whoever this page's
+ * OWN Redux cache last saw on air, and that cache goes stale the moment a
+ * DIFFERENT page's action changes who's live — exactly what beat 4 does
+ * (B leaves on B's page, then A goes live on A's page, which never
+ * re-fetched). Skipping the reload here doesn't skip the prompt; it just
+ * means this DJ's own click opens a dialog naming a DJ who already left,
+ * and no `/flowsheet/join` is ever sent — which is indistinguishable from a
+ * hang until you go looking for why the mutation wait timed out.
+ */
+async function goLiveNoCollision(flowsheet: FlowsheetPage): Promise<void> {
+  const page = flowsheet.page;
+  await flowsheet.goto();
+  await flowsheet.waitForEntriesLoaded();
+  await expect(flowsheet.goLiveButton).toBeEnabled({ timeout: 10000 });
+  await page.waitForTimeout(300); // let a prior mutation's rollback settle
+
+  const alreadyLive = (await flowsheet.liveStatus.textContent())?.includes("On Air");
+  if (alreadyLive) return;
+
+  const mutationResponse = page.waitForResponse(
+    (r) => r.url().includes("/flowsheet/join") && r.request().method() === "POST",
+    { timeout: 15000 }
+  );
+  await flowsheet.goLiveButton.click();
+  const response = await mutationResponse;
+  expect(response.ok(), "expected a plain go-live with no open-show collision").toBe(true);
+  await expect(flowsheet.liveStatus).toContainText("On Air", { timeout: 10000 });
+}
+
+/**
+ * Click one handoff-dialog button and report both halves of the resulting
+ * `POST /flowsheet/join`: the decision this DJ actually sent, and what the
+ * server answered. Beats 3 and 4 read `body.id`'s presence to tell a real
+ * takeover from a co-host join — see go-live-handoff.ts's
+ * `takeoverWasHonored`.
+ */
+async function decideHandoff(
+  flowsheet: FlowsheetPage,
+  choice: "go-live-handoff-join" | "go-live-handoff-takeover"
+): Promise<{
+  ok: boolean;
+  intent: string;
+  expectedShowId?: number;
+  body: Record<string, unknown>;
+}> {
+  const page = flowsheet.page;
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().includes("/flowsheet/join") && r.request().method() === "POST",
+      { timeout: 15000 }
+    ),
+    page.getByTestId(choice).click(),
+  ]);
+  const requestBody = (response.request().postDataJSON() ?? {}) as {
+    intent?: string;
+    expected_show_id?: number;
+  };
+  const body = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  return {
+    ok: response.ok(),
+    intent: requestBody.intent ?? "",
+    expectedShowId: requestBody.expected_show_id,
+    body,
+  };
+}
+
+/**
+ * Reload `flowsheet`'s page and read back the two sources the banner has to
+ * agree with each other: `GET /flowsheet/djs-on-air` (the full on-air
+ * membership) and the `on_air` field on the paginated entries response
+ * (backs the NowPlaying widget's single-name banner). Both fire on mount, so
+ * one reload answers both.
+ *
+ * Reads both bodies through `page.route()` interception rather than
+ * `page.waitForResponse(...).json()`. The latter reads the body via CDP's
+ * `Network.getResponseBody` against the frame that served it — and a reload
+ * is exactly a frame replacement, so the read can lose the race and throw
+ * `Protocol error (Network.getResponseBody): No resource with given
+ * identifier found` ("response body is not available for a response that
+ * was navigated away from"), which is what happened locally on this file's
+ * very first beat. `route.fetch()` performs the request itself and hands
+ * back a body Playwright already holds in Node, decoupled from the
+ * browser-side frame's lifecycle — fulfilling with that same response still
+ * delivers the real data to the app, so this changes nothing about what the
+ * page receives.
+ */
+async function fetchLiveState(flowsheet: FlowsheetPage): Promise<LiveState> {
+  const page = flowsheet.page;
+  let djsOnAir: RawOnAirDj[] | undefined;
+  let onAir: { dj_name: string } | null | undefined;
+
+  const isDjsOnAir = (url: URL) => url.pathname.endsWith("/flowsheet/djs-on-air");
+  const isEntriesPage = (url: URL) =>
+    url.pathname.includes("/flowsheet") && url.searchParams.has("page");
+
+  await page.route(isDjsOnAir, async (route) => {
+    const response = await route.fetch();
+    djsOnAir = (await response.json()) as RawOnAirDj[];
+    await route.fulfill({ response });
+  });
+  await page.route(isEntriesPage, async (route) => {
+    const response = await route.fetch();
+    const body = (await response.json()) as { on_air?: { dj_name: string } | null };
+    onAir = body.on_air ?? null;
+    await route.fulfill({ response });
+  });
+
+  try {
+    await flowsheet.goto();
+    await flowsheet.waitForEntriesLoaded();
+    await expect
+      .poll(() => djsOnAir !== undefined && onAir !== undefined, { timeout: 15000 })
+      .toBe(true);
+  } finally {
+    await page.unroute(isDjsOnAir);
+    await page.unroute(isEntriesPage);
+  }
+
+  return { djsOnAir: djsOnAir ?? [], onAir: onAir ?? null };
+}

--- a/e2e/tests/flowsheet/go-live-takeover.spec.ts
+++ b/e2e/tests/flowsheet/go-live-takeover.spec.ts
@@ -1,7 +1,10 @@
-import { test, expect, type BrowserContext, type Page } from "@playwright/test";
+import type { BrowserContext, Page } from "@playwright/test";
 import path from "path";
 import { FlowsheetPage } from "../../pages/flowsheet.page";
-import { TAKEOVER_DJ_A, TAKEOVER_DJ_B } from "../../fixtures/auth.fixture";
+// The repo's extended `test`, not `@playwright/test`'s, so a guard added to the
+// shared one later (a console-error assertion, a per-test cleanup) covers this
+// file too. Its extra fixtures go unused here; that costs nothing.
+import { test, expect, TAKEOVER_DJ_A, TAKEOVER_DJ_B } from "../../fixtures/auth.fixture";
 
 const authDir = path.join(__dirname, "../../.auth");
 const MOCK_TUBAFRENZY_URL = process.env.MOCK_TUBAFRENZY_URL || "http://localhost:9091";
@@ -39,8 +42,23 @@ test.describe("Go-live takeover", () => {
   let pageB: Page;
   let flowsheetA: FlowsheetPage;
   let flowsheetB: FlowsheetPage;
+  /**
+   * Highest mirror-request id the mock had already assigned when this attempt
+   * started. Beat 5 searches only past it.
+   *
+   * The mock's buffer is process-global and outlives a Playwright retry, while
+   * `mode: "serial"` re-runs every beat on retry. Without a watermark, beat 5's
+   * `find` would happily match the *previous* attempt's create and signoff and
+   * pass on evidence this attempt never produced.
+   */
+  let mirrorWatermark = 0;
 
   test.beforeAll(async ({ browser }) => {
+    // Hook timeouts are their own budget — a suite-scoped `test.setTimeout`
+    // governs the tests, not this. Two `goto` + `waitForEntriesLoaded` pairs
+    // and two `ensureOffAir` calls (which fall through to `leave` when a stale
+    // local database left a DJ live) can outrun the config's 20s default.
+    test.setTimeout(90_000);
     const baseURL = process.env.E2E_BASE_URL || "http://localhost:3000";
     contextA = await browser.newContext({
       baseURL,
@@ -65,6 +83,12 @@ test.describe("Go-live takeover", () => {
     // previous attempt.
     await flowsheetA.ensureOffAir();
     await flowsheetB.ensureOffAir();
+
+    // Read the watermark last: the sign-offs `ensureOffAir` may just have sent
+    // belong to whatever ran before this attempt, not to it.
+    const seen = await pageA.request.get(`${MOCK_TUBAFRENZY_URL}/__requests`);
+    const priorRequests = seen.ok() ? ((await seen.json()) as MirrorRequest[]) : [];
+    mirrorWatermark = priorRequests.reduce((max, r) => Math.max(max, r.id), 0);
   });
 
   test.afterAll(async () => {
@@ -165,7 +189,9 @@ test.describe("Go-live takeover", () => {
     await expect(async () => {
       const response = await pageA.request.get(`${MOCK_TUBAFRENZY_URL}/__requests`);
       expect(response.ok()).toBe(true);
-      const requests = (await response.json()) as MirrorRequest[];
+      const requests = ((await response.json()) as MirrorRequest[]).filter(
+        (r) => r.id > mirrorWatermark
+      );
 
       const aCreate = requests.find(
         (r) =>


### PR DESCRIPTION
## What this does

Adds `e2e/tests/flowsheet/go-live-takeover.spec.ts` — the six-beat end-to-end spec [#1267](https://github.com/WXYC/dj-site/issues/1267) asked for and [#1288](https://github.com/WXYC/dj-site/pull/1288) could not carry — plus the four pieces of infrastructure [#1289](https://github.com/WXYC/dj-site/issues/1289) enumerates as prerequisites: the flag reaching the Backend process, a dedicated workflow job with its own Backend-Service, a dedicated pair of sessions, and a mock tubafrenzy that can be interrogated.

Closes #1289.

## How the flag was proven to reach the *server*, not just the client

`FLOWSHEET_TAKEOVER_ENABLED=true` sits at line 667 of `.github/workflows/e2e-tests.yml`, inside the `cat > .env << 'EOF'` heredoc that spans 634–668 — **not** the workflow-level `env:` block, which never reaches the process spawned by `node apps/backend/dist/app.js`.

Placement alone is a claim, though, so beat 3 makes the running server prove it. It asserts the actual `POST /flowsheet/join` **response shape**:

```ts
expect(typeof decision.body.id).toBe("number");
expect(decision.body.id).not.toBe(decision.expectedShowId);
```

With the flag off, the route ignores `intent` entirely and co-hosts, answering with a ShowDJ (`show_id`/`dj_id`, never a numeric `id`). A numeric `id` that *differs* from the `expected_show_id` the request sent is only producible by a server that actually closed A's show and opened a new one for B. This matters because the client-side pre-check (`useOpenShowHandoff`) is flag-independent: the dialog in beat 2 renders either way, so an assertion that merely checked "the prompt appeared" would have passed happily against a Backend that never received the flag. Beat 4 asserts the inverse shape for a co-host join.

## Both isolation mechanisms, and why neither is redundant

The issue's argument that a dedicated Playwright project is insufficient is correct, and this PR does not rely on one. Two distinct mechanisms, doing two different jobs:

- **A separate workflow job, `e2e-takeover`** — its own Postgres, Auth, Backend-Service, mock tubafrenzy, and `--workers=1` on the CLI (`workers` is a `TestConfig`-level option, so no project-level setting can produce it). *This is what provides the isolation*: a Backend-Service no sibling worker shares, and the only one in CI running with the takeover flag on.
- **A `chromium-takeover` project plus `testIgnore` on the sharded `chromium` project** — `testMatch` cannot exclude a file, which is why this needs `testIgnore`. *This is what prevents double execution*: without it the spec would run in the takeover job **and** in some shard of the 4-way matrix, where a takeover click would end a sibling worker's show mid-test.

`e2e-all` now `needs: [e2e, e2e-takeover]` and fails on a takeover-job failure, keeping the single required check honest.

## Beat 5 asserts targeting, not ordering

Per the issue: `aCreate.id === signoff.body.radioShowId` (the sign-off names the tubafrenzy id *this mock* assigned A's create) and `bCreate` exists. No sequence assertion. Ordering is unenforceable here — the route registers the start tap's `res.once('finish')` before the controller runs, and both taps then await independent PostHog round-trips — so an ordering assertion would be flaky by construction rather than by accident. The mock gains a bounded (500-entry) ring buffer and a `GET /__requests` route; `/__requests` is not itself recorded.

## Three bugs found during implementation that the issue did not anticipate

**1. `djName` was silently dropped during onboarding — for every provisioned identity, not just the new pair.** The admin roster's `createAccount({ realName, djName })` only seeds a *suggestion*; `/onboarding?token=…` renders `<OnboardingForm />` with no props, so both fields arrive empty and onboarding makes the real choice. `completeOnboardingWithInviteToken` filled the hardcoded fallbacks `"E2E Test User"` / `"E2E DJ"` whenever the field was not already non-empty — which it never was. So `CLASSIC_MD_USER` and `CLASSIC_DJ_USER` have been landing in the database as `E2E Test User` / `E2E DJ` this whole time; nothing ever asserted on their names, so it went unnoticed. (It is also latently hostile to reconciliation: `rosterAccountExists` searches the roster by `identity.realName`, a value the account never ended up carrying.) Fixed with an explicit `{ realName, djName }` override parameter that wins over the pre-fill, because a caller that named a value needs *that* value, not "any non-empty one". The takeover spec cannot work without it — beats 1, 3 and 4 distinguish the two DJs by `dj_name`, and both would have been `E2E DJ`.

**2. CDP body-read race after reload.** `page.waitForResponse(...).then(r => r.json())` intermittently threw `Protocol error (Network.getResponseBody): No resource with given identifier found`. A reload is a frame replacement, and the CDP body read races it — a known Playwright gotcha, not an app bug. `fetchLiveState` now reads both bodies through `page.route()` interception (`route.fetch()` + `route.fulfill({ response })`), so Playwright performs the request from Node and already holds the body, decoupled from the browser frame's lifecycle. The page still receives the real response.

**3. Stale client-side cache.** `goLiveNoCollision` could hit A's *own* handoff dialog: `useOpenShowHandoff`'s pre-check reads whoever that page's Redux cache last saw on air, and beat 4 changes who is live from a *different* page (B leaves on B's page, then A goes live on A's page, which never re-fetched). The dialog then names a DJ who already left and no `/flowsheet/join` is ever sent — indistinguishable from a hang until you find the mutation wait that timed out. Fixed by reloading inside the helper.

## Verification

- The `e2e-takeover` job was run end to end **locally, six times**, against real Postgres, a real Backend-Service built and started with the flag, real Auth, real dj-site, and the real mock. The final two consecutive runs were **15/15 green in ~2.5 min each** (9 setup steps + 6 beats).
- `--list` on the sharded `chromium` project: **219 tests in 30 files, zero occurrences** of `go-live-takeover`. `--list` on `chromium-takeover`: the 6 beats and nothing else.
- `tsc --noEmit` clean; `eslint e2e/` reports 0 errors (72 pre-existing warnings, none new).
- **Not run locally:** the full sharded `chromium` project (all 219 tests). Its exclusion of the new spec was verified by `--list` rather than by execution; CI runs the matrix itself.

## One simplification versus the issue's plan

The paired-branch dance the issue anticipated turned out to be unnecessary. `FLOWSHEET_TAKEOVER_ENABLED` had already merged to Backend-Service `main` (`4654332d`, rebase-merged from `fdcf845a`), so the shared ref resolver lands on `main` naturally. The new job still uses the same resolver as the sharded job, so the two cannot silently drift onto different Backend refs.

## Not touched

`e2e/pages/flowsheet.page.ts` is unchanged. `answerHandoffPromptIfShown` still clicks **"Join Existing Show"** and only that — the constraint the issue asks not to relax. The takeover click lives exclusively in the new spec, in its own job, on its own Backend.

## Related

- [#1267](https://github.com/WXYC/dj-site/issues/1267), [#1288](https://github.com/WXYC/dj-site/pull/1288), [WXYC/Backend-Service#2232](https://github.com/WXYC/Backend-Service/issues/2232)
