### PR TITLE
refactor(flowsheet): consolidate the two on-air name formatters into one shared extractor

### DIFF
--- a/lib/features/flowsheet/api.ts
+++ b/lib/features/flowsheet/api.ts
@@ -169,8 +169,10 @@ export const flowsheetApi = createApi({
         // Seed the banner with the real dj_name so the public /live page never
         // renders a "Live" placeholder during the refetch window. A joiner
         // with no display name must not blank the banner or leave a trailing
-        // comma: format only the named DJs, and when none exist keep the
-        // previous banner until the refetch lands. (#621)
+        // comma: `formatOnAirSummary` already drops blank names on its own, so
+        // a nameless-only draft.djs renders as the off-air label rather than a
+        // blank or a trailing comma, and a named DJ already on air keeps
+        // reading correctly regardless of who else just joined unnamed.
         const patchLive = dispatch(
           flowsheetApi.util.updateQueryData(
             "whoIsLive",
@@ -182,10 +184,7 @@ export const flowsheetApi = createApi({
                   id: arg.dj_id,
                   dj_name: arg.dj_name ?? "",
                 });
-                const named = draft.djs.filter((d) => d.dj_name);
-                if (named.length) {
-                  draft.onAir = formatOnAirSummary(named);
-                }
+                draft.onAir = formatOnAirSummary(draft.djs);
               }
             }
           )

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -28,7 +28,15 @@ import {
  */
 export function formatOnAirSummary(djs: OnAirDJResponse[]): string {
   return formatNameList(
-    djs.map((dj) => dj.dj_name),
+    // `dj_name` is declared non-nullable, and the wire disagrees: the backend
+    // runs each account DJ's handle through its Anonymous-filtering resolver,
+    // which answers `null` for a handle that is blank or the literal
+    // "Anonymous" — so a DJ with no on-air handle arrives here as
+    // `dj_name: null`. Coerce rather than trust the declaration. `.trim()`
+    // downstream would throw, and this runs on the server-render seed path
+    // OUTSIDE the seed fetch's catch, where a throw takes down the public
+    // page instead of degrading to the client-fetched loading state.
+    djs.map((dj) => dj.dj_name ?? ""),
     { whenEmpty: OFF_AIR_LABEL }
   );
 }

--- a/lib/features/flowsheet/conversions.ts
+++ b/lib/features/flowsheet/conversions.ts
@@ -2,6 +2,7 @@ import { Rotation } from "../rotation/types";
 import { formatStationDateTime } from "@/src/utilities/stationTime";
 import { OFF_AIR_LABEL } from "./constants";
 import { hasLinkedAlbumId } from "./linkage";
+import { formatNameList } from "./name-list";
 import { seedableArtistName } from "./various-artists-guard";
 import {
   FlowsheetEntry,
@@ -13,9 +14,23 @@ import {
   OnAirDJResponse,
 } from "./types";
 
+/**
+ * "Turncoat, desire path" — a plain comma join, no conjunction (unlike
+ * `formatDjNames`'s "and"; the banner has no verb to agree with).
+ *
+ * Filters blank names through the same `nonBlankNames` `formatDjNames` uses
+ * (see `./name-list`), which this function used not to do: a blank `dj_name`
+ * — a real possibility, since a DJ account can now be created with no on-air
+ * handle — used to ride straight into the joined string (`"Turncoat, "`, or
+ * bare `""` for an all-blank list), because only one of this function's three
+ * call sites pre-filtered before calling it. Every call site now gets the
+ * same filter for free, whether it pre-filters or not.
+ */
 export function formatOnAirSummary(djs: OnAirDJResponse[]): string {
-  if (!djs.length) return OFF_AIR_LABEL;
-  return djs.map((dj) => dj.dj_name).join(", ");
+  return formatNameList(
+    djs.map((dj) => dj.dj_name),
+    { whenEmpty: OFF_AIR_LABEL }
+  );
 }
 
 /**

--- a/lib/features/flowsheet/go-live-handoff.ts
+++ b/lib/features/flowsheet/go-live-handoff.ts
@@ -10,6 +10,8 @@
  * readings, so it is the headline here, not the show's start time.
  */
 
+import { formatNameList, nonBlankNames } from "./name-list";
+
 /** The wire values `POST /flowsheet/join` accepts for an explicit decision. */
 export type JoinIntent = "join" | "takeover";
 
@@ -132,10 +134,7 @@ function unwrapRejection(
 
 /** "dj sue", "dj sue and eureka!", "dj sue, eureka! and DJ boy". */
 export function formatDjNames(names: readonly string[]): string {
-  const cleaned = names.map((n) => n.trim()).filter((n) => n.length > 0);
-  if (cleaned.length === 0) return "Someone";
-  if (cleaned.length === 1) return cleaned[0];
-  return `${cleaned.slice(0, -1).join(", ")} and ${cleaned[cleaned.length - 1]}`;
+  return formatNameList(names, { whenEmpty: "Someone", conjunction: "and" });
 }
 
 /**
@@ -184,10 +183,11 @@ export function describeOpenShow(
   now: number = Date.now()
 ): string {
   const elapsed = formatElapsedSince(handoff.lastLoggedAt, now);
-  // Subject and verb are derived from ONE filtered list, so they cannot
-  // disagree. Counting the raw array instead would render "dj sue are on air"
-  // for a show whose second DJ has a blank handle.
-  const named = handoff.djNames.map((n) => n.trim()).filter((n) => n.length > 0);
+  // Subject and verb are derived from the SAME filtered list — `nonBlankNames`,
+  // the one blank-name filter `formatDjNames` also runs on `named` below — so
+  // they cannot disagree. Counting the raw array instead would render "dj sue
+  // are on air" for a show whose second DJ has a blank handle.
+  const named = nonBlankNames(handoff.djNames);
   const verb = named.length > 1 ? "are" : "is";
   const subject = formatDjNames(named);
   return elapsed === null

--- a/lib/features/flowsheet/name-list.ts
+++ b/lib/features/flowsheet/name-list.ts
@@ -1,0 +1,61 @@
+/**
+ * The one blank-name filter behind every DJ-name-list renderer, plus the
+ * join mechanics built on top of it.
+ *
+ * Before this module, three call sites spelled "drop blank/whitespace names"
+ * independently: `formatDjNames`'s own inline `.trim().filter(...)`,
+ * `describeOpenShow`'s copy of the same expression (needed because the
+ * "is"/"are" verb has to agree with the rendered list), and the joinShow
+ * optimistic patch in `api.ts` (`.filter((d) => d.dj_name)`, a *different*
+ * spelling — untrimmed truthiness, over DJ objects rather than strings).
+ * `formatOnAirSummary` did not filter at all, trusting whichever caller
+ * happened to pre-filter for it.
+ *
+ * The divergence between the first two once produced the sentence "dj sue
+ * are on air": the verb came from an unfiltered count while the name came
+ * from a filtered list, so a blank second co-host inflated the count without
+ * appearing in the sentence. Routing every caller through the same
+ * `nonBlankNames` makes that class of bug structurally impossible — a count
+ * and a rendered list taken from this module can no longer disagree, because
+ * they were never two lists to begin with.
+ */
+
+/** Trim and drop blank/whitespace-only names. The one blank-name filter. */
+export function nonBlankNames(names: readonly string[]): string[] {
+  return names.map((name) => name.trim()).filter((name) => name.length > 0);
+}
+
+/**
+ * How a name list reads as prose. The two things callers are meant to
+ * differ on — everything else (the blank-name filter, the 0/1/2+ branching)
+ * is shared.
+ */
+export type NameListStyle = {
+  /** Rendered when there are no non-blank names at all. */
+  readonly whenEmpty: string;
+  /**
+   * Word placed before the final name once there are 2+ names, e.g. "and" →
+   * "a, b and c". Omit for a plain comma join with no conjunction ("a, b").
+   */
+  readonly conjunction?: string;
+};
+
+/**
+ * Filter blank names, then join what survives as prose.
+ *
+ * The shared implementation behind `formatDjNames` (the go-live handoff
+ * prompt: "Someone" when empty, "and" before the last name — verb agreement
+ * upstream depends on this filtering, not just the rendered text) and
+ * `formatOnAirSummary` (the on-air banner: `OFF_AIR_LABEL` when empty, a
+ * plain comma join, no conjunction).
+ */
+export function formatNameList(
+  names: readonly string[],
+  style: NameListStyle
+): string {
+  const cleaned = nonBlankNames(names);
+  if (cleaned.length === 0) return style.whenEmpty;
+  if (cleaned.length === 1) return cleaned[0];
+  if (!style.conjunction) return cleaned.join(", ");
+  return `${cleaned.slice(0, -1).join(", ")} ${style.conjunction} ${cleaned[cleaned.length - 1]}`;
+}

--- a/src/widgets/NowPlaying/index.tsx
+++ b/src/widgets/NowPlaying/index.tsx
@@ -77,7 +77,13 @@ export default function NowPlaying({
   // the server seed so the public page renders the on-air state on first paint.
   const onAirData = whoIsLiveData ?? initialOnAirData;
   const onAirDJ = onAirData?.onAir;
-  const live = onAirDJ !== undefined && onAirDJ !== "Off Air" && !djError;
+  // Liveness comes from the DJ list, not from the banner text. The two are
+  // built together — an empty list is the only thing that produces the off-air
+  // label — but the banner is a *display* string, and reading liveness out of
+  // it makes every naming decision a liveness decision: a live DJ with no
+  // on-air handle formats to the off-air label and would read as OFF AIR on
+  // the public page while a show is running.
+  const live = (onAirData?.djs.length ?? 0) > 0 && !djError;
   // Show today's spinner only while the query is loading AND no seed is present;
   // with a seed there is already content to render.
   const djLoading = whoIsLiveLoading && onAirData === undefined;

--- a/tests/integration/components/widgets/NowPlaying/index.test.tsx
+++ b/tests/integration/components/widgets/NowPlaying/index.test.tsx
@@ -182,6 +182,23 @@ describe("NowPlaying", () => {
       );
     });
 
+    // A DJ with no on-air handle formats to the off-air label — there is no
+    // name to render — but a show is running. Liveness must come from the DJ
+    // list, not from the banner text, or the public page reads OFF AIR mid-show.
+    it("should be live when a DJ with no on-air handle is on air", () => {
+      mockUseWhoIsLiveQuery.mockReturnValue({
+        data: { onAir: "Off Air", djs: [{ id: "1", dj_name: "" }] },
+        isLoading: false,
+        isError: false,
+      });
+
+      render(<NowPlaying mini={false} />);
+      expect(screen.getByTestId("now-playing-main")).toHaveAttribute(
+        "data-live",
+        "true"
+      );
+    });
+
     it("should not be live when djError is true", () => {
       mockUseWhoIsLiveQuery.mockReturnValue({
         data: mockDJsOnAirData,

--- a/tests/unit/lib/features/flowsheet/conversions.test.ts
+++ b/tests/unit/lib/features/flowsheet/conversions.test.ts
@@ -6,6 +6,7 @@ import {
   convertV2FlowsheetResponse,
   entryToFreezePayload,
   extractFlowsheetEntries,
+  formatOnAirSummary,
 } from "@/lib/features/flowsheet/conversions";
 import {
   createTestFlowsheetQuery,
@@ -345,6 +346,39 @@ describe("flowsheet conversions", () => {
 
       expect(result.djs[0].id).toBeNull();
       expect(result.onAir).toBe("DJ MONSTER");
+    });
+  });
+
+  // formatOnAirSummary previously trusted its caller to pre-filter blank
+  // names (only one of its three call sites did); these cases were untested
+  // and produced a bare "" for an all-blank list, or a trailing "Name, " for
+  // a mix of real and blank names. It now filters blank names itself, the
+  // same way formatDjNames does, so every call site reads correctly whether
+  // or not it pre-filters.
+  describe("formatOnAirSummary", () => {
+    it("falls back to the off-air label for an all-blank list, not a bare empty string", () => {
+      const result = formatOnAirSummary([createTestOnAirDJResponse({ dj_name: "" })]);
+      expect(result).toBe("Off Air");
+    });
+
+    it("falls back to the off-air label for a whitespace-only name", () => {
+      const result = formatOnAirSummary([createTestOnAirDJResponse({ dj_name: "   " })]);
+      expect(result).toBe("Off Air");
+    });
+
+    it("drops a blank co-host instead of leaving a trailing comma", () => {
+      const result = formatOnAirSummary([
+        createTestOnAirDJResponse({ id: "1", dj_name: "Turncoat" }),
+        createTestOnAirDJResponse({ id: "2", dj_name: "" }),
+      ]);
+      expect(result).toBe("Turncoat");
+    });
+
+    it("trims a padded name", () => {
+      const result = formatOnAirSummary([
+        createTestOnAirDJResponse({ dj_name: "  Turncoat  " }),
+      ]);
+      expect(result).toBe("Turncoat");
     });
   });
 

--- a/tests/unit/lib/features/flowsheet/conversions.test.ts
+++ b/tests/unit/lib/features/flowsheet/conversions.test.ts
@@ -27,6 +27,7 @@ import type {
   FlowsheetShowBlockEntry,
   FlowsheetBreakpointEntry,
   FlowsheetMessageEntry,
+  OnAirDJResponse,
 } from "@/lib/features/flowsheet/types";
 import { Rotation } from "@/lib/features/rotation/types";
 
@@ -346,6 +347,33 @@ describe("flowsheet conversions", () => {
 
       expect(result.djs[0].id).toBeNull();
       expect(result.onAir).toBe("DJ MONSTER");
+    });
+
+    // The wire disagrees with the declared type: the backend's on-air resolver
+    // answers null for a handle that is blank or the literal "Anonymous", so a
+    // DJ created without an on-air handle arrives with dj_name: null. This runs
+    // on the server-render seed path outside the seed fetch's catch, so a throw
+    // here is a failed public-page render, not a degraded one.
+    it("survives a null dj_name from the wire", () => {
+      const response = [
+        { id: "1", dj_name: null },
+      ] as unknown as OnAirDJResponse[];
+
+      expect(() => convertDJsOnAir(response)).not.toThrow();
+      expect(convertDJsOnAir(response).onAir).toBe("Off Air");
+    });
+
+    // A nameless DJ is still on air. The banner has nothing to render, so it
+    // falls back to the off-air label — but `djs` stays non-empty, and that is
+    // the list liveness is read from. Collapsing the two would put "OFF AIR" on
+    // the public page during a live show.
+    it("keeps a nameless on-air DJ in djs even though the banner reads off air", () => {
+      const result = convertDJsOnAir([
+        createTestOnAirDJResponse({ id: "1", dj_name: "" }),
+      ]);
+
+      expect(result.djs).toHaveLength(1);
+      expect(result.onAir).toBe("Off Air");
     });
   });
 

--- a/tests/unit/lib/features/flowsheet/name-list.test.ts
+++ b/tests/unit/lib/features/flowsheet/name-list.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatNameList,
+  nonBlankNames,
+} from "@/lib/features/flowsheet/name-list";
+
+describe("nonBlankNames", () => {
+  it.each([
+    [[], []],
+    [["dj sue"], ["dj sue"]],
+    [["", "  ", "dj sue"], ["dj sue"]],
+    [["  dj sue  ", "eureka!"], ["dj sue", "eureka!"]],
+    [["", "   "], []],
+  ])("filters %j to %j", (names, expected) => {
+    expect(nonBlankNames(names)).toEqual(expected);
+  });
+});
+
+describe("formatNameList", () => {
+  // The two axes callers are meant to differ on: the empty-list fallback
+  // text, and whether a conjunction joins the final name.
+  describe("with a conjunction (formatDjNames' style)", () => {
+    const style = { whenEmpty: "Someone", conjunction: "and" };
+
+    it.each([
+      [[], "Someone"],
+      [["dj sue"], "dj sue"],
+      [["dj sue", "eureka!"], "dj sue and eureka!"],
+      [["dj sue", "eureka!", "DJ boy"], "dj sue, eureka! and DJ boy"],
+      [["", "  ", "dj sue"], "dj sue"],
+      [["", "   "], "Someone"],
+    ])("formats %j as %s", (names, expected) => {
+      expect(formatNameList(names, style)).toBe(expected);
+    });
+  });
+
+  // A plain comma join, no conjunction word — formatOnAirSummary's style.
+  describe("without a conjunction (formatOnAirSummary's style)", () => {
+    const style = { whenEmpty: "Off Air" };
+
+    it.each([
+      [[], "Off Air"],
+      [["Turncoat"], "Turncoat"],
+      [["Turncoat", "desire path"], "Turncoat, desire path"],
+      [["Turncoat", "desire path", "Marz"], "Turncoat, desire path, Marz"],
+      [["Turncoat", ""], "Turncoat"],
+      [["", "   "], "Off Air"],
+    ])("formats %j as %s", (names, expected) => {
+      expect(formatNameList(names, style)).toBe(expected);
+    });
+  });
+
+  // The bug this module exists to make structurally impossible: a count and
+  // a rendered list taken from two different filters can disagree ("dj sue
+  // are on air" for a single visible name). Deriving both from the same
+  // `nonBlankNames` call, as callers are expected to, cannot.
+  it("a count taken from nonBlankNames always agrees with the list formatNameList renders", () => {
+    const raw = ["dj sue", "  ", ""];
+    const filtered = nonBlankNames(raw);
+    const rendered = formatNameList(raw, { whenEmpty: "Someone", conjunction: "and" });
+
+    expect(filtered).toHaveLength(1);
+    expect(rendered).toBe("dj sue");
+    // A verb chosen from filtered.length ("is" for 1) agrees with rendered:
+    // singular count, singular-looking name, never "dj sue are on air".
+  });
+});


### PR DESCRIPTION
Closes #1295.

`formatDjNames` (`go-live-handoff.ts`) and `formatOnAirSummary` (`conversions.ts`) answered the same question over the same input with different blank-name handling. New `lib/features/flowsheet/name-list.ts` holds the one implementation; both are now thin callers of it.

## What is shared, and what stays parameterized

The ticket's central constraint was that this is **not a delete** — both callers' differences are deliberate and both survive verbatim.

**Shared** (`nonBlankNames` + `formatNameList`):

- the blank-name filter: trim every name, drop what is left empty;
- the 0 / 1 / 2+ branching.

**Parameterized** (`NameListStyle`) — exactly the two axes the callers were meant to differ on:

| | `formatDjNames` (go-live prompt) | `formatOnAirSummary` (on-air banner) |
|---|---|---|
| `whenEmpty` | `"Someone"` | `OFF_AIR_LABEL` |
| `conjunction` | `"and"` — "dj sue, eureka! and DJ boy" | none; plain comma join — "Turncoat, desire path" |

The conjunction is not cosmetic: the prompt sentence carries a verb ("… **are** on air"), and `describeOpenShow` takes that verb's number from the same filtered list the subject is rendered from. The banner has no verb, so it takes a plain comma join.

`nonBlankNames` and `formatNameList` are separately exported for the same reason. `describeOpenShow` needs the **filtered count** for verb agreement without wanting the formatted string; folding the two into one function would push that call site back into spelling its own filter, which is precisely the defect this PR removes.

## A third divergent spelling, eliminated

The issue counted three spellings of the blank-name filter but located only two. The third was in `api.ts`'s `joinShow` optimistic patch: `.filter((d) => d.dj_name)` — untrimmed truthiness, applied to DJ objects rather than name strings, so a whitespace-only handle passed it where the other two dropped it.

Two consequences:

- `describeOpenShow` now takes its verb-agreement count from `nonBlankNames` directly rather than re-deriving `.map(trim).filter(length)` inline. Same expression, one source.
- `joinShow`'s patch simplifies to an unconditional `draft.onAir = formatOnAirSummary(draft.djs)`. The old pre-filter-and-guard (`const named = draft.djs.filter(d => d.dj_name); if (named.length) { … }`) existed because `formatOnAirSummary` did not filter; now that it does, the pre-filter is redundant and the guard's "keep the previous banner when nobody is named" fallback converges on the same string the post-refetch `convertDJsOnAir` will produce anyway (`OFF_AIR_LABEL`), instead of leaving a stale one in place. Both #621 regression tests still pass unchanged.

## One deliberate behavior change

**This is the one place the refactor departs from "preserve both callers' output exactly."**

`formatOnAirSummary` never filtered blank names itself — it trusted whichever caller happened to pre-filter, and only one of its three call sites did (`joinShow`; `leaveShow` and `convertDJsOnAir` did not). Its actual outputs were probed before any source was touched:

| input | old output | new output |
|---|---|---|
| `[{ dj_name: "" }]` | `""` (bare empty string) | `"Off Air"` |
| `[{ dj_name: "   " }]` | `"   "` (raw whitespace) | `"Off Air"` |
| `[{ dj_name: "Turncoat" }, { dj_name: "" }]` | `"Turncoat, "` (trailing artifact) | `"Turncoat"` |
| `[{ dj_name: "  Turncoat  " }]` | `"  Turncoat  "` (untrimmed) | `"Turncoat"` |

These were fixed rather than preserved. The justification is that a blank handle is now a **live scenario, not a hypothetical**: `14b71993 fix(roster): let a DJ be added without an on-air handle` is on `main`, so `auth_user.dj_name` can legitimately be NULL for an account created through either roster path. Preserving those outputs would have been preserving a bug — and preserving it in the two call sites that never pre-filtered, which are the ones that read from the server.

New tests in `conversions.test.ts` pin the corrected outputs. Every divergence from the old implementation is on input containing a blank or an untrimmed name; on clean input the two are byte-for-byte identical.

## Two consequences of that change, found in review and fixed (second commit)

Following the nameless DJ one step further turned up two things the refactor would otherwise have shipped. Both are newly reachable for exactly the population `14b71993` created, and both are covered by tests that fail without their fix.

**A null `dj_name` crashed the public page.** `dj_name` is declared non-nullable, and the wire disagrees. Backend-Service's `getOnAirDJs` runs each account DJ's handle through `resolveDjDisplayName`, which returns `null` for a handle that is blank or the literal `"Anonymous"` — so a DJ with no on-air handle arrives as `dj_name: null`. The old `.join(", ")` coerced that to `""`; the consolidated path's `.trim()` throws on it. Where it throws is the problem: `fetchWhoIsLiveSeed` calls `convertDJsOnAir` **outside** `fetchBackendSeed`'s catch, so the throw escapes the seed fetch's documented fail-open contract and takes down the server render of the public `/live` page rather than degrading it to the client-fetched loading state. Coerced at the wire boundary (`dj.dj_name ?? ""`), which is where the declaration is the thing that is wrong.

Note the underlying contract drift: `api.yaml`'s `OnAirDJ.dj_name` is non-nullable while the backend's `getOnAirDJs` is typed `dj_name: string | null` and documents the null case. That is a cross-repo fix, not this PR's — worth a follow-up ticket against the contract.

**A nameless DJ read as OFF AIR while on air.** With the null handled, an all-blank list formats to `OFF_AIR_LABEL` — correct, there is no name to render. But `NowPlaying` derived liveness by comparing that banner string to `"Off Air"` (a hardcoded copy of the constant), so a running show with a handle-less DJ would have rendered **OFF AIR** on the public page. Liveness now comes from `onAirData.djs.length`: `convertDJsOnAir` returns an empty `djs` for every genuinely-off-air case, so the list answers the liveness question directly, and the banner goes back to being only a display string. This also removes the hardcoded label copy.

The second finding is why `convertDJsOnAir` deliberately keeps `djs` non-empty while `onAir` reads off-air for a nameless DJ; a test pins that pairing so it is not "tidied up" into agreement later.

## Verification

- `formatDjNames` and `describeOpenShow` are byte-identical to their pre-refactor implementations across an exhaustive input space of 0–3 names drawn from a nine-atom alphabet (empty, single space, multiple spaces, tab, padded and unpadded real handles) — 820 inputs, zero divergences.
- `formatOnAirSummary` diverges on 734 of those 820 inputs, **all** of which contain a blank or untrimmed name; zero divergences on clean input.
- Removing the filter from `nonBlankNames` fails `joinShow.optimistic.test.ts` on both #621 cases (`''` for a solo unnamed joiner, `'Marz, '` for the mixed pair) — the `api.ts` simplification's dependency on the shared filter is covered, not assumed.
- Reverting the `?? ""` fails the new `convertDJsOnAir` case with the exact production symptom, `TypeError: Cannot read properties of null (reading 'trim')`; reverting the liveness change fails the new `NowPlaying` case.
- Existing `formatDjNames`, `describeOpenShow` (including #1288's "ignores blank handles when choosing the verb" regression) and `convertDJsOnAir` tests pass unchanged.
- 364 test files / 5322 tests passing; `tsc --noEmit` clean; lint 0 errors (191 pre-existing warnings, none added); `next build` clean.

`GoLiveHandoffDialog.tsx` is deliberately untouched — #1291 is open against it. `lib/features/flowsheet/types.ts` likewise — #830 owns it, which is why the null is handled at the boundary rather than by widening the type.
